### PR TITLE
benchmark: util.go

### DIFF
--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -96,7 +96,7 @@ func mustCreateConn() *clientv3.Client {
 		Endpoints:   connEndpoints,
 		DialTimeout: dialTimeout,
 	}
-	if !tls.Empty() {
+	if !tls.Empty() || tls.TrustedCAFile != "" {
 		cfgtls, err := tls.ClientConfig()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "bad tls config: %v\n", err)


### PR DESCRIPTION
allow client to setup TLS with cluster members, without the client having to offer TLS authentication itself

fixes #10142 