### PR TITLE
words: whitelist unfreed

### DIFF
--- a/.words
+++ b/.words
@@ -103,3 +103,4 @@ CallOptions
 PermitWithoutStream
 __lostleader
 ErrConnClosing
+unfreed


### PR DESCRIPTION
whitelist keyword 'unfreed' for goword. It is from the bbolt error message, used by error message in clientv3/snapshot.



