### PR TITLE
clientv3/balancer: change balancer name to builder name.

### DIFF
--- a/clientv3/balancer/balancer.go
+++ b/clientv3/balancer/balancer.go
@@ -54,7 +54,7 @@ func (b *builder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balan
 	bb := &baseBalancer{
 		id:     strconv.FormatInt(time.Now().UnixNano(), 36),
 		policy: b.cfg.Policy,
-		name:   b.cfg.Policy.String(),
+		name:   b.cfg.Name,
 		lg:     b.cfg.Logger,
 
 		addrToSc: make(map[resolver.Address]balancer.SubConn),
@@ -66,9 +66,6 @@ func (b *builder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balan
 
 		// initialize picker always returns "ErrNoSubConnAvailable"
 		Picker: picker.NewErr(balancer.ErrNoSubConnAvailable),
-	}
-	if b.cfg.Name != "" {
-		bb.name = b.cfg.Name
 	}
 	if bb.lg == nil {
 		bb.lg = zap.NewNop()


### PR DESCRIPTION
https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/clientv3/balancer/balancer.go#L53-L60

reasons:
1. `baseBalancer.name` should be more of a `cfg` name because the policy name is not the lb name
2.  there has been modified if  `b.cfg.Name` is not empty string.

https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/clientv3/balancer/balancer.go#L70-L72

Modify:
Direct use of ` b.cfg.Name `.