### PR TITLE
mvcc/backend: use stable sort instead of unstable.

### DIFF
--- a/mvcc/backend/tx_buffer.go
+++ b/mvcc/backend/tx_buffer.go
@@ -63,8 +63,7 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 			continue
 		}
 		if !txw.seq && wb.used > 1 {
-			// assume no duplicate keys
-			sort.Sort(wb)
+			sort.Stable(wb)
 		}
 		rb.merge(wb)
 	}


### PR DESCRIPTION
https://github.com/etcd-io/etcd/blob/6937b772326fd27af77072405af88b2356407431/mvcc/backend/tx_buffer.go#L66-L67

The code here is a little weird,
- why  not use stable sort method instead. So there's no hypothesis here. 
- possible disordering will affect the correct result.

use unstable method `sort.Sort`
```shell
BenchmarkBackendPut-4   	   20000	     68780 ns/op	    2441 B/op	       7 allocs/op
```

use stable method `sort.Stable`
```shell
BenchmarkBackendPut-4   	   20000	     69271 ns/op	    2364 B/op	       7 allocs/op
```

There was no significant change in CPU and memory usage

If there are other considerations, ignore the submission.