### PR TITLE
clientv3: automated cherry pick of #10153 to release-3.2

### DIFF
--- a/clientv3/concurrency/mutex.go
+++ b/clientv3/concurrency/mutex.go
@@ -69,11 +69,10 @@ func (m *Mutex) Lock(ctx context.Context) error {
 
 	// wait for deletion revisions prior to myKey
 	hdr, werr := waitDeletes(ctx, client, m.pfx, m.myRev-1)
-	// release lock key if cancelled
-	select {
-	case <-ctx.Done():
+	// release lock key if wait failed
+	if werr != nil {
 		m.Unlock(client.Ctx())
-	default:
+	} else {
 		m.hdr = hdr
 	}
 	return werr


### PR DESCRIPTION
Cherry pick of #10153 on release-3.2.

#10153: clientv3: concurrency.Mutex.Lock() - preserve invariant