### PR TITLE
chore(trasnsporter): delete unused variables

### DIFF
--- a/transporter.go
+++ b/transporter.go
@@ -151,12 +151,10 @@ func (t transporter) SendSnapshotRecoveryRequest(server *raft.Server, peer *raft
 
 // Send server side POST request
 func (t transporter) Post(path string, body io.Reader) (*http.Response, error) {
-	resp, err := t.client.Post(path, "application/json", body)
-	return resp, err
+	return t.client.Post(path, "application/json", body)
 }
 
 // Send server side GET request
 func (t transporter) Get(path string) (*http.Response, error) {
-	resp, err := t.client.Get(path)
-	return resp, err
+	return t.client.Get(path)
 }


### PR DESCRIPTION
just return directly instead of creating intermediate variables
