### PR TITLE
pkg/testutil: add blankline between two functions

### DIFF
--- a/pkg/testutil/recorder.go
+++ b/pkg/testutil/recorder.go
@@ -49,6 +49,7 @@ func (r *RecorderBuffered) Record(a Action) {
 	r.actions = append(r.actions, a)
 	r.Unlock()
 }
+
 func (r *RecorderBuffered) Action() []Action {
 	r.Lock()
 	cpy := make([]Action, len(r.actions))
@@ -56,6 +57,7 @@ func (r *RecorderBuffered) Action() []Action {
 	r.Unlock()
 	return cpy
 }
+
 func (r *RecorderBuffered) Wait(n int) (acts []Action, err error) {
 	// legacy racey behavior
 	WaitSchedule()


### PR DESCRIPTION
There are no empty lines between some functions, which is strange.

https://github.com/etcd-io/etcd/blob/daec0718136dab067da4f3d2872e76d2893bcd48/pkg/testutil/recorder.go#L42-L70