### PR TITLE
clientv3: clean up unused code.

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -666,12 +665,4 @@ func IsConnCanceled(err error) bool {
 	}
 	// <= gRPC v1.7.x returns 'errors.New("grpc: the client connection is closing")'
 	return strings.Contains(err.Error(), "grpc: the client connection is closing")
-}
-
-func getHost(ep string) string {
-	url, uerr := url.Parse(ep)
-	if uerr != nil || !strings.Contains(ep, "://") {
-		return ep
-	}
-	return url.Host
 }


### PR DESCRIPTION
`getHost ` has two same definitions:

https://github.com/etcd-io/etcd/blob/939b4f8599f617541e1f1121167df22ecabddf89/clientv3/balancer/grpc1.7-health.go#L612-L618

https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/clientv3/client.go#L671-L677

the second unused which can be removed.