### PR TITLE
fix(server compilation): compile bug in peer_server_handlers.go

### DIFF
--- a/server/peer_server_handlers.go
+++ b/server/peer_server_handlers.go
@@ -71,7 +71,7 @@ func (ps *PeerServer) AppendEntriesHttpHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	if !resp.Success {
+	if !resp.Success() {
 		log.Debugf("[Append Entry] Step back")
 	}
 


### PR DESCRIPTION
resp.Success is a func() bool, not a bool.  Call it.

The code was retrieved using: "go get github.com/coreos/etcd" with go 1.2 on Mac 10.8.5.
