### PR TITLE
WIP: require a flat network for static bootstrap

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 # Use goreman to run `go get github.com/mattn/goreman`
-etcd0: ./etcd -id 0x0 -l :8080 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'
-etcd1: ./etcd -id 0x1 -l :8081 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'
-etcd2: ./etcd -id 0x2 -l :8082 -peers '0x0=localhost:8080&0x1=localhost:8081&0x2=localhost:8082'
+etcd0: ./etcd -addr localhost:8080 -peers 'localhost:8080,localhost:8081,localhost:8082'
+etcd1: ./etcd -addr localhost:8081 -peers 'localhost:8080,localhost:8081,localhost:8082'
+etcd2: ./etcd -addr localhost:8082 -peers 'localhost:8080,localhost:8081,localhost:8082'


### PR DESCRIPTION
I like the idea of making bootstrapping a deterministic process but I feel
making the user generate the id is too complicated still. This is a 
proof-of-concept does not require that the user set the IDs of each machine.

Instead etcd requires you have one IP per machine. If you want to add IPs to
the machines you can do that after the initial bootstrap using dynamic
configuration.

I want to avoid having the id be something the user thinks about ever; because
it is an implementation detail that etcd should manage. When using a discovery
service it will be randomly generated and when using this POC it will be
generated based on a consistent hash.

Example three machine cluster:

```
etcd0: ./etcd -addr localhost:8080 -peers 'localhost:8080,localhost:8081,localhost:8082'
etcd1: ./etcd -addr localhost:8081 -peers 'localhost:8080,localhost:8081,localhost:8082'
etcd2: ./etcd -addr localhost:8082 -peers 'localhost:8080,localhost:8081,localhost:8082'
```

TODO:
- [ ] Why is the raft machine id a int64 instead of uint64?!?!?!?!
- [ ] Better way to generate ID than sha1 hash?!

/cc @xianngli @bmizerany
