### PR TITLE
Update clients-matrix.md

### DIFF
--- a/Documentation/clients-matrix.md
+++ b/Documentation/clients-matrix.md
@@ -3,6 +3,41 @@
 As etcd features support is really uneven between client libraries, a compatibility matrix can be important.
 We will consider in detail only the features of clients supporting the v2 API. Clients still supporting the v1 API *only* are listed below.
 
+## v2 clients
+
+The v2 API has a lot of features, we will categorize them in a few categories:
+- **Language**: The language in which the client library was written.
+- **HTTPS Auth**: Support for SSL-certificate based authentication
+- **Reconnect**: If the client is able to reconnect automatically to another server if one fails.
+- **Mod/Lock**: Support for the locking module
+- **Mod/Leader**: Support for the leader election module
+- **GET,PUT,POST,DEL Features**: Support for all the modifiers when calling the etcd server with said HTTP method.
+
+### Supported features matrix
+**Legend**
+**F**: Full support **G**: Good support **B**: Basic support
+**Y**: Feature supported  **-**: Feature not supported
+
+Sorted alphabetically on language/name
+
+|Client |**Language**|**HTTPS Auth**|**Re-connect**|**GET**|**PUT**|**POST**|**DEL**|**Mod Lock**|**Mod Leader**|
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
+|[etcd-api](https://github.com/jdarcy/etcd-api)                   |C      |-|Y|B|G|-|B|-|-|
+|[etcdcpp](https://github.com/edwardcapriolo/etcdcpp)             |C++    |-|-|F|F|G|-|-|-|
+|[cetcd](https://github.com/dwwoelfel/cetcd)                      |Clojure|-|-|F|F|-|G|-|-|
+|[clj-etcd](https://github.com/rthomas/clj-etcd)                  |Clojure|-|-|G|G|-|B|-|-|
+|[etcd-clojure](https://github.com/aterreno/etcd-clojure)         |Clojure|-|-|F|F|F|F|-|-|
+|[go-etcd](https://github.com/coreos/go-etcd)                     |go     |Y|Y|F|F|F|F|-|-|
+|[jetcd](https://github.com/diwakergupta/jetcd)                   |java   |Y|-|B|B|-|B|-|-|
+|[Etcd.jl](https://github.com/forio/Etcd.jl)                      |Julia  |-|-|F|F|F|F|Y|Y|
+|[etcetera](https://github.com/drusellers/etcetera)               |.net   |-|-|F|F|F|F|-|-|
+|[node-etcd](https://github.com/stianeikeland/node-etcd)          |nodejs |Y|-|F|F|-|F|-|-|
+|[nodejs-etcd](https://github.com/lavagetto/nodejs-etcd)          |nodejs |Y|-|F|F|F|F|-|-|
+|[p5-etcd](https://metacpan.org/release/Etcd)                     |perl   |-|-|F|F|F|F|-|-|
+|[python-etcd](https://github.com/jplana/python-etcd)             |python |Y|Y|F|F|F|F|Y|-|
+|[python-etcd-client](https://github.com/dsoprea/PythonEtcdClient)|python |Y|Y|F|F|F|F|Y|Y|
+|[etcd-ruby](https://github.com/ranjib/etcd-ruby)                 |ruby   |-|-|F|F|F|F|-|-|
+
 ## v1-only clients
 
 Clients supporting only the API version 1
@@ -13,33 +48,3 @@ Clients supporting only the API version 1
 - [iconara/etcd-rb](https://github.com/iconara/etcd-rb) Ruby
 - [jpfuentes2/etcd-ruby](https://github.com/jpfuentes2/etcd-ruby) Ruby
 - [marshall-lee/etcd.erl](https://github.com/marshall-lee/etcd.erl) Erlang
-
-
-## v2 clients
-
-The v2 API has a lot of features, we will categorize them in a few categories:
-
-- **HTTPS Auth**: Support for SSL-certificate based authentication
-- **Reconnect**: If the client is able to reconnect automatically to another server if one fails.
-- **Mod/Lock**: Support for the locking module
-- **Mod/Leader**: Support for the leader election module
-- **GET,PUT,POST,DEL Features**: Support for all the modifiers when calling the etcd server with said HTTP method.
-
-
-### Supported features matrix
-
-| Client| [go-etcd](https://github.com/coreos/go-etcd) | [jetcd](https://github.com/diwakergupta/jetcd) | [python-etcd](https://github.com/jplana/python-etcd) | [python-etcd-client](https://github.com/dsoprea/PythonEtcdClient) | [node-etcd](https://github.com/stianeikeland/node-etcd) | [nodejs-etcd](https://github.com/lavagetto/nodejs-etcd) | [etcd-ruby](https://github.com/ranjib/etcd-ruby) | [etcd-api](https://github.com/jdarcy/etcd-api) | [cetcd](https://github.com/dwwoelfel/cetcd) |  [clj-etcd](https://github.com/rthomas/clj-etcd) | [etcetera](https://github.com/drusellers/etcetera)| [Etcd.jl](https://github.com/forio/Etcd.jl) | [p5-etcd](https://metacpan.org/release/Etcd) | [etcdcpp](https://github.com/edwardcapriolo/etcdcpp)  | [etcd-clojure](https://github.com/aterreno/etcd-clojure)
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
-| **HTTPS Auth**    | Y | Y | Y | Y | Y | Y | - | - | - | - | - | - | - | - | - |
-| **Reconnect**     | Y | - | Y | Y | - | - | - | Y | - | - | - | - | - | - | - |
-| **Mod/Lock**      | - | - | Y | Y | - | - | - | - | - | - | - | Y | - | - | - |
-| **Mod/Leader**    | - | - | - | Y | - | - | - | - | - | - | - | Y | - | - | - |
-| **GET Features**  | F | B | F | F | F | F | F | B | F | G | F | F | F | F | F |
-| **PUT Features**  | F | B | F | F | F | F | F | G | F | G | F | F | F | F | F |
-| **POST Features** | F | - | F | F | - | F | F | - | - | - | F | F | F | G | F |
-| **DEL Features**  | F | B | F | F | F | F | F | B | G | B | F | F | F | - | F |
-
-**Legend**
-
-**F**: Full support **G**: Good support **B**: Basic support
-**Y**: Feature supported  **-**: Feature not supported


### PR DESCRIPTION
Something went wrong while squashing (Was first squash) So this is a new squashed pull request of the discussed changes in issue #958 

---

Swapped the clients with the features on the clients matrix so it is more comprehensible. The old version got too large to show on the screen. This new layout added a language column so you can quickly see the language of the client library.

Also moved v1-only clients to the bottom since v2 is what most people are looking for today.

Compare this new version:
https://github.com/jurmous/etcd/blob/patch-3/Documentation/clients-matrix.md

With the current:
https://github.com/coreos/etcd/blob/master/Documentation/clients-matrix.md
