### PR TITLE
Update build script to fail on error.

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 ETCD_PACKAGE=github.com/coreos/etcd
 export GOPATH="${PWD}"

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Get GOPATH, etc from build
 . ./build


### PR DESCRIPTION
This fixes the issue in https://github.com/coreos/etcd/pull/247 where errors in the build script and test script don't cause the whole build to fail.

This uses the [-e bash flag](http://pubs.opengroup.org/onlinepubs/009695399/utilities/set.html#tag_04_127_03).

We may need to update this to support other shells or we can move to a Makefile which has fail-on-error as the default behavior.

/cc: @philips @xiangli-cmu
