### PR TITLE
*: allow fully concurrent large read

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -86,8 +86,6 @@ type Authenticator interface {
 }
 
 func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
-	defer warnOfExpensiveReadOnlyRangeRequest(s.getLogger(), time.Now(), r)
-
 	if !r.Serializable {
 		err := s.linearizableReadNotify(ctx)
 		if err != nil {

--- a/mvcc/backend/concurrent_read_tx.go
+++ b/mvcc/backend/concurrent_read_tx.go
@@ -1,0 +1,38 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	bolt "github.com/coreos/bbolt"
+)
+
+type concurrentReadTx struct {
+	tx *bolt.Tx
+}
+
+func (rt *concurrentReadTx) Lock()   {}
+func (rt *concurrentReadTx) Unlock() { rt.tx.Rollback() }
+
+func (rt *concurrentReadTx) UnsafeRange(bucketName, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
+	bucket := rt.tx.Bucket(bucketName)
+	if bucket == nil {
+		plog.Fatalf("bucket %s does not exist", bucketName)
+	}
+	return unsafeRange(bucket.Cursor(), key, endKey, limit)
+}
+
+func (rt *concurrentReadTx) UnsafeForEach(bucketName []byte, visitor func(k, v []byte) error) error {
+	return unsafeForEach(rt.tx, bucketName, visitor)
+}

--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -91,10 +91,11 @@ func (ti *treeIndex) keyIndex(keyi *keyIndex) *keyIndex {
 func (ti *treeIndex) visit(key, end []byte, f func(ki *keyIndex)) {
 	keyi, endi := &keyIndex{key: key}, &keyIndex{key: end}
 
-	ti.RLock()
-	defer ti.RUnlock()
+	ti.Lock()
+	clone := ti.tree.Clone()
+	ti.Unlock()
 
-	ti.tree.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
+	clone.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
 		if len(endi.key) > 0 && !item.Less(endi) {
 			return false
 		}

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -640,7 +640,7 @@ func TestTxnBlockBackendForceCommit(t *testing.T) {
 	s := NewStore(zap.NewExample(), b, &lease.FakeLessor{}, nil)
 	defer os.Remove(tmpPath)
 
-	txn := s.Read()
+	txn := s.Write()
 
 	done := make(chan struct{})
 	go func() {
@@ -742,6 +742,7 @@ type fakeBackend struct {
 
 func (b *fakeBackend) BatchTx() backend.BatchTx                                    { return b.tx }
 func (b *fakeBackend) ReadTx() backend.ReadTx                                      { return b.tx }
+func (b *fakeBackend) ConcurrentReadTx() backend.ReadTx                            { return b.tx }
 func (b *fakeBackend) Hash(ignores map[backend.IgnoreKey]struct{}) (uint32, error) { return 0, nil }
 func (b *fakeBackend) Size() int64                                                 { return 0 }
 func (b *fakeBackend) SizeInUse() int64                                            { return 0 }


### PR DESCRIPTION
This PR fully solve the large read blocking issue.

Previously, a large read can block put for seconds. With this patch, there is no blocking at all.

/cc @heyitsanthony 
