### PR TITLE
dashboard: remove protocol from google fonts links so they work with https

### DIFF
--- a/mod/dashboard/app/index.html
+++ b/mod/dashboard/app/index.html
@@ -7,8 +7,8 @@
     <title>etcd dashboard</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
-    <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,400italic,600,700,900" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600,700" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,400italic,600,700,900" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600,700" rel="stylesheet" type="text/css">
     <!-- build:css styles/styles.css -->
     <link rel="stylesheet" href="styles/bootstrap.css">
     <link rel="stylesheet" href="styles/main.css">


### PR DESCRIPTION
When an etcd cluster is secured with client certs, the dashboard will fail to load fonts and show the following error in the developer console:

```
[blocked] The page at 'https://etcd:4001/mod/dashboard/' was loaded over HTTPS, but ran insecure content from 'http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,400italic,600,700,900': this content should also be loaded over HTTPS.
 54.215.11.69/:10
[blocked] The page at 'https://etcd:4001/mod/dashboard/' was loaded over HTTPS, but ran insecure content from 'http://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600,700': this content should also be loaded over HTTPS.
```

Removing the protocols from the links will allow them to be loaded over HTTP or HTTPS.
