### PR TITLE
feat(get): get from quorum

### DIFF
--- a/server/v2/get_handler.go
+++ b/server/v2/get_handler.go
@@ -17,6 +17,14 @@ func GetHandler(w http.ResponseWriter, req *http.Request, s Server) error {
 	vars := mux.Vars(req)
 	key := "/" + vars["key"]
 
+	recursive := (req.FormValue("recursive") == "true")
+	sort := (req.FormValue("sorted") == "true")
+
+	if req.FormValue("quorum") == "true" {
+		c := s.Store().CommandFactory().CreateGetCommand(key, recursive, sort)
+		return s.Dispatch(c, w, req)
+	}
+
 	// Help client to redirect the request to the current leader
 	if req.FormValue("consistent") == "true" && s.State() != raft.Leader {
 		leader := s.Leader()
@@ -35,8 +43,6 @@ func GetHandler(w http.ResponseWriter, req *http.Request, s Server) error {
 		return nil
 	}
 
-	recursive := (req.FormValue("recursive") == "true")
-	sort := (req.FormValue("sorted") == "true")
 	waitIndex := req.FormValue("waitIndex")
 	stream := (req.FormValue("stream") == "true")
 

--- a/store/command_factory.go
+++ b/store/command_factory.go
@@ -24,6 +24,7 @@ type CommandFactory interface {
 		prevIndex uint64, expireTime time.Time) raft.Command
 	CreateCompareAndDeleteCommand(key string, prevValue string, prevIndex uint64) raft.Command
 	CreateSyncCommand(now time.Time) raft.Command
+	CreateGetCommand(key string, recursive, sorted bool) raft.Command
 }
 
 // RegisterCommandFactory adds a command factory to the global registry.

--- a/store/v2/command_factory.go
+++ b/store/v2/command_factory.go
@@ -89,3 +89,11 @@ func (f *CommandFactory) CreateSyncCommand(now time.Time) raft.Command {
 		Time: time.Now(),
 	}
 }
+
+func (f *CommandFactory) CreateGetCommand(key string, recursive, sorted bool) raft.Command {
+	return &GetCommand{
+		Key:       key,
+		Recursive: recursive,
+		Sorted:    sorted,
+	}
+}

--- a/store/v2/get_command.go
+++ b/store/v2/get_command.go
@@ -1,0 +1,35 @@
+package v2
+
+import (
+	"github.com/coreos/etcd/log"
+	"github.com/coreos/etcd/store"
+	"github.com/coreos/etcd/third_party/github.com/goraft/raft"
+)
+
+func init() {
+	raft.RegisterCommand(&GetCommand{})
+}
+
+// The GetCommand gets a key from the Store.
+type GetCommand struct {
+	Key       string `json:"key"`
+	Recursive bool   `json:"recursive"`
+	Sorted    bool   `json:sorted`
+}
+
+// The name of the get command in the log
+func (c *GetCommand) CommandName() string {
+	return "etcd:get"
+}
+
+// Get the key
+func (c *GetCommand) Apply(context raft.Context) (interface{}, error) {
+	s, _ := context.Server().StateMachine().(store.Store)
+	e, err := s.Get(c.Key, c.Recursive, c.Sorted)
+
+	if err != nil {
+		log.Debug(err)
+		return nil, err
+	}
+	return e, nil
+}


### PR DESCRIPTION
@bmizerany @philips 

I do not suggest people to use this function unless they know exactly what they want.
This is just for `linearizability` in real time order. `Index` is a better indication of the actual order of events.
Nothing to do with etcd's write consensus/consistency model. 
