### PR TITLE
Documentation: DEPRECATE --logger flag.

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -313,6 +313,9 @@ The security flags help to [build a secure etcd cluster][security].
 ## Logging flags
 
 ### --logger
+
+**DEPRECATED**
+
 + Specify 'zap' for structured logging or 'capnslog'.
 + default: capnslog
 + env variable: ETCD_LOGGER


### PR DESCRIPTION
Logger flag available from 3.4 has been deprecated since structured logging is now the only option for logging as of v3.5.0.

[See CHANGELOG-3.5.md](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.5.md#etcd-server)
