### PR TITLE
return 410 Gone for member that has been removed in /v2/members -XDELETE

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -211,6 +211,8 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		err = h.server.RemoveMember(ctx, uint64(id))
 		switch {
+		case err == etcdserver.ErrIDRemoved:
+			writeError(w, httptypes.NewHTTPError(http.StatusGone, fmt.Sprintf("Member permanently removed: %s", idStr)))
 		case err == etcdserver.ErrIDNotFound:
 			writeError(w, httptypes.NewHTTPError(http.StatusNotFound, fmt.Sprintf("No such member: %s", idStr)))
 		case err != nil:

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -786,6 +786,18 @@ func TestServeMembersFail(t *testing.T) {
 			http.StatusInternalServerError,
 		},
 		{
+			// etcdserver.RemoveMember error with preivously removed ID
+			&http.Request{
+				URL:    mustNewURL(t, path.Join(membersPrefix, "0")),
+				Method: "DELETE",
+			},
+			&errServer{
+				etcdserver.ErrIDRemoved,
+			},
+
+			http.StatusGone,
+		},
+		{
 			// etcdserver.RemoveMember error with nonexistent ID
 			&http.Request{
 				URL:    mustNewURL(t, path.Join(membersPrefix, "0")),


### PR DESCRIPTION
The requested resource is no longer available at the server and no forwarding address is known. This condition is expected to be considered permanent. 
