### PR TITLE
etcdserver: fix data race in leaderStats.Followers

### DIFF
--- a/etcdserver/cluster_store.go
+++ b/etcdserver/cluster_store.go
@@ -149,12 +149,7 @@ func send(c *http.Client, cls ClusterStore, m raftpb.Message, ss *stats.ServerSt
 			ss.SendAppendReq(len(data))
 		}
 		to := strconv.FormatUint(m.To, 16)
-		fs, ok := ls.Followers[to]
-		if !ok {
-			fs = &stats.FollowerStats{}
-			fs.Latency.Minimum = 1 << 63
-			ls.Followers[to] = fs
-		}
+		fs := ls.Follower(to)
 
 		start := time.Now()
 		sent := httpPost(c, u, data)


### PR DESCRIPTION
data race comes when 
https://github.com/coreos/etcd/blob/master/etcdserver/cluster_store.go#L152
and 
https://github.com/coreos/etcd/blob/master/etcdserver/cluster_store.go#L156
happens at the same time
