### PR TITLE
feat(etcd): add listen host parameter

### DIFF
--- a/etcd_server.go
+++ b/etcd_server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"net/url"
 )
 
 type etcdServer struct {
@@ -15,18 +14,12 @@ type etcdServer struct {
 
 var e *etcdServer
 
-func newEtcdServer(name string, urlStr string, tlsConf *TLSConfig, tlsInfo *TLSInfo) *etcdServer {
-	u, err := url.Parse(urlStr)
-
-	if err != nil {
-		fatalf("invalid url '%s': %s", e.url, err)
-	}
-
+func newEtcdServer(name string, urlStr string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo) *etcdServer {
 	return &etcdServer{
 		Server: http.Server{
 			Handler:   NewEtcdMuxer(),
 			TLSConfig: &tlsConf.Server,
-			Addr:      u.Host,
+			Addr:      listenHost,
 		},
 		name:    name,
 		url:     urlStr,

--- a/raft_server.go
+++ b/raft_server.go
@@ -20,13 +20,14 @@ type raftServer struct {
 	joinIndex uint64
 	name      string
 	url       string
+	listenHost string
 	tlsConf   *TLSConfig
 	tlsInfo   *TLSInfo
 }
 
 var r *raftServer
 
-func newRaftServer(name string, url string, tlsConf *TLSConfig, tlsInfo *TLSInfo) *raftServer {
+func newRaftServer(name string, url string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo) *raftServer {
 
 	// Create transporter for raft
 	raftTransporter := newTransporter(tlsConf.Scheme, tlsConf.Client)
@@ -41,6 +42,7 @@ func newRaftServer(name string, url string, tlsConf *TLSConfig, tlsInfo *TLSInfo
 		version: raftVersion,
 		name:    name,
 		url:     url,
+		listenHost: listenHost,
 		tlsConf: tlsConf,
 		tlsInfo: tlsInfo,
 	}
@@ -134,15 +136,14 @@ func startAsFollower() {
 
 // Start to listen and response raft command
 func (r *raftServer) startTransport(scheme string, tlsConf tls.Config) {
-	u, _ := url.Parse(r.url)
-	infof("raft server [%s:%s]", r.name, u)
+	infof("raft server [%s:%s]", r.name, r.listenHost)
 
 	raftMux := http.NewServeMux()
 
 	server := &http.Server{
 		Handler:   raftMux,
 		TLSConfig: &tlsConf,
-		Addr:      u.Host,
+		Addr:      r.listenHost,
 	}
 
 	// internal commands

--- a/util.go
+++ b/util.go
@@ -106,6 +106,22 @@ func sanitizeURL(host string, defaultScheme string) string {
 	return p.String()
 }
 
+// sanitizeListenHost cleans up the ListenHost parameter and appends a port
+// if necessary based on the advertised port.
+func sanitizeListenHost(listen string, advertised string) string {
+	aurl, err := url.Parse(advertised)
+	if err != nil {
+		fatal(err)
+	}
+
+	_, aport, err := net.SplitHostPort(aurl.Host)
+	if err != nil {
+		fatal(err)
+	}
+
+	return net.JoinHostPort(listen, aport)
+}
+
 func check(err error) {
 	if err != nil {
 		fatal(err)


### PR DESCRIPTION
this separates out the listening IP from the advertised IP. This is necessary
so that we can hit etcd on 127.0.0.1 but also advertise the right IP to the
rest of the cluster.
