### PR TITLE
etcdserver: add missing lg assignment.

### DIFF
--- a/etcdserver/api/v2v3/server.go
+++ b/etcdserver/api/v2v3/server.go
@@ -44,7 +44,7 @@ type v2v3Server struct {
 }
 
 func NewServer(lg *zap.Logger, c *clientv3.Client, pfx string) etcdserver.ServerPeer {
-	return &v2v3Server{c: c, store: newStore(c, pfx)}
+	return &v2v3Server{lg: lg, c: c, store: newStore(c, pfx)}
 }
 
 func (s *v2v3Server) ClientCertAuthEnabled() bool { return false }

--- a/etcdserver/apply_v2.go
+++ b/etcdserver/apply_v2.go
@@ -38,7 +38,7 @@ type ApplierV2 interface {
 }
 
 func NewApplierV2(lg *zap.Logger, s v2store.Store, c *membership.RaftCluster) ApplierV2 {
-	return &applierV2store{store: s, cluster: c}
+	return &applierV2store{lg: lg, store: s, cluster: c}
 }
 
 type applierV2store struct {


### PR DESCRIPTION
add missing lg assignment.

There are two modifications：

first:
https://github.com/etcd-io/etcd/blob/fde617d2dc73c418ace7e4aab535b5dd1503f6f3/etcdserver/apply_v2.go#L40-L42

`applierV2store` has `lg` field

https://github.com/etcd-io/etcd/blob/fde617d2dc73c418ace7e4aab535b5dd1503f6f3/etcdserver/apply_v2.go#L44-L48

second:

https://github.com/etcd-io/etcd/blob/fde617d2dc73c418ace7e4aab535b5dd1503f6f3/etcdserver/api/v2v3/server.go#L46-L48

`v2v3Server` has `lg` field

https://github.com/etcd-io/etcd/blob/fde617d2dc73c418ace7e4aab535b5dd1503f6f3/etcdserver/api/v2v3/server.go#L39-L44