### PR TITLE
feat(build): add initial build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src
+etcd

--- a/build
+++ b/build
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+ETCD_PACKAGE=github.com/coreos/etcd
+GOPATH=${PWD}
+SRC_DIR=$GOPATH/src
+ETCD_DIR=$SRC_DIR/$ETCD_PACKAGE
+
+ETCD_BASE=$(dirname ${ETCD_DIR})
+if [ ! -d ${ETCD_BASE} ]; then
+	mkdir -p ${ETCD_BASE}
+fi
+
+if [ ! -h ${ETCD_DIR} ]; then
+	ln -s ../../../ ${ETCD_DIR}
+fi
+
+go get -d ./...
+go build ${ETCD_PACKAGE}


### PR DESCRIPTION
add a simple build script that sets up a gopath and uses the current git
directory for the github.com/coreos/etcd packages.

There aren't a lot of great alternatives to doing it this way unless we
want to check in all of the dependencies into the repo (which is
actually a good practice probably).
