### PR TITLE
404 on DELETE member w/ invalid ID

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -209,7 +209,7 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		id, err := strconv.ParseUint(idStr, 16, 64)
 		if err != nil {
-			writeError(w, httptypes.NewHTTPError(http.StatusBadRequest, err.Error()))
+			writeError(w, httptypes.NewHTTPError(http.StatusNotFound, fmt.Sprintf("No such member: %s", idStr)))
 			return
 		}
 		err = h.server.RemoveMember(ctx, id)

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -793,7 +793,7 @@ func TestServeMembersFail(t *testing.T) {
 			},
 			nil,
 
-			http.StatusBadRequest,
+			http.StatusNotFound,
 		},
 		{
 			// etcdserver.RemoveMember with no ID


### PR DESCRIPTION
The fact that we validate the member ID as a hex-encoded uint64 is an optimization in the server. Failing this check does not warrant a different user-facing error code than if that ID was valid but does not represent an existing member.

Rebased on #1492
