### PR TITLE
raft: log start and stop of the node

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -217,6 +217,7 @@ func (n *node) run(r *raft) {
 	lead := None
 	prevSoftSt := r.softState()
 	prevHardSt := r.HardState
+	log.Printf("raft.node: %x [leader: %x, softState: %+v, hardState: %+v] starts running", r.id, lead, *prevSoftSt, prevHardSt)
 
 	for {
 		if advancec != nil {
@@ -311,6 +312,7 @@ func (n *node) run(r *raft) {
 			advancec = nil
 		case <-n.stop:
 			close(n.done)
+			log.Printf("raft.node: %x stops running", r.id)
 			return
 		}
 	}


### PR DESCRIPTION
The log is like this:

```
2014/12/08 13:48:29 raft.node: 924e2e83e93f2560 [leader: 0, softState: {Lead:0 RaftState:StateFollower Nodes:[]}, hardState: {Term:3 Vote:0 Commit:32 XXX_unrecognized:[]}] starts running
```

for #1877 
