### PR TITLE
mvcc: Clone for batch index compaction and shorten lock

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -34,6 +34,7 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.3.0...v3.4.0) and [
   - e.g. a node is removed from cluster, or [`raftpb.MsgProp` arrives at current leader while there is an ongoing leadership transfer](https://github.com/coreos/etcd/issues/8975).
 - Add [`snapshot`](https://github.com/coreos/etcd/pull/9118) package for easier snapshot workflow (see [`godoc.org/github.com/etcd/snapshot`](https://godoc.org/github.com/coreos/etcd/snapshot) for more).
 - Improve [functional tester](https://github.com/coreos/etcd/tree/master/functional) coverage: [proxy layer to run network fault tests in CI](https://github.com/coreos/etcd/pull/9081), [TLS is enabled both for server and client](https://github.com/coreos/etcd/pull/9534), [liveness mode](https://github.com/coreos/etcd/issues/9230), [shuffle test sequence](https://github.com/coreos/etcd/issues/9381), [membership reconfiguration failure cases](https://github.com/coreos/etcd/pull/9564), [disastrous quorum loss and snapshot recover from a seed member](https://github.com/coreos/etcd/pull/9565), [embedded etcd](https://github.com/coreos/etcd/pull/9572).
+- Improve [index compaction blocking](https://github.com/coreos/etcd/pull/9511) by using a copy on write clone to avoid holding the lock for the traversal of the entire index.
 
 ### Breaking Changes
 

--- a/mvcc/index_bench_test.go
+++ b/mvcc/index_bench_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvcc
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func BenchmarkIndexCompact1(b *testing.B)       { benchmarkIndexCompact(b, 1) }
+func BenchmarkIndexCompact100(b *testing.B)     { benchmarkIndexCompact(b, 100) }
+func BenchmarkIndexCompact10000(b *testing.B)   { benchmarkIndexCompact(b, 10000) }
+func BenchmarkIndexCompact100000(b *testing.B)  { benchmarkIndexCompact(b, 100000) }
+func BenchmarkIndexCompact1000000(b *testing.B) { benchmarkIndexCompact(b, 1000000) }
+
+func benchmarkIndexCompact(b *testing.B, size int) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	bytesN := 64
+	keys := createBytesSlice(bytesN, size)
+	for i := 1; i < size; i++ {
+		kvindex.Put(keys[i], revision{main: int64(i), sub: int64(i)})
+	}
+	b.ResetTimer()
+	for i := 1; i < b.N; i++ {
+		kvindex.Compact(int64(i))
+	}
+}


### PR DESCRIPTION
This is to address #9506 - When the BTree index grows to millions of entries, index compaction must iterate over all of them and this can take a substantial amount of time while continuing to hold the lock. This lock means that any concurrent read/writes will wait until compaction completes. By breaking compaction into batches of 10000, similar to the backend compaction, this allows relief for contention of the index lock. 

We came up with the following test as a way of validating that there is contention that blocks puts to the index while compaction is ongoing. On the `master` branch this test will fail, but it passes with our provided changes. We felt this test was useful for us in proving the issue but does not fit well into the existing test suite for etcd as far as we can tell. 

Coauthored with @cosgroveb

```go
func TestIndexCompactAndRuntime(t *testing.T) {                           
  ti := newTreeIndex()                                                    
  size := 1000000                                                         
  bytesN := 64                                                            
  keys := createBytesSlice(bytesN, size)                                  
  for i := 1; i < size-1; i++ {                                           
    ti.Put(keys[i], revision {main: int64(i), sub: int64(i)})             
  }                                                                       
  go ti.Compact(int64(500000))                                            
  time.Sleep(200000 * time.Nanosecond)                                  
  t1 := time.Now().UnixNano()                                             
  ti.Put(keys[size-1], revision {main: int64(size-1), sub: int64(size-1)})
  t2 := time.Now().UnixNano() - t1                                        
  if t2 > 150000000 {                                                     
    t.Errorf("Run time took too long! %v", t2)                            
  }                                                                       
}                                                                         
```
