### PR TITLE
raft: fix unstable.maybeFirstIndex

### DIFF
--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -543,7 +543,7 @@ func TestCompaction(t *testing.T) {
 	}
 }
 
-func TestLogRestore(t *testing.T) {
+func TestLogNew(t *testing.T) {
 	index := uint64(1000)
 	term := uint64(1000)
 	snap := pb.SnapshotMetadata{Index: index, Term: term}
@@ -556,6 +556,36 @@ func TestLogRestore(t *testing.T) {
 	}
 	if raftLog.firstIndex() != index+1 {
 		t.Errorf("firstIndex = %d, want %d", raftLog.firstIndex(), index+1)
+	}
+	if raftLog.committed != index {
+		t.Errorf("comitted = %d, want %d", raftLog.committed, index)
+	}
+	if raftLog.unstable.offset != index+1 {
+		t.Errorf("unstable = %d, want %d", raftLog.unstable, index+1)
+	}
+	if raftLog.term(index) != term {
+		t.Errorf("term = %d, want %d", raftLog.term(index), term)
+	}
+}
+
+func TestLogRestore(t *testing.T) {
+	index := uint64(1000)
+	term := uint64(1000)
+	snap := pb.Snapshot{
+		Metadata: pb.SnapshotMetadata{Index: index, Term: term},
+	}
+	storage := NewMemoryStorage()
+	raftLog := newLog(storage)
+	raftLog.restore(snap)
+
+	if len(raftLog.allEntries()) != 0 {
+		t.Errorf("len = %d, want 0", len(raftLog.allEntries()))
+	}
+	if raftLog.firstIndex() != index+1 {
+		t.Errorf("firstIndex = %d, want %d", raftLog.firstIndex(), index+1)
+	}
+	if raftLog.lastIndex() != index {
+		t.Errorf("lastIndex = %d, want %d", raftLog.lastIndex(), index)
 	}
 	if raftLog.committed != index {
 		t.Errorf("comitted = %d, want %d", raftLog.committed, index)

--- a/raft/log_unstable.go
+++ b/raft/log_unstable.go
@@ -33,7 +33,7 @@ type unstable struct {
 // maybeFirstIndex returns the first index if it has a snapshot.
 func (u *unstable) maybeFirstIndex() (uint64, bool) {
 	if u.snapshot != nil {
-		return u.snapshot.Metadata.Index, true
+		return u.snapshot.Metadata.Index + 1, true
 	}
 	return 0, false
 }


### PR DESCRIPTION
It should return the index of the first following entry instead of the index
of dummy entry.
