### PR TITLE
Fix mod/lock and mod/leader return error codes.

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -35,11 +35,16 @@ const (
 	EcodeRootROnly      = 107
 	EcodeDirNotEmpty    = 108
 
-	EcodeValueRequired      = 200
-	EcodePrevValueRequired  = 201
-	EcodeTTLNaN             = 202
-	EcodeIndexNaN           = 203
-	EcodeValueOrTTLRequired = 204
+	EcodeValueRequired        = 200
+	EcodePrevValueRequired    = 201
+	EcodeTTLNaN               = 202
+	EcodeIndexNaN             = 203
+	EcodeValueOrTTLRequired   = 204
+	EcodeTimeoutNaN           = 205
+	EcodeNameRequired         = 206
+	EcodeIndexOrValueRequired = 207
+	EcodeIndexValueMutex      = 208
+	EcodeInvalidField         = 209
 
 	EcodeRaftInternal = 300
 	EcodeLeaderElect  = 301
@@ -68,6 +73,11 @@ func init() {
 	errors[EcodeTTLNaN] = "The given TTL in POST form is not a number"
 	errors[EcodeIndexNaN] = "The given index in POST form is not a number"
 	errors[EcodeValueOrTTLRequired] = "Value or TTL is required in POST form"
+	errors[EcodeTimeoutNaN] = "The given timeout in POST form is not a number"
+	errors[EcodeNameRequired] = "Name is required in POST form"
+	errors[EcodeIndexOrValueRequired] = "Index or value is required"
+	errors[EcodeIndexValueMutex] = "Index and value cannot both be specified"
+	errors[EcodeInvalidField] = "Invalid field"
 
 	// raft related errors
 	errors[EcodeRaftInternal] = "Raft Internal Error"

--- a/mod/leader/v2/get_handler.go
+++ b/mod/leader/v2/get_handler.go
@@ -9,21 +9,18 @@ import (
 )
 
 // getHandler retrieves the current leader.
-func (h *handler) getHandler(w http.ResponseWriter, req *http.Request) {
+func (h *handler) getHandler(w http.ResponseWriter, req *http.Request) error {
 	vars := mux.Vars(req)
 
 	// Proxy the request to the lock service.
 	url := fmt.Sprintf("%s/mod/v2/lock/%s?field=value", h.addr, vars["key"])
 	resp, err := h.client.Get(url)
 	if err != nil {
-		http.Error(w, "read leader error: " + err.Error(), http.StatusInternalServerError)
-		return
+		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		w.Write([]byte("get leader error: "))
-	}
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
+	return nil
 }

--- a/mod/leader/v2/tests/mod_leader_test.go
+++ b/mod/leader/v2/tests/mod_leader_test.go
@@ -14,23 +14,27 @@ import (
 func TestModLeaderSet(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
 		// Set leader.
-		body, err := testSetLeader(s, "foo", "xxx", 10)
+		body, status, err := testSetLeader(s, "foo", "xxx", 10)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Check that the leader is set.
-		body, err = testGetLeader(s, "foo")
+		body, status, err = testGetLeader(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "xxx")
 
 		// Delete leader.
-		body, err = testDeleteLeader(s, "foo", "xxx")
+		body, status, err = testDeleteLeader(s, "foo", "xxx")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 
 		// Check that the leader is removed.
-		body, err = testGetLeader(s, "foo")
+		body, status, err = testGetLeader(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 	})
 }
@@ -39,42 +43,45 @@ func TestModLeaderSet(t *testing.T) {
 func TestModLeaderRenew(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
 		// Set leader.
-		body, err := testSetLeader(s, "foo", "xxx", 2)
+		body, status, err := testSetLeader(s, "foo", "xxx", 2)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		time.Sleep(1 * time.Second)
 
 		// Renew leader.
-		body, err = testSetLeader(s, "foo", "xxx", 3)
+		body, status, err = testSetLeader(s, "foo", "xxx", 3)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		time.Sleep(2 * time.Second)
 
 		// Check that the leader is set.
-		body, err = testGetLeader(s, "foo")
+		body, status, err = testGetLeader(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "xxx")
 	})
 }
 
 
 
-func testSetLeader(s *server.Server, key string, name string, ttl int) (string, error) {
+func testSetLeader(s *server.Server, key string, name string, ttl int) (string, int, error) {
 	resp, err := tests.PutForm(fmt.Sprintf("%s/mod/v2/leader/%s?name=%s&ttl=%d", s.URL(), key, name, ttl), nil)
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testGetLeader(s *server.Server, key string) (string, error) {
+func testGetLeader(s *server.Server, key string) (string, int, error) {
 	resp, err := tests.Get(fmt.Sprintf("%s/mod/v2/leader/%s", s.URL(), key))
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testDeleteLeader(s *server.Server, key string, name string) (string, error) {
+func testDeleteLeader(s *server.Server, key string, name string) (string, int, error) {
 	resp, err := tests.DeleteForm(fmt.Sprintf("%s/mod/v2/leader/%s?name=%s", s.URL(), key, name), nil)
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }

--- a/mod/lock/v2/renew_handler.go
+++ b/mod/lock/v2/renew_handler.go
@@ -6,11 +6,12 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
+	etcdErr "github.com/coreos/etcd/error"
 )
 
 // renewLockHandler attempts to update the TTL on an existing lock.
 // Returns a 200 OK if successful. Returns non-200 on error.
-func (h *handler) renewLockHandler(w http.ResponseWriter, req *http.Request) {
+func (h *handler) renewLockHandler(w http.ResponseWriter, req *http.Request) error {
 	h.client.SyncCluster()
 
 	// Read the lock path.
@@ -20,31 +21,26 @@ func (h *handler) renewLockHandler(w http.ResponseWriter, req *http.Request) {
 	// Parse new TTL parameter.
 	ttl, err := strconv.Atoi(req.FormValue("ttl"))
 	if err != nil {
-		http.Error(w, "invalid ttl: " + err.Error(), http.StatusInternalServerError)
-		return
+		return etcdErr.NewError(etcdErr.EcodeTTLNaN, "Renew", 0)
 	}
 
 	// Read and set defaults for index and value.
 	index := req.FormValue("index")
 	value := req.FormValue("value")
 	if len(index) == 0 && len(value) == 0 {
-		// The index or value is required.
-		http.Error(w, "renew lock error: index or value required", http.StatusInternalServerError)
-		return
+		return etcdErr.NewError(etcdErr.EcodeIndexOrValueRequired, "Renew", 0)
 	}
 
 	if len(index) == 0 {
 		// If index is not specified then look it up by value.
 		resp, err := h.client.Get(keypath, true, true)
 		if err != nil {
-			http.Error(w, "renew lock index error: " + err.Error(), http.StatusInternalServerError)
-			return
+			return err
 		}
 		nodes := lockNodes{resp.Node.Nodes}
 		node, _ := nodes.FindByValue(value)
 		if node == nil {
-			http.Error(w, "renew lock error: cannot find: " + value, http.StatusInternalServerError)
-			return
+			return etcdErr.NewError(etcdErr.EcodeKeyNotFound, "Renew", 0)
 		}
 		index = path.Base(node.Key)
 
@@ -52,16 +48,15 @@ func (h *handler) renewLockHandler(w http.ResponseWriter, req *http.Request) {
 		// If value is not specified then default it to the previous value.
 		resp, err := h.client.Get(path.Join(keypath, index), true, false)
 		if err != nil {
-			http.Error(w, "renew lock value error: " + err.Error(), http.StatusInternalServerError)
-			return
+			return err
 		}
 		value = resp.Node.Value
 	}
 
 	// Renew the lock, if it exists.
-	_, err = h.client.Update(path.Join(keypath, index), value, uint64(ttl))
-	if err != nil {
-		http.Error(w, "renew lock error: " + err.Error(), http.StatusInternalServerError)
-		return
+	if _, err = h.client.Update(path.Join(keypath, index), value, uint64(ttl)); err != nil {
+		return err
 	}
+
+	return nil
 }

--- a/mod/lock/v2/tests/mod_lock_test.go
+++ b/mod/lock/v2/tests/mod_lock_test.go
@@ -14,23 +14,27 @@ import (
 func TestModLockAcquireAndRelease(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
 		// Acquire lock.
-		body, err := testAcquireLock(s, "foo", "", 10)
+		body, status, err := testAcquireLock(s, "foo", "", 10)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Check that we have the lock.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Release lock.
-		body, err = testReleaseLock(s, "foo", "2", "")
+		body, status, err = testReleaseLock(s, "foo", "2", "")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 
 		// Check that we have the lock.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 	})
 }
@@ -42,8 +46,9 @@ func TestModLockBlockUntilAcquire(t *testing.T) {
 
 		// Acquire lock #1.
 		go func() {
-			body, err := testAcquireLock(s, "foo", "", 10)
+			body, status, err := testAcquireLock(s, "foo", "", 10)
 			assert.NoError(t, err)
+			assert.Equal(t, status, 200)
 			assert.Equal(t, body, "2")
 			c <- true
 		}()
@@ -53,8 +58,9 @@ func TestModLockBlockUntilAcquire(t *testing.T) {
 		waiting := true
 		go func() {
 			c <- true
-			body, err := testAcquireLock(s, "foo", "", 10)
+			body, status, err := testAcquireLock(s, "foo", "", 10)
 			assert.NoError(t, err)
+			assert.Equal(t, status, 200)
 			assert.Equal(t, body, "4")
 			waiting = false
 		}()
@@ -63,29 +69,34 @@ func TestModLockBlockUntilAcquire(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Check that we have the lock #1.
-		body, err := testGetLockIndex(s, "foo")
+		body, status, err := testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Check that we are still waiting for lock #2.
 		assert.Equal(t, waiting, true)
 
 		// Release lock #1.
-		body, err = testReleaseLock(s, "foo", "2", "")
+		_, status, err = testReleaseLock(s, "foo", "2", "")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 
 		// Check that we have lock #2.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "4")
 
 		// Release lock #2.
-		body, err = testReleaseLock(s, "foo", "4", "")
+		_, status, err = testReleaseLock(s, "foo", "4", "")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 
 		// Check that we have no lock.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 	})
 }
@@ -97,8 +108,9 @@ func TestModLockExpireAndRelease(t *testing.T) {
 
 		// Acquire lock #1.
 		go func() {
-			body, err := testAcquireLock(s, "foo", "", 2)
+			body, status, err := testAcquireLock(s, "foo", "", 2)
 			assert.NoError(t, err)
+			assert.Equal(t, status, 200)
 			assert.Equal(t, body, "2")
 			c <- true
 		}()
@@ -107,8 +119,9 @@ func TestModLockExpireAndRelease(t *testing.T) {
 		// Acquire lock #2.
 		go func() {
 			c <- true
-			body, err := testAcquireLock(s, "foo", "", 10)
+			body, status, err := testAcquireLock(s, "foo", "", 10)
 			assert.NoError(t, err)
+			assert.Equal(t, status, 200)
 			assert.Equal(t, body, "4")
 		}()
 		<- c
@@ -116,16 +129,18 @@ func TestModLockExpireAndRelease(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Check that we have the lock #1.
-		body, err := testGetLockIndex(s, "foo")
+		body, status, err := testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Wait for lock #1 TTL.
 		time.Sleep(2 * time.Second)
 
 		// Check that we have lock #2.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "4")
 	})
 }
@@ -134,34 +149,39 @@ func TestModLockExpireAndRelease(t *testing.T) {
 func TestModLockRenew(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
 		// Acquire lock.
-		body, err := testAcquireLock(s, "foo", "", 3)
+		body, status, err := testAcquireLock(s, "foo", "", 3)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		time.Sleep(2 * time.Second)
 
 		// Check that we have the lock.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Renew lock.
-		body, err = testRenewLock(s, "foo", "2", "", 3)
+		body, status, err = testRenewLock(s, "foo", "2", "", 3)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 
 		time.Sleep(2 * time.Second)
 
 		// Check that we still have the lock.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		time.Sleep(2 * time.Second)
 
 		// Check that lock was released.
-		body, err = testGetLockIndex(s, "foo")
+		body, status, err = testGetLockIndex(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 	})
 }
@@ -170,55 +190,59 @@ func TestModLockRenew(t *testing.T) {
 func TestModLockAcquireAndReleaseByValue(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
 		// Acquire lock.
-		body, err := testAcquireLock(s, "foo", "XXX", 10)
+		body, status, err := testAcquireLock(s, "foo", "XXX", 10)
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "2")
 
 		// Check that we have the lock.
-		body, err = testGetLockValue(s, "foo")
+		body, status, err = testGetLockValue(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "XXX")
 
 		// Release lock.
-		body, err = testReleaseLock(s, "foo", "", "XXX")
+		body, status, err = testReleaseLock(s, "foo", "", "XXX")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 
 		// Check that we released the lock.
-		body, err = testGetLockValue(s, "foo")
+		body, status, err = testGetLockValue(s, "foo")
 		assert.NoError(t, err)
+		assert.Equal(t, status, 200)
 		assert.Equal(t, body, "")
 	})
 }
 
 
 
-func testAcquireLock(s *server.Server, key string, value string, ttl int) (string, error) {
+func testAcquireLock(s *server.Server, key string, value string, ttl int) (string, int, error) {
 	resp, err := tests.PostForm(fmt.Sprintf("%s/mod/v2/lock/%s?value=%s&ttl=%d", s.URL(), key, value, ttl), nil)
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testGetLockIndex(s *server.Server, key string) (string, error) {
+func testGetLockIndex(s *server.Server, key string) (string, int, error) {
 	resp, err := tests.Get(fmt.Sprintf("%s/mod/v2/lock/%s?field=index", s.URL(), key))
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testGetLockValue(s *server.Server, key string) (string, error) {
+func testGetLockValue(s *server.Server, key string) (string, int, error) {
 	resp, err := tests.Get(fmt.Sprintf("%s/mod/v2/lock/%s", s.URL(), key))
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testReleaseLock(s *server.Server, key string, index string, value string) (string, error) {
+func testReleaseLock(s *server.Server, key string, index string, value string) (string, int, error) {
 	resp, err := tests.DeleteForm(fmt.Sprintf("%s/mod/v2/lock/%s?index=%s&value=%s", s.URL(), key, index, value), nil)
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }
 
-func testRenewLock(s *server.Server, key string, index string, value string, ttl int) (string, error) {
+func testRenewLock(s *server.Server, key string, index string, value string, ttl int) (string, int, error) {
 	resp, err := tests.PutForm(fmt.Sprintf("%s/mod/v2/lock/%s?index=%s&value=%s&ttl=%d", s.URL(), key, index, value, ttl), nil)
 	ret := tests.ReadBody(resp)
-	return string(ret), err
+	return string(ret), resp.StatusCode, err
 }


### PR DESCRIPTION
This pull request fixes the `mod/lock` and `mod/leader` endpoints to use the standard `etcd/error` package.

See also: #446, #412

/cc: @philips @xiangli-cmu
