### PR TITLE
bugfix: use Rlock instead of Lock in raftexample.

### DIFF
--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -95,8 +95,8 @@ func (s *kvstore) readCommits(commitC <-chan *string, errorC <-chan error) {
 }
 
 func (s *kvstore) getSnapshot() ([]byte, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return json.Marshal(s.kvStore)
 }
 


### PR DESCRIPTION
contrib/raftexample: use Rlock instead of Lock in getSnapshot function.

https://github.com/etcd-io/etcd/blob/ab544f2dde1eab69cc555a609dc259291e532544/contrib/raftexample/kvstore.go#L97-L101

`json.Marshal` is an readonly operation.

Fixes #10090 