### PR TITLE
doc: Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/Documentation/dev-guide/api_grpc_gateway.md
+++ b/Documentation/dev-guide/api_grpc_gateway.md
@@ -129,7 +129,7 @@ Generated [Swagger][swagger] API definitions can be found at [rpc.swagger.json][
 [api-ref]: ./api_reference_v3.md
 [go-client]: https://github.com/coreos/etcd/tree/master/clientv3
 [etcdctl]: https://github.com/coreos/etcd/tree/master/etcdctl
-[grpc]: http://www.grpc.io/
+[grpc]: https://www.grpc.io/
 [grpc-gateway]: https://github.com/grpc-ecosystem/grpc-gateway
 [json-mapping]: https://developers.google.com/protocol-buffers/docs/proto3#json
 [swagger]: http://swagger.io/

--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -76,7 +76,7 @@ In theory, it’s possible to build these primitives atop any storage systems pr
 For distributed coordination, choosing etcd can help prevent operational headaches and save engineering effort.
 
 [production-users]: ../production-users.md
-[grpc]: http://www.grpc.io
+[grpc]: https://www.grpc.io
 [consul-bulletproof]: https://www.consul.io/docs/internals/sessions.html
 [curator]: http://curator.apache.org/
 [cockroach]: https://github.com/cockroachdb/cockroach

--- a/clientv3/README.md
+++ b/clientv3/README.md
@@ -28,7 +28,7 @@ if err != nil {
 defer cli.Close()
 ```
 
-etcd v3 uses [`gRPC`](http://www.grpc.io) for remote procedure calls. And `clientv3` uses
+etcd v3 uses [`gRPC`](https://www.grpc.io) for remote procedure calls. And `clientv3` uses
 [`grpc-go`](https://github.com/grpc/grpc-go) to connect to etcd. Make sure to close the client after using it.
 If the client is not closed, the connection will have leaky goroutines. To specify client request timeout,
 pass `context.WithTimeout` to APIs:


### PR DESCRIPTION
Currently, when we access the URL http://www.grpc.io, it is redirected to https://www.grpc.io automatically.
So this commit aims to replace **HTTP** to **HTTPs** for security.
