### PR TITLE
"unsetting" a TTL fails

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -178,11 +178,14 @@ func parseRequest(r *http.Request, id int64) (etcdserverpb.Request, error) {
 			`invalid value for "waitIndex"`,
 		)
 	}
-	if ttl, err = getUint64(r.Form, "ttl"); err != nil {
-		return emptyReq, etcdErr.NewRequestError(
-			etcdErr.EcodeTTLNaN,
-			`invalid value for "ttl"`,
-		)
+	// An empty TTL value is equivalent to it being unset entirely
+	if len(r.FormValue("ttl")) > 0 {
+		if ttl, err = getUint64(r.Form, "ttl"); err != nil {
+			return emptyReq, etcdErr.NewRequestError(
+				etcdErr.EcodeTTLNaN,
+				`invalid value for "ttl"`,
+			)
+		}
 	}
 
 	var rec, sort, wait, stream bool

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -286,6 +286,26 @@ func TestGoodParseRequest(t *testing.T) {
 			},
 		},
 		{
+			// zero TTL specified
+			mustNewRequest(t, "foo?ttl=0"),
+			etcdserverpb.Request{
+				Id:         1234,
+				Method:     "GET",
+				Path:       "/foo",
+				Expiration: 0,
+			},
+		},
+		{
+			// empty TTL specified
+			mustNewRequest(t, "foo?ttl="),
+			etcdserverpb.Request{
+				Id:         1234,
+				Method:     "GET",
+				Path:       "/foo",
+				Expiration: 0,
+			},
+		},
+		{
 			// prevExist should be non-null if specified
 			mustNewForm(
 				t,
@@ -373,6 +393,17 @@ func TestGoodParseRequest(t *testing.T) {
 		if !reflect.DeepEqual(got, tt.w) {
 			t.Errorf("#%d: request=%#v, want %#v", i, got, tt.w)
 		}
+	}
+
+	// Test TTL separately until we don't rely on the time module...
+	now := time.Now().UnixNano()
+	req := mustNewForm(t, "foo", url.Values{"ttl": []string{"100"}})
+	got, err := parseRequest(req, 1234)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got.Expiration <= now {
+		t.Fatalf("expiration = %v, wanted > %v", got.Expiration, now)
 	}
 }
 


### PR DESCRIPTION
According to https://github.com/coreos/etcd/blob/master/Documentation/api.md#using-key-ttl, you should be able to set a TTL to an empty value to "unset" it. My attempt to do so failed:

```
% curl -L http://127.0.0.1:4001/v2/keys/foo -XPUT -d value=bar -d ttl=
{"errorCode":202,"message":"The given TTL in POST form is not a number","cause":"invalid value for \"ttl\"","index":0}
```
