### PR TITLE
pkg/transport: change write size from 1MB -> 5MB

### DIFF
--- a/pkg/transport/timeout_dialer_test.go
+++ b/pkg/transport/timeout_dialer_test.go
@@ -43,7 +43,7 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 	defer conn.Close()
 
 	// fill the socket buffer
-	data := make([]byte, 1024*1024)
+	data := make([]byte, 5*1024*1024)
 	timer := time.AfterFunc(d.wtimeoutd*5, func() {
 		t.Fatal("wait timeout")
 	})

--- a/pkg/transport/timeout_listener_test.go
+++ b/pkg/transport/timeout_listener_test.go
@@ -52,7 +52,7 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 	defer conn.Close()
 
 	// fill the socket buffer
-	data := make([]byte, 1024*1024)
+	data := make([]byte, 5*1024*1024)
 	timer := time.AfterFunc(wln.wtimeoutd*5, func() {
 		t.Fatal("wait timeout")
 	})


### PR DESCRIPTION
As we move to container-based infrastructure testing env
on travis, the tcp write buffer is more than 1MB. Change
the test according to the change on the testing env.
