### PR TITLE
contrib/raftexample: fix backend storage loading from a snapshot

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -39,8 +39,6 @@ type kv struct {
 
 func newKVStore(snapshotter *snap.Snapshotter, proposeC chan<- string, commitC <-chan *string, errorC <-chan error) *kvstore {
 	s := &kvstore{proposeC: proposeC, kvStore: make(map[string]string), snapshotter: snapshotter}
-	// replay log into key-value map
-	s.readCommits(commitC, errorC)
 	// read commits from raft into kvStore map until error
 	go s.readCommits(commitC, errorC)
 	return s
@@ -68,7 +66,7 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 			// OR signaled to load snapshot
 			snapshot, err := s.snapshotter.Load()
 			if err == snap.ErrNoSnapshot {
-				return
+				continue
 			}
 			if err != nil {
 				log.Panic(err)


### PR DESCRIPTION
Current code has a bug with the backend storage populating from a snapshot.

**Reproduce**: 

1. Start cluster:

```goreman start```

2. Set more than 10000 entries:

```
for i in $(seq 1 10010);  do echo $i;  curl -L http://127.0.0.1:12380/key$i -XPUT -d values$i; done
``` 

3. Try to restart cluster. Cluster doesn't open listen port, and override entries from MemStorage with snapshot load func.

**What were done**
-  fix load snapshot logic for backend; 
-  decreased the number of snapshot entries to make it more likely to find any other snapshot related bugs; 
-  delete lastIndex because we don't need it anymore with new logic.
