### PR TITLE
wal: add option for set preallocated wal size

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -52,6 +52,7 @@ const (
 	DefaultName                  = "default"
 	DefaultMaxSnapshots          = 5
 	DefaultMaxWALs               = 5
+	DefaultMinWALSize            = 64 * 1000 * 1000
 	DefaultMaxTxnOps             = uint(128)
 	DefaultMaxRequestBytes       = 1.5 * 1024 * 1024
 	DefaultGRPCKeepAliveMinTime  = 5 * time.Second
@@ -130,8 +131,9 @@ type Config struct {
 	// Always use "DefaultSnapshotCatchUpEntries"
 	SnapshotCatchUpEntries uint64
 
-	MaxSnapFiles uint `json:"max-snapshots"`
-	MaxWalFiles  uint `json:"max-wals"`
+	MaxSnapFiles uint  `json:"max-snapshots"`
+	MaxWalFiles  uint  `json:"max-wals"`
+	MinWalSize   int64 `json:"min-wal-size"`
 
 	// TickMs is the number of milliseconds between heartbeat ticks.
 	// TODO: decouple tickMs and heartbeat tick (current heartbeat tick = 1).
@@ -373,6 +375,7 @@ func NewConfig() *Config {
 	cfg := &Config{
 		MaxSnapFiles: DefaultMaxSnapshots,
 		MaxWalFiles:  DefaultMaxWALs,
+		MinWalSize:   DefaultMinWALSize,
 
 		Name: DefaultName,
 

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -171,6 +171,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		SnapshotCatchUpEntries:     cfg.SnapshotCatchUpEntries,
 		MaxSnapFiles:               cfg.MaxSnapFiles,
 		MaxWALFiles:                cfg.MaxWalFiles,
+		MinWalSize:                 cfg.MinWalSize,
 		InitialPeerURLsMap:         urlsmap,
 		InitialClusterToken:        token,
 		DiscoveryURL:               cfg.Durl,

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -148,6 +148,7 @@ func newConfig() *config {
 		"List of URLs to listen on for the metrics and health endpoints.",
 	)
 	fs.UintVar(&cfg.ec.MaxSnapFiles, "max-snapshots", cfg.ec.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited).")
+	fs.Int64Var(&cfg.ec.MinWalSize, "min-wal-size", cfg.ec.MinWalSize, "Preallocated wal size in bytes.")
 	fs.UintVar(&cfg.ec.MaxWalFiles, "max-wals", cfg.ec.MaxWalFiles, "Maximum number of wal files to retain (0 is unlimited).")
 	fs.StringVar(&cfg.ec.Name, "name", cfg.ec.Name, "Human-readable name for this member.")
 	fs.Uint64Var(&cfg.ec.SnapshotCount, "snapshot-count", cfg.ec.SnapshotCount, "Number of committed transactions to trigger a snapshot to disk.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -65,6 +65,8 @@ Member:
     List of URLs to listen on for client traffic.
   --max-snapshots '` + strconv.Itoa(embed.DefaultMaxSnapshots) + `'
     Maximum number of snapshot files to retain (0 is unlimited).
+  --min-wal-size '` + strconv.Itoa(embed.DefaultMinWALSize) + `'
+    Preallocated wal size in bytes.
   --max-wals '` + strconv.Itoa(embed.DefaultMaxWALs) + `'
     Maximum number of wal files to retain (0 is unlimited).
   --quota-backend-bytes '0'

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -55,6 +55,7 @@ type ServerConfig struct {
 
 	MaxSnapFiles uint
 	MaxWALFiles  uint
+	MinWalSize   int64
 
 	// BackendBatchInterval is the maximum time before commit the backend transaction.
 	BackendBatchInterval time.Duration

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -311,6 +311,9 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 	}
 
 	haveWAL := wal.Exist(cfg.WALDir())
+	if cfg.MinWalSize > 0 {
+		wal.SegmentSizeBytes = cfg.MinWalSize
+	}
 
 	if err = fileutil.TouchDirAll(cfg.SnapDir()); err != nil {
 		if cfg.Logger != nil {


### PR DESCRIPTION
For some small environments wal size 64MB are too big. Allow set it by env/cmdline.
