### PR TITLE
etcdctl: add environment support to certs args

### DIFF
--- a/etcdctl/command/util.go
+++ b/etcdctl/command/util.go
@@ -91,10 +91,26 @@ func getEndpoints(c *cli.Context) ([]string, error) {
 }
 
 func getTransport(c *cli.Context) (*http.Transport, error) {
+	cafile := c.GlobalString("ca-file")
+	certfile := c.GlobalString("cert-file")
+	keyfile := c.GlobalString("key-file")
+
+	// Use an environment variable if nothing was supplied on the
+	// command line
+	if cafile == "" {
+		cafile = os.Getenv("ETCDCTL_CA_FILE")
+	}
+	if certfile == "" {
+		certfile = os.Getenv("ETCDCTL_CERT_FILE")
+	}
+	if keyfile == "" {
+		keyfile = os.Getenv("ETCDCTL_KEY_FILE")
+	}
+
 	tls := transport.TLSInfo{
-		CAFile:   c.GlobalString("ca-file"),
-		CertFile: c.GlobalString("cert-file"),
-		KeyFile:  c.GlobalString("key-file"),
+		CAFile:   cafile,
+		CertFile: certfile,
+		KeyFile:  keyfile,
 	}
 	return transport.NewTransport(tls)
 


### PR DESCRIPTION
Because `etcdctl` support `ETCDCTL_PEERS`, we must support `ETCDCTL_CA_FILE`, `ETCDCTL_CERT_FILE` and `ETCDCTL_KEY_FILE` too.
