### PR TITLE
sender logs garbage

### DIFF
--- a/etcdserver/sender.go
+++ b/etcdserver/sender.go
@@ -164,7 +164,7 @@ func (s *sender) post(data []byte) error {
 	req.Header.Set("X-Etcd-Cluster-ID", s.cid.String())
 	resp, err := s.c.Do(req)
 	if err != nil {
-		return fmt.Errorf("do request %+v error: %v", req, err)
+		return fmt.Errorf("error posting to %q: %v", req.URL.String(), err)
 	}
 	resp.Body.Close()
 


### PR DESCRIPTION
```
11:59:59 etcd3 | �"���ϩ�SYNC"(28HPX`hpx���������:
11:59:59 etcd3 | �"ۙ���SYNC"(28HPX`hpxن�������:
11:59:59 etcd3 | �"�����Έ�|SYNC"(28HPX`hpx���������:
11:59:59 etcd3 | �"Ԩ����?SYNC"(28HPX`hpx�Ø������:
11:59:59 etcd3 | �"׉������8SYNC"(28HPX`hpx��ͽ�����:
11:59:59 etcd3 | �"ټ÷�Ң�sSYNC"(28HPX`hpẍ́�������:
11:59:59 etcd3 | �"��ȼ��ߋCSYNC"(28HPX`hpx�߹������:
11:59:59 etcd3 | �"��ي��vSYNC"(28HPX`hpx����:
11:59:59 etcd3 | �"���񠑐�ZSYNC"(28HPX`hpx�ڥ����:
11:59:59 etcd3 | �"��������ySYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"��ȼ'SYNC"(28HPX`hpx�����:
11:59:59 etcd3 | �"��ς����JSYNC"(28HPX`hpx�����:
11:59:59 etcd3 | �"��̅����SYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"��������'SYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"�����΍�RSYNC"(28HPX`hpx��䍎��:
11:59:59 etcd3 | �"������ܑSYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"��͖����)SYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"���ή���gSYNC"(28HPX`hpx���ٓ��:
11:59:59 etcd3 | �"�Ʊ�¿��8SYNC"(28HPX`hpxݠ�Ǖ��:
11:59:59 etcd3 | �"�������SYNC"(28HPX`hpx�������:
11:59:59 etcd3 | �"��������SSYNC"(28HPX`hpxأ�����:
11:59:59 etcd3 | �"��ð뽳�CSYNC"(28HPX`hpxݒ���:
11:59:59 etcd3 | �"ҿ������~SYNC"(28HPX`hpx�������@�J
11:59:59 etcd3 |  P} ContentLength:6367 TransferEncoding:[] Close:false Host:localhost:70123 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil>} error: Post http://localhost:70123/raft: dial tcp: invalid port 70123
12:00:00 etcd3 | 2014/11/07 12:00:00 sender: do request &{Method:POST URL:http://localhost:70123/raft Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[X-Etcd-Cluster-Id:[e9c7614f68f35fb2] Content-Type:[application/protobuf]] Body:{Reader������������ɾЋ�� 
12:00:00 etcd3 | (0@J
12:00:00 etcd3 |  P} ContentLength:42 TransferEncoding:[] Close:false Host:localhost:70123 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil>} error: Post http://localhost:70123/raft: dial tcp: invalid port 70123
```

etc, etc
