### PR TITLE
embed: add zap logger builder

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -301,6 +301,9 @@ type Config struct {
 	// Debug is true, to enable debug level logging.
 	Debug bool `json:"debug"`
 
+	// ZapLoggerBuilder is used to build the zap logger.
+	ZapLoggerBuilder func(*Config) error
+
 	// logger logs server-side operations. The default is nil,
 	// and "setupLogging" must be called before starting server.
 	// Do not set logger directly.


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>
In order to improve the ELK system, we want to use a custom zap encoder or more features in `zapcore`.  So we need a custom builder to build the zap logger in the embed config. This PR added
a `ZapLoggerBuilder` to build a custom zap logger. I think some users may have the same needs, so I hope we can merge this.