### PR TITLE
mvcc/backend: code format optimization

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -399,14 +399,7 @@ func (b *backend) defrag() error {
 			plog.Panicf("cannot open database at %s (%v)", dbp, err)
 		}
 	}
-	b.batchTx.tx, err = b.db.Begin(true)
-	if err != nil {
-		if b.lg != nil {
-			b.lg.Fatal("failed to begin tx", zap.Error(err))
-		} else {
-			plog.Fatalf("cannot begin tx (%s)", err)
-		}
-	}
+	b.batchTx.tx = b.unsafeBegin(true)
 
 	b.readTx.reset()
 	b.readTx.tx = b.unsafeBegin(false)


### PR DESCRIPTION

https://github.com/etcd-io/etcd/blob/7a759c18d294698f537f8be91927354818a71e51/mvcc/backend/backend.go#L402-L412

1. function `(*backend). unsafeBegin` has defined, which function is equal to code in line 402-409.
2. readTx is created by `(*backend). unsafeBegin`

changed like below:

```golang
	b.batchTx.tx = b.unsafeBegin(true)

 	b.readTx.reset()
	b.readTx.tx = b.unsafeBegin(false)
```

It's just code format optimization **not bugs**.