### PR TITLE
etcdserver: support newly-join member bootstrap

### DIFF
--- a/etcdserver/cluster_state.go
+++ b/etcdserver/cluster_state.go
@@ -21,12 +21,14 @@ import (
 )
 
 const (
-	ClusterStateValueNew = "new"
+	ClusterStateValueNew      = "new"
+	ClusterStateValueExisting = "existing"
 )
 
 var (
 	ClusterStateValues = []string{
 		ClusterStateValueNew,
+		ClusterStateValueExisting,
 	}
 )
 

--- a/etcdserver/member.go
+++ b/etcdserver/member.go
@@ -96,3 +96,11 @@ func parseMemberID(key string) uint64 {
 func removedMemberStoreKey(id uint64) string {
 	return path.Join(storeRemovedMembersPrefix, idAsHex(id))
 }
+
+type SortableMemberSliceByPeerURLs []*Member
+
+func (p SortableMemberSliceByPeerURLs) Len() int { return len(p) }
+func (p SortableMemberSliceByPeerURLs) Less(i, j int) bool {
+	return p[i].PeerURLs[0] < p[j].PeerURLs[0]
+}
+func (p SortableMemberSliceByPeerURLs) Swap(i, j int) { p[i], p[j] = p[j], p[i] }


### PR DESCRIPTION
```
1 > $ goreman -f="Procfile" start
2 > $ curl -XPOST http://127.0.0.1:4001/v2/admin/members/ -H "Content-Type:application/json" -d '{"PeerURLs":["http://127.0.0.1:7004"]}'
2 > $ ./bin/etcd -name node4 -listen-client-urls http://127.0.0.1:4004 -advertise-client-urls http://127.0.0.1:4004 -listen-peer-urls http://127.0.0.1:7004 -advertise-peer-urls http://127.0.0.1:7004 -initial-cluster 'node1=http://localhost:7001,node2=http://localhost:7002,node3=http://localhost:7003,node4=http://127.0.0.1:7004' -initial-cluster-state existing
```

The cluster runs well.
