### PR TITLE
fix(api) fix of redirect loop when there is no leader

### DIFF
--- a/server/v2/get_handler.go
+++ b/server/v2/get_handler.go
@@ -19,7 +19,11 @@ func GetHandler(w http.ResponseWriter, req *http.Request, s Server) error {
 
 	// Help client to redirect the request to the current leader
 	if req.FormValue("consistent") == "true" && s.State() != raft.Leader {
-		leader := s.Leader()
+		leader, err := s.Leader()
+		if err != nil {
+			return err
+		}
+
 		hostname, _ := s.ClientURL(leader)
 
 		url, err := url.Parse(hostname)

--- a/server/v2/v2.go
+++ b/server/v2/v2.go
@@ -9,7 +9,7 @@ import (
 // The Server interface provides all the methods required for the v2 API.
 type Server interface {
 	State() string
-	Leader() string
+	Leader() (string, error)
 	CommitIndex() uint64
 	Term() uint64
 	PeerURL(string) (string, bool)


### PR DESCRIPTION
https://github.com/coreos/etcd/pull/628#I tried to solve the following issue:

when client ask partitioned peer to get actual value of the key it will get HTTP redirect to same peer.
For example I have a setup of two peers on 4001 (leader) and 4002 (follower). After leader died in accident I ask peer
`curl -L http://127.0.0.1:4002/v2/keys/my`
and get some value. That is OK. But request of 
`curl -L http://127.0.0.1:4002/v2/keys/my?consistent=true`
leads to curl error "too many redirects" because peer don't know who is the leader and use empty URL as path to leader and return HTTP redirect (301) to `/v2/keys/my?consistent=true` (to himself).

Should I add specific test for this?
