### PR TITLE
*: s/Id/ID/

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -77,7 +77,7 @@ func (ps *Peers) String() string {
 	return v.Encode()
 }
 
-func (ps Peers) Ids() []int64 {
+func (ps Peers) IDs() []int64 {
 	var ids []int64
 	for id := range ps {
 		ids = append(ids, id)
@@ -176,7 +176,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h Handler) serveKeys(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	rr, err := parseRequest(r, genId())
+	rr, err := parseRequest(r, genID())
 	if err != nil {
 		log.Println(err) // reading of body failed
 		return
@@ -234,8 +234,8 @@ func (h Handler) serveRaft(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 }
 
-// genId generates a random id that is: n < 0 < n.
-func genId() int64 {
+// genID generates a random id that is: n < 0 < n.
+func genID() int64 {
 	for {
 		b := make([]byte, 8)
 		if _, err := io.ReadFull(crand.Reader, b); err != nil {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	fid     = flag.String("id", "0x1", "Id of this server")
+	fid     = flag.String("id", "0x1", "ID of this server")
 	timeout = flag.Duration("timeout", 10*time.Second, "Request Timeout")
 	laddr   = flag.String("l", ":8080", "HTTP service address (e.g., ':8080')")
 	dir     = flag.String("data-dir", "", "Path to the data directory")
@@ -56,7 +56,7 @@ func main() {
 		log.Fatalf("main: cannot create data directory: %v", err)
 	}
 
-	n, w := startRaft(id, peers.Ids(), path.Join(*dir, "wal"))
+	n, w := startRaft(id, peers.IDs(), path.Join(*dir, "wal"))
 
 	tk := time.NewTicker(100 * time.Millisecond)
 	s := &etcdserver.Server{
@@ -80,13 +80,13 @@ func main() {
 // If the wal dir does not exist, startRaft will start a new raft node.
 // If the wal dir exists, startRaft will restart the previous raft node.
 // startRaft returns the started raft node and the opened wal.
-func startRaft(id int64, peerIds []int64, waldir string) (raft.Node, *wal.WAL) {
+func startRaft(id int64, peerIDs []int64, waldir string) (raft.Node, *wal.WAL) {
 	if !wal.Exist(waldir) {
 		w, err := wal.Create(waldir)
 		if err != nil {
 			log.Fatal(err)
 		}
-		n := raft.Start(id, peerIds, 10, 1)
+		n := raft.Start(id, peerIDs, 10, 1)
 		return n, w
 	}
 
@@ -104,6 +104,6 @@ func startRaft(id int64, peerIds []int64, waldir string) (raft.Node, *wal.WAL) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	n := raft.Restart(id, peerIds, 10, 1, st, ents)
+	n := raft.Restart(id, peerIDs, 10, 1, st, ents)
 	return n, w
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	ErrIdMismatch  = errors.New("wal: unmatch id")
+	ErrIDMismatch  = errors.New("wal: unmatch id")
 	ErrNotFound    = errors.New("wal: file is not found")
 	ErrCRCMismatch = errors.New("wal: crc mismatch")
 	crcTable       = crc32.MakeTable(crc32.Castagnoli)
@@ -162,7 +162,7 @@ func (w *WAL) ReadAll() (id int64, state raftpb.State, ents []raftpb.Entry, err 
 			i := mustUnmarshalInfo(rec.Data)
 			if id != 0 && id != i.Id {
 				state.Reset()
-				return 0, state, nil, ErrIdMismatch
+				return 0, state, nil, ErrIDMismatch
 			}
 			id = i.Id
 		case crcType:


### PR DESCRIPTION
golang convention dictates that the individual characters in an
abbreviation should all have the same case. Use ID instead of Id.

The protobuf generator still generates code that does not meet
this convention, but that's a fight for another day.
