### PR TITLE
embed, pkg/types: allow metrics listener to bind to unix socket

### DIFF
--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -29,7 +29,6 @@ func TestValidateURLsValueBad(t *testing.T) {
 		"127.0.0.1:",
 		// unix sockets not supported
 		"unix://",
-		"unix://tmp/etcd.sock",
 		// bad strings
 		"somewhere",
 		"234#$",
@@ -51,6 +50,7 @@ func TestValidateURLsValueGood(t *testing.T) {
 		"http://10.1.1.1:80",
 		"http://localhost:80",
 		"http://:80",
+		"unix://tmp/etcd.sock",
 	}
 	for i, in := range tests {
 		u := URLsValue{}

--- a/pkg/types/urls.go
+++ b/pkg/types/urls.go
@@ -40,7 +40,9 @@ func NewURLs(strs []string) (URLs, error) {
 			return nil, fmt.Errorf("URL scheme must be http, https, unix, or unixs: %s", in)
 		}
 		if u.Scheme == "unix" || u.Scheme == "unixs" {
-			return nil, fmt.Errorf("Unix scheme must have a proper path set in the form unix://path/to/socket: %s", in)
+			if u.Path == "" {
+				return nil, fmt.Errorf("Unix scheme must have a proper path set in the form unix://path/to/socket: %s", in)
+			}
 		}
 		if u.Scheme != "unix" && u.Scheme != "unixs" {
 			if _, _, err := net.SplitHostPort(u.Host); err != nil {

--- a/pkg/types/urls.go
+++ b/pkg/types/urls.go
@@ -39,11 +39,13 @@ func NewURLs(strs []string) (URLs, error) {
 		if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "unix" && u.Scheme != "unixs" {
 			return nil, fmt.Errorf("URL scheme must be http, https, unix, or unixs: %s", in)
 		}
-		if _, _, err := net.SplitHostPort(u.Host); err != nil {
-			return nil, fmt.Errorf(`URL address does not have the form "host:port": %s`, in)
-		}
-		if u.Path != "" {
-			return nil, fmt.Errorf("URL must not contain a path: %s", in)
+		if u.Scheme != "unix" && u.Scheme != "unixs" {
+			if _, _, err := net.SplitHostPort(u.Host); err != nil {
+				return nil, fmt.Errorf(`URL address does not have the form "host:port": %s`, in)
+			}
+			if u.Path != "" {
+				return nil, fmt.Errorf("URL must not contain a path: %s", in)
+			}
 		}
 		all[i] = *u
 	}

--- a/pkg/types/urls.go
+++ b/pkg/types/urls.go
@@ -39,6 +39,9 @@ func NewURLs(strs []string) (URLs, error) {
 		if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "unix" && u.Scheme != "unixs" {
 			return nil, fmt.Errorf("URL scheme must be http, https, unix, or unixs: %s", in)
 		}
+		if u.Scheme == "unix" || u.Scheme == "unixs" {
+			return nil, fmt.Errorf("Unix scheme must have a proper path set in the form unix://path/to/socket: %s", in)
+		}
 		if u.Scheme != "unix" && u.Scheme != "unixs" {
 			if _, _, err := net.SplitHostPort(u.Host); err != nil {
 				return nil, fmt.Errorf(`URL address does not have the form "host:port": %s`, in)

--- a/pkg/types/urls_test.go
+++ b/pkg/types/urls_test.go
@@ -125,6 +125,10 @@ func TestURLsStringSlice(t *testing.T) {
 			[]string{"http://127.0.0.1:2379"},
 		},
 		{
+			testutil.MustNewURLs(t, []string{"unix://var/run/socket"}),
+			[]string{"unix://var/run/socket"},
+		},
+		{
 			testutil.MustNewURLs(t, []string{
 				"http://127.0.0.1:2379",
 				"http://127.0.0.2:2379",
@@ -159,6 +163,8 @@ func TestNewURLsFail(t *testing.T) {
 		{"http://127.0.0.1"},
 		// contain a path
 		{"http://127.0.0.1:2379/path"},
+		// contain a path
+		{"unix://"},
 	}
 	for i, tt := range tests {
 		_, err := NewURLs(tt)


### PR DESCRIPTION
Details:
* pkg/types/url: fixed valdiation in pkg/types to properly validate unix socket urls
* embed: properly create the unix socket listener for metrics sockets