### PR TITLE
fix: race detector failures

### DIFF
--- a/server/raft_server_stats.go
+++ b/server/raft_server_stats.go
@@ -1,38 +1,40 @@
 package server
 
 import (
+	"sync"
 	"time"
 
 	"github.com/coreos/etcd/third_party/github.com/coreos/raft"
 )
 
 type raftServerStats struct {
-	Name		string		`json:"name"`
-	State		string		`json:"state"`
-	StartTime	time.Time	`json:"startTime"`
+	sync.Mutex
+	Name      string    `json:"name"`
+	State     string    `json:"state"`
+	StartTime time.Time `json:"startTime"`
 
-	LeaderInfo	struct {
-		Name		string	`json:"leader"`
-		Uptime		string	`json:"uptime"`
-		startTime	time.Time
-	}	`json:"leaderInfo"`
+	LeaderInfo struct {
+		Name      string `json:"leader"`
+		Uptime    string `json:"uptime"`
+		startTime time.Time
+	} `json:"leaderInfo"`
 
-	RecvAppendRequestCnt	uint64	`json:"recvAppendRequestCnt,"`
-	RecvingPkgRate		float64	`json:"recvPkgRate,omitempty"`
-	RecvingBandwidthRate	float64	`json:"recvBandwidthRate,omitempty"`
+	RecvAppendRequestCnt uint64  `json:"recvAppendRequestCnt,"`
+	RecvingPkgRate       float64 `json:"recvPkgRate,omitempty"`
+	RecvingBandwidthRate float64 `json:"recvBandwidthRate,omitempty"`
 
-	SendAppendRequestCnt	uint64	`json:"sendAppendRequestCnt"`
-	SendingPkgRate		float64	`json:"sendPkgRate,omitempty"`
-	SendingBandwidthRate	float64	`json:"sendBandwidthRate,omitempty"`
+	SendAppendRequestCnt uint64  `json:"sendAppendRequestCnt"`
+	SendingPkgRate       float64 `json:"sendPkgRate,omitempty"`
+	SendingBandwidthRate float64 `json:"sendBandwidthRate,omitempty"`
 
-	sendRateQueue	*statsQueue
-	recvRateQueue	*statsQueue
+	sendRateQueue *statsQueue
+	recvRateQueue *statsQueue
 }
 
 func NewRaftServerStats(name string) *raftServerStats {
 	return &raftServerStats{
-		Name:		name,
-		StartTime:	time.Now(),
+		Name:      name,
+		StartTime: time.Now(),
 		sendRateQueue: &statsQueue{
 			back: -1,
 		},
@@ -43,6 +45,9 @@ func NewRaftServerStats(name string) *raftServerStats {
 }
 
 func (ss *raftServerStats) RecvAppendReq(leaderName string, pkgSize int) {
+	ss.Lock()
+	defer ss.Unlock()
+
 	ss.State = raft.Follower
 	if leaderName != ss.LeaderInfo.Name {
 		ss.LeaderInfo.Name = leaderName
@@ -54,6 +59,9 @@ func (ss *raftServerStats) RecvAppendReq(leaderName string, pkgSize int) {
 }
 
 func (ss *raftServerStats) SendAppendReq(pkgSize int) {
+	ss.Lock()
+	defer ss.Unlock()
+
 	now := time.Now()
 
 	if ss.State != raft.Leader {

--- a/server/registry.go
+++ b/server/registry.go
@@ -164,6 +164,8 @@ func (r *Registry) urls(leaderName, selfName string, url func(name string) (stri
 
 // Removes a node from the cache.
 func (r *Registry) Invalidate(name string) {
+	r.Lock()
+	defer r.Unlock()
 	delete(r.nodes, name)
 }
 

--- a/tests/functional/discovery_test.go
+++ b/tests/functional/discovery_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/coreos/etcd/third_party/github.com/stretchr/testify/assert"
 
-	etcdtest "github.com/coreos/etcd/tests"
 	"github.com/coreos/etcd/server"
+	etcdtest "github.com/coreos/etcd/tests"
 	goetcd "github.com/coreos/etcd/third_party/github.com/coreos/go-etcd/etcd"
 )
 
@@ -50,6 +50,7 @@ func TestDiscoveryDownNoBackupPeers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	ts.Close()
 
 	if !g.success {
 		t.Fatal("Discovery server never called")

--- a/tests/functional/internal_version_test.go
+++ b/tests/functional/internal_version_test.go
@@ -47,6 +47,7 @@ func TestInternalVersion(t *testing.T) {
 		t.Fatal("etcd node should not be up")
 		return
 	}
+	ts.Close()
 
 	if checkedVersion == false {
 		t.Fatal("etcd did not check the version")


### PR DESCRIPTION
This pull request fixes all race conditions reported by the Go race detector as reported by @titanous in #600:
- `server/v2/tests`
- `mod/lock/v2/tests`
- `tests/functional`
- `tests/functional` with `-race` enabled in `./build`

I tried to use `sync/atomic` on the leader value in go-raft for a while but could not get it to work. It doesn't seem like string values will work with that package -- even with `StorePointer` and `LoadPointer`.

I'll add a separate pull request for go-raft after this is reviewed.

_Note_: This commit still experiences the same issue as [Drone build 91](https://drone.io/github.com/coreos/etcd/91) so the build still hangs towards the end.

/cc @xiangli-cmu @philips
