### PR TITLE
StopNotify

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -391,6 +391,10 @@ func (s *EtcdServer) Stop() {
 	<-s.done
 }
 
+// StopNotify returns a channel that receives a empty struct
+// when the server is stopped.
+func (s *EtcdServer) StopNotify() <-chan struct{} { return s.done }
+
 // Do interprets r and performs an operation on s.store according to r.Method
 // and other fields. If r.Method is "POST", "PUT", "DELETE", or a "GET" with
 // Quorum == true, r will be sent through consensus before performing its

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1135,6 +1135,30 @@ func TestPublishRetry(t *testing.T) {
 	}
 }
 
+func TestStopNotify(t *testing.T) {
+	s := &EtcdServer{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go func() {
+		<-s.stop
+		close(s.done)
+	}()
+
+	notifier := s.StopNotify()
+	select {
+	case <-notifier:
+		t.Fatalf("received unexpected stop notification")
+	default:
+	}
+	s.Stop()
+	select {
+	case <-notifier:
+	default:
+		t.Fatalf("cannot receive stop notification")
+	}
+}
+
 func TestGetOtherPeerURLs(t *testing.T) {
 	tests := []struct {
 		membs []*Member


### PR DESCRIPTION
Add `StopNotify` to `etcdsever`. 
So the launcher of `etcdserver` can be notified when `etcdserver` is stopped. 
