### PR TITLE
raft: fix send

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -184,7 +184,12 @@ func (r *raft) poll(id int64, v bool) (granted int) {
 // send persists state to stable storage and then sends to its mailbox.
 func (r *raft) send(m pb.Message) {
 	m.From = r.id
-	m.Term = r.Term
+	// do not attach term to msgProp
+	// proposals are a way to forward to the leader and
+	// should be treated as local message.
+	if m.Type != msgProp {
+		m.Term = r.Term
+	}
 	r.msgs = append(r.msgs, m)
 }
 


### PR DESCRIPTION
send should not attach current term to msgProp. Send should simply do proxy for msgProp without
changing its term. msgProp has a special term 0, which indicates that it is a local message.
/cc @dterei 
