### PR TITLE
Fix non-HTTPS link

### DIFF
--- a/mod/dashboard/app/index.html
+++ b/mod/dashboard/app/index.html
@@ -26,7 +26,7 @@
     <div id="footer">
       <div id="powered-by" class="text-center">Powered by <a href="https://github.com/coreos/etcd" tabindex="-1">etcd</a></div>
       <div id="coreos-logo">
-        <a href="http://coreos.com" tabindex="-1"><img src="images/logo.svg"/></a>
+        <a href="https://coreos.com" tabindex="-1"><img src="images/logo.svg"/></a>
       </div>
     </div>
 


### PR DESCRIPTION
The CoreOS link at the bottom of the dashboard was using HTTPS. When Etcd is configured with SSL the browser gives a warning that not all content is secure. This is the only thing on the page that is not secure and since CoreOS has SSL available on the site, it's an easy fix.
