### PR TITLE
etcdserver: re-order ServerConfig fields

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -271,8 +271,8 @@ func startEtcd() error {
 		DiscoveryURL:    *durl,
 		DiscoveryProxy:  *dproxy,
 		NewCluster:      clusterStateFlag.String() == clusterStateFlagNew,
-		Transport:       pt,
 		ForceNewCluster: *forceNewCluster,
+		Transport:       pt,
 	}
 	var s *etcdserver.EtcdServer
 	s, err = etcdserver.NewServer(cfg)

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -35,8 +35,8 @@ type ServerConfig struct {
 	SnapCount       uint64
 	Cluster         *Cluster
 	NewCluster      bool
-	Transport       *http.Transport
 	ForceNewCluster bool
+	Transport       *http.Transport
 }
 
 // VerifyBootstrapConfig sanity-checks the initial config and returns an error


### PR DESCRIPTION
More logical to have the Cluster fields grouped together.
