### PR TITLE
wal: not return ErrIndexNotFound in ReadAll

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -46,7 +46,6 @@ const (
 var (
 	ErrMetadataConflict = errors.New("wal: conflicting metadata found")
 	ErrFileNotFound     = errors.New("wal: file not found")
-	ErrIndexNotFound    = errors.New("wal: index not found in file")
 	ErrCRCMismatch      = errors.New("wal: crc mismatch")
 	crcTable            = crc32.MakeTable(crc32.Castagnoli)
 )
@@ -203,10 +202,6 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 	if err != io.EOF {
 		state.Reset()
 		return nil, state, nil, err
-	}
-	if w.enti < w.ri {
-		state.Reset()
-		return nil, state, nil, ErrIndexNotFound
 	}
 
 	// close decoder, disable reading

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -364,8 +364,8 @@ func TestOpenAtUncommittedIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	// commit up to index 0, try to read index 1
-	if _, _, _, err := w.ReadAll(); err != ErrIndexNotFound {
-		t.Errorf("err = %v, want %v", err, ErrIndexNotFound)
+	if _, _, _, err := w.ReadAll(); err != nil {
+		t.Errorf("err = %v, want nil", err)
 	}
 	w.Close()
 }


### PR DESCRIPTION
This IndexNotFound case is reasonable now because we don't write dummy
entries into wals any more.
