### PR TITLE
grpcproxy: disambiguate flags for setting client vs. serving TLS config

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -112,9 +112,9 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grpcProxyDataDir, "data-dir", "default.proxy", "Data directory for persistent data")
 
 	// client TLS for connecting to server
-	cmd.Flags().StringVar(&grpcProxyCert, "cert", "", "identify secure connections with etcd servers using this TLS certificate file")
-	cmd.Flags().StringVar(&grpcProxyKey, "key", "", "identify secure connections with etcd servers using this TLS key file")
-	cmd.Flags().StringVar(&grpcProxyCA, "cacert", "", "verify certificates of TLS-enabled secure etcd servers using this CA bundle")
+	cmd.Flags().StringVar(&grpcProxyCert, "client-cert-file", "", "identify secure connections with etcd servers using this TLS certificate file")
+	cmd.Flags().StringVar(&grpcProxyKey, "client-key-file", "", "identify secure connections with etcd servers using this TLS key file")
+	cmd.Flags().StringVar(&grpcProxyCA, "client-ca-file", "", "verify certificates of TLS-enabled secure etcd servers using this CA bundle")
 	cmd.Flags().BoolVar(&grpcProxyInsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip authentication of etcd server TLS certificates")
 
 	// client TLS for connecting to proxy


### PR DESCRIPTION
presently, the options are not self-describing, and i can see easy
errors being made- the client certs specified by --cert were even
accidentally used for serving in the current etcd release. let's change
them in the proxy for the next major release.

this does remove a flag that was previously in use in the proxy
(--cert) but i'm trying to make the flags match etcd itself, with its
--client-cert-file and --peer-cert-file flags. happy to go either way,
as long as 'client' or 'server' is added to either set, preferably both.
