### PR TITLE
wrap goversion check in func for ast building

### DIFF
--- a/go_version.go
+++ b/go_version.go
@@ -1,3 +1,7 @@
 // +build !go1.2
 
-"etcd requires go 1.2 or greater to build"
+package main
+
+func etcdNoSupportLessGoOnePointTwo() {
+	"etcd requires go 1.2 or greater to build"
+}


### PR DESCRIPTION
I realize this is minutiae, but PR'ing for the greater good I guess. Doing testing of a lot of go packages and this came up in the log and was an easy fix. 
