### PR TITLE
Manually update version checks, should be 10 

### DIFF
--- a/client/keys.generated.go
+++ b/client/keys.generated.go
@@ -32,9 +32,9 @@ var (
 type codecSelfer8411 struct{}
 
 func init() {
-	if codec1978.GenVersion != 8 {
+	if codec1978.GenVersion != 10 {
 		_, file, _, _ := runtime.Caller(0)
-		panic("codecgen version mismatch: current: 8, need " + strconv.FormatInt(int64(codec1978.GenVersion), 10) + ". Re-generate file: " + file)
+		panic("codecgen version mismatch: current: 10, need " + strconv.FormatInt(int64(codec1978.GenVersion), 10) + ". Re-generate file: " + file)
 	}
 	if false { // reference the types, but skip this branch at build/run time
 		var v0 time.Duration


### PR DESCRIPTION
Update version checks, should be 10 instead of 8 as it caused the following error 

```goroutine 1 [running]:
github.com/coreos/etcd/client.init.0()
        /Users/msoliman/go_projects/pkg/mod/github.com/coreos/etcd@v3.3.10+incompatible/client/keys.generated.go:45 +0x104
```

Based on referenced version v.1.1.1, the version is 10: 

https://github.com/ugorji/go/blob/772ced7fd4c2f6322c07537a9a93b68d74551fa6/codec/gen-helper.generated.go#L17


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
