### PR TITLE
fix(test): add sleep in createCluster

### DIFF
--- a/test.go
+++ b/test.go
@@ -74,6 +74,14 @@ func createCluster(size int, procAttr *os.ProcAttr) ([][]string, []*os.Process, 
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// TODOBP: Change this sleep to wait until the master is up.
+		// The problem is that if the master isn't up then the children
+		// have to retry. This retry can take upwards of 15 seconds
+		// which slows tests way down and some of them fail.
+		if i == 0 {
+			time.Sleep(time.Second)
+		}
 	}
 
 	return argGroup, etcds, nil


### PR DESCRIPTION
The problem is that if the master isn't up when the children start then the
children have to retry. This retry can take upwards of 15 seconds which slows
tests way down and some of them fail.
