### PR TITLE
fix(TestV2Watch): ensure server has started

### DIFF
--- a/server/v2/tests/get_handler_test.go
+++ b/server/v2/tests/get_handler_test.go
@@ -90,6 +90,13 @@ func TestV2GetKeyRecursively(t *testing.T) {
 //
 func TestV2WatchKey(t *testing.T) {
 	tests.RunServer(func(s *server.Server) {
+		// There exists a little gap between etcd ready to serve and
+		// it actually serves the first request, which means the response
+		// delay could be a little bigger.
+		// This test is time sensitive, so it does one request to ensure
+		// that the server is working.
+		tests.Get(fmt.Sprintf("%s%s", s.URL(), "/v2/keys/foo/bar"))
+
 		var watchResp *http.Response
 		c := make(chan bool)
 		go func() {


### PR DESCRIPTION
bug fix to pass tests.
It doesn't appear in autotest for my own branch, but happens in master one.

The bug is introduced in #775.
The old implementation always waits for 50ms to ensure server has started, and I propose that it is just needed for time-sensitive tests.
