### PR TITLE
DO NOT MERGE

### DIFF
--- a/server/listener.go
+++ b/server/listener.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"net"
+	"time"
+)
+
+type listener struct {
+	*net.TCPListener
+}
+
+func Listen(n string, laddr string) (*listener, error) {
+	tcpListener, err := net.Listen(n, laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &listener{tcpListener.(*net.TCPListener)}, nil
+}
+
+func (l *listener) Accept() (net.Conn, error) {
+	c, err := l.AcceptTCP()
+	if err != nil {
+		return nil, err
+	}
+
+	// Detect client failure
+	c.SetKeepAlive(true)
+	c.SetKeepAlivePeriod(time.Millisecond * 200)
+
+	// Seems no way to detect half-disconnection
+
+	return c, nil
+}

--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -183,7 +183,7 @@ func (s *PeerServer) listenAndServe() error {
 	if addr == "" {
 		addr = ":http"
 	}
-	l, e := net.Listen("tcp", addr)
+	l, e := Listen("tcp", addr)
 	if e != nil {
 		return e
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -191,7 +191,7 @@ func (s *Server) listenAndServe() error {
 	if addr == "" {
 		addr = ":http"
 	}
-	l, e := net.Listen("tcp", addr)
+	l, e := Listen("tcp", addr)
 	if e != nil {
 		return e
 	}


### PR DESCRIPTION
@bcwaldon Hmm... I do not think a customized listener will do the trick. 

Provide no tcp level close notification. 

We can do it at http level as your last pull request. I do not like that approach, since we create a blocking go-routine for each request rather than each connection. But I am fine with just using it for now.
