### PR TITLE
main: deprecate peers flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ var (
 		"peer-addr",
 		"peer-heartbeat-interval",
 		"peer-election-timeout",
+		"peers",
 		"peers-file",
 		"retry-interval",
 		"snapshot",


### PR DESCRIPTION
per #1155 - this fell out in #1147 - I assume we want to deprecate it in favour of bootstrap-config now?
