### PR TITLE
README: update handling of security vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,7 @@ See [reporting bugs](Documentation/reporting_bugs.md) for details about reportin
 
 ## Reporting a security vulnerability
 
-Due to their public nature, GitHub and mailing lists are NOT appropriate places for reporting vulnerabilities. Please refer to CoreOS's [security disclosure][disclosure] process when reporting issues that may be security related.
-
-[disclosure]: https://coreos.com/security/disclosure/
+A security vulnerability can be reported as an issue, however, GitHub and mailing lists may NOT always be an appropriate place for reporting vulnerabilities. In that case, please reach out to the project [MAINTAINERS](https://github.com/etcd-io/etcd/blob/master/MAINTAINERS) to first discuss the vulnerabilities with them and take necessary action per such discussion.
 
 ### License
 


### PR DESCRIPTION
We may not want to suggest to contact CoreOS now. We could remove this
section but consiering the nature of the subject, discussion with the project
maintainers probably a good idea if someone doesn't find it comfortable
to report an issue right away.


