### PR TITLE
RFC *: introduce a new option --batch-append for controlling AppendEntrie…

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -132,6 +132,10 @@ type Config struct {
 	// auth
 
 	AuthToken string `json:"auth-token"`
+
+	// performance
+
+	BatchAppend string `json:"batch-append"`
 }
 
 // configYAML holds the config suitable for yaml parsing
@@ -184,6 +188,7 @@ func NewConfig() *Config {
 		Metrics:             "basic",
 		EnableV2:            true,
 		AuthToken:           "simple",
+		BatchAppend:         "0,0",
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -142,6 +142,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		StrictReconfigCheck:     cfg.StrictReconfigCheck,
 		ClientCertAuthEnabled:   cfg.ClientTLSInfo.ClientCertAuth,
 		AuthToken:               cfg.AuthToken,
+		BatchAppend:             cfg.BatchAppend,
 	}
 
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -208,6 +208,9 @@ func newConfig() *config {
 	// auth
 	fs.StringVar(&cfg.AuthToken, "auth-token", cfg.AuthToken, "Specify auth token specific options.")
 
+	// performance
+	fs.StringVar(&cfg.BatchAppend, "batch-append", cfg.BatchAppend, "Specify parameters related to batch appending")
+
 	// ignored
 	for _, f := range cfg.ignored {
 		fs.Var(&flags.IgnoredFlag{Name: f}, f, "")

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -61,6 +61,8 @@ type ServerConfig struct {
 	ClientCertAuthEnabled bool
 
 	AuthToken string
+
+	BatchAppend string
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case


### PR DESCRIPTION
…s() triggering

Raft algorithm itself and the raft package of etcd support batched
log appending because the RPC AppendEntries() is capable of appending
multiple log entries at once. However, current etcd doesn't have an
option for controlling the batching.

This commit adds a new option --batch-append for controlling the
behaviour, The form of its parameter is like this:
<integer>:<duration>. The first integer is interpreted as the maximum
number of log entries that will be appended at once. The second
duration is the duration for triggering AppendEntries(). If the
duration passes, AppendEntries() will be issued even if a number of
batched log entries is less than the number that is specified in the
first part of the parameter.

Below is a slack benchmark result on my single machine (the purpose of
the option is reducing synchronous log write in WAL and improving
write throughput, so benchmarking on a single box is informative for
estimating the affection):

1. --batch-append=0,0 (same to the current master branch):
```
$ ./benchmark --conns=10 --clients=10 put
Summary:
  Total:        32.2357 secs.
  Slowest:      0.4025 secs.
  Fastest:      0.0055 secs.
  Average:      0.0322 secs.
  Stddev:       0.0190 secs.
  Requests/sec: 310.2154

Response time histogram:
  0.0055 [1]    |
  0.0452 [8914] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0849 [952]  |∎∎∎∎
  0.1246 [79]   |
  0.1643 [8]    |
  0.2040 [19]   |
  0.2437 [9]    |
  0.2834 [8]    |
  0.3231 [8]    |
  0.3628 [1]    |
  0.4025 [1]    |

Latency distribution:
  10% in 0.0168 secs.
  25% in 0.0223 secs.
  50% in 0.0297 secs.
  75% in 0.0372 secs.
  90% in 0.0459 secs.
  95% in 0.0530 secs.
  99% in 0.0976 secs.
  99.9% in 0.3123 secs.
```

2. --batch-append=10,100us
```
$ ./benchmark --conns=10 --clients=10 put
Summary:
  Total:        26.2247 secs.
  Slowest:      0.1303 secs.
  Fastest:      0.0060 secs.
  Average:      0.0261 secs.
  Stddev:       0.0104 secs.
  Requests/sec: 381.3198

Response time histogram:
  0.0060 [1]    |
  0.0185 [1740] |∎∎∎∎∎∎∎∎∎∎∎
  0.0309 [6097] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0433 [1648] |∎∎∎∎∎∎∎∎∎∎
  0.0557 [443]  |∎∎
  0.0682 [11]   |
  0.0806 [0]    |
  0.0930 [15]   |
  0.1054 [9]    |
  0.1179 [18]   |
  0.1303 [18]   |

Latency distribution:
  10% in 0.0161 secs.
  25% in 0.0202 secs.
  50% in 0.0245 secs.
  75% in 0.0296 secs.
  90% in 0.0377 secs.
  95% in 0.0436 secs.
  99% in 0.0528 secs.
  99.9% in 0.1195 secs.
```

We can see some improvement of write throughput (surprisingly
latencies are also improved).

Configuring the option isn't so easy because the improvement (or
degrading) depends on a workload and performance requirement
(throughput vs latency). So the detailed evaluation isn't performed
yet. If the change can be acceptable, I'll perform more detailed and
realistic evaluation.
