### PR TITLE
bill-of-materials: update to fix 'bom' test failure

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -36,7 +36,7 @@
 		]
 	},
 	{
-		"project": "github.com/coreos/pkg",
+		"project": "github.com/coreos/pkg/capnslog",
 		"licenses": [
 			{
 				"type": "Apache License 2.0",


### PR DESCRIPTION
Just realized the 'bom' test has been failing for a while in master branch. Re-generated `bill-of-materials.json` using `scripts/updatebom.sh`.