### PR TITLE
rafthttp: fixes issue 1903

### DIFF
--- a/rafthttp/sender.go
+++ b/rafthttp/sender.go
@@ -279,6 +279,6 @@ func (s *sender) post(data []byte) error {
 	case http.StatusNoContent:
 		return nil
 	default:
-		return fmt.Errorf("unhandled status %s", http.StatusText(resp.StatusCode))
+		return fmt.Errorf("unexpected http status %s while posting to %q", http.StatusText(resp.StatusCode), req.URL.String())
 	}
 }


### PR DESCRIPTION
Record the URL being fetched in the log when we 404
