### PR TITLE
pkg/fileutil: fix typo (remvoed -> removed)

### DIFF
--- a/pkg/fileutil/purge.go
+++ b/pkg/fileutil/purge.go
@@ -32,7 +32,7 @@ func PurgeFile(dirname string, suffix string, max uint, interval time.Duration, 
 					errC <- err
 					return
 				}
-				log.Printf("filePurge: successfully remvoed file %s", f)
+				log.Printf("filePurge: successfully removed file %s", f)
 				newfnames = newfnames[1:]
 			}
 			select {


### PR DESCRIPTION
Spelling error on log output of purge.go
