### PR TITLE
rafthttp: increase sender buffer size

### DIFF
--- a/rafthttp/sender.go
+++ b/rafthttp/sender.go
@@ -32,7 +32,11 @@ import (
 
 const (
 	connPerSender = 4
-	senderBufSize = connPerSender * 4
+	// senderBufSize is the size of sender buffer, which helps hold the
+	// temporary network latency.
+	// The size ensures that sender does not drop messages when the network
+	// is out of work for less than 1 second in good path.
+	senderBufSize = 64
 
 	appRespBatchMs = 50
 


### PR DESCRIPTION
The buffer size is set big enough to buffer all messages generated in
one second as a follower in good path.

In good path, a follower will only send MsgAppResp back. Considering our peak throughput is around 4000req/s, and the batch number is 100, it is good when we can buffer 40 messages.

fixes #1787 
