### PR TITLE
etcdserver, raft: cleanup raft.Storage interface and raft.MemoryStora…

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -56,7 +56,7 @@ type raftNode struct {
 
 	// raft backing for the commit/error channel
 	node        raft.Node
-	raftStorage *raft.MemoryStorage
+	raftStorage raft.Storage
 	wal         *wal.WAL
 
 	snapshotter      *raftsnap.Snapshotter
@@ -230,7 +230,7 @@ func (rc *raftNode) replayWAL() *wal.WAL {
 	if err != nil {
 		log.Fatalf("raftexample: failed to read WAL (%v)", err)
 	}
-	rc.raftStorage = raft.NewMemoryStorage()
+	rc.raftStorage = raft.NewStorage()
 	if snapshot != nil {
 		rc.raftStorage.ApplySnapshot(*snapshot)
 	}

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -156,7 +156,7 @@ func TestStopRaftWhenWaitingForApplyDone(t *testing.T) {
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
 		storage:     mockstorage.NewStorageRecorder(""),
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		transport:   rafthttp.NewNopTransporter(),
 	})
 	srv := &EtcdServer{r: *r}
@@ -183,7 +183,7 @@ func TestConfgChangeBlocksApply(t *testing.T) {
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
 		storage:     mockstorage.NewStorageRecorder(""),
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		transport:   rafthttp.NewNopTransporter(),
 	})
 	srv := &EtcdServer{r: *r}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -261,7 +261,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 	var (
 		w  *wal.WAL
 		n  raft.Node
-		s  *raft.MemoryStorage
+		s  raft.Storage
 		id types.ID
 		cl *membership.RaftCluster
 	)

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -172,7 +172,7 @@ func TestApplyRepeat(t *testing.T) {
 	cl.AddMember(&membership.Member{ID: 1234})
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		storage:     mockstorage.NewStorageRecorder(""),
 		transport:   rafthttp.NewNopTransporter(),
 	})
