### PR TITLE
etcdserver: add "etcd_server_health_success/failures"

### DIFF
--- a/etcdserver/api/etcdhttp/metrics.go
+++ b/etcdserver/api/etcdhttp/metrics.go
@@ -44,11 +44,6 @@ func HandlePrometheus(mux *http.ServeMux) {
 	mux.Handle(pathMetrics, promhttp.Handler())
 }
 
-// HandleHealth registers health handler on '/health'.
-func HandleHealth(mux *http.ServeMux, srv etcdserver.ServerV2) {
-	mux.Handle(PathHealth, NewHealthHandler(func() Health { return checkHealth(srv) }))
-}
-
 // NewHealthHandler handles '/health' requests.
 func NewHealthHandler(hfunc func() Health) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
With https://github.com/etcd-io/etcd/pull/10155, I am trying to improve server side metrics.

People use `/health` endpoint heavily to monitor etcd server status.

Helpful to have server-side metrics to tell how many health check have been made, and how many of which were marked "failed".