### PR TITLE
Added fetching of etcd from git in order to build it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get install -qy build-essential curl git
 RUN curl -s https://go.googlecode.com/files/go1.2.src.tar.gz | tar -v -C /usr/local -xz
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 ENV PATH /usr/local/go/bin:$PATH
+RUN cd /opt && git clone https://github.com/coreos/etcd.git
 ADD . /opt/etcd
 RUN cd /opt/etcd && ./build
 EXPOSE 4001 7001


### PR DESCRIPTION
When I tried to use the Dockerfile in master, when it got to the point of building etcd, it tried to cd to /opt/etcd, which did not exist. I added a line to cd to /opt and then git clone the etcd repo. 
