### PR TITLE
pkg/flags: fix "TestSetFlagsFromEnvParsingError"

### DIFF
--- a/pkg/flags/flag_test.go
+++ b/pkg/flags/flag_test.go
@@ -17,6 +17,7 @@ package flags
 import (
 	"flag"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -80,7 +81,14 @@ func TestSetFlagsFromEnvParsingError(t *testing.T) {
 	}
 	defer os.Unsetenv("ETCD_HEARTBEAT_INTERVAL")
 
-	if serr := SetFlagsFromEnv("ETCD", fs); serr.Error() != `invalid value "100 # ms" for ETCD_HEARTBEAT_INTERVAL: strconv.ParseUint: parsing "100 # ms": invalid syntax` {
-		t.Fatalf("expected parsing error, got %v", serr)
+	err := SetFlagsFromEnv("ETCD", fs)
+	for _, v := range []string{"invalid syntax", "parse error"} {
+		if strings.Contains(err.Error(), v) {
+			err = nil
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
 	}
 }


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/10208.

/cc @sudeeshjohn 
