### PR TITLE
clientv3/integration: add timeout case.

### DIFF
--- a/clientv3/integration/network_partition_test.go
+++ b/clientv3/integration/network_partition_test.go
@@ -310,10 +310,19 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 		t.Fatalf("expected %v, got %v", rpctypes.ErrLeaderChanged, err)
 	}
 
-	ctx, cancel = context.WithTimeout(context.TODO(), 10*time.Second)
-	_, err = kvc.Get(ctx, "a")
-	cancel()
-	if err != nil {
-		t.Fatalf("expected nil, got %v", err)
+	for i := 0; i < 5; i++ {
+		ctx, cancel = context.WithTimeout(context.TODO(), 10*time.Second)
+		_, err = kvc.Get(ctx, "a")
+		cancel()
+		if err != nil {
+			if err == rpctypes.ErrTimeout {
+				<-time.After(time.Second)
+				i++
+				continue
+			}
+			t.Fatalf("expected nil or timeout, got %v", err)
+		}
+		// No error returned and no retry required
+		break
 	}
 }


### PR DESCRIPTION
The problem of build fails will be randomly encountered at the time of submission. Found associated with TestDropReadUnderNetworkPartition. After analysis, the case was found to have problems.

https://github.com/etcd-io/etcd/blob/f0aeb705ceb1daca072af0a54be6b43c87bbc23e/clientv3/integration/network_partition_test.go#L270

When the network partitioning occurs (the leader is isolated), the other two followers may select a new leader (in this case, the original testcase will succeed), or the new leader may not be selected (in this case, the original testcase will failed).

The following may occur when `rs = <-s.r.readStateC` blocked (the new leader not selected):
https://github.com/etcd-io/etcd/blob/f0aeb705ceb1daca072af0a54be6b43c87bbc23e/etcdserver/v3_server.go#L702-L710

Testcase failures appear randomly.