### PR TITLE
Remove id from dashboard mixin

### DIFF
--- a/Documentation/etcd-mixin/mixin.libsonnet
+++ b/Documentation/etcd-mixin/mixin.libsonnet
@@ -231,7 +231,7 @@
 
   grafanaDashboards+:: {
     'etcd.json': {
-      id: 6,
+      uid: std.md5('etcd.json'),
       title: 'etcd',
       description: 'etcd sample Grafana dashboard with Prometheus',
       tags: [],

--- a/Documentation/op-guide/grafana.json
+++ b/Documentation/op-guide/grafana.json
@@ -9,7 +9,6 @@
         "editable": true,
         "gnetId": null,
         "hideControls": false,
-        "id": 6,
         "links": [
 
         ],
@@ -341,7 +340,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "etcd_mvcc_db_total_size_in_bytes{job=\"$cluster\"}",
+                                "expr": "etcd_debugging_mvcc_db_total_size_in_bytes{job=\"$cluster\"}",
                                 "hide": false,
                                 "interval": "",
                                 "intervalFactor": 2,
@@ -1220,6 +1219,7 @@
         },
         "timezone": "browser",
         "title": "etcd",
+        "uid": "c2f4e12cdf69feb95caa41a5a1b423d9",
         "version": 215
     }
 }


### PR DESCRIPTION
Grafana provisioned dashboards cannot contain id.
It causes dashboard to be skipped and error in logs
```
lvl=eror msg="provisioned dashboard json files cannot contain id" logger=provisioning.dashboard type=file name=default
```
cc @tomwilkie @brancz
