### PR TITLE
Add #10443 fix to changelogs

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -8,6 +8,13 @@ The [minimum recommended etcd versions to run in **production**](https://groups.
 
 <hr>
 
+## [v3.1.21](https://github.com/etcd-io/etcd/releases/tag/v3.1.21) (2019-TBD)
+
+### etcdctl
+
+- [Strip out insecure endpoints from DNS SRV records when using discovery](https://github.com/etcd-io/etcd/pull/10443) with etcdctl v2
+
+<hr>
 
 ## [v3.1.20](https://github.com/etcd-io/etcd/releases/tag/v3.1.20) (2018-10-10)
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -11,6 +11,9 @@ The [minimum recommended etcd versions to run in **production**](https://groups.
 
 ## [v3.2.27](https://github.com/etcd-io/etcd/releases/tag/v3.2.27) (2019-TBD)
 
+### etcdctl
+
+- [Strip out insecure endpoints from DNS SRV records when using discovery](https://github.com/etcd-io/etcd/pull/10443) with etcdctl v2
 
 <hr>
 

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -429,6 +429,7 @@ Note: **v3.5 will deprecate `etcd --log-package-levels` flag for `capnslog`**; `
   save`.
   - User can specify timeout of `etcdctl snapshot save` command using flag
     `--command-timeout`.
+  - Fix etcdctl to [strip out insecure endpoints from DNS SRV records when using discovery](https://github.com/etcd-io/etcd/pull/10443)
 
 ### gRPC proxy
 

--- a/etcdctl/ctlv2/command/util.go
+++ b/etcdctl/ctlv2/command/util.go
@@ -104,7 +104,7 @@ func getDomainDiscoveryFlagValue(c *cli.Context) ([]string, error) {
 	// strip insecure connections
 	ret := []string{}
 	for _, ep := range eps {
-		if strings.HasPrefix("http://", ep) {
+		if strings.HasPrefix(ep, "http://") {
 			fmt.Fprintf(os.Stderr, "ignoring discovered insecure endpoint %q\n", ep)
 			continue
 		}

--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -444,7 +444,7 @@ func endpointsFromFlagValue(cmd *cobra.Command) ([]string, error) {
 	// strip insecure connections
 	ret := []string{}
 	for _, ep := range eps {
-		if strings.HasPrefix("http://", ep) {
+		if strings.HasPrefix(ep, "http://") {
 			fmt.Fprintf(os.Stderr, "ignoring discovered insecure endpoint %q\n", ep)
 			continue
 		}


### PR DESCRIPTION
See #10443 which was backported to 3.1 and 3.2 today.