### PR TITLE
etcdserver: exit program when node is removed

### DIFF
--- a/etcdserver/sender.go
+++ b/etcdserver/sender.go
@@ -108,11 +108,11 @@ func httpPost(c *http.Client, url string, cid uint64, data []byte) bool {
 	switch resp.StatusCode {
 	case http.StatusPreconditionFailed:
 		// TODO: shutdown the etcdserver gracefully?
-		log.Panicf("clusterID mismatch")
+		log.Fatalf("etcd: conflicting cluster ID with the target cluster (%s != %s). Exiting.", resp.Header.Get("X-Etcd-Cluster-ID"), strutil.IDAsHex(cid))
 		return false
 	case http.StatusForbidden:
 		// TODO: stop the server
-		log.Panicf("the member has been removed")
+		log.Fatalf("etcd: this member has been permanently removed from the cluster. Exiting.")
 		return false
 	case http.StatusNoContent:
 		return true


### PR DESCRIPTION
Originally added in https://github.com/coreos/etcd/commit/400dd2d7bce39851220899bb6d98086583e73ead,
and removed by mistake when refactor cluster.
