### PR TITLE
etcdmain: Fix misuse "-addr" flag

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -190,7 +190,7 @@ func Main() {
 
 // startEtcd launches the etcd server and HTTP handlers for client/server communication.
 func startEtcd() (<-chan struct{}, error) {
-	apurls, err := flags.URLsFromFlags(fs, "initial-advertise-peer-urls", "addr", peerTLSInfo)
+	apurls, err := flags.URLsFromFlags(fs, "initial-advertise-peer-urls", "peer-addr", peerTLSInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ func startEtcd() (<-chan struct{}, error) {
 
 // startProxy launches an HTTP proxy for client communication which proxies to other etcd nodes.
 func startProxy() error {
-	apurls, err := flags.URLsFromFlags(fs, "initial-advertise-peer-urls", "addr", peerTLSInfo)
+	apurls, err := flags.URLsFromFlags(fs, "initial-advertise-peer-urls", "peer-addr", peerTLSInfo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
etcdmain: Fix misuse "-addr" flag

In code, it uses "-advertise-client-urls" or "-addr" flags to get the list of this member's peer URLs, 
It should be using "-peer-addr" flag instead of "-addr" flag.
