### PR TITLE
etcdhttp: only log when error deserves it

### DIFF
--- a/etcdserver/etcdhttp/http.go
+++ b/etcdserver/etcdhttp/http.go
@@ -44,13 +44,13 @@ func writeError(w http.ResponseWriter, err error) {
 	if err == nil {
 		return
 	}
-	log.Println(err)
 	switch e := err.(type) {
 	case *etcdErr.Error:
 		e.WriteTo(w)
 	case *httptypes.HTTPError:
 		e.WriteTo(w)
 	default:
+		log.Printf("etcdhttp: unexpected error: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
It is unnecessary to log every single error the user might generate through the HTTP API. Log only those errors that we don't really understand, or that we know are internal errors.
