### PR TITLE
contrib/raftexample: restore kvstore after replaying has done rather …

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -345,7 +345,7 @@ func (rc *raftNode) publishSnapshot(snapshotToSave raftpb.Snapshot) {
 var snapshotCatchUpEntriesN uint64 = 10000
 
 func (rc *raftNode) maybeTriggerSnapshot() {
-	if rc.appliedIndex-rc.snapshotIndex <= rc.snapCount {
+	if rc.appliedIndex-rc.snapshotIndex < rc.snapCount {
 		return
 	}
 


### PR DESCRIPTION
…than overwite it

1. after replayWAL when restart node in raftexample, we may resubmit those entries whose
   index are larger than the last snapshot Index, then we will continuously receive those
   entries from Ready() until we receive the entry with index == lastIndex, we may put a
   nil to commitC which indicate replaying has done, and then, in readCommits(), kvstore
   may be overwited using the last snapshot info in recoverFromSnapshot(), so those entries
   with index larger than the last snapshot Index are discard due to this operation.

2. in the previous version, readCommit will never return unlesss encounter an ErrNoSnapshot,
   so, if snapshot has happened before restart node, this node will never start http server.

3. in maybeTriggerSnapshot(), the first judgement shoule use "<" rather than "<=".

# Contributing guidelines

Please read our [contribution workflow][contributing] before submitting a pull request.

[contributing]: https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow
