### PR TITLE
Doc: remove word you

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Due to their public nature, GitHub and mailing lists are NOT appropriate places 
 
 ## etcd Emeritus Maintainers
 
-These emeritus maintainers dedicated a part of their career to etcd and reviewed code, triaged bugs, and pushed the project forward over a substantial period of time. Thank you.
+These emeritus maintainers dedicated a part of their career to etcd and reviewed code, triaged bugs, and pushed the project forward over a substantial period of time. Their contribution is greatly appreciated.
 
 * Fanmin Shi 
 


### PR DESCRIPTION
`markdown_you` CI test fails due to the appearance of word 'you' in documents.

Ref: https://travis-ci.com/etcd-io/etcd/jobs/202993572#L560

cc @philips 
