### PR TITLE
clientv3: automated cherry pick of #10153 to release 3.1

### DIFF
--- a/clientv3/concurrency/mutex.go
+++ b/clientv3/concurrency/mutex.go
@@ -58,11 +58,9 @@ func (m *Mutex) Lock(ctx context.Context) error {
 
 	// wait for deletion revisions prior to myKey
 	err = waitDeletes(ctx, client, m.pfx, m.myRev-1)
-	// release lock key if cancelled
-	select {
-	case <-ctx.Done():
+	// release lock key if wait failed
+	if err != nil {
 		m.Unlock(client.Ctx())
-	default:
 	}
 	return err
 }


### PR DESCRIPTION
Cherry pick of #10153 on release-3.1.

#10153: clientv3: concurrency.Mutex.Lock() - preserve invariant