### PR TITLE
Add symlink for etcd to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD . /opt/etcd
 RUN cd /opt/etcd && ./build
 RUN ln -s /opt/etcd/etcd /usr/local/bin/etcd
 EXPOSE 4001 7001
-ENTRYPOINT ["/opt/etcd/etcd", "-c", "0.0.0.0:4001", "-s", "0.0.0.0:7001"]
+CMD ["/opt/etcd/etcd", "-c", "0.0.0.0:4001", "-s", "0.0.0.0:7001"]


### PR DESCRIPTION
This way, running the image with a custom entrypoint doesn't require the full cmd path (`/opt/etcd/etcd`), which a user must first look up in this Dockerfile. I believe being able to directly call the binary is pretty much standard for docker images.
