### PR TITLE
raft: not compact log if the compact index < first index of the log

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -534,6 +534,10 @@ func (r *raft) compact(index uint64, nodes []uint64, d []byte) {
 	if index > r.raftLog.applied {
 		panic(fmt.Sprintf("raft: compact index (%d) exceeds applied index (%d)", index, r.raftLog.applied))
 	}
+	if index < r.raftLog.offset {
+		//TODO: return an error?
+		return
+	}
 	r.raftLog.snap(d, index, r.raftLog.term(index), nodes)
 	r.raftLog.compact(index)
 }


### PR DESCRIPTION
It should ignore the compact operation instead of panic because the case that
the log is restored from snapshot before executing compact is reasonable.

fixes #1774 
