### PR TITLE
WIP, DO NOT MERGE: *: make Range() fine grained

### DIFF
--- a/clientv3/op.go
+++ b/clientv3/op.go
@@ -48,7 +48,8 @@ type Op struct {
 	maxCreateRev int64
 
 	// for range, watch
-	rev int64
+	rev              int64
+	rangeMaxKeysOnce int64
 
 	// for watch, put, delete
 	prevKV bool
@@ -310,6 +311,10 @@ func WithLease(leaseID LeaseID) OpOption {
 // WithLimit limits the number of results to return from 'Get' request.
 // If WithLimit is given a 0 limit, it is treated as no limit.
 func WithLimit(n int64) OpOption { return func(op *Op) { op.limit = n } }
+
+// WithRangeMaxKeysOnce limits the number of read keys in a single read transaction
+// during Range() RPC. If WithRangeMaxKeysOnce is given a 0 limit, it is treated as no limit.
+func WithRangeMaxKeysOnce(n int64) OpOption { return func(op *Op) { op.rangeMaxKeysOnce = n } }
 
 // WithRev specifies the store revision for 'Get' request.
 // Or the start revision of 'Watch' request.

--- a/embed/config.go
+++ b/embed/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	SnapCount               uint64 `json:"snapshot-count"`
 	AutoCompactionRetention string `json:"auto-compaction-retention"`
 	AutoCompactionMode      string `json:"auto-compaction-mode"`
+	RangeMaxKeysOnce        uint64 `json:"range-max-keys-once"`
 
 	// TickMs is the number of milliseconds between heartbeat ticks.
 	// TODO: decouple tickMs and heartbeat tick (current heartbeat tick = 1).

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -181,6 +181,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		InitialCorruptCheck:     cfg.ExperimentalInitialCorruptCheck,
 		CorruptCheckTime:        cfg.ExperimentalCorruptCheckTime,
 		Debug:                   cfg.Debug,
+		RangeMaxKeysOnce:        cfg.RangeMaxKeysOnce,
 	}
 
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/etcdctl/ctlv3/command/get_command.go
+++ b/etcdctl/ctlv3/command/get_command.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	getConsistency string
-	getLimit       int64
-	getSortOrder   string
-	getSortTarget  string
-	getPrefix      bool
-	getFromKey     bool
-	getRev         int64
-	getKeysOnly    bool
-	printValueOnly bool
+	getConsistency      string
+	getLimit            int64
+	getSortOrder        string
+	getSortTarget       string
+	getPrefix           bool
+	getFromKey          bool
+	getRev              int64
+	getKeysOnly         bool
+	printValueOnly      bool
+	getRangeMaxKeysOnce int64
 )
 
 // NewGetCommand returns the cobra command for "get".
@@ -51,6 +52,8 @@ func NewGetCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&getRev, "rev", 0, "Specify the kv revision")
 	cmd.Flags().BoolVar(&getKeysOnly, "keys-only", false, "Get only the keys")
 	cmd.Flags().BoolVar(&printValueOnly, "print-value-only", false, `Only write values when using the "simple" output format`)
+	cmd.Flags().Int64Var(&getRangeMaxKeysOnce, "range-max-keys-once", 0, "Specify the maximum number of read keys in a single read transaction")
+
 	return cmd
 }
 
@@ -157,6 +160,10 @@ func getGetOp(cmd *cobra.Command, args []string) (string, []clientv3.OpOption) {
 
 	if getKeysOnly {
 		opts = append(opts, clientv3.WithKeysOnly())
+	}
+
+	if getRangeMaxKeysOnce != 0 {
+		opts = append(opts, clientv3.WithRangeMaxKeysOnce(getRangeMaxKeysOnce))
 	}
 
 	return key, opts

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -203,6 +203,7 @@ func newConfig() *config {
 
 	fs.StringVar(&cfg.ec.AutoCompactionRetention, "auto-compaction-retention", "0", "Auto compaction retention for mvcc key value store. 0 means disable auto compaction.")
 	fs.StringVar(&cfg.ec.AutoCompactionMode, "auto-compaction-mode", "periodic", "interpret 'auto-compaction-retention' one of: periodic|revision. 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. '5m'). 'revision' for revision number based retention.")
+	fs.Uint64Var(&cfg.ec.RangeMaxKeysOnce, "range-max-keys-once", 0, "A number of maximum keys which can be read in a single read transaction during range request. 0 means the maximum number is not limited.")
 
 	// pprof profiler via HTTP
 	fs.BoolVar(&cfg.ec.EnablePprof, "enable-pprof", false, "Enable runtime profiling data via HTTP server. Address is at client URL + \"/debug/pprof/\"")

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -72,6 +72,8 @@ type ServerConfig struct {
 	CorruptCheckTime    time.Duration
 
 	Debug bool
+
+	RangeMaxKeysOnce uint64
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case

--- a/pkg/keyutil/keyutil.go
+++ b/pkg/keyutil/keyutil.go
@@ -1,0 +1,40 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keyutil exports utility functions related to etcd3's key name.
+
+package keyutil
+
+// NextKey returns a name of next key of the given key. The key and the next key don't have any keys between them.
+func NextKey(key []byte) []byte {
+	for i := len(key) - 1; 0 <= i; i-- {
+		if key[i] < 0xff {
+			key[i]++
+			return key[:i+1]
+		}
+	}
+
+	return []byte{0}
+}
+
+// MkGteRange determines if the range end is a >= range. This works around grpc
+// sending empty byte strings as nil; >= is encoded in the range end as '\0'.
+// If it is a GTE range, then []byte{} is returned to indicate the empty byte
+// string (vs nil being no byte string).
+func MkGteRange(rangeEnd []byte) []byte {
+	if len(rangeEnd) == 1 && rangeEnd[0] == 0 {
+		return []byte{}
+	}
+	return rangeEnd
+}


### PR DESCRIPTION
Current Range() tries to read entire requested range of keys in a
single read transaction. It can introduce long waiting of writer
transactions which can be observed as high latency spikes. For solving
this problem, this commit lets serializable Range() split its read
transaction in a fine grained manner. In the interval of the read
transactions, concurrent write RPCs (e.g. Put(), DeleteRange()) can
have a chance of starting their transactions. Serializable read only
Txn() is also turned into the smaller transactions.

This commit also adds a new option `--range-max-keys-once` to
etcd. With the option, users can specify the maximum number of keys
read in a single transaction during Range().