### PR TITLE
etcdserver: use types.URL as the type of RaftAttributes.PeerURLs

### DIFF
--- a/etcdserver/cluster.go
+++ b/etcdserver/cluster.go
@@ -164,9 +164,7 @@ func (c *cluster) PeerURLs() []string {
 	defer c.Unlock()
 	urls := make([]string, 0)
 	for _, p := range c.members {
-		for _, addr := range p.PeerURLs {
-			urls = append(urls, addr)
-		}
+		urls = append(urls, p.PeerURLs.StringSlice()...)
 	}
 	sort.Strings(urls)
 	return urls
@@ -247,7 +245,7 @@ func (c *cluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 		}
 		urls := make(map[string]bool)
 		for _, m := range members {
-			for _, u := range m.PeerURLs {
+			for _, u := range m.PeerURLs.StringSlice() {
 				urls[u] = true
 			}
 		}
@@ -255,7 +253,7 @@ func (c *cluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 		if err := json.Unmarshal(cc.Context, m); err != nil {
 			plog.Panicf("unmarshal member should never fail: %v", err)
 		}
-		for _, u := range m.PeerURLs {
+		for _, u := range m.PeerURLs.StringSlice() {
 			if urls[u] {
 				return ErrPeerURLexists
 			}
@@ -273,7 +271,7 @@ func (c *cluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 			if m.ID == id {
 				continue
 			}
-			for _, u := range m.PeerURLs {
+			for _, u := range m.PeerURLs.StringSlice() {
 				urls[u] = true
 			}
 		}
@@ -281,7 +279,7 @@ func (c *cluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 		if err := json.Unmarshal(cc.Context, m); err != nil {
 			plog.Panicf("unmarshal member should never fail: %v", err)
 		}
-		for _, u := range m.PeerURLs {
+		for _, u := range m.PeerURLs.StringSlice() {
 			if urls[u] {
 				return ErrPeerURLexists
 			}
@@ -484,7 +482,7 @@ func ValidateClusterAndAssignIDs(local *cluster, existing *cluster) error {
 	sort.Sort(MembersByPeerURLs(lms))
 
 	for i := range ems {
-		if !netutil.URLStringsEqual(ems[i].PeerURLs, lms[i].PeerURLs) {
+		if !netutil.URLStringsEqual(ems[i].PeerURLs.StringSlice(), lms[i].PeerURLs.StringSlice()) {
 			return fmt.Errorf("unmatched member while checking PeerURLs")
 		}
 		lms[i].ID = ems[i].ID

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -104,7 +104,7 @@ func getRemotePeerURLs(cl Cluster, local string) []string {
 		if m.Name == local {
 			continue
 		}
-		us = append(us, m.PeerURLs...)
+		us = append(us, m.PeerURLs.StringSlice()...)
 	}
 	sort.Strings(us)
 	return us
@@ -224,7 +224,7 @@ func getVersion(m *Member, tr *http.Transport) (*version.Versions, error) {
 	)
 
 	for _, u := range m.PeerURLs {
-		resp, err = cc.Get(u + "/version")
+		resp, err = cc.Get(u.String() + "/version")
 		if err != nil {
 			plog.Warningf("failed to reach the peerURL(%s) of member %s (%v)", u, m.ID, err)
 			continue

--- a/etcdserver/etcdhttp/client.go
+++ b/etcdserver/etcdhttp/client.go
@@ -273,7 +273,7 @@ func (h *membersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		m := etcdserver.Member{
 			ID:             id,
-			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: req.PeerURLs.StringSlice()},
+			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: req.PeerURLs},
 		}
 		err := h.server.UpdateMember(ctx, m)
 		switch {
@@ -766,7 +766,7 @@ func newMember(m *etcdserver.Member) httptypes.Member {
 		ClientURLs: make([]string, len(m.ClientURLs)),
 	}
 
-	copy(tm.PeerURLs, m.PeerURLs)
+	copy(tm.PeerURLs, m.PeerURLs.StringSlice())
 	copy(tm.ClientURLs, m.ClientURLs)
 
 	return tm

--- a/etcdserver/etcdhttp/client_test.go
+++ b/etcdserver/etcdhttp/client_test.go
@@ -701,7 +701,7 @@ func TestServeMembersCreate(t *testing.T) {
 	wm := etcdserver.Member{
 		ID: 3064321551348478165,
 		RaftAttributes: etcdserver.RaftAttributes{
-			PeerURLs: []string{"http://127.0.0.1:1"},
+			PeerURLs: testutil.MustNewURLs(t, []string{"http://127.0.0.1:1"}),
 		},
 	}
 
@@ -776,7 +776,7 @@ func TestServeMembersUpdate(t *testing.T) {
 	wm := etcdserver.Member{
 		ID: 1,
 		RaftAttributes: etcdserver.RaftAttributes{
-			PeerURLs: []string{"http://127.0.0.1:1"},
+			PeerURLs: testutil.MustNewURLs(t, []string{"http://127.0.0.1:1"}),
 		},
 	}
 
@@ -1924,12 +1924,12 @@ func TestNewMemberCollection(t *testing.T) {
 		{
 			ID:             12,
 			Attributes:     etcdserver.Attributes{ClientURLs: []string{"http://localhost:8080", "http://localhost:8081"}},
-			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: []string{"http://localhost:8082", "http://localhost:8083"}},
+			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: testutil.MustNewURLs(t, []string{"http://localhost:8082", "http://localhost:8083"})},
 		},
 		{
 			ID:             13,
 			Attributes:     etcdserver.Attributes{ClientURLs: []string{"http://localhost:9090", "http://localhost:9091"}},
-			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: []string{"http://localhost:9092", "http://localhost:9093"}},
+			RaftAttributes: etcdserver.RaftAttributes{PeerURLs: testutil.MustNewURLs(t, []string{"http://localhost:9092", "http://localhost:9093"})},
 		},
 	}
 	got := newMemberCollection(fixture)
@@ -1956,7 +1956,7 @@ func TestNewMember(t *testing.T) {
 	fixture := &etcdserver.Member{
 		ID:             12,
 		Attributes:     etcdserver.Attributes{ClientURLs: []string{"http://localhost:8080", "http://localhost:8081"}},
-		RaftAttributes: etcdserver.RaftAttributes{PeerURLs: []string{"http://localhost:8082", "http://localhost:8083"}},
+		RaftAttributes: etcdserver.RaftAttributes{PeerURLs: testutil.MustNewURLs(t, []string{"http://localhost:8082", "http://localhost:8083"})},
 	}
 	got := newMember(fixture)
 

--- a/etcdserver/member_test.go
+++ b/etcdserver/member_test.go
@@ -61,20 +61,20 @@ func TestMemberPick(t *testing.T) {
 		urls map[string]bool
 	}{
 		{
-			newTestMember(1, []string{"abc", "def", "ghi", "jkl", "mno", "pqr", "stu"}, "", nil),
+			newTestMember(1, []string{"http://abc:2380", "http://def:2380", "http://ghi:2380", "http://jkl:2380", "http://mno:2380", "http://pqr:2380", "http://stu:2380"}, "", nil),
 			map[string]bool{
-				"abc": true,
-				"def": true,
-				"ghi": true,
-				"jkl": true,
-				"mno": true,
-				"pqr": true,
-				"stu": true,
+				"http://abc:2380": true,
+				"http://def:2380": true,
+				"http://ghi:2380": true,
+				"http://jkl:2380": true,
+				"http://mno:2380": true,
+				"http://pqr:2380": true,
+				"http://stu:2380": true,
 			},
 		},
 		{
-			newTestMember(2, []string{"xyz"}, "", nil),
-			map[string]bool{"xyz": true},
+			newTestMember(2, []string{"http://xyz:2380"}, "", nil),
+			map[string]bool{"http://xyz:2380": true},
 		},
 	}
 	for i, tt := range tests {
@@ -91,9 +91,9 @@ func TestMemberPick(t *testing.T) {
 func TestMemberClone(t *testing.T) {
 	tests := []*Member{
 		newTestMember(1, nil, "abc", nil),
-		newTestMember(1, []string{"http://a"}, "abc", nil),
+		newTestMember(1, []string{"http://a:2380"}, "abc", nil),
 		newTestMember(1, nil, "abc", []string{"http://b"}),
-		newTestMember(1, []string{"http://a"}, "abc", []string{"http://b"}),
+		newTestMember(1, []string{"http://a:2380"}, "abc", []string{"http://b"}),
 	}
 	for i, tt := range tests {
 		nm := tt.Clone()
@@ -107,9 +107,18 @@ func TestMemberClone(t *testing.T) {
 }
 
 func newTestMember(id uint64, peerURLs []string, name string, clientURLs []string) *Member {
+	var pus types.URLs
+	// empty peerURLs is allowed here to faciliate testing
+	if len(peerURLs) != 0 {
+		var err error
+		pus, err = types.NewURLs(peerURLs)
+		if err != nil {
+			plog.Panic(err)
+		}
+	}
 	return &Member{
 		ID:             types.ID(id),
-		RaftAttributes: RaftAttributes{PeerURLs: peerURLs},
+		RaftAttributes: RaftAttributes{PeerURLs: pus},
 		Attributes:     Attributes{Name: name, ClientURLs: clientURLs},
 	}
 }

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -425,9 +425,13 @@ func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raf
 		next++
 	}
 	if !found {
+		us, err := types.NewURLs([]string{"http://localhost:7001", "http://localhost:2380"})
+		if err != nil {
+			plog.Panicf("unexpected NewURLs error (%v)", err)
+		}
 		m := Member{
 			ID:             types.ID(self),
-			RaftAttributes: RaftAttributes{PeerURLs: []string{"http://localhost:7001", "http://localhost:2380"}},
+			RaftAttributes: RaftAttributes{PeerURLs: us},
 		}
 		ctx, err := json.Marshal(m)
 		if err != nil {

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/pkg/pbutil"
-	"github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 )
@@ -69,10 +68,7 @@ func TestGetIDs(t *testing.T) {
 }
 
 func TestCreateConfigChangeEnts(t *testing.T) {
-	m := Member{
-		ID:             types.ID(1),
-		RaftAttributes: RaftAttributes{PeerURLs: []string{"http://localhost:7001", "http://localhost:2380"}},
-	}
+	m := newTestMember(1, []string{"http://localhost:7001", "http://localhost:2380"}, "", nil)
 	ctx, err := json.Marshal(m)
 	if err != nil {
 		t.Fatal(err)

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -410,7 +410,7 @@ func TestApplyConfChangeError(t *testing.T) {
 	cl := newCluster("")
 	cl.SetStore(store.New())
 	for i := 1; i <= 4; i++ {
-		cl.AddMember(&Member{ID: types.ID(i)})
+		cl.AddMember(newTestMember(uint64(i), []string{fmt.Sprintf("http://127.0.0.1:%d", i)}, "", nil))
 	}
 	cl.RemoveMember(4)
 
@@ -475,7 +475,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 	cl := newCluster("")
 	cl.SetStore(store.New())
 	for i := 1; i <= 3; i++ {
-		cl.AddMember(&Member{ID: types.ID(i)})
+		cl.AddMember(newTestMember(uint64(i), []string{fmt.Sprintf("http://127.0.0.1:%d", i)}, "", nil))
 	}
 	srv := &EtcdServer{
 		id: 1,
@@ -926,8 +926,7 @@ func TestAddMember(t *testing.T) {
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
 	s.start()
-	m := Member{ID: 1234, RaftAttributes: RaftAttributes{PeerURLs: []string{"foo"}}}
-	err := s.AddMember(context.TODO(), m)
+	err := s.AddMember(context.TODO(), *newTestMember(1234, []string{"http://127.0.0.1:2380"}, "", nil))
 	gaction := n.Action()
 	s.Stop()
 
@@ -952,7 +951,7 @@ func TestRemoveMember(t *testing.T) {
 	cl := newTestCluster(nil)
 	st := store.New()
 	cl.SetStore(store.New())
-	cl.AddMember(&Member{ID: 1234})
+	cl.AddMember(newTestMember(1234, []string{"http://127.0.0.1:2380"}, "", nil))
 	s := &EtcdServer{
 		r: raftNode{
 			Node:        n,
@@ -991,7 +990,7 @@ func TestUpdateMember(t *testing.T) {
 	cl := newTestCluster(nil)
 	st := store.New()
 	cl.SetStore(st)
-	cl.AddMember(&Member{ID: 1234})
+	cl.AddMember(newTestMember(1234, []string{"http://127.0.0.1:2380"}, "", nil))
 	s := &EtcdServer{
 		r: raftNode{
 			Node:        n,
@@ -1004,7 +1003,7 @@ func TestUpdateMember(t *testing.T) {
 		reqIDGen: idutil.NewGenerator(0, time.Time{}),
 	}
 	s.start()
-	wm := Member{ID: 1234, RaftAttributes: RaftAttributes{PeerURLs: []string{"http://127.0.0.1:1"}}}
+	wm := *newTestMember(1234, []string{"http://127.0.0.1:1"}, "", nil)
 	err := s.UpdateMember(context.TODO(), wm)
 	gaction := n.Action()
 	s.Stop()
@@ -1178,28 +1177,28 @@ func TestGetOtherPeerURLs(t *testing.T) {
 	}{
 		{
 			[]*Member{
-				newTestMember(1, []string{"http://10.0.0.1"}, "a", nil),
+				newTestMember(1, []string{"http://10.0.0.1:2380"}, "a", nil),
 			},
 			"a",
 			[]string{},
 		},
 		{
 			[]*Member{
-				newTestMember(1, []string{"http://10.0.0.1"}, "a", nil),
-				newTestMember(2, []string{"http://10.0.0.2"}, "b", nil),
-				newTestMember(3, []string{"http://10.0.0.3"}, "c", nil),
+				newTestMember(1, []string{"http://10.0.0.1:2380"}, "a", nil),
+				newTestMember(2, []string{"http://10.0.0.2:2380"}, "b", nil),
+				newTestMember(3, []string{"http://10.0.0.3:2380"}, "c", nil),
 			},
 			"a",
-			[]string{"http://10.0.0.2", "http://10.0.0.3"},
+			[]string{"http://10.0.0.2:2380", "http://10.0.0.3:2380"},
 		},
 		{
 			[]*Member{
-				newTestMember(1, []string{"http://10.0.0.1"}, "a", nil),
-				newTestMember(3, []string{"http://10.0.0.3"}, "c", nil),
-				newTestMember(2, []string{"http://10.0.0.2"}, "b", nil),
+				newTestMember(1, []string{"http://10.0.0.1:2380"}, "a", nil),
+				newTestMember(3, []string{"http://10.0.0.3:2380"}, "c", nil),
+				newTestMember(2, []string{"http://10.0.0.2:2380"}, "b", nil),
 			},
 			"a",
-			[]string{"http://10.0.0.2", "http://10.0.0.3"},
+			[]string{"http://10.0.0.2:2380", "http://10.0.0.3:2380"},
 		},
 	}
 	for i, tt := range tests {

--- a/pkg/types/urls.go
+++ b/pkg/types/urls.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -25,6 +26,15 @@ import (
 
 type URLs []url.URL
 
+// NewURLs creates and initializes a new URLs using the given URL strings
+// as its initial contents.
+// If no URL string is given, it returns error.
+// The given URL string should follow the rules:
+// 1. "http" or "https" scheme
+// 2. network address is in the form "host:port", "[host]:port" or
+// "[ipv6-host%zone]:port"
+// 3. empty URL path
+// The returned URLs are sorted in increasing order of URL strings.
 func NewURLs(strs []string) (URLs, error) {
 	all := make([]url.URL, len(strs))
 	if len(all) == 0 {
@@ -55,6 +65,27 @@ func NewURLs(strs []string) (URLs, error) {
 
 func (us URLs) String() string {
 	return strings.Join(us.StringSlice(), ",")
+}
+
+// MarshalJSON marshals URLs into valid JSON description,
+// which is a JSON array of URL strings.
+func (us URLs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(us.StringSlice())
+}
+
+// UnmarshalJSON unmarshals a JSON description of URLs.
+func (us *URLs) UnmarshalJSON(b []byte) error {
+	var s []string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	nus, err := NewURLs(s)
+	if err != nil {
+		return err
+	}
+	*us = nus
+	return nil
 }
 
 func (us *URLs) Sort() {

--- a/pkg/types/urls_test.go
+++ b/pkg/types/urls_test.go
@@ -91,6 +91,43 @@ func TestURLsString(t *testing.T) {
 	}
 }
 
+func TestURLsJSON(t *testing.T) {
+	tests := []struct {
+		us URLs
+		b  []byte
+	}{
+		{
+			testutil.MustNewURLs(t, []string{"http://127.0.0.1:2379"}),
+			[]byte(`["http://127.0.0.1:2379"]`),
+		},
+		{
+			testutil.MustNewURLs(t, []string{
+				"http://127.0.0.1:2379",
+				"http://127.0.0.2:2379",
+			}),
+			[]byte(`["http://127.0.0.1:2379","http://127.0.0.2:2379"]`),
+		},
+	}
+	for i, tt := range tests {
+		b, err := tt.us.MarshalJSON()
+		if err != nil {
+			t.Fatalf("unexpected MarshalJSON error (%v)", err)
+		}
+		if !reflect.DeepEqual(b, tt.b) {
+			t.Errorf("#%d: json = %s, want %s", i, b, tt.b)
+		}
+
+		var us URLs
+		err = us.UnmarshalJSON(tt.b)
+		if err != nil {
+			t.Fatalf("unexpected UnmarshalJSON error (%v)", err)
+		}
+		if !reflect.DeepEqual(us, tt.us) {
+			t.Errorf("#%d: urls = %s, want %s", i, us, tt.us)
+		}
+	}
+}
+
 func TestURLsSort(t *testing.T) {
 	g := testutil.MustNewURLs(t, []string{
 		"http://127.0.0.4:2379",


### PR DESCRIPTION
This ensures that PeerURLs are always valid URLs that follow
rules on URL scheme, address and path. Moreover, PeerURLs cannot
be empty URLs.

The change keeps backward compatiblity:
1. It keeps the JSON description of RaftAttributes, so the original data
   in the store could be unmarshalled as before.
2. The PeerURLs in old members could always pass new checks because PeerURLs
   are always built through types.NewURLs first, then converted into string
   slice. I have checked this in the whole repo.

address #3622 

/cc @gyuho 
