### PR TITLE
fixes bug with the etcd docker image not being able to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ ENV PATH /usr/local/go/bin:$PATH
 ADD . /opt/etcd
 RUN cd /opt/etcd && ./build
 EXPOSE 4001 7001
-ENTRYPOINT ["/opt/etcd/etcd"]
+ENTRYPOINT ["/opt/etcd/bin/etcd"]
 


### PR DESCRIPTION
etcd is now in the bin directory, updated entrypoint to reflect that.