@@ -679,7 +679,7 @@ func TestDoProposal(t *testing.T) {
 		r := newRaftNode(raftNodeConfig{
 			Node:        newNodeCommitter(),
 			storage:     mockstorage.NewStorageRecorder(""),
-			raftStorage: raft.NewMemoryStorage(),
+			raftStorage: raft.NewStorage(),
 			transport:   rafthttp.NewNopTransporter(),
 		})
 		srv := &EtcdServer{
@@ -849,7 +849,7 @@ func TestSyncTrigger(t *testing.T) {
 	tk := &time.Ticker{C: st}
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		transport:   rafthttp.NewNopTransporter(),
 		storage:     mockstorage.NewStorageRecorder(""),
 	})
@@ -903,7 +903,7 @@ func TestSnapshot(t *testing.T) {
 		os.RemoveAll(tmpPath)
 	}()
 
-	s := raft.NewMemoryStorage()
+	s := raft.NewStorage()
 	s.Append([]raftpb.Entry{{Index: 1}})
 	st := mockstore.NewRecorderStream()
 	p := mockstorage.NewStorageRecorderStream("")
@@ -972,7 +972,7 @@ func TestSnapshotOrdering(t *testing.T) {
 		t.Fatalf("couldn't make snap dir (%v)", err)
 	}
 
-	rs := raft.NewMemoryStorage()
+	rs := raft.NewStorage()
 	p := mockstorage.NewStorageRecorderStream(testdir)
 	tr, snapDoneC := rafthttp.NewSnapTransporter(snapdir)
 	r := newRaftNode(raftNodeConfig{
@@ -1039,7 +1039,7 @@ func TestTriggerSnap(t *testing.T) {
 	p := mockstorage.NewStorageRecorderStream("")
 	r := newRaftNode(raftNodeConfig{
 		Node:        newNodeCommitter(),
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		storage:     p,
 		transport:   rafthttp.NewNopTransporter(),
 	})
@@ -1098,7 +1098,7 @@ func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
 		t.Fatalf("Couldn't make snap dir (%v)", err)
 	}
 
-	rs := raft.NewMemoryStorage()
+	rs := raft.NewStorage()
 	tr, snapDoneC := rafthttp.NewSnapTransporter(testdir)
 	r := newRaftNode(raftNodeConfig{
 		isIDRemoved: func(id uint64) bool { return cl.IsIDRemoved(types.ID(id)) },
@@ -1187,7 +1187,7 @@ func TestAddMember(t *testing.T) {
 	cl.SetStore(st)
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		storage:     mockstorage.NewStorageRecorder(""),
 		transport:   rafthttp.NewNopTransporter(),
 	})
@@ -1228,7 +1228,7 @@ func TestRemoveMember(t *testing.T) {
 	cl.AddMember(&membership.Member{ID: 1234})
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		storage:     mockstorage.NewStorageRecorder(""),
 		transport:   rafthttp.NewNopTransporter(),
 	})
@@ -1268,7 +1268,7 @@ func TestUpdateMember(t *testing.T) {
 	cl.AddMember(&membership.Member{ID: 1234})
 	r := newRaftNode(raftNodeConfig{
 		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
+		raftStorage: raft.NewStorage(),
 		storage:     mockstorage.NewStorageRecorder(""),
 		transport:   rafthttp.NewNopTransporter(),
 	})

--- a/raft/README.md
+++ b/raft/README.md
@@ -57,7 +57,7 @@ The primary object in raft is a Node. Either start a Node from scratch using raf
 
 To start a three-node cluster
 ```go
-  storage := raft.NewMemoryStorage()
+  storage := raft.NewStorage()
   c := &Config{
     ID:              0x01,
     ElectionTick:    10,
@@ -87,7 +87,7 @@ To allow a new node to join this cluster, do not pass in any peers. First, add t
 
 To restart a node from previous state:
 ```go
-  storage := raft.NewMemoryStorage()
+  storage := raft.NewStorage()
 
   // Recover the in-memory storage from persistent snapshot, state and entries.
   storage.ApplySnapshot(snapshot)

--- a/raft/doc.go
+++ b/raft/doc.go
@@ -32,7 +32,7 @@ using raft.StartNode or start a Node from some initial state using raft.RestartN
 
 To start a node from scratch:
 
-  storage := raft.NewMemoryStorage()
+  storage := raft.NewStorage()
   c := &Config{
     ID:              0x01,
     ElectionTick:    10,
@@ -45,7 +45,7 @@ To start a node from scratch:
 
 To restart a node from previous state:
 
-  storage := raft.NewMemoryStorage()
+  storage := raft.NewStorage()
 
   // recover the in-memory storage from persistent
   // snapshot, state and entries.

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -45,7 +45,7 @@ func TestFindConflict(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		raftLog := newLog(NewMemoryStorage(), raftLogger)
+		raftLog := newLog(newMemoryStorage(), raftLogger)
 		raftLog.append(previousEnts...)
 
 		gconflict := raftLog.findConflict(tt.ents)
@@ -57,7 +57,7 @@ func TestFindConflict(t *testing.T) {
 
 func TestIsUpToDate(t *testing.T) {
 	previousEnts := []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
-	raftLog := newLog(NewMemoryStorage(), raftLogger)
+	raftLog := newLog(newMemoryStorage(), raftLogger)
 	raftLog.append(previousEnts...)
 	tests := []struct {
 		lastIndex uint64
@@ -123,7 +123,7 @@ func TestAppend(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		storage := NewMemoryStorage()
+		storage := newMemoryStorage()
 		storage.Append(previousEnts)
 		raftLog := newLog(storage, raftLogger)
 
@@ -236,7 +236,7 @@ func TestLogMaybeAppend(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		raftLog := newLog(NewMemoryStorage(), raftLogger)
+		raftLog := newLog(newMemoryStorage(), raftLogger)
 		raftLog.append(previousEnts...)
 		raftLog.committed = commit
 		func() {
@@ -280,7 +280,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	lastIndex := uint64(1000)
 	unstableIndex := uint64(750)
 	lastTerm := lastIndex
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	for i = 1; i <= unstableIndex; i++ {
 		storage.Append([]pb.Entry{{Term: uint64(i), Index: uint64(i)}})
 	}
@@ -356,7 +356,7 @@ func TestHasNextEnts(t *testing.T) {
 		{5, false},
 	}
 	for i, tt := range tests {
-		storage := NewMemoryStorage()
+		storage := newMemoryStorage()
 		storage.ApplySnapshot(snap)
 		raftLog := newLog(storage, raftLogger)
 		raftLog.append(ents...)
@@ -389,7 +389,7 @@ func TestNextEnts(t *testing.T) {
 		{5, nil},
 	}
 	for i, tt := range tests {
-		storage := NewMemoryStorage()
+		storage := newMemoryStorage()
 		storage.ApplySnapshot(snap)
 		raftLog := newLog(storage, raftLogger)
 		raftLog.append(ents...)
@@ -417,7 +417,7 @@ func TestUnstableEnts(t *testing.T) {
 
 	for i, tt := range tests {
 		// append stable entries to storage
-		storage := NewMemoryStorage()
+		storage := newMemoryStorage()
 		storage.Append(previousEnts[:tt.unstable-1])
 
 		// append unstable entries to raftlog
@@ -459,7 +459,7 @@ func TestCommitTo(t *testing.T) {
 					}
 				}
 			}()
-			raftLog := newLog(NewMemoryStorage(), raftLogger)
+			raftLog := newLog(newMemoryStorage(), raftLogger)
 			raftLog.append(previousEnts...)
 			raftLog.committed = commit
 			raftLog.commitTo(tt.commit)
@@ -482,7 +482,7 @@ func TestStableTo(t *testing.T) {
 		{3, 1, 1}, // bad index
 	}
 	for i, tt := range tests {
-		raftLog := newLog(NewMemoryStorage(), raftLogger)
+		raftLog := newLog(newMemoryStorage(), raftLogger)
 		raftLog.append([]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}...)
 		raftLog.stableTo(tt.stablei, tt.stablet)
 		if raftLog.unstable.offset != tt.wunstable {
@@ -517,7 +517,7 @@ func TestStableToWithSnap(t *testing.T) {
 		{snapi - 1, snapt + 1, []pb.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
 	}
 	for i, tt := range tests {
-		s := NewMemoryStorage()
+		s := newMemoryStorage()
 		s.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: snapi, Term: snapt}})
 		raftLog := newLog(s, raftLogger)
 		raftLog.append(tt.newEnts...)
@@ -553,7 +553,7 @@ func TestCompaction(t *testing.T) {
 				}
 			}()
 
-			storage := NewMemoryStorage()
+			storage := newMemoryStorage()
 			for i := uint64(1); i <= tt.lastIndex; i++ {
 				storage.Append([]pb.Entry{{Index: i}})
 			}
@@ -581,7 +581,7 @@ func TestLogRestore(t *testing.T) {
 	index := uint64(1000)
 	term := uint64(1000)
 	snap := pb.SnapshotMetadata{Index: index, Term: term}
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: snap})
 	raftLog := newLog(storage, raftLogger)
 
@@ -605,7 +605,7 @@ func TestLogRestore(t *testing.T) {
 func TestIsOutOfBounds(t *testing.T) {
 	offset := uint64(100)
 	num := uint64(100)
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset}})
 	l := newLog(storage, raftLogger)
 	for i := uint64(1); i <= num; i++ {
@@ -688,7 +688,7 @@ func TestTerm(t *testing.T) {
 	offset := uint64(100)
 	num := uint64(100)
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset, Term: 1}})
 	l := newLog(storage, raftLogger)
 	for i = 1; i < num; i++ {
@@ -718,7 +718,7 @@ func TestTermWithUnstableSnapshot(t *testing.T) {
 	storagesnapi := uint64(100)
 	unstablesnapi := storagesnapi + 5
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: storagesnapi, Term: 1}})
 	l := newLog(storage, raftLogger)
 	l.restore(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: unstablesnapi, Term: 1}})
@@ -752,7 +752,7 @@ func TestSlice(t *testing.T) {
 	half := offset + num/2
 	halfe := pb.Entry{Index: half, Term: half}
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset}})
 	for i = 1; i < num/2; i++ {
 		storage.Append([]pb.Entry{{Index: offset + i, Term: offset + i}})

--- a/raft/node_bench_test.go
+++ b/raft/node_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkOneNode(b *testing.B) {
 	defer cancel()
 
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -115,7 +115,7 @@ func TestNodePropose(t *testing.T) {
 	}
 
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 	n.Campaign(context.TODO())
@@ -155,7 +155,7 @@ func TestNodeReadIndex(t *testing.T) {
 	wrs := []ReadState{{Index: uint64(1), RequestCtx: []byte("somedata")}}
 
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	r.readStates = wrs
 
@@ -195,9 +195,9 @@ func TestNodeReadIndex(t *testing.T) {
 // TestDisableProposalForwarding ensures that proposals are not forwarded to
 // the leader when DisableProposalForwarding is true.
 func TestDisableProposalForwarding(t *testing.T) {
-	r1 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-	r2 := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-	cfg3 := newTestConfig(3, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
+	r1 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
+	r2 := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
+	cfg3 := newTestConfig(3, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
 	cfg3.DisableProposalForwarding = true
 	r3 := newRaft(cfg3)
 	nt := newNetwork(r1, r2, r3)
@@ -227,9 +227,9 @@ func TestDisableProposalForwarding(t *testing.T) {
 // TestNodeReadIndexToOldLeader ensures that raftpb.MsgReadIndex to old leader
 // gets forwarded to the new leader and 'send' method does not attach its term.
 func TestNodeReadIndexToOldLeader(t *testing.T) {
-	r1 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-	r2 := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-	r3 := newTestRaft(3, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
+	r1 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
+	r2 := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
+	r3 := newTestRaft(3, []uint64{1, 2, 3}, 10, 1, newMemoryStorage())
 
 	nt := newNetwork(r1, r2, r3)
 
@@ -292,7 +292,7 @@ func TestNodeProposeConfig(t *testing.T) {
 	}
 
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 	n.Campaign(context.TODO())
@@ -330,7 +330,7 @@ func TestNodeProposeConfig(t *testing.T) {
 // not affect the later propose to add new node.
 func TestNodeProposeAddDuplicateNode(t *testing.T) {
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 	n.Campaign(context.TODO())
@@ -406,7 +406,7 @@ func TestNodeProposeAddDuplicateNode(t *testing.T) {
 // who is the current leader.
 func TestBlockProposal(t *testing.T) {
 	n := newNode()
-	r := newTestRaft(1, []uint64{1}, 10, 1, NewMemoryStorage())
+	r := newTestRaft(1, []uint64{1}, 10, 1, newMemoryStorage())
 	go n.run(r)
 	defer n.Stop()
 
@@ -437,7 +437,7 @@ func TestBlockProposal(t *testing.T) {
 // elapsed of the underlying raft state machine.
 func TestNodeTick(t *testing.T) {
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 	elapsed := r.electionElapsed
@@ -457,7 +457,7 @@ func TestNodeTick(t *testing.T) {
 // processing, and that it is idempotent
 func TestNodeStop(t *testing.T) {
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	donec := make(chan struct{})
 
@@ -540,7 +540,7 @@ func TestNodeStart(t *testing.T) {
 			MustSync:         true,
 		},
 	}
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	c := &Config{
 		ID:              1,
 		ElectionTick:    10,
@@ -593,7 +593,7 @@ func TestNodeRestart(t *testing.T) {
 		MustSync:         true,
 	}
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.SetHardState(st)
 	storage.Append(entries)
 	c := &Config{
@@ -638,7 +638,7 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 		MustSync:         true,
 	}
 
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	s.SetHardState(st)
 	s.ApplySnapshot(snap)
 	s.Append(entries)
@@ -669,7 +669,7 @@ func TestNodeAdvance(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	c := &Config{
 		ID:              1,
 		ElectionTick:    10,
@@ -740,7 +740,7 @@ func TestNodeProposeAddLearnerNode(t *testing.T) {
 	ticker := time.NewTicker(time.Millisecond * 100)
 	defer ticker.Stop()
 	n := newNode()
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	r := newTestRaft(1, []uint64{1}, 10, 1, s)
 	go n.run(r)
 	n.Campaign(context.TODO())

--- a/raft/raft_flow_control_test.go
+++ b/raft/raft_flow_control_test.go
@@ -24,7 +24,7 @@ import (
 // 1. msgApp can fill the sending window until full
 // 2. when the window is full, no more msgApp can be sent.
 func TestMsgAppFlowControlFull(t *testing.T) {
-	r := newTestRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage())
+	r := newTestRaft(1, []uint64{1, 2}, 5, 1, newMemoryStorage())
 	r.becomeCandidate()
 	r.becomeLeader()
 
@@ -60,7 +60,7 @@ func TestMsgAppFlowControlFull(t *testing.T) {
 // 1. valid msgAppResp.index moves the windows to pass all smaller or equal index.
 // 2. out-of-dated msgAppResp has no effect on the sliding window.
 func TestMsgAppFlowControlMoveForward(t *testing.T) {
-	r := newTestRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage())
+	r := newTestRaft(1, []uint64{1, 2}, 5, 1, newMemoryStorage())
 	r.becomeCandidate()
 	r.becomeLeader()
 
@@ -105,7 +105,7 @@ func TestMsgAppFlowControlMoveForward(t *testing.T) {
 // TestMsgAppFlowControlRecvHeartbeat ensures a heartbeat response
 // frees one slot if the window is full.
 func TestMsgAppFlowControlRecvHeartbeat(t *testing.T) {
-	r := newTestRaft(1, []uint64{1, 2}, 5, 1, NewMemoryStorage())
+	r := newTestRaft(1, []uint64{1, 2}, 5, 1, newMemoryStorage())
 	r.becomeCandidate()
 	r.becomeLeader()
 

--- a/raft/raft_snap_test.go
+++ b/raft/raft_snap_test.go
@@ -31,7 +31,7 @@ var (
 )
 
 func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	sm := newTestRaft(1, []uint64{1}, 10, 1, storage)
 	sm.restore(testingSnap)
 
@@ -49,7 +49,7 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 }
 
 func TestPendingSnapshotPauseReplication(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	sm := newTestRaft(1, []uint64{1, 2}, 10, 1, storage)
 	sm.restore(testingSnap)
 
@@ -66,7 +66,7 @@ func TestPendingSnapshotPauseReplication(t *testing.T) {
 }
 
 func TestSnapshotFailure(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	sm := newTestRaft(1, []uint64{1, 2}, 10, 1, storage)
 	sm.restore(testingSnap)
 
@@ -89,7 +89,7 @@ func TestSnapshotFailure(t *testing.T) {
 }
 
 func TestSnapshotSucceed(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	sm := newTestRaft(1, []uint64{1, 2}, 10, 1, storage)
 	sm.restore(testingSnap)
 
@@ -112,7 +112,7 @@ func TestSnapshotSucceed(t *testing.T) {
 }
 
 func TestSnapshotAbort(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	sm := newTestRaft(1, []uint64{1, 2}, 10, 1, storage)
 	sm.restore(testingSnap)
 

--- a/raft/rafttest/node.go
+++ b/raft/rafttest/node.go
@@ -32,14 +32,14 @@ type node struct {
 	pausec chan bool
 
 	// stable
-	storage *raft.MemoryStorage
+	storage raft.Storage
 
 	mu    sync.Mutex // guards state
 	state raftpb.HardState
 }
 
 func startNode(id uint64, peers []raft.Peer, iface iface) *node {
-	st := raft.NewMemoryStorage()
+	st := raft.NewStorage()
 	c := &raft.Config{
 		ID:              id,
 		ElectionTick:    10,

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -25,7 +25,7 @@ import (
 // TestRawNodeStep ensures that RawNode.Step ignore local message.
 func TestRawNodeStep(t *testing.T) {
 	for i, msgn := range raftpb.MessageType_name {
-		s := NewMemoryStorage()
+		s := newMemoryStorage()
 		rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, s), []Peer{{ID: 1}})
 		if err != nil {
 			t.Fatal(err)
@@ -47,7 +47,7 @@ func TestRawNodeStep(t *testing.T) {
 // TestRawNodeProposeAndConfChange ensures that RawNode.Propose and RawNode.ProposeConfChange
 // send the given proposal and ConfChange to the underlying raft.
 func TestRawNodeProposeAndConfChange(t *testing.T) {
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	var err error
 	rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, s), []Peer{{ID: 1}})
 	if err != nil {
@@ -113,7 +113,7 @@ func TestRawNodeProposeAndConfChange(t *testing.T) {
 // TestRawNodeProposeAddDuplicateNode ensures that two proposes to add the same node should
 // not affect the later propose to add new node.
 func TestRawNodeProposeAddDuplicateNode(t *testing.T) {
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, s), []Peer{{ID: 1}})
 	if err != nil {
 		t.Fatal(err)
@@ -196,7 +196,7 @@ func TestRawNodeReadIndex(t *testing.T) {
 	}
 	wrs := []ReadState{{Index: uint64(1), RequestCtx: []byte("somedata")}}
 
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	c := newTestConfig(1, nil, 10, 1, s)
 	rawNode, err := NewRawNode(c, []Peer{{ID: 1}})
 	if err != nil {
@@ -284,7 +284,7 @@ func TestRawNodeStart(t *testing.T) {
 		},
 	}
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, storage), []Peer{{ID: 1}})
 	if err != nil {
 		t.Fatal(err)
@@ -332,7 +332,7 @@ func TestRawNodeRestart(t *testing.T) {
 		MustSync:         true,
 	}
 
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	storage.SetHardState(st)
 	storage.Append(entries)
 	rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, storage), nil)
@@ -369,7 +369,7 @@ func TestRawNodeRestartFromSnapshot(t *testing.T) {
 		MustSync:         true,
 	}
 
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 	s.SetHardState(st)
 	s.ApplySnapshot(snap)
 	s.Append(entries)
@@ -391,7 +391,7 @@ func TestRawNodeRestartFromSnapshot(t *testing.T) {
 // no dependency check between Ready() and Advance()
 
 func TestRawNodeStatus(t *testing.T) {
-	storage := NewMemoryStorage()
+	storage := newMemoryStorage()
 	rawNode, err := NewRawNode(newTestConfig(1, nil, 10, 1, storage), []Peer{{ID: 1}})
 	if err != nil {
 		t.Fatal(err)

--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -39,7 +39,7 @@ func TestStorageTerm(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &MemoryStorage{ents: ents}
+		s := &memoryStorage{ents: ents}
 
 		func() {
 			defer func() {
@@ -86,7 +86,7 @@ func TestStorageEntries(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &MemoryStorage{ents: ents}
+		s := &memoryStorage{ents: ents}
 		entries, err := s.Entries(tt.lo, tt.hi, tt.maxsize)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
@@ -99,7 +99,7 @@ func TestStorageEntries(t *testing.T) {
 
 func TestStorageLastIndex(t *testing.T) {
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
-	s := &MemoryStorage{ents: ents}
+	s := &memoryStorage{ents: ents}
 
 	last, err := s.LastIndex()
 	if err != nil {
@@ -121,7 +121,7 @@ func TestStorageLastIndex(t *testing.T) {
 
 func TestStorageFirstIndex(t *testing.T) {
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
-	s := &MemoryStorage{ents: ents}
+	s := &memoryStorage{ents: ents}
 
 	first, err := s.FirstIndex()
 	if err != nil {
@@ -158,7 +158,7 @@ func TestStorageCompact(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &MemoryStorage{ents: ents}
+		s := &memoryStorage{ents: ents}
 		err := s.Compact(tt.i)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
@@ -191,7 +191,7 @@ func TestStorageCreateSnapshot(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &MemoryStorage{ents: ents}
+		s := &memoryStorage{ents: ents}
 		snap, err := s.CreateSnapshot(tt.i, cs, data)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
@@ -246,7 +246,7 @@ func TestStorageAppend(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &MemoryStorage{ents: ents}
+		s := &memoryStorage{ents: ents}
 		err := s.Append(tt.entries)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
@@ -265,7 +265,7 @@ func TestStorageApplySnapshot(t *testing.T) {
 		{Data: data, Metadata: pb.SnapshotMetadata{Index: 3, Term: 3, ConfState: *cs}},
 	}
 
-	s := NewMemoryStorage()
+	s := newMemoryStorage()
 
 	//Apply Snapshot successful
 	i := 0


### PR DESCRIPTION
…ge struct

This commit lets raft.MemoryStorage be private (the new name is simply
memoryStorage) for cleaner separation between packages. MemoryStorage
doesn't have global variable fields and external packages use it as an
object which implements raft.Storage in many cases. I think the struct
doesn't need to be a global thing.

I found the interface separation isn't clean enough during reworking https://github.com/coreos/etcd/pull/7782. To the best of my knowledge, making MemoryStorage private wouldn't be a problem.