### PR TITLE
etcdserver: add return to get function.

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -108,7 +108,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 	if err = s.doSerialize(ctx, chk, get); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return resp, err
 }
 
 func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
@@ -155,7 +155,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		if err = s.doSerialize(ctx, chk, get); err != nil {
 			return nil, err
 		}
-		return resp, nil
+		return resp, err
 	}
 
 	resp, err := s.raftRequest(ctx, pb.InternalRaftRequest{Txn: r})


### PR DESCRIPTION
add the return value to `get` function

https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/etcdserver/v3_server.go#L541

The main reason：

https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/etcdserver/v3_server.go#L550-L559

if `get` has no return value(`error`)
2) and just has an error
3) and `doSerialize ` return `auth.ErrAuthOldRevision`

In the following code processing, the error returned in second step will be emit.

https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/etcdserver/v3_server.go#L105-L109

Other reasons：
1) `chk` has return type.
2) adding return type is more elegant

