### PR TITLE
wal: OpenFromIndex fails if it cannot find previous index

### DIFF
--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -111,8 +111,8 @@ func TestOpenAtIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(emptydir)
-	if _, err = OpenAtIndex(emptydir, 0); err != ErrNotFound {
-		t.Errorf("err = %v, want %v", err, ErrNotFound)
+	if _, err = OpenAtIndex(emptydir, 0); err != ErrFileNotFound {
+		t.Errorf("err = %v, want %v", err, ErrFileNotFound)
 	}
 }
 
@@ -315,8 +315,8 @@ func TestRecoverAfterCut(t *testing.T) {
 		w, err := OpenAtIndex(p, int64(i))
 		if err != nil {
 			if i <= 4 {
-				if err != ErrNotFound {
-					t.Errorf("#%d: err = %v, want %v", i, err, ErrNotFound)
+				if err != ErrFileNotFound {
+					t.Errorf("#%d: err = %v, want %v", i, err, ErrFileNotFound)
 				}
 			} else {
 				t.Errorf("#%d: err = %v, want nil", i, err)
@@ -360,8 +360,8 @@ func TestOpenAtUncommittedIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	// commit up to index 0, try to read index 1
-	if _, _, _, err := w.ReadAll(); err != ErrNotFound {
-		t.Errorf("err = %v, want %v", err, ErrNotFound)
+	if _, _, _, err := w.ReadAll(); err != ErrIndexNotFound {
+		t.Errorf("err = %v, want %v", err, ErrIndexNotFound)
 	}
 	w.Close()
 }


### PR DESCRIPTION
Example:
We save entry 1, 2, 3 to WAL.
If we try to open 100, it should fail.
#1033 point 2.
