### PR TITLE
Fix listener

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -222,7 +222,7 @@ func startEtcd() error {
 	plns := make([]net.Listener, 0)
 	for _, u := range lpurls {
 		var l net.Listener
-		l, err = transport.NewListener(u.Host, peerTLSInfo)
+		l, err = transport.NewListener(u.Host, u.Scheme, peerTLSInfo)
 		if err != nil {
 			return err
 		}
@@ -246,7 +246,7 @@ func startEtcd() error {
 	clns := make([]net.Listener, 0)
 	for _, u := range lcurls {
 		var l net.Listener
-		l, err = transport.NewListener(u.Host, clientTLSInfo)
+		l, err = transport.NewListener(u.Host, u.Scheme, clientTLSInfo)
 		if err != nil {
 			return err
 		}
@@ -349,7 +349,7 @@ func startProxy() error {
 	}
 	// Start a proxy server goroutine for each listen address
 	for _, u := range lcurls {
-		l, err := transport.NewListener(u.Host, clientTLSInfo)
+		l, err := transport.NewListener(u.Host, u.Scheme, clientTLSInfo)
 		if err != nil {
 			return err
 		}

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -27,13 +27,13 @@ import (
 	"time"
 )
 
-func NewListener(addr string, info TLSInfo) (net.Listener, error) {
+func NewListener(addr string, scheme string, info TLSInfo) (net.Listener, error) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
 
-	if !info.Empty() {
+	if !info.Empty() && scheme == "https" {
 		cfg, err := info.ServerConfig()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fix #1633

Create a tls listener only if the tlsInfo is not empty and the scheme is HTTPS
