### PR TITLE
raft: raft.restore should never truncate the log at current term.

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -163,7 +163,7 @@ func newRaft(id uint64, peers []uint64, election, heartbeat int, storage Storage
 	if !isHardStateEqual(hs, emptyState) {
 		r.loadState(hs)
 	}
-	r.becomeFollower(0, None)
+	r.becomeFollower(r.Term, None)
 	return r
 }
 


### PR DESCRIPTION
A raft state machine might receive out of date snapshot due to network latency.
A raft state machine MUST NOT truncate its matched log entries of current term
when it tries to restore a snapshot.
