### PR TITLE
scripts/simple-cluster

### DIFF
--- a/scripts/simple-cluster
+++ b/scripts/simple-cluster
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+die() {
+	echo 1>&2 "usage: etcd-simple <member #> <discovery url>"
+	exit 1
+}
+
+set -e
+
+n=$1
+durl=$2
+
+(test -z "$n" || test -z "$durl") && die
+
+./bin/etcd -peer-addr 127.0.0.1:700$n -addr 127.0.0.1:400$n -discovery=$durl -data-dir machines/machine$n -name machine$n


### PR DESCRIPTION
This script is intended to make setting up Etcd clusters on your development machine faster, and easier.
