### PR TITLE
Documentation: Annotate --logger flag

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -313,6 +313,9 @@ The security flags help to [build a secure etcd cluster][security].
 ## Logging flags
 
 ### --logger
+
+**Available from v3.4**
+
 + Specify 'zap' for structured logging or 'capnslog'.
 + default: capnslog
 + env variable: ETCD_LOGGER


### PR DESCRIPTION
This commit annotates the `--logger` flag to let users know that it is not available in versions 3.3.x or later.
