### PR TITLE
Watches do not return X-Etcd-Index header

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -352,6 +352,7 @@ func handleWatch(ctx context.Context, w http.ResponseWriter, wa store.Watcher, s
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Etcd-Index", fmt.Sprint(wa.StartIndex()))
 	w.Header().Set("X-Raft-Index", fmt.Sprint(rt.Index()))
 	w.Header().Set("X-Raft-Term", fmt.Sprint(rt.Term()))
 	w.WriteHeader(http.StatusOK)

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1059,6 +1059,7 @@ func (s *storeRecorder) DeleteExpiredKeys(cutoff time.Time) {
 type stubWatcher struct{}
 
 func (w *stubWatcher) EventChan() chan *store.Event { return nil }
+func (w *stubWatcher) StartIndex() uint64           { return 0 }
 func (w *stubWatcher) Remove()                      {}
 
 // errStoreRecorder returns an store error on Get, Watch request

--- a/store/watcher.go
+++ b/store/watcher.go
@@ -18,6 +18,7 @@ package store
 
 type Watcher interface {
 	EventChan() chan *Event
+	StartIndex() uint64 // The EtcdIndex at which the Watcher was created
 	Remove()
 }
 
@@ -26,6 +27,7 @@ type watcher struct {
 	stream     bool
 	recursive  bool
 	sinceIndex uint64
+	startIndex uint64
 	hub        *watcherHub
 	removed    bool
 	remove     func()
@@ -33,6 +35,10 @@ type watcher struct {
 
 func (w *watcher) EventChan() chan *Event {
 	return w.eventChan
+}
+
+func (w *watcher) StartIndex() uint64 {
+	return w.startIndex
 }
 
 // notify function notifies the watcher. If the watcher interests in the given path,

--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -51,6 +51,7 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 		recursive:  recursive,
 		stream:     stream,
 		sinceIndex: index,
+		startIndex: storeIndex,
 		hub:        wh,
 	}
 


### PR DESCRIPTION
This is not necessarily a problem as it's unclear what value it should be. It can be current etcd index or it can be the index of the event being returned. Maybe it should not be returned.

However this does break compatibility with 0.4.6.
