### PR TITLE
[WIP]Set GOPROXY to GoCenter to ensure reproducible and faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ notifications:
 env:
   global:
   - GO111MODULE=on
+  - GOPROXY=https://gocenter.io
   matrix:
   - TARGET=linux-amd64-fmt
   - TARGET=linux-amd64-integration-1-cpu
@@ -75,37 +76,37 @@ script:
  - >
     case "${TARGET}" in
       linux-amd64-fmt)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 PASSES='fmt bom dep' ./test"
         ;;
       linux-amd64-integration-1-cpu)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 CPU=1 PASSES='integration' ./test"
         ;;
       linux-amd64-integration-2-cpu)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 CPU=2 PASSES='integration' ./test"
         ;;
       linux-amd64-integration-4-cpu)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 CPU=4 PASSES='integration' ./test"
         ;;
       linux-amd64-functional)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "./build && GOARCH=amd64 PASSES='functional' ./test"
         ;;
       linux-amd64-unit)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 PASSES='unit' ./test"
         ;;
       all-build)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=amd64 PASSES='build' ./test \
             && GOARCH=386 PASSES='build' ./test \
@@ -125,7 +126,7 @@ script:
         GOARCH=amd64 PASSES='fmt unit' ./test
         ;;
       linux-386-unit)
-        docker run --rm -e GO111MODULE \
+        docker run --rm -e GO111MODULE -e GOPROXY \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
           /bin/bash -c "GOARCH=386 PASSES='unit' ./test"
         ;;


### PR DESCRIPTION
Availability and immutability of go module dependencies are critical, especially since a lot of 'go get' are performed at various containerized build steps of etcd. Pointing GOPROXY to GoCenter will ensure availability and immutability of these modules even if they go private. It also ensures faster builds.
