### PR TITLE
embed: set log-outputs 'default' to 'stderr' config when zap mode

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -339,6 +339,7 @@ The security flags help to [build a secure etcd cluster][security].
 + Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd, or list of comma separated output targets.
 + default: default
 + env variable: ETCD_LOG_OUTPUTS
++ 'default' use 'stderr' config for v3.4 during zap logger migraion
 
 ### --debug
 + Drop the default log level to DEBUG for all subpackages.

--- a/embed/config_logging.go
+++ b/embed/config_logging.go
@@ -152,7 +152,8 @@ func (cfg *Config) setupLogging() error {
 		for _, v := range cfg.LogOutputs {
 			switch v {
 			case DefaultLogOutput:
-				return errors.New("'--log-outputs=default' is not supported for v3.4 during zap logger migraion (use 'journal', 'stderr', 'stdout', etc.)")
+				outputPaths[StdErrLogOutput] = struct{}{}
+				errOutputPaths[StdErrLogOutput] = struct{}{}
 
 			case JournalLogOutput:
 				isJournal = true


### PR DESCRIPTION
set --log-outputs=default to --log-outputs=stderr when --logger=zap

fix #10303 