### PR TITLE
etcdctl: fix interactive mode panic

### DIFF
--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -101,6 +101,10 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 		l = strings.TrimSuffix(l, "\n")
 
 		args := argify(l)
+		if len(args) < 1 {
+			fmt.Fprintf(os.Stderr, "Invalid command: %s (watch and progress supported)\n", l)
+			continue
+		}
 		switch args[0] {
 		case "watch":
 			if len(args) < 2 && envKey == "" {


### PR DESCRIPTION
Don't panic if command is given in interactive mode, give a nice error
message instead.

Before:

```sh
 $ ./bin/etcdctl watch -i
 <hit return>
 panic: runtime error: index out of range

 goroutine 1 [running]:
 etcdctl/ctlv3/command.watchInteractiveFunc(...)
 	etcd/etcdctl/ctlv3/command/watch_command.go:104 ...
```

After:

```sh
 $ ./bin/etcdctl watch -i
 <hit return>
 Invalid command:  (watch and progress supported)
 foo
 Invalid command foo (only support watch)
```