### PR TITLE
client: return ErrNoEndpoint when none available

### DIFF
--- a/client/http_test.go
+++ b/client/http_test.go
@@ -234,6 +234,14 @@ func TestHTTPClusterClientDo(t *testing.T) {
 			wantErr: ErrCanceled,
 		},
 
+		// return err if there are no endpoints
+		{
+			client: &httpClusterClient{
+				endpoints: []HTTPClient{},
+			},
+			wantErr: ErrNoEndpoints,
+		},
+
 		// return err if all endpoints return arbitrary errors
 		{
 			client: &httpClusterClient{


### PR DESCRIPTION
In certain cases (for example, if a cluster peer is accessible but it has no
members listed), the httpClusterClient could have an empty set of endpoints as
a result of the Sync. This means that its Do function could potentially return
a nil response and nil error, with catastrophic consequences for callers.

To be safe (particularly about this latter behaviour), this change errors in
both Sync and Do if no endpoints are available.
