### PR TITLE
raft: fix link typo

### DIFF
--- a/raft/doc.go
+++ b/raft/doc.go
@@ -23,7 +23,7 @@ For more details on Raft, see "In Search of an Understandable Consensus Algorith
 
 A simple example application, _raftexample_, is also available to help illustrate
 how to use this package in practice:
-https://go.etcd.io/etcd/tree/master/contrib/raftexample
+https://github.com/etcd-io/etcd/tree/master/contrib/raftexample
 
 Usage
 


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/10071.
