### PR TITLE
wal: include logger in WAL returned by openAtIndex

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -311,6 +311,7 @@ func openAtIndex(lg *zap.Logger, dirpath string, snap walpb.Snapshot, write bool
 
 	// create a WAL ready for reading
 	w := &WAL{
+		lg:        lg,
 		dir:       dirpath,
 		start:     snap,
 		decoder:   newDecoder(rs...),


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

Fixed: logger is now included within the WAL struct that is returned by `openAtIndex`, thus ensuring that the logger passed to `Open` and `OpenForRead` is duly returned back, within the WAL.