### PR TITLE
raft: heartbeat is only response for maintaining leader dominance

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -190,16 +190,11 @@ func (r *raft) sendAppend(to int64) {
 	r.send(m)
 }
 
-// sendHeartbeat sends RRPC, without entries to the given peer.
+// sendHeartbeat sends an empty msgApp
 func (r *raft) sendHeartbeat(to int64) {
-	pr := r.prs[to]
-	index := max(pr.next-1, r.raftLog.offset)
 	m := pb.Message{
-		To:      to,
-		Type:    msgApp,
-		Index:   index,
-		LogTerm: r.raftLog.term(index),
-		Commit:  r.raftLog.committed,
+		To:   to,
+		Type: msgApp,
 	}
 	r.send(m)
 }


### PR DESCRIPTION
Separate the health checking logic and actual entry appending logic.

Follower will always reply `accept` to heartbeat. Heartbeat will not trigger `msgApp` or `msgSnap` even if the follower is not synced with leader or is not matched with leader's log.
