### PR TITLE
MAINTAINERS: add Sam Batschelet

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,6 +12,7 @@ Fanmin Shi <fashi@redhat.com> (@fanminshi) pkg:*
 Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*
+Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
 Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*
 
 Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:go.etcd.io/etcd/raft


### PR DESCRIPTION
etcd maintainers and community,
I would like to offer my service as a maintainer of the etcd project. I consider the role a great honor and will work very hard to not only grow the community but also to ensure the health of the project. Over the past 2 years, I have been a top 7 contributor and have recently shifted my career to etcd fulltime. Thank you for your consideration.

/cc @heyitsanthony @philips @fanminshi @gyuho @mitake @jpbetz @xiang90 

ref: https://github.com/etcd-io/etcd/graphs/contributors?from=2016-11-20&to=2018-11-14&type=c