### PR TITLE
*: Fix embedded mutexes leaking methods

### DIFF
--- a/etcdserver/stats/server.go
+++ b/etcdserver/stats/server.go
@@ -50,13 +50,13 @@ type ServerStats struct {
 	sendRateQueue *statsQueue
 	recvRateQueue *statsQueue
 
-	sync.Mutex
+	mu sync.Mutex
 }
 
 func (ss *ServerStats) JSON() []byte {
-	ss.Lock()
+	ss.mu.Lock()
 	stats := *ss
-	ss.Unlock()
+	ss.mu.Unlock()
 	stats.LeaderInfo.Uptime = time.Since(stats.LeaderInfo.StartTime).String()
 	stats.SendingPkgRate, stats.SendingBandwidthRate = stats.SendRates()
 	stats.RecvingPkgRate, stats.RecvingBandwidthRate = stats.RecvRates()
@@ -97,8 +97,8 @@ func (ss *ServerStats) SendRates() (float64, float64) {
 // RecvAppendReq updates the ServerStats in response to an AppendRequest
 // from the given leader being received
 func (ss *ServerStats) RecvAppendReq(leader string, reqSize int) {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
 
 	now := time.Now()
 
@@ -120,8 +120,8 @@ func (ss *ServerStats) RecvAppendReq(leader string, reqSize int) {
 // SendAppendReq updates the ServerStats in response to an AppendRequest
 // being sent by this server
 func (ss *ServerStats) SendAppendReq(reqSize int) {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
 
 	ss.becomeLeader()
 
@@ -136,8 +136,8 @@ func (ss *ServerStats) SendAppendReq(reqSize int) {
 }
 
 func (ss *ServerStats) BecomeLeader() {
-	ss.Lock()
-	defer ss.Unlock()
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
 	ss.becomeLeader()
 }
 

--- a/pkg/testutil/recorder.go
+++ b/pkg/testutil/recorder.go
@@ -40,20 +40,20 @@ type Recorder interface {
 
 // RecorderBuffered appends all Actions to a slice
 type RecorderBuffered struct {
-	sync.Mutex
+	mu      sync.Mutex
 	actions []Action
 }
 
 func (r *RecorderBuffered) Record(a Action) {
-	r.Lock()
+	r.mu.Lock()
 	r.actions = append(r.actions, a)
-	r.Unlock()
+	r.mu.Unlock()
 }
 func (r *RecorderBuffered) Action() []Action {
-	r.Lock()
+	r.mu.Lock()
 	cpy := make([]Action, len(r.actions))
 	copy(cpy, r.actions)
-	r.Unlock()
+	r.mu.Unlock()
 	return cpy
 }
 func (r *RecorderBuffered) Wait(n int) (acts []Action, err error) {


### PR DESCRIPTION
This pull request cleans up all exported structs that were leaking the Lock/Unlock methods from an embedded mutex.