### PR TITLE
etcdserver/etcdhttp: remove log message for every received raft

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -276,7 +276,6 @@ func (h serverHandler) serveRaft(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "error unmarshaling raft message", http.StatusBadRequest)
 		return
 	}
-	log.Printf("etcdhttp: raft recv message from %x: %+v", m.From, m)
 	if err := h.server.Process(context.TODO(), m); err != nil {
 		log.Println("etcdhttp: error processing raft message:", err)
 		switch err {


### PR DESCRIPTION
@xiangli-cmu @unihorn do we still need this? it's terribly noisy.
