### PR TITLE
integration: use cancel instead of close.

### DIFF
--- a/integration/v3_alarm_test.go
+++ b/integration/v3_alarm_test.go
@@ -88,8 +88,8 @@ func TestV3StorageQuotaApply(t *testing.T) {
 		}
 	}
 
-	ctx, close := context.WithTimeout(context.TODO(), RequestWaitTimeout)
-	defer close()
+	ctx, cancel := context.WithTimeout(context.TODO(), RequestWaitTimeout)
+	defer cancel()
 
 	// small quota machine should reject put
 	if _, err := kvc0.Put(ctx, &pb.PutRequest{Key: key, Value: smallbuf}); err == nil {


### PR DESCRIPTION
use cancel instead of close.

1. close is builtin function name
2. cancel is more general