### PR TITLE
fix(server): avoid race conditions in Run/Stop

### DIFF
--- a/etcd/etcd_test.go
+++ b/etcd/etcd_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2013 CoreOS Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/coreos/etcd/config"
+)
+
+func TestRunStop(t *testing.T) {
+	path, _ := ioutil.TempDir("", "etcd-")
+	defer os.RemoveAll(path)
+
+	config := config.New()
+	config.Name = "ETCDTEST"
+	config.DataDir = path
+	config.Addr = "localhost:0"
+	config.Peer.Addr = "localhost:0"
+
+	if err := config.Sanitize(); err != nil {
+		t.Fatal(err)
+	}
+
+	etcd := New(config)
+	go etcd.Run()
+	<-etcd.ReadyNotify()
+	etcd.Stop()
+}

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,9 @@
 
 . ./build
 
+go test -i ./etcd
+go test -v ./etcd -race
+
 go test -i ./http
 go test -v ./http -race
 


### PR DESCRIPTION
- don't close ready channel until PeerServer is listening.
  avoids possible panic in Stop() if PeerServer is nil.
- avoid data race in Run() (err variable was shared between 2 goroutines)
- avoid data race in PeerServer Start/Stop (PeerServer.closeChan)
