### PR TITLE
Add support for sequentially-named keys

### DIFF
--- a/command.go
+++ b/command.go
@@ -30,6 +30,7 @@ type SetCommand struct {
 	Key        string    `json:"key"`
 	Value      string    `json:"value"`
 	ExpireTime time.Time `json:"expireTime"`
+	Sequential bool      `json:"sequential"`
 }
 
 // The name of the set command in the log
@@ -39,7 +40,7 @@ func (c *SetCommand) CommandName() string {
 
 // Set the key-value pair
 func (c *SetCommand) Apply(server *raft.Server) (interface{}, error) {
-	return etcdStore.Set(c.Key, c.Value, c.ExpireTime, server.CommitIndex())
+	return etcdStore.Set(c.Key, c.Value, c.ExpireTime, c.Sequential, server.CommitIndex())
 }
 
 // TestAndSet command
@@ -168,7 +169,7 @@ func (c *JoinCommand) Apply(raftServer *raft.Server) (interface{}, error) {
 	// add machine in etcd storage
 	key := path.Join("_etcd/machines", c.Name)
 	value := fmt.Sprintf("raft=%s&etcd=%s&raftVersion=%s", c.RaftURL, c.EtcdURL, c.RaftVersion)
-	etcdStore.Set(key, value, time.Unix(0, 0), raftServer.CommitIndex())
+	etcdStore.Set(key, value, time.Unix(0, 0), false, raftServer.CommitIndex())
 
 	// add peer stats
 	if c.Name != r.Name() {

--- a/error/error.go
+++ b/error/error.go
@@ -23,6 +23,8 @@ func init() {
 	errors[201] = "PrevValue is Required in POST form"
 	errors[202] = "The given TTL in POST form is not a number"
 	errors[203] = "The given index in POST form is not a number"
+	errors[204] = "The given sequential in POST form is not a valid boolean"
+	errors[205] = "Can not specify both PrevValue and sequential in POST form"
 
 	// raft related errors
 	errors[300] = "Raft Internal Error"

--- a/etcd_handlers.go
+++ b/etcd_handlers.go
@@ -109,7 +109,22 @@ func SetHttpHandler(w http.ResponseWriter, req *http.Request) error {
 		return etcdErr.NewError(202, "Set")
 	}
 
-	if prevValueArr, ok := req.Form["prevValue"]; ok && len(prevValueArr) > 0 {
+	strSequential := req.Form.Get("sequential")
+	sequential := false
+	if strSequential != "" {
+		sequential, err = parseBoolean(strSequential)
+		if err != nil {
+			return etcdErr.NewError(204, "Set")
+		}
+	}
+
+	prevValueArr, ok := req.Form["prefValue"]
+
+	if ok && len(prevValueArr) > 0 && sequential {
+		return etcdErr.NewError(205, "Set")
+	}
+
+	if ok && len(prevValueArr) > 0 {
 		command := &TestAndSetCommand{
 			Key:        key,
 			Value:      value,
@@ -124,6 +139,7 @@ func SetHttpHandler(w http.ResponseWriter, req *http.Request) error {
 			Key:        key,
 			Value:      value,
 			ExpireTime: expireTime,
+			Sequential: sequential,
 		}
 
 		return dispatch(command, w, req, true)

--- a/util.go
+++ b/util.go
@@ -36,6 +36,18 @@ func durationToExpireTime(strDuration string) (time.Time, error) {
 	}
 }
 
+// Convert a string boolean to a boolean
+func parseBoolean(strBoolean string) (bool, error) {
+	switch strBoolean {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("Malformed boolean value: %s", strBoolean)
+	}
+}
+
 //--------------------------------------
 // Web Helper
 //--------------------------------------
@@ -237,6 +249,7 @@ func send(c chan bool) {
 		command.Key = "foo"
 		command.Value = "bar"
 		command.ExpireTime = time.Unix(0, 0)
+		command.Sequential = false
 		r.Do(command)
 	}
 	c <- true


### PR DESCRIPTION
By passing sequential=true to a set call, etcd appends a monotonically
increasing (0-padded) number to the key name before actually storing
it. Sequentially-named keys are useful for patterns like leader
election or mutexes where it's necessary to have an externally visible
ordering of requests.

This turned out to be pretty straightforward, as etcd already
maintains something we can use as a monotonically increasing number -
namely the current index of the raft machine, so we just append that
to the key name.
