### PR TITLE
TTL=0 should expire keys "now"

### DIFF
--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -294,16 +294,6 @@ func TestGoodParseRequest(t *testing.T) {
 			},
 		},
 		{
-			// zero TTL specified
-			mustNewRequest(t, "foo?ttl=0"),
-			etcdserverpb.Request{
-				Id:         1234,
-				Method:     "GET",
-				Path:       "/foo",
-				Expiration: 0,
-			},
-		},
-		{
 			// empty TTL specified
 			mustNewRequest(t, "foo?ttl="),
 			etcdserverpb.Request{
@@ -427,6 +417,16 @@ func TestGoodParseRequest(t *testing.T) {
 	now := time.Now().UnixNano()
 	req := mustNewForm(t, "foo", url.Values{"ttl": []string{"100"}})
 	got, err := parseRequest(req, 1234)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got.Expiration <= now {
+		t.Fatalf("expiration = %v, wanted > %v", got.Expiration, now)
+	}
+
+	// ensure TTL=0 results in an expiration time
+	req = mustNewForm(t, "foo", url.Values{"ttl": []string{"0"}})
+	got, err = parseRequest(req, 1234)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}


### PR DESCRIPTION
0.4.6 behaviour:

```
; curl -L http://127.0.0.1:4001/v2/keys/bar 
{"action":"get","node":{"key":"/bar","value":"bar","modifiedIndex":20,"createdIndex":20}}
; curl -L http://127.0.0.1:4001/v2/keys/bar -XPUT -d value=bar -d ttl=0
{"action":"set","node":{"key":"/bar","value":"bar","expiration":"2014-09-24T17:17:52.500773513-07:00","modifiedIndex":25,"createdIndex":25},"prevNode":{"key":"/bar","value":"bar","modifiedIndex":20,"createdIndex":20}}: trevize fleet upstream-master ; 
; curl -L http://127.0.0.1:4001/v2/keys/bar 
{"errorCode":100,"message":"Key not found","cause":"/bar","index":27}
```
