### PR TITLE
scripts: add build, cover and update test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage
 /gopath
 /go-bindata
 /machine*

--- a/build
+++ b/build
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+ORG_PATH="github.com/coreos"
+REPO_PATH="${ORG_PATH}/etcd"
+
+# If the user hasn't set up a GOPATH, make one for them
+if [[ -z "$GOPATH" ]]; then 
+	GOPATH=${PWD}/gopath
+	if [ ! -h gopath/src/${REPO_PATH} ]; then
+		mkdir -p gopath/src/${ORG_PATH}
+		ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+	fi
+	# Similarly, set up GOBIN if not already set
+	if [[ -z "$GOBIN" ]]; then 
+		GOBIN=${PWD}/bin
+	fi
+fi
+
+export GOPATH=$GOPATH
+export GOBIN=$GOBIN
+
+eval $(go env)
+
+go install ${REPO_PATH}

--- a/cover
+++ b/cover
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+#
+# Generate coverage HTML for a package
+# e.g. PKG=./unit ./cover
+#
+
+if [ -z "$PKG" ]; then
+	echo "cover only works with a single package, sorry"
+	exit 255
+fi
+
+COVEROUT="coverage"
+
+if ! [ -d "$COVEROUT" ]; then
+	mkdir "$COVEROUT"
+fi
+
+# strip leading dot/slash and trailing slash and sanitize other slashes
+# e.g. ./etcdserver/etcdhttp/ ==> etcdserver_etcdhttp
+COVERPKG=${PKG/#./}
+COVERPKG=${COVERPKG/#\//}
+COVERPKG=${COVERPKG/%\//}
+COVERPKG=${COVERPKG//\//_}
+
+# generate arg for "go test"
+export COVER="-coverprofile ${COVEROUT}/${COVERPKG}.out"
+
+source ./test
+
+go tool cover -html=${COVEROUT}/${COVERPKG}.out

--- a/test
+++ b/test
@@ -1,6 +1,50 @@
 #!/bin/sh
-go test ./wal \
-	./snap \
-	./etcdserver/... \
-	./raft \
-	./store
+#
+# Run all etcd tests
+# ./test
+# ./test -v
+#
+# Run tests for one package
+#
+# PKG=./wal ./test
+# PKG=snap ./test
+
+# Invoke ./cover for HTML output
+COVER=${COVER:-"-cover"}
+
+source ./build
+
+TESTABLE="wal snap etcdserver etcdserver/etcdhttp etcdserver/etcdserverpb raft store"
+FORMATTABLE="$TESTABLE cors.go main.go"
+
+# user has not provided PKG override
+if [ -z "$PKG" ]; then
+	TEST=$TESTABLE
+	FMT=$FORMATTABLE
+
+# user has provided PKG override
+else
+	# strip out leading dotslashes and trailing slashes from PKG=./foo/
+	TEST=${PKG/#./}
+	TEST=${TEST/#\//}
+	TEST=${TEST/%\//}
+
+	# only run gofmt on packages provided by user
+	FMT="$TEST"
+fi
+
+# split TEST into an array and prepend REPO_PATH to each local package
+split=(${TEST// / })
+TEST=${split[@]/#/${REPO_PATH}/}
+
+echo "Running tests..."
+go test ${COVER} $@ ${TEST}
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l $FMT)
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+echo "Success"


### PR DESCRIPTION
This adds a build script that attempts to be as user friendly as possible: if
they have already set $GOPATH and/or $GOBIN, use those environment variables.
If not, create a gopath for them in this directory. This should facilitate
both `go get` and `git clone` usage.

The `test` script is updated, and the new `cover` script facilitates easy
coverage generation for the repo's constituent packages by setting the PKG
environment variable.
