### PR TITLE
etcdmain: fix sd_notify for restricted environments

### DIFF
--- a/etcdmain/main.go
+++ b/etcdmain/main.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/daemon"
-	systemdutil "github.com/coreos/go-systemd/util"
 	"go.uber.org/zap"
 )
 
@@ -48,27 +47,12 @@ func Main() {
 }
 
 func notifySystemd(lg *zap.Logger) {
-	if !systemdutil.IsRunningSystemd() {
-		return
-	}
-
-	if lg != nil {
-		lg.Info("host was booted with systemd, sends READY=1 message to init daemon")
-	}
-	sent, err := daemon.SdNotify(false, "READY=1")
+	_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
 	if err != nil {
 		if lg != nil {
 			lg.Error("failed to notify systemd for readiness", zap.Error(err))
 		} else {
 			plog.Errorf("failed to notify systemd for readiness: %v", err)
-		}
-	}
-
-	if !sent {
-		if lg != nil {
-			lg.Warn("forgot to set Type=notify in systemd service file?")
-		} else {
-			plog.Errorf("forgot to set Type=notify in systemd service file?")
 		}
 	}
 }


### PR DESCRIPTION
For now `IsRunningSystemd()` checks if system **booted** with systemd, not running it (and doing it in dumb way just by checking `/run/systemd/system` exists and it's directory). There are cases when system isn't booted with systemd, but etcd still **need** to notify it:
* Restricted service (like `TemporaryFileSystem=/run + BindReadOnlyPaths=/run/systemd/notify`)
* [Portable services](https://systemd.io/PORTABLE_SERVICES.html) (same approach)

Internally `daemon.SdNotify()` doing all work for us - detecting *notify socket* (not *booted systemd*), handling errors /etc. The only case that etcd should handle - `err != nil` to notify users about broken notify socket.

After that change I got working portable service for etcd without any harm to any existing installations/setups/etc