### PR TITLE
api/v2auth: remove defer in loop.

### DIFF
--- a/etcdserver/api/v2auth/auth_requests.go
+++ b/etcdserver/api/v2auth/auth_requests.go
@@ -32,7 +32,6 @@ func (s *store) ensureAuthDirectories() error {
 	}
 	for _, res := range []string{StorePermsPrefix, StorePermsPrefix + "/users/", StorePermsPrefix + "/roles/"} {
 		ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
-		defer cancel()
 		pe := false
 		rr := etcdserverpb.Request{
 			Method:    "PUT",
@@ -41,6 +40,7 @@ func (s *store) ensureAuthDirectories() error {
 			PrevExist: &pe,
 		}
 		_, err := s.server.Do(ctx, rr)
+		cancel()
 		if err != nil {
 			if e, ok := err.(*v2error.Error); ok {
 				if e.ErrorCode == v2error.EcodeNodeExist {


### PR DESCRIPTION
remove defer in loop.

There are defer call in loop, 
https://github.com/etcd-io/etcd/blob/f0aeb705ceb1daca072af0a54be6b43c87bbc23e/etcdserver/api/v2auth/auth_requests.go#L33-L36

`defer cancel`  does not execute until the function returns, which is not appropriate, because `s.server.Do` is not an async call. It should call them at the end of each loop iteration.
