### PR TITLE
clientv3/integration: Remove outdated comments.

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/integration"
 	"go.etcd.io/etcd/mvcc/mvccpb"
@@ -37,7 +38,7 @@ func TestKVPutError(t *testing.T) {
 	defer testutil.AfterTest(t)
 
 	var (
-		maxReqBytes = 1.5 * 1024 * 1024 // hard coded max in v3_server.go
+		maxReqBytes = embed.DefaultMaxRequestBytes
 		quota       = int64(int(maxReqBytes) + 8*os.Getpagesize())
 	)
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, QuotaBackendBytes: quota, ClientMaxCallSendMsgSize: 100 * 1024 * 1024})

--- a/clientv3/integration/watch_fragment_test.go
+++ b/clientv3/integration/watch_fragment_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/integration"
 	"go.etcd.io/etcd/pkg/testutil"
 )
@@ -65,10 +66,10 @@ func TestWatchFragmentEnableWithGRPCLimit(t *testing.T) {
 func testWatchFragment(t *testing.T, fragment, exceedRecvLimit bool) {
 	cfg := &integration.ClusterConfig{
 		Size:            1,
-		MaxRequestBytes: 1.5 * 1024 * 1024,
+		MaxRequestBytes: embed.DefaultMaxRequestBytes,
 	}
 	if exceedRecvLimit {
-		cfg.ClientMaxCallRecvMsgSize = 1.5 * 1024 * 1024
+		cfg.ClientMaxCallRecvMsgSize = embed.DefaultMaxRequestBytes
 	}
 	clus := integration.NewClusterV3(t, cfg)
 	defer clus.Terminate(t)


### PR DESCRIPTION
Remove outdated comments.

The content pointed to by the annotation has been deleted at [commit 9e77](https://github.com/etcd-io/etcd/commit/9e7740011b5ec2af85fd21f93b527a21a2953f4c), and it remains misleading.


