### PR TITLE
fix(etcd): remove insecureskipverify

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -481,8 +481,10 @@ func tlsConfigFromInfo(info TLSInfo) (t TLSConfig, ok bool) {
 	t.Scheme = "https"
 	t.Server.ClientAuth, t.Server.ClientCAs = newCertPool(CAFile)
 
+	// The client should trust the RootCA that the Server uses since
+	// everyone is a peer in the network.
 	t.Client.Certificates = []tls.Certificate{tlsCert}
-	t.Client.InsecureSkipVerify = true
+	t.Client.RootCAs = t.Server.ClientCAs
 
 	return t, true
 }


### PR DESCRIPTION
The client certs and server certs should share the same CA since everyone is
a peer. Use this logic instead of InsecureSkipVerify.

Test-plan: tested manually and tests pass still.
