### PR TITLE
POST /v2/members should accept a member name in addition to the peerURLs

### DIFF
--- a/Documentation/0.5/other_apis.md
+++ b/Documentation/0.5/other_apis.md
@@ -58,7 +58,7 @@ If the POST body is malformed an HTTP 400 will be returned. If the member exists
 ```
 POST /v2/members HTTP/1.1
 
-{"peerURLs": ["http://10.0.0.10:2379"]}
+{"name":"foo","peerURLs": ["http://10.0.0.10:2379"]}
 ```
 
 ### Example
@@ -70,6 +70,7 @@ curl http://10.0.0.10:2379/v2/members -XPOST -H "Content-Type: application/json"
 ```json
 {
     "id": "3777296169",
+    "name":"foo",
     "peerURLs": [
         "http://10.0.0.10:2379"
     ]

--- a/client/members.go
+++ b/client/members.go
@@ -41,7 +41,7 @@ func NewMembersAPI(c HTTPClient) MembersAPI {
 
 type MembersAPI interface {
 	List(ctx context.Context) ([]httptypes.Member, error)
-	Add(ctx context.Context, peerURL string) (*httptypes.Member, error)
+	Add(ctx context.Context, name, peerURL string) (*httptypes.Member, error)
 	Remove(ctx context.Context, mID string) error
 }
 
@@ -68,13 +68,13 @@ func (m *httpMembersAPI) List(ctx context.Context) ([]httptypes.Member, error) {
 	return []httptypes.Member(mCollection), nil
 }
 
-func (m *httpMembersAPI) Add(ctx context.Context, peerURL string) (*httptypes.Member, error) {
+func (m *httpMembersAPI) Add(ctx context.Context, name, peerURL string) (*httptypes.Member, error) {
 	urls, err := types.NewURLs([]string{peerURL})
 	if err != nil {
 		return nil, err
 	}
 
-	req := &membersAPIActionAdd{peerURLs: urls}
+	req := &membersAPIActionAdd{name: name, peerURLs: urls}
 	resp, body, err := m.client.Do(ctx, req)
 	if err != nil {
 		return nil, err
@@ -122,12 +122,16 @@ func (d *membersAPIActionRemove) HTTPRequest(ep url.URL) *http.Request {
 }
 
 type membersAPIActionAdd struct {
+	name     string
 	peerURLs types.URLs
 }
 
 func (a *membersAPIActionAdd) HTTPRequest(ep url.URL) *http.Request {
 	u := v2MembersURL(ep)
-	m := httptypes.MemberCreateRequest{PeerURLs: a.peerURLs}
+	m := httptypes.MemberCreateRequest{
+		Name:     a.name,
+		PeerURLs: a.peerURLs,
+	}
 	b, _ := json.Marshal(&m)
 	req, _ := http.NewRequest("POST", u.String(), bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")

--- a/client/members_test.go
+++ b/client/members_test.go
@@ -45,6 +45,7 @@ func TestMembersAPIActionList(t *testing.T) {
 func TestMembersAPIActionAdd(t *testing.T) {
 	ep := url.URL{Scheme: "http", Host: "example.com"}
 	act := &membersAPIActionAdd{
+		name: "foobar",
 		peerURLs: types.URLs([]url.URL{
 			url.URL{Scheme: "https", Host: "127.0.0.1:8081"},
 			url.URL{Scheme: "http", Host: "127.0.0.1:8080"},
@@ -59,7 +60,7 @@ func TestMembersAPIActionAdd(t *testing.T) {
 	wantHeader := http.Header{
 		"Content-Type": []string{"application/json"},
 	}
-	wantBody := []byte(`{"peerURLs":["https://127.0.0.1:8081","http://127.0.0.1:8080"]}`)
+	wantBody := []byte(`{"name":"foobar","peerURLs":["https://127.0.0.1:8081","http://127.0.0.1:8080"]}`)
 
 	got := *act.HTTPRequest(ep)
 	err := assertResponse(got, wantURL, wantHeader, wantBody)

--- a/etcdctl/command/member_commands.go
+++ b/etcdctl/command/member_commands.go
@@ -106,9 +106,10 @@ func actionMemberAdd(c *cli.Context) {
 
 	mAPI := mustNewMembersAPI(c)
 
+	name := args[0]
 	url := args[1]
 	ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
-	m, err := mAPI.Add(ctx, url)
+	m, err := mAPI.Add(ctx, name, url)
 	cancel()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -116,8 +117,7 @@ func actionMemberAdd(c *cli.Context) {
 	}
 
 	newID := m.ID
-	newName := args[0]
-	fmt.Printf("Added member named %s with ID %s to cluster\n", newName, newID)
+	fmt.Printf("Added member named %s with ID %s to cluster\n", name, newID)
 
 	ctx, cancel = context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 	members, err := mAPI.List(ctx)
@@ -132,14 +132,14 @@ func actionMemberAdd(c *cli.Context) {
 		for _, u := range m.PeerURLs {
 			n := m.Name
 			if m.ID == newID {
-				n = newName
+				n = name
 			}
 			conf = append(conf, fmt.Sprintf("%s=%s", n, u))
 		}
 	}
 
 	fmt.Print("\n")
-	fmt.Printf("ETCD_NAME=%q\n", newName)
+	fmt.Printf("ETCD_NAME=%q\n", name)
 	fmt.Printf("ETCD_INITIAL_CLUSTER=%q\n", strings.Join(conf, ","))
 	fmt.Printf("ETCD_INITIAL_CLUSTER_STATE=\"existing\"\n")
 }

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -185,7 +185,7 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		now := h.clock.Now()
-		m := etcdserver.NewMember("", req.PeerURLs, "", &now)
+		m := etcdserver.NewMember(req.Name, req.PeerURLs, "", &now)
 		err = h.server.AddMember(ctx, *m)
 		switch {
 		case err == etcdserver.ErrIDExists || err == etcdserver.ErrPeerURLexists:

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -615,7 +615,7 @@ func TestServeMembers(t *testing.T) {
 
 func TestServeMembersCreate(t *testing.T) {
 	u := mustNewURL(t, membersPrefix)
-	b := []byte(`{"peerURLs":["http://127.0.0.1:1"]}`)
+	b := []byte(`{"name":"hello","peerURLs":["http://127.0.0.1:1"]}`)
 	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(b))
 	if err != nil {
 		t.Fatal(err)
@@ -646,7 +646,7 @@ func TestServeMembersCreate(t *testing.T) {
 		t.Errorf("cid = %s, want %s", gcid, wcid)
 	}
 
-	wb := `{"id":"2a86a83729b330d5","name":"","peerURLs":["http://127.0.0.1:1"],"clientURLs":[]}` + "\n"
+	wb := `{"id":"2a86a83729b330d5","name":"hello","peerURLs":["http://127.0.0.1:1"],"clientURLs":[]}` + "\n"
 	g := rw.Body.String()
 	if g != wb {
 		t.Errorf("got body=%q, want %q", g, wb)
@@ -654,6 +654,9 @@ func TestServeMembersCreate(t *testing.T) {
 
 	wm := etcdserver.Member{
 		ID: 3064321551348478165,
+		Attributes: etcdserver.Attributes{
+			Name: "hello",
+		},
 		RaftAttributes: etcdserver.RaftAttributes{
 			PeerURLs: []string{"http://127.0.0.1:1"},
 		},

--- a/etcdserver/etcdhttp/httptypes/member.go
+++ b/etcdserver/etcdhttp/httptypes/member.go
@@ -18,6 +18,7 @@ package httptypes
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/coreos/etcd/pkg/types"
 )
@@ -30,13 +31,16 @@ type Member struct {
 }
 
 type MemberCreateRequest struct {
+	Name     string
 	PeerURLs types.URLs
 }
 
 func (m *MemberCreateRequest) MarshalJSON() ([]byte, error) {
 	s := struct {
+		Name     string   `json:"name"`
 		PeerURLs []string `json:"peerURLs"`
 	}{
+		Name:     m.Name,
 		PeerURLs: make([]string, len(m.PeerURLs)),
 	}
 
@@ -48,7 +52,9 @@ func (m *MemberCreateRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (m *MemberCreateRequest) UnmarshalJSON(data []byte) error {
+	fmt.Printf("got: %v\n", string(data))
 	s := struct {
+		Name     string   `json:"name"`
 		PeerURLs []string `json:"peerURLs"`
 	}{}
 
@@ -62,6 +68,7 @@ func (m *MemberCreateRequest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	m.Name = s.Name
 	m.PeerURLs = urls
 	return nil
 }

--- a/etcdserver/etcdhttp/httptypes/member_test.go
+++ b/etcdserver/etcdhttp/httptypes/member_test.go
@@ -202,12 +202,13 @@ func TestMemberCreateRequestUnmarshalFail(t *testing.T) {
 
 func TestMemberCreateRequestMarshal(t *testing.T) {
 	req := MemberCreateRequest{
+		Name: "foobar",
 		PeerURLs: types.URLs([]url.URL{
 			url.URL{Scheme: "http", Host: "127.0.0.1:8081"},
 			url.URL{Scheme: "https", Host: "127.0.0.1:8080"},
 		}),
 	}
-	want := []byte(`{"peerURLs":["http://127.0.0.1:8081","https://127.0.0.1:8080"]}`)
+	want := []byte(`{"name":"foobar","peerURLs":["http://127.0.0.1:8081","https://127.0.0.1:8080"]}`)
 
 	got, err := json.Marshal(&req)
 	if err != nil {


### PR DESCRIPTION
Currently members are only added with a peerURL and not a name. This makes it hard to log events from the members endpoint and feels inconsistent. 

https://github.com/coreos/etcd/blob/master/Documentation/0.5/other_apis.md#post-v2members
