### PR TITLE
bugfix: use the backend create by snapshot instead of origin one in tests

### DIFF
--- a/mvcc/backend/backend_test.go
+++ b/mvcc/backend/backend_test.go
@@ -74,7 +74,7 @@ func TestBackendSnapshot(t *testing.T) {
 	nb := New(bcfg)
 	defer cleanup(nb, f.Name())
 
-	newTx := b.BatchTx()
+	newTx := nb.BatchTx()
 	newTx.Lock()
 	ks, _ := newTx.UnsafeRange([]byte("test"), []byte("foo"), []byte("goo"), 0)
 	if len(ks) != 1 {


### PR DESCRIPTION
mvcc/backend: use the backend create by snapshot instead of origin one in tests

fixes #10177 