### PR TITLE
config: increase default election timeout to 1200 ms

### DIFF
--- a/config/timeout.go
+++ b/config/timeout.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	// The amount of time (in ms) to elapse without a heartbeat before becoming a candidate
-	defaultElectionTimeout = 200
+	defaultElectionTimeout = 1200
 
 	// The frequency (in ms) by which heartbeats are sent to followers.
 	defaultHeartbeatInterval = 50


### PR DESCRIPTION
This is the value we have been using on EC2, OpenStack, and Rackspace.
Part of the reason why I have been able to trigger a bug in go-raft
seems to be the leader thrashing that is happening on my GCE test
clusters right now.

Mostly I am posting this to start a discussion on what the default
timeouts really should be, the current values are clearly not well
suited for virtual machines which is our primary target. The tuning
document describes determining values in terms of ping time but the ping
time between these GCE systems is under 1 ms.

So what should the values actually be? What should the tuning document
suggest as a metric for choosing more precise values?
