### PR TITLE
Documentation: Clarify etcd security documentation

### DIFF
--- a/Documentation/security.md
+++ b/Documentation/security.md
@@ -1,34 +1,50 @@
-# Reading and Writing over HTTPS
+# Etcd security model
 
-## Transport Security with HTTPS
+Etcd supports SSL/TLS as well as authentication through client certificates, both for clients to server as well as peer (server to server / cluster) communication.
 
-Etcd supports SSL/TLS and client cert authentication for clients to server, as well as server to server communication.
+To get up and running you first need to have a CA certificate and a signed key pair for your node. It is recommended to create and sign a new key pair for every node in a cluster.
 
-First, you need to have a CA cert `clientCA.crt` and signed key pair `client.crt`, `client.key`.
-This site has a good reference for how to generate self-signed key pairs:
+For convenience the [etcd-ca](https://github.com/coreos/etcd-ca) tool provides an easy interface to certificate generation, alternatively this site provides a good reference on how to generate self-signed key pairs:
+
 http://www.g-loaded.eu/2005/11/10/be-your-own-ca/
-Or you could use [etcd-ca](https://github.com/coreos/etcd-ca) to generate certs and keys.
 
-For testing you can use the certificates in the `fixtures/ca` directory.
+## Basic setup
 
-Let's configure etcd to use this keypair:
+Etcd takes several certificate related configuration options, either through command-line flags or environment variables:
+
+**Client-to-server communication:**
+
+`--cert-file=<path>`: Certificate used for SSL/TLS connections **to** etcd. When this option is set, you can reach etcd through HTTPS - for example at `https://127.0.0.1:4001`  
+`--key-file=<path>`: Key for the certificate. Must be unencrypted.  
+`--ca-file=<path>`: When this is set etcd will check all incoming HTTPS requests for a client certificate signed by the supplied CA, requests that don't supply a valid client certificate will fail.
+
+**Peer (server-to-server / cluster) communication:**
+
+The peer options work the same way as the client-to-server options:
+
+`--peer-cert-file=<path>`: Certificate used for SSL/TLS connections between peers. This will be used both for listening on the peer address as well as sending requests to other peers.  
+`--peer-key-file=<path>`: Key for the certificate. Must be unencrypted.  
+`--peer-ca-file=<path>`: When set, etcd will check all incoming peer requests from the cluster for valid client certificates signed by the supplied CA.
+
+If either a client-to-server or peer certificate is supplied the key must also be set. All of these configuration options are also available through the environment variables, `ETCD_CA_FILE`, `ETCD_PEER_CA_FILE` and so on.
+
+## Example 1: Client-to-server transport security with HTTPS
+
+For this you need your CA certificate (`ca.crt`) and signed key pair (`server.crt`, `server.key`) ready. If you just want to test the functionality, there are example certificates provided in the [etcd git repository](https://github.com/coreos/etcd/tree/master/fixtures/ca) (namely `server.crt` and `server.key.insecure`).
+
+Assuming you have these files ready, let's configure etcd to use them to provide simple HTTPS transport security.
 
 ```sh
-./etcd -f -name machine0 -data-dir machine0 -cert-file=./fixtures/ca/server.crt -key-file=./fixtures/ca/server.key.insecure
+etcd -name machine0 -data-dir machine0 -cert-file=/path/to/server.crt -key-file=/path/to/server.key
 ```
 
-There are a few new options we're using:
-
-* `-f` - forces a new machine configuration, even if an existing configuration is found. (WARNING: data loss!)
-* `-cert-file` and `-key-file` specify the location of the cert and key files to be used for for transport layer security between the client and server.
-
-You can now test the configuration using HTTPS:
+This should start up fine and you can now test the configuration by speaking HTTPS to etcd:
 
 ```sh
-curl --cacert ./fixtures/ca/server-chain.pem https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
+curl --cacert /path/to/ca.crt https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
 ```
 
-You should be able to see the handshake succeed.
+You should be able to see the handshake succeed. Because we use self-signed certificates with our own certificate authorities you need to provide the CA to curl using the `--cacert` option. Another possibility would be to add your CA certificate to the trusted certificates on your system (usually in `/etc/ssl/certs`).
 
 **OSX 10.9+ Users**: curl 7.30.0 on OSX 10.9+ doesn't understand certificates passed in on the command line.
 Instead you must import the dummy ca.crt directly into the keychain or add the `-k` flag to curl to ignore errors.
@@ -36,42 +52,28 @@ If you want to test without the `-k` flag run `open ./fixtures/ca/ca.crt` and fo
 Please remove this certificate after you are done testing!
 If you know of a workaround let us know.
 
-```
-...
-SSLv3, TLS handshake, Finished (20):
-...
-```
+## Example 2: Client-to-server authentication with HTTPS client certificates
 
-And also the response from the etcd server:
+For now we've given the etcd client the ability to verify the server identity and provide transport security. We can however also use client certificates to prevent unauthorized access to etcd.
 
-```json
-{
-    "action": "set",
-    "key": "/foo",
-    "modifiedIndex": 3,
-    "value": "bar"
-}
-```
+The clients will provide their certificates to the server and the server will check whether the cert is signed by the supplied CA and decide whether to serve the request.
 
-
-## Authentication with HTTPS Client Certificates
-
-We can also do authentication using CA certs.
-The clients will provide their cert to the server and the server will check whether the cert is signed by the CA and decide whether to serve the request.
+You need the same files mentioned in the first example for this, as well as a key pair for the client (`client.crt`, `client.key`) signed by the same certificate authority.
 
 ```sh
-./etcd -f -name machine0 -data-dir machine0 -ca-file=./fixtures/ca/ca.crt -cert-file=./fixtures/ca/server.crt -key-file=./fixtures/ca/server.key.insecure
+etcd -name machine0 -data-dir machine0 -ca-file=/path/to/ca.crt -cert-file=/path/to/server.crt -key-file=/path/to/server.key
 ```
 
-```-ca-file``` is the path to the CA cert.
+Notice that the addition of the `-ca-file` option automatically enables client certificate checking.
 
-Try the same request to this server:
+
+Now try the same request as above to this server:
 
 ```sh
-curl --cacert ./fixtures/ca/server-chain.pem https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
+curl --cacert /path/to/ca.crt https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
 ```
 
-The request should be rejected by the server.
+The request should be rejected by the server:
 
 ```
 ...
@@ -79,10 +81,10 @@ routines:SSL3_READ_BYTES:sslv3 alert bad certificate
 ...
 ```
 
-We need to give the CA signed cert to the server.
+To make it succeed, we need to give the CA signed client certificate to the server:
 
 ```sh
-curl --key ./fixtures/ca/server2.key.insecure --cert ./fixtures/ca/server2.crt --cacert ./fixtures/ca/server-chain.pem -L https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
+curl --cacert /path/to/ca.crt --cert /path/to/client.crt --key /path/to/client.key -L https://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -v
 ```
 
 You should able to see:
@@ -108,7 +110,28 @@ And also the response from the server:
 }
 ```
 
-### Why SSLv3 alert handshake failure when using SSL client auth?
+## Example 3: Transport security & client certificates in a cluster
+
+Etcd supports the same model as above for **peer communication**, that means the communication between etcd nodes in a cluster.
+
+Assuming we have our `ca.crt` and two nodes with their own keypairs (`node1.crt` & `node1.key`, `node2.crt` & `node2.key`) signed by this CA, we launch etcd as follows:
+
+
+```sh
+DISCOVERY_URL=... # from https://discovery.etcd.io/new
+
+# Node1
+etcd -name node1 -data-dir node1 -ca-file=/path/to/ca.crt -cert-file=/path/to/node1.crt -key-file=/path/to/node1.key -peer-addr ${node1_public_ip}:7001 -discovery ${DISCOVERY_URL}
+
+# Node2
+etcd -name node1 -data-dir node2 -ca-file=/path/to/ca.crt -cert-file=/path/to/node2.crt -key-file=/path/to/node2.key -peer-addr ${node2_public_ip}:7001 -discovery ${DISCOVERY_URL}
+```
+
+The etcd nodes will form a cluster and all communication between nodes in the cluster will be encrypted and authenticated using the client certificates. You will see in the output of etcd that the addresses it connects to use HTTPS.
+
+## Frequently Asked Questions
+
+### I'm seeing a SSLv3 alert handshake failure when using SSL client authentication?
 
 The `crypto/tls` package of `golang` checks the key usage of the certificate public key before using it.
 To use the certificate public key to do client auth, we need to add `clientAuth` to `Extended Key Usage` when creating the certificate public key.
@@ -129,3 +152,8 @@ When creating the cert be sure to reference it in the `-extensions` flag:
 ```
 openssl ca -config openssl.cnf -policy policy_anything -extensions ssl_client -out certs/machine.crt -infiles machine.csr
 ```
+
+### With peer certificate authentication I receive "certificate is valid for 127.0.0.1, not $MY_IP"
+Make sure that you sign your certificates with a Subject Name your node's public IP address. The `etcd-ca` tool for example provides an `--ip=` option for its `new-cert` command.
+
+If you need your certificate to be signed for your node's FQDN in its Subject Name then you could use Subject Alternative Names (short IP SNAs) to add your IP address. This is not [currently supported](https://github.com/coreos/etcd-ca/issues/29) by `etcd-ca` but can be done [with openssl](http://wiki.cacert.org/FAQ/subjectAltName).


### PR DESCRIPTION
I set up all the security features in etcd in my sandbox cluster recently and felt that the documentation was a bit lacking, so this commit rewrites large parts of it.

You can see this rendered at: https://github.com/tazjin/etcd/blob/etcd-security-docs/Documentation/security.md

It's supposed to be structured as a _base introduction_ -> _clear examples_ -> _FAQ_.

The first FAQ question is the same that was in the old documentation - if somebody could check whether that issue is still relevant that'd be great (I personally haven't run into it).

Please comment if you think it could be improved or with other feedback.

//V
