### PR TITLE
Documentation/op-guide: fix typo.

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -338,7 +338,7 @@ The security flags help to [build a secure etcd cluster][security].
 ### --log-outputs
 + Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd, or list of comma separated output targets.
 + default: default
-+ env variable: ETCD_LOG_OUTPUT
++ env variable: ETCD_LOG_OUTPUTS
 
 ### --debug
 + Drop the default log level to DEBUG for all subpackages.


### PR DESCRIPTION
```
### --logger

**Available from v3.4**

+ Specify 'zap' for structured logging or 'capnslog'.
+ default: capnslog
+ env variable: ETCD_LOGGER

### --log-outputs
+ Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd, or list of comma separated output targets.
+ default: default
+ env variable: ETCD_LOG_OUTPUT
```

Error writing in environment variable `ETCD_LOG_OUTPUT`, which should be `ETCD_LOG_OUTPUTS`.
