### PR TITLE
integration: bump timeout for good path

### DIFF
--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -847,7 +847,7 @@ func TestV2WatchWithIndex(t *testing.T) {
 
 	select {
 	case <-c:
-	case <-time.After(time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("cannot get watch result")
 	}
 


### PR DESCRIPTION
When waiting for a watch result, we expect the good path to complete quickly
here so we don't need to time out so aggressively. (Failure noted in #1600)
