### PR TITLE
fix(README): fixup leader docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,7 +1037,7 @@ Here's the API:
 **Attempt to set a value for the "order_processing" leader key:**
 
 ```sh
-curl -X POST http://127.0.0.1:4001/mod/v2/leader/order_processing?ttl=60 -d name=myserver1.foo.com
+curl -X PUT http://127.0.0.1:4001/mod/v2/leader/order_processing?ttl=60 -d name=myserver1.foo.com
 ```
 
 **Retrieve the current value for the "order_processing" leader key:**
@@ -1050,14 +1050,14 @@ myserver1.foo.com
 **Remove a value from the "order_processing" leader key:**
 
 ```sh
-curl -X POST http://127.0.0.1:4001/mod/v2/leader/order_processing?name=myserver1.foo.com
+curl -X DELETE http://127.0.0.1:4001/mod/v2/leader/order_processing?name=myserver1.foo.com
 ```
 
 If multiple clients attempt to set the value for a key then only one will succeed.
 The other clients will hang until the current value is removed because of TTL or because of a `DELETE` operation.
 Multiple clients can submit the same value and will all be notified when that value succeeds.
 
-To update the TTL of a value simply reissue the same `POST` command that you used to set the value.
+To update the TTL of a value simply reissue the same `PUT` command that you used to set the value.
 
 
 ## Contributing


### PR DESCRIPTION
The leader module uses PUT to set a leader value and DELETE to delete one. Fix
the documents to reflect that.
