### PR TITLE
raft: promise snapshot.index <= committed and applied

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -29,7 +29,9 @@ type raftLog struct {
 	committed uint64
 	applied   uint64
 	offset    uint64
-	snapshot  pb.Snapshot
+	// Invariant: snapshot.index <= committed
+	// Invariant: snapshot.index <= applied
+	snapshot pb.Snapshot
 }
 
 func newLog() *raftLog {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -19,6 +19,7 @@ package raft
 import (
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"sort"
 
@@ -555,6 +556,9 @@ func (r *raft) loadEnts(ents []pb.Entry) {
 }
 
 func (r *raft) loadState(state pb.HardState) {
+	if state.Commit < r.raftLog.committed {
+		log.Panicf("loaded committed %d should >= current committed %d", state.Commit, r.raftLog.committed)
+	}
 	r.raftLog.committed = state.Commit
 	r.Term = state.Term
 	r.Vote = state.Vote


### PR DESCRIPTION
snapshot is set in these places:
- start an empty node

snapshot.index is set to 0, while committed and applied are set to 0.
Because committed and applied always increase, they are both always
bigger than snapshot.index.
- start from snapshot and log

snapshot.index, committed, applied is set to the index of loaded snapshot at
the first step. When raft loads state from log, it ensures that loaded
committed >= current committed. So it is fine in this case.
- receive snapshot from leader

If snapshot.index <= committed, raft ignores this snapshot. Otherwise,
snapshot.index, committed, applied is set to the index of received snapshot.

In sum, snapshot.index always <= committed and applied.
