### PR TITLE
contrib/raftexample: correct the wrong handling of snapCount

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -348,7 +348,7 @@ func (rc *raftNode) publishSnapshot(snapshotToSave raftpb.Snapshot) {
 var snapshotCatchUpEntriesN uint64 = 10000
 
 func (rc *raftNode) maybeTriggerSnapshot() {
-	if rc.appliedIndex-rc.snapshotIndex <= rc.snapCount {
+	if rc.appliedIndex-rc.snapshotIndex < rc.snapCount {
 		return
 	}
 


### PR DESCRIPTION
If `snapCount` means the count of new entries which will be put into the new snapshot since the last snapshot, `<=` should be `<` in the following code from `maybeTriggerSnapshot` method.

```
	if rc.appliedIndex-rc.snapshotIndex <= rc.snapCount {
		return
	}
```
