### PR TITLE
raft: Add Term to SoftState.

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -36,10 +36,11 @@ var (
 type SoftState struct {
 	Lead      uint64
 	RaftState StateType
+	Term      uint64
 }
 
 func (a *SoftState) equal(b *SoftState) bool {
-	return a.Lead == b.Lead && a.RaftState == b.RaftState
+	return a.Lead == b.Lead && a.RaftState == b.RaftState && a.Term == b.Term
 }
 
 // Ready encapsulates the entries and messages that are ready to read,

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -305,7 +305,7 @@ func TestNodeStart(t *testing.T) {
 	}
 	wants := []Ready{
 		{
-			SoftState: &SoftState{Lead: 1, RaftState: StateLeader},
+			SoftState: &SoftState{Lead: 1, RaftState: StateLeader, Term: 2},
 			HardState: raftpb.HardState{Term: 2, Commit: 2},
 			Entries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
@@ -446,6 +446,7 @@ func TestSoftStateEqual(t *testing.T) {
 		{&SoftState{}, true},
 		{&SoftState{Lead: 1}, false},
 		{&SoftState{RaftState: StateLeader}, false},
+		{&SoftState{Term: 1}, false},
 	}
 	for i, tt := range tests {
 		if g := tt.st.equal(&SoftState{}); g != tt.we {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -175,7 +175,13 @@ func (r *raft) hasLeader() bool { return r.lead != None }
 
 func (r *raft) leader() uint64 { return r.lead }
 
-func (r *raft) softState() *SoftState { return &SoftState{Lead: r.lead, RaftState: r.state} }
+func (r *raft) softState() *SoftState {
+	return &SoftState{
+		Lead:      r.lead,
+		RaftState: r.state,
+		Term:      r.Term,
+	}
+}
 
 func (r *raft) q() int { return len(r.prs)/2 + 1 }
 


### PR DESCRIPTION
Applications need this to detect when elections have occurred.
Uncommitted proposals may be dropped during elections and may
need to be retried afterwards.
