### PR TITLE
feat(peer_server): forbid rejoining with different name

### DIFF
--- a/tests/functional/rejoin_test.go
+++ b/tests/functional/rejoin_test.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/third_party/github.com/coreos/go-etcd/etcd"
+)
+
+// Create a five nodes
+// Kill one of the node and rejoin with different name
+func TestRejoinWithDifferentName(t *testing.T) {
+	procAttr := new(os.ProcAttr)
+	procAttr.Files = []*os.File{nil, os.Stdout, os.Stderr}
+
+	clusterSize := 5
+	argGroup, etcds, err := CreateCluster(clusterSize, procAttr, false)
+
+	if err != nil {
+		t.Fatal("cannot create cluster")
+	}
+
+	defer DestroyCluster(etcds)
+
+	time.Sleep(2 * time.Second)
+
+	c := etcd.NewClient(nil)
+
+	c.SyncCluster()
+
+	num := rand.Int() % clusterSize
+	fmt.Println("kill node", num+1)
+
+	// kill
+	etcds[num].Kill()
+	etcds[num].Release()
+	time.Sleep(time.Second)
+
+	// restart
+	etcds[num], err = os.StartProcess(EtcdBinPath, argGroup[num], procAttr)
+	if err != nil {
+		panic(err)
+	}
+
+	timer := time.AfterFunc(time.Second, func (){
+		etcds[num].Kill()
+		etcds[num].Release()
+		etcds[num] = nil
+		t.Fatal("new etcd should fail immediately")
+	})
+	etcds[num].Wait()
+	timer.Stop()
+}

--- a/tests/functional/util.go
+++ b/tests/functional/util.go
@@ -143,6 +143,9 @@ func CreateCluster(size int, procAttr *os.ProcAttr, ssl bool) ([][]string, []*os
 // Destroy all the nodes in the cluster
 func DestroyCluster(etcds []*os.Process) error {
 	for _, etcd := range etcds {
+		if etcd == nil {
+			continue
+		}
 		err := etcd.Kill()
 		if err != nil {
 			panic(err.Error())


### PR DESCRIPTION
Or it will confuse the cluster, especially the heartbeat between nodes.
