### PR TITLE
docs: set snapshot to be true in default configuration

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -84,7 +84,7 @@ max_cluster_size = 9
 max_result_buffer = 1024
 max_retry_attempts = 3
 name = "default-name"
-snapshot = false
+snapshot = true
 verbose = false
 very_verbose = false
 


### PR DESCRIPTION
If snapshot is false, it will consume much memory and become rather
slow after several days. Make it on as default.
#915
