### PR TITLE
fix(peer join) fix wrong join command redirection

### DIFF
--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -510,15 +510,15 @@ func (s *PeerServer) joinByPeer(server raft.Server, peer string, scheme string) 
 			if resp.StatusCode == http.StatusTemporaryRedirect {
 				address := resp.Header.Get("Location")
 				log.Debugf("Send Join Request to %s", address)
-				c := &JoinCommandV1{
+				c := &JoinCommandV2{
 					MinVersion: store.MinVersion(),
 					MaxVersion: store.MaxVersion(),
 					Name:       server.Name(),
-					RaftURL:    s.Config.URL,
-					EtcdURL:    s.server.URL(),
+					PeerURL:    s.Config.URL,
+					ClientURL:  s.server.URL(),
 				}
 				json.NewEncoder(&b).Encode(c)
-				resp, _, err = t.Post(address, &b)
+				resp, _, err = t.Put(address, &b)
 
 			} else if resp.StatusCode == http.StatusBadRequest {
 				log.Debug("Reach max number peers in the cluster")

--- a/server/transporter.go
+++ b/server/transporter.go
@@ -247,6 +247,13 @@ func (t *transporter) Get(urlStr string) (*http.Response, *http.Request, error) 
 	return resp, req, err
 }
 
+// Send server side PUT request
+func (t *transporter) Put(urlStr string, body io.Reader) (*http.Response, *http.Request, error) {
+	req, _ := http.NewRequest("PUT", urlStr, body)
+	resp, err := t.client.Do(req)
+	return resp, req, err
+}
+
 // PostSnapshot posts a json format snapshot to the given url
 // The underlying HTTP transport has a minute level timeout
 func (t *transporter) PostSnapshot(url string, body io.Reader) (*http.Response, error) {


### PR DESCRIPTION
1. We use PUT request to do a V2 join. So we should redirect a PUT request rather than a POST.
2. /admin only accept V2Join request. Send out V2Join instead of V1Join.
