### PR TITLE
fix(Documentation): single machine clusters have some stats undefined

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -1054,8 +1054,8 @@ Each node keeps a number of internal statistics:
 - `recvBandwidthRate`: number of bytes per second this node is receiving (follower only)
 - `recvPkgRate`: number of requests per second this node is receiving (follower only)
 - `sendAppendRequestCnt`: number of requests that this node has sent
-- `sendBandwidthRate`: number of bytes per second this node is receiving (leader only)
-- `sendPkgRate`: number of requests per second this node is receiving (leader only)
+- `sendBandwidthRate`: number of bytes per second this node is receiving (leader only). This value is undefined on single machine clusters.
+- `sendPkgRate`: number of requests per second this node is receiving (leader only). This value is undefined on single machine clusters.
 - `state`: either leader or folower
 - `startTime`: the time when this node was started
 


### PR DESCRIPTION
document that single machine clusters will omit sendBandwidthRate and 
sendPkgRate.

Via http://thread.gmane.org/gmane.comp.distributed.etcd/218
