### PR TITLE
feat(README): add link to trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See [etcdctl][etcdctl] for a simple command line client. Or feel free to just us
 
 - Mailing list: http://coreos.com/lists/etcd-dev/
 - IRC: #coreos on irc.freenode.net
+- Planning/Roadmap: https://trello.com/b/OiEbU547/etcd
+- Bugs: https://github.com/coreos/etcd/issues
 
 ## Getting Started
 


### PR DESCRIPTION
Add a link to the trello project planning so people know what the roadmap plan and work in progress is.
