### PR TITLE
Fixed --strict-reconfig-check#10462

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -182,7 +182,7 @@ To start etcd automatically using custom settings at startup in Linux, using a [
 
 ### --strict-reconfig-check
 + Reject reconfiguration requests that would cause quorum loss.
-+ default: false
++ default: true
 + env variable: ETCD_STRICT_RECONFIG_CHECK
 
 ### --auto-compaction-retention


### PR DESCRIPTION
Changed **--strict-reconfig-check** to **default: true** in file

https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md#--strict-reconfig-check

Fixes Issue #10462 



Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
