### PR TITLE
refactor(mod): remove the /etcd/ prefix

### DIFF
--- a/mod/README.md
+++ b/mod/README.md
@@ -1,7 +1,7 @@
 ## Etcd modules
 
 etcd modules (mods) are higher order pieces of functionality that only
-speak to the client etcd API and are presented in the `/etcd/mod` HTTP path
+speak to the client etcd API and are presented in the `/mod` HTTP path
 of the etcd service.
 
 The basic idea is that etcd can ship things like dashboards, master

--- a/mod/dashboard/README.md
+++ b/mod/dashboard/README.md
@@ -24,4 +24,4 @@ bower install
 
 Run etcd like you normally would and afterward browse to:
 
-http://localhost:4001/etcd/mod/dashboard/
+http://localhost:4001/mod/dashboard/

--- a/server/server.go
+++ b/server/server.go
@@ -123,7 +123,7 @@ func (s *Server) installV2() {
 
 func (s *Server) installMod() {
 	r := s.Handler.(*mux.Router)
-	r.PathPrefix("/etcd/mod").Handler(http.StripPrefix("/etcd/mod", mod.HttpHandler()))
+	r.PathPrefix("/mod").Handler(http.StripPrefix("/mod", mod.HttpHandler()))
 }
 
 // Adds a v1 server handler to the router.


### PR DESCRIPTION
Originally we were going to move all of the API endpoints to /etcd/ so that
you could move etcd traffic over a multiplexed HTTP proxy with other service
but since we don't have a strong use case for this just remove this for now.
