### PR TITLE
clientv3/integration: Don't retry other endpoints when err == rpctypes.ErrAuthNotEnable 

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -310,6 +310,10 @@ func (c *Client) getToken(ctx context.Context) error {
 		var resp *AuthenticateResponse
 		resp, err = auth.authenticate(ctx, c.Username, c.Password)
 		if err != nil {
+			// return err without retrying other endpoints
+			if err == rpctypes.ErrAuthNotEnabled {
+				return err
+			}
 			continue
 		}
 


### PR DESCRIPTION
Fixes #10430