### PR TITLE
CHANGELOG: update changelogs for backport of PR #10646

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -14,6 +14,10 @@ The [minimum recommended etcd versions to run in **production**](https://groups.
 
 - [Strip out insecure endpoints from DNS SRV records when using discovery](https://github.com/etcd-io/etcd/pull/10443) with etcdctl v2
 
+### Metrics, Monitoring
+
+- Fix bug where [db_compaction_total_duration_milliseconds metric incorrectly measured duration as 0](https://github.com/etcd-io/etcd/pull/10646).
+
 <hr>
 
 ## [v3.1.20](https://github.com/etcd-io/etcd/releases/tag/v3.1.20) (2018-10-10)

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -15,6 +15,10 @@ The [minimum recommended etcd versions to run in **production**](https://groups.
 
 - [Strip out insecure endpoints from DNS SRV records when using discovery](https://github.com/etcd-io/etcd/pull/10443) with etcdctl v2
 
+### Metrics, Monitoring
+
+- Fix bug where [db_compaction_total_duration_milliseconds metric incorrectly measured duration as 0](https://github.com/etcd-io/etcd/pull/10646).
+
 <hr>
 
 

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -21,6 +21,9 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.11...v3.3.12) an
 
 - Compile with [*Go 1.10.8*](https://golang.org/doc/devel/release.html#go1.10).
 
+### Metrics, Monitoring
+
+- Fix bug where [db_compaction_total_duration_milliseconds metric incorrectly measured duration as 0](https://github.com/etcd-io/etcd/pull/10646).
 
 <hr>
 


### PR DESCRIPTION
This is just the changelog update for the PR # 10646 backports:

3.3 - #10656
3.2 - #10657
3.1 - #10658