### PR TITLE
*: s/prevExists/prevExist/

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -207,35 +207,35 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		)
 	}
 
-	// prevExists is nullable, so leave it null if not specified
+	// prevExist is nullable, so leave it null if not specified
 	var pe *bool
-	if _, ok := r.Form["prevExists"]; ok {
-		bv, err := getBool(r.Form, "prevExists")
+	if _, ok := r.Form["prevExist"]; ok {
+		bv, err := getBool(r.Form, "prevExist")
 		if err != nil {
 			return emptyReq, etcdErr.NewRequestError(
 				etcdErr.EcodeInvalidField,
-				"invalid value for prevExists",
+				"invalid value for prevExist",
 			)
 		}
 		pe = &bv
 	}
 
 	rr := etcdserverpb.Request{
-		Id:         id,
-		Method:     r.Method,
-		Path:       p,
-		Val:        r.FormValue("value"),
-		PrevValue:  r.FormValue("prevValue"),
-		PrevIndex:  pIdx,
-		PrevExists: pe,
-		Recursive:  rec,
-		Since:      wIdx,
-		Sorted:     sort,
-		Wait:       wait,
+		Id:        id,
+		Method:    r.Method,
+		Path:      p,
+		Val:       r.FormValue("value"),
+		PrevValue: r.FormValue("prevValue"),
+		PrevIndex: pIdx,
+		PrevExist: pe,
+		Recursive: rec,
+		Since:     wIdx,
+		Sorted:    sort,
+		Wait:      wait,
 	}
 
 	if pe != nil {
-		rr.PrevExists = pe
+		rr.PrevExist = pe
 	}
 
 	// TODO(jonboulle): use fake clock instead of time module

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -99,7 +99,7 @@ func TestBadParseRequest(t *testing.T) {
 			mustNewForm(t, "foo", url.Values{"ttl": []string{"-1"}}),
 			etcdErr.EcodeTTLNaN,
 		},
-		// bad values for recursive, sorted, wait, prevExists
+		// bad values for recursive, sorted, wait, prevExist
 		{
 			mustNewForm(t, "foo", url.Values{"recursive": []string{"hahaha"}}),
 			etcdErr.EcodeInvalidField,
@@ -129,16 +129,16 @@ func TestBadParseRequest(t *testing.T) {
 			etcdErr.EcodeInvalidField,
 		},
 		{
-			mustNewForm(t, "foo", url.Values{"prevExists": []string{"yes"}}),
+			mustNewForm(t, "foo", url.Values{"prevExist": []string{"yes"}}),
 			etcdErr.EcodeInvalidField,
 		},
 		{
-			mustNewForm(t, "foo", url.Values{"prevExists": []string{"#2"}}),
+			mustNewForm(t, "foo", url.Values{"prevExist": []string{"#2"}}),
 			etcdErr.EcodeInvalidField,
 		},
 		// query values are considered
 		{
-			mustNewRequest(t, "foo?prevExists=wrong"),
+			mustNewRequest(t, "foo?prevExist=wrong"),
 			etcdErr.EcodeInvalidField,
 		},
 		{
@@ -157,8 +157,8 @@ func TestBadParseRequest(t *testing.T) {
 		{
 			mustNewForm(
 				t,
-				"foo?prevExists=false",
-				url.Values{"prevExists": []string{"yes"}},
+				"foo?prevExist=false",
+				url.Values{"prevExist": []string{"yes"}},
 			),
 			etcdErr.EcodeInvalidField,
 		},
@@ -269,31 +269,31 @@ func TestGoodParseRequest(t *testing.T) {
 			},
 		},
 		{
-			// prevExists should be non-null if specified
+			// prevExist should be non-null if specified
 			mustNewForm(
 				t,
 				"foo",
-				url.Values{"prevExists": []string{"true"}},
+				url.Values{"prevExist": []string{"true"}},
 			),
 			etcdserverpb.Request{
-				Id:         1234,
-				Method:     "PUT",
-				PrevExists: boolp(true),
-				Path:       "/foo",
+				Id:        1234,
+				Method:    "PUT",
+				PrevExist: boolp(true),
+				Path:      "/foo",
 			},
 		},
 		{
-			// prevExists should be non-null if specified
+			// prevExist should be non-null if specified
 			mustNewForm(
 				t,
 				"foo",
-				url.Values{"prevExists": []string{"false"}},
+				url.Values{"prevExist": []string{"false"}},
 			),
 			etcdserverpb.Request{
-				Id:         1234,
-				Method:     "PUT",
-				PrevExists: boolp(false),
-				Path:       "/foo",
+				Id:        1234,
+				Method:    "PUT",
+				PrevExist: boolp(false),
+				Path:      "/foo",
 			},
 		},
 		// mix various fields
@@ -302,18 +302,18 @@ func TestGoodParseRequest(t *testing.T) {
 				t,
 				"foo",
 				url.Values{
-					"value":      []string{"some value"},
-					"prevExists": []string{"true"},
-					"prevValue":  []string{"previous value"},
+					"value":     []string{"some value"},
+					"prevExist": []string{"true"},
+					"prevValue": []string{"previous value"},
 				},
 			),
 			etcdserverpb.Request{
-				Id:         1234,
-				Method:     "PUT",
-				PrevExists: boolp(true),
-				PrevValue:  "previous value",
-				Val:        "some value",
-				Path:       "/foo",
+				Id:        1234,
+				Method:    "PUT",
+				PrevExist: boolp(true),
+				PrevValue: "previous value",
+				Val:       "some value",
+				Path:      "/foo",
 			},
 		},
 		// query parameters should be used if given

--- a/etcdserver/etcdserverpb/etcdserver.pb.go
+++ b/etcdserver/etcdserverpb/etcdserver.pb.go
@@ -35,7 +35,7 @@ type Request struct {
 	Dir              bool   `protobuf:"varint,5,req,name=dir" json:"dir"`
 	PrevValue        string `protobuf:"bytes,6,req,name=prevValue" json:"prevValue"`
 	PrevIndex        uint64 `protobuf:"varint,7,req,name=prevIndex" json:"prevIndex"`
-	PrevExists       *bool  `protobuf:"varint,8,req,name=prevExists" json:"prevExists,omitempty"`
+	PrevExist        *bool  `protobuf:"varint,8,req,name=prevExist" json:"prevExist,omitempty"`
 	Expiration       int64  `protobuf:"varint,9,req,name=expiration" json:"expiration"`
 	Wait             bool   `protobuf:"varint,10,req,name=wait" json:"wait"`
 	Since            uint64 `protobuf:"varint,11,req,name=since" json:"since"`
@@ -223,7 +223,7 @@ func (m *Request) Unmarshal(data []byte) error {
 				}
 			}
 			b := bool(v != 0)
-			m.PrevExists = &b
+			m.PrevExist = &b
 		case 9:
 			if wireType != 0 {
 				return code_google_com_p_gogoprotobuf_proto.ErrWrongType
@@ -374,7 +374,7 @@ func (m *Request) Size() (n int) {
 	l = len(m.PrevValue)
 	n += 1 + l + sovEtcdserver(uint64(l))
 	n += 1 + sovEtcdserver(uint64(m.PrevIndex))
-	if m.PrevExists != nil {
+	if m.PrevExist != nil {
 		n += 2
 	}
 	n += 1 + sovEtcdserver(uint64(m.Expiration))
@@ -448,10 +448,10 @@ func (m *Request) MarshalTo(data []byte) (n int, err error) {
 	data[i] = 0x38
 	i++
 	i = encodeVarintEtcdserver(data, i, uint64(m.PrevIndex))
-	if m.PrevExists != nil {
+	if m.PrevExist != nil {
 		data[i] = 0x40
 		i++
-		if *m.PrevExists {
+		if *m.PrevExist {
 			data[i] = 1
 		} else {
 			data[i] = 0

--- a/etcdserver/etcdserverpb/etcdserver.proto
+++ b/etcdserver/etcdserverpb/etcdserver.proto
@@ -15,7 +15,7 @@ message Request {
 	required bool   dir        =  5 [(gogoproto.nullable) = false];
 	required string prevValue  =  6 [(gogoproto.nullable) = false];
 	required uint64  prevIndex =  7 [(gogoproto.nullable) = false];
-	required bool   prevExists =  8 [(gogoproto.nullable) = true];
+	required bool   prevExist  =  8 [(gogoproto.nullable) = true];
 	required int64  expiration =  9 [(gogoproto.nullable) = false];
 	required bool   wait       = 10 [(gogoproto.nullable) = false];
 	required uint64  since     = 11 [(gogoproto.nullable) = false];

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -251,7 +251,7 @@ func (s *EtcdServer) apply(r pb.Request) Response {
 	case "POST":
 		return f(s.Store.Create(r.Path, r.Dir, r.Val, true, expr))
 	case "PUT":
-		exists, existsSet := getBool(r.PrevExists)
+		exists, existsSet := getBool(r.PrevExist)
 		switch {
 		case existsSet:
 			if exists {

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -69,19 +69,19 @@ func TestApply(t *testing.T) {
 			Response{Event: &store.Event{}}, []string{"Create"},
 		},
 		{
-			pb.Request{Method: "PUT", Id: 1, PrevExists: boolp(true), PrevIndex: 1},
+			pb.Request{Method: "PUT", Id: 1, PrevExist: boolp(true), PrevIndex: 1},
 			Response{Event: &store.Event{}}, []string{"Update"},
 		},
 		{
-			pb.Request{Method: "PUT", Id: 1, PrevExists: boolp(false), PrevIndex: 1},
+			pb.Request{Method: "PUT", Id: 1, PrevExist: boolp(false), PrevIndex: 1},
 			Response{Event: &store.Event{}}, []string{"Create"},
 		},
 		{
-			pb.Request{Method: "PUT", Id: 1, PrevExists: boolp(true)},
+			pb.Request{Method: "PUT", Id: 1, PrevExist: boolp(true)},
 			Response{Event: &store.Event{}}, []string{"Update"},
 		},
 		{
-			pb.Request{Method: "PUT", Id: 1, PrevExists: boolp(false)},
+			pb.Request{Method: "PUT", Id: 1, PrevExist: boolp(false)},
 			Response{Event: &store.Event{}}, []string{"Create"},
 		},
 		{


### PR DESCRIPTION
It looks like this got a little out of hand. etcd v0.4.6 uses `prevExist`.
