### PR TITLE
fix(Dockerfile): debconf use noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:12.04
 # Let's install go just like Docker (from source).
 RUN apt-get update -q
-RUN apt-get install -qy build-essential curl git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy build-essential curl git
 RUN curl -s https://go.googlecode.com/files/go1.2.src.tar.gz | tar -v -C /usr/local -xz
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 ENV PATH /usr/local/go/bin:$PATH


### PR DESCRIPTION
DEBIAN_FRONTEND=noninteractive tells apt-get install to use the
noninteractive front end for debconf. This keeps the system from
attempting to interact with the user during package configuration.
Without it, debconf issues warnings like:

```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (@INC contains:
/etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2
/usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14
/usr/local/lib/site_perl .) at
/usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
```
