### PR TITLE
change type of port to unit16

### DIFF
--- a/command.go
+++ b/command.go
@@ -107,8 +107,8 @@ func (c *WatchCommand) Apply(server *raft.Server) (interface{}, error) {
 type JoinCommand struct {
 	Name       string `json:"name"`
 	Hostname   string `json:"hostName"`
-	RaftPort   int    `json:"raftPort"`
-	ClientPort int    `json:"clientPort"`
+	RaftPort   uint16 `json:"raftPort"`
+	ClientPort uint16 `json:"clientPort"`
 }
 
 // The name of the join command in the log

--- a/etcd.go
+++ b/etcd.go
@@ -34,9 +34,9 @@ var machinesFile string
 var cluster []string
 
 var hostname string
-var clientPort int
-var raftPort int
-var webPort int
+var clientPort uint16
+var raftPort uint16
+var webPort uint16
 
 var serverCertFile string
 var serverKeyFile string
@@ -108,9 +108,9 @@ const (
 
 type Info struct {
 	Hostname   string `json:"hostname"`
-	RaftPort   int    `json:"raftPort"`
-	ClientPort int    `json:"clientPort"`
-	WebPort    int    `json:"webPort"`
+	RaftPort   uint16 `json:"raftPort"`
+	ClientPort uint16 `json:"clientPort"`
+	WebPort    uint16 `json:"webPort"`
 
 	ServerCertFile string `json:"serverCertFile"`
 	ServerKeyFile  string `json:"serverKeyFile"`
@@ -328,7 +328,7 @@ func dialTimeout(network, addr string) (net.Conn, error) {
 }
 
 // Start to listen and response raft command
-func startRaftTransport(port int, st int) {
+func startRaftTransport(port uint16, st int) {
 
 	// internal commands
 	http.HandleFunc("/join", JoinHttpHandler)
@@ -368,7 +368,7 @@ func startRaftTransport(port int, st int) {
 }
 
 // Start to listen and response client command
-func startClientTransport(port int, st int) {
+func startClientTransport(port uint16, st int) {
 	// external commands
 	http.HandleFunc("/"+version+"/keys/", Multiplexer)
 	http.HandleFunc("/"+version+"/watch/", WatchHttpHandler)

--- a/machines.go
+++ b/machines.go
@@ -6,13 +6,13 @@ import (
 
 type machine struct {
 	hostname   string
-	raftPort   int
-	clientPort int
+	raftPort   uint16
+	clientPort uint16
 }
 
 var machinesMap = map[string]machine{}
 
-func addMachine(name string, hostname string, raftPort int, clientPort int) {
+func addMachine(name string, hostname string, raftPort uint16, clientPort uint16) {
 
 	machinesMap[name] = machine{hostname, raftPort, clientPort}
 

--- a/web/web.go
+++ b/web/web.go
@@ -24,7 +24,7 @@ func mainHandler(c http.ResponseWriter, req *http.Request) {
 	mainTempl.Execute(c, p)
 }
 
-func Start(server *raft.Server, port int) {
+func Start(server *raft.Server, port uint16) {
 	mainTempl = template.Must(template.New("index.html").Parse(index_html))
 	s = server
 


### PR DESCRIPTION
In modern computers, the port numbers are between 1 and 65535, so unit16 is
sufficient.
