### PR TITLE
pkg/transport, rafthttp: CancelableTransport

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -840,7 +840,7 @@ func mustNewTransport(t *testing.T, tlsInfo transport.TLSInfo) *http.Transport {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tr
+	return tr.Transport
 }
 
 type SortableMemberSliceByPeerURLs []client.Member

--- a/pkg/transport/cancelable_transport_test.go
+++ b/pkg/transport/cancelable_transport_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCancelableTransportCancel(t *testing.T) {
+	sock := "whatever:123"
+	l, err := NewUnixListener(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	tr, trerr := NewTransport(TLSInfo{}, time.Second)
+	if trerr != nil {
+		t.Fatal(trerr)
+	}
+	tr.Cancel()
+
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		req, reqerr := http.NewRequest("GET", "unix://"+sock, strings.NewReader("abc"))
+		if reqerr != nil {
+			errc <- reqerr
+			return
+		}
+		resp, rerr := tr.RoundTrip(req)
+		if rerr == nil {
+			errc <- fmt.Errorf("round trip succeeded with %+v, expected error", resp)
+		}
+	}()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for roundtrip to cancel")
+	}
+}

--- a/pkg/transport/timeout_dialer.go
+++ b/pkg/transport/timeout_dialer.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -26,7 +27,11 @@ type rwTimeoutDialer struct {
 }
 
 func (d *rwTimeoutDialer) Dial(network, address string) (net.Conn, error) {
-	conn, err := d.Dialer.Dial(network, address)
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *rwTimeoutDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := d.Dialer.DialContext(ctx, network, address)
 	tconn := &timeoutConn{
 		rdtimeoutd: d.rdtimeoutd,
 		wtimeoutd:  d.wtimeoutd,

--- a/rafthttp/util.go
+++ b/rafthttp/util.go
@@ -45,7 +45,7 @@ func NewListener(u url.URL, tlscfg *tls.Config) (net.Listener, error) {
 
 // NewRoundTripper returns a roundTripper used to send requests
 // to rafthttp listener of remote peers.
-func NewRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (http.RoundTripper, error) {
+func NewRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (*transport.CancelableTransport, error) {
 	// It uses timeout transport to pair with remote timeout listeners.
 	// It sets no read/write timeout, because message in requests may
 	// take long time to write out before reading out the response.
@@ -57,7 +57,7 @@ func NewRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (http
 // Read/write timeout is set for stream roundTripper to promptly
 // find out broken status, which minimizes the number of messages
 // sent on broken connection.
-func newStreamRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (http.RoundTripper, error) {
+func newStreamRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration) (*transport.CancelableTransport, error) {
 	return transport.NewTimeoutTransport(tlsInfo, dialTimeout, ConnReadTimeout, ConnWriteTimeout)
 }
 


### PR DESCRIPTION
A transport that is tied to a context. Lets the consumer cancel all requests
and dials with a single Cancel.

Related: #7594
