### PR TITLE
fix(mod/lock): correct watch index to remove cpu load

### DIFF
--- a/mod/lock/v2/lock_nodes.go
+++ b/mod/lock/v2/lock_nodes.go
@@ -41,17 +41,20 @@ func (s lockNodes) FindByValue(value string) (*etcd.Node, int) {
 	return nil, 0
 }
 
-// Retrieves the index that occurs before a given index.
-func (s lockNodes) PrevIndex(index int) int {
+// Find the node with the largest index in the lockNodes that is smaller than the given index. Also return the lastModified index of that node.
+func (s lockNodes) PrevIndex(index int) (int, int) {
 	sort.Sort(s)
 
+	// Iterate over each node to find the given index. We keep track of the
+	// previous index on each iteration so we can return it when we match the
+	// index we're looking for.
 	var prevIndex int
 	for _, node := range s.Nodes {
 		idx, _ := strconv.Atoi(path.Base(node.Key))
 		if index == idx {
-			return prevIndex
+			return prevIndex, int(node.ModifiedIndex)
 		}
 		prevIndex = idx
 	}
-	return 0
+	return 0, 0
 }


### PR DESCRIPTION
The waitIndex was being pulled from the wrong node in the lock parent which caused the watch to be returned immediately. This caused a continuous stream of get/watch calls while a client was waiting for a lock.

Confirmed with @oleksiyk that this change fixes https://github.com/coreos/etcd/issues/575.

/cc @philips @xiangli-cmu
