### PR TITLE
fix(server/v2): redirect to ClientURL not PeerURL

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -96,6 +96,11 @@ func (s *Server) PeerURL(name string) (string, bool) {
 	return s.registry.PeerURL(name)
 }
 
+// ClientURL retrieves the Client URL for a given node name.
+func (s *Server) ClientURL(name string) (string, bool) {
+	return s.registry.ClientURL(name)
+}
+
 // Returns a reference to the Store.
 func (s *Server) Store() store.Store {
 	return s.store

--- a/server/v2/get_handler.go
+++ b/server/v2/get_handler.go
@@ -23,7 +23,7 @@ func GetHandler(w http.ResponseWriter, req *http.Request, s Server) error {
 	// Help client to redirect the request to the current leader
 	if req.FormValue("consistent") == "true" && s.State() != raft.Leader {
 		leader := s.Leader()
-		hostname, _ := s.PeerURL(leader)
+		hostname, _ := s.ClientURL(leader)
 		url := hostname + req.URL.Path
 		log.Debugf("Redirect consistent get to %s", url)
 		http.Redirect(w, req, url, http.StatusTemporaryRedirect)

--- a/server/v2/v2.go
+++ b/server/v2/v2.go
@@ -13,6 +13,7 @@ type Server interface {
 	CommitIndex() uint64
 	Term() uint64
 	PeerURL(string) (string, bool)
+	ClientURL(string) (string, bool)
 	Store() store.Store
 	Dispatch(raft.Command, http.ResponseWriter, *http.Request) error
 }

--- a/tests/mock/server_v2.go
+++ b/tests/mock/server_v2.go
@@ -45,6 +45,11 @@ func (s *ServerV2) PeerURL(name string) (string, bool) {
 	return args.String(0), args.Bool(1)
 }
 
+func (s *ServerV2) ClientURL(name string) (string, bool) {
+	args := s.Called(name)
+	return args.String(0), args.Bool(1)
+}
+
 func (s *ServerV2) Store() store.Store {
 	return s.store
 }


### PR DESCRIPTION
If consistent is set you must redirect the client to the leader's ClientURL
not the PeerURL.
