### PR TITLE
Documentation: fix timeout tuning TOML example

### DIFF
--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -41,7 +41,7 @@ Or you can set the values within the configuration file:
 ```toml
 [peer]
 heartbeat_interval = 100
-election_timeout = 100
+election_timeout = 500
 ```
 
 The values are specified in milliseconds.


### PR DESCRIPTION
this makes the TOML example for tuning the peer election timeout consistent
with the guide's advice and with the other examples.
