### PR TITLE
fix(server/v2): set correct content-type for etcdError response

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -143,5 +143,6 @@ func (e Error) Write(w http.ResponseWriter) {
 			status = http.StatusInternalServerError
 		}
 	}
-	http.Error(w, e.toJsonString(), status)
+	w.WriteHeader(status)
+	fmt.Fprintln(w, e.toJsonString())
 }

--- a/server/v2/tests/get_handler_test.go
+++ b/server/v2/tests/get_handler_test.go
@@ -24,12 +24,15 @@ func TestV2GetKey(t *testing.T) {
 		v.Set("value", "XXX")
 		fullURL := fmt.Sprintf("%s%s", s.URL(), "/v2/keys/foo/bar")
 		resp, _ := tests.Get(fullURL)
+		assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 		assert.Equal(t, resp.StatusCode, http.StatusNotFound)
 
 		resp, _ = tests.PutForm(fullURL, v)
+		assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 		tests.ReadBody(resp)
 
 		resp, _ = tests.Get(fullURL)
+		assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 		assert.Equal(t, resp.StatusCode, http.StatusOK)
 		body := tests.ReadBodyJSON(resp)
 		assert.Equal(t, body["action"], "get", "")


### PR DESCRIPTION
"net/http".Error reset the content type, so we get rid of it and
write our own one.

fixes #469
