### PR TITLE
docs(libraries-and-tools.md) Add vulcan proxy and kubernetes

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -90,3 +90,5 @@ A detailed recap of client functionalities can be found in the [clients compatib
 - [configdb](https://git.autistici.org/ai/configdb/tree/master) - A REST relational abstraction on top of arbitrary database backends, aimed at storing configs and inventories.
 - [scrz](https://github.com/scrz/scrz) - Container manager, stores configuration in etcd.
 - [fleet](https://github.com/coreos/fleet) - Distributed init system
+- [GoogleCloudPlatform/kubernetes](https://github.com/GoogleCloudPlatform/kubernetes) - Container cluster manager.
+- [mailgun/vulcand](https://github.com/mailgun/vulcand) - HTTP proxy that uses etcd as a configuration backend.


### PR DESCRIPTION
Both vulcan proxy (vulcand) and Google kubernetes utilize etcd as
as storage engine.
