### PR TITLE
etcdserver: fatal testing if launch cannot finish for a long time

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -157,7 +157,11 @@ func (c *cluster) Launch(t *testing.T) {
 			wg.Done()
 		}(m)
 	}
+	timer := time.AfterFunc(10*time.Second, func() {
+		t.Fatal("wait too long for members' launch")
+	})
 	wg.Wait()
+	timer.Stop()
 	// wait cluster to be stable to receive future client requests
 	c.waitClientURLsPublished(t)
 }


### PR DESCRIPTION
from https://travis-ci.org/coreos/etcd/builds/40595377
it should give better error message.
