### PR TITLE
etcdserver: not get cluster info from self peer urls

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1093,6 +1093,47 @@ func TestPublishRetry(t *testing.T) {
 	}
 }
 
+func TestGetOtherPeerURLs(t *testing.T) {
+	tests := []struct {
+		membs []*Member
+		self  string
+		wurls []string
+	}{
+		{
+			[]*Member{
+				newTestMemberp(1, []string{"http://10.0.0.1"}, "a", nil),
+			},
+			"a",
+			[]string{},
+		},
+		{
+			[]*Member{
+				newTestMemberp(1, []string{"http://10.0.0.1"}, "a", nil),
+				newTestMemberp(2, []string{"http://10.0.0.2"}, "b", nil),
+				newTestMemberp(3, []string{"http://10.0.0.3"}, "c", nil),
+			},
+			"a",
+			[]string{"http://10.0.0.2", "http://10.0.0.3"},
+		},
+		{
+			[]*Member{
+				newTestMemberp(1, []string{"http://10.0.0.1"}, "a", nil),
+				newTestMemberp(3, []string{"http://10.0.0.3"}, "c", nil),
+				newTestMemberp(2, []string{"http://10.0.0.2"}, "b", nil),
+			},
+			"a",
+			[]string{"http://10.0.0.2", "http://10.0.0.3"},
+		},
+	}
+	for i, tt := range tests {
+		cl := NewClusterFromMembers("", types.ID(0), tt.membs)
+		urls := getOtherPeerURLs(cl, tt.self)
+		if !reflect.DeepEqual(urls, tt.wurls) {
+			t.Errorf("#%d: urls = %+v, want %+v", i, urls, tt.wurls)
+		}
+	}
+}
+
 func TestGetBool(t *testing.T) {
 	tests := []struct {
 		b    *bool


### PR DESCRIPTION
Self peer urls have not started to serve at the time that it tries to
get cluster info, so it is useless to get cluster info from self peer
urls.

fixes https://travis-ci.org/coreos/etcd/builds/40354752 in #1664 
