### PR TITLE
Enable handling URIs with trailing slashes

### DIFF
--- a/server/peer_server.go
+++ b/server/peer_server.go
@@ -337,6 +337,7 @@ func (s *PeerServer) RemoveNotify() <-chan bool {
 
 func (s *PeerServer) HTTPHandler() http.Handler {
 	router := mux.NewRouter()
+	router.StrictSlash(true)
 
 	// internal commands
 	router.HandleFunc("/name", s.NameHttpHandler)


### PR DESCRIPTION
fix(server/peer_server): Enable API server to handle trailing slashes

Fixes #826
This sets StrictSlash to true, which enables redirecting /config/ to /config. This prevents the server from throwing and error.
