### PR TITLE
pkg/schedule: lock fifo.mu while todo is not nil

### DIFF
--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -155,11 +155,11 @@ func (f *fifo) run() {
 			}
 		} else {
 			todo(f.ctx)
-			f.finishCond.L.Lock()
+			f.mu.Lock()
 			f.finished++
 			f.pendings = f.pendings[1:]
 			f.finishCond.Broadcast()
-			f.finishCond.L.Unlock()
+			f.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
if we want to update fifo's member, we should lock fifo.mu

Fixes #10330
