### PR TITLE
feat(etcd): use hostname as machine name

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -42,7 +42,12 @@ func main() {
 		log.Fatal("info:", err)
 	}
 	if info.Name == "" {
-		log.Fatal("ERROR: server name required. e.g. '-n=server_name'")
+		host, err := os.Hostname()
+		if err != nil || host == "" {
+			log.Fatal("Machine name required and hostname not set. e.g. '-n=machine_name'")
+		}
+		log.Warnf("Using hostname %s as the machine name. You must ensure this name is unique among etcd machines.", host)
+		info.Name = host
 	}
 
 	// Retrieve TLS configuration.


### PR DESCRIPTION
by default I don't want etcd to require parameters so people can rapidly
try it out. Try to use the hostname as the name instead.
