### PR TITLE
improve the out-of-box experience for people using coreos/etcd container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ ENV PATH /usr/local/go/bin:$PATH
 ADD . /opt/etcd
 RUN cd /opt/etcd && ./build
 EXPOSE 4001 7001
-ENTRYPOINT ["/opt/etcd/bin/etcd"]
-
+ENTRYPOINT ["/opt/etcd/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+IP_ADDR=$(ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
+
+exec /opt/etcd/bin/etcd -addr $IP_ADDR:4001 -peer-addr $IP_ADDR:7001 "$@"


### PR DESCRIPTION
Currently spinning up one container with `docker run coreos/etcd` will allow
you to connect (etcd is listening on the container's eth0 IP), but many
client libraries will generate strange errors because the advertised addresses
default to 127.0.0.1.

It would be unfortunate if people decided etcd wasn't worth the trouble
just because they couldn't get the simplest-possible configuration working.

This can be easily fixed in this
single-container-with-no-additional-args scenario by adding a wrapper
script that looks up the container's eth0 IP and advertises that.

It still allows overriding if -addr and/or -peer-addr are supplied in
the docker run call.
