### PR TITLE
tools: fix building failures on Win

### DIFF
--- a/tools/etcd-dump-metrics/install_windows.go
+++ b/tools/etcd-dump-metrics/install_windows.go
@@ -18,6 +18,6 @@ package main
 
 import "errors"
 
-func install(ver, dir string) error {
-	return errors.New("windows install is not supported yet")
+func install(ver, dir string) (string, error) {
+	return "", errors.New("windows install is not supported yet")
 }


### PR DESCRIPTION
When building tools on Win,it shows `.\main.go:68:12: assignment mismatch: 2 variables but 1 values`.The reason is the return variables not match the calling from `main.go` and i try to fix it.