### PR TITLE
raftexample: added build instruction  and minor refactoring

### DIFF
--- a/contrib/raftexample/README.md
+++ b/contrib/raftexample/README.md
@@ -8,11 +8,11 @@ raftexample is an example usage of etcd's [raft library](../../raft). It provide
 
 ### Building raftexample
 
-Clone `etcd` to `<your directory>/src/go.etcd.io/etcd`
+Clone `etcd` to `<directory>/src/go.etcd.io/etcd`
 
 ```sh
-export GOPATH=<your directory>
-cd <your directory>/src/go.etcd.io/etcd/contrib/raftexample
+export GOPATH=<directory>
+cd <directory>/src/go.etcd.io/etcd/contrib/raftexample
 go build -o raftexample
 ```
 

--- a/contrib/raftexample/README.md
+++ b/contrib/raftexample/README.md
@@ -6,6 +6,16 @@ raftexample is an example usage of etcd's [raft library](../../raft). It provide
 
 ## Getting Started
 
+### Building raftexample
+
+Clone `etcd` to `<your directory>/src/go.etcd.io/etcd`
+
+```sh
+export GOPATH=<your directory>
+cd <your directory>/src/go.etcd.io/etcd/contrib/raftexample
+go build -o raftexample
+```
+
 ### Running single node raftexample
 
 First start a single-member cluster of raftexample:

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -48,8 +48,8 @@ func newKVStore(snapshotter *snap.Snapshotter, proposeC chan<- string, commitC <
 
 func (s *kvstore) Lookup(key string) (string, bool) {
 	s.mu.RLock()
+	defer s.mu.RUnlock()
 	v, ok := s.kvStore[key]
-	s.mu.RUnlock()
 	return v, ok
 }
 
@@ -106,7 +106,7 @@ func (s *kvstore) recoverFromSnapshot(snapshot []byte) error {
 		return err
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.kvStore = store
-	s.mu.Unlock()
 	return nil
 }


### PR DESCRIPTION
When trying out raftexample, there's no instruction on how to build the source. So i added few steps to make it clearer to the user.

Also using `defer` to unlock mutex in couple of places in `kvstore.go`.