### PR TITLE
headerTimeout should be longer and body should be shorter

### DIFF
--- a/server/transporter.go
+++ b/server/transporter.go
@@ -223,7 +223,7 @@ func (t *transporter) Get(urlStr string) (*http.Response, *http.Request, error) 
 // Cancel the on fly HTTP transaction when timeout happens.
 func (t *transporter) CancelWhenTimeout(req *http.Request) {
 	go func() {
-		time.Sleep(ElectionTimeout)
+		time.Sleep(tranTimeout)
 		t.transport.CancelRequest(req)
 	}()
 }


### PR DESCRIPTION
The raft server will not send back response hander until it receives all the post body.
So the headerTimeout for the transporter should be long.  
