### PR TITLE
etcdserver/etcdhttp: store location adjustment

### DIFF
--- a/etcdserver/cluster_store.go
+++ b/etcdserver/cluster_store.go
@@ -53,7 +53,7 @@ func (s *clusterStore) Add(m Member) {
 // lock here.
 func (s *clusterStore) Get() Cluster {
 	c := &Cluster{}
-	e, err := s.Store.Get(membersKVPrefix, true, true)
+	e, err := s.Store.Get(MemberSpacePrefix, true, true)
 	if err != nil {
 		if v, ok := err.(*etcdErr.Error); ok && v.ErrorCode == etcdErr.EcodeKeyNotFound {
 			return *c

--- a/etcdserver/cluster_store_test.go
+++ b/etcdserver/cluster_store_test.go
@@ -18,7 +18,7 @@ func TestClusterStoreAdd(t *testing.T) {
 		{
 			name: "Create",
 			params: []interface{}{
-				membersKVPrefix + "1/raftAttributes",
+				MemberSpacePrefix + "/1/raftAttributes",
 				false,
 				`{"PeerURLs":null}`,
 				false,
@@ -28,7 +28,7 @@ func TestClusterStoreAdd(t *testing.T) {
 		{
 			name: "Create",
 			params: []interface{}{
-				membersKVPrefix + "1/attributes",
+				MemberSpacePrefix + "/1/attributes",
 				false,
 				`{"Name":"node1","ClientURLs":null}`,
 				false,
@@ -96,7 +96,7 @@ func TestClusterStoreDelete(t *testing.T) {
 	cs.Add(newTestMember(1, nil, "node1", nil))
 	cs.Remove(1)
 
-	wdeletes := []string{membersKVPrefix + "1"}
+	wdeletes := []string{MemberSpacePrefix + "/1"}
 	if !reflect.DeepEqual(st.deletes, wdeletes) {
 		t.Error("deletes = %v, want %v", st.deletes, wdeletes)
 	}

--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -88,6 +88,7 @@ func (h serverHandler) serveKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rr.Path = etcdserver.KeySpacePrefix + rr.Path
 	resp, err := h.server.Do(ctx, rr)
 	if err != nil {
 		writeError(w, err)
@@ -96,14 +97,15 @@ func (h serverHandler) serveKeys(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case resp.Event != nil:
-		if err := writeEvent(w, resp.Event, h.timer); err != nil {
+		ev := trimEventPrefix(resp.Event, etcdserver.KeySpacePrefix)
+		if err := writeEvent(w, ev, h.timer); err != nil {
 			// Should never be reached
 			log.Printf("error writing event: %v", err)
 		}
 	case resp.Watcher != nil:
 		ctx, cancel := context.WithTimeout(context.Background(), defaultWatchTimeout)
 		defer cancel()
-		handleWatch(ctx, w, resp.Watcher, rr.Stream, h.timer)
+		handleKeyWatch(ctx, w, resp.Watcher, rr.Stream, h.timer)
 	default:
 		writeError(w, errors.New("received response with no Event/Watcher!"))
 	}
@@ -342,7 +344,7 @@ func writeEvent(w http.ResponseWriter, ev *store.Event, rt etcdserver.RaftTimer)
 	return json.NewEncoder(w).Encode(ev)
 }
 
-func handleWatch(ctx context.Context, w http.ResponseWriter, wa store.Watcher, stream bool, rt etcdserver.RaftTimer) {
+func handleKeyWatch(ctx context.Context, w http.ResponseWriter, wa store.Watcher, stream bool, rt etcdserver.RaftTimer) {
 	defer wa.Remove()
 	ech := wa.EventChan()
 	var nch <-chan bool
@@ -374,6 +376,7 @@ func handleWatch(ctx context.Context, w http.ResponseWriter, wa store.Watcher, s
 				// send to the client in time. Then we simply end streaming.
 				return
 			}
+			ev = trimEventPrefix(ev, etcdserver.KeySpacePrefix)
 			if err := json.NewEncoder(w).Encode(ev); err != nil {
 				// Should never be reached
 				log.Println("error writing event: %v", err)
@@ -399,4 +402,24 @@ func allowMethod(w http.ResponseWriter, m string, ms ...string) bool {
 	w.Header().Set("Allow", strings.Join(ms, ","))
 	http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 	return false
+}
+
+func trimEventPrefix(ev *store.Event, pre string) *store.Event {
+	if ev == nil {
+		return nil
+	}
+	ev.Node = trimNodeExternPrefix(ev.Node, pre)
+	ev.PrevNode = trimNodeExternPrefix(ev.PrevNode, pre)
+	return ev
+}
+
+func trimNodeExternPrefix(n *store.NodeExtern, pre string) *store.NodeExtern {
+	if n == nil {
+		return nil
+	}
+	n.Key = strings.TrimPrefix(n.Key, pre)
+	for _, nn := range n.Nodes {
+		nn = trimNodeExternPrefix(nn, pre)
+	}
+	return n
 }

--- a/etcdserver/member.go
+++ b/etcdserver/member.go
@@ -12,8 +12,6 @@ import (
 	"github.com/coreos/etcd/pkg/types"
 )
 
-const membersKVPrefix = "/_etcd/members/"
-
 // RaftAttributes represents the raft related attributes of an etcd member.
 type RaftAttributes struct {
 	// TODO(philips): ensure these are URLs
@@ -55,7 +53,7 @@ func newMember(name string, peerURLs types.URLs, now *time.Time) *Member {
 }
 
 func (m Member) storeKey() string {
-	return path.Join(membersKVPrefix, strconv.FormatUint(m.ID, 16))
+	return path.Join(MemberSpacePrefix, strconv.FormatUint(m.ID, 16))
 }
 
 func parseMemberID(key string) uint64 {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -29,6 +29,9 @@ const (
 	DefaultSnapCount   = 10000
 	// TODO: calculate based on heartbeat interval
 	defaultPublishRetryInterval = 5 * time.Second
+
+	KeySpacePrefix    = "/keys"
+	MemberSpacePrefix = "/members"
 )
 
 var (


### PR DESCRIPTION
Detailed adjustment:
/\* -> /keys/*
/_etcd/machines/\* -> /members/*

And it keeps results returned to users the same as before.

fixes #1279 
