### PR TITLE
fix(store.go) fix wrong modifiedIndex of a directory after adding/deletion child nodes

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -567,8 +567,7 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 			break
 		}
 
-		s.CurrentIndex++
-		e := newEvent(Expire, node.Path, s.CurrentIndex, node.CreatedIndex)
+		e := newEvent(Expire, node.Path, s.CurrentIndex+1, node.CreatedIndex)
 		e.PrevNode = node.Repr(false, false)
 
 		callback := func(path string) { // notify function
@@ -578,6 +577,8 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 
 		s.ttlKeyHeap.pop()
 		node.Remove(true, true, callback)
+
+		s.CurrentIndex++
 
 		s.Stats.Inc(ExpireCount)
 


### PR DESCRIPTION
A directory is a map of child nodes. We should update the modifiedIndex of the parent directory if the map changes.

The test of this modification passed. However etcd functional test is failing. I am going to look into that problem.
