### PR TITLE
fix(etcd): remove duplicate DataDir setup

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -52,17 +52,6 @@ func main() {
 		profile(config.CPUProfileFile)
 	}
 
-	// Setup a default directory based on the machine name
-	if config.DataDir == "" {
-		config.DataDir = config.Name + ".etcd"
-		log.Warnf("Using the directory %s as the etcd configuration directory because a directory was not specified. ", config.DataDir)
-	}
-
-	// Create data directory if it doesn't already exist.
-	if err := os.MkdirAll(config.DataDir, 0744); err != nil {
-		log.Fatalf("Unable to create path: %s", err)
-	}
-
 	// Load info object.
 	info, err := config.Info()
 	if err != nil {


### PR DESCRIPTION
In the refactor of the configuration and flags I think that we accidently
placed this logic twice. The side effect is that we always ended up with a
`.etcd` directory.
