### PR TITLE
fix(etcd): Fix forced config reset

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -52,16 +52,6 @@ func main() {
 		profile(config.CPUProfileFile)
 	}
 
-	// Only guess the machine name if there is no data dir specified
-	// because the info file will should have our name
-	if config.Name == "" && config.DataDir == "" {
-		config.NameFromHostname()
-	}
-
-	if config.DataDir == "" && config.Name != "" {
-		config.DataDirFromName()
-	}
-
 	if config.DataDir == "" {
 		log.Fatal("The data dir was not set and could not be guessed from machine name")
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -131,6 +131,11 @@ func (c *Config) Load(arguments []string) error {
 		return fmt.Errorf("sanitize: %v", err)
 	}
 
+	// Force remove server configuration if specified.
+	if c.Force {
+		c.Reset()
+	}
+
 	return nil
 }
 
@@ -278,11 +283,6 @@ func (c *Config) LoadFlags(arguments []string) error {
 		c.CorsOrigins = trimsplit(cors, ",")
 	}
 
-	// Force remove server configuration if specified.
-	if c.Force {
-		c.Reset()
-	}
-
 	return nil
 }
 
@@ -402,6 +402,16 @@ func (c *Config) Sanitize() error {
 	}
 	if c.Peer.BindAddr, err = sanitizeBindAddr(c.Peer.BindAddr, c.Peer.Addr); err != nil {
 		return fmt.Errorf("Peer Listen Host: %s", err)
+	}
+
+	// Only guess the machine name if there is no data dir specified
+	// because the info file should have our name
+	if c.Name == "" && c.DataDir == "" {
+		c.NameFromHostname()
+	}
+
+	if c.DataDir == "" && c.Name != "" {
+		c.DataDirFromName()
 	}
 
 	return nil

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -313,6 +313,24 @@ func TestConfigNameFlag(t *testing.T) {
 	assert.Equal(t, c.Name, "test-name", "")
 }
 
+// Ensures that a Name gets guessed if not specified
+func TestConfigNameGuess(t *testing.T) {
+	c := NewConfig()
+	assert.Nil(t, c.LoadFlags([]string{}), "")
+	assert.Nil(t, c.Sanitize())
+	name, _ := os.Hostname()
+	assert.Equal(t, c.Name, name, "")
+}
+
+// Ensures that a DataDir gets guessed if not specified
+func TestConfigDataDirGuess(t *testing.T) {
+	c := NewConfig()
+	assert.Nil(t, c.LoadFlags([]string{}), "")
+	assert.Nil(t, c.Sanitize())
+	name, _ := os.Hostname()
+	assert.Equal(t, c.DataDir, name+".etcd", "")
+}
+
 // Ensures that Snapshot can be parsed from the environment.
 func TestConfigSnapshotEnv(t *testing.T) {
 	withEnv("ETCD_SNAPSHOT", "1", func(c *Config) {


### PR DESCRIPTION
When a server name or a data directory were not provided, the reset
functionality would fail to clear out config files from the appropriate place.
This calcualtes the default server name and data directory before reset is
called.
