### PR TITLE
scripts: build-aci: add a simple build-aci tool

### DIFF
--- a/scripts/build-aci
+++ b/scripts/build-aci
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+cat <<DF > app
+{
+    "acVersion": "1.0.0",
+    "acKind": "AppManifest",
+    "name": "coreos.com/etcd",
+    "os": "linux",
+    "arch": "amd64",
+    "exec": [
+        "/etcd", "main"
+    ],
+    "user": "1000",
+    "group": "1000"
+}
+DF
+
+actool build .


### PR DESCRIPTION
This will build an ACI from an etcd tarball. This can be slimmed down
once the `actool` gets better.
