### PR TITLE
etcdserver: set peers properly when started with force-new-cluster

### DIFF
--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -152,7 +152,7 @@ func (c *ServerConfig) print(initial bool) {
 		}
 	}
 	plog.Infof("advertise client URLs = %s", c.ClientURLs)
-	if initial {
+	if initial || c.ForceNewCluster {
 		plog.Infof("initial advertise peer URLs = %s", c.PeerURLs)
 		plog.Infof("initial cluster = %s", c.InitialPeerURLsMap)
 	}

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -325,7 +325,7 @@ func restartAsStandaloneNode(cfg *ServerConfig, snapshot *raftpb.Snapshot) (type
 	}
 
 	// force append the configuration change entries
-	toAppEnts := createConfigChangeEnts(getIDs(snapshot, ents), uint64(id), st.Term, st.Commit)
+	toAppEnts := createConfigChangeEnts(getIDs(snapshot, ents), uint64(id), st.Term, st.Commit, cfg.PeerURLs)
 	ents = append(ents, toAppEnts...)
 
 	// force commit newly appended entries
@@ -401,7 +401,7 @@ func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
 // `self` is _not_ removed, even if present in the set.
 // If `self` is not inside the given ids, it creates a Raft entry to add a
 // default member with the given `self`.
-func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raftpb.Entry {
+func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64, peerURLs types.URLs) []raftpb.Entry {
 	ents := make([]raftpb.Entry, 0)
 	next := index + 1
 	found := false
@@ -426,7 +426,7 @@ func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raf
 	if !found {
 		m := Member{
 			ID:             types.ID(self),
-			RaftAttributes: RaftAttributes{PeerURLs: []string{"http://localhost:7001", "http://localhost:2380"}},
+			RaftAttributes: RaftAttributes{PeerURLs: peerURLs.StringSlice()},
 		}
 		ctx, err := json.Marshal(m)
 		if err != nil {

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"encoding/json"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -73,6 +74,7 @@ func TestCreateConfigChangeEnts(t *testing.T) {
 		ID:             types.ID(1),
 		RaftAttributes: RaftAttributes{PeerURLs: []string{"http://localhost:7001", "http://localhost:2380"}},
 	}
+	testUrls := types.URLs([]url.URL{{Scheme: "http", Host: "localhost:7001"}, {Scheme: "http", Host: "localhost:2380"}})
 	ctx, err := json.Marshal(m)
 	if err != nil {
 		t.Fatal(err)
@@ -141,7 +143,7 @@ func TestCreateConfigChangeEnts(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		gents := createConfigChangeEnts(tt.ids, tt.self, tt.term, tt.index)
+		gents := createConfigChangeEnts(tt.ids, tt.self, tt.term, tt.index, testUrls)
 		if !reflect.DeepEqual(gents, tt.wents) {
 			t.Errorf("#%d: ents = %v, want %v", i, gents, tt.wents)
 		}


### PR DESCRIPTION
I was testing restores, and was using `force-new-cluster`, but each time I found the new cluster came up with default peer urls of `[http://localhost:2380 http://localhost:7001]`.  This created problems because I wanted to initialize a new cluster with a IP and port.

Tracking down the error, I found the values hard coded.  This commit removes the hard coded values, and passes along the configuration information from boot to the method setting up the new cluster.
