### PR TITLE
client: return timeout error for gateway timeout

### DIFF
--- a/client/http_test.go
+++ b/client/http_test.go
@@ -325,7 +325,7 @@ func TestUnmarshalErrorResponse(t *testing.T) {
 		{http.StatusNotImplemented, unrecognized},
 		{http.StatusBadGateway, unrecognized},
 		{http.StatusServiceUnavailable, unrecognized},
-		{http.StatusGatewayTimeout, unrecognized},
+		{http.StatusGatewayTimeout, ErrGatewayTimeout},
 		{http.StatusHTTPVersionNotSupported, unrecognized},
 	}
 


### PR DESCRIPTION
So discovery could trigger its retry logic for gateway timeout too. [no longer true]
so user could know explicitly what happens:

```
yichengq@1 ~/s/g/c/etcd> time bin/etcd -name foo -advertise-peer-urls=http://127.0.0.1:10101 -discovery $(curl -s https://discovery.etcd.io/new)
2014/10/13 11:42:38 main: no data-dir provided, using default data-dir ./623679009225009941_etcd_data
2014/10/13 11:43:38 etcd: client: gateway timeout
```
