### PR TITLE
rafthttp: only batch good MsgAppResp

### DIFF
--- a/rafthttp/batcher.go
+++ b/rafthttp/batcher.go
@@ -37,5 +37,5 @@ func (b *Batcher) Reset(t time.Time) {
 }
 
 func canBatch(m raftpb.Message) bool {
-	return m.Type == raftpb.MsgAppResp
+	return m.Type == raftpb.MsgAppResp && m.Reject == false
 }


### PR DESCRIPTION
A MsgAppResp with Reject set should be sent back to the leader as soon
as possible instead of batching.
