### PR TITLE
Flag `-timeout` not descriptive

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -35,15 +35,12 @@ const (
 var errClosed = errors.New("etcdhttp: client closed connection")
 
 // NewClientHandler generates a muxed http.Handler with the given parameters to serve etcd client requests.
-func NewClientHandler(server *etcdserver.EtcdServer, timeout time.Duration) http.Handler {
+func NewClientHandler(server *etcdserver.EtcdServer) http.Handler {
 	sh := &serverHandler{
 		server:       server,
 		clusterStore: server.ClusterStore,
 		timer:        server,
-		timeout:      timeout,
-	}
-	if sh.timeout == 0 {
-		sh.timeout = defaultServerTimeout
+		timeout:      defaultServerTimeout,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(keysPrefix, sh.serveKeys)

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -591,7 +591,7 @@ func TestV2MachinesEndpoint(t *testing.T) {
 		{"POST", http.StatusMethodNotAllowed},
 	}
 
-	m := NewClientHandler(&etcdserver.EtcdServer{ClusterStore: &fakeCluster{}}, time.Hour)
+	m := NewClientHandler(&etcdserver.EtcdServer{ClusterStore: &fakeCluster{}})
 	s := httptest.NewServer(m)
 	defer s.Close()
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/coreos/etcd/etcdserver"
 	"github.com/coreos/etcd/etcdserver/etcdhttp"
@@ -27,7 +26,6 @@ const (
 
 var (
 	name         = flag.String("name", "default", "Unique human-readable name for this node")
-	timeout      = flag.Duration("timeout", 10*time.Second, "Request Timeout")
 	dir          = flag.String("data-dir", "", "Path to the data directory")
 	snapCount    = flag.Uint64("snapshot-count", etcdserver.DefaultSnapCount, "Number of committed transactions to trigger a snapshot")
 	printVersion = flag.Bool("version", false, "Print the version and exit")
@@ -150,7 +148,7 @@ func startEtcd() {
 	s.Start()
 
 	ch := &pkg.CORSHandler{
-		Handler: etcdhttp.NewClientHandler(s, *timeout),
+		Handler: etcdhttp.NewClientHandler(s),
 		Info:    cors,
 	}
 	ph := etcdhttp.NewPeerHandler(s)


### PR DESCRIPTION
The `-timeout` flag is incredibly nebulous. It needs a more specific name and a description of what it actually controls.
