### PR TITLE
refactor remove the extra function

### DIFF
--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -115,7 +115,7 @@ func (s *PeerServer) ListenAndServe(snapshot bool, cluster []string) {
 
 	} else {
 		// Rejoin the previous cluster
-		cluster = s.registry.URLs(s.Leader(), s.name, s.registry.peerURL)
+		cluster = s.registry.PeerURLs(s.Leader(), s.name)
 		for i := 0; i < len(cluster); i++ {
 			u, err := url.Parse(cluster[i])
 			if err != nil {

--- a/server/registry.go
+++ b/server/registry.go
@@ -111,8 +111,18 @@ func (r *Registry) peerURL(name string) (string, bool) {
 	return "", false
 }
 
-// Retrieves the URLs  for all nodes using url function.
-func (r *Registry) URLs(leaderName, selfName string, url func(name string) (string, bool)) []string {
+// Retrieves the Client URLs for all nodes.
+func (r *Registry) ClientURLs(leaderName, selfName string) []string {
+	return r.urls(leaderName, selfName, r.clientURL)
+}
+
+// Retrieves the Peer URLs for all nodes.
+func (r *Registry) PeerURLs(leaderName, selfName string) []string {
+	return r.urls(leaderName, selfName, r.peerURL)
+}
+
+// Retrieves the URLs for all nodes using url function.
+func (r *Registry) urls(leaderName, selfName string, url func(name string) (string, bool)) []string {
 	r.Lock()
 	defer r.Unlock()
 

--- a/server/server.go
+++ b/server/server.go
@@ -258,7 +258,7 @@ func (s *Server) GetLeaderHandler(w http.ResponseWriter, req *http.Request) erro
 
 // Handler to return all the known machines in the current cluster.
 func (s *Server) GetMachinesHandler(w http.ResponseWriter, req *http.Request) error {
-	machines := s.registry.URLs(s.peerServer.Leader(), s.name, s.registry.clientURL)
+	machines := s.registry.ClientURLs(s.peerServer.Leader(), s.name)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(strings.Join(machines, ", ")))
 	return nil


### PR DESCRIPTION
The `URLs` and `PeerURLs` share the same logic, expect one function call. 
Combine them by using function pointer.
