### PR TITLE
raft: always write dummy entry to storage

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -216,8 +216,8 @@ func (l *raftLog) snap(d []byte, index, term uint64, nodes []uint64) {
 }
 
 func (l *raftLog) restore(s pb.Snapshot) {
-	l.ents = []pb.Entry{{Term: s.Term}}
-	l.unstable = s.Index + 1
+	l.ents = []pb.Entry{{Index: s.Index, Term: s.Term}}
+	l.unstable = s.Index
 	l.committed = s.Index
 	l.offset = s.Index
 	l.snapshot = s

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -501,8 +501,8 @@ func TestLogRestore(t *testing.T) {
 	if raftLog.committed != index {
 		t.Errorf("comitted = %d, want %d", raftLog.committed, index)
 	}
-	if raftLog.unstable != index+1 {
-		t.Errorf("unstable = %d, want %d", raftLog.unstable, index+1)
+	if raftLog.unstable != index {
+		t.Errorf("unstable = %d, want %d", raftLog.unstable, index)
 	}
 	if raftLog.term(index) != term {
 		t.Errorf("term = %d, want %d", raftLog.term(index), term)


### PR DESCRIPTION
Fix #1791. 
