### PR TITLE
raft: not call stableTo for restored snapshot

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -292,10 +292,6 @@ func (n *node) run(r *raft) {
 				prevHardSt = rd.HardState
 			}
 			if !IsEmptySnap(rd.Snapshot) {
-				if rd.Snapshot.Metadata.Index > prevLastUnstablei {
-					prevLastUnstablei = rd.Snapshot.Metadata.Index
-					havePrevLastUnstablei = true
-				}
 				prevSnapi = rd.Snapshot.Metadata.Index
 			}
 			r.msgs = nil


### PR DESCRIPTION
Stable has been set when restoring the snapshot in raftlog, so we don't need
to set it after advance.
