### PR TITLE
etcdserver/api/rafthttp: fix the location of close http body.

### DIFF
--- a/etcdserver/api/rafthttp/pipeline.go
+++ b/etcdserver/api/rafthttp/pipeline.go
@@ -155,12 +155,12 @@ func (p *pipeline) post(data []byte) (err error) {
 		p.picker.unreachable(u)
 		return err
 	}
+	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		p.picker.unreachable(u)
 		return err
 	}
-	resp.Body.Close()
 
 	err = checkPostResponse(resp, b, req, p.peerID)
 	if err != nil {


### PR DESCRIPTION
The close method may not be called.

https://github.com/etcd-io/etcd/blob/6da17cda18307eff6e946c824fb7b64ecaf34fbe/etcdserver/api/rafthttp/pipeline.go#L158-L163