### PR TITLE
etcdserver: exit program when apply conf change of remove self

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -638,6 +638,10 @@ func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, nodes []uint64) error
 		s.Cluster.AddMember(m)
 	case raftpb.ConfChangeRemoveNode:
 		s.Cluster.RemoveMember(cc.NodeID)
+		if cc.NodeID == s.id {
+			// TODO: stop the server
+			log.Fatalf("etcd: this member has been permanently removed from the cluster. Exiting.")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
etcd supports to exit when it is rejected by its peers when sending
raft messages. But it does not cover the single node case because
it does not have peer. This patch fills this gap.

fixes #1444 
