### PR TITLE
wal logs saveState too frequently

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"log"
 	"os"
 	"path"
 	"sort"
@@ -68,7 +67,6 @@ type WAL struct {
 
 // Create creates a WAL ready for appending records.
 func Create(dirpath string) (*WAL, error) {
-	log.Printf("path=%s wal.create", dirpath)
 	if Exist(dirpath) {
 		return nil, os.ErrExist
 	}
@@ -101,7 +99,6 @@ func Create(dirpath string) (*WAL, error) {
 // index. The WAL cannot be appended to before reading out all of its
 // previous records.
 func OpenAtIndex(dirpath string, index int64) (*WAL, error) {
-	log.Printf("path=%s wal.load index=%d", dirpath, index)
 	names, err := readDir(dirpath)
 	if err != nil {
 		return nil, err
@@ -222,8 +219,6 @@ func (w *WAL) Cut() error {
 	w.Sync()
 	w.f.Close()
 
-	log.Printf("wal.cut index=%d prevfile=%s curfile=%s", w.enti, w.f.Name(), f.Name())
-
 	// update writer and save the previous crc
 	w.f = f
 	w.seq++
@@ -242,7 +237,6 @@ func (w *WAL) Sync() error {
 }
 
 func (w *WAL) Close() {
-	log.Printf("path=%s wal.close", w.f.Name())
 	if w.f != nil {
 		w.Sync()
 		w.f.Close()
@@ -250,7 +244,6 @@ func (w *WAL) Close() {
 }
 
 func (w *WAL) SaveInfo(i *raftpb.Info) error {
-	log.Printf("path=%s wal.saveInfo id=%d", w.f.Name(), i.Id)
 	b, err := i.Marshal()
 	if err != nil {
 		panic(err)
@@ -276,7 +269,6 @@ func (w *WAL) SaveState(s *raftpb.HardState) error {
 	if raft.IsEmptyHardState(*s) {
 		return nil
 	}
-	log.Printf("path=%s wal.saveState state=\"%+v\"", w.f.Name(), s)
 	b, err := s.Marshal()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Started etcd (on existing data dir) with no clients and etcd starting printing a commit line every second:

```
2014/09/22 13:35:16 main: no data-dir is given, using default data-dir ./0x1_etcd_data
2014/09/22 13:35:16 path=0x1_etcd_data/wal wal.load index=0
2014/09/22 13:35:16 Listening for peers on :7001
2014/09/22 13:35:16 Listening for client requests on 127.0.0.1:4001
2014/09/22 13:35:17 raft: leader changed from 0x0 to 0x1
2014/09/22 13:35:17 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:88 "
2014/09/22 13:35:17 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:89 "
2014/09/22 13:35:18 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:90 "
2014/09/22 13:35:18 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:91 "
2014/09/22 13:35:19 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:92 "
2014/09/22 13:35:19 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:93 "
2014/09/22 13:35:20 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:94 "
2014/09/22 13:35:20 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:95 "
2014/09/22 13:35:21 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:96 "
2014/09/22 13:35:21 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:97 "
2014/09/22 13:35:22 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:98 "
2014/09/22 13:35:22 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:99 "
2014/09/22 13:35:23 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:100 "
2014/09/22 13:35:23 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:101 "
2014/09/22 13:35:24 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:102 "
2014/09/22 13:35:24 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:103 "
2014/09/22 13:35:25 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:104 "
2014/09/22 13:35:25 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:105 "
2014/09/22 13:35:26 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:106 "
2014/09/22 13:35:26 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:107 "
2014/09/22 13:35:27 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:108 "
2014/09/22 13:35:27 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:109 "
2014/09/22 13:35:28 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:110 "
2014/09/22 13:35:28 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:111 "
2014/09/22 13:35:29 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:112 "
2014/09/22 13:35:29 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:113 "
2014/09/22 13:35:30 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:114 "
2014/09/22 13:35:30 path=0x1_etcd_data/wal/0000000000000000-0000000000000000.wal wal.saveState state="term:8 vote:0 commit:115 "
```
