### PR TITLE
embed: the initialization close code is not used.

### DIFF
--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -506,7 +506,7 @@ func configurePeerListeners(cfg *Config) (peers []*peerListener, err error) {
 				}
 			}
 		}
-		peers[i] = &peerListener{close: func(context.Context) error { return nil }}
+		peers[i] = new(peerListener)
 		peers[i].Listener, err = rafthttp.NewListener(u, &cfg.PeerTLSInfo)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION

https://github.com/etcd-io/etcd/blob/7f450bf6967638673dd88fd4e730b01d1303d5ff/embed/etcd.go#L509-L517

The first initialization of `close` is not necessary. 
If `rafthttp.NewListener` failed, return nil. 
If `rafthttp.NewListener` ok, `close` is set again.

not bug just optimize.