### PR TITLE
Improve watch error reporting when using grpc proxy

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -16,6 +16,7 @@ package clientv3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -333,7 +334,7 @@ func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) Watch
 	case <-wr.ctx.Done():
 	case <-donec:
 		if wgs.closeErr != nil {
-			closeCh <- WatchResponse{closeErr: wgs.closeErr}
+			closeCh <- WatchResponse{Canceled: true, closeErr: wgs.closeErr}
 			break
 		}
 		// retry; may have dropped stream from no ctxs
@@ -348,7 +349,7 @@ func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) Watch
 		case <-ctx.Done():
 		case <-donec:
 			if wgs.closeErr != nil {
-				closeCh <- WatchResponse{closeErr: wgs.closeErr}
+				closeCh <- WatchResponse{Canceled: true, closeErr: wgs.closeErr}
 				break
 			}
 			// retry; may have dropped stream from no ctxs
@@ -432,6 +433,7 @@ func (w *watcher) closeStream(wgs *watchGrpcStream) {
 func (w *watchGrpcStream) addSubstream(resp *pb.WatchResponse, ws *watcherStream) {
 	// check watch ID for backward compatibility (<= v3.3)
 	if resp.WatchId == -1 || (resp.Canceled && resp.CancelReason != "") {
+		w.closeErr = v3rpc.Error(errors.New(resp.CancelReason))
 		// failed; no channel
 		close(ws.recvc)
 		return
@@ -457,7 +459,7 @@ func (w *watchGrpcStream) closeSubstream(ws *watcherStream) {
 	}
 	// close subscriber's channel
 	if closeErr := w.closeErr; closeErr != nil && ws.initReq.ctx.Err() == nil {
-		go w.sendCloseSubstream(ws, &WatchResponse{closeErr: w.closeErr})
+		go w.sendCloseSubstream(ws, &WatchResponse{Canceled: true, closeErr: w.closeErr})
 	} else if ws.outc != nil {
 		close(ws.outc)
 	}

--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -229,11 +229,14 @@ func (wps *watchProxyStream) recvLoop() error {
 		case *pb.WatchRequest_CreateRequest:
 			cr := uv.CreateRequest
 
-			if err = wps.checkPermissionForWatch(cr.Key, cr.RangeEnd); err != nil && err == rpctypes.ErrPermissionDenied {
-				// Return WatchResponse which is caused by permission checking if and only if
-				// the error is permission denied. For other errors (e.g. timeout or connection closed),
-				// the permission checking mechanism should do nothing for preserving error code.
-				wps.watchCh <- &pb.WatchResponse{Header: &pb.ResponseHeader{}, WatchId: -1, Created: true, Canceled: true}
+			if err := wps.checkPermissionForWatch(cr.Key, cr.RangeEnd); err != nil {
+				wps.watchCh <- &pb.WatchResponse{
+					Header:       &pb.ResponseHeader{},
+					WatchId:      -1,
+					Created:      true,
+					Canceled:     true,
+					CancelReason: err.Error(),
+				}
 				continue
 			}
 


### PR DESCRIPTION
## Rational
V3 watches currently block indefinitely on error when using the grpc proxy.

This PR Fixes #10008

## Reproduce
1. Start etcd cluster
2. Add a role and enable auth
3. Start a grpc proxy to the etcd cluster
4. Run `etcdctl watch foo --endpoint=<grpc-endpoint>`
The watch will hang indefinitely with no errors returned. The error, in this case, is `user name is empty`

## Changes
* ***Return reason to client when server cancels watch***
    This change allows Watch users to retrieve the cancel reason when a
    watch is canceled by the server. Additionally WatchResponses with
    closeErr set now have Canceled set true which is in line with the
    documentation for the Canceled field.

* ***return errors to client during watch create***    
    Now returns errors from checkPermissionForWatch() via the CancelReason
    field. This allows clients to understand why the watch was canceled.
    Additionally, this change protects a watch from starting and that
    otherwise might hang indefinitely.

## Resolution
After applying the changes
```
$ etcdctl watch foo --endpoint=<grpc-endpoint>
watch was canceled (etcdserver: user name is empty)
Error: watch is canceled by the server
```