### PR TITLE
script protobuf generation

### DIFF
--- a/etcdserver/etcdserverpb/genproto.sh
+++ b/etcdserver/etcdserverpb/genproto.sh
@@ -1,8 +1,0 @@
-set -e
-protoc --gogo_out=. -I=.:$GOPATH/src/code.google.com/p/gogoprotobuf/protobuf:$GOPATH/src *.proto
-
-prefix=github.com/coreos/etcd/third_party
-sed \
-	-i'.bak' \
-	"s|code.google.com/p/gogoprotobuf/proto|$prefix/code.google.com/p/gogoprotobuf/proto|" *.go
-rm *.bak

--- a/raft/raftpb/genproto.sh
+++ b/raft/raftpb/genproto.sh
@@ -1,8 +1,0 @@
-set -e
-protoc --gogo_out=. -I=.:$GOPATH/src/code.google.com/p/gogoprotobuf/protobuf:$GOPATH/src *.proto
-
-prefix=github.com/coreos/etcd/third_party
-sed \
-	-i'.bak' \
-	"s|code.google.com/p/gogoprotobuf/proto|$prefix/code.google.com/p/gogoprotobuf/proto|" *.go
-rm *.bak

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+#
+# Generate all etcd protobuf bindings.
+# Run from repository root.
+#
+
+PREFIX="github.com/coreos/etcd/third_party"
+DIRS="./wal/walpb ./etcdserver/etcdserverpb ./snap/snappb ./raft/raftpb"
+
+SHA="20c42d4d4d776b60d32c2d35ecac40a60793f661"
+
+if ! protoc --version > /dev/null; then
+	echo "could not find protoc, is it installed + in PATH?"
+	exit 255
+fi
+
+# Ensure we have the right version of protoc-gen-gogo by building it every time.
+# TODO(jonboulle): vendor this instead of `go get`ting it.
+export GOPATH=${PWD}/gopath
+export GOBIN=${PWD}/bin
+go get code.google.com/p/gogoprotobuf/{proto,protoc-gen-gogo,gogoproto}
+pushd ${GOPATH}/src/code.google.com/p/gogoprotobuf
+	git reset --hard ${SHA}
+	make
+popd
+
+export PATH="${GOBIN}:${PATH}"
+
+for dir in ${DIRS}; do
+	pushd ${dir}
+		protoc --gogo_out=. -I=.:${GOPATH}/src/code.google.com/p/gogoprotobuf/protobuf:${GOPATH}/src *.proto
+		sed -i".bak" -e "s|code.google.com/p/gogoprotobuf/proto|${PREFIX}/code.google.com/p/gogoprotobuf/proto|" *.go
+		rm -f *.bak
+	popd
+done

--- a/snap/snappb/genproto.sh
+++ b/snap/snappb/genproto.sh
@@ -1,8 +1,0 @@
-set -e
-protoc --gogo_out=. -I=.:$GOPATH/src/code.google.com/p/gogoprotobuf/protobuf:$GOPATH/src *.proto
-
-prefix=github.com/coreos/etcd/third_party
-sed \
-	-i'.bak' \
-	"s|code.google.com/p/gogoprotobuf/proto|$prefix/code.google.com/p/gogoprotobuf/proto|" *.go
-rm *.bak

--- a/wal/walpb/genproto.sh
+++ b/wal/walpb/genproto.sh
@@ -1,8 +1,0 @@
-set -e
-protoc --gogo_out=. -I=.:$GOPATH/src/code.google.com/p/gogoprotobuf/protobuf:$GOPATH/src *.proto
-
-prefix=github.com/coreos/etcd/third_party
-sed \
-	-i'.bak' \
-	"s|code.google.com/p/gogoprotobuf/proto|$prefix/code.google.com/p/gogoprotobuf/proto|" *.go
-rm *.bak


### PR DESCRIPTION
Since protobuf generation relies on a particular version of go libraries `code.google.com/p/gogoprotobuf/{proto,protoc-gen-gogo,gogoproto}`, we need to vendor them so that we can build the bindings consistently. We do something similar in fleet when generating the API bindings with a bit of [Godep mangling](https://github.com/coreos/fleet/blob/master/contrib/schema_generator_import.go)
