### PR TITLE
mvcc: release lock early when traversing index

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -92,9 +92,10 @@ func (ti *treeIndex) visit(key, end []byte, f func(ki *keyIndex)) {
 	keyi, endi := &keyIndex{key: key}, &keyIndex{key: end}
 
 	ti.RLock()
-	defer ti.RUnlock()
+	clone := ti.tree.Clone()
+	ti.RUnlock()
 
-	ti.tree.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
+	clone.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
 		if len(endi.key) > 0 && !item.Less(endi) {
 			return false
 		}


### PR DESCRIPTION
Make a copy-on-write clone of the index tree when start traversing. So that lock can be released right after the clone to improve backend concurrency.

Suggested by @xiang90.

