### PR TITLE
etcdserver: init time.Time only if Expiration > 0

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -241,12 +241,20 @@ func (s *EtcdServer) sync(timeout time.Duration) {
 	}()
 }
 
+func getExpirationTime(r *pb.Request) time.Time {
+	var t time.Time
+	if r.Expiration != 0 {
+		t = time.Unix(0, r.Expiration)
+	}
+	return t
+}
+
 // apply interprets r as a call to store.X and returns an Response interpreted from store.Event
 func (s *EtcdServer) apply(r pb.Request) Response {
 	f := func(ev *store.Event, err error) Response {
 		return Response{Event: ev, err: err}
 	}
-	expr := time.Unix(0, r.Expiration)
+	expr := getExpirationTime(&r)
 	switch r.Method {
 	case "POST":
 		return f(s.Store.Create(r.Path, r.Dir, r.Val, true, expr))

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -16,6 +16,33 @@ import (
 	"github.com/coreos/etcd/third_party/code.google.com/p/go.net/context"
 )
 
+func TestGetExpirationTime(t *testing.T) {
+	tests := []struct {
+		r    pb.Request
+		want time.Time
+	}{
+		{
+			pb.Request{Expiration: 0},
+			time.Time{},
+		},
+		{
+			pb.Request{Expiration: 60000},
+			time.Unix(0, 60000),
+		},
+		{
+			pb.Request{Expiration: -60000},
+			time.Unix(0, -60000),
+		},
+	}
+
+	for i, tt := range tests {
+		got := getExpirationTime(&tt.r)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Errorf("#%d: incorrect expiration time: want=%v got=%v", i, tt.want, got)
+		}
+	}
+}
+
 // TestDoLocalAction tests requests which do not need to go through raft to be applied,
 // and are served through local data.
 func TestDoLocalAction(t *testing.T) {


### PR DESCRIPTION
golang's concept of "zero" time does not align with the zero value of
a unix timestamp. Initializing time.Time with a unix timestamp of 0
makes time.Time.IsZero fail. Solve this by initializing time.Time only
if we care about the time.

Fix #1129 
