### PR TITLE
hack(store/store): multiple sets on a directory

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -488,9 +488,6 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 	// force will try to replace a existing file
 	if n != nil {
 		if replace {
-			if n.IsDir() {
-				return nil, etcdErr.NewError(etcdErr.EcodeNotFile, nodePath, currIndex)
-			}
 			e.PrevNode = n.Repr(false, false)
 
 			n.Remove(false, false, nil)


### PR DESCRIPTION
We should allow people to set the ttl on a directory multiple times in a row.
As it is you have to first do PUT foobar2?ttl=30 and then PUT 
foobar2?ttl=30?prevExist=true

```
$ ./bin/etcdctl setdir foobar2  --ttl 30
$ ./bin/etcdctl setdir foobar2  --ttl 30
Error: 102: Not a file (/foobar2) [2]
```

Reported by AmandaC in IRC.

This patch is not mergeable but we need to figure out something that is.
