### PR TITLE
tests/e2e: add missing return error.

### DIFF
--- a/tests/e2e/etcd_process.go
+++ b/tests/e2e/etcd_process.go
@@ -104,18 +104,22 @@ func (ep *etcdServerProcess) Restart() error {
 	return ep.Start()
 }
 
-func (ep *etcdServerProcess) Stop() error {
+func (ep *etcdServerProcess) Stop() (err error) {
 	if ep == nil || ep.proc == nil {
 		return nil
 	}
-	if err := ep.proc.Stop(); err != nil {
+	err = ep.proc.Stop()
+	if err != nil {
 		return err
 	}
 	ep.proc = nil
 	<-ep.donec
 	ep.donec = make(chan struct{})
 	if ep.cfg.purl.Scheme == "unix" || ep.cfg.purl.Scheme == "unixs" {
-		os.Remove(ep.cfg.purl.Host + ep.cfg.purl.Path)
+		err = os.Remove(ep.cfg.purl.Host + ep.cfg.purl.Path)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
missing return error when call `os.Remove`

https://github.com/etcd-io/etcd/blob/1e42503bea073b559fca682219242a801cf4d587/tests/e2e/etcd_process.go#L107-L121