### PR TITLE
raft: filter out messages from unknown sender.

### DIFF
--- a/raft/util.go
+++ b/raft/util.go
@@ -44,6 +44,10 @@ func max(a, b uint64) uint64 {
 	return b
 }
 
+func IsLocalMsg(m pb.Message) bool { return m.Type == pb.MsgHup || m.Type == pb.MsgBeat }
+
+func IsResponseMsg(m pb.Message) bool { return m.Type == pb.MsgAppResp || m.Type == pb.MsgVoteResp }
+
 // DescribeMessage returns a concise human-readable description of a
 // Message for debugging.
 func DescribeMessage(m pb.Message) string {


### PR DESCRIPTION
If we cannot find the `m.from` from current peers in the raft and it is a response
message, we should filter it out or raft panics. We are not targeting to avoid
malicious peers.

It has to be done in the raft node layer synchronously. Although we can check
it at the application layer asynchronously, but after the checking and before
the message going into raft, the raft state machine might make progress and
unfortunately remove the `m.from` peer.

Fix #1851
