### PR TITLE
WIP: integration: add v2v3 emulation

### DIFF
--- a/etcdserver/api/v2v3/cluster.go
+++ b/etcdserver/api/v2v3/cluster.go
@@ -15,6 +15,9 @@
 package v2v3
 
 import (
+	"context"
+	"time"
+
 	"github.com/coreos/etcd/etcdserver/membership"
 	"github.com/coreos/etcd/pkg/types"
 
@@ -25,7 +28,18 @@ func (s *v2v3Server) ID() types.ID {
 	// TODO: use an actual member ID
 	return types.ID(0xe7cd2f00d)
 }
-func (s *v2v3Server) ClientURLs() []string                  { panic("STUB") }
-func (s *v2v3Server) Members() []*membership.Member         { panic("STUB") }
+func (s *v2v3Server) ClientURLs() []string { panic("STUB") }
+
+func (s *v2v3Server) Members() []*membership.Member {
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+	resp, err := s.c.MemberList(ctx)
+	if err != nil {
+		// TODO: how can we upport errors here?
+		panic("STUB")
+	}
+	return v3MembersToMembership(resp.Members)
+}
+
 func (s *v2v3Server) Member(id types.ID) *membership.Member { panic("STUB") }
 func (s *v2v3Server) Version() *semver.Version              { panic("STUB") }

--- a/integration/v2_api_test.go
+++ b/integration/v2_api_test.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !v2v3
+
+package integration
+
+import "github.com/coreos/etcd/etcdserver"
+
+const v2IndexOffset = 3
+
+func (m *member) v2API() etcdserver.ServerPeer {
+	return m.s
+}

--- a/integration/v2_http_kv_test.go
+++ b/integration/v2_http_kv_test.go
@@ -54,19 +54,19 @@ func TestV2Set(t *testing.T) {
 			"/v2/keys/foo/bar",
 			v,
 			http.StatusCreated,
-			`{"action":"set","node":{"key":"/foo/bar","value":"bar","modifiedIndex":4,"createdIndex":4}}`,
+			fmt.Sprintf(`{"action":"set","node":{"key":"/foo/bar","value":"bar","modifiedIndex":%d,"createdIndex":%d}}`, v2IndexOffset+1, v2IndexOffset+1),
 		},
 		{
 			"/v2/keys/foodir?dir=true",
 			url.Values{},
 			http.StatusCreated,
-			`{"action":"set","node":{"key":"/foodir","dir":true,"modifiedIndex":5,"createdIndex":5}}`,
+			fmt.Sprintf(`{"action":"set","node":{"key":"/foodir","dir":true,"modifiedIndex":%d,"createdIndex":%d}}`, v2IndexOffset+2, v2IndexOffset+2),
 		},
 		{
 			"/v2/keys/fooempty",
 			url.Values(map[string][]string{"value": {""}}),
 			http.StatusCreated,
-			`{"action":"set","node":{"key":"/fooempty","value":"","modifiedIndex":6,"createdIndex":6}}`,
+			fmt.Sprintf(`{"action":"set","node":{"key":"/fooempty","value":"","modifiedIndex":%d,"createdIndex":%d}}`, v2IndexOffset+3, v2IndexOffset+3),
 		},
 		{
 			"/v2/keys/foo/novalue",

--- a/integration/v2v3_api_test.go
+++ b/integration/v2v3_api_test.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build v2v3
+
+package integration
+
+import "github.com/coreos/etcd/etcdserver"
+
+const v2IndexOffset = 0
+
+func (m *member) v2API() etcdserver.ServerPeer {
+	return m.v2v3Server
+}


### PR DESCRIPTION
from #9626.

Run existing integration tests for v2 api (`TestV2`) on v2v3 emulation to improve the compatibility between them.