### PR TITLE
Documentation: Fix etcdHighNumberOfFailedGRPCRequests rules return NaN value

### DIFF
--- a/Documentation/etcd-mixin/mixin.libsonnet
+++ b/Documentation/etcd-mixin/mixin.libsonnet
@@ -51,9 +51,9 @@
             alert: 'etcdHighNumberOfFailedGRPCRequests',
             expr: |||
               100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-                /
-              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method)
-                > 1
+              / sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method) > 0
+              or sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method) > bool 0
+              > 1
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -67,9 +67,9 @@
             alert: 'etcdHighNumberOfFailedGRPCRequests',
             expr: |||
               100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-                /
-              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method)
-                > 5
+              / sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method) > 0
+              or sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method) > bool 0
+              > 5
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -151,8 +151,9 @@
           {
             alert: 'etcdHighNumberOfFailedHTTPRequests',
             expr: |||
-              sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{%(etcd_selector)s}[5m]))
-              BY (method) > 0.01
+              sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{%(etcd_selector)s}[5m])) BY (method)
+              or sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) > bool 0
+              > 0.01
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -165,8 +166,9 @@
           {
             alert: 'etcdHighNumberOfFailedHTTPRequests',
             expr: |||
-              sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{%(etcd_selector)s}[5m]))
-              BY (method) > 0.05
+              sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{%(etcd_selector)s}[5m])) BY (method)
+              or sum(rate(etcd_http_failed_total{%(etcd_selector)s, code!="404"}[5m])) BY (method) > bool 0
+              > 0.05
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/Documentation/op-guide/etcd3_alert.rules
+++ b/Documentation/op-guide/etcd3_alert.rules
@@ -44,7 +44,9 @@ ANNOTATIONS {
 # alert if more than 1% of gRPC method calls have failed within the last 5 minutes
 ALERT HighNumberOfFailedGRPCRequests
 IF 100 * (sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 1
+  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 0
+  or sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) > bool 0
+  > 1
 FOR 10m
 LABELS {
   severity = "warning"
@@ -57,7 +59,9 @@ ANNOTATIONS {
 # alert if more than 5% of gRPC method calls have failed within the last 5 minutes
 ALERT HighNumberOfFailedGRPCRequests
 IF 100 * (sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 5
+  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 0
+  or sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) > bool 0
+  > 5
 FOR 5m
 LABELS {
   severity = "critical"

--- a/Documentation/op-guide/etcd3_alert.rules.yml
+++ b/Documentation/op-guide/etcd3_alert.rules.yml
@@ -34,10 +34,10 @@ groups:
       message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
         $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
     expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        /
-      sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        > 1
+      sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+      / sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method) > 0
+      or sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method) > bool 0
+      > 1
     for: 10m
     labels:
       severity: warning
@@ -46,10 +46,10 @@ groups:
       message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
         $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
     expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        /
-      sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        > 5
+      sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+      / sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method) > 0
+      or sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method) > bool 0
+      > 5
     for: 5m
     labels:
       severity: critical
@@ -107,8 +107,9 @@ groups:
       message: '{{ $value }}% of requests for {{ $labels.method }} failed on etcd
         instance {{ $labels.instance }}'
     expr: |
-      sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m]))
-      BY (method) > 0.01
+      sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m])) BY (method) > 0 
+      or sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) > bool 0
+      > 0.01
     for: 10m
     labels:
       severity: warning
@@ -117,8 +118,9 @@ groups:
       message: '{{ $value }}% of requests for {{ $labels.method }} failed on etcd
         instance {{ $labels.instance }}.'
     expr: |
-      sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m]))
-      BY (method) > 0.05
+      sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job=~".*etcd.*"}[5m])) BY (method) > 0 
+      or sum(rate(etcd_http_failed_total{job=~".*etcd.*", code!="404"}[5m])) BY (method) > bool 0
+      > 0.05
     for: 10m
     labels:
       severity: critical


### PR DESCRIPTION
**what changed?**
Rules etcdHighNumberOfFailedGRPCRequests in [etcd3_alert.rules.yml](https://github.com/etcd-io/etcd/blob/c7c689452735a955d32126e3af8f3b18cbd9cf83/Documentation/op-guide/etcd3_alert.rules.yml#L36)

**why this change was made?**
The original rules will return NaN value of etcdHighNumberOfFailedGRPCRequests, but it should be a zero value. as image
![etcd_rule_org](https://user-images.githubusercontent.com/15335634/55942824-d1aab500-5c77-11e9-9818-7cebdd5489d5.png)
The denominator sometimes is zero，and return a NaN value of rules. Replace division with comparison, as image
![etcd_rule_fix](https://user-images.githubusercontent.com/15335634/55943183-ac6a7680-5c78-11e9-9de3-63addf28d773.jpg)
