### PR TITLE
client: pass around statuscode instead of Response

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -53,13 +53,13 @@ type httpClient struct {
 	timeout   time.Duration
 }
 
-func (c *httpClient) doWithTimeout(act httpAction) (*http.Response, []byte, error) {
+func (c *httpClient) doWithTimeout(act httpAction) (int, []byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	return c.do(ctx, act)
 }
 
-func (c *httpClient) do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
+func (c *httpClient) do(ctx context.Context, act httpAction) (int, []byte, error) {
 	req := act.httpRequest(c.endpoint)
 
 	rtchan := make(chan roundTripResponse, 1)
@@ -91,9 +91,9 @@ func (c *httpClient) do(ctx context.Context, act httpAction) (*http.Response, []
 	}()
 
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
-	return resp, body, err
+	return resp.StatusCode, body, err
 }

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -78,14 +78,14 @@ func TestHTTPClientDoSuccess(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader("foo")),
 	}
 
-	resp, body, err := c.do(context.Background(), &fakeAction{})
+	code, body, err := c.do(context.Background(), &fakeAction{})
 	if err != nil {
 		t.Fatalf("incorrect error value: want=nil got=%v", err)
 	}
 
 	wantCode := http.StatusTeapot
-	if wantCode != resp.StatusCode {
-		t.Fatalf("invalid response code: want=%d got=%d", wantCode, resp.StatusCode)
+	if wantCode != code {
+		t.Fatalf("invalid response code: want=%d got=%d", wantCode, code)
 	}
 
 	wantBody := []byte("foo")

--- a/client/keys.go
+++ b/client/keys.go
@@ -114,12 +114,12 @@ func (k *httpKeysAPI) Create(key, val string, ttl time.Duration) (*Response, err
 		create.TTL = &uttl
 	}
 
-	httpresp, body, err := k.client.doWithTimeout(create)
+	code, body, err := k.client.doWithTimeout(create)
 	if err != nil {
 		return nil, err
 	}
 
-	return unmarshalHTTPResponse(httpresp.StatusCode, body)
+	return unmarshalHTTPResponse(code, body)
 }
 
 func (k *httpKeysAPI) Get(key string) (*Response, error) {
@@ -128,12 +128,12 @@ func (k *httpKeysAPI) Get(key string) (*Response, error) {
 		Recursive: false,
 	}
 
-	httpresp, body, err := k.client.doWithTimeout(get)
+	code, body, err := k.client.doWithTimeout(get)
 	if err != nil {
 		return nil, err
 	}
 
-	return unmarshalHTTPResponse(httpresp.StatusCode, body)
+	return unmarshalHTTPResponse(code, body)
 }
 
 func (k *httpKeysAPI) Watch(key string, idx uint64) Watcher {
@@ -165,12 +165,12 @@ type httpWatcher struct {
 
 func (hw *httpWatcher) Next() (*Response, error) {
 	//TODO(bcwaldon): This needs to be cancellable by the calling user
-	httpresp, body, err := hw.client.do(context.Background(), &hw.nextWait)
+	code, body, err := hw.client.do(context.Background(), &hw.nextWait)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := unmarshalHTTPResponse(httpresp.StatusCode, body)
+	resp, err := unmarshalHTTPResponse(code, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/members.go
+++ b/client/members.go
@@ -64,12 +64,12 @@ type httpMembersAPI struct {
 }
 
 func (m *httpMembersAPI) List() ([]httptypes.Member, error) {
-	httpresp, body, err := m.client.doWithTimeout(&membersAPIActionList{})
+	code, body, err := m.client.doWithTimeout(&membersAPIActionList{})
 	if err != nil {
 		return nil, err
 	}
 
-	if err := assertStatusCode(http.StatusOK, httpresp.StatusCode); err != nil {
+	if err := assertStatusCode(http.StatusOK, code); err != nil {
 		return nil, err
 	}
 
@@ -83,12 +83,12 @@ func (m *httpMembersAPI) List() ([]httptypes.Member, error) {
 
 func (m *httpMembersAPI) Add(peerURL string) (*httptypes.Member, error) {
 	req := &membersAPIActionAdd{peerURL: peerURL}
-	httpresp, body, err := m.client.doWithTimeout(req)
+	code, body, err := m.client.doWithTimeout(req)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := assertStatusCode(http.StatusCreated, httpresp.StatusCode); err != nil {
+	if err := assertStatusCode(http.StatusCreated, code); err != nil {
 		return nil, err
 	}
 
@@ -102,12 +102,12 @@ func (m *httpMembersAPI) Add(peerURL string) (*httptypes.Member, error) {
 
 func (m *httpMembersAPI) Remove(memberID string) error {
 	req := &membersAPIActionRemove{memberID: memberID}
-	httpresp, _, err := m.client.doWithTimeout(req)
+	code, _, err := m.client.doWithTimeout(req)
 	if err != nil {
 		return err
 	}
 
-	return assertStatusCode(http.StatusNoContent, httpresp.StatusCode)
+	return assertStatusCode(http.StatusNoContent, code)
 }
 
 type membersAPIActionList struct{}


### PR DESCRIPTION
There's no real need for do and doWithTimeout to return Responses when
the only field of interest is the status code.

This also removes the superfluous httpMembersAPIResponse struct.
