### PR TITLE
Fix backup snapshots

### DIFF
--- a/etcdctl/command/backup_command.go
+++ b/etcdctl/command/backup_command.go
@@ -19,6 +19,7 @@ package command
 import (
 	"log"
 	"math/rand"
+	"os"
 	"path"
 	"time"
 
@@ -49,6 +50,9 @@ func handleBackup(c *cli.Context) {
 	srcWAL := path.Join(c.String("data-dir"), "wal")
 	destWAL := path.Join(c.String("backup-dir"), "wal")
 
+	if err := os.MkdirAll(destSnap, 0700); err != nil {
+		log.Fatalf("failed creating backup snapshot dir %v: %v", destSnap, err)
+	}
 	ss := snap.New(srcSnap)
 	snapshot, err := ss.Load()
 	if err != nil && err != snap.ErrNoSnapshot {


### PR DESCRIPTION
The backup tool currently silently fails to write snapshots, due to a missing directory. When one tries to load a backup whose WAL expects a snapshot, starting the cluster fails with `etcd: unknown wal version in data dir`

(This was discussed briefly on [a mailing list thread](https://groups.google.com/forum/?hl=en#!topic/etcd-dev/YEqbp4_zr38))

This change ensures the output directory is made first.
