### PR TITLE
etcdctl: More helpful error handling in member add

### DIFF
--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -96,8 +96,17 @@ The items in the lists are ID, Status, Name, Peer Addrs, Client Addrs.
 
 // memberAddCommandFunc executes the "member add" command.
 func memberAddCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
+	if len(args) < 1 {
 		ExitWithError(ExitBadArgs, fmt.Errorf("member name not provided."))
+	}
+	if len(args) > 1 {
+		errorstring := "too many arguments"
+		for _, v := range args {
+			if strings.HasPrefix(strings.ToLower(v), "http"){
+				errorstring += ", did you mean \"--peer-urls " + v + "\""
+			}
+		}
+		ExitWithError(ExitBadArgs, fmt.Errorf(errorstring))
 	}
 	newMemberName := args[0]
 


### PR DESCRIPTION
This PR refers to issue #10120

Maintain existing error message for not-enough-args
Add "too many args" if too many args
Add more helpful error message if v2 syntax was used

New output:
```
sauer@host:~/dev/etcd$ ./bin/etcdctl --endpoints http://localhost:5001 member add
Error: member name not provided.
sauer@host:~/dev/etcd$ ./bin/etcdctl --endpoints http://localhost:5001 member add node2 node2
Error: too many arguments
sauer@host:~/dev/etcd$ ./bin/etcdctl --endpoints http://localhost:5001 member add node2 http://localhost:6002
Error: too many arguments, did you mean "--peer-urls http://localhost:6002"
sauer@host:~/dev/etcd$ ./bin/etcdctl --endpoints http://localhost:5001 member add http://localhost:6002 node2
Error: too many arguments, did you mean "--peer-urls http://localhost:6002"
```


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
