### PR TITLE
docs: fix documentation for HTTP read/write timeouts

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -75,8 +75,8 @@ cors = []
 cpu_profile_file = ""
 data_dir = "."
 discovery = "http://etcd.local:4001/v2/keys/_etcd/registry/examplecluster"
-http_read_timeout = 10
-http_write_timeout = 10
+http_read_timeout = 10.0
+http_write_timeout = 10.0
 key_file = ""
 peers = []
 peers_file = ""
@@ -112,8 +112,8 @@ sync_interval = 5.0
  * `ETCD_CPU_PROFILE_FILE`
  * `ETCD_DATA_DIR`
  * `ETCD_DISCOVERY`
- * `ETCD_CLUSTER_HTTP_READ_TIMEOUT`
- * `ETCD_CLUSTER_HTTP_WRITE_TIMEOUT`
+ * `ETCD_HTTP_READ_TIMEOUT`
+ * `ETCD_HTTP_WRITE_TIMEOUT`
  * `ETCD_KEY_FILE`
  * `ETCD_PEERS`
  * `ETCD_PEERS_FILE`


### PR DESCRIPTION
The documentation for these options has been incorrect ever since their
addition via commit 084dcb55. This broke upgrading a CoreOS stable
cluster to 410.0.0 because the user was using the example TOML config
which contains:

```
http_write_timeout = 10
```

This was silently ignored in the old stable version which predates the
addition of these options. After upgrading etcd began failing with:

```
Type mismatch for 'config.Config.http_write_timeout': Expected float
but found 'int64’.
```

Original issue: https://github.com/coreos/update_engine/issues/45
