### PR TITLE
fix(peer_server) set content type to application/json in admin

### DIFF
--- a/server/peer_server_handlers.go
+++ b/server/peer_server_handlers.go
@@ -188,6 +188,7 @@ func (ps *PeerServer) RemoveHttpHandler(w http.ResponseWriter, req *http.Request
 
 // Returns a JSON-encoded cluster configuration.
 func (ps *PeerServer) getClusterConfigHttpHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ps.ClusterConfig())
 }
 
@@ -217,6 +218,7 @@ func (ps *PeerServer) setClusterConfigHttpHandler(w http.ResponseWriter, req *ht
 	log.Debugf("[recv] Update Cluster Config Request")
 	ps.server.Dispatch(c, w, req)
 
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ps.ClusterConfig())
 }
 
@@ -230,6 +232,7 @@ func (ps *PeerServer) getMachinesHttpHandler(w http.ResponseWriter, req *http.Re
 		}
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(&machines)
 }
 
@@ -237,6 +240,7 @@ func (ps *PeerServer) getMachinesHttpHandler(w http.ResponseWriter, req *http.Re
 func (ps *PeerServer) getMachineHttpHandler(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	m := ps.getMachineMessage(vars["name"], ps.raftServer.Leader())
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(m)
 }
 

--- a/tests/functional/cluster_config_test.go
+++ b/tests/functional/cluster_config_test.go
@@ -25,6 +25,7 @@ func TestClusterConfigSet(t *testing.T) {
 	resp, _ = tests.Get("http://localhost:7002/v2/admin/config")
 	body := tests.ReadBodyJSON(resp)
 	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 	assert.Equal(t, body["activeSize"], 3)
 	assert.Equal(t, body["removeDelay"], 60)
 }
@@ -44,6 +45,7 @@ func TestClusterConfigReload(t *testing.T) {
 	resp, _ = tests.Get("http://localhost:7002/v2/admin/config")
 	body := tests.ReadBodyJSON(resp)
 	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 	assert.Equal(t, body["activeSize"], 3)
 	assert.Equal(t, body["removeDelay"], 60)
 
@@ -59,6 +61,7 @@ func TestClusterConfigReload(t *testing.T) {
 	resp, _ = tests.Get("http://localhost:7002/v2/admin/config")
 	body = tests.ReadBodyJSON(resp)
 	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 	assert.Equal(t, body["activeSize"], 3)
 	assert.Equal(t, body["removeDelay"], 60)
 }
@@ -76,6 +79,7 @@ func TestGetMachines(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Equal(t, resp.StatusCode, 200)
+	assert.Equal(t, resp.Header.Get("Content-Type"), "application/json")
 	machines := make([]map[string]interface{}, 0)
 	b := tests.ReadBody(resp)
 	json.Unmarshal(b, &machines)


### PR DESCRIPTION
Fixes #853

This sets the `Content-Type` header to `application/json` for the /v2/admin/ urls. 
