### PR TITLE
rafthttp: add batcher

### DIFF
--- a/rafthttp/batcher.go
+++ b/rafthttp/batcher.go
@@ -1,0 +1,41 @@
+package rafthttp
+
+import (
+	"time"
+
+	"github.com/coreos/etcd/raft/raftpb"
+)
+
+type Batcher struct {
+	batchedN int
+	batchedT time.Time
+	batchN   int
+	batchD   time.Duration
+}
+
+func NewBatcher(n int, d time.Duration) *Batcher {
+	return &Batcher{
+		batchN:   n,
+		batchD:   d,
+		batchedT: time.Now(),
+	}
+}
+
+func (b *Batcher) ShouldBatch(now time.Time) bool {
+	b.batchedN++
+	batchedD := now.Sub(b.batchedT)
+	if b.batchedN >= b.batchN || batchedD >= b.batchD {
+		b.Reset(now)
+		return false
+	}
+	return true
+}
+
+func (b *Batcher) Reset(t time.Time) {
+	b.batchedN = 0
+	b.batchedT = t
+}
+
+func canBatch(m raftpb.Message) bool {
+	return m.Type == raftpb.MsgAppResp
+}

--- a/rafthttp/batcher_test.go
+++ b/rafthttp/batcher_test.go
@@ -1,0 +1,61 @@
+package rafthttp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBatcherNum(t *testing.T) {
+	n := 100
+	largeD := time.Minute
+	tests := []struct {
+		n         int
+		wnotbatch int
+	}{
+		{n - 1, 0},
+		{n, 1},
+		{n + 1, 1},
+		{2*n + 1, 2},
+		{3*n + 1, 3},
+	}
+
+	for i, tt := range tests {
+		b := NewBatcher(n, largeD)
+		notbatched := 0
+		for j := 0; j < tt.n; j++ {
+			if !b.ShouldBatch(time.Now()) {
+				notbatched++
+			}
+		}
+		if notbatched != tt.wnotbatch {
+			t.Errorf("#%d: notbatched = %d, want %d", i, notbatched, tt.wnotbatch)
+		}
+	}
+}
+
+func TestBatcherTime(t *testing.T) {
+	largeN := 10000
+	tests := []struct {
+		nms       int
+		wnotbatch int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+	}
+
+	for i, tt := range tests {
+		b := NewBatcher(largeN, time.Millisecond)
+		baseT := b.batchedT
+		notbatched := 0
+		for j := 0; j < tt.nms+1; j++ {
+			if !b.ShouldBatch(baseT.Add(time.Duration(j) * time.Millisecond)) {
+				notbatched++
+			}
+		}
+		if notbatched != tt.wnotbatch {
+			t.Errorf("#%d: notbatched = %d, want %d", i, notbatched, tt.wnotbatch)
+		}
+	}
+}


### PR DESCRIPTION
After we enable streaming, there will be a large amount of msgAppResp due to high
rate msgApp. We should batch msgAppResp in a meanful way.
