### PR TITLE
store: use a larger buffer for eventChan

### DIFF
--- a/store/watcher_hub.go
+++ b/store/watcher_hub.go
@@ -47,7 +47,7 @@ func (wh *watcherHub) watch(key string, recursive, stream bool, index, storeInde
 	}
 
 	w := &watcher{
-		eventChan:  make(chan *Event, 1), // use a buffered channel
+		eventChan:  make(chan *Event, 100), // use a buffered channel
 		recursive:  recursive,
 		stream:     stream,
 		sinceIndex: index,


### PR DESCRIPTION
The event channel for watches can drop events too easily in the case of 
streaming watches. This increases the buffer to a more useful level.

Reference:
- https://github.com/coreos/etcd/blob/master/store/watcher.go#L69
- https://github.com/coreos/etcd/issues/1074

This is a suboptimal solution, but an improvement in anticipation of the store being reworked much more substantially.
