### PR TITLE
raft: fix heartbeat

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -189,7 +189,7 @@ func (r *raft) sendAppend(to int64) {
 // sendHeartbeat sends RRPC, without entries to the given peer.
 func (r *raft) sendHeartbeat(to int64) {
 	pr := r.prs[to]
-	index := max(pr.next-1, r.raftLog.lastIndex())
+	index := max(pr.next-1, r.raftLog.offset)
 	m := pb.Message{
 		To:      to,
 		Type:    msgApp,


### PR DESCRIPTION
heartbeat should be the same as normal message append with previous index equal to next -1. 
heartbeat should always be accepted by a synced follower. 

if previous index is smaller than the log offset (which due to snapshot), we can just send a heartbeat with log offset. It will cause a rejection from the unsynced follower. After receiving the rejection, the leader will send a snapshot.
