### PR TITLE
Update go-systemd packages to fix panic

### DIFF
--- a/third_party/github.com/coreos/go-systemd/activation/files.go
+++ b/third_party/github.com/coreos/go-systemd/activation/files.go
@@ -1,3 +1,4 @@
+// Package activation implements primitives for systemd socket activation.
 package activation
 
 import (

--- a/third_party/github.com/coreos/go-systemd/dbus/dbus.go
+++ b/third_party/github.com/coreos/go-systemd/dbus/dbus.go
@@ -1,0 +1,100 @@
+// Integration with the systemd D-Bus API.  See http://www.freedesktop.org/wiki/Software/systemd/dbus/
+package dbus
+
+import (
+	"github.com/guelfey/go.dbus"
+	"sync"
+)
+
+const signalBuffer = 100
+
+type Conn struct {
+	sysconn     *dbus.Conn
+	sysobj      *dbus.Object
+	jobListener struct {
+		jobs map[dbus.ObjectPath]chan string
+		sync.Mutex
+	}
+	subscriber struct {
+		updateCh chan<- *SubStateUpdate
+		errCh    chan<- error
+		sync.Mutex
+		ignore      map[dbus.ObjectPath]int64
+		cleanIgnore int64
+	}
+	dispatch map[string]func(dbus.Signal)
+}
+
+func New() *Conn {
+	c := new(Conn)
+	c.initConnection()
+	c.initJobs()
+	c.initSubscription()
+	c.initDispatch()
+	return c
+}
+
+func (c *Conn) initConnection() {
+	var err error
+	c.sysconn, err = dbus.SystemBusPrivate()
+	if err != nil {
+		return
+	}
+
+	err = c.sysconn.Auth(nil)
+	if err != nil {
+		c.sysconn.Close()
+		return
+	}
+
+	err = c.sysconn.Hello()
+	if err != nil {
+		c.sysconn.Close()
+		return
+	}
+
+	c.sysobj = c.sysconn.Object("org.freedesktop.systemd1", dbus.ObjectPath("/org/freedesktop/systemd1"))
+
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.systemd1.Manager',member='JobRemoved'")
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.systemd1.Manager',member='UnitNew'")
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'")
+
+	err = c.sysobj.Call("org.freedesktop.systemd1.Manager.Subscribe", 0).Store()
+	if err != nil {
+		c.sysconn.Close()
+		return
+	}
+}
+
+func (c *Conn) initDispatch() {
+	ch := make(chan *dbus.Signal, signalBuffer)
+
+	c.sysconn.Signal(ch)
+
+	go func() {
+		for {
+			signal := <-ch
+			switch signal.Name {
+			case "org.freedesktop.systemd1.Manager.JobRemoved":
+				c.jobComplete(signal)
+
+				unitName := signal.Body[2].(string)
+				var unitPath dbus.ObjectPath
+				c.sysobj.Call("GetUnit", 0, unitName).Store(&unitPath)
+				if unitPath != dbus.ObjectPath("") {
+					c.sendSubStateUpdate(unitPath)
+				}
+			case "org.freedesktop.systemd1.Manager.UnitNew":
+				c.sendSubStateUpdate(signal.Body[1].(dbus.ObjectPath))
+			case "org.freedesktop.DBus.Properties.PropertiesChanged":
+				if signal.Body[0].(string) == "org.freedesktop.systemd1.Unit" {
+					// we only care about SubState updates, which are a Unit property
+					c.sendSubStateUpdate(signal.Path)
+				}
+			}
+		}
+	}()
+}

--- a/third_party/github.com/coreos/go-systemd/dbus/methods.go
+++ b/third_party/github.com/coreos/go-systemd/dbus/methods.go
@@ -1,0 +1,166 @@
+package dbus
+
+import (
+	"github.com/guelfey/go.dbus"
+)
+
+func (c *Conn) initJobs() {
+	c.jobListener.jobs = make(map[dbus.ObjectPath]chan string)
+}
+
+func (c *Conn) jobComplete(signal *dbus.Signal) {
+	var id uint32
+	var job dbus.ObjectPath
+	var unit string
+	var result string
+	dbus.Store(signal.Body, &id, &job, &unit, &result)
+	c.jobListener.Lock()
+	out, ok := c.jobListener.jobs[job]
+	if ok {
+		out <- result
+	}
+	c.jobListener.Unlock()
+}
+
+func (c *Conn) startJob(job string, args ...interface{}) (<-chan string, error) {
+	c.jobListener.Lock()
+	defer c.jobListener.Unlock()
+
+	ch := make(chan string, 1)
+	var path dbus.ObjectPath
+	err := c.sysobj.Call(job, 0, args...).Store(&path)
+	if err != nil {
+		return nil, err
+	}
+	c.jobListener.jobs[path] = ch
+	return ch, nil
+}
+
+func (c *Conn) runJob(job string, args ...interface{}) (string, error) {
+	respCh, err := c.startJob(job, args...)
+	if err != nil {
+		return "", err
+	}
+	return <-respCh, nil
+}
+
+// StartUnit enqeues a start job and depending jobs, if any (unless otherwise
+// specified by the mode string).
+//
+// Takes the unit to activate, plus a mode string. The mode needs to be one of
+// replace, fail, isolate, ignore-dependencies, ignore-requirements. If
+// "replace" the call will start the unit and its dependencies, possibly
+// replacing already queued jobs that conflict with this. If "fail" the call
+// will start the unit and its dependencies, but will fail if this would change
+// an already queued job. If "isolate" the call will start the unit in question
+// and terminate all units that aren't dependencies of it. If
+// "ignore-dependencies" it will start a unit but ignore all its dependencies.
+// If "ignore-requirements" it will start a unit but only ignore the
+// requirement dependencies. It is not recommended to make use of the latter
+// two options.
+//
+// Result string: one of done, canceled, timeout, failed, dependency, skipped.
+// done indicates successful execution of a job. canceled indicates that a job
+// has been canceled  before it finished execution. timeout indicates that the
+// job timeout was reached. failed indicates that the job failed. dependency
+// indicates that a job this job has been depending on failed and the job hence
+// has been removed too. skipped indicates that a job was skipped because it
+// didn't apply to the units current state.
+func (c *Conn) StartUnit(name string, mode string) (string, error) {
+	return c.runJob("StartUnit", name, mode)
+}
+
+// StopUnit is similar to StartUnit but stops the specified unit rather
+// than starting it.
+func (c *Conn) StopUnit(name string, mode string) (string, error) {
+	return c.runJob("StopUnit", name, mode)
+}
+
+// ReloadUnit reloads a unit.  Reloading is done only if the unit is already running and fails otherwise.
+func (c *Conn) ReloadUnit(name string, mode string) (string, error) {
+	return c.runJob("ReloadUnit", name, mode)
+}
+
+// RestartUnit restarts a service.  If a service is restarted that isn't
+// running it will be started.
+func (c *Conn) RestartUnit(name string, mode string) (string, error) {
+	return c.runJob("RestartUnit", name, mode)
+}
+
+// TryRestartUnit is like RestartUnit, except that a service that isn't running
+// is not affected by the restart.
+func (c *Conn) TryRestartUnit(name string, mode string) (string, error) {
+	return c.runJob("TryRestartUnit", name, mode)
+}
+
+// ReloadOrRestart attempts a reload if the unit supports it and use a restart
+// otherwise.
+func (c *Conn) ReloadOrRestartUnit(name string, mode string) (string, error) {
+	return c.runJob("ReloadOrRestartUnit", name, mode)
+}
+
+// ReloadOrTryRestart attempts a reload if the unit supports it and use a "Try"
+// flavored restart otherwise.
+func (c *Conn) ReloadOrTryRestartUnit(name string, mode string) (string, error) {
+	return c.runJob("ReloadOrTryRestartUnit", name, mode)
+}
+
+// StartTransientUnit() may be used to create and start a transient unit, which
+// will be released as soon as it is not running or referenced anymore or the
+// system is rebooted. name is the unit name including suffix, and must be
+// unique. mode is the same as in StartUnit(), properties contains properties
+// of the unit.
+func (c *Conn) StartTransientUnit(name string, mode string, properties ...Property) (string, error) {
+	// the dbus interface for this method does not use the last argument and
+	// should simply be given an empty list.  We use a concrete type here
+	// (instead of the more appropriate interface{}) to satisfy the dbus library.
+	return c.runJob("StartTransientUnit", name, mode, properties, make([]string, 0))
+}
+
+// KillUnit takes the unit name and a UNIX signal number to send.  All of the unit's
+// processes are killed.
+func (c *Conn) KillUnit(name string, signal int32) {
+	c.sysobj.Call("KillUnit", 0, name, "all", signal).Store()
+}
+
+// ListUnits returns an array with all currently loaded units. Note that
+// units may be known by multiple names at the same time, and hence there might
+// be more unit names loaded than actual units behind them.
+func (c *Conn) ListUnits() ([]UnitStatus, error) {
+	result := make([][]interface{}, 0)
+	err := c.sysobj.Call("ListUnits", 0).Store(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	resultInterface := make([]interface{}, len(result))
+	for i := range result {
+		resultInterface[i] = result[i]
+	}
+
+	status := make([]UnitStatus, len(result))
+	statusInterface := make([]interface{}, len(status))
+	for i := range status {
+		statusInterface[i] = &status[i]
+	}
+
+	err = dbus.Store(resultInterface, statusInterface...)
+	if err != nil {
+		return nil, err
+	}
+
+	return status, nil
+}
+
+type UnitStatus struct {
+	Name        string          // The primary unit name as string
+	Description string          // The human readable description string
+	LoadState   string          // The load state (i.e. whether the unit file has been loaded successfully)
+	ActiveState string          // The active state (i.e. whether the unit is currently started or not)
+	SubState    string          // The sub state (a more fine-grained version of the active state that is specific to the unit type, which the active state is not)
+	Followed    string          // A unit that is being followed in its state by this unit, if there is any, otherwise the empty string.
+	Path        dbus.ObjectPath // The unit object path
+	JobId       uint32          // If there is a job queued for the job unit the numeric job id, 0 otherwise
+	JobType     string          // The job type as string
+	JobPath     dbus.ObjectPath // The job object path
+}

--- a/third_party/github.com/coreos/go-systemd/dbus/properties.go
+++ b/third_party/github.com/coreos/go-systemd/dbus/properties.go
@@ -1,0 +1,193 @@
+package dbus
+
+import (
+	"github.com/guelfey/go.dbus"
+)
+
+// From the systemd docs:
+//
+// The properties array of StartTransientUnit() may take many of the settings
+// that may also be configured in unit files. Not all parameters are currently
+// accepted though, but we plan to cover more properties with future release.
+// Currently you may set the Description, Slice and all dependency types of
+// units, as well as RemainAfterExit, ExecStart for service units,
+// TimeoutStopUSec and PIDs for scope units, and CPUAccounting, CPUShares,
+// BlockIOAccounting, BlockIOWeight, BlockIOReadBandwidth,
+// BlockIOWriteBandwidth, BlockIODeviceWeight, MemoryAccounting, MemoryLimit,
+// DevicePolicy, DeviceAllow for services/scopes/slices. These fields map
+// directly to their counterparts in unit files and as normal D-Bus object
+// properties. The exception here is the PIDs field of scope units which is
+// used for construction of the scope only and specifies the initial PIDs to
+// add to the scope object.
+
+type Property property
+
+type property struct {
+	Name  string
+	Value dbus.Variant
+}
+
+type execStart struct {
+	Path             string   // the binary path to execute
+	Args             []string // an array with all arguments to pass to the executed command, starting with argument 0
+	UncleanIsFailure bool     // a boolean whether it should be considered a failure if the process exits uncleanly
+}
+
+// PropExecStart sets the ExecStart service property.  The first argument is a
+// slice with the binary path to execute followed by the arguments to pass to
+// the executed command. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
+func PropExecStart(command []string, uncleanIsFailure bool) Property {
+	return Property(
+		property{
+			Name: "ExecStart",
+			Value: dbus.MakeVariant(
+				[]execStart{
+					execStart{
+						Path:             command[0],
+						Args:             command,
+						UncleanIsFailure: uncleanIsFailure,
+					}})})
+}
+
+// PropRemainAfterExit sets the RemainAfterExit service property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#RemainAfterExit=
+func PropRemainAfterExit(b bool) Property {
+	return Property(
+		property{
+			Name:  "RemainAfterExit",
+			Value: dbus.MakeVariant(b),
+		})
+}
+
+// PropDescription sets the Description unit property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.unit#Description=
+func PropDescription(desc string) Property {
+	return Property(
+		property{
+			Name:  "Description",
+			Value: dbus.MakeVariant(desc),
+		})
+}
+
+func propDependency(name string, units []string) Property {
+	return Property(
+		property{
+			Name:  name,
+			Value: dbus.MakeVariant(units),
+		})
+}
+
+// PropRequires sets the Requires unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Requires=
+func PropRequires(units ...string) Property {
+	return propDependency("Requires", units)
+}
+
+// PropRequiresOverridable sets the RequiresOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#RequiresOverridable=
+func PropRequiresOverridable(units ...string) Property {
+	return propDependency("RequiresOverridable", units)
+}
+
+// PropRequisite sets the Requisite unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Requisite=
+func PropRequisite(units ...string) Property {
+	return propDependency("Requisite", units)
+}
+
+// PropRequisiteOverridable sets the RequisiteOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#RequisiteOverridable=
+func PropRequisiteOverridable(units ...string) Property {
+	return propDependency("RequisiteOverridable", units)
+}
+
+// PropWants sets the Wants unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Wants=
+func PropWants(units ...string) Property {
+	return propDependency("Wants", units)
+}
+
+// PropBindsTo sets the BindsTo unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#BindsTo=
+func PropBindsTo(units ...string) Property {
+	return propDependency("BindsTo", units)
+}
+
+// PropRequiredBy sets the RequiredBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#RequiredBy=
+func PropRequiredBy(units ...string) Property {
+	return propDependency("RequiredBy", units)
+}
+
+// PropRequiredByOverridable sets the RequiredByOverridable unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#RequiredByOverridable=
+func PropRequiredByOverridable(units ...string) Property {
+	return propDependency("RequiredByOverridable", units)
+}
+
+// PropWantedBy sets the WantedBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#WantedBy=
+func PropWantedBy(units ...string) Property {
+	return propDependency("WantedBy", units)
+}
+
+// PropBoundBy sets the BoundBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#BoundBy=
+func PropBoundBy(units ...string) Property {
+	return propDependency("BoundBy", units)
+}
+
+// PropConflicts sets the Conflicts unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Conflicts=
+func PropConflicts(units ...string) Property {
+	return propDependency("Conflicts", units)
+}
+
+// PropConflictedBy sets the ConflictedBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#ConflictedBy=
+func PropConflictedBy(units ...string) Property {
+	return propDependency("ConflictedBy", units)
+}
+
+// PropBefore sets the Before unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Before=
+func PropBefore(units ...string) Property {
+	return propDependency("Before", units)
+}
+
+// PropAfter sets the After unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#After=
+func PropAfter(units ...string) Property {
+	return propDependency("After", units)
+}
+
+// PropOnFailure sets the OnFailure unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#OnFailure=
+func PropOnFailure(units ...string) Property {
+	return propDependency("OnFailure", units)
+}
+
+// PropTriggers sets the Triggers unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#Triggers=
+func PropTriggers(units ...string) Property {
+	return propDependency("Triggers", units)
+}
+
+// PropTriggeredBy sets the TriggeredBy unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#TriggeredBy=
+func PropTriggeredBy(units ...string) Property {
+	return propDependency("TriggeredBy", units)
+}
+
+// PropPropagatesReloadTo sets the PropagatesReloadTo unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#PropagatesReloadTo=
+func PropPropagatesReloadTo(units ...string) Property {
+	return propDependency("PropagatesReloadTo", units)
+}
+
+// PropRequiresMountsFor sets the RequiresMountsFor unit property.  See
+// http://www.freedesktop.org/software/systemd/main/systemd.unit.html#RequiresMountsFor=
+func PropRequiresMountsFor(units ...string) Property {
+	return propDependency("RequiresMountsFor", units)
+}

--- a/third_party/github.com/coreos/go-systemd/dbus/subscription.go
+++ b/third_party/github.com/coreos/go-systemd/dbus/subscription.go
@@ -1,0 +1,182 @@
+package dbus
+
+import (
+	"github.com/guelfey/go.dbus"
+	"time"
+)
+
+const (
+	cleanIgnoreInterval = int64(10 * time.Second)
+	ignoreInterval      = int64(30 * time.Millisecond)
+)
+
+func (c *Conn) initSubscription() {
+	c.subscriber.ignore = make(map[dbus.ObjectPath]int64)
+}
+
+// Returns two unbuffered channels which will receive all changed units every
+// @interval@ seconds.  Deleted units are sent as nil.
+func (c *Conn) SubscribeUnits(interval time.Duration) (<-chan map[string]*UnitStatus, <-chan error) {
+	return c.SubscribeUnitsCustom(interval, 0, func(u1, u2 *UnitStatus) bool { return *u1 != *u2 })
+}
+
+// SubscribeUnitsCustom is like SubscribeUnits but lets you specify the buffer
+// size of the channels and the comparison function for detecting changes.
+func (c *Conn) SubscribeUnitsCustom(interval time.Duration, buffer int, isChanged func(*UnitStatus, *UnitStatus) bool) (<-chan map[string]*UnitStatus, <-chan error) {
+	old := make(map[string]*UnitStatus)
+	statusChan := make(chan map[string]*UnitStatus, buffer)
+	errChan := make(chan error, buffer)
+
+	go func() {
+		for {
+			timerChan := time.After(interval)
+
+			units, err := c.ListUnits()
+			if err == nil {
+				cur := make(map[string]*UnitStatus)
+				for i := range units {
+					cur[units[i].Name] = &units[i]
+				}
+
+				// add all new or changed units
+				changed := make(map[string]*UnitStatus)
+				for n, u := range cur {
+					if oldU, ok := old[n]; !ok || isChanged(oldU, u) {
+						changed[n] = u
+					}
+					delete(old, n)
+				}
+
+				// add all deleted units
+				for oldN := range old {
+					changed[oldN] = nil
+				}
+
+				old = cur
+
+				statusChan <- changed
+			} else {
+				errChan <- err
+			}
+
+			<-timerChan
+		}
+	}()
+
+	return statusChan, errChan
+}
+
+type SubStateUpdate struct {
+	UnitName string
+	SubState string
+}
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+// SetSubStateSubscriber writes to updateCh when any unit's substate changes.
+// Althrough this writes to updateCh on every state change, the reported state
+// may be more recent than the change that generated it (due to an unavoidable
+// race in the systemd dbus interface).  That is, this method provides a good
+// way to keep a current view of all units' states, but is not guaranteed to
+// show every state transition they go through.  Furthermore, state changes
+// will only be written to the channel with non-blocking writes.  If updateCh
+// is full, it attempts to write an error to errCh; if errCh is full, the error
+// passes silently.
+func (c *Conn) SetSubStateSubscriber(updateCh chan<- *SubStateUpdate, errCh chan<- error) {
+	c.subscriber.Lock()
+	defer c.subscriber.Unlock()
+	c.subscriber.updateCh = updateCh
+	c.subscriber.errCh = errCh
+}
+
+func (c *Conn) sendSubStateUpdate(path dbus.ObjectPath) {
+	c.subscriber.Lock()
+	defer c.subscriber.Unlock()
+	if c.subscriber.updateCh == nil {
+		return
+	}
+
+	if c.shouldIgnore(path) {
+		return
+	}
+
+	info, err := c.getUnitInfo(path)
+	if err != nil {
+		select {
+		case c.subscriber.errCh <- err:
+		default:
+		}
+	}
+
+	name := info["Id"].Value().(string)
+	substate := info["SubState"].Value().(string)
+
+	update := &SubStateUpdate{name, substate}
+	select {
+	case c.subscriber.updateCh <- update:
+	default:
+		select {
+		case c.subscriber.errCh <- Error("update channel full!"):
+		default:
+		}
+	}
+
+	c.updateIgnore(path, info)
+}
+
+func (c *Conn) getUnitInfo(path dbus.ObjectPath) (map[string]dbus.Variant, error) {
+	var err error
+	var props map[string]dbus.Variant
+	obj := c.sysconn.Object("org.freedesktop.systemd1", path)
+	err = obj.Call("GetAll", 0, "org.freedesktop.systemd1.Unit").Store(&props)
+	if err != nil {
+		return nil, err
+	}
+	return props, nil
+}
+
+// The ignore functions work around a wart in the systemd dbus interface.
+// Requesting the properties of an unloaded unit will cause systemd to send a
+// pair of UnitNew/UnitRemoved signals.  Because we need to get a unit's
+// properties on UnitNew (as that's the only indication of a new unit coming up
+// for the first time), we would enter an infinite loop if we did not attempt
+// to detect and ignore these spurious signals.  The signal themselves are
+// indistinguishable from relevant ones, so we (somewhat hackishly) ignore an
+// unloaded unit's signals for a short time after requesting its properties.
+// This means that we will miss e.g. a transient unit being restarted
+// *immediately* upon failure and also a transient unit being started
+// immediately after requesting its status (with systemctl status, for example,
+// because this causes a UnitNew signal to be sent which then causes us to fetch
+// the properties).
+
+func (c *Conn) shouldIgnore(path dbus.ObjectPath) bool {
+	t, ok := c.subscriber.ignore[path]
+	return ok && t >= time.Now().UnixNano()
+}
+
+func (c *Conn) updateIgnore(path dbus.ObjectPath, info map[string]dbus.Variant) {
+	c.cleanIgnore()
+
+	// unit is unloaded - it will trigger bad systemd dbus behavior
+	if info["LoadState"].Value().(string) == "not-found" {
+		c.subscriber.ignore[path] = time.Now().UnixNano() + ignoreInterval
+	}
+}
+
+// without this, ignore would grow unboundedly over time
+func (c *Conn) cleanIgnore() {
+	now := time.Now().UnixNano()
+	if c.subscriber.cleanIgnore < now {
+		c.subscriber.cleanIgnore = now + cleanIgnoreInterval
+
+		for p, t := range c.subscriber.ignore {
+			if t < now {
+				delete(c.subscriber.ignore, p)
+			}
+		}
+	}
+}

--- a/third_party/github.com/coreos/go-systemd/journal/send.go
+++ b/third_party/github.com/coreos/go-systemd/journal/send.go
@@ -3,6 +3,7 @@ package journal
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"encoding/binary"
 )
 
 // Priority of a journal message
@@ -32,7 +32,11 @@ const (
 var conn net.Conn
 
 func init() {
-	conn, _ = net.Dial("unixgram", "/run/systemd/journal/socket")
+	var err error
+	conn, err = net.Dial("unixgram", "/run/systemd/journal/socket")
+	if err != nil {
+		conn = nil
+	}
 }
 
 // Enabled returns true iff the systemd journal is available for logging


### PR DESCRIPTION
Compiling etcd with Go 1.2rc2 exposed some behaviour which I have been unable to replicate with Go 1.1.2.

```
$ go version
go version go1.2rc2 linux/amd64
$ ./build
$ ./etcd -d node0 -n node0
[etcd] Oct 22 10:32:30.694 INFO      | Found node configuration in 'node0/info'. Ignoring flags
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x54c007]

goroutine 1 [running]:
runtime.panic(0x71ef00, 0xbc5788)
    /usr/local/src/go/src/pkg/runtime/panic.c:266 +0xb6
net.(*UnixConn).Write(0x0, 0xc21009f000, 0x104, 0x192, 0xbcc560, ...)
    /usr/local/src/go/src/pkg/net/dial.go:1 +0x17
bytes.(*Buffer).WriteTo(0xc210052540, 0x7f64dc4a1bb0, 0x0, 0x0, 0x0, ...)
    /usr/local/src/go/src/pkg/bytes/buffer.go:202 +0xc5
io.Copy(0x7f64dc4a1bb0, 0x0, 0x7f64dc4a1b88, 0xc210052540, 0x0, ...)
    /usr/local/src/go/src/pkg/io/io.go:344 +0xa5
github.com/coreos/go-systemd/journal.Send(0xc210051980, 0x38, 0x6, 0xc21009a180, 0xc21001ea01, ...)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/go-systemd/journal/send.go:62 +0x2d0
github.com/coreos/go-log/log.(*journalSink).Log(0xbd6530, 0xc21009a150)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/go-log/log/sinks.go:84 +0x228
github.com/coreos/go-log/log.(*combinedSink).Log(0xc21004b580, 0xc21009a150)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/go-log/log/sinks.go:121 +0x67
github.com/coreos/go-log/log.(*Logger).Log(0xc2100504e0, 0x6, 0x7f64dc471aa0, 0x1, 0x1)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/go-log/log/commands.go:37 +0x14e
github.com/coreos/go-log/log.(*Logger).Infof(0xc2100504e0, 0x80f250, 0x30, 0x7f64dc471bb0, 0x1, ...)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/go-log/log/commands.go:92 +0xfc
main.infof(0x80f250, 0x30, 0x7f64dc471bb0, 0x1, 0x1)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/etcd/util.go:178 +0x5c
main.getInfo(0x7fffae224342, 0x5, 0xc2000001e4)
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/etcd/config.go:49 +0x79b
main.main()
    /home/matt/dev/go/src/github.com/coreos/etcd/src/github.com/coreos/etcd/etcd.go:224 +0x75d

goroutine 3 [runnable]:
os/signal.loop()
    /usr/local/src/go/src/pkg/os/signal/signal_unix.go:19
created by os/signal.init·1
    /usr/local/src/go/src/pkg/os/signal/signal_unix.go:27 +0x31

```

With Go 1.1.2, this panic does not occur:

```
$ go version
go version go1.1.2 linux/amd64
$ ./build
$ ./etcd -d node0 -n node0
[etcd] Oct 22 10:36:05.995 INFO      | Found node configuration in 'node0/info'. Ignoring flags
[etcd] Oct 22 10:36:05.996 WARNING   | the entire cluster is down! this machine will restart the cluster.
[etcd] Oct 22 10:36:05.996 INFO      | etcd server [name node0, listen on 127.0.0.1:4001, advertised url http://127.0.0.1:4001]
[etcd] Oct 22 10:36:05.996 INFO      | raft server [name node0, listen on 127.0.0.1:7001, advertised url http://127.0.0.1:7001]
^C
```

I was able to fix the panic by updating third_party/coreos/go-systemd to the latest version (coreos/go-systemd@af0e6cd015e5fad8d9d090ad7aa343a1f680318d). The relevant commit is probably https://github.com/coreos/go-systemd/commit/3a065f53e80d56dbce94e501e523ffad15bae44b which checks whether `net.Dial` succeeds.

With the updated go-systemd packages:

```
$ go version
go version go1.2rc2 linux/amd64
$ ./build
$ ./etcd -d node0 -n node0
[etcd] Oct 22 10:43:39.197 INFO      | Found node configuration in 'node0/info'. Ignoring flags
[etcd] Oct 22 10:43:39.199 WARNING   | the entire cluster is down! this machine will restart the cluster.
[etcd] Oct 22 10:43:39.199 INFO      | etcd server [name node0, listen on 127.0.0.1:4001, advertised url http://127.0.0.1:4001]
[etcd] Oct 22 10:43:39.200 INFO      | raft server [name node0, listen on 127.0.0.1:7001, advertised url http://127.0.0.1:7001]
^C
```

All tests pass. This applies to builds with Go 1.1, Go 1.1.1 and Go 1.1.2 too.

The thing I haven't had time to investigate is what's changed between Go 1.1.2 and the release candidate to cause this change in behaviour. But since there's now a feature freeze we can probably safely assume this fix will apply to Go 1.2 as well.

At the moment I've cloned `go-systemd` and removed `.git`: if there's another way I should be doing the merge, please let me know.
