### PR TITLE
fix(server/v1): don't fail put on new v1 key

### DIFF
--- a/server/v1/tests/put_handler_test.go
+++ b/server/v1/tests/put_handler_test.go
@@ -1,0 +1,29 @@
+package v2
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/coreos/etcd/server"
+	"github.com/coreos/etcd/tests"
+	"github.com/coreos/etcd/third_party/github.com/stretchr/testify/assert"
+)
+
+// Ensures that a key is set to a given value.
+//
+//   $ curl -X PUT localhost:4001/v1/keys/foo/bar -d value=XXX
+//
+func TestV1SetKey(t *testing.T) {
+	tests.RunServer(func(s *server.Server) {
+		v := url.Values{}
+		v.Set("value", "XXX")
+		resp, err := tests.PutForm(fmt.Sprintf("%s%s", s.URL(), "/v1/keys/foo/bar"), v)
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+		body := tests.ReadBody(resp)
+		assert.Nil(t, err, "")
+
+		assert.Equal(t, string(body), `{"action":"set","key":"/foo/bar","value":"XXX","newKey":true,"index":2}`, "")
+	})
+}

--- a/store/event.go
+++ b/store/event.go
@@ -53,10 +53,13 @@ func (event *Event) Response(currentIndex uint64) interface{} {
 			Action:     event.Action,
 			Key:        event.Node.Key,
 			Value:      event.Node.Value,
-			PrevValue:  event.PrevNode.Value,
 			Index:      event.Node.ModifiedIndex,
 			TTL:        event.Node.TTL,
 			Expiration: event.Node.Expiration,
+		}
+
+		if event.PrevNode != nil {
+			response.PrevValue = event.PrevNode.Value
 		}
 
 		if currentIndex != 0 {

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,9 @@ go test -v ./server
 go test -i ./config
 go test -v ./config
 
+go test -i ./server/v1/tests
+go test -v ./server/v1/tests
+
 go test -i ./server/v2/tests
 go test -v ./server/v2/tests
 


### PR DESCRIPTION
We weren't checking for PrevNode being nil in the v1 code path. Do this and
add a test.

Fixes #557
