### PR TITLE
etcd: print initial cluster members during startup

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -151,6 +151,7 @@ func startEtcd() {
 	if err != nil {
 		log.Fatalf("etcd: error setting up initial cluster: %v", err)
 	}
+	log.Printf("etcd: initial cluster members: %s", cls.String())
 
 	if *dir == "" {
 		*dir = fmt.Sprintf("%v.etcd", *name)


### PR DESCRIPTION
etcd now prints the initial clusters members during startup.

```
2014/11/03 10:32:46 etcd: initial cluster members: etcd0=http://127.0.0.1:2380,etcd1=http://127.0.0.1:2390,etcd2=http://127.0.0.1:240
```
