### PR TITLE
raft: fix transmission logic

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -379,11 +379,7 @@ func (r *raft) Step(m pb.Message) error {
 }
 
 func (r *raft) handleAppendEntries(m pb.Message) {
-	if r.raftLog.maybeAppend(m.Index, m.LogTerm, m.Commit, m.Entries...) {
-		mlastIndex := m.Index
-		if len(m.Entries) != 0 {
-			mlastIndex = m.Entries[len(m.Entries)-1].Index
-		}
+	if mlastIndex, ok := r.raftLog.maybeAppend(m.Index, m.LogTerm, m.Commit, m.Entries...); ok {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: mlastIndex})
 	} else {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: m.Index, Reject: true})


### PR DESCRIPTION
As explained in #1366, the leader fails to transmit the missed
logs if it receives a hearbeat response from a follower that is
not yet matched in the leader. When a follower is not matched,
there are append responses that do not explicitly reject but
imply a gap.

This commit is based on @xiangli-cmu's idea. We should only acknowledge
upto the index of logs in the append message. This way responses to
heartbeats would never interfer with the log synchronization because
their log index is always 0.

All test cases pass.

Fixes #1366
