### PR TITLE
Logging member ID as int

### DIFF
--- a/etcdserver/sender.go
+++ b/etcdserver/sender.go
@@ -58,7 +58,7 @@ func send(c *http.Client, cl *Cluster, m raftpb.Message, ss *stats.ServerStats, 
 			// TODO: unknown peer id.. what do we do? I
 			// don't think his should ever happen, need to
 			// look into this further.
-			log.Printf("etcdhttp: no member for %d", m.To)
+			log.Printf("etcdhttp: no member for %s", strutil.IDAsHex(m.To))
 			return
 		}
 		u := fmt.Sprintf("%s%s", memb.PickPeerURL(), raftPrefix)


### PR DESCRIPTION
```
2014/10/29 14:15:39 etcdhttp: no member for 176869799018424574
```
