### PR TITLE
test: introduce test script

### DIFF
--- a/test
+++ b/test
@@ -1,0 +1,6 @@
+#!/bin/sh
+go test ./wal \
+	./snap \
+	./etcdserver/... \
+	./raft \
+	./store


### PR DESCRIPTION
Why do this? `go test ./...` has a ton of annoying output:

```
?       github.com/coreos/etcd  [no test files]
?       github.com/coreos/etcd/crc  [no test files]
?       github.com/coreos/etcd/elog [no test files]
?       github.com/coreos/etcd/error    [no test files] ok  
github.com/coreos/etcd/etcdserver   0.267s ok  
github.com/coreos/etcd/etcdserver/etcdhttp  0.022s
?       github.com/coreos/etcd/etcdserver/etcdserverpb  [no test files] ok  
github.com/coreos/etcd/raft 0.157s
?       github.com/coreos/etcd/raft/raftpb  [no test files] ok  
github.com/coreos/etcd/snap 0.018s
?       github.com/coreos/etcd/snap/snappb  [no test files] 
third_party/code.google.com/p/gogoprotobuf/proto/testdata/test.pb.go:1234: 
undefined: __emptyarchive__.Extension ok    github.com/coreos/etcd/store
4.247s ok github.com/coreos/etcd/third_party/code.google.com/p/go.net/context 
2.724s FAIL 
github.com/coreos/etcd/third_party/code.google.com/p/gogoprotobuf/proto
[build failed] ok 
github.com/coreos/etcd/third_party/github.com/stretchr/testify/assert 0.013s 
ok      github.com/coreos/etcd/wait 0.010s ok  
github.com/coreos/etcd/wal  0.024s
?       github.com/coreos/etcd/wal/walpb    [no test files]
```

And we have no had to manually configure drone.io which I want to avoid: 
https://drone.io/github.com/coreos/etcd/admin
