### PR TITLE
bugfix:dead lock on store.mu when store.Compact in tore.Restore happens

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -302,7 +302,6 @@ func (s *store) Commit() {
 
 func (s *store) Restore(b backend.Backend) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	close(s.stopc)
 	s.fifoSched.Stop()
@@ -314,11 +313,12 @@ func (s *store) Restore(b backend.Backend) error {
 	s.compactMainRev = -1
 	s.fifoSched = schedule.NewFIFOScheduler()
 	s.stopc = make(chan struct{})
-
+	s.mu.Unlock()
 	return s.restore()
 }
 
 func (s *store) restore() error {
+	s.mu.Lock()
 	b := s.b
 	reportDbTotalSizeInBytesMu.Lock()
 	reportDbTotalSizeInBytes = func() float64 { return float64(b.Size()) }
@@ -413,7 +413,7 @@ func (s *store) restore() error {
 	}
 
 	tx.Unlock()
-
+	s.mu.Unlock()
 	if scheduledCompact != 0 {
 		s.Compact(scheduledCompact)
 


### PR DESCRIPTION
scripts: bugfix, dead lock on store.mu when store.Compact in tore.Restore happens

when store.Restore call store.restore call restore.Compact, store.mu will be locked.