### PR TITLE
raft: add learner field to progress stringer

### DIFF
--- a/raft/progress.go
+++ b/raft/progress.go
@@ -185,7 +185,8 @@ func (pr *Progress) needSnapshotAbort() bool {
 }
 
 func (pr *Progress) String() string {
-	return fmt.Sprintf("next = %d, match = %d, state = %s, waiting = %v, pendingSnapshot = %d", pr.Next, pr.Match, pr.State, pr.IsPaused(), pr.PendingSnapshot)
+	return fmt.Sprintf("next = %d, match = %d, state = %s, waiting = %v, pendingSnapshot = %d, recentActive = %v, isLearner = %v",
+		pr.Next, pr.Match, pr.State, pr.IsPaused(), pr.PendingSnapshot, pr.RecentActive, pr.IsLearner)
 }
 
 type inflights struct {


### PR DESCRIPTION
Update the raft progress `String()` method to include `RecentActive` and `IsLearner` fields.