### PR TITLE
*: fix broken import paths in proto files

### DIFF
--- a/Documentation/dev-guide/api_concurrency_reference_v3.md
+++ b/Documentation/dev-guide/api_concurrency_reference_v3.md
@@ -1,6 +1,4 @@
----
-title: etcd concurrency API Reference
----
+### etcd concurrency API Reference
 
 
 This is a generated documentation. Please read the proto files for more.

--- a/Documentation/dev-guide/api_reference_v3.md
+++ b/Documentation/dev-guide/api_reference_v3.md
@@ -1,6 +1,4 @@
----
-title: etcd API Reference
----
+### etcd API Reference
 
 
 This is a generated documentation. Please read the proto files for more.

--- a/etcdserver/api/v3election/v3electionpb/gw/v3election.pb.gw.go
+++ b/etcdserver/api/v3election/v3electionpb/gw/v3election.pb.gw.go
@@ -9,7 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/api/v3election/v3electionpb"
+	"go.etcd.io/etcd/etcdserver/api/v3election/v3electionpb"
 	"io"
 	"net/http"
 

--- a/etcdserver/api/v3election/v3electionpb/v3election.pb.go
+++ b/etcdserver/api/v3election/v3electionpb/v3election.pb.go
@@ -29,9 +29,9 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 
-	etcdserverpb "go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+	etcdserverpb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 
-	mvccpb "go.etcd.io/etcd/v3/mvcc/mvccpb"
+	mvccpb "go.etcd.io/etcd/mvcc/mvccpb"
 
 	context "golang.org/x/net/context"
 

--- a/etcdserver/api/v3election/v3electionpb/v3election.proto
+++ b/etcdserver/api/v3election/v3electionpb/v3election.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package v3electionpb;
 
 import "gogoproto/gogo.proto";
-import "etcd/v3/etcdserver/etcdserverpb/rpc.proto";
-import "etcd/v3/mvcc/mvccpb/kv.proto";
+import "etcd/etcdserver/etcdserverpb/rpc.proto";
+import "etcd/mvcc/mvccpb/kv.proto";
 
 // for grpc-gateway
 import "google/api/annotations.proto";

--- a/etcdserver/api/v3lock/v3lockpb/gw/v3lock.pb.gw.go
+++ b/etcdserver/api/v3lock/v3lockpb/gw/v3lock.pb.gw.go
@@ -9,7 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/api/v3lock/v3lockpb"
+	"go.etcd.io/etcd/etcdserver/api/v3lock/v3lockpb"
 	"io"
 	"net/http"
 

--- a/etcdserver/api/v3lock/v3lockpb/v3lock.pb.go
+++ b/etcdserver/api/v3lock/v3lockpb/v3lock.pb.go
@@ -24,7 +24,7 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 
-	etcdserverpb "go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+	etcdserverpb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 
 	context "golang.org/x/net/context"
 

--- a/etcdserver/api/v3lock/v3lockpb/v3lock.proto
+++ b/etcdserver/api/v3lock/v3lockpb/v3lock.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package v3lockpb;
 
 import "gogoproto/gogo.proto";
-import "etcd/v3/etcdserver/etcdserverpb/rpc.proto";
+import "etcd/etcdserver/etcdserverpb/rpc.proto";
 
 // for grpc-gateway
 import "google/api/annotations.proto";

--- a/etcdserver/etcdserverpb/gw/rpc.pb.gw.go
+++ b/etcdserver/etcdserverpb/gw/rpc.pb.gw.go
@@ -9,7 +9,7 @@ It translates gRPC into RESTful JSON APIs.
 package gw
 
 import (
-	"go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"io"
 	"net/http"
 

--- a/etcdserver/etcdserverpb/rpc.pb.go
+++ b/etcdserver/etcdserverpb/rpc.pb.go
@@ -12,9 +12,9 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 
-	mvccpb "go.etcd.io/etcd/v3/mvcc/mvccpb"
+	mvccpb "go.etcd.io/etcd/mvcc/mvccpb"
 
-	authpb "go.etcd.io/etcd/v3/auth/authpb"
+	authpb "go.etcd.io/etcd/auth/authpb"
 
 	context "golang.org/x/net/context"
 

--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package etcdserverpb;
 
 import "gogoproto/gogo.proto";
-import "etcd/v3/mvcc/mvccpb/kv.proto";
-import "etcd/v3/auth/authpb/auth.proto";
+import "etcd/mvcc/mvccpb/kv.proto";
+import "etcd/auth/authpb/auth.proto";
 
 // for grpc-gateway
 import "google/api/annotations.proto";

--- a/lease/leasepb/lease.pb.go
+++ b/lease/leasepb/lease.pb.go
@@ -23,7 +23,7 @@ import (
 
 	_ "github.com/gogo/protobuf/gogoproto"
 
-	etcdserverpb "go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+	etcdserverpb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 
 	io "io"
 )

--- a/lease/leasepb/lease.proto
+++ b/lease/leasepb/lease.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package leasepb;
 
 import "gogoproto/gogo.proto";
-import "etcd/v3/etcdserver/etcdserverpb/rpc.proto";
+import "etcd/etcdserver/etcdserverpb/rpc.proto";
 
 option (gogoproto.marshaler_all) = true;
 option (gogoproto.sizer_all) = true;


### PR DESCRIPTION
It seems that 9150bf52d6 of https://github.com/etcd-io/etcd/pull/10640
broke import paths of proto files. Because of this scripts/genproto.sh
causes errors on the latest master branch. This commit fixes the
broken paths.
