### PR TITLE
Added Access-Control-Allow-Headers for CORS requests

### DIFF
--- a/http/cors.go
+++ b/http/cors.go
@@ -54,6 +54,7 @@ type CORSHandler struct {
 func (h *CORSHandler) addHeader(w http.ResponseWriter, origin string) {
 	w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 	w.Header().Add("Access-Control-Allow-Origin", origin)
+	w.Header().Add("Access-Control-Allow-Headers", "accept, content-type")
 }
 
 // ServeHTTP adds the correct CORS headers based on the origin and returns immediately


### PR DESCRIPTION
Specifying Content-Type, for instance, on a CORS request would cause the request to be rejected.

For example, in Angular.js, the default is to send Content-Type when using $http.put(). This would result in the following error:

Request header field Content-Type is not allowed by Access-Control-Allow-Headers
