### PR TITLE
raft: set raft.Commit too when setting raftLog.committed

### DIFF
--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -943,10 +943,6 @@ func TestTriggerSnap(t *testing.T) {
 	ctx := context.Background()
 	s := raft.NewMemoryStorage()
 	n := raft.StartNode(0xBAD0, mustMakePeerSlice(t, 0xBAD0), 10, 1, s)
-	rd := <-n.Ready()
-	s.Append(rd.Entries)
-	n.Advance()
-	n.ApplyConfChange(raftpb.ConfChange{Type: raftpb.ConfChangeAddNode, NodeID: 0xBAD0})
 	n.Campaign(ctx)
 	st := &storeRecorder{}
 	p := &storageRecorder{}

--- a/raft/node.go
+++ b/raft/node.go
@@ -150,6 +150,7 @@ func StartNode(id uint64, peers []Peer, election, heartbeat int, storage Storage
 	// TODO(bdarnell): These entries are still unstable; do we need to preserve
 	// the invariant that committed < unstable?
 	r.raftLog.committed = r.raftLog.lastIndex()
+	r.Commit = r.raftLog.committed
 	// Now apply them, mainly so that the application can call Campaign
 	// immediately after StartNode in tests. Note that these nodes will
 	// be added to raft twice: here and when the application's Ready


### PR DESCRIPTION
This helps to apply init entries when advance before any raft.Commit refresh.

Or it cannot commit to the latest commit because raft.Commit is set wrong. (https://github.com/coreos/etcd/blob/master/raft/node.go#L315)

the fix on snapshot test will be improved after i fix snapi.
