### PR TITLE
main: undeprecate peers-file for now

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ var (
 		"peer-addr",
 		"peer-heartbeat-interval",
 		"peer-election-timeout",
-		"peers-file",
 		"retry-interval",
 		"snapshot",
 		"v",


### PR DESCRIPTION
per #1188 it probably isn't safe to start 0.5 if someone has --peers-file configured. So until we come up with an answer for that, stop this arg from being silently ignored.
