### PR TITLE
 close http request body after read it.

### DIFF
--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -31,6 +31,7 @@ type httpKVAPI struct {
 
 func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	key := r.RequestURI
+	defer r.Body.Close()
 	switch {
 	case r.Method == "PUT":
 		v, err := ioutil.ReadAll(r.Body)

--- a/lease/leasehttp/http.go
+++ b/lease/leasehttp/http.go
@@ -52,6 +52,7 @@ func (h *leaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer r.Body.Close()
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "error reading body", http.StatusBadRequest)


### PR DESCRIPTION
close it after read`http.Request.Body` .

one of them is:

https://github.com/etcd-io/etcd/blob/6da17cda18307eff6e946c824fb7b64ecaf34fbe/contrib/raftexample/httpapi.go#L32-L34
