### PR TITLE
tests(snapshot): expand reasonable range for index

### DIFF
--- a/tests/functional/simple_snapshot_test.go
+++ b/tests/functional/simple_snapshot_test.go
@@ -56,7 +56,7 @@ func TestSnapshot(t *testing.T) {
 
 	index, _ := strconv.Atoi(snapshots[0].Name()[2:5])
 
-	if index < 507 || index > 515 {
+	if index < 503 || index > 515 {
 		t.Fatal("wrong name of snapshot :", snapshots[0].Name())
 	}
 
@@ -89,7 +89,7 @@ func TestSnapshot(t *testing.T) {
 
 	index, _ = strconv.Atoi(snapshots[0].Name()[2:6])
 
-	if index < 1014 || index > 1025 {
+	if index < 1010 || index > 1025 {
 		t.Fatal("wrong name of snapshot :", snapshots[0].Name())
 	}
 }


### PR DESCRIPTION
snapshot file was createed with name '0_503.ss' and '0_1010.ss' when testing.

Found when testing #764
