### PR TITLE
Add link for etcd-backup

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -3,6 +3,7 @@
 **Tools**
 
 - [etcdctl](https://github.com/coreos/etcdctl) - A command line client for etcd
+- [etcd-backup](https://github.com/fanhattan/etcd-backup) - A powerful command line utility for dumping/restoring etcd - Supports v2
 - [etcd-dump](https://npmjs.org/package/etcd-dump) - Command line utility for dumping/restoring etcd.
 - [etcd-fs](https://github.com/xetorthio/etcd-fs) - FUSE filesystem for etcd
 - [etcd-browser](https://github.com/henszey/etcd-browser) - A web-based key/value editor for etcd using AngularJS


### PR DESCRIPTION
Hey Guys!

We recently decided to add etcd to our stack and despite a few bugs we love it. I spent some time looking at a backup utility for it and was not able to find something that worked properly (I had a lot of troubles with etcd-dump, specially when trying to restore the dataset). Eventually I decided to write one: It's very powerful, works perfectly on V2 and has some nice features(respects expiration dates and empty directories, supports backup and restore strategies, etc.).

Performance wise I was able to save a full dump of the data set of 2 Millions data points in 4 minutes. The dump file was 75Mo (json file).  And it took 15 minutes to restore it(the etcd cluster was the bottleneck at that point). We have been using it for a month in production now and are very happy about it, so we figure it was time to share it with the world.

Thanks,
Thomas.
