### PR TITLE
etcdserver: Fix panic when restoring from backup (-force-new-cluster)

### DIFF
--- a/etcdserver/force_cluster.go
+++ b/etcdserver/force_cluster.go
@@ -33,8 +33,12 @@ func restartAsStandaloneNode(cfg *ServerConfig, index uint64, snapshot *raftpb.S
 	cfg.Cluster.SetID(cid)
 
 	// discard the previously uncommitted entries
-	if len(ents) != 0 {
-		ents = ents[:st.Commit+1]
+	for i, ent := range ents {
+		if ent.Index > st.Commit {
+			log.Printf("etcdserver: discarding %d uncommited WAL entries ", len(ents)-i)
+			ents = ents[:i]
+			break
+		}
 	}
 
 	// force append the configuration change entries


### PR DESCRIPTION
Fixes the following panic when trying to restore from backups with snapshots:

```
./bin/etcd -data-dir /backup-data -force-new-cluster
2014/11/25 14:14:04 etcd: listening for peers on http://localhost:2380
2014/11/25 14:14:04 etcd: listening for peers on http://localhost:7001
2014/11/25 14:14:04 etcd: listening for client requests on http://0.0.0.0:4001
2014/11/25 14:14:04 etcdserver: recovering from snapshot at index 25581499
2014/11/25 14:14:04 etcdserver: name = default
2014/11/25 14:14:04 etcdserver: force new cluster
2014/11/25 14:14:04 etcdserver: data dir = /backup/data
2014/11/25 14:14:04 etcdserver: snapshot count = 10000
2014/11/25 14:14:04 etcdserver: advertise client URLs = http://localhost:2379,http://localhost:4001
2014/11/25 14:14:04 etcdserver: loaded peers from snapshot: (...list of peers...)
panic: runtime error: slice bounds out of range

goroutine 16 [running]:
runtime.panic(0x3a93e0, 0x60ccef)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/panic.c:279 +0xf5
github.com/coreos/etcd/etcdserver.restartAsStandaloneNode(0xc20805a1b0, 0x18657bb, 0xc208004240, 0x1, 0x0, 0x0, 0xc20801090c)
    /Users/orls/projects/etcd/gopath/src/github.com/coreos/etcd/etcdserver/force_cluster.go:37 +0x65b
github.com/coreos/etcd/etcdserver.NewServer(0xc20805a1b0, 0x3, 0x0, 0x0)
    /Users/orls/projects/etcd/gopath/src/github.com/coreos/etcd/etcdserver/server.go:289 +0x15a6
github.com/coreos/etcd/etcdmain.startEtcd(0x0, 0x0, 0x0)
    /Users/orls/projects/etcd/gopath/src/github.com/coreos/etcd/etcdmain/etcd.go:291 +0x1572
github.com/coreos/etcd/etcdmain.Main()
    /Users/orls/projects/etcd/gopath/src/github.com/coreos/etcd/etcdmain/etcd.go:176 +0x38b
main.main()
    /Users/orls/projects/etcd/gopath/src/github.com/coreos/etcd/main.go:33 +0x1a

goroutine 19 [finalizer wait]:
runtime.park(0x14290, 0x6108d0, 0x60f389)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x6108d0, 0x60f389)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1445

goroutine 17 [syscall]:
runtime.goexit()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1445
```
