### PR TITLE
raft: nodes return sorted ids

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -531,6 +531,7 @@ func (r *raft) nodes() []uint64 {
 	for k := range r.prs {
 		nodes = append(nodes, k)
 	}
+	sort.Sort(uint64Slice(nodes))
 	return nodes
 }
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -997,7 +997,6 @@ func TestRestore(t *testing.T) {
 		t.Errorf("log.lastTerm = %d, want %d", sm.raftLog.term(s.Index), s.Term)
 	}
 	sg := sm.nodes()
-	sort.Sort(uint64Slice(sg))
 	if !reflect.DeepEqual(sg, s.Nodes) {
 		t.Errorf("sm.Nodes = %+v, want %+v", sg, s.Nodes)
 	}
@@ -1166,7 +1165,6 @@ func TestAddNode(t *testing.T) {
 		t.Errorf("pendingConf = %v, want false", r.pendingConf)
 	}
 	nodes := r.nodes()
-	sort.Sort(uint64Slice(nodes))
 	wnodes := []uint64{1, 2}
 	if !reflect.DeepEqual(nodes, wnodes) {
 		t.Errorf("nodes = %v, want %v", nodes, wnodes)
@@ -1206,6 +1204,28 @@ func TestPromotable(t *testing.T) {
 		}
 		if g := r.promotable(); g != tt.wp {
 			t.Errorf("#%d: promotable = %v, want %v", i, g, tt.wp)
+		}
+	}
+}
+
+func TestRaftNodes(t *testing.T) {
+	tests := []struct {
+		ids  []uint64
+		wids []uint64
+	}{
+		{
+			[]uint64{1, 2, 3},
+			[]uint64{1, 2, 3},
+		},
+		{
+			[]uint64{3, 2, 1},
+			[]uint64{1, 2, 3},
+		},
+	}
+	for i, tt := range tests {
+		r := newRaft(1, tt.ids, 10, 1)
+		if !reflect.DeepEqual(r.nodes(), tt.wids) {
+			t.Errorf("#%d: nodes = %+v, want %+v", i, r.nodes(), tt.wids)
 		}
 	}
 }


### PR DESCRIPTION
This makes raft.softState return the same result when its soft state is
not changed.

improved from #1691 
