### PR TITLE
Fix some misspells

### DIFF
--- a/client/keys_bench_test.go
+++ b/client/keys_bench_test.go
@@ -61,7 +61,7 @@ func benchmarkResponseUnmarshalling(b *testing.B, children, size int) {
 	newResponse := new(Response)
 	for i := 0; i < b.N; i++ {
 		if newResponse, err = unmarshalSuccessfulKeysResponse(header, body); err != nil {
-			b.Errorf("error unmarshaling response (%v)", err)
+			b.Errorf("error unmarshalling response (%v)", err)
 		}
 
 	}

--- a/etcdserver/api/rafthttp/http.go
+++ b/etcdserver/api/rafthttp/http.go
@@ -131,7 +131,7 @@ func (h *pipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			plog.Errorf("failed to unmarshal raft message (%v)", err)
 		}
-		http.Error(w, "error unmarshaling raft message", http.StatusBadRequest)
+		http.Error(w, "error unmarshalling raft message", http.StatusBadRequest)
 		recvFailures.WithLabelValues(r.RemoteAddr).Inc()
 		return
 	}


### PR DESCRIPTION
"unmarshaling" to "unmarshalling" in line 64 and 134.