### PR TITLE
etcdhttp: trim StoreKeysPrefix from error in serveKeys

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -124,6 +124,7 @@ func (h serverHandler) serveKeys(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.server.Do(ctx, rr)
 	if err != nil {
+		err = trimErrorPrefix(err, etcdserver.StoreKeysPrefix)
 		writeError(w, err)
 		return
 	}
@@ -586,4 +587,11 @@ func trimNodeExternPrefix(n *store.NodeExtern, prefix string) *store.NodeExtern 
 		nn = trimNodeExternPrefix(nn, prefix)
 	}
 	return n
+}
+
+func trimErrorPrefix(err error, prefix string) error {
+	if e, ok := err.(*etcdErr.Error); ok {
+		e.Cause = strings.TrimPrefix(e.Cause, prefix)
+	}
+	return err
 }


### PR DESCRIPTION
It returns error messaage like this now:
'{"errorCode":100,"message":"Key not found","cause":"/1/pants","index":10}'

The commit trims '/1' prefix from cause field if exists.

This is a hack to make it display well. It is correct because all error causes
that contain Path puts Path at the head of the string.

fixes #1389 
