### PR TITLE
gitignore: add _etcd_data directory ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /machine*
 /bin
 .vagrant
-*.etcd
+/*_etcd_data
 etcd


### PR DESCRIPTION
After 9a57d1067d8613cd5aa8bd6e00b7522553784770 we want to ignore all of these
_etcd_data directories.
