### PR TITLE
Doc: Update basic usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This will bring up etcd listening on port 2379 for client communication and on p
 Next, let's set a single key, and then retrieve it:
 
 ```
-etcdctl put mykey "this is awesome"
+etcdctl mk mykey "this is awesome"
 etcdctl get mykey
 ```
 


### PR DESCRIPTION
Because of there is no put command in the latest etcdctl.It is better replace the put command with mk for starters to use.