### PR TITLE
raft: remove unused compactThreshold

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -6,10 +6,6 @@ import (
 	pb "github.com/coreos/etcd/raft/raftpb"
 )
 
-const (
-	defaultCompactThreshold = 10000
-)
-
 type raftLog struct {
 	ents      []pb.Entry
 	unstable  uint64
@@ -17,19 +13,14 @@ type raftLog struct {
 	applied   uint64
 	offset    uint64
 	snapshot  pb.Snapshot
-
-	// want a compact after the number of entries exceeds the threshold
-	// TODO(xiangli) size might be a better criteria
-	compactThreshold uint64
 }
 
 func newLog() *raftLog {
 	return &raftLog{
-		ents:             make([]pb.Entry, 1),
-		unstable:         0,
-		committed:        0,
-		applied:          0,
-		compactThreshold: defaultCompactThreshold,
+		ents:      make([]pb.Entry, 1),
+		unstable:  0,
+		committed: 0,
+		applied:   0,
 	}
 }
 
@@ -176,10 +167,6 @@ func (l *raftLog) snap(d []byte, index, term uint64, nodes []uint64, removed []u
 		Term:         term,
 		RemovedNodes: removed,
 	}
-}
-
-func (l *raftLog) shouldCompact() bool {
-	return (l.applied - l.offset) > l.compactThreshold
 }
 
 func (l *raftLog) restore(s pb.Snapshot) {

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -896,8 +896,8 @@ func TestRecvMsgBeat(t *testing.T) {
 
 func TestRestore(t *testing.T) {
 	s := pb.Snapshot{
-		Index:        defaultCompactThreshold + 1,
-		Term:         defaultCompactThreshold + 1,
+		Index:        11, // magic number
+		Term:         11, // magic number
 		Nodes:        []uint64{1, 2, 3},
 		RemovedNodes: []uint64{4, 5},
 	}
@@ -934,8 +934,8 @@ func TestRestore(t *testing.T) {
 
 func TestProvideSnap(t *testing.T) {
 	s := pb.Snapshot{
-		Index: defaultCompactThreshold + 1,
-		Term:  defaultCompactThreshold + 1,
+		Index: 11, // magic number
+		Term:  11, // magic number
 		Nodes: []uint64{1, 2},
 	}
 	sm := newRaft(1, []uint64{1}, 10, 1)
@@ -963,8 +963,8 @@ func TestProvideSnap(t *testing.T) {
 
 func TestRestoreFromSnapMsg(t *testing.T) {
 	s := pb.Snapshot{
-		Index: defaultCompactThreshold + 1,
-		Term:  defaultCompactThreshold + 1,
+		Index: 11, // magic number
+		Term:  11, // magic number
 		Nodes: []uint64{1, 2},
 	}
 	m := pb.Message{Type: pb.MsgSnap, From: 1, Term: 2, Snapshot: s}
@@ -982,7 +982,7 @@ func TestSlowNodeRestore(t *testing.T) {
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
 	nt.isolate(3)
-	for j := 0; j < defaultCompactThreshold+1; j++ {
+	for j := 0; j <= 100; j++ {
 		nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 	}
 	lead := nt.peers[1].(*raft)


### PR DESCRIPTION
This speeds up the test considerably (3.5s -> 1.5s), and I don't see a strong reason that it needs to be such a high figure in the tests
