### PR TITLE
raft: fixed messages lost

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -382,8 +382,8 @@ func (n *node) run(r *raft) {
 				prevSnapi = rd.Snapshot.Metadata.Index
 			}
 
-			r.msgs = nil
-			r.readStates = nil
+			r.msgs = r.msgs[len(rd.Messages):]
+			r.readStates = r.readStates[len(rd.ReadStates):]
 			advancec = n.advancec
 		case <-advancec:
 			if prevHardSt.Commit != 0 {


### PR DESCRIPTION
After newReady() is called, if other cases are ready to proceed, for example propc, all new appended msg in r.msg and r.readStates will be lost in the next sending when readyc case is processed and both r.msgs and r.readStates are assigned to nil.


Please read https://github.com/coreos/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
