### PR TITLE
CHANGELOG-3.3: update from #9990

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -12,6 +12,7 @@ See [code changes](https://github.com/coreos/etcd/compare/v3.3.9...v3.3.10) and 
 
 - Improve ["became inactive" warning log](https://github.com/etcd-io/etcd/pull/10024), which indicates message send to a peer failed.
 - Improve [read index wait timeout warning log](https://github.com/etcd-io/etcd/pull/10026), which indicates that local node might have slow network.
+- Add [gRPC interceptor for debugging logs](https://github.com/etcd-io/etcd/pull/9990); enable `etcd --debug` flag to see per-request debug information.
 - Add [consistency check in snapshot status](https://github.com/etcd-io/etcd/pull/10109). If consistency check on snapshot file fails, `snapshot status` returns error.
 
 ### Metrics, Monitoring


### PR DESCRIPTION
CHANGELOG-3.3: update from #9990. 

This is already added to CHANGELOG-3.1, 3.2 and 3.4, but missing in CHANGELOG-3.3.

/cc @gyuho 
