### PR TITLE
docs: install etcdctl with `go get` as well

### DIFF
--- a/Documentation/dl_build.md
+++ b/Documentation/dl_build.md
@@ -27,6 +27,7 @@ To build a vendored `etcd` from the `master` branch via `go get`:
 $ echo $GOPATH
 /Users/example/go
 $ go get -v go.etcd.io/etcd
+$ go get -v go.etcd.io/etcd/etcdctl
 ```
 
 ## Test the installation
@@ -35,14 +36,14 @@ Check the etcd binary is built correctly by starting etcd and setting a key.
 
 ### Starting etcd
 
-If etcd is built without using GOPATH, run the following:
+If etcd is built without using `go get`, run the following:
 
-```
+```sh
 $ ./bin/etcd
 ```
-If etcd is built using GOPATH, run the following:
+If etcd is built using `go get`, run the following:
 
-```
+```sh
 $ $GOPATH/bin/etcd
 ```
 
@@ -50,10 +51,12 @@ $ $GOPATH/bin/etcd
 
 Run the following:
 
-```
+```sh
 $ ETCDCTL_API=3 ./bin/etcdctl put foo bar
 OK
 ```
+
+(or `ETCDCTL_API=3 $GOPATH/bin/etcdctl put foo bar` if etcdctl was installed with `go get`)
 
 If OK is printed, then etcd is working!
 


### PR DESCRIPTION
The documentation recommends using `etcdctl` to verify that etcd has
been built correctly, but the `go get` command provided does not install
it. This changes it so that it does, and also clarifies terminology
('using `go get`', referring to the command used to install it, rather
than 'using `$GOPATH`').
