### PR TITLE
etcdserver: print out initial cluster members

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -151,7 +151,6 @@ func startEtcd() {
 	if err != nil {
 		log.Fatalf("etcd: error setting up initial cluster: %v", err)
 	}
-	log.Printf("etcd: initial cluster members: %s", cls.String())
 
 	if *dir == "" {
 		*dir = fmt.Sprintf("%v.etcd", *name)

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -216,6 +216,7 @@ func NewServer(cfg *ServerConfig) *EtcdServer {
 			}
 		}
 		cfg.Cluster.SetStore(st)
+		log.Printf("etcdserver: initial cluster members: %s", cfg.Cluster)
 		id, n, w = startNode(cfg, cfg.Cluster.MemberIDs())
 	case haveWAL:
 		if cfg.ShouldDiscover() {


### PR DESCRIPTION
It is moved from etcdmain pkg because the line should only be printed out
when etcd bootstraps at the first time.

follow up for #1576 
@kelseyhightower 
