### PR TITLE
CONTRIBUTING: clarify commit message style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,13 @@ questions: what changed and why. The subject line should feature the what and
 the body of the commit should describe the why.
 
 ```
-scripts: add the test-cluster command
+etcdserver: add grpc interceptor to log info on incoming requests
 
-this uses tmux to setup a test cluster that can easily be killed and started for debugging.
+To improve debuggability of etcd v3. Added a grpc interceptor to log
+info on incoming requests to etcd server. The log output includes
+remote client info, request content (with value field redacted), request
+handling latency, response size, etc. Uses zap logger if available,
+otherwise uses capnslog.
 
 Fixes #38
 ```
@@ -52,11 +56,38 @@ Fixes #38
 The format can be described more formally as follows:
 
 ```
-<subsystem>: <what changed>
+<package>: <what changed>
 <BLANK LINE>
 <why this change was made>
 <BLANK LINE>
 <footer>
 ```
 
-The first line is the subject and should be no longer than 70 characters, the second line is always blank, and other lines should be wrapped at 80 characters. This allows the message to be easier to read on GitHub as well as in various git tools.
+The first line is the subject and should be no longer than 70 characters, the second
+line is always blank, and other lines should be wrapped at 80 characters. This allows
+the message to be easier to read on GitHub as well as in various git tools.
+
+### Pull request across multiple files and packages
+
+If multiple files in a package are changed in a pull request for example:
+
+```
+etcdserver/config.go
+etcdserver/corrupt.go
+```
+
+At the end of the review process if multiple commits exist for a single package they
+should be squashed/rebased into a single commit before being merged.
+
+```
+etcdserver: <what changed>
+[..]
+```
+
+If a pull request spans many packages these commits should be squashed/rebased into a single
+commit using message with a more generic `*:` prefix.
+
+```
+*: <what changed>
+[..]
+```


### PR DESCRIPTION
The commit message style that etcd repo uses is something that is not fully documented. The PR clarifies what is expected from contributors.

/cc @gyuho @xiang90 @jpbetz
