### PR TITLE
etcdmain: better logging for discovery error

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -181,6 +181,9 @@ func (d *discovery) createSelf(contents string) error {
 	resp, err := d.c.Create(ctx, d.selfKey(), contents, -1)
 	cancel()
 	if err != nil {
+		if err == client.ErrKeyExists {
+			return ErrDuplicateID
+		}
 		return err
 	}
 

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -189,7 +189,13 @@ func Main() {
 		err = startProxy()
 	}
 	if err != nil {
-		log.Fatalf("etcd: %v", err)
+		switch err {
+		case discovery.ErrDuplicateID:
+			log.Fatalf("etcd: member %s has previously registered with discovery service (%s), but the data-dir (%s) on disk cannot be found.",
+				*name, *durl, *dir)
+		default:
+			log.Fatalf("etcd: %v", err)
+		}
 	}
 	<-stopped
 }


### PR DESCRIPTION
Fix #1862 

Logging as 

```
2014/12/11 15:42:26 no data-dir provided, using default data-dir ./infra1.etcd
2014/12/11 15:42:26 etcd: listening for peers on http://127.0.0.1:7001
2014/12/11 15:42:26 etcd: listening for client requests on http://127.0.0.1:4001
2014/12/11 15:42:26 etcd: stopping listening for client requests on http://127.0.0.1:4001
2014/12/11 15:42:26 etcd: stopping listening for peers on http://127.0.0.1:7001
2014/12/11 15:42:26 etcd: member infra1 has already registered with discovery service (https://discovery.etcd.io/b5d065d6e8078f60374c83a498e3d8f6), but the data-dir (infra1.etcd) on disk cannot be found.
```

instead of 

```
no data-dir provided, using default data-dir ./4e5fdea7886a46a69302ffb826351eab.etcd
etcd: listening for peers on http://0.0.0.0:2379
etcd: listening for client requests on http://0.0.0.0:2380
etcd: stopping listening for client requests on http://0.0.0.0:2380
etcd: stopping listening for peers on http://0.0.0.0:2379
etcd: client: key already exists
```

/cc @robszumski 
