### PR TITLE
e2e: improve Watch coverage

### DIFF
--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -36,13 +36,18 @@ func TestCtlV3AuthMemberAdd(t *testing.T)           { testCtl(t, authTestMemberA
 func TestCtlV3AuthMemberRemove(t *testing.T) {
 	testCtl(t, authTestMemberRemove, withQuorum(), withNoStrictReconfig())
 }
-func TestCtlV3AuthMemberUpdate(t *testing.T)     { testCtl(t, authTestMemberUpdate) }
-func TestCtlV3AuthCertCN(t *testing.T)           { testCtl(t, authTestCertCN, withCfg(configClientTLSCertAuth)) }
-func TestCtlV3AuthRevokeWithDelete(t *testing.T) { testCtl(t, authTestRevokeWithDelete) }
-func TestCtlV3AuthInvalidMgmt(t *testing.T)      { testCtl(t, authTestInvalidMgmt) }
-func TestCtlV3AuthFromKeyPerm(t *testing.T)      { testCtl(t, authTestFromKeyPerm) }
-func TestCtlV3AuthAndWatch(t *testing.T)         { testCtl(t, authTestWatch) }
-func TestCtlV3AuthAndWatchJWT(t *testing.T)      { testCtl(t, authTestWatch, withCfg(configJWT)) }
+func TestCtlV3AuthMemberUpdate(t *testing.T)      { testCtl(t, authTestMemberUpdate) }
+func TestCtlV3AuthCertCN(t *testing.T)            { testCtl(t, authTestCertCN, withCfg(configClientTLSCertAuth)) }
+func TestCtlV3AuthRevokeWithDelete(t *testing.T)  { testCtl(t, authTestRevokeWithDelete) }
+func TestCtlV3AuthInvalidMgmt(t *testing.T)       { testCtl(t, authTestInvalidMgmt) }
+func TestCtlV3AuthFromKeyPerm(t *testing.T)       { testCtl(t, authTestFromKeyPerm) }
+func TestCtlV3AuthAndWatch(t *testing.T)          { testCtl(t, authTestWatch) }
+func TestCtlV3AuthAndWatchClientTLS(t *testing.T) { testCtl(t, authTestWatch, withCfg(configClientTLS)) }
+func TestCtlV3AuthAndWatchPeerTLS(t *testing.T)   { testCtl(t, authTestWatch, withCfg(configPeerTLS)) }
+func TestCtlV3AuthAndWatchClientAutoTLS(t *testing.T) {
+	testCtl(t, authTestWatch, withCfg(configAutoTLS))
+}
+func TestCtlV3AuthAndWatchInteractive(t *testing.T) { testCtl(t, authTestWatch, withInteractive()) }
 
 func TestCtlV3AuthLeaseTestKeepAlive(t *testing.T)         { testCtl(t, authLeaseTestKeepAlive) }
 func TestCtlV3AuthLeaseTestTimeToLiveExpired(t *testing.T) { testCtl(t, authLeaseTestTimeToLiveExpired) }

--- a/tests/e2e/ctl_v3_watch_no_cov_test.go
+++ b/tests/e2e/ctl_v3_watch_no_cov_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 )
 
-func TestCtlV3Watch(t *testing.T)          { testCtl(t, watchTest) }
-func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(configNoTLS)) }
-func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(configClientTLS)) }
-func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(configPeerTLS)) }
-func TestCtlV3WatchTimeout(t *testing.T)   { testCtl(t, watchTest, withDialTimeout(0)) }
+func TestCtlV3Watch(t *testing.T)              { testCtl(t, watchTest) }
+func TestCtlV3WatchNoTLS(t *testing.T)         { testCtl(t, watchTest, withCfg(configNoTLS)) }
+func TestCtlV3WatchClientTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(configClientTLS)) }
+func TestCtlV3WatchPeerTLS(t *testing.T)       { testCtl(t, watchTest, withCfg(configPeerTLS)) }
+func TestCtlV3WatchClientAutoTLS(t *testing.T) { testCtl(t, watchTest, withCfg(configAutoTLS)) }
+func TestCtlV3WatchTimeout(t *testing.T)       { testCtl(t, watchTest, withDialTimeout(-1)) }
 
 func TestCtlV3WatchInteractive(t *testing.T) {
 	testCtl(t, watchTest, withInteractive())
@@ -38,6 +39,12 @@ func TestCtlV3WatchInteractiveClientTLS(t *testing.T) {
 }
 func TestCtlV3WatchInteractivePeerTLS(t *testing.T) {
 	testCtl(t, watchTest, withInteractive(), withCfg(configPeerTLS))
+}
+func TestCtlV3WatchInteractiveClientAutoTLS(t *testing.T) {
+	testCtl(t, watchTest, withInteractive(), withCfg(configAutoTLS))
+}
+func TestCtlV3WatchInteractiveTimeout(t *testing.T) {
+	testCtl(t, watchTest, withInteractive(), withDialTimeout(0), withCfg(configAutoTLS))
 }
 
 func watchTest(cx ctlCtx) {


### PR DESCRIPTION
Incremental test coverage improvement for Watch.

Initial testing seems to fail during TestCtlV3AuthAndWatchInteractive.

ref: https://github.com/coreos/etcd/issues/9149