### PR TITLE
wip: implement the bootstrap-config option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # Use goreman to run `go get github.com/mattn/goreman`
-etcd1: bin/etcd -id 0x1 -bind-addr 127.0.0.1:4001 -peer-bind-addr :7001 -peers '0x1=localhost:7001&0x2=localhost:7002&0x3=localhost:7003'
-etcd2: bin/etcd -id 0x2 -bind-addr 127.0.0.1:4002 -peer-bind-addr :7002 -peers '0x1=localhost:7001&0x2=localhost:7002&0x3=localhost:7003'
-etcd3: bin/etcd -id 0x3 -bind-addr 127.0.0.1:4003 -peer-bind-addr :7003 -peers '0x1=localhost:7001&0x2=localhost:7002&0x3=localhost:7003'
-proxy: bin/etcd -proxy=on -bind-addr 127.0.0.1:8080 -peers '0x1=localhost:7001&0x2=localhost:7002&0x3=localhost:7003'
+etcd1: bin/etcd -name node1 -bind-addr 127.0.0.1:4001 -peer-bind-addr :7001 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
+etcd2: bin/etcd -name node2 -bind-addr 127.0.0.1:4002 -peer-bind-addr :7002 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
+etcd3: bin/etcd -name node3 -bind-addr 127.0.0.1:4003 -peer-bind-addr :7003 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
+proxy: bin/etcd -proxy=on -bind-addr 127.0.0.1:8080 -peers 'localhost:7001,localhost:7002,localhost:7003'

