### PR TITLE
docs: add etcd-lock into libraries-and-tools.md

### DIFF
--- a/Documentation/libraries-and-tools.md
+++ b/Documentation/libraries-and-tools.md
@@ -7,6 +7,7 @@
 - [etcd-dump](https://npmjs.org/package/etcd-dump) - Command line utility for dumping/restoring etcd.
 - [etcd-fs](https://github.com/xetorthio/etcd-fs) - FUSE filesystem for etcd
 - [etcd-browser](https://github.com/henszey/etcd-browser) - A web-based key/value editor for etcd using AngularJS
+- [etcd-lock](https://github.com/datawisesystems/etcd-lock) - A lock implementation for etcd
 
 **Go libraries**
 


### PR DESCRIPTION
Lock implementation for etcd. It has three go routines:
    a) acquire - loop that watches for the lock to be free and tries to acquire it.
    b) watch - to watch for lock changes
    c) refresh - to refresh the ttl when the lock is acquired

All the changes in lock ownership are notified on the events channel. Any feedback welcome!
