### PR TITLE
server: Flush headers when using wait=true and stream=true

### DIFF
--- a/server/v2/get_handler.go
+++ b/server/v2/get_handler.go
@@ -68,6 +68,7 @@ func handleWatch(key string, recursive, stream bool, waitIndex string, w http.Re
 	closeChan := cn.CloseNotify()
 
 	writeHeaders(w, s)
+	w.(http.Flusher).Flush()
 
 	if stream {
 		// watcher hub will not help to remove stream watcher


### PR DESCRIPTION
Many http clients will missbehave unless they get an initial http-
response, even when long-polling. It also saves the user/client from
having to handle headers on the first action of the watch, but rather
handle the response immediately.
