### PR TITLE
etcdserver: initialise ServerStats with leader name if available, fixes  #561

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -308,7 +308,11 @@ func (s *EtcdServer) start() {
 	s.w = wait.New()
 	s.done = make(chan struct{})
 	s.stop = make(chan struct{})
-	s.stats.Initialize()
+	var leader string
+	if s.lstats != nil {
+		leader = s.lstats.Leader
+	}
+	s.stats.Initialize(leader)
 	// TODO: if this is an empty log, writes all peer infos
 	// into the first entry
 	go s.run()

--- a/etcdserver/stats/server.go
+++ b/etcdserver/stats/server.go
@@ -70,13 +70,14 @@ func (ss *ServerStats) JSON() []byte {
 }
 
 // Initialize clears the statistics of ServerStats and resets its start time
-func (ss *ServerStats) Initialize() {
+func (ss *ServerStats) Initialize(leader string) {
 	if ss == nil {
 		return
 	}
 	now := time.Now()
 	ss.StartTime = now
 	ss.LeaderInfo.StartTime = now
+	ss.LeaderInfo.Name = leader
 	ss.sendRateQueue = &statsQueue{
 		back: -1,
 	}


### PR DESCRIPTION
When starting an EtcdServer set leader name in ServerStats if a leader already defined in LeaderStats. On a single machine cluster there are no AppendRequest calls to set leader name, while the machine is an active leader stats shows a default string as leader name. With this fix the name is correctly set.

Fixes #561
