### PR TITLE
create .godir

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,0 +1,1 @@
+github.com/coreos/etcd


### PR DESCRIPTION
This should fix the binary name, as well as Godeps being always fetched from git.
