### PR TITLE
feat(Dockerfile): remove ADD so the trusted build works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get install -y python-software-properties git
 RUN add-apt-repository -y ppa:duh/golang
 RUN apt-get update
 RUN apt-get install -y golang
-ADD . /opt/etcd
+RUN git clone https://github.com/coreos/etcd.git /opt/etcd
 RUN cd /opt/etcd && ./build
-EXPOSE 4001 7001
 ENTRYPOINT ["/opt/etcd/etcd"]
-


### PR DESCRIPTION
Removed the `ADD` line because the trusted build system doesn't have etcd checked out locally. This will make the build a little slower but shouldn't affect things otherwise.

I also removed the `EXPOSE` since you have to use `-p` to expose ports these days.
