### PR TITLE
feat(store/store_bench_test.go) add a benchmark for set operation 

### DIFF
--- a/store/store_bench_test.go
+++ b/store/store_bench_test.go
@@ -48,6 +48,57 @@ func BenchmarkStoreSetWithJson4096Bytes(b *testing.B) {
 	benchStoreSet(b, 4096, json.Marshal)
 }
 
+func BenchmarkStoreDelete(b *testing.B) {
+	b.StopTimer()
+
+	s := newStore()
+	kvs, _ := generateNRandomKV(b.N, 128)
+
+	memStats := new(runtime.MemStats)
+	runtime.GC()
+	runtime.ReadMemStats(memStats)
+
+	for i := 0; i < b.N; i++ {
+		_, err := s.Set(kvs[i][0], false, kvs[i][1], Permanent)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	setMemStats := new(runtime.MemStats)
+	runtime.GC()
+	runtime.ReadMemStats(setMemStats)
+
+	b.StartTimer()
+
+	for i := range kvs {
+		s.Delete(kvs[i][0], false, false)
+	}
+
+	b.StopTimer()
+
+	// clean up
+	e, err := s.Get("/", false, false)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, n := range e.Node.Nodes {
+		_, err := s.Delete(n.Key, true, true)
+		if err != nil {
+			panic(err)
+		}
+	}
+	s.WatcherHub.EventHistory = nil
+
+	deleteMemStats := new(runtime.MemStats)
+	runtime.GC()
+	runtime.ReadMemStats(deleteMemStats)
+
+	fmt.Printf("\nBefore set Alloc: %v; After set Alloc: %v, After delete Alloc: %v\n",
+		memStats.Alloc/1000, setMemStats.Alloc/1000, deleteMemStats.Alloc/1000)
+}
+
 func benchStoreSet(b *testing.B, valueSize int, process func(interface{}) ([]byte, error)) {
 	s := newStore()
 	b.StopTimer()
@@ -68,6 +119,7 @@ func benchStoreSet(b *testing.B, valueSize int, process func(interface{}) ([]byt
 		}
 	}
 
+	kvs = nil
 	b.StopTimer()
 	memStats := new(runtime.MemStats)
 	runtime.GC()


### PR DESCRIPTION
BenchmarkStoreSet     500000          6212 ns/op 
BenchmarkStoreSetWithJson     200000         10213 ns/op

about 150K set op/second and 100K setWithJson op/second on a i5 2.3G MBP
