### PR TITLE
scripts: build-docker tag and use ENTRYPOINT

### DIFF
--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -6,7 +6,7 @@ FROM scratch
 ADD etcd /
 ADD etcdctl /
 EXPOSE 4001 7001 2379 2380
-CMD ["/etcd"]
+ENTRYPOINT ["/etcd"]
 DF
 
-docker build .
+docker build -t quay.io/coreos/etcd:${1} .


### PR DESCRIPTION
Use ENTRYPOINT so people can specify flags to etcd without providing the
binary.

Thanks to @hugod in IRC for pointing this out.
