### PR TITLE
Extract Store into an interface.

### DIFF
--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -30,7 +30,7 @@ type PeerServer struct {
 	followersStats *raftFollowersStats
 	serverStats    *raftServerStats
 	registry       *Registry
-	store          *store.Store
+	store          store.Store
 	snapConf       *snapshotConf
 	MaxClusterSize int
 	RetryTimes     int
@@ -49,7 +49,7 @@ type snapshotConf struct {
 	writesThr uint64
 }
 
-func NewPeerServer(name string, path string, url string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo, registry *Registry, store *store.Store) *PeerServer {
+func NewPeerServer(name string, path string, url string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo, registry *Registry, store store.Store) *PeerServer {
 	s := &PeerServer{
 		name:       name,
 		url:        url,

--- a/server/registry.go
+++ b/server/registry.go
@@ -18,7 +18,7 @@ const RegistryKey = "/_etcd/machines"
 // The Registry stores URL information for nodes.
 type Registry struct {
 	sync.Mutex
-	store *store.Store
+	store store.Store
 	nodes map[string]*node
 }
 
@@ -30,7 +30,7 @@ type node struct {
 }
 
 // Creates a new Registry.
-func NewRegistry(s *store.Store) *Registry {
+func NewRegistry(s store.Store) *Registry {
 	return &Registry{
 		store: s,
 		nodes: make(map[string]*node),

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ type Server struct {
 	http.Server
 	peerServer  *PeerServer
 	registry    *Registry
-	store       *store.Store
+	store       store.Store
 	name        string
 	url         string
 	tlsConf     *TLSConfig
@@ -30,7 +30,7 @@ type Server struct {
 }
 
 // Creates a new Server.
-func New(name string, urlStr string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo, peerServer *PeerServer, registry *Registry, store *store.Store) *Server {
+func New(name string, urlStr string, listenHost string, tlsConf *TLSConfig, tlsInfo *TLSInfo, peerServer *PeerServer, registry *Registry, store store.Store) *Server {
 	s := &Server{
 		Server: http.Server{
 			Handler:   mux.NewRouter(),
@@ -85,7 +85,7 @@ func (s *Server) PeerURL(name string) (string, bool) {
 }
 
 // Returns a reference to the Store.
-func (s *Server) Store() *store.Store {
+func (s *Server) Store() store.Store {
 	return s.store
 }
 

--- a/server/v1/v1.go
+++ b/server/v1/v1.go
@@ -10,6 +10,6 @@ import (
 type Server interface {
 	CommitIndex() uint64
 	Term() uint64
-	Store() *store.Store
+	Store() store.Store
 	Dispatch(raft.Command, http.ResponseWriter, *http.Request) error
 }

--- a/server/v2/v2.go
+++ b/server/v2/v2.go
@@ -13,6 +13,6 @@ type Server interface {
 	CommitIndex() uint64
 	Term() uint64
 	PeerURL(string) (string, bool)
-	Store() *store.Store
+	Store() store.Store
 	Dispatch(raft.Command, http.ResponseWriter, *http.Request) error
 }

--- a/store/create_command.go
+++ b/store/create_command.go
@@ -26,7 +26,7 @@ func (c *CreateCommand) CommandName() string {
 
 // Create node
 func (c *CreateCommand) Apply(server *raft.Server) (interface{}, error) {
-	s, _ := server.StateMachine().(*Store)
+	s, _ := server.StateMachine().(Store)
 
 	e, err := s.Create(c.Key, c.Value, c.IncrementalSuffix, c.Force, c.ExpireTime, server.CommitIndex(), server.Term())
 

--- a/store/delete_command.go
+++ b/store/delete_command.go
@@ -22,7 +22,7 @@ func (c *DeleteCommand) CommandName() string {
 
 // Delete the key
 func (c *DeleteCommand) Apply(server *raft.Server) (interface{}, error) {
-	s, _ := server.StateMachine().(*Store)
+	s, _ := server.StateMachine().(Store)
 
 	e, err := s.Delete(c.Key, c.Recursive, server.CommitIndex(), server.Term())
 

--- a/store/stats_test.go
+++ b/store/stats_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBasicStats(t *testing.T) {
-	s := New()
+	s := newStore()
 	keys := GenKeys(rand.Intn(100), 5)
 
 	var i uint64
@@ -140,7 +140,7 @@ func TestBasicStats(t *testing.T) {
 		t.Fatalf("TestAndSetFail [%d] != Stats.TestAndSetFail [%d]", TestAndSetFail, s.Stats.TestAndSetFail)
 	}
 
-	s = New()
+	s = newStore()
 	SetSuccess = 0
 	SetFail = 0
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateAndGet(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	s.Create("/foobar", "bar", false, false, Permanent, 1, 1)
 
@@ -66,7 +66,7 @@ func TestCreateAndGet(t *testing.T) {
 }
 
 func TestUpdateFile(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	_, err := s.Create("/foo/bar", "bar", false, false, Permanent, 1, 1)
 
@@ -161,7 +161,7 @@ func TestUpdateFile(t *testing.T) {
 }
 
 func TestListDirectory(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	// create dir /foo
 	// set key-value /foo/foo=bar
@@ -206,7 +206,7 @@ func TestListDirectory(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	s.Create("/foo", "bar", false, false, Permanent, 1, 1)
 	_, err := s.Delete("/foo", false, 1, 1)
@@ -245,7 +245,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestExpire(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	expire := time.Now().Add(time.Second)
 
@@ -287,7 +287,7 @@ func TestExpire(t *testing.T) {
 }
 
 func TestTestAndSet(t *testing.T) { // TODO prevValue == nil ?
-	s := New()
+	s := newStore()
 	s.Create("/foo", "bar", false, false, Permanent, 1, 1)
 
 	// test on wrong previous value
@@ -320,7 +320,7 @@ func TestTestAndSet(t *testing.T) { // TODO prevValue == nil ?
 }
 
 func TestWatch(t *testing.T) {
-	s := New()
+	s := newStore()
 	// watch at a deeper path
 	c, _ := s.Watch("/foo/foo/foo", false, 0, 0, 1)
 	s.Create("/foo/foo/foo", "bar", false, false, Permanent, 1, 1)
@@ -409,7 +409,7 @@ func TestWatch(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	// simulating random creation
 	keys := GenKeys(80, 4)
@@ -447,7 +447,7 @@ func TestSort(t *testing.T) {
 }
 
 func TestSaveAndRecover(t *testing.T) {
-	s := New()
+	s := newStore()
 
 	// simulating random creation
 	keys := GenKeys(8, 4)
@@ -469,7 +469,7 @@ func TestSaveAndRecover(t *testing.T) {
 	s.Create("/foo/foo", "bar", false, false, expire, 1, 1)
 	b, err := s.Save()
 
-	cloneFs := New()
+	cloneFs := newStore()
 	time.Sleep(2 * time.Second)
 
 	cloneFs.Recovery(b)
@@ -521,7 +521,7 @@ func GenKeys(num int, depth int) []string {
 	return keys
 }
 
-func createAndGet(s *Store, path string, t *testing.T) {
+func createAndGet(s *store, path string, t *testing.T) {
 	_, err := s.Create(path, "bar", false, false, Permanent, 1, 1)
 
 	if err != nil {

--- a/store/test_and_set_command.go
+++ b/store/test_and_set_command.go
@@ -27,7 +27,7 @@ func (c *TestAndSetCommand) CommandName() string {
 
 // Set the key-value pair if the current value of the key equals to the given prevValue
 func (c *TestAndSetCommand) Apply(server *raft.Server) (interface{}, error) {
-	s, _ := server.StateMachine().(*Store)
+	s, _ := server.StateMachine().(Store)
 
 	e, err := s.TestAndSet(c.Key, c.PrevValue, c.PrevIndex,
 		c.Value, c.ExpireTime, server.CommitIndex(), server.Term())

--- a/store/update_command.go
+++ b/store/update_command.go
@@ -25,7 +25,7 @@ func (c *UpdateCommand) CommandName() string {
 
 // Update node
 func (c *UpdateCommand) Apply(server *raft.Server) (interface{}, error) {
-	s, _ := server.StateMachine().(*Store)
+	s, _ := server.StateMachine().(Store)
 
 	e, err := s.Update(c.Key, c.Value, c.ExpireTime, server.CommitIndex(), server.Term())
 

--- a/store/watcher_test.go
+++ b/store/watcher_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestWatcher(t *testing.T) {
-	s := New()
+	s := newStore()
 	wh := s.WatcherHub
 	c, err := wh.watch("/foo", true, 1)
 	if err != nil {


### PR DESCRIPTION
@xiangli-cmu @philips This extracts out the `Store` into an interface so we can start mocking it for unit tests. It's mostly straightforward. The biggest change is attaching the `*store.store` to the `Node`. I had to do that so the Node could know the specific store type and that way I didn't have to open up a bunch of the internal details of the store.
