### PR TITLE
fix(etcd): Fix forced config reset

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -52,16 +52,6 @@ func main() {
 		profile(config.CPUProfileFile)
 	}
 
-	// Only guess the machine name if there is no data dir specified
-	// because the info file will should have our name
-	if config.Name == "" && config.DataDir == "" {
-		config.NameFromHostname()
-	}
-
-	if config.DataDir == "" && config.Name != "" {
-		config.DataDirFromName()
-	}
-
 	if config.DataDir == "" {
 		log.Fatal("The data dir was not set and could not be guessed from machine name")
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -131,6 +131,21 @@ func (c *Config) Load(arguments []string) error {
 		return fmt.Errorf("sanitize: %v", err)
 	}
 
+	// Only guess the machine name if there is no data dir specified
+	// because the info file will should have our name
+	if c.Name == "" && c.DataDir == "" {
+		c.NameFromHostname()
+	}
+
+	if c.DataDir == "" && c.Name != "" {
+		c.DataDirFromName()
+	}
+
+	// Force remove server configuration if specified.
+	if c.Force {
+		c.Reset()
+	}
+
 	return nil
 }
 
@@ -276,11 +291,6 @@ func (c *Config) LoadFlags(arguments []string) error {
 	}
 	if cors != "" {
 		c.CorsOrigins = trimsplit(cors, ",")
-	}
-
-	// Force remove server configuration if specified.
-	if c.Force {
-		c.Reset()
 	}
 
 	return nil


### PR DESCRIPTION
When a server name or a data directory were not provided, the
reset functionality would fail to clear out config files from
the appropriate place. This calcualtes the default server name
and data directory before reset is called.
