### PR TITLE
etcdmain: format usage

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -105,6 +105,11 @@ var (
 )
 
 func init() {
+	fs.Usage = func() {
+		fmt.Println(usageline)
+		fmt.Println(flagsline)
+	}
+
 	fs.Var(clusterStateFlag, "initial-cluster-state", "Initial cluster configuration for bootstrapping")
 	if err := clusterStateFlag.Set(clusterStateFlagNew); err != nil {
 		// Should never happen.
@@ -152,7 +157,6 @@ func init() {
 }
 
 func Main() {
-	fs.Usage = flags.UsageWithIgnoredFlagsFunc(fs, ignored)
 	perr := fs.Parse(os.Args[1:])
 	switch perr {
 	case nil:

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -1,0 +1,80 @@
+package etcdmain
+
+var (
+	usageline = `usage: etcd [flags]
+       start an etcd server
+
+       etcd --version
+       show the version of etcd
+
+       etcd -h | --help
+       show the help information about etcd
+	`
+	flagsline = `
+member flags:
+
+	--name 'default'
+		human-readable name for this member.
+	--data-dir '${name}.etcd'
+		path to the data directory.
+	--snapshot-count '10000'
+		number of committed transactions to trigger a snapshot to disk.
+	--listen-peer-urls 'http://localhost:2380,http://localhost:7001'
+		list of URLs to listen on for peer traffic.
+	--listen-client-urls 'http://localhost:2379,http://localhost:4001'
+		list of URLs to listen on for client traffic.
+	-cors ''
+		comma-separated whitelist of origins for CORS (cross-origin resource sharing).
+
+
+clustering flags:
+
+	--initial-advertise-peer-urls 'http://localhost:2380,http://localhost:7001'
+		list of this member's peer URLs to advertise to the rest of the cluster. 
+	--initial-cluster 'default=http://localhost:2380,default=http://localhost:7001'
+		initial cluster configuration for bootstrapping.
+	--initial-cluster-state 'new'
+		initial cluster state ('new' or 'existing').
+	--initial-cluster-token 'etcd-cluster'
+		initial cluster token for the etcd cluster during bootstrap.
+	--advertise-client-urls 'http://localhost:2379,http://localhost:4001'
+		list of this member's client URLs to advertise to the rest of the cluster.
+	--discovery ''
+		discovery URL used to bootstrap the cluster.
+	--discovery-fallback 'proxy'
+		expected behavior ('exit' or 'proxy') when discovery services fails.
+	--discovery-proxy ''
+		HTTP proxy to use for traffic to discovery service.
+
+
+proxy flags:
+
+	--proxy 'off'
+		proxy mode setting ('off', 'readonly' or 'on').
+
+
+security flags:
+
+	--ca-file ''
+		path to the client server TLS CA file.
+	--cert-file ''
+		path to the client server TLS cert file.
+	--key-file ''
+		path to the client server TLS key file.
+	--peer-ca-file ''
+		path to the peer server TLS CA file.
+	--peer-cert-file ''
+		path to the peer server TLS cert file.
+	--peer-key-file ''
+		path to the peer server TLS key file.
+
+
+unsafe flags:
+
+Please be CAUTIOUS to use unsafe flags because it will break the guarantee given 
+by consensus protocol. 
+	
+	--force-new-cluster 'false'
+		force to create a new one-member cluster.
+`
+)

--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -62,24 +62,6 @@ func (f *IgnoredFlag) String() string {
 	return ""
 }
 
-func UsageWithIgnoredFlagsFunc(fs *flag.FlagSet, ignore []string) func() {
-	iMap := make(map[string]struct{}, len(ignore))
-	for _, name := range ignore {
-		iMap[name] = struct{}{}
-	}
-
-	return func() {
-		fs.VisitAll(func(f *flag.Flag) {
-			if _, ok := iMap[f.Name]; ok {
-				return
-			}
-
-			format := "  -%s=%s: %s\n"
-			fmt.Fprintf(os.Stderr, format, f.Name, f.DefValue, f.Usage)
-		})
-	}
-}
-
 // SetFlagsFromEnv parses all registered flags in the given flagset,
 // and if they are not already set it attempts to set their values from
 // environment variables. Environment variables take the name of the flag but


### PR DESCRIPTION
Fix #1649 

Follow the go cmd style and our doc at https://github.com/coreos/etcd/blob/master/Documentation/0.5/configuration.md

do we still want to print out the deprecated flags? 

/cc @bcwaldon @jonboulle @robszumski 
