### PR TITLE
Trimsplit Wasn't using separator, more efficient.

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -38,8 +38,8 @@ func redirect(hostname string, w http.ResponseWriter, req *http.Request) {
 // white space removed, as defined by Unicode.
 func trimsplit(s, sep string) []string {
 	trimmed := strings.Split(s, sep)
-	for i, r := range trimmed {
-		trimmed[i] = strings.TrimSpace(r)
+	for i := range trimmed {
+		trimmed[i] = strings.TrimSpace(trimmed[i])
 	}
 	return trimmed
 }


### PR DESCRIPTION
Using append like that can be pretty slow when it matters and it eats a lof of memory too.

Here's a little test to manually verify it works:

http://play.golang.org/p/mV7qEPXK8U
