### PR TITLE
raft: stop logging IDs with 0x prefix

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -219,7 +219,7 @@ func (n *node) run(r *raft) {
 		}
 
 		if rd.SoftState != nil && lead != rd.SoftState.Lead {
-			log.Printf("raft: leader changed from %#x to %#x", lead, rd.SoftState.Lead)
+			log.Printf("raft: leader changed from %x to %x", lead, rd.SoftState.Lead)
 			lead = rd.SoftState.Lead
 			if r.hasLeader() {
 				propc = n.propc


### PR DESCRIPTION
I decided not to use pkg/strutil.IDAsHex since that would introduce a dependency on the etcd project from the raft pkg - not sure if that's ok.

Fix #1445 
