### PR TITLE
readme: updated build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ You can build etcd from source:
 ```sh
 git clone https://github.com/coreos/etcd
 cd etcd
-./build
+export GOPATH=${PWD}
+go get
+go build
 ```
 
 This will generate a binary called `./bin/etcd`.


### PR DESCRIPTION
The proper way to build etcd is with [go build] and not ./build

Fixes #994
