### PR TITLE
fix #10754

### DIFF
--- a/clientv3/retry_interceptor.go
+++ b/clientv3/retry_interceptor.go
@@ -79,7 +79,7 @@ func (c *Client) unaryClientInterceptor(logger *zap.Logger, optFuncs ...retryOpt
 						zap.String("target", cc.Target()),
 						zap.Error(gterr),
 					)
-					return lastErr // return the original error for simplicity
+					return gterr // lastErr must be invalid auth token
 				}
 				continue
 			}


### PR DESCRIPTION
clientv3: return getToken error when retryAuth

return `get token error` instead of the `lastErr`, since `lastErr` is always "invalid auth token"

Fixes #10754
