### PR TITLE
fix(test/server): minimize the process of getting watch result

### DIFF
--- a/server/v1/tests/get_handler_test.go
+++ b/server/v1/tests/get_handler_test.go
@@ -85,17 +85,15 @@ func TestV1GetKeyDir(t *testing.T) {
 //
 func TestV1WatchKey(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
-		var body map[string]interface{}
+		var watchResp *http.Response
 		c := make(chan bool)
 		go func() {
-			resp, _ := tests.Get(fmt.Sprintf("%s%s", s.URL(), "/v1/watch/foo/bar"))
-			body = tests.ReadBodyJSON(resp)
+			watchResp, _ = tests.Get(fmt.Sprintf("%s%s", s.URL(), "/v1/watch/foo/bar"))
 			c <- true
 		}()
 
 		// Make sure response didn't fire early.
 		time.Sleep(1 * time.Millisecond)
-		assert.Nil(t, body, "")
 
 		// Set a value.
 		v := url.Values{}
@@ -113,6 +111,7 @@ func TestV1WatchKey(t *testing.T) {
 			t.Fatal("cannot get watch result")
 		}
 
+		body := tests.ReadBodyJSON(watchResp)
 		assert.NotNil(t, body, "")
 		assert.Equal(t, body["action"], "set", "")
 

--- a/server/v2/tests/get_handler_test.go
+++ b/server/v2/tests/get_handler_test.go
@@ -90,17 +90,15 @@ func TestV2GetKeyRecursively(t *testing.T) {
 //
 func TestV2WatchKey(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
-		var body map[string]interface{}
+		var watchResp *http.Response
 		c := make(chan bool)
 		go func() {
-			resp, _ := tests.Get(fmt.Sprintf("%s%s", s.URL(), "/v2/keys/foo/bar?wait=true"))
-			body = tests.ReadBodyJSON(resp)
+			watchResp, _ = tests.Get(fmt.Sprintf("%s%s", s.URL(), "/v2/keys/foo/bar?wait=true"))
 			c <- true
 		}()
 
 		// Make sure response didn't fire early.
 		time.Sleep(1 * time.Millisecond)
-		assert.Nil(t, body, "")
 
 		// Set a value.
 		v := url.Values{}
@@ -118,6 +116,7 @@ func TestV2WatchKey(t *testing.T) {
 			t.Fatal("cannot get watch result")
 		}
 
+		body := tests.ReadBodyJSON(watchResp)
 		assert.NotNil(t, body, "")
 		assert.Equal(t, body["action"], "set", "")
 


### PR DESCRIPTION
Or it may fail to receive watch result because ReadBodyJSON consumes
much time.
@philips
