### PR TITLE
[WIP] etcd-mixin: Don't show apiserver and kube-controllers in cluster dropdown

### DIFF
--- a/Documentation/etcd-mixin/mixin.libsonnet
+++ b/Documentation/etcd-mixin/mixin.libsonnet
@@ -1236,7 +1236,7 @@
             multi: false,
             name: 'cluster',
             options: [],
-            query: 'label_values(etcd_server_has_leader, job)',
+            query: 'label_values(etcd_server_has_leader{job!="kube-controllers", job!="apiserver"}, job)',
             refresh: 1,
             regex: '',
             sort: 2,


### PR DESCRIPTION
Today we received a bug report that the etcd dashboard shows clusters that aren't real clusters like _apiserver_ and _kube-controllers_. 

Screenshot: https://bugzilla.redhat.com/attachment.cgi?id=1485839
Bug Report: https://bugzilla.redhat.com/show_bug.cgi?id=1631926

Apparently some Kubernetes components expose the `etcd_server_has_leader` metric as well, as they are probably vendoring etcd as library which then registers these metrics.
You can take a look at all `etcd_` prefix metrics by running  `kubectl proxy` in one terminal and then run `curl -s http://localhost:8001/metrics | grep etcd_` in another terminal.

This will eventually be fixed on the Kubernetes side with the metrics overhaul:
https://github.com/kubernetes/kubernetes/pull/67476#issuecomment-413785762

As a workaround, we propose to simply drop the `etcd_server_has_leader` metric for job _apiserver_ & _kube-controllers_.

@mxinden @brancz @tomwilkie 