### PR TITLE
raft: update unstable when calling stableTo with 0

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -134,9 +134,6 @@ func (l *raftLog) appliedTo(i uint64) {
 }
 
 func (l *raftLog) stableTo(i uint64) {
-	if i == 0 {
-		return
-	}
 	l.unstable = i + 1
 }
 

--- a/raft/node.go
+++ b/raft/node.go
@@ -298,9 +298,7 @@ func (n *node) run(r *raft) {
 			if prevHardSt.Commit != 0 {
 				r.raftLog.appliedTo(prevHardSt.Commit)
 			}
-			if prevLastUnstablei != 0 {
-				r.raftLog.stableTo(prevLastUnstablei)
-			}
+			r.raftLog.stableTo(prevLastUnstablei)
 			advancec = nil
 		case <-n.done:
 			return


### PR DESCRIPTION
It should update unstable in this case because it may happen that raft only writes entry
0 into stable storage.

for #1644 
It makes the test rather slow because etcdserver keeps getting new ready with entry 0 as entries and writing it to disk before the leader syncs the whole log to the follower. It may happen 10000+ times when increasing cluster size from 3 to 6.
