### PR TITLE
Change token example to use returned value only

### DIFF
--- a/Documentation/cluster-discovery.md
+++ b/Documentation/cluster-discovery.md
@@ -20,8 +20,8 @@ Here's a full example:
 
 ```
 TOKEN=$(curl https://discovery.etcd.io/new)
-./etcd -name instance1 -peer-addr 10.1.2.3:7001 -addr 10.1.2.3:4001 -discovery https://discovery.etcd.io/$TOKEN
-./etcd -name instance2 -peer-addr 10.1.2.4:7002 -addr 10.1.2.4:4002 -discovery https://discovery.etcd.io/$TOKEN
+./etcd -name instance1 -peer-addr 10.1.2.3:7001 -addr 10.1.2.3:4001 -discovery $TOKEN
+./etcd -name instance2 -peer-addr 10.1.2.4:7002 -addr 10.1.2.4:4002 -discovery $TOKEN
 ```
 
 ## Running Your Own Discovery Endpoint


### PR DESCRIPTION
The discovery.etcd.io/new endpoint already returns a complete URL containing the host, so there is no need to specify it on the command line.
