### PR TITLE
Added dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:12.04
+RUN apt-get update
+RUN apt-get install -y python-software-properties git
+RUN add-apt-repository -y ppa:duh/golang
+RUN apt-get update
+RUN apt-get install -y golang
+ADD . /opt/etcd
+RUN cd /opt/etcd && ./build
+EXPOSE 4001 7001
+ENTRYPOINT ["/opt/etcd/etcd", "-c", "0.0.0.0:4001", "-s", "0.0.0.0:7001"]


### PR DESCRIPTION
Seems so obvious, so why is there none? Useful for deployment (perhaps outside of CoreOS) or development.

This docker file builds an image, which launches the binary automatically. To build:

```
docker build -t coreos/etcd .
```

To run:

```
docker run -d coreos/etcd
```

any arguments you pass, will be passed to the etcd binary (in addition to the flags to bind to 0.0.0.0, otherwise it won't work):

```
docker run -t -i coreos/etcd --help
```
