### PR TITLE
etcdmain: use same error.

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -287,7 +287,7 @@ func startEtcdOrProxyV2() {
 	case lerr := <-errc:
 		// fatal out on listener errors
 		if lg != nil {
-			lg.Fatal("listener failed", zap.Error(err))
+			lg.Fatal("listener failed", zap.Error(lerr))
 		} else {
 			plog.Fatal(lerr)
 		}


### PR DESCRIPTION
two log handers use different error info.

fixed it. use `err` instead of `lerr` which has no conflict with `err` before `select`.