### PR TITLE
feat(go_version): check go version at build time

### DIFF
--- a/go_version.go
+++ b/go_version.go
@@ -1,0 +1,3 @@
+// +build !go1.1
+
+"etcd requires go 1.1 or greater to build"


### PR DESCRIPTION
```
$ ./build can't load package: package github.com/coreos/etcd: 
src/github.com/coreos/etcd/go_version.go:3:1: expected 'package', found
'STRING' "etcd requires go 1.1 or greater to build"
```
