### PR TITLE
fix(etcd): get consistent with etcdctl on printing versions

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -43,7 +43,7 @@ func main() {
 		fmt.Println(err.Error() + "\n")
 		os.Exit(1)
 	} else if config.ShowVersion {
-		fmt.Println(server.ReleaseVersion)
+		fmt.Println("etcd version", server.ReleaseVersion)
 		os.Exit(0)
 	} else if config.ShowHelp {
 		fmt.Println(server.Usage() + "\n")

--- a/server/release_version.go
+++ b/server/release_version.go
@@ -1,3 +1,3 @@
 package server
 
-const ReleaseVersion = "v0.3.0+git"
+const ReleaseVersion = "0.3.0+git"


### PR DESCRIPTION
Lets get a bit more consistent in printing the versions:

```
$ ./bin/etcd -version
etcd version 0.3.0+git
$ ./bin/etcdctl -v
etcdctl version 0.3.0+git
```
