### PR TITLE
flags/urls: reject url without port

### DIFF
--- a/pkg/flags/urls.go
+++ b/pkg/flags/urls.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 )
@@ -27,6 +28,9 @@ func (us *URLs) Set(s string) error {
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
 			return fmt.Errorf("URL scheme must be http or https: %s", s)
+		}
+		if _, _, err := net.SplitHostPort(u.Host); err != nil {
+			return fmt.Errorf(`URL address does not have the form "host:port": %s`, s)
 		}
 		if u.Path != "" {
 			return fmt.Errorf("URL must not contain a path: %s", s)

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -21,6 +21,7 @@ func TestValidateURLsBad(t *testing.T) {
 		"234#$",
 		"file://foo/bar",
 		"http://hello/asdf",
+		"http://10.1.1.1",
 	}
 	for i, in := range tests {
 		u := URLs{}
@@ -34,7 +35,8 @@ func TestValidateURLsGood(t *testing.T) {
 	tests := []string{
 		"https://1.2.3.4:8080",
 		"http://10.1.1.1:80",
-		"http://10.1.1.1",
+		"http://localhost:80",
+		"http://:80",
 	}
 	for i, in := range tests {
 		u := URLs{}


### PR DESCRIPTION
For now, if etcd receives a url without port, it will listen on a random
port, which is useless.
