### PR TITLE
raft: increase term to 1 before append initial entries

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -137,6 +137,9 @@ func StartNode(id uint64, peers []Peer, election, heartbeat int, storage Storage
 	n := newNode()
 	r := newRaft(id, nil, election, heartbeat, storage)
 
+	// become the follower at term 1 and apply initial configuration
+	// entires of term 1
+	r.becomeFollower(1, None)
 	for _, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		d, err := cc.Marshal()

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -306,20 +306,20 @@ func TestNodeStart(t *testing.T) {
 	wants := []Ready{
 		{
 			SoftState: &SoftState{Lead: 1, Nodes: []uint64{1}, RaftState: StateLeader},
-			HardState: raftpb.HardState{Term: 1, Commit: 2},
+			HardState: raftpb.HardState{Term: 2, Commit: 2},
 			Entries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
-				{Term: 1, Index: 2},
+				{Term: 2, Index: 2},
 			},
 			CommittedEntries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
-				{Term: 1, Index: 2},
+				{Term: 2, Index: 2},
 			},
 		},
 		{
-			HardState:        raftpb.HardState{Term: 1, Commit: 3},
-			Entries:          []raftpb.Entry{{Term: 1, Index: 3, Data: []byte("foo")}},
-			CommittedEntries: []raftpb.Entry{{Term: 1, Index: 3, Data: []byte("foo")}},
+			HardState:        raftpb.HardState{Term: 2, Commit: 3},
+			Entries:          []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
+			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
 		},
 	}
 	storage := NewMemoryStorage()


### PR DESCRIPTION
Because the term of new raft is 0, it is weird to have term-1 committed
entries in the log.

This causes problem on stableTo. Let us assume there is one conf add node entry in the log when init. When the external caller calls advance, it tries to stableTo (term: 1, index: 1), which is rejected because the term does not match. It keeps doing this until someone becomes the leader.

/cc @xiang90 @bdarnell
