### PR TITLE
lease: refactor lease's benchmark.

### DIFF
--- a/lease/lessor.go
+++ b/lease/lessor.go
@@ -924,3 +924,10 @@ func (fl *FakeLessor) ExpiredLeasesC() <-chan []*Lease { return nil }
 func (fl *FakeLessor) Recover(b backend.Backend, rd RangeDeleter) {}
 
 func (fl *FakeLessor) Stop() {}
+
+type FakeTxnDelete struct {
+	backend.BatchTx
+}
+
+func (ftd *FakeTxnDelete) DeleteRange(key, end []byte) (n, rev int64) { return 0, 0 }
+func (ftd *FakeTxnDelete) End()                                       { ftd.Unlock() }


### PR DESCRIPTION
Lease's benchmark were added when we optimize lease expiration check in  [#9418](https://github.com/etcd-io/etcd/pull/9418).

However, some problems exist.

- For `benchmarkLessorFindExpired`, lease's ttl  is always more than 100 second.
When call `findExpiredLeases`, we always only compare leaseHeap's first element ttl with current time and return immediately.

- Lessor is not primary, so `Renew` do nothing and `Grant` ignore ttl.

- We always call `Grant` with increasing ttl. `leaseHeap` degenerates into sorted array.

- Wrong use size. 
Such as BenchmarkLessorGrant1 and BenchmarkLessorGrant10000. Assume b.N  is 500000. For BenchmarkLessorGrant1, we call `Grant` 500001 times and observer last 500000 call. For BenchmarkLessorGrant10000, we call `Grant` 510000 times and observer last 500000 call. I don't think the results of these two tests will be too different.