### PR TITLE
store: fix recursive/dir arguments

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -269,7 +269,7 @@ func (s *EtcdServer) apply(r pb.Request) Response {
 		case r.PrevIndex > 0 || r.PrevValue != "":
 			return f(s.Store.CompareAndDelete(r.Path, r.PrevValue, r.PrevIndex))
 		default:
-			return f(s.Store.Delete(r.Path, r.Recursive, r.Dir))
+			return f(s.Store.Delete(r.Path, r.Dir, r.Recursive))
 		}
 	case "QGET":
 		return f(s.Store.Get(r.Path, r.Recursive, r.Sorted))

--- a/store/store.go
+++ b/store/store.go
@@ -48,7 +48,7 @@ type Store interface {
 		expireTime time.Time) (*Event, error)
 	CompareAndSwap(nodePath string, prevValue string, prevIndex uint64,
 		value string, expireTime time.Time) (*Event, error)
-	Delete(nodePath string, recursive, dir bool) (*Event, error)
+	Delete(nodePath string, dir, recursive bool) (*Event, error)
 	CompareAndDelete(nodePath string, prevValue string, prevIndex uint64) (*Event, error)
 
 	Watch(prefix string, recursive, stream bool, sinceIndex uint64) (Watcher, error)


### PR DESCRIPTION
The arguments of the function in the interface vs. the implementation were inadvertently swapped. 
