### PR TITLE
fix(mod/dashboard): Adding SVG MimeType

### DIFF
--- a/mod/dashboard/dashboard.go
+++ b/mod/dashboard/dashboard.go
@@ -23,6 +23,9 @@ func memoryFileServer(w http.ResponseWriter, req *http.Request) {
 	if file == "browser" || file == "stats" {
 		file = file + ".html"
 	}
+	if len(file) > 4 && file[len(file)-4:] == ".svg" {
+		w.Header().Set("Content-Type", "image/svg+xml")
+	}
 	upath = path.Join(dir, file)
 	b, err := resources.Asset(upath)
 


### PR DESCRIPTION
Adding mimetype (`img/svg+xml`) to SVG images so that they display properly in the dashboard on chrome.
