### PR TITLE
doc: link directly to members API

### DIFF
--- a/Documentation/0.5/admin_guide.md
+++ b/Documentation/0.5/admin_guide.md
@@ -17,4 +17,4 @@ The data directory has two sub-directories in it:
 1. restart a etcd member without previous data directory
 2. restart a etcd member with different data directory
 
-[0]: https://github.com/coreos/etcd/blob/master/Documentation/0.5/other_apis.md
+[0]: https://github.com/coreos/etcd/blob/master/Documentation/0.5/other_apis.md#members-api


### PR DESCRIPTION
We are going to add the stats and config API docs to the other_apis.md document, so let's go ahead and future-proof this reference by linking directly to the members API heading.
