### PR TITLE
etcdserver: mark removed instead of deletion on removed members

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -98,6 +98,9 @@ func (c Cluster) String() string {
 func (c Cluster) IDs() []uint64 {
 	var ids []uint64
 	for _, m := range c {
+		if m.Removed {
+			continue
+		}
 		ids = append(ids, m.ID)
 	}
 	sort.Sort(types.Uint64Slice(ids))
@@ -110,6 +113,9 @@ func (c Cluster) IDs() []uint64 {
 func (c Cluster) PeerURLs() []string {
 	endpoints := make([]string, 0)
 	for _, p := range c {
+		if p.Removed {
+			continue
+		}
 		for _, addr := range p.PeerURLs {
 			endpoints = append(endpoints, addr)
 		}
@@ -124,6 +130,9 @@ func (c Cluster) PeerURLs() []string {
 func (c Cluster) ClientURLs() []string {
 	urls := make([]string, 0)
 	for _, p := range c {
+		if p.Removed {
+			continue
+		}
 		for _, url := range p.ClientURLs {
 			urls = append(urls, url)
 		}

--- a/etcdserver/cluster_store.go
+++ b/etcdserver/cluster_store.go
@@ -35,6 +35,10 @@ type clusterStore struct {
 // Add puts a new Member into the store.
 // A Member with a matching id must not exist.
 func (s *clusterStore) Add(m Member) {
+	if m.Removed == true {
+		log.Panicf("unexpected Removed == true")
+	}
+
 	b, err := json.Marshal(m.RaftAttributes)
 	if err != nil {
 		log.Panicf("marshal error: %v", err)
@@ -97,12 +101,20 @@ func nodeToMember(n *store.NodeExtern) (Member, error) {
 	return m, nil
 }
 
-// Remove removes a member from the store.
-// The given id MUST exist.
+// Remove marks a member as removed in the store.
+// The given id MUST exists as active member.
 func (s *clusterStore) Remove(id uint64) {
-	p := s.Get().FindID(id).storeKey()
-	if _, err := s.Store.Delete(p, true, true); err != nil {
-		log.Panicf("delete peer should never fail: %v", err)
+	m := s.Get().FindID(id)
+	if m.Removed == true {
+		log.Panicf("unexpected Removed == true")
+	}
+	m.Removed = true
+	b, err := json.Marshal(m.RaftAttributes)
+	if err != nil {
+		log.Panicf("marshal error: %v", err)
+	}
+	if _, err := s.Store.Set(m.storeKey()+raftAttributesSuffix, false, string(b), store.Permanent); err != nil {
+		log.Panicf("set raftAttributes should never fail: %v", err)
 	}
 }
 

--- a/etcdserver/member.go
+++ b/etcdserver/member.go
@@ -18,6 +18,7 @@ const membersKVPrefix = "/_etcd/members/"
 type RaftAttributes struct {
 	// TODO(philips): ensure these are URLs
 	PeerURLs []string
+	Removed  bool
 }
 
 // Attributes represents all the non-raft related attributes of an etcd member.


### PR DESCRIPTION
etcd may send MsgDenied to removed peers, so etcdserver needs to maintain
their info even if they are removed.
