### PR TITLE
fix issue that metric db_compaction_total_duration_milliseconds is always 0

### DIFF
--- a/mvcc/kvstore_compaction.go
+++ b/mvcc/kvstore_compaction.go
@@ -23,7 +23,7 @@ import (
 
 func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struct{}) bool {
 	totalStart := time.Now()
-	defer dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
+	defer func() { dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond)) }()
 	keyCompactions := 0
 	defer func() { dbCompactionKeysCounter.Add(float64(keyCompactions)) }()
 


### PR DESCRIPTION
defer dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
Here, it will calculate `float64(time.Since(totalStart) / time.Millisecond)` when call defer directly and push into function stack, so the duration is quite small, less than 1 millisecond, so this value is always zero.
```
# HELP etcd_debugging_mvcc_db_compaction_total_duration_milliseconds Bucketed histogram of db compaction total duration.
# TYPE etcd_debugging_mvcc_db_compaction_total_duration_milliseconds histogram
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="100"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="200"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="400"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="800"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="1600"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="3200"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="6400"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="12800"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="25600"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="51200"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="102400"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="204800"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="409600"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="819200"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_bucket{le="+Inf"} 3564
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum 0
etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_count 3564
```