### PR TITLE
fix(server): Set Server.pendingSnapshot back to nil after saving a snapshot fails.

### DIFF
--- a/third_party/github.com/goraft/raft/server.go
+++ b/third_party/github.com/goraft/raft/server.go
@@ -1248,6 +1248,7 @@ func (s *server) saveSnapshot() error {
 
 	// Write snapshot to disk.
 	if err := s.pendingSnapshot.save(); err != nil {
+		s.pendingSnapshot = nil
 		return err
 	}
 


### PR DESCRIPTION
When a snapshot fails to save, Sever.pendingSnapshot is not set to nil (like it is after a snapshot is successfully saved).  This causes all future calls to TakeSnapshot() to fail with an error "Snapshot: Last snapshot is not finished."

Fixes #1496
