### PR TITLE
MAINTAINERS: remove fanmin shi

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,7 +8,6 @@
 
 Anthony Romano <romanoanthony061@gmail.com> (@heyitsanthony) pkg:*
 Brandon Philips <bphilips@redhat.com> (@philips) pkg:*
-Fanmin Shi <fashi@redhat.com> (@fanminshi) pkg:*
 Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*


### PR DESCRIPTION
I no longer have the time to maintain etcd as my career takes me to a different direction; Hence, I think it is appropriate to remove myself from the maintainer responsibility.

Working on etcd project was one of the most challenging and rewarding experiences I ever had. Thanks @xiang90 @gyuho @heyitsanthony @philips
