### PR TITLE
Switch to goraft/raft

### DIFF
--- a/command.go
+++ b/command.go
@@ -26,7 +26,7 @@ import (
 
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/etcd/store"
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 const commandPrefix = "etcd:"

--- a/etcd.go
+++ b/etcd.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/store"
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 //------------------------------------------------------------------------------

--- a/etcd_handlers.go
+++ b/etcd_handlers.go
@@ -25,7 +25,7 @@ import (
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/etcd/store"
 	"github.com/coreos/etcd/mod"
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 //-------------------------------------------------------------------

--- a/raft_handlers.go
+++ b/raft_handlers.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 //-------------------------------------------------------------

--- a/raft_server.go
+++ b/raft_server.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	etcdErr "github.com/coreos/etcd/error"
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 type raftServer struct {

--- a/raft_stats.go
+++ b/raft_stats.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 const (

--- a/transporter.go
+++ b/transporter.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 )
 
 // Timeout for setup internal raft http connection

--- a/web/web.go
+++ b/web/web.go
@@ -19,7 +19,7 @@ package web
 import (
 	"code.google.com/p/go.net/websocket"
 	"fmt"
-	"github.com/coreos/go-raft"
+	"github.com/goraft/raft"
 	"html/template"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
Since goraft/raft looks like a canonical place to get golang's raft implementation then it sounds like a good idea to switch to it completely.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
