### PR TITLE
proxy: make --cipher-suites take effect for the proxy

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -531,7 +531,7 @@ func (cfg *configYAML) configFromFile(path string) error {
 	return cfg.Validate()
 }
 
-func updateCipherSuites(tls *transport.TLSInfo, ss []string) error {
+func UpdateCipherSuites(tls *transport.TLSInfo, ss []string) error {
 	if len(tls.CipherSuites) > 0 && len(ss) > 0 {
 		return fmt.Errorf("TLSInfo.CipherSuites is already specified (given %v)", ss)
 	}
@@ -761,7 +761,7 @@ func (cfg *Config) ClientSelfCert() (err error) {
 	if err != nil {
 		return err
 	}
-	return updateCipherSuites(&cfg.ClientTLSInfo, cfg.CipherSuites)
+	return UpdateCipherSuites(&cfg.ClientTLSInfo, cfg.CipherSuites)
 }
 
 func (cfg *Config) PeerSelfCert() (err error) {
@@ -784,7 +784,7 @@ func (cfg *Config) PeerSelfCert() (err error) {
 	if err != nil {
 		return err
 	}
-	return updateCipherSuites(&cfg.PeerTLSInfo, cfg.CipherSuites)
+	return UpdateCipherSuites(&cfg.PeerTLSInfo, cfg.CipherSuites)
 }
 
 // UpdateDefaultClusterFromName updates cluster advertise URLs with, if available, default host,

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -448,7 +448,7 @@ func stopServers(ctx context.Context, ss *servers) {
 func (e *Etcd) Err() <-chan error { return e.errc }
 
 func configurePeerListeners(cfg *Config) (peers []*peerListener, err error) {
-	if err = updateCipherSuites(&cfg.PeerTLSInfo, cfg.CipherSuites); err != nil {
+	if err = UpdateCipherSuites(&cfg.PeerTLSInfo, cfg.CipherSuites); err != nil {
 		return nil, err
 	}
 	if err = cfg.PeerSelfCert(); err != nil {
@@ -585,7 +585,7 @@ func (e *Etcd) servePeers() (err error) {
 }
 
 func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err error) {
-	if err = updateCipherSuites(&cfg.ClientTLSInfo, cfg.CipherSuites); err != nil {
+	if err = UpdateCipherSuites(&cfg.ClientTLSInfo, cfg.CipherSuites); err != nil {
 		return nil, err
 	}
 	if err = cfg.ClientSelfCert(); err != nil {

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -527,6 +527,23 @@ func startProxy(cfg *config) error {
 		}
 	}
 
+	if len(cfg.ec.CipherSuites) == 0 {
+		if lg != nil {
+			lg.Info("proxy using default cipher suites")
+		} else {
+			plog.Info("proxy: using default cipher suites")
+		}
+	} else {
+		if lg != nil {
+			lg.Info("proxy using cipher suites:", zap.Strings("cipher-suites", cfg.ec.CipherSuites))
+		} else {
+			plog.Infof("proxy: using cipher suites: %v", cfg.ec.CipherSuites)
+		}
+		if err = embed.UpdateCipherSuites(&listenerTLS, cfg.ec.CipherSuites); err != nil {
+			return err
+		}
+	}
+
 	// Start a proxy server goroutine for each listen address
 	for _, u := range cfg.ec.LCUrls {
 		l, err := transport.NewListener(u.Host, u.Scheme, &listenerTLS)


### PR DESCRIPTION
This fixes https://github.com/etcd-io/etcd/issues/10659.

It'd be great if this could be back-applied to 3.3 as well as 3.4.