### PR TITLE
etcdserver: use hex for cluster and machine id

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -244,7 +244,7 @@ func (h serverHandler) serveRaft(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "error unmarshaling raft message", http.StatusBadRequest)
 		return
 	}
-	log.Printf("etcdhttp: raft recv message from %#x: %+v", m.From, m)
+	log.Printf("etcdhttp: raft recv message from %x: %+v", m.From, m)
 	if err := h.server.Process(context.TODO(), m); err != nil {
 		log.Println("etcdhttp: error processing raft message:", err)
 		switch err {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -683,7 +683,7 @@ func restartNode(cfg *ServerConfig, index uint64, snapshot *raftpb.Snapshot) (id
 	var metadata pb.Metadata
 	pbutil.MustUnmarshal(&metadata, wmetadata)
 	id, cid = metadata.NodeID, metadata.ClusterID
-	log.Printf("etcdserver: restart node %d in cluster %d at commit index %d", id, cid, st.Commit)
+	log.Printf("etcdserver: restart member %x in cluster %x at commit index %d", id, cid, st.Commit)
 	n = raft.RestartNode(id, 10, 1, snapshot, st, ents)
 	return
 }


### PR DESCRIPTION
Continue using hex everywhere. Including here.

TODO: cleanup the printing of the structs which currently have decimal
to/from:

`{Type:MsgAppResp To:9973738105406047488 From:17050684879817348455 T...`
