### PR TITLE
pkg/transport: remove tls version restrictions.

### DIFF
--- a/pkg/transport/transport_test.go
+++ b/pkg/transport/transport_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 )
 
-// TestNewTransportTLSInvalidCipherSuitesTLS12 expects a client with invalid
+// TestNewTransportTLSInvalidCipherSuitesTLS expects a client with invalid
 // cipher suites fail to handshake with the server.
-func TestNewTransportTLSInvalidCipherSuitesTLS12(t *testing.T) {
+func TestNewTransportTLSInvalidCipherSuitesTLS(t *testing.T) {
 	tlsInfo, del, err := createSelfCert()
 	if err != nil {
 		t.Fatalf("unable to create cert: %v", err)
@@ -57,7 +57,6 @@ func TestNewTransportTLSInvalidCipherSuitesTLS12(t *testing.T) {
 	}()
 	go func() {
 		tr, err := NewTransport(cliTLS, 3*time.Second)
-		tr.TLSClientConfig.MaxVersion = tls.VersionTLS12
 		if err != nil {
 			t.Fatalf("unexpected NewTransport error: %v", err)
 		}


### PR DESCRIPTION
the [origin commit] (4bd81d09334653f5e6091e0658f4292fa0d3e8a0) it works. 
This modification is temporary which can be cancelled.

go version:
go version go1.12 darwin/amd64

go src :

https://github.com/golang/go/blob/1c2d4da10f6edf9a83fb0cffaaf9f631f462d26b/src/crypto/tls/handshake_server.go#L308-L311

```go
	if hs.suite == nil {
		c.sendAlert(alertHandshakeFailure)
		return errors.New("tls: no cipher suite supported by both client and server")
	}
```

no need to add `tr.TLSClientConfig.MaxVersion = tls.VersionTLS12`. 

The issue involved in the original modification #10267 