### PR TITLE
main: Fix compilation error on master

### DIFF
--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func startEtcd() {
 
 	s := &etcdserver.EtcdServer{
 		Name:       *name,
-		ClientURLs: strings.Split(acurls.String(), ","),
+		ClientURLs: strings.Split(cls.Get().String(), ","),
 		Store:      st,
 		Node:       n,
 		Storage: struct {


### PR DESCRIPTION
The `acurls` variable does not exist. After this change the build successes and `./test` passes
