### PR TITLE
Download and build Go 1.2 in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y python-software-properties git
-RUN add-apt-repository -y ppa:duh/golang
-RUN apt-get update
-RUN apt-get install -y golang
+# Let's install go just like Docker (from source).
+RUN apt-get update -q
+RUN apt-get install -qy build-essential curl git
+RUN curl -s https://go.googlecode.com/files/go1.2.src.tar.gz | tar -v -C /usr/local -xz
+RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
+ENV PATH /usr/local/go/bin:$PATH
 ADD . /opt/etcd
 RUN cd /opt/etcd && ./build
 EXPOSE 4001 7001

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd etcd
 
 This will generate a binary in the base directory called `./etcd`.
 
-_NOTE_: you need go 1.1+. Please check your installation with
+_NOTE_: you need go 1.2+. Please check your installation with
 
 ```
 go version

--- a/go_version.go
+++ b/go_version.go
@@ -1,3 +1,3 @@
-// +build !go1.1
+// +build !go1.2
 
-"etcd requires go 1.1 or greater to build"
+"etcd requires go 1.2 or greater to build"


### PR DESCRIPTION
The dependency BurntSushi/toml actually needs Go 1.2, because it uses
encoding.TextUnmarshaler, which didn't exist in Go 1.1. Since the PPA
that we use doesn't have Go 1.2 yet, we will use the same method as
Docker, i.e. download Go source tarball and compile it.
