### PR TITLE
pkg/transport: Limit InvalidCipherSuites to TLS12

### DIFF
--- a/pkg/transport/transport_test.go
+++ b/pkg/transport/transport_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 )
 
-// TestNewTransportTLSInvalidCipherSuites expects a client with invalid
+// TestNewTransportTLSInvalidCipherSuitesTLS12 expects a client with invalid
 // cipher suites fail to handshake with the server.
-func TestNewTransportTLSInvalidCipherSuites(t *testing.T) {
+func TestNewTransportTLSInvalidCipherSuitesTLS12(t *testing.T) {
 	tlsInfo, del, err := createSelfCert()
 	if err != nil {
 		t.Fatalf("unable to create cert: %v", err)
@@ -57,6 +57,7 @@ func TestNewTransportTLSInvalidCipherSuites(t *testing.T) {
 	}()
 	go func() {
 		tr, err := NewTransport(cliTLS, 3*time.Second)
+		tr.TLSClientConfig.MaxVersion = tls.VersionTLS12
 		if err != nil {
 			t.Fatalf("unexpected NewTransport error: %v", err)
 		}


### PR DESCRIPTION
Fixes: https://github.com/etcd-io/etcd/issues/10267