### PR TITLE
Attempting to remove nonexistent member mishandled

### DIFF
--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -762,7 +762,7 @@ func TestServeMembersFail(t *testing.T) {
 			http.StatusInternalServerError,
 		},
 		{
-			// etcdserver.RemoveMember error
+			// etcdserver.RemoveMember error with arbitrary server error
 			&http.Request{
 				URL:    mustNewURL(t, path.Join(membersPrefix, "1")),
 				Method: "DELETE",
@@ -774,7 +774,29 @@ func TestServeMembersFail(t *testing.T) {
 			http.StatusInternalServerError,
 		},
 		{
-			// etcdserver.RemoveMember error
+			// etcdserver.RemoveMember error with nonexistent ID
+			&http.Request{
+				URL:    mustNewURL(t, path.Join(membersPrefix, "0")),
+				Method: "DELETE",
+			},
+			&errServer{
+				etcdserver.ErrIDNotFound,
+			},
+
+			http.StatusNotFound,
+		},
+		{
+			// etcdserver.RemoveMember error with badly formed ID
+			&http.Request{
+				URL:    mustNewURL(t, path.Join(membersPrefix, "bad_id")),
+				Method: "DELETE",
+			},
+			nil,
+
+			http.StatusBadRequest,
+		},
+		{
+			// etcdserver.RemoveMember with no ID
 			&http.Request{
 				URL:    mustNewURL(t, membersPrefix),
 				Method: "DELETE",


### PR DESCRIPTION
1. Spin up a single-node etcd cluster.
2. Attempt to remove a non-existent member:

```
% curl -i -X DELETE http://127.0.0.1:4001/v2/admin/members/2745e2525fce8fe
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
X-Etcd-Cluster-Id: a940b9ecc6609d71
Date: Wed, 29 Oct 2014 21:30:59 GMT
Transfer-Encoding: chunked

Internal Server Error
```

There are two problems:
1. A 500 is returned rather than a 404.
2. etcd is logging stuff, but it really doesn't need to log anything since this is a user-level error:

```
2014/10/29 14:30:59 etcdhttp: remove node 2745e2525fce8fe
2014/10/29 14:30:59 etcdhttp: error removing node 2745e2525fce8fe: etcdserver: ID not found
2014/10/29 14:30:59 etcdserver: ID not found
```
