### PR TITLE
tools/etcd-dump-db: add "--timeout" flag

### DIFF
--- a/tools/etcd-dump-db/backend.go
+++ b/tools/etcd-dump-db/backend.go
@@ -32,9 +32,9 @@ func snapDir(dataDir string) string {
 }
 
 func getBuckets(dbPath string) (buckets []string, err error) {
-	db, derr := bolt.Open(dbPath, 0600, &bolt.Options{})
+	db, derr := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: flockTimeout})
 	if derr != nil {
-		return nil, derr
+		return nil, fmt.Errorf("failed to open bolt DB %v", derr)
 	}
 	defer db.Close()
 
@@ -94,9 +94,9 @@ func leaseDecoder(k, v []byte) {
 }
 
 func iterateBucket(dbPath, bucket string, limit uint64, decode bool) (err error) {
-	db, derr := bolt.Open(dbPath, 0600, &bolt.Options{})
-	if derr != nil {
-		return derr
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: flockTimeout})
+	if err != nil {
+		return fmt.Errorf("failed to open bolt DB %v", err)
 	}
 	defer db.Close()
 

--- a/tools/etcd-dump-db/main.go
+++ b/tools/etcd-dump-db/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -46,10 +47,12 @@ var (
 	}
 )
 
+var flockTimeout time.Duration
 var iterateBucketLimit uint64
 var iterateBucketDecode bool
 
 func init() {
+	rootCommand.PersistentFlags().DurationVar(&flockTimeout, "timeout", 10*time.Second, "time to wait to obtain a file lock on db file, 0 to block indefinitely")
 	iterateBucketCommand.PersistentFlags().Uint64Var(&iterateBucketLimit, "limit", 0, "max number of key-value pairs to iterate (0< to iterate all)")
 	iterateBucketCommand.PersistentFlags().BoolVar(&iterateBucketDecode, "decode", false, "true to decode Protocol Buffer encoded data")
 


### PR DESCRIPTION
By default, wait up to 10 seconds to obtain flocks.

Fix https://github.com/etcd-io/etcd/issues/10089.