### PR TITLE
fix(store.go) include node.dir = true when updating a directory's ttl

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -432,9 +432,13 @@ func (s *store) Update(nodePath string, newValue string, expireTime time.Time) (
 
 	n.Write(newValue, nextIndex)
 
-	// copy the value for safety
-	newValueCopy := ustrings.Clone(newValue)
-	eNode.Value = &newValueCopy
+	if n.IsDir() {
+		eNode.Dir = true
+	} else {
+		// copy the value for safety
+		newValueCopy := ustrings.Clone(newValue)
+		eNode.Value = &newValueCopy
+	}
 
 	// update ttl
 	n.UpdateTTL(expireTime)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -287,8 +287,9 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 
 	s.Create("/foo", true, "", false, Permanent)
 	s.Create("/foo/bar", false, "baz", false, Permanent)
-	_, err := s.Update("/foo", "", time.Now().Add(500*time.Millisecond))
-	e, _ := s.Get("/foo/bar", false, false)
+	e, err := s.Update("/foo", "", time.Now().Add(500*time.Millisecond))
+	assert.Equal(t, e.Node.Dir, true, "")
+	e, _ = s.Get("/foo/bar", false, false)
 	assert.Equal(t, *e.Node.Value, "baz", "")
 
 	time.Sleep(600 * time.Millisecond)


### PR DESCRIPTION
Fixes coreos/etcd#736
