### PR TITLE
rafthttp: increase the size of streaming buffer

### DIFF
--- a/rafthttp/streamer.go
+++ b/rafthttp/streamer.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	streamBufSize = 1024
+	streamBufSize = 4096
 )
 
 type WriteFlusher interface {


### PR DESCRIPTION
The old 1024 value is too small and is very likely to be full and
break the streaming in good path.

Moreover, A bigger value may help write more into the io.Writer when switching
to handle goroutine.
