### PR TITLE
build: statically compile etcdctl binary

### DIFF
--- a/build
+++ b/build
@@ -12,5 +12,5 @@ ln -s ${PWD} $GOPATH/src/${REPO_PATH}
 eval $(go env)
 
 go build -o bin/etcd ${REPO_PATH}
-go build -o bin/etcdctl ${REPO_PATH}/etcdctl
+CGO_ENABLED=0 go build -a -ldflags '-s' -o bin/etcdctl ${REPO_PATH}/etcdctl
 go build -o bin/etcd-migrate ${REPO_PATH}/migrate/cmd/etcd-migrate


### PR DESCRIPTION
Same story as [my recent fleet PR](https://github.com/coreos/fleet/pull/1027).

Having a static etcdctl enables running it inside a small busybox container which allows the creation and usage of one-off Docker containers for querying / manipulating etcd values from within other containers on CoreOS. This is much easier than installing etcdctl or using curl everywhere.
