### PR TITLE
`prevValue` ignored when no value provided

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -218,6 +218,14 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		)
 	}
 
+	pV := r.FormValue("prevValue")
+	if _, ok := r.Form["prevValue"]; ok && pV == "" {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`"prevValue" cannot be empty`,
+		)
+	}
+
 	// prevExist is nullable, so leave it null if not specified
 	var pe *bool
 	if _, ok := r.Form["prevExist"]; ok {
@@ -236,7 +244,7 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		Method:    r.Method,
 		Path:      p,
 		Val:       r.FormValue("value"),
-		PrevValue: r.FormValue("prevValue"),
+		PrevValue: pV,
 		PrevIndex: pIdx,
 		PrevExist: pe,
 		Recursive: rec,

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -147,6 +147,11 @@ func TestBadParseRequest(t *testing.T) {
 			mustNewForm(t, "foo", url.Values{"stream": []string{"something"}}),
 			etcdErr.EcodeInvalidField,
 		},
+		// prevValue cannot be empty
+		{
+			mustNewForm(t, "foo", url.Values{"prevValue": []string{""}}),
+			etcdErr.EcodeInvalidField,
+		},
 		// wait is only valid with GET requests
 		{
 			mustNewMethodRequest(t, "HEAD", "foo?wait=true"),


### PR DESCRIPTION
I want to change the value of a key only if the previous value is empty. If I attempt to do this using curl, the request succeeds when it really should fail:

```
% curl -L http://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar
{"action":"set","node":{"key":"/foo","value":"bar","modifiedIndex":19,"createdIndex":19}}

% curl -L http://127.0.0.1:4001/v2/keys/foo -XPUT -d value=foo -d prevValue=
{"action":"set","node":{"key":"/foo","value":"foo","modifiedIndex":20,"createdIndex":20},"prevNode":{"key":"/foo","value":"bar","modifiedIndex":19,"createdIndex":19}}
```
