### PR TITLE
raft:  add a test case in TestStorageAppend

### DIFF
--- a/raft/storage_test.go
+++ b/raft/storage_test.go
@@ -211,6 +211,11 @@ func TestStorageAppend(t *testing.T) {
 		wentries []pb.Entry
 	}{
 		{
+			[]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}},
+			nil,
+			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},
+		},
+		{
 			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},
 			nil,
 			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},


### PR DESCRIPTION
There is no test coverage：

https://github.com/etcd-io/etcd/blob/ee9dcbca0d89dc563c9e6bc725fab0c6f21d689b/raft/storage.go#L250-L253

add case:

```
		{
			[]pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}},
			nil,
			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},
		},
```
