### PR TITLE
*: stop using 0xBEEF

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-etcd0: ./etcd -id 0xBEEF0 -l :8080 -peers '0xBEEF0=localhost:8080&0xBEEF1=localhost:8081&0xBEEF2=localhost:8082'
-etcd1: ./etcd -id 0xBEEF1 -l :8081 -peers '0xBEEF0=localhost:8080&0xBEEF1=localhost:8081&0xBEEF2=localhost:8082'
-etcd2: ./etcd -id 0xBEEF2 -l :8082 -peers '0xBEEF0=localhost:8080&0xBEEF1=localhost:8081&0xBEEF2=localhost:8082'
+etcd0: ./etcd -id 0x0 -l :8080 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'
+etcd1: ./etcd -id 0x1 -l :8081 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'
+etcd2: ./etcd -id 0x2 -l :8082 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -158,7 +158,7 @@ func TestRecover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	i := &raftpb.Info{Id: int64(0xBEEF)}
+	i := &raftpb.Info{Id: int64(0xBAD0)}
 	if err = w.SaveInfo(i); err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestRecoverAfterCut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	info := &raftpb.Info{Id: int64(0xBEEF)}
+	info := &raftpb.Info{Id: int64(0xBAD1)}
 	if err = w.SaveInfo(info); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Using 0xBEEF is annoying in examples because it makes it makes it look like
the user can use ascii or something. In the Procfile use 0x0,0x1,0x2,etc and
use 0xBAD0 in test.
