### PR TITLE
New created peers should accept any snapshots.

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1270,7 +1270,10 @@ func (r *raft) restore(s pb.Snapshot) bool {
 	}
 
 	// The normal peer can't become learner.
-	if !r.isLearner {
+	//
+	// Both of `prs` and `learnerPrs` are empty means the peer is new created by
+	// conf change, in which case we should accept snapshots make it as learner.
+	if (r.prs.len() > 0 || r.learnerPrs.len() > 0) && !r.isLearner {
 		for _, id := range s.Metadata.ConfState.Learners {
 			if id == r.id {
 				r.logger.Errorf("%x can't become learner when restores snapshot [index: %d, term: %d]", r.id, s.Metadata.Index, s.Metadata.Term)

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1273,7 +1273,7 @@ func (r *raft) restore(s pb.Snapshot) bool {
 	//
 	// Both of `prs` and `learnerPrs` are empty means the peer is new created by
 	// conf change, in which case we should accept snapshots make it as learner.
-	if (r.prs.len() > 0 || r.learnerPrs.len() > 0) && !r.isLearner {
+	if r.initialized() && r.isLearner {
 		for _, id := range s.Metadata.ConfState.Learners {
 			if id == r.id {
 				r.logger.Errorf("%x can't become learner when restores snapshot [index: %d, term: %d]", r.id, s.Metadata.Index, s.Metadata.Term)


### PR DESCRIPTION
The PR trys to fix https://github.com/coreos/etcd/issues/9498 with same solution in [TiKV](https://github.com/pingcap/raft-rs/blob/master/src/raft.rs#L1776).

Please take a quickly look at it. If the design is agreed, I will add more test cases for this.

task list:
- [x] Fix the issue.
- [ ] More test cases.