### PR TITLE
  raft: cleanup wal directory if creation fails

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -234,9 +234,9 @@ func (w *WAL) cleanupWAL(lg *zap.Logger) {
 	var err error
 	if err = w.Close(); err != nil {
 		if lg != nil {
-			lg.Panic("failed to closeup WAL during cleanup", zap.Error(err))
+			lg.Panic("failed to close WAL during cleanup", zap.Error(err))
 		} else {
-			plog.Panicf("failed to closeup WAL during cleanup: %v", err)
+			plog.Panicf("failed to close WAL during cleanup: %v", err)
 		}
 	}
 	brokenDirName := fmt.Sprintf("%s.broken.%v", w.dir, time.Now().Format("20060102.150405.999999"))


### PR DESCRIPTION
  delete <data-dir>/member/wal if any operation after the rename in
  wal.Create fails to avoid reading an inconsistent WAL on restart.

  Fixes #10688


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
