### PR TITLE
Change get -> keys in an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ curl -L http://127.0.0.1:4001/v1/keys/foo/foo_dir/bar -d value=barbarbar
 Let us list them next.
 
 ```sh
-curl -L http://127.0.0.1:4001/v1/get/foo/
+curl -L http://127.0.0.1:4001/v1/keys/foo/
 ```
 
 We should see the response as an array of items


### PR DESCRIPTION
Hi, I was going through the examples in the readme and one of them didn't work, looks like you changed the paths from /get to /keys and missed one example.

etcd looks great!
