### PR TITLE
Add version upgrade endpoint.

### DIFF
--- a/store/command_factory.go
+++ b/store/command_factory.go
@@ -15,6 +15,7 @@ var minVersion, maxVersion int
 // depending on the current version of the store.
 type CommandFactory interface {
 	Version() int
+	CreateUpgradeCommand() raft.Command
 	CreateSetCommand(key string, value string, expireTime time.Time) raft.Command
 	CreateCreateCommand(key string, value string, expireTime time.Time, unique bool) raft.Command
 	CreateUpdateCommand(key string, value string, expireTime time.Time) raft.Command

--- a/store/v2/command_factory.go
+++ b/store/v2/command_factory.go
@@ -20,6 +20,11 @@ func (f *CommandFactory) Version() int {
 	return 2
 }
 
+// CreateUpgradeCommand is a no-op since version 2 is the first version to support store versioning.
+func (f *CommandFactory) CreateUpgradeCommand() raft.Command {
+	return &raft.NOPCommand{}
+}
+
 // CreateSetCommand creates a version 2 command to set a key to a given value in the store.
 func (f *CommandFactory) CreateSetCommand(key string, value string, expireTime time.Time) raft.Command {
 	return &SetCommand{

--- a/store/v2/compare_and_swap_command.go
+++ b/store/v2/compare_and_swap_command.go
@@ -23,7 +23,7 @@ type CompareAndSwapCommand struct {
 
 // The name of the testAndSet command in the log
 func (c *CompareAndSwapCommand) CommandName() string {
-	return "etcd:v2:compareAndSwap"
+	return "etcd:compareAndSwap"
 }
 
 // Set the key-value pair if the current value of the key equals to the given prevValue

--- a/store/v2/create_command.go
+++ b/store/v2/create_command.go
@@ -22,7 +22,7 @@ type CreateCommand struct {
 
 // The name of the create command in the log
 func (c *CreateCommand) CommandName() string {
-	return "etcd:v2:create"
+	return "etcd:create"
 }
 
 // Create node

--- a/store/v2/delete_command.go
+++ b/store/v2/delete_command.go
@@ -18,7 +18,7 @@ type DeleteCommand struct {
 
 // The name of the delete command in the log
 func (c *DeleteCommand) CommandName() string {
-	return "etcd:v2:delete"
+	return "etcd:delete"
 }
 
 // Delete the key

--- a/store/v2/set_command.go
+++ b/store/v2/set_command.go
@@ -21,7 +21,7 @@ type SetCommand struct {
 
 // The name of the create command in the log
 func (c *SetCommand) CommandName() string {
-	return "etcd:v2:set"
+	return "etcd:set"
 }
 
 // Create node

--- a/store/v2/update_command.go
+++ b/store/v2/update_command.go
@@ -20,7 +20,7 @@ type UpdateCommand struct {
 
 // The name of the update command in the log
 func (c *UpdateCommand) CommandName() string {
-	return "etcd:v2:update"
+	return "etcd:update"
 }
 
 // Create node

--- a/tests/functional/version_check_test.go
+++ b/tests/functional/version_check_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// Ensure that a node can reply to a version check appropriately.
+func TestVersionCheck(t *testing.T) {
+	procAttr := new(os.ProcAttr)
+	procAttr.Files = []*os.File{nil, os.Stdout, os.Stderr}
+	args := []string{"etcd", "-n=node1", "-f", "-d=/tmp/version_check"}
+
+	process, err := os.StartProcess(EtcdBinPath, args, procAttr)
+	if err != nil {
+		t.Fatal("start process failed:" + err.Error())
+		return
+	}
+	defer process.Kill()
+
+	time.Sleep(time.Second)
+
+	// Check a version too small.
+	resp, _ := http.Get("http://localhost:7001/version/1/check")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatal("Invalid version check: ", resp.StatusCode)
+	}
+
+	// Check a version too large.
+	resp, _ = http.Get("http://localhost:7001/version/3/check")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatal("Invalid version check: ", resp.StatusCode)
+	}
+
+	// Check a version that's just right.
+	resp, _ = http.Get("http://localhost:7001/version/2/check")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Invalid version check: ", resp.StatusCode)
+	}
+}
+


### PR DESCRIPTION
## Overview

I added an endpoint for upgrading the cluster manually. Since v2 is the first version that supports internal versioning, there's no upgrade to be done. Also, since new versions will probably have some kind of migration code I'm only allowing upgrades of a single version at a time.
## Changes
- Added `PeerServer#Upgradable()` that checks if the next version is compatible with all nodes in the cluster.
- Added `GET /version/:version/check` that checks if the given `:version` is supported. For example, `GET /version/2/check` would return a `200`.
- Added `GET /upgrade` endpoint that will manually perform an upgrade. We can add a trigger to call this endpoint on the leader upon join but it's not necessary until `v3` so I figured I'd hold off.
- Removed the `:v2` from the Raft command names so that upgrades from `v1` will not be corrupted.
- Upgraded the `PeerServer` handler to use the Gorilla mux.

/cc: @philips @xiangli-cmu 
