### PR TITLE
main: clarify the usage of the -peers flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 )
 
 func init() {
-	flag.Var(peers, "peers", "your peers")
+	flag.Var(peers, "peers", "Your peers (e.g., '0x1=localhost:8080')")
 	flag.Var(addrs, "bind-addr", "List of HTTP service addresses (e.g., '127.0.0.1:4001,10.0.0.1:8080')")
 	flag.Var(proxyFlag, "proxy", fmt.Sprintf("Valid values include %s", strings.Join(proxyFlagValues, ", ")))
 	peers.Set("0x1=localhost:8080")


### PR DESCRIPTION
This PR clarifies how the -peers flag is used. I had to read the source code to understand how it is set.
