### PR TITLE
add (python2.7 and python3.5+) Python client for etcd v3, using gRPC-…

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -54,6 +54,7 @@
 - [txaio-etcd](https://github.com/crossbario/txaio-etcd) - Asynchronous etcd v3-only client library for Twisted (today) and asyncio (future)
 - [dims/etcd3-gateway](https://github.com/dims/etcd3-gateway) - etcd v3 API library using the HTTP grpc gateway
 - [aioetcd3](https://github.com/gaopeiliang/aioetcd3) - (Python 3.6+) etcd v3 API for asyncio
+- [Revolution1/etcd3-py](https://github.com/Revolution1/etcd3-py) - (python2.7 and python3.5+) Python client for etcd v3, using gRPC-JSON-Gateway
 
 **Node libraries**
 


### PR DESCRIPTION
Here is a Python client for etcd v3.
https://github.com/Revolution1/etcd3-py


Python client for etcd v3 (Using gRPC-JSON-Gateway)

* Free software: Apache Software License 2.0
* Source Code: https://github.com/Revolution1/etcd3-py
* Documentation: https://etcd3-py.readthedocs.io.
* etcd version required: v3.2.2+

Notice: The authentication header through gRPC-JSON-Gateway only supported in [etcd v3.3.0+](https://github.com/coreos/etcd/pull/7999)

## Features

* [x] Support python2.7 and python3.5+
* [x] Sync client based on requests
* [x] Async client based on aiohttp
* [x] TLS Connection
* [x] support APIs
    * [x] Auth
    * [x] KV
    * [x] Watch
    * [x] Cluster
    * [x] Lease
    * [x] Lock
    * [x] Maintenance
    * [x] Extra APIs
* [x] stateful utilities
    * [x] Watch
    * [x] Lease
    * [x] Transaction
    * [x] Lock