### PR TITLE
Fix delete key as directory

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -131,7 +131,7 @@ func (e Error) Write(w http.ResponseWriter) {
 	switch e.ErrorCode {
 	case EcodeKeyNotFound:
 		status = http.StatusNotFound
-	case EcodeNotFile, EcodeDirNotEmpty:
+	case EcodeNotFile, EcodeDirNotEmpty, EcodeNotDir:
 		status = http.StatusForbidden
 	case EcodeTestFailed, EcodeNodeExist:
 		status = http.StatusPreconditionFailed

--- a/store/store.go
+++ b/store/store.go
@@ -280,6 +280,10 @@ func (s *store) Delete(nodePath string, dir, recursive bool) (*Event, error) {
 
 	if n.IsDir() {
 		eNode.Dir = true
+	} else {
+		if dir {
+			return nil, etcdErr.NewError(etcdErr.EcodeNotDir, n.Path, s.Index())
+		}
 	}
 
 	callback := func(path string) { // notify function


### PR DESCRIPTION
related to #556 (please check comments)
1. original issue is not resolved as current behavior looks reasonable: return HTTP.forbidden if prevIndex / prevValue is specified for directory delete request (I have added test for this nevertheless)
2. store will return error if client specified `dir` / `recursive` on key/value pair for delete
