### PR TITLE
fix(tests/v1_migration): correct HTTP response

### DIFF
--- a/tests/functional/v1_migration_test.go
+++ b/tests/functional/v1_migration_test.go
@@ -95,7 +95,7 @@ func TestV1ClusterMigration(t *testing.T) {
 	body := tests.ReadBody(resp)
 	assert.Nil(t, err, "")
 	assert.Equal(t, resp.StatusCode, http.StatusNotFound)
-	assert.Equal(t, string(body), `{"errorCode":100,"message":"Key not found","cause":"/message","index":10}`+"\n")
+	assert.Equal(t, string(body), `{"errorCode":100,"message":"Key not found","cause":"/message","index":11}`+"\n")
 
 	// Ensure TTL'd message is removed.
 	resp, err = tests.Get("http://localhost:4001/v2/keys/foo")


### PR DESCRIPTION
The bug is introduced in 03839ca8 due to the mistake.
