### PR TITLE
fix(README): we are building containers too

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or feel free to just use curl, as in the examples below.
 
 ### Getting etcd
 
-The latest release is available as a binary at [Github][github-release].
+The latest release and setup instructions are available at [Github][github-release].
 
 [github-release]: https://github.com/coreos/etcd/releases/
 


### PR DESCRIPTION
We are building a docker container now too so don't get specific about just
the binary.

I thought about adding instructions to the README but lets just keep following
the pattern of putting version getting started guides on the release page.
