### PR TITLE
feat(etcd): create unique directory on no-flag case

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -47,11 +47,6 @@ func main() {
 		log.Verbose = true
 	}
 
-	// Create data directory if it doesn't already exist.
-	if err := os.MkdirAll(config.DataDir, 0744); err != nil {
-		log.Fatalf("Unable to create path: %s", err)
-	}
-
 	// Load info object.
 	info, err := config.Info()
 	if err != nil {
@@ -64,6 +59,17 @@ func main() {
 		}
 		log.Warnf("Using hostname %s as the machine name. You must ensure this name is unique among etcd machines.", host)
 		info.Name = host
+	}
+
+	// Setup a default directory based on the machine name
+	if config.DataDir == "" {
+		config.DataDir = info.Name + ".etcd"
+		log.Warnf("Using the directory %s as the etcd configuration directory because a directory was not specified. ", config.DataDir)
+	}
+
+	// Create data directory if it doesn't already exist.
+	if err := os.MkdirAll(config.DataDir, 0744); err != nil {
+		log.Fatalf("Unable to create path: %s", err)
 	}
 
 	// Retrieve TLS configuration.

--- a/server/config.go
+++ b/server/config.go
@@ -57,7 +57,6 @@ func NewConfig() *Config {
 	c.SystemPath = DefaultSystemConfigPath
 	c.AdvertisedUrl = "127.0.0.1:4001"
 	c.AdvertisedUrl = "127.0.0.1:4001"
-	c.DataDir = "."
 	c.MaxClusterSize = 9
 	c.MaxResultBuffer = 1024
 	c.MaxRetryAttempts = 3


### PR DESCRIPTION
Tell etcd to store the log and configuration into directory in the pattern of
`${machineName}.etcd` if no directory is specified.
