### PR TITLE
Transporter with timeout

### DIFF
--- a/raft_server.go
+++ b/raft_server.go
@@ -31,7 +31,7 @@ func newRaftServer(name string, url string, listenHost string, tlsConf *TLSConfi
 
 	// Create transporter for raft
 	raftTransporter := newTransporter(tlsConf.Scheme, tlsConf.Client, ElectionTimeout)
-	
+
 	// Create raft server
 	server, err := raft.NewServer(name, dirPath, raftTransporter, etcdStore, nil)
 
@@ -198,7 +198,7 @@ func joinCluster(cluster []string) bool {
 			if _, ok := err.(etcdErr.Error); ok {
 				fatal(err)
 			}
-			
+
 			debugf("cannot join to cluster via machine %s %s", machine, err)
 		}
 	}

--- a/transporter.go
+++ b/transporter.go
@@ -21,7 +21,7 @@ type transporter struct {
 // response struct
 type transporterResponse struct {
 	resp *http.Response
-	err error
+	err  error
 }
 
 // Create transporter using by raft server
@@ -162,11 +162,11 @@ func (t *transporter) SendSnapshotRecoveryRequest(server *raft.Server, peer *raf
 func (t *transporter) Post(path string, body io.Reader) (*http.Response, error) {
 
 	c := make(chan *transporterResponse, 1)
-	
+
 	go func() {
 		tr := new(transporterResponse)
 		tr.resp, tr.err = t.client.Post(path, "application/json", body)
-		c <-tr
+		c <- tr
 	}()
 
 	return t.waitResponse(c)
@@ -177,11 +177,11 @@ func (t *transporter) Post(path string, body io.Reader) (*http.Response, error) 
 func (t *transporter) Get(path string) (*http.Response, error) {
 
 	c := make(chan *transporterResponse, 1)
-	
+
 	go func() {
 		tr := new(transporterResponse)
 		tr.resp, tr.err = t.client.Get(path)
-		c <-tr
+		c <- tr
 	}()
 
 	return t.waitResponse(c)
@@ -195,7 +195,7 @@ func (t *transporter) waitResponse(responseChan chan *transporterResponse) (*htt
 	case <-timeoutChan:
 		return nil, fmt.Errorf("Wait Response Timeout: %v", t.timeout)
 
-	case r:= <-responseChan:
+	case r := <-responseChan:
 		return r.resp, r.err
 	}
 

--- a/transporter_test.go
+++ b/transporter_test.go
@@ -15,7 +15,7 @@ func TestTransporterTimeout(t *testing.T) {
 	ts.Get("http://google.com")
 	_, err := ts.Get("http://google.com:9999") // it doesn't exisit
 	if err == nil || err.Error() != "Wait Response Timeout: 1s" {
-		t.Fatal("timeout error: ", err.Error( ))
+		t.Fatal("timeout error: ", err.Error())
 	}
 
 	_, err = ts.Post("http://google.com:9999", nil) // it doesn't exisit


### PR DESCRIPTION
Well, I found that if network is partitioned after launching the servers, the server will get blocked for 45 seconds when sending POST request to the servers in another network group.  That is because of the default connection time out is 45 seconds. But in fact, the time out only needs to be just one heartbeat,  so I add the `waitResponse` function to set the time out equals one heartbeat by default.
