### PR TITLE
etcdctl: two member fixes

### DIFF
--- a/etcdctl/command/member_commands.go
+++ b/etcdctl/command/member_commands.go
@@ -12,8 +12,8 @@ import (
 
 func NewMemberCommand() cli.Command {
 	return cli.Command{
-		Name: "member",
-		Usage:  "member add, remove and list subcommands",
+		Name:  "member",
+		Usage: "member add, remove and list subcommands",
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:   "list",
@@ -70,20 +70,44 @@ func actionMemberList(c *cli.Context) {
 
 func actionMemberAdd(c *cli.Context) {
 	args := c.Args()
-	if len(args) != 1 {
-		fmt.Fprintln(os.Stderr, "Provide a single member peerURL")
+	if len(args) != 2 {
+		fmt.Fprintln(os.Stderr, "Provide a name and a single member peerURL")
 		os.Exit(1)
 	}
 
 	mAPI := mustNewMembersAPI(c)
-	url := args[0]
+
+	url := args[1]
 	m, err := mAPI.Add(url)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
-	fmt.Printf("Added member to cluster with ID %s", m.ID)
+	newID := m.ID
+	newName := args[0]
+	fmt.Printf("Added member named %s with ID %s to cluster\n", newName, newID)
+
+	members, err := mAPI.List()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	conf := []string{}
+	for _, m := range members {
+		for _, u := range m.PeerURLs {
+			n := m.Name
+			if m.ID == newID {
+				n = newName
+			}
+			conf = append(conf, fmt.Sprintf("%s=%s", n, u))
+		}
+	}
+
+	fmt.Printf("ETCD_NAME=%q\n", newName)
+	fmt.Printf("ETCD_INITIAL_CLUSTER=%q\n", strings.Join(conf, ","))
+	fmt.Printf("ETCD_INITIAL_CLUSTER_STATE=existing\n")
 }
 
 func actionMemberRemove(c *cli.Context) {


### PR DESCRIPTION
437a10d (Brandon Philips, 4 minutes ago)
   etcdctl: take a name and print out the initial cluster

   To help the user lets print out the configuration that they will need to
   give to their new member:

   $ etcdctl member add infra4 http://localhost:7004 added member
   9bf1b35fc7761a23 to cluster ETCD_NAME="infra4"
   ETCD_INITIAL_CLUSTER="node2=http://localhost:7002,node3=http://localhost:7003,infra4=http://localhost:7004,node1=http://localhost:7001"

   This is a little weird because the API doesn't take a name so the user
   gives us a name and we just pass it on through.

8f3be20 (Brandon Philips, 37 minutes ago)
   etcdctl: add help on the members subcommands
