### PR TITLE
No logs when members added/removed from cluster

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -648,8 +648,11 @@ func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, nodes []uint64) error
 			panic("unexpected nodeID mismatch")
 		}
 		s.Cluster.AddMember(m)
+		log.Printf("etcdserver: added node %s to cluster", types.ID(cc.NodeID))
 	case raftpb.ConfChangeRemoveNode:
-		s.Cluster.RemoveMember(types.ID(cc.NodeID))
+		id := types.ID(cc.NodeID)
+		s.Cluster.RemoveMember(id)
+		log.Printf("etcdserver: removed node %s from cluster", id)
 	}
 	return nil
 }


### PR DESCRIPTION
I would expect to see logs across the entire cluster when a member is successfully added or removed. Currently, there are no such logs, and I have no way to tell what the current state of my cluster was at a given time based on the logs alone.
