### PR TITLE
raft: remove raftLog.resetUnstable and resetNextEnts

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -114,10 +114,6 @@ func (l *raftLog) unstableEnts() []pb.Entry {
 	return cpy
 }
 
-func (l *raftLog) resetUnstable() {
-	l.unstable = l.lastIndex() + 1
-}
-
 // nextEnts returns all the available entries for execution.
 // all the returned entries will be marked as applied.
 func (l *raftLog) nextEnts() (ents []pb.Entry) {
@@ -125,12 +121,6 @@ func (l *raftLog) nextEnts() (ents []pb.Entry) {
 		return l.slice(l.applied+1, l.committed+1)
 	}
 	return nil
-}
-
-func (l *raftLog) resetNextEnts() {
-	if l.committed > l.applied {
-		l.applied = l.committed
-	}
 }
 
 func (l *raftLog) appliedTo(i uint64) {

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -286,7 +286,7 @@ func TestCompactionSideEffects(t *testing.T) {
 		raftLog.append(uint64(i), pb.Entry{Term: uint64(i + 1), Index: uint64(i + 1)})
 	}
 	raftLog.maybeCommit(lastIndex, lastTerm)
-	raftLog.resetNextEnts()
+	raftLog.appliedTo(raftLog.committed)
 
 	raftLog.compact(500)
 
@@ -342,7 +342,7 @@ func TestUnstableEnts(t *testing.T) {
 		raftLog.append(0, previousEnts...)
 		raftLog.unstable = tt.unstable
 		ents := raftLog.unstableEnts()
-		raftLog.resetUnstable()
+		raftLog.stableTo(raftLog.lastIndex())
 		if !reflect.DeepEqual(ents, tt.wents) {
 			t.Errorf("#%d: unstableEnts = %+v, want %+v", i, ents, tt.wents)
 		}
@@ -384,7 +384,7 @@ func TestCompaction(t *testing.T) {
 				raftLog.append(uint64(i), pb.Entry{})
 			}
 			raftLog.maybeCommit(tt.applied, 0)
-			raftLog.resetNextEnts()
+			raftLog.appliedTo(raftLog.committed)
 
 			for j := 0; j < len(tt.compact); j++ {
 				raftLog.compact(tt.compact[j])

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -891,8 +891,8 @@ func commitNoopEntry(r *raft) {
 	}
 	// ignore further messages to refresh followers' commmit index
 	r.readMessages()
-	r.raftLog.resetNextEnts()
-	r.raftLog.resetUnstable()
+	r.raftLog.appliedTo(r.raftLog.committed)
+	r.raftLog.stableTo(r.raftLog.lastIndex())
 }
 
 func acceptAndReply(m pb.Message) pb.Message {

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -31,7 +31,7 @@ import (
 // nextEnts returns the appliable entries and updates the applied index
 func nextEnts(r *raft) (ents []pb.Entry) {
 	ents = r.raftLog.nextEnts()
-	r.raftLog.resetNextEnts()
+	r.raftLog.appliedTo(r.raftLog.committed)
 	return ents
 }
 


### PR DESCRIPTION
These methods are no longer used outside of tests and are redundant with
the new stableTo and appliedTo methods.
