### PR TITLE
fix Compare and swap returns incorrect cause

### DIFF
--- a/server/v1/tests/put_handler_test.go
+++ b/server/v1/tests/put_handler_test.go
@@ -151,7 +151,7 @@ func TestV1SetKeyCASOnValueFail(t *testing.T) {
 		body := tests.ReadBodyJSON(resp)
 		assert.Equal(t, body["errorCode"], 101, "")
 		assert.Equal(t, body["message"], "Compare failed", "")
-		assert.Equal(t, body["cause"], "[AAA != XXX] [0 != 2]", "")
+		assert.Equal(t, body["cause"], "[AAA != XXX]", "")
 		assert.Equal(t, body["index"], 2, "")
 	})
 }


### PR DESCRIPTION
fix for issue #611

Note that compare-and-delete cause changed too.
I worry about modifications in v1 tests while v1 API is frozen.

Thank you!
