### PR TITLE
Consistently handle (lack of) trailing slash in HTTP request

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -220,6 +220,10 @@ func (h serverHandler) serveAdminMembers(w http.ResponseWriter, r *http.Request)
 		}
 	case "DELETE":
 		idStr := trimPrefix(r.URL.Path, adminMembersPrefix)
+		if idStr == "" {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		id, err := strconv.ParseUint(idStr, 16, 64)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/etcdserver/etcdhttp/http_test.go
+++ b/etcdserver/etcdhttp/http_test.go
@@ -1657,6 +1657,16 @@ func TestServeAdminMembersFail(t *testing.T) {
 
 			http.StatusInternalServerError,
 		},
+		{
+			// etcdserver.RemoveMember error
+			&http.Request{
+				URL:    mustNewURL(t, adminMembersPrefix),
+				Method: "DELETE",
+			},
+			nil,
+
+			http.StatusMethodNotAllowed,
+		},
 	}
 	for i, tt := range tests {
 		h := &serverHandler{


### PR DESCRIPTION
If I GET the /v2/keys collection without a trailing slash, I get the following response:

```
% curl -i localhost:4002/v2/keys
HTTP/1.1 200 OK
Content-Type: application/json
X-Etcd-Index: 10
X-Raft-Index: 1477
X-Raft-Term: 1
Date: Fri, 24 Oct 2014 20:41:04 GMT
Transfer-Encoding: chunked

{"action":"get","node":{"dir":true,"nodes":[{"key":"/foo","value":"bar","modifiedIndex":10,"createdIndex":10}],"modifiedIndex":10,"createdIndex":10}}
```

However, if I GET the /v2/admin/members collection without a trailing slash, I get a 301:

```
% curl -i localhost:4002/v2/admin/members
HTTP/1.1 301 Moved Permanently
Location: /v2/admin/members/
Date: Fri, 24 Oct 2014 20:41:08 GMT
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked

<a href="/v2/admin/members/">Moved Permanently</a>.
```

Se need to be consistent here. The "correct" thing to do here is to require no trailing slash to access the collection, while the presence of a trailing slash (regardless of what follows it) meaning the request references a specific item in the collection. The solution most helpful to our users is to handle a trailing slash followed by an empty path element the same as if the trailing slash was not provided. 
