### PR TITLE
fix(server): override port of bind

### DIFF
--- a/server/config_test.go
+++ b/server/config_test.go
@@ -223,6 +223,29 @@ func TestConfigBindAddrFlag(t *testing.T) {
 	assert.Equal(t, c.BindAddr, "127.0.0.1:4003", "")
 }
 
+// Ensures that a the Listen Host port overrides the advertised port
+func TestConfigBindAddrOverride(t *testing.T) {
+	c := NewConfig()
+	assert.Nil(t, c.LoadFlags([]string{"-addr", "127.0.0.1:4009", "-bind-addr", "127.0.0.1:4010"}), "")
+	assert.Nil(t, c.Sanitize())
+	assert.Equal(t, c.BindAddr, "127.0.0.1:4010", "")
+}
+
+// Ensures that a the Listen Host inherits its port from the advertised addr
+func TestConfigBindAddrInheritPort(t *testing.T) {
+	c := NewConfig()
+	assert.Nil(t, c.LoadFlags([]string{"-addr", "127.0.0.1:4009", "-bind-addr", "127.0.0.1"}), "")
+	assert.Nil(t, c.Sanitize())
+	assert.Equal(t, c.BindAddr, "127.0.0.1:4009", "")
+}
+
+// Ensures that a port only argument errors out
+func TestConfigBindAddrErrorOnNoHost(t *testing.T) {
+	c := NewConfig()
+	assert.Nil(t, c.LoadFlags([]string{"-addr", "127.0.0.1:4009", "-bind-addr", ":4010"}), "")
+	assert.Error(t, c.Sanitize())
+}
+
 // Ensures that the peers can be parsed from the environment.
 func TestConfigPeersEnv(t *testing.T) {
 	withEnv("ETCD_PEERS", "coreos.com:4001,coreos.com:4002", func(c *Config) {

--- a/server/usage.go
+++ b/server/usage.go
@@ -31,18 +31,18 @@ Cluster Configuration Options:
                                   should match the peer's '-peer-addr' flag.
 
 Client Communication Options:
-  -addr=<host:port>   The public host:port used for client communication.
-  -bind-addr=<host>   The listening hostname used for client communication.
-  -ca-file=<path>     Path to the client CA file.
-  -cert-file=<path>   Path to the client cert file.
-  -key-file=<path>    Path to the client key file.
+  -addr=<host:port>         The public host:port used for client communication.
+  -bind-addr=<host[:port]>  The listening host:port used for client communication.
+  -ca-file=<path>           Path to the client CA file.
+  -cert-file=<path>         Path to the client cert file.
+  -key-file=<path>          Path to the client key file.
 
 Peer Communication Options:
-  -peer-addr=<host:port>  The public host:port used for peer communication.
-  -peer-bind-addr=<host>  The listening hostname used for peer communication.
-  -peer-ca-file=<path>    Path to the peer CA file.
-  -peer-cert-file=<path>  Path to the peer cert file.
-  -peer-key-file=<path>   Path to the peer key file.
+  -peer-addr=<host:port>         The public host:port used for peer communication.
+  -peer-bind-addr=<host[:port]>  The listening host:port used for peer communication.
+  -peer-ca-file=<path>           Path to the peer CA file.
+  -peer-cert-file=<path>         Path to the peer cert file.
+  -peer-key-file=<path>          Path to the peer key file.
 
 Other Options:
   -max-result-buffer   Max size of the result buffer.


### PR DESCRIPTION
Allow people to specify ports on the `-bind-addr` arguments so that they can
use randomly assigned port numbers in containers.
