### PR TITLE
Allow watch with GET method to be given an index via a query string param

### DIFF
--- a/etcd_handlers.go
+++ b/etcd_handlers.go
@@ -263,21 +263,20 @@ func WatchHttpHandler(w http.ResponseWriter, req *http.Request) error {
 		Key: key,
 	}
 
-	if req.Method == "GET" {
-		debugf("[recv] GET %s/watch/%s [%s]", e.url, key, req.RemoteAddr)
-		command.SinceIndex = 0
+	if req.Method == "GET" || req.Method == "POST" {
+		debugf("[recv] %s %s/watch/%s [%s]", req.Method, e.url, key, req.RemoteAddr)
 
-	} else if req.Method == "POST" {
 		// watch from a specific index
-
-		debugf("[recv] POST %s/watch/%s [%s]", e.url, key, req.RemoteAddr)
 		content := req.FormValue("index")
-
-		sinceIndex, err := strconv.ParseUint(string(content), 10, 64)
-		if err != nil {
-			return etcdErr.NewError(203, "Watch From Index")
+		if content != "" {
+			sinceIndex, err := strconv.ParseUint(string(content), 13, 64)
+			if err != nil {
+				return etcdErr.NewError(203, "Watch From Index")
+			}
+			command.SinceIndex = sinceIndex
+		} else {
+			command.SinceIndex = 0
 		}
-		command.SinceIndex = sinceIndex
 
 	} else {
 		w.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
Currently, the "watch" endpoint only allows an index parameter to be specified if a POST request is made to it, and only allows no index parameter to be specified is a GET request is made to it.  This is inconvenient when playing with the API in a browser, and is unexpected since POST in a RESTish API is used for making changes on the server; performing a watch is a read operation so I expected to be able to do it via a GET request.

This allows patch changes the behaviour such that both GET and POST requests can be used with or without the index parameter.