--- a/etcdserver/etcdhttp/flags.go
+++ b/etcdserver/etcdhttp/flags.go
@@ -1,0 +1,136 @@
+package etcdhttp
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Cluster contains a mapping of node IDs to a list of hostnames/IP addresses
+type Cluster map[int64][]string
+
+// addScheme adds the protocol prefix to a string; currently only HTTP
+// TODO: improve this when implementing TLS
+func addScheme(addr string) string {
+	return fmt.Sprintf("http://%s", addr)
+}
+
+// Pick chooses a random address from a given Peer's addresses, and returns it as
+// an addressible URI. If the given peer does not exist, an empty string is returned.
+func (ps Cluster) Pick(id int64) string {
+	addrs := ps[id]
+	if len(addrs) == 0 {
+		return ""
+	}
+	return addScheme(addrs[rand.Intn(len(addrs))])
+}
+
+// Set parses command line sets of names to IPs formatted like:
+// mach0=1.1.1.1,2.2.2.2 mach0=1.1.1.1 mach1=2.2.2.2,3.3.3.3
+func (ps *Cluster) Set(s string) error {
+	m := make(map[int64][]string)
+	for _, f := range strings.Fields(s) {
+		pcnf := strings.SplitN(f, "=", 2)
+		if len(pcnf) != 2 {
+			return fmt.Errorf("Too few entries for %q", pcnf)
+		}
+		var nn NodeName
+		nn.Set(pcnf[0])
+		m[nn.ID()] = strings.Split(pcnf[1], ",")
+	}
+	*ps = m
+	return nil
+}
+
+func (ps *Cluster) String() string {
+	v := url.Values{}
+	for k, vv := range *ps {
+		for i := range vv {
+			v.Add(strconv.FormatInt(k, 16), vv[i])
+		}
+	}
+	return v.Encode()
+}
+
+func (ps Cluster) IDs() []int64 {
+	var ids []int64
+	for id := range ps {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+type Endpoints []string
+
+func (ep *Endpoints) Set(s string) error {
+	endpoints := make([]string, 0)
+	for _, addr := range strings.Split(s, ",") {
+		endpoints = append(endpoints, addScheme(addr))
+	}
+
+	*ep = endpoints
+
+	return nil
+}
+
+func (ep *Endpoints) String() string {
+	return strings.Join([]string(*ep), ",")
+}
+
+func (ep Endpoints) List() []string {
+	return []string(ep)
+}
+
+// Endpoints returns a list of all peer addresses. Each address is prefixed
+// with the scheme (currently "http://"). The returned list is sorted in
+// ascending lexicographical order.
+func (ps Cluster) Endpoints() Endpoints {
+	endpoints := make([]string, 0)
+	for _, addrs := range ps {
+		for _, addr := range addrs {
+			endpoints = append(endpoints, addScheme(addr))
+		}
+	}
+	sort.Strings(endpoints)
+
+	return endpoints
+}
+
+// NodeName implements the flag.Value interface for choosing a default
+// etcd node name and generating the internal ID using a sha hash.
+type NodeName string
+
+func (nn *NodeName) Set(s string) error {
+	if s != "" {
+		*nn = NodeName(s)
+		return nil
+	}
+
+	host, err := os.Hostname()
+	if host != "" && err == nil {
+		*nn = NodeName(host)
+		return nil
+	}
+
+	*nn = NodeName("default")
+	return nil
+}
+
+func (nn *NodeName) String() string {
+	return string(*nn)
+}
+
+func (nn *NodeName) ID() int64 {
+	hash := sha1.Sum([]byte(*nn))
+	out := int64(binary.BigEndian.Uint64(hash[:8]))
+	if out < 0 {
+		out = out * -1
+	}
+	return out
+}

--- a/etcdserver/etcdhttp/flags_test.go
+++ b/etcdserver/etcdhttp/flags_test.go
@@ -1,0 +1,135 @@
+package etcdhttp
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCluster(t *testing.T) {
+	tests := []struct {
+		in      string
+		wids    []int64
+		wep     Endpoints
+		wstring string
+	}{
+		{
+			"mach1=1.1.1.1",
+			[]int64{6766124441145243813},
+			[]string{"http://1.1.1.1"},
+			"5de61a54ac8cf8a5=1.1.1.1",
+		},
+		{
+			"mach2=2.2.2.2",
+			[]int64{4216210504111742903},
+			[]string{"http://2.2.2.2"},
+			"3a82fd1d73d9dfb7=2.2.2.2",
+		},
+		{
+			"mach1=1.1.1.1,1.1.1.2 mach2=2.2.2.2",
+			[]int64{4216210504111742903, 6766124441145243813},
+			[]string{"http://1.1.1.1", "http://1.1.1.2", "http://2.2.2.2"},
+			"3a82fd1d73d9dfb7=2.2.2.2&5de61a54ac8cf8a5=1.1.1.1&5de61a54ac8cf8a5=1.1.1.2",
+		},
+		{
+			"mach3=3.3.3.3 mach4=4.4.4.4 mach1=1.1.1.1,1.1.1.2 mach2=2.2.2.2",
+			[]int64{539760383923670193, 1066726282636464211, 4216210504111742903, 6766124441145243813},
+			[]string{"http://1.1.1.1", "http://1.1.1.2", "http://2.2.2.2",
+				"http://3.3.3.3", "http://4.4.4.4"},
+			"3a82fd1d73d9dfb7=2.2.2.2&5de61a54ac8cf8a5=1.1.1.1&5de61a54ac8cf8a5=1.1.1.2&77d9d359b994cb1=3.3.3.3&ecdc5e6fd1e9053=4.4.4.4",
+		},
+	}
+	for i, tt := range tests {
+		p := &Cluster{}
+		err := p.Set(tt.in)
+		if err != nil {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+		}
+		ids := int64Slice(p.IDs())
+		sort.Sort(ids)
+		if !reflect.DeepEqual([]int64(ids), tt.wids) {
+			t.Errorf("#%d: IDs=%#v, want %#v", i, []int64(ids), tt.wids)
+		}
+		ep := p.Endpoints()
+		if !reflect.DeepEqual(ep, tt.wep) {
+			t.Errorf("#%d: Endpoints=%#v, want %#v", i, ep, tt.wep)
+		}
+		s := p.String()
+		if s != tt.wstring {
+			t.Errorf("#%d: string=%q, want %q", i, s, tt.wstring)
+		}
+	}
+}
+
+type int64Slice []int64
+
+func (p int64Slice) Len() int           { return len(p) }
+func (p int64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func TestClusterSetBad(t *testing.T) {
+	tests := []string{
+		// garbage URL
+		"asdf%%",
+	}
+	for i, tt := range tests {
+		p := &Cluster{}
+		if err := p.Set(tt); err == nil {
+			t.Errorf("#%d: err=nil unexpectedly", i)
+		}
+	}
+}
+
+func TestClusterPick(t *testing.T) {
+	ps := &Cluster{
+		1: []string{"abc", "def", "ghi", "jkl", "mno", "pqr", "stu"},
+		2: []string{"xyz"},
+		3: []string{},
+	}
+	ids := map[string]bool{
+		"http://abc": true,
+		"http://def": true,
+		"http://ghi": true,
+		"http://jkl": true,
+		"http://mno": true,
+		"http://pqr": true,
+		"http://stu": true,
+	}
+	for i := 0; i < 1000; i++ {
+		a := ps.Pick(1)
+		if _, ok := ids[a]; !ok {
+			t.Errorf("returned ID %q not in expected range!", a)
+			break
+		}
+	}
+	if b := ps.Pick(2); b != "http://xyz" {
+		t.Errorf("id=%q, want %q", b, "http://xyz")
+	}
+	if c := ps.Pick(3); c != "" {
+		t.Errorf("id=%q, want \"\"", c)
+	}
+}
+
+func TestNodeName(t *testing.T) {
+	tests := []struct {
+		in string
+		id int64
+	}{
+		{
+			"mach1",
+			0x5de61a54ac8cf8a5,
+		},
+	}
+
+	for i, tt := range tests {
+		var n NodeName
+		err := n.Set(tt.in)
+		if err != nil {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+		}
+		if n.ID() != tt.id {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+		}
+	}
+
+}

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -32,10 +32,10 @@ const (
 var errClosed = errors.New("etcdhttp: client closed connection")
 
 // NewClientHandler generates a muxed http.Handler with the given parameters to serve etcd client requests.
-func NewClientHandler(server etcdserver.Server, peers Peers, timeout time.Duration) http.Handler {
+func NewClientHandler(server etcdserver.Server, cluster Cluster, timeout time.Duration) http.Handler {
 	sh := &serverHandler{
 		server:  server,
-		peers:   peers,
+		cluster: cluster,
 		timeout: timeout,
 	}
 	if sh.timeout == 0 {
@@ -66,7 +66,7 @@ func NewPeerHandler(server etcdserver.Server) http.Handler {
 type serverHandler struct {
 	timeout time.Duration
 	server  etcdserver.Server
-	peers   Peers
+	cluster Cluster
 }
 
 func (h serverHandler) serveKeys(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +115,7 @@ func (h serverHandler) serveMachines(w http.ResponseWriter, r *http.Request) {
 	if !allowMethod(w, r.Method, "GET", "HEAD") {
 		return
 	}
-	endpoints := h.peers.Endpoints()
+	endpoints := h.cluster.Endpoints()
 	w.Write([]byte(strings.Join(endpoints, ", ")))
 }
 

--- a/etcdserver/etcdhttp/peers.go
+++ b/etcdserver/etcdhttp/peers.go
@@ -2,90 +2,14 @@ package etcdhttp
 
 import (
 	"bytes"
-	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
-	"net/url"
-	"sort"
-	"strconv"
 
 	"github.com/coreos/etcd/elog"
 	"github.com/coreos/etcd/raft/raftpb"
 )
 
-// Peers contains a mapping of unique IDs to a list of hostnames/IP addresses
-type Peers map[int64][]string
-
-// addScheme adds the protocol prefix to a string; currently only HTTP
-// TODO: improve this when implementing TLS
-func addScheme(addr string) string {
-	return fmt.Sprintf("http://%s", addr)
-}
-
-// Pick chooses a random address from a given Peer's addresses, and returns it as
-// an addressible URI. If the given peer does not exist, an empty string is returned.
-func (ps Peers) Pick(id int64) string {
-	addrs := ps[id]
-	if len(addrs) == 0 {
-		return ""
-	}
-	return addScheme(addrs[rand.Intn(len(addrs))])
-}
-
-// Set parses command line sets of names to IPs formatted like:
-// a=1.1.1.1&a=1.1.1.2&b=2.2.2.2
-func (ps *Peers) Set(s string) error {
-	m := make(map[int64][]string)
-	v, err := url.ParseQuery(s)
-	if err != nil {
-		return err
-	}
-	for k, v := range v {
-		id, err := strconv.ParseInt(k, 0, 64)
-		if err != nil {
-			return err
-		}
-		m[id] = v
-	}
-	*ps = m
-	return nil
-}
-
-func (ps *Peers) String() string {
-	v := url.Values{}
-	for k, vv := range *ps {
-		for i := range vv {
-			v.Add(strconv.FormatInt(k, 16), vv[i])
-		}
-	}
-	return v.Encode()
-}
-
-func (ps Peers) IDs() []int64 {
-	var ids []int64
-	for id := range ps {
-		ids = append(ids, id)
-	}
-	return ids
-}
-
-// Endpoints returns a list of all peer addresses. Each address is prefixed
-// with the scheme (currently "http://"). The returned list is sorted in
-// ascending lexicographical order.
-func (ps Peers) Endpoints() []string {
-	endpoints := make([]string, 0)
-	for _, addrs := range ps {
-		for _, addr := range addrs {
-			endpoints = append(endpoints, addScheme(addr))
-		}
-	}
-	sort.Strings(endpoints)
-
-	return endpoints
-}
-
-func Sender(p Peers) func(msgs []raftpb.Message) {
+func Sender(p Cluster) func(msgs []raftpb.Message) {
 	return func(msgs []raftpb.Message) {
 		for _, m := range msgs {
 			// TODO: reuse go routines
@@ -95,7 +19,7 @@ func Sender(p Peers) func(msgs []raftpb.Message) {
 	}
 }
 
-func send(p Peers, m raftpb.Message) {
+func send(p Cluster, m raftpb.Message) {
 	// TODO (xiangli): reasonable retry logic
 	for i := 0; i < 3; i++ {
 		url := p.Pick(m.To)

--- a/etcdserver/etcdhttp/peers_test.go
+++ b/etcdserver/etcdhttp/peers_test.go
@@ -3,120 +3,11 @@ package etcdhttp
 import (
 	"net/http"
 	"net/http/httptest"
-	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
 	"github.com/coreos/etcd/raft/raftpb"
 )
-
-func TestPeers(t *testing.T) {
-	tests := []struct {
-		in      string
-		wids    []int64
-		wep     []string
-		wstring string
-	}{
-		{
-			"1=1.1.1.1",
-			[]int64{1},
-			[]string{"http://1.1.1.1"},
-			"1=1.1.1.1",
-		},
-		{
-			"2=2.2.2.2",
-			[]int64{2},
-			[]string{"http://2.2.2.2"},
-			"2=2.2.2.2",
-		},
-		{
-			"1=1.1.1.1&1=1.1.1.2&2=2.2.2.2",
-			[]int64{1, 2},
-			[]string{"http://1.1.1.1", "http://1.1.1.2", "http://2.2.2.2"},
-			"1=1.1.1.1&1=1.1.1.2&2=2.2.2.2",
-		},
-		{
-			"3=3.3.3.3&4=4.4.4.4&1=1.1.1.1&1=1.1.1.2&2=2.2.2.2",
-			[]int64{1, 2, 3, 4},
-			[]string{"http://1.1.1.1", "http://1.1.1.2", "http://2.2.2.2",
-				"http://3.3.3.3", "http://4.4.4.4"},
-			"1=1.1.1.1&1=1.1.1.2&2=2.2.2.2&3=3.3.3.3&4=4.4.4.4",
-		},
-	}
-	for i, tt := range tests {
-		p := &Peers{}
-		err := p.Set(tt.in)
-		if err != nil {
-			t.Errorf("#%d: err=%v, want nil", i, err)
-		}
-		ids := int64Slice(p.IDs())
-		sort.Sort(ids)
-		if !reflect.DeepEqual([]int64(ids), tt.wids) {
-			t.Errorf("#%d: IDs=%#v, want %#v", i, []int64(ids), tt.wids)
-		}
-		ep := p.Endpoints()
-		if !reflect.DeepEqual(ep, tt.wep) {
-			t.Errorf("#%d: Endpoints=%#v, want %#v", i, ep, tt.wep)
-		}
-		s := p.String()
-		if s != tt.wstring {
-			t.Errorf("#%d: string=%q, want %q", i, s, tt.wstring)
-		}
-	}
-}
-
-type int64Slice []int64
-
-func (p int64Slice) Len() int           { return len(p) }
-func (p int64Slice) Less(i, j int) bool { return p[i] < p[j] }
-func (p int64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
-func TestPeersSetBad(t *testing.T) {
-	tests := []string{
-		// garbage URL
-		"asdf%%",
-		// non-int64 keys
-		"a=1.2.3.4",
-		"-1-23=1.2.3.4",
-	}
-	for i, tt := range tests {
-		p := &Peers{}
-		if err := p.Set(tt); err == nil {
-			t.Errorf("#%d: err=nil unexpectedly", i)
-		}
-	}
-}
-
-func TestPeersPick(t *testing.T) {
-	ps := &Peers{
-		1: []string{"abc", "def", "ghi", "jkl", "mno", "pqr", "stu"},
-		2: []string{"xyz"},
-		3: []string{},
-	}
-	ids := map[string]bool{
-		"http://abc": true,
-		"http://def": true,
-		"http://ghi": true,
-		"http://jkl": true,
-		"http://mno": true,
-		"http://pqr": true,
-		"http://stu": true,
-	}
-	for i := 0; i < 1000; i++ {
-		a := ps.Pick(1)
-		if _, ok := ids[a]; !ok {
-			t.Errorf("returned ID %q not in expected range!", a)
-			break
-		}
-	}
-	if b := ps.Pick(2); b != "http://xyz" {
-		t.Errorf("id=%q, want %q", b, "http://xyz")
-	}
-	if c := ps.Pick(3); c != "" {
-		t.Errorf("id=%q, want \"\"", c)
-	}
-}
 
 func TestHttpPost(t *testing.T) {
 	var tr *http.Request
@@ -212,7 +103,7 @@ func TestSend(t *testing.T) {
 		tr = nil
 		rc = tt.code
 		ts := httptest.NewServer(h)
-		ps := Peers{
+		ps := Cluster{
 			42: []string{strings.TrimPrefix(ts.URL, "http://")},
 		}
 		send(ps, tt.m)

--- a/main_test.go
+++ b/main_test.go
@@ -13,8 +13,8 @@ func TestSetFlagsFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	// command-line flags take precedence over env vars
-	os.Setenv("ETCD_ID", "woof")
-	if err := flag.Set("id", "quack"); err != nil {
+	os.Setenv("ETCD_NAME", "woof")
+	if err := flag.Set("name", "quack"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -22,7 +22,7 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	for f, want := range map[string]string{
 		"data-dir":       "",
 		"peer-bind-addr": "1.2.3.4",
-		"id":             "quack",
+		"name":           "quack",
 	} {
 		if got := flag.Lookup(f).Value.String(); got != want {
 			t.Fatalf("flag %q=%q, want %q", f, got, want)
@@ -34,7 +34,7 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	for f, want := range map[string]string{
 		"data-dir":       "/foo/bar",
 		"peer-bind-addr": "1.2.3.4",
-		"id":             "quack",
+		"name":           "quack",
 	} {
 		if got := flag.Lookup(f).Value.String(); got != want {
 			t.Errorf("flag %q=%q, want %q", f, got, want)


### PR DESCRIPTION
The basic goal of this PR is to make the static bootstrap process not expose the concept of ID and to instead re-introduce the human-readable name concept. This will also reclaim the 'peers' flag to be used by proxy or dynamic configuration. Note: Names can be changed later via dynamic configuration but the ID will remain the same.

TODO
- [ ] Wait on #1123
- [x] Parse the new space separated bootstrap-config format
- [ ] Ensure that the NodeName.ID()'s don't have collisions
- [ ] Generate initial cluster ID from a similar hash of the bootstrap-config
- [ ] Write documentation on static bootstrap

```
./etcd -name node1 -bind-addr 127.0.0.1:4001 -peer-bind-addr :7001 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
./etcd -name node2 -bind-addr 127.0.0.1:4002 -peer-bind-addr :7002 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
./etcd -name node3 -bind-addr 127.0.0.1:4003 -peer-bind-addr :7003 -bootstrap-config 'node1=localhost:7001 node2=localhost:7002 node3=localhost:7003'
```
