### PR TITLE
raft: return 0 for term of compacted index

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -199,7 +199,9 @@ func (l *raftLog) stableSnapTo(i uint64) { l.unstable.stableSnapTo(i) }
 func (l *raftLog) lastTerm() uint64 { return l.term(l.lastIndex()) }
 
 func (l *raftLog) term(i uint64) uint64 {
-	if i > l.lastIndex() {
+	// the valid term range is [index of dummy entry, last index]
+	dummyIndex := l.firstIndex() - 1
+	if i < dummyIndex || i > l.lastIndex() {
 		return 0
 	}
 


### PR DESCRIPTION
It is necessary to make this check because of the following case:
1. memory storage contains ents from index 0 to 50, and unstable has
   ents from index 50 to 60.
2. raft receives an incoming snapshot with index 100.
3. raft restores its unstable to 100, but has not applied snapshot on memory storage.
4. raft receives an out-dated MsgApp from index 60.
5. raft finds the term of index 60 to check the match.
6. raft asks memory storage about the term of index 60 after it failed to get
   it from unstable.
7. memory storage panics because it knows nothing about index 60.

fixes #1847 
