### PR TITLE
*: clean log.Print

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -193,7 +193,6 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, err)
 			return
 		}
-		log.Printf("etcdhttp: added node %x with peer urls %s", m.ID, req.PeerURLs)
 
 		res := newMember(m)
 		w.Header().Set("Content-Type", "application/json")

--- a/etcdserver/sender.go
+++ b/etcdserver/sender.go
@@ -59,7 +59,7 @@ func send(c *http.Client, cl *Cluster, m raftpb.Message, ss *stats.ServerStats, 
 				// TODO: unknown peer id.. what do we do? I
 				// don't think his should ever happen, need to
 				// look into this further.
-				log.Printf("etcdhttp: error sending message to unknown receiver %s", strutil.IDAsHex(m.To))
+				log.Printf("etcdserver: error sending message to unknown receiver %s", strutil.IDAsHex(m.To))
 			}
 			return
 		}
@@ -69,7 +69,7 @@ func send(c *http.Client, cl *Cluster, m raftpb.Message, ss *stats.ServerStats, 
 		// of messages out at a time.
 		data, err := m.Marshal()
 		if err != nil {
-			log.Println("etcdhttp: dropping message:", err)
+			log.Println("sender: dropping message:", err)
 			return // drop bad message
 		}
 		if m.Type == raftpb.MsgApp {

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -465,7 +465,6 @@ func (s *EtcdServer) Term() uint64 {
 func (s *EtcdServer) configure(ctx context.Context, cc raftpb.ConfChange) error {
 	ch := s.w.Register(cc.ID)
 	if err := s.node.ProposeConfChange(ctx, cc); err != nil {
-		log.Printf("configure error: %v", err)
 		s.w.Trigger(cc.ID, nil)
 		return err
 	}

--- a/etcdserver/stats/leader.go
+++ b/etcdserver/stats/leader.go
@@ -49,7 +49,7 @@ func (ls *LeaderStats) JSON() []byte {
 	b, err := json.Marshal(stats)
 	// TODO(jonboulle): appropriate error handling?
 	if err != nil {
-		log.Printf("error marshalling leader stats: %v", err)
+		log.Printf("stats: error marshalling leader stats: %v", err)
 	}
 	return b
 }

--- a/etcdserver/stats/server.go
+++ b/etcdserver/stats/server.go
@@ -64,7 +64,7 @@ func (ss *ServerStats) JSON() []byte {
 	b, err := json.Marshal(stats)
 	// TODO(jonboulle): appropriate error handling?
 	if err != nil {
-		log.Printf("error marshalling server stats: %v", err)
+		log.Printf("stats: error marshalling server stats: %v", err)
 	}
 	return b
 }

--- a/proxy/director.go
+++ b/proxy/director.go
@@ -62,7 +62,7 @@ func (d *director) refresh() {
 	for _, u := range urls {
 		uu, err := url.Parse(u)
 		if err != nil {
-			log.Printf("upstream URL invalid: %v", err)
+			log.Printf("proxy: upstream URL invalid: %v", err)
 			continue
 		}
 		endpoints = append(endpoints, newEndpoint(*uu))

--- a/snap/snapshotter.go
+++ b/snap/snapshotter.go
@@ -102,25 +102,25 @@ func loadSnap(dir, name string) (*raftpb.Snapshot, error) {
 
 	b, err = ioutil.ReadFile(fpath)
 	if err != nil {
-		log.Printf("Snapshotter cannot read file %v: %v", name, err)
+		log.Printf("snap: snapshotter cannot read file %v: %v", name, err)
 		return nil, err
 	}
 
 	var serializedSnap snappb.Snapshot
 	if err = serializedSnap.Unmarshal(b); err != nil {
-		log.Printf("Corrupted snapshot file %v: %v", name, err)
+		log.Printf("snap: corrupted snapshot file %v: %v", name, err)
 		return nil, err
 	}
 	crc := crc32.Update(0, crcTable, serializedSnap.Data)
 	if crc != serializedSnap.Crc {
-		log.Printf("Corrupted snapshot file %v: crc mismatch", name)
+		log.Printf("snap: corrupted snapshot file %v: crc mismatch", name)
 		err = ErrCRCMismatch
 		return nil, err
 	}
 
 	var snap raftpb.Snapshot
 	if err = snap.Unmarshal(serializedSnap.Data); err != nil {
-		log.Printf("Corrupted snapshot file %v: %v", name, err)
+		log.Printf("snap: corrupted snapshot file %v: %v", name, err)
 		return nil, err
 	}
 	return &snap, nil
@@ -152,7 +152,7 @@ func checkSuffix(names []string) []string {
 		if strings.HasSuffix(names[i], snapSuffix) {
 			snaps = append(snaps, names[i])
 		} else {
-			log.Printf("Unexpected non-snap file %v", names[i])
+			log.Printf("snap: unexpected non-snap file %v", names[i])
 		}
 	}
 	return snaps
@@ -161,6 +161,6 @@ func checkSuffix(names []string) []string {
 func renameBroken(path string) {
 	brokenPath := path + ".broken"
 	if err := os.Rename(path, brokenPath); err != nil {
-		log.Printf("Cannot rename broken snapshot file %v to %v: %v", path, brokenPath, err)
+		log.Printf("snap: cannot rename broken snapshot file %v to %v: %v", path, brokenPath, err)
 	}
 }

--- a/wal/util.go
+++ b/wal/util.go
@@ -82,7 +82,7 @@ func checkWalNames(names []string) []string {
 	wnames := make([]string, 0)
 	for _, name := range names {
 		if _, _, err := parseWalName(name); err != nil {
-			log.Printf("parse %s: %v", name, err)
+			log.Printf("wal: parse %s error: %v", name, err)
 			continue
 		}
 		wnames = append(wnames, name)


### PR DESCRIPTION
1. only log things by default that the operator of etcd may need to react to
2. put package name at the head of log lines

for #1409 
