### PR TITLE
Unable to create directories

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -188,7 +188,7 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		}
 	}
 
-	var rec, sort, wait, stream bool
+	var rec, sort, wait, dir, stream bool
 	if rec, err = getBool(r.Form, "recursive"); err != nil {
 		return emptyReq, etcdErr.NewRequestError(
 			etcdErr.EcodeInvalidField,
@@ -205,6 +205,13 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		return emptyReq, etcdErr.NewRequestError(
 			etcdErr.EcodeInvalidField,
 			`invalid value for "wait"`,
+		)
+	}
+	// TODO(jonboulle): define what parameters dir is/isn't compatible with?
+	if dir, err = getBool(r.Form, "dir"); err != nil {
+		return emptyReq, etcdErr.NewRequestError(
+			etcdErr.EcodeInvalidField,
+			`invalid value for "dir"`,
 		)
 	}
 	if stream, err = getBool(r.Form, "stream"); err != nil {
@@ -247,6 +254,7 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 		Method:    r.Method,
 		Path:      p,
 		Val:       r.FormValue("value"),
+		Dir:       dir,
 		PrevValue: pV,
 		PrevIndex: pIdx,
 		PrevExist: pe,

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -102,7 +102,7 @@ func TestBadParseRequest(t *testing.T) {
 			mustNewForm(t, "foo", url.Values{"ttl": []string{"-1"}}),
 			etcdErr.EcodeTTLNaN,
 		},
-		// bad values for recursive, sorted, wait, prevExist, stream
+		// bad values for recursive, sorted, wait, prevExist, dir, stream
 		{
 			mustNewForm(t, "foo", url.Values{"recursive": []string{"hahaha"}}),
 			etcdErr.EcodeInvalidField,
@@ -137,6 +137,14 @@ func TestBadParseRequest(t *testing.T) {
 		},
 		{
 			mustNewForm(t, "foo", url.Values{"prevExist": []string{"#2"}}),
+			etcdErr.EcodeInvalidField,
+		},
+		{
+			mustNewForm(t, "foo", url.Values{"dir": []string{"no"}}),
+			etcdErr.EcodeInvalidField,
+		},
+		{
+			mustNewForm(t, "foo", url.Values{"dir": []string{"file"}}),
 			etcdErr.EcodeInvalidField,
 		},
 		{
@@ -303,6 +311,26 @@ func TestGoodParseRequest(t *testing.T) {
 				Method:     "GET",
 				Path:       "/foo",
 				Expiration: 0,
+			},
+		},
+		{
+			// dir specified
+			mustNewRequest(t, "foo?dir=true"),
+			etcdserverpb.Request{
+				Id:     1234,
+				Method: "GET",
+				Dir:    true,
+				Path:   "/foo",
+			},
+		},
+		{
+			// dir specified negatively
+			mustNewRequest(t, "foo?dir=false"),
+			etcdserverpb.Request{
+				Id:     1234,
+				Method: "GET",
+				Dir:    false,
+				Path:   "/foo",
 			},
 		},
 		{


### PR DESCRIPTION
According to https://github.com/coreos/etcd/blob/master/Documentation/api.md#creating-directories, the following example should create a directory:

```
% curl -L http://127.0.0.1:4001/v2/keys/dir -XPUT -d dir=true
{"action":"set","node":{"key":"/dir","value":"","modifiedIndex":71,"createdIndex":71}}
```

Note the lack of `"dir": true` in the returned object. Thinking that maybe the `dir` key is just missing, I tried to create a key under the `/dir` keyspace:

```
% curl -L http://127.0.0.1:4001/v2/keys/dir/key -XPUT -d value=foo
{"errorCode":104,"message":"Not a directory","cause":"/dir","index":71}
```
