### PR TITLE
raftexample: remove the leading slash for a key-value store key

### DIFF
--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -30,7 +30,7 @@ type httpKVAPI struct {
 }
 
 func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	key := r.RequestURI
+	key := r.RequestURI[1:]
 	switch {
 	case r.Method == "PUT":
 		v, err := ioutil.ReadAll(r.Body)
@@ -59,7 +59,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		nodeId, err := strconv.ParseUint(key[1:], 0, 64)
+		nodeId, err := strconv.ParseUint(key, 0, 64)
 		if err != nil {
 			log.Printf("Failed to convert ID for conf change (%v)\n", err)
 			http.Error(w, "Failed on POST", http.StatusBadRequest)
@@ -76,7 +76,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// As above, optimistic that raft will apply the conf change
 		w.WriteHeader(http.StatusNoContent)
 	case r.Method == "DELETE":
-		nodeId, err := strconv.ParseUint(key[1:], 0, 64)
+		nodeId, err := strconv.ParseUint(key, 0, 64)
 		if err != nil {
 			log.Printf("Failed to convert ID for conf change (%v)\n", err)
 			http.Error(w, "Failed on DELETE", http.StatusBadRequest)


### PR DESCRIPTION
The following command puts key "/my-key" with value "hello" into the
key-value store. According to README.md, key "my-key" with value "hello"
should be put instead. So the leading slash should be removed.

curl -L http://127.0.0.1:12380/my-key -XPUT -d hello
