### PR TITLE
etcdhttp/etcdserver: support HEAD on /v2/keys/ namespace

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -93,7 +93,7 @@ type keysHandler struct {
 }
 
 func (h *keysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if !allowMethod(w, r.Method, "GET", "PUT", "POST", "DELETE") {
+	if !allowMethod(w, r.Method, "HEAD", "GET", "PUT", "POST", "DELETE") {
 		return
 	}
 	w.Header().Set("X-Etcd-Cluster-ID", h.clusterInfo.ID().String())

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -409,6 +409,12 @@ func (s *EtcdServer) Do(ctx context.Context, r pb.Request) (Response, error) {
 			}
 			return Response{Event: ev}, nil
 		}
+	case "HEAD":
+		ev, err := s.store.Get(r.Path, r.Recursive, r.Sorted)
+		if err != nil {
+			return Response{}, err
+		}
+		return Response{Event: ev}, nil
 	default:
 		return Response{}, ErrUnknownMethod
 	}

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -88,6 +88,16 @@ func TestDoLocalAction(t *testing.T) {
 			},
 		},
 		{
+			pb.Request{Method: "HEAD", ID: 1},
+			Response{Event: &store.Event{}}, nil,
+			[]action{
+				action{
+					name:   "Get",
+					params: []interface{}{"", false, false},
+				},
+			},
+		},
+		{
 			pb.Request{Method: "BADMETHOD", ID: 1},
 			Response{}, ErrUnknownMethod, []action{},
 		},
@@ -125,6 +135,10 @@ func TestDoBadLocalAction(t *testing.T) {
 		},
 		{
 			pb.Request{Method: "GET", ID: 1},
+			[]action{action{name: "Get"}},
+		},
+		{
+			pb.Request{Method: "HEAD", ID: 1},
 			[]action{action{name: "Get"}},
 		},
 	}

--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -912,8 +912,6 @@ func TestV2WatchKeyInDir(t *testing.T) {
 	}
 }
 
-// TODO(jonboulle): enable once #1590 is fixed
-/*
 func TestV2Head(t *testing.T) {
 	cl := cluster{Size: 1}
 	cl.Launch(t)
@@ -930,8 +928,8 @@ func TestV2Head(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
-	if resp.ContentLength != -1 {
-		t.Errorf("ContentLength = %d, want -1", resp.ContentLength)
+	if resp.ContentLength <= 0 {
+		t.Errorf("ContentLength = %d, want > 0", resp.ContentLength)
 	}
 
 	resp, _ = tc.PutForm(fullURL, v)
@@ -942,11 +940,10 @@ func TestV2Head(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	if resp.ContentLength != -1 {
-		t.Errorf("ContentLength = %d, want -1", resp.ContentLength)
+	if resp.ContentLength <= 0 {
+		t.Errorf("ContentLength = %d, want > 0", resp.ContentLength)
 	}
 }
-*/
 
 func checkBody(body map[string]interface{}, w map[string]interface{}) error {
 	if body["node"] != nil {


### PR DESCRIPTION
fixes #1590 

```
$ curl http://127.0.0.1:4001/v2/keys/foo -I
HTTP/1.1 200 OK
Content-Type: application/json
X-Etcd-Cluster-Id: e9c7614f68f35fb2
X-Etcd-Index: 34
X-Raft-Index: 537
X-Raft-Term: 9
Date: Tue, 04 Nov 2014 06:01:00 GMT
```
