### PR TITLE
raft: fix soft state equal

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -19,7 +19,6 @@ package raft
 import (
 	"errors"
 	"log"
-	"reflect"
 
 	"github.com/coreos/etcd/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	pb "github.com/coreos/etcd/raft/raftpb"
@@ -41,7 +40,22 @@ type SoftState struct {
 }
 
 func (a *SoftState) equal(b *SoftState) bool {
-	return reflect.DeepEqual(a, b)
+	if a.Lead != b.Lead || a.RaftState != b.RaftState {
+		return false
+	}
+	if len(a.Nodes) != len(b.Nodes) {
+		return false
+	}
+	idmap := make(map[uint64]bool)
+	for _, id := range a.Nodes {
+		idmap[id] = true
+	}
+	for _, id := range b.Nodes {
+		if !idmap[id] {
+			return false
+		}
+	}
+	return true
 }
 
 // Ready encapsulates the entries and messages that are ready to read,

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -316,17 +316,19 @@ func TestNodeAdvance(t *testing.T) {
 }
 
 func TestSoftStateEqual(t *testing.T) {
+	softState := &SoftState{Lead: 1, RaftState: StateLeader, Nodes: []uint64{1, 2}}
 	tests := []struct {
 		st *SoftState
 		we bool
 	}{
-		{&SoftState{}, true},
-		{&SoftState{Lead: 1}, false},
-		{&SoftState{RaftState: StateLeader}, false},
-		{&SoftState{Nodes: []uint64{1, 2}}, false},
+		{softState, true},
+		{&SoftState{RaftState: StateLeader, Nodes: []uint64{1, 2}}, false},
+		{&SoftState{Lead: 1, Nodes: []uint64{1, 2}}, false},
+		{&SoftState{Lead: 1, RaftState: StateLeader}, false},
+		{&SoftState{Lead: 1, RaftState: StateLeader, Nodes: []uint64{2, 1}}, true},
 	}
 	for i, tt := range tests {
-		if g := tt.st.equal(&SoftState{}); g != tt.we {
+		if g := tt.st.equal(softState); g != tt.we {
 			t.Errorf("#%d, equal = %v, want %v", i, g, tt.we)
 		}
 	}


### PR DESCRIPTION
It should think that reordered nodes are the same.

for #1664 
