### PR TITLE
fix(docs): name defaults to uuid not hostname

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -26,7 +26,7 @@ The full documentation is contained in the [API docs](https://github.com/coreos/
 
 ### Required
 
-* `-name` - The node name. Defaults to the hostname.
+* `-name` - The node name. Defaults to a UUID.
 
 ### Optional
 


### PR DESCRIPTION
I wish this page -name does not default to hostname - it defaults to a UUID like value
