### PR TITLE
integration: fix bug in TestMetricsHealth

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -188,11 +188,11 @@ func TestMetricsHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hv, err := clus.Members[0].Metric("etcd_server_health_success")
+	hv, err := clus.Members[0].Metric("etcd_server_health_failure")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hv != "1" {
-		t.Fatalf("expected '1' from /health, got %q", hv)
+	if hv != "0" {
+		t.Fatalf("expected '0' from etcd_server_health_failure, got %q", hv)
 	}
 }


### PR DESCRIPTION
integration: fix bug in TestMetricsHealth

TestMetricsHealth check the value of etcd_server_health_success, which returns "The total number of successful health checks", if it's not "1" then the test fails. However, the test runs [three times with 1, 2, 4 CPUs by default](https://github.com/etcd-io/etcd/blob/d5c93a7b0b5c434bf87d8de4d55d5a3b4ed4ed64/test#L117), so on the second run, value of etcd_server_health_success is 2 and on the third run, value of etcd_server_health_success is 3, which causes TestMetricsHealth test fail on the second and third time.

In the fix, I make it to check the value of  etcd_server_health_failure instead of etcd_server_health_succuess. 

Fixes #10172 

@gyuho 