### PR TITLE
integration: increase retry times for request

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -36,7 +36,10 @@ func testCluster(t *testing.T, size int) {
 	for i := 0; i < size; i++ {
 		for _, u := range c.Members[i].ClientURLs {
 			var err error
-			for j := 0; j < 3; j++ {
+			// TODO: find a stable way to determine whether it succeeds
+			// the request timeout in server side doesn't imply what happens
+			// in the cluster now.
+			for j := 0; j < 100; j++ {
 				if err = setKey(u, "/foo", "bar"); err == nil {
 					break
 				}


### PR DESCRIPTION
As a client, it doesn't have good ways to figure out what happens when its request fails. It just retry enough times until success now.

etcd may fail in travis due to put data failure in etcd cluster:
https://travis-ci.org/coreos/etcd/builds/38673516

The reason for it is a lot:
1. travis sometimes runs rather slow
2. newly-built cluster need to elect leader and publish info
3. -race testing makes it slow
The root cause for it is that integration tests uses real time in testing, but it is (may be) reasonable because integration testing tests the actual behavior.
