### PR TITLE
feat(server): Halt handling of disconnected clients

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/coreos/etcd/log"
+)
+
+type clientConnectionWatcher struct {
+	next interface{}
+}
+
+func (self *clientConnectionWatcher) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var closed <-chan bool
+	notifier, ok := w.(http.CloseNotifier)
+	if ok {
+		closed = notifier.CloseNotify()
+	} else {
+		// ok==false indicates the server does not have the ability
+		// to tell when the client has closed. In this case, we simply
+		// make a channel that is never used.
+		closed = make(chan bool)
+	}
+
+	done := make(chan bool)
+	go func() {
+		self.next.(http.Handler).ServeHTTP(w, req)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		return
+	case <-closed:
+		log.Debug("Client initiated connection close before response was ready - closing server socket")
+		w.Header().Set("Connection", "close")
+		return
+	}
+}

--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -274,9 +274,10 @@ func (s *PeerServer) startTransport(scheme string, tlsConf tls.Config) error {
 	log.Infof("raft server [name %s, listen on %s, advertised url %s]", s.name, s.bindAddr, s.url)
 
 	router := mux.NewRouter()
+	handler := &clientConnectionWatcher{router}
 
 	s.httpServer = &http.Server{
-		Handler:   router,
+		Handler:   handler,
 		TLSConfig: &tlsConf,
 		Addr:      s.bindAddr,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -39,10 +39,11 @@ type Server struct {
 func New(name string, urlStr string, bindAddr string, tlsConf *TLSConfig, tlsInfo *TLSInfo, peerServer *PeerServer, registry *Registry, store store.Store) *Server {
 	r := mux.NewRouter()
 	cors := &corsHandler{router: r}
+	handler := &clientConnectionWatcher{cors}
 
 	s := &Server{
 		Server: http.Server{
-			Handler:   cors,
+			Handler:   handler,
 			TLSConfig: &tlsConf.Server,
 			Addr:      bindAddr,
 		},


### PR DESCRIPTION
Use net/http's CloseNotifier to detect when a connection has been closed in a
new middleware to proactively halt server-side processing for disconnected
clients.
