### PR TITLE
wal: change wal filename format

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,8 +106,8 @@ func startRaft(id int64, peerIDs []int64, waldir string) (raft.Node, *wal.WAL) {
 	}
 
 	// restart a node from previous wal
-	// TODO(xiangli): check snapshot; not open from zero
-	w, err := wal.OpenAtIndex(waldir, 0)
+	// TODO(xiangli): check snapshot; not open from one
+	w, err := wal.OpenAtIndex(waldir, 1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/wal/util.go
+++ b/wal/util.go
@@ -14,9 +14,9 @@ func Exist(dirpath string) bool {
 	return len(names) != 0
 }
 
-// The input names should be sorted.
-// serachIndex returns the array index of the last name that has
-// a smaller raft index section than the given raft index.
+// searchIndex returns the last array index of names whose raft index section is
+// equal to or smaller than the given index.
+// The given names MUST be sorted.
 func searchIndex(names []string, index int64) (int, bool) {
 	for i := len(names) - 1; i >= 0; i-- {
 		name := names[i]

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -75,7 +75,7 @@ func Create(dirpath string) (*WAL, error) {
 		return nil, err
 	}
 
-	p := path.Join(dirpath, fmt.Sprintf("%016x-%016x.wal", 0, 0))
+	p := path.Join(dirpath, fmt.Sprintf("%016x-%016x.wal", 0, 1))
 	f, err := os.OpenFile(p, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
@@ -153,8 +153,8 @@ func (w *WAL) ReadAll() (id int64, state raftpb.State, ents []raftpb.Entry, err 
 		switch rec.Type {
 		case entryType:
 			e := mustUnmarshalEntry(rec.Data)
-			if e.Index > w.ri {
-				ents = append(ents[:e.Index-w.ri-1], e)
+			if e.Index >= w.ri {
+				ents = append(ents[:e.Index-w.ri], e)
 			}
 		case stateType:
 			state = mustUnmarshalState(rec.Data)
@@ -200,7 +200,7 @@ func (w *WAL) Cut(index int64) error {
 	log.Printf("wal.cut index=%d", index)
 
 	// create a new wal file with name sequence + 1
-	fpath := path.Join(w.dir, fmt.Sprintf("%016x-%016x.wal", w.seq+1, index))
+	fpath := path.Join(w.dir, fmt.Sprintf("%016x-%016x.wal", w.seq+1, index+1))
 	f, err := os.OpenFile(fpath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return err


### PR DESCRIPTION
Make raftIndex section to be expected raftIndex of next entry.

It makes filename more intuitive and straight-forward.

The commit also adds comments for filename format.
#1033
