### PR TITLE
X-Etcd-Index returns the node's modifiedIndex

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -292,7 +292,7 @@ func writeEvent(w http.ResponseWriter, ev *store.Event) error {
 		return errors.New("cannot write empty Event!")
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Add("X-Etcd-Index", fmt.Sprint(ev.Index()))
+	w.Header().Add("X-Etcd-Index", fmt.Sprint(ev.EtcdIndex))
 
 	if ev.IsCreated() {
 		w.WriteHeader(http.StatusCreated)

--- a/store/event.go
+++ b/store/event.go
@@ -12,9 +12,10 @@ const (
 )
 
 type Event struct {
-	Action   string      `json:"action"`
-	Node     *NodeExtern `json:"node,omitempty"`
-	PrevNode *NodeExtern `json:"prevNode,omitempty"`
+	Action    string      `json:"action"`
+	Node      *NodeExtern `json:"node,omitempty"`
+	PrevNode  *NodeExtern `json:"prevNode,omitempty"`
+	EtcdIndex uint64      `json:"-"`
 }
 
 func newEvent(action string, key string, modifiedIndex, createdIndex uint64) *Event {

--- a/store/watcher_test.go
+++ b/store/watcher_test.go
@@ -23,7 +23,7 @@ import (
 func TestWatcher(t *testing.T) {
 	s := newStore()
 	wh := s.WatcherHub
-	w, err := wh.watch("/foo", true, false, 1)
+	w, err := wh.watch("/foo", true, false, 1, 1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -46,7 +46,7 @@ func TestWatcher(t *testing.T) {
 		t.Fatal("recv != send")
 	}
 
-	w, _ = wh.watch("/foo", false, false, 2)
+	w, _ = wh.watch("/foo", false, false, 2, 1)
 	c = w.EventChan()
 
 	e = newEvent(Create, "/foo/bar", 2, 2)
@@ -71,7 +71,7 @@ func TestWatcher(t *testing.T) {
 	}
 
 	// ensure we are doing exact matching rather than prefix matching
-	w, _ = wh.watch("/fo", true, false, 1)
+	w, _ = wh.watch("/fo", true, false, 1, 1)
 	c = w.EventChan()
 
 	select {


### PR DESCRIPTION
It used to return the _current_ etcd index. There's little value in returning the modifiedIndex as it's already included in the JSON response. Having the _current_ etcd index is crucial for watching keys.
