### PR TITLE
raft: Modify testcase of leader election With CheckQuorum enabled.

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -2043,7 +2043,7 @@ func TestLeaderElectionWithCheckQuorum(t *testing.T) {
 	for i := 0; i < a.electionTimeout; i++ {
 		a.tick()
 	}
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := 0; i < b.electionTimeout-1; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
@@ -2052,9 +2052,16 @@ func TestLeaderElectionWithCheckQuorum(t *testing.T) {
 		t.Errorf("state = %s, want %s", a.state, StateFollower)
 	}
 
+	if c.state != StateCandidate {
+		t.Errorf("state = %s, want %s", c.state, StateCandidate)
+	}
+
+	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
+
 	if c.state != StateLeader {
 		t.Errorf("state = %s, want %s", c.state, StateLeader)
 	}
+
 }
 
 // TestFreeStuckCandidateWithCheckQuorum ensures that a candidate with a higher term


### PR DESCRIPTION
Modify the testcase below:

https://github.com/etcd-io/etcd/blob/a00bff7848db1dcead692e2bea1d7c87e8a2c157/raft/raft_test.go#L2014

The reason for this change is that if set the following variable to false, the case will pass as well.In this way, testcase loses its proper function.

https://github.com/etcd-io/etcd/blob/a00bff7848db1dcead692e2bea1d7c87e8a2c157/raft/raft_test.go#L2019-L2021

The modified scheme is that b does not time out, a does, and then c processes the HUP message again, and finally c becomes the leader. Thus, when checkQuorum is false, c will be the leader and not the candidate.
