### PR TITLE
doc: add note about discovery proxy

### DIFF
--- a/Documentation/0.5/clustering.md
+++ b/Documentation/0.5/clustering.md
@@ -121,6 +121,8 @@ $ etcd -name infra2 -advertise-peer-urls http://10.0.1.12:2379 -discovery https:
 This will cause each machine to register itself with the etcd service and begin
 the cluster once all machines have been registered.
 
+You can use the environment variable `ETCD_DISCOVERY_PROXY` to cause etcd to use an HTTP proxy to connect to the discovery service.
+
 ### Error and Warning Cases
 
 #### Discovery Server Errors


### PR DESCRIPTION
We can add this to the other documentation too but I'd rather wait until 0.5 becomes mainline so we don't confuse people in the 0.4 documentation.
