### PR TITLE
test: stop running gofmt ./

### DIFF
--- a/test
+++ b/test
@@ -14,8 +14,10 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="client etcdserver etcdserver/etcdhttp etcdserver/etcdserverpb functional proxy raft snap store wait wal ./"
-FORMATTABLE="$TESTABLE cors.go"
+# Hack: gofmt ./ will recursively check the .git directory. So use *.go for gofmt.
+TESTABLE_AND_FORMATTABLE="client etcdserver etcdserver/etcdhttp etcdserver/etcdserverpb functional proxy raft snap store wait wal"
+TESTABLE="$TESTABLE_AND_FORMATTABLE ./"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE *.go"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
gofmt ./ will recursively check the .git directory. So use *.go for
gofmt instead

/cc @bcwaldon
