### PR TITLE
raft: add a one node bench

### DIFF
--- a/raft/node_bench_test.go
+++ b/raft/node_bench_test.go
@@ -1,0 +1,25 @@
+package raft
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/third_party/code.google.com/p/go.net/context"
+)
+
+func BenchmarkOneNode(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	n := Start(1, []int64{1}, 0, 0)
+	defer n.Stop()
+
+	n.Campaign(ctx)
+	for i := 0; i < b.N; i++ {
+		<-n.Ready()
+		n.Propose(ctx, []byte("foo"))
+	}
+	rd := <-n.Ready()
+	if rd.HardState.Commit != int64(b.N+1) {
+		b.Errorf("commit = %d, want %d", b.N+1)
+	}
+}


### PR DESCRIPTION
```
 1000000          2810 ns/op        1807 B/op         10 allocs/op
ok      github.com/coreos/etcd/raft 2.875s
```

We definitely want to reduce the allocation per commit.
