### PR TITLE
chore(server): remove web url

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -41,7 +41,6 @@ configuration files.
 * `-v` - Enable verbose logging. Defaults to `false`.
 * `-vv` - Enable very verbose logging. Defaults to `false`.
 * `-version` - Print the version and exit.
-* `-web-url` - The hostname:port of web interface.
 
 ## Configuration File
 
@@ -66,7 +65,6 @@ name = "default-name"
 snapshot = false
 verbose = false
 very_verbose = false
-web_url = ""
 
 [peer]
 addr = "127.0.0.1:7001"

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -29,7 +29,6 @@ func TestConfigTOML(t *testing.T) {
 		snapshot = true
 		verbose = true
 		very_verbose = true
-		web_url = "/web"
 
 		[peer]
 		addr = "127.0.0.1:7002"
@@ -82,7 +81,6 @@ func TestConfigEnv(t *testing.T) {
 	os.Setenv("ETCD_SNAPSHOT", "true")
 	os.Setenv("ETCD_VERBOSE", "1")
 	os.Setenv("ETCD_VERY_VERBOSE", "yes")
-	os.Setenv("ETCD_WEB_URL", "/web")
 	os.Setenv("ETCD_PEER_ADDR", "127.0.0.1:7002")
 	os.Setenv("ETCD_PEER_CA_FILE", "/tmp/peer/file.ca")
 	os.Setenv("ETCD_PEER_CERT_FILE", "/tmp/peer/file.cert")


### PR DESCRIPTION
web URL is not longer used so remove it from tests and configuration 
documents.
