### PR TITLE
travis: fix tests by using proper code path - release-3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,22 +42,22 @@ script:
       linux-amd64-integration)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='integration' ./test"
+          /bin/bash -c "cd /go/src/github.com/coreos/etcd; GOARCH=amd64 PASSES='integration' ./test"
         ;;
       linux-amd64-functional)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
+          /bin/bash -c "cd /go/src/github.com/coreos/etcd; ./build && GOARCH=amd64 PASSES='functional' ./test"
         ;;
       linux-amd64-unit)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
+          /bin/bash -c "cd /go/src/github.com/coreos/etcd; GOARCH=amd64 PASSES='unit' ./test"
         ;;
       all-build)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='build' ./test \
+          /bin/bash -c "cd /go/src/github.com/coreos/etcd; GOARCH=amd64 PASSES='build' ./test \
             && GOARCH=386 PASSES='build' ./test \
             && GO_BUILD_FLAGS='-v' GOOS=darwin GOARCH=amd64 ./build \
             && GO_BUILD_FLAGS='-v' GOOS=windows GOARCH=amd64 ./build \
@@ -68,6 +68,6 @@ script:
       linux-386-unit)
         docker run --rm \
           --volume=`pwd`:/go/src/github.com/coreos/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
+          /bin/bash -c "cd /go/src/github.com/coreos/etcd; GOARCH=386 PASSES='unit' ./test"
         ;;
     esac


### PR DESCRIPTION
Currently, Travis testing in release-3.3 is broken this PR resolves that. The test container has a different working directory to accommodate the new org. To eliminate this issue and keep it simple for generating new test containers the path is explicitly set for the etcd src.

https://github.com/etcd-io/etcd/blob/c7c689452735a955d32126e3af8f3b18cbd9cf83/tests/Dockerfile#L43