### PR TITLE
pkg/transport: Add test for "deny incoming peer certs with wrong IP SAN"

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -89,7 +89,7 @@ func (info TLSInfo) Empty() bool {
 	return info.CertFile == "" && info.KeyFile == ""
 }
 
-func SelfCert(dirpath string, hosts []string) (info TLSInfo, err error) {
+func SelfCert(dirpath string, hosts []string, additionalUsages ...x509.ExtKeyUsage) (info TLSInfo, err error) {
 	if err = os.MkdirAll(dirpath, 0700); err != nil {
 		return
 	}
@@ -118,7 +118,7 @@ func SelfCert(dirpath string, hosts []string) (info TLSInfo, err error) {
 		NotAfter:     time.Now().Add(365 * (24 * time.Hour)),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           append([]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, additionalUsages...),
 		BasicConstraintsValid: true,
 	}
 


### PR DESCRIPTION
Thanks to @MartinWeindel who actually wrote the test  https://github.com/etcd-io/etcd/pull/10524. The PR #10524 is to add a flag so IP checking for incoming peer certs can be skipped if wanted, and @MartinWeindel found out that there was no test added at first place for the implementation of #7687. So all I did here is just to add the test to 3.2 when this feature was introduced. 