### PR TITLE
fix: check whether net.Dial succeeds, otherwise we end up making a nil pointer

### DIFF
--- a/third_party/github.com/coreos/go-systemd/journal/send.go
+++ b/third_party/github.com/coreos/go-systemd/journal/send.go
@@ -3,6 +3,7 @@ package journal
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"encoding/binary"
 )
 
 // Priority of a journal message
@@ -32,7 +32,11 @@ const (
 var conn net.Conn
 
 func init() {
-	conn, _ = net.Dial("unixgram", "/run/systemd/journal/socket")
+	var err error
+	conn, err = net.Dial("unixgram", "/run/systemd/journal/socket")
+	if err != nil {
+		conn = nil
+	}
 }
 
 // Enabled returns true iff the systemd journal is available for logging


### PR DESCRIPTION
In bundled version of go-systemd, there is a bug in `func init()` on line 34, where a connection is instantiated, and the error is thrown away. This leads to the global `conn` being a nil pointer, and anything trying to use that at a later time will crash the program.

This pull requests addresses this by checking whether `net.Dial` fails, and if so, explicitly set `conn` to nil, so the rest of the code can appropriately handle that condition, as it is already coded to do.

Problem observed on Mac OSX 10.8.5, even after creating `/run/systemd/journal/` and having it be writable by the user.
