### PR TITLE
print out remote peers' information and config change in the cluster

### DIFF
--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -223,7 +223,6 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Printf("etcdhttp: error removing node %s: %v", id, err)
 			writeError(w, err)
 		default:
-			log.Printf("etcdhttp: removed node %x", id)
 			w.WriteHeader(http.StatusNoContent)
 		}
 	}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -666,12 +666,12 @@ func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange) error {
 		}
 		s.Cluster.AddMember(m)
 		s.sender.Add(m)
-		log.Printf("etcdserver: added node %s %v to cluster", types.ID(cc.NodeID), m.PeerURLs)
+		log.Printf("etcdserver: added node %s %v to cluster %s", types.ID(cc.NodeID), m.PeerURLs, s.Cluster.ID())
 	case raftpb.ConfChangeRemoveNode:
 		id := types.ID(cc.NodeID)
 		s.Cluster.RemoveMember(id)
 		s.sender.Remove(id)
-		log.Printf("etcdserver: removed node %s from cluster", id)
+		log.Printf("etcdserver: removed node %s from cluster %s", id, s.Cluster.ID())
 	}
 	return nil
 }


### PR DESCRIPTION
for debug usage and understanding of the cluster setting
