### PR TITLE
clientv3/ordering: adjust violation count.

### DIFF
--- a/clientv3/ordering/util.go
+++ b/clientv3/ordering/util.go
@@ -29,8 +29,13 @@ var ErrNoGreaterRev = errors.New("etcdclient: no cluster members have a revision
 func NewOrderViolationSwitchEndpointClosure(c clientv3.Client) OrderViolationFunc {
 	var mu sync.Mutex
 	violationCount := 0
+	prev := 0
 	return func(op clientv3.Op, resp clientv3.OpResponse, prevRev int64) error {
-		if violationCount > len(c.Endpoints()) {
+		if prev != len(c.Endpoints()) {
+			prev = len(c.Endpoints())
+			violationCount = 0
+		}
+		if violationCount >= len(c.Endpoints()) {
 			return ErrNoGreaterRev
 		}
 		mu.Lock()


### PR DESCRIPTION
three changes

first:
`func (c *Client) Endpoints() (eps []string)` remove naked return

second:
Concurrent access is possible in`func (c *Client) Endpoints() (eps []string)`  , so mutex required.
https://github.com/etcd-io/etcd/blob/ebb559af59faa0421b617259afb90f8d9fa00cd6/clientv3/client.go#L164-L175

third:
`violationCount` should reset after endpoints changed.
