### PR TITLE
fix(mod/lock) Fix two issues found in the heavily loaded tests

### DIFF
--- a/mod/lock/v2/acquire_handler.go
+++ b/mod/lock/v2/acquire_handler.go
@@ -164,7 +164,6 @@ func (h *handler) watch(keypath string, index int, closeChan <- chan bool) error
 		if err != nil {
 			return fmt.Errorf("lock watch lookup error: %s", err.Error())
 		}
-		waitIndex := resp.Node.ModifiedIndex
 		nodes := lockNodes{resp.Node.Nodes}
 		prevIndex := nodes.PrevIndex(index)
 
@@ -174,6 +173,13 @@ func (h *handler) watch(keypath string, index int, closeChan <- chan bool) error
 		}
 
 		// Watch previous index until it's gone.
+		waitIndex := resp.Node.ModifiedIndex
+
+		// Since event store has only 1000 histories we should use first node's CreatedIndex if available
+		if firstNode := nodes.First(); firstNode != nil {
+			waitIndex = firstNode.CreatedIndex
+		}
+
 		_, err = h.client.Watch(path.Join(keypath, strconv.Itoa(prevIndex)), waitIndex, false, nil, stopWatchChan)
 		if err == etcd.ErrWatchStoppedByUser {
 			return fmt.Errorf("lock watch closed")


### PR DESCRIPTION
I found two issues in lock module in the heavily loaded tests.

In a certain situation a goroutine launched in watch() attempts to send a message to closed channel. Fixed in 4c2942f

It seems that a 'ModifiedIndex' in a lock directory is not incremented once the directory initialized. If (latest index  - the ModifiedIndex) > 1000 and prevIndex exists at the time, etcd always returns 401 EcodeEventIndexCleared and a request has been never queued until no prevIndex found. I tried to fix in 1273875 but I'm not sure this is correct.
