### PR TITLE
mvcc: protect tree clone with write lock

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -91,9 +91,9 @@ func (ti *treeIndex) keyIndex(keyi *keyIndex) *keyIndex {
 func (ti *treeIndex) visit(key, end []byte, f func(ki *keyIndex)) {
 	keyi, endi := &keyIndex{key: key}, &keyIndex{key: end}
 
-	ti.RLock()
+	ti.Lock()
 	clone := ti.tree.Clone()
-	ti.RUnlock()
+	ti.Unlock()
 
 	clone.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
 		if len(endi.key) > 0 && !item.Less(endi) {


### PR DESCRIPTION
Use write lock when cloning index tree.

Fixes #10697.

cc @xiang90
