### PR TITLE
Update clients-matrix.md

### DIFF
--- a/Documentation/clients-matrix.md
+++ b/Documentation/clients-matrix.md
@@ -14,21 +14,6 @@ The v2 API has a lot of features, we will categorize them in a few categories:
 - **GET,PUT,POST,DEL Features**: Support for all the modifiers when calling the etcd server with said HTTP method.
 
 ### Supported features matrix
-<<<<<<< HEAD
-=======
-
-| Client| [go-etcd](https://github.com/coreos/go-etcd) | [jetcd](https://github.com/diwakergupta/jetcd) | [python-etcd](https://github.com/jplana/python-etcd) | [python-etcd-client](https://github.com/dsoprea/PythonEtcdClient) | [node-etcd](https://github.com/stianeikeland/node-etcd) | [nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) | [etcd-ruby](https://github.com/ranjib/etcd-ruby) | [etcd-api](https://github.com/jdarcy/etcd-api) | [cetcd](https://github.com/dwwoelfel/cetcd) |  [clj-etcd](https://github.com/rthomas/clj-etcd) | [etcetera](https://github.com/drusellers/etcetera)| [Etcd.jl](https://github.com/forio/Etcd.jl) | [p5-etcd](https://metacpan.org/release/Etcd) | [etcdcpp](https://github.com/edwardcapriolo/etcdcpp)  | [etcd-clojure](https://github.com/aterreno/etcd-clojure)
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
-| **HTTPS Auth**    | Y | Y | Y | Y | Y | Y | - | - | - | - | - | - | - | - | - |
-| **Reconnect**     | Y | - | Y | Y | - | - | - | Y | - | - | - | - | - | - | - |
-| **Mod/Lock**      | - | - | Y | Y | - | - | - | - | - | - | - | Y | - | - | - |
-| **Mod/Leader**    | - | - | - | Y | - | - | - | - | - | - | - | Y | - | - | - |
-| **GET Features**  | F | B | F | F | F | F | F | B | F | G | F | F | F | F | F |
-| **PUT Features**  | F | B | F | F | F | F | F | G | F | G | F | F | F | F | F |
-| **POST Features** | F | - | F | F | - | F | F | - | - | - | F | F | F | G | F |
-| **DEL Features**  | F | B | F | F | F | F | F | B | G | B | F | F | F | - | F |
-
->>>>>>> master
 **Legend**
 **F**: Full support **G**: Good support **B**: Basic support
 **Y**: Feature supported  **-**: Feature not supported


### PR DESCRIPTION
Swapped the clients with the features on the clients matrix so it is more comprehensible. The old version got too large to show on the screen. This new layout added a language column so you can quickly see the language of the client library.

Also moved v1-only clients to the bottom since v2 is what most people are looking for today.

Compare this new version:
https://github.com/jurmous/etcd/blob/patch-3/Documentation/clients-matrix.md

With the current:
https://github.com/coreos/etcd/blob/master/Documentation/clients-matrix.md
