### PR TITLE
metrics: add reporting of `closed request prematurely`

### DIFF
--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -64,6 +64,7 @@ const (
 	zeroEndpoints         forwardingError = "zero_endpoints"
 	failedSendingRequest  forwardingError = "failed_sending_request"
 	failedGettingResponse forwardingError = "failed_getting_response"
+	closedPrematurely     forwardingError = "closed_prematurely"
 )
 
 func init() {

--- a/proxy/reverse.go
+++ b/proxy/reverse.go
@@ -115,6 +115,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 			select {
 			case <-closeNotifier.CloseNotify():
 				atomic.StoreInt32(&requestClosed, 1)
+				reportRequestDropped(clientreq, closedPrematurely)
 				log.Printf("proxy: client %v closed request prematurely", clientreq.RemoteAddr)
 				cancel()
 			case <-completeCh:

--- a/proxy/reverse.go
+++ b/proxy/reverse.go
@@ -67,6 +67,8 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 	*proxyreq = *clientreq
 	startTime := time.Now()
 
+	reportIncomingRequest(clientreq)
+
 	var (
 		proxybody []byte
 		err       error


### PR DESCRIPTION
Adds monitoring of the `closed request prematurely` problem on the proxy.
Fixes not reporting the incoming request (must have been dropped in merge resolutions).
https://github.com/coreos/etcd/issues/3405
