### PR TITLE
clientv3/integration/leasing_test.go: Fix t.Fatalf error message

### DIFF
--- a/clientv3/balancer/picker/picker_policy.go
+++ b/clientv3/balancer/picker/picker_policy.go
@@ -31,7 +31,7 @@ const (
 	// TODO: only send loads to pinned address "RoundrobinFailover"
 	// just like how 3.3 client works
 	//
-	// TODO: priotize leader
+	// TODO: prioritize leader
 	// TODO: health-check
 	// TODO: weighted roundrobin
 	// TODO: power of two random choice

--- a/clientv3/integration/leasing_test.go
+++ b/clientv3/integration/leasing_test.go
@@ -310,7 +310,7 @@ func TestLeasingRevGet(t *testing.T) {
 		t.Fatal(gerr)
 	}
 	if len(getResp.Kvs) != 1 || string(getResp.Kvs[0].Value) != "abc" {
-		t.Fatalf(`expeted "k"->"abc" at rev=%d, got response %+v`, putResp.Header.Revision, getResp)
+		t.Fatalf(`expected "k"->"abc" at rev=%d, got response %+v`, putResp.Header.Revision, getResp)
 	}
 	// check current revision
 	getResp, gerr = lkv.Get(context.TODO(), "k")
@@ -318,7 +318,7 @@ func TestLeasingRevGet(t *testing.T) {
 		t.Fatal(gerr)
 	}
 	if len(getResp.Kvs) != 1 || string(getResp.Kvs[0].Value) != "def" {
-		t.Fatalf(`expeted "k"->"abc" at rev=%d, got response %+v`, putResp.Header.Revision, getResp)
+		t.Fatalf(`expected "k"->"abc" at rev=%d, got response %+v`, putResp.Header.Revision, getResp)
 	}
 }
 


### PR DESCRIPTION
1. "priotize" to "prioritize" in line 34.
2. "expeted" to "expected".