### PR TITLE
Concurrent GET requests should not block.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -27,7 +27,7 @@ type Store struct {
 	// the watching condition.
 	// It is needed so that clone() can atomically replicate the Store
 	// and do the log snapshot in a go routine.
-	mutex sync.Mutex
+	mutex sync.RWMutex
 
 	// WatcherHub is where we register all the clients
 	// who issue a watch request
@@ -304,8 +304,8 @@ func (s *Store) internalGet(key string) *Response {
 // If key is a file return the file
 // If key is a directory reuturn an array of files
 func (s *Store) Get(key string) ([]byte, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 
 	resps, err := s.RawGet(key)
 


### PR DESCRIPTION
GET requests could be executed concurrently without blocking.

Changed `Mutex` to a read-write lock.
