### PR TITLE
api/rafthttp: remove deprecated req.Cancel.

### DIFF
--- a/etcdserver/api/rafthttp/fake_roundtripper_test.go
+++ b/etcdserver/api/rafthttp/fake_roundtripper_test.go
@@ -28,8 +28,6 @@ func (t *roundTripperBlocker) RoundTrip(req *http.Request) (*http.Response, erro
 	select {
 	case <-t.unblockc:
 		return &http.Response{StatusCode: http.StatusNoContent, Body: &nopReadCloser{}}, nil
-	case <-req.Cancel:
-		return nil, errors.New("request canceled")
 	case <-ctx.Done():
 		return nil, errors.New("request canceled")
 	case <-c:


### PR DESCRIPTION
https://github.com/etcd-io/etcd/blob/f0aeb705ceb1daca072af0a54be6b43c87bbc23e/etcdserver/api/rafthttp/fake_roundtripper_test.go#L31-L32

`req.Cancel` should be removed. There are two reasons:


**first**:
[http - GoDoc](https://godoc.org/net/http#Request)

```
type Request struct {
    ...
    // Cancel is an optional channel whose closure indicates that the client
    // request should be regarded as canceled. Not all implementations of
    // RoundTripper may support Cancel.
    //
    // For server requests, this field is not applicable.
    //
    // Deprecated: Use the Context and WithContext methods
    // instead. If a Request's Cancel field and context are both
    // set, it is undefined whether Cancel is respected.
    Cancel <-chan struct{}
    ...
```

As mentioned above, `req.Cancel` is deprecated. 

**second**:
https://github.com/etcd-io/etcd/blob/f0aeb705ceb1daca072af0a54be6b43c87bbc23e/etcdserver/api/rafthttp/pipeline.go#L138-L152

`req` was created via `createPostRequest`,  but there are no deprecated usage in the function.
