### PR TITLE
integration: attempt more times to listen on specified port

### DIFF
--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -372,7 +372,7 @@ func newListenerWithAddr(t *testing.T, addr string) net.Listener {
 	var l net.Listener
 	// TODO: we want to reuse a previous closed port immediately.
 	// a better way is to set SO_REUSExx instead of doing retry.
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		l, err = net.Listen("tcp", addr)
 		if err == nil {
 			break


### PR DESCRIPTION
Travis is rather slow, and it may fail to listen on that port sometimes.

for https://travis-ci.org/coreos/etcd/builds/42246680
