### PR TITLE
store: return utc time to user

### DIFF
--- a/store/node.go
+++ b/store/node.go
@@ -150,7 +150,8 @@ func (n *node) expirationAndTTL(clock clockwork.Clock) (*time.Time, int64) {
 		if (ttlN % time.Second) > 0 {
 			ttl++
 		}
-		return &n.ExpireTime, int64(ttl)
+		t := n.ExpireTime.UTC()
+		return &t, int64(ttl)
 	}
 	return nil, 0
 }


### PR DESCRIPTION
Fix #1264 
return utc instead of local time

```
{"action":"set","node":{"key":"/foo","value":"bar","expiration":"2014-12-12T00:23:24.805038436Z","ttl":5,"modifiedIndex":3,"createdIndex":3}} 
```
