### PR TITLE
main: use node name as default dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func startEtcd() {
 	}
 
 	if *dir == "" {
-		*dir = fmt.Sprintf("%v_etcd_data", self.ID)
+		*dir = fmt.Sprintf("%v_etcd_data", self.Name)
 		log.Printf("etcd: no data-dir provided, using default data-dir ./%s", *dir)
 	}
 	if err := os.MkdirAll(*dir, privateDirMode); err != nil {


### PR DESCRIPTION
We use nodeID as the default dir previously. It works fine before we do dynamic nodeID
generation (introducing time). After the change the dynamic nodeID will change every
time we restart the etcd process. If the user does not provide the data dir, the default
dir will change every time. It is not the desired behavior.

In this commit, we change the default data dir to node name. If the user changes the node
name and does provide the data dir, etcd still cannot recover from previous state. But it
is much better than using nodeID. And it is actually a documentation issue.
