### PR TITLE
update doc demo command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This will bring up etcd listening on port 2379 for client communication and on p
 Next, let's set a single key, and then retrieve it:
 
 ```
-etcdctl put mykey "this is awesome"
+etcdctl set mykey "this is awesome"
 etcdctl get mykey
 ```
 


### PR DESCRIPTION
run env
```
[root@localhost ~]# etcdctl --version
etcdctl version: 3.3.13
API version: 2
```

when i run command from doc
```
[root@localhost ~]# etcdctl put mykey "this is awesome"
No help topic for 'put'
```

so i see the help info
```
[root@localhost ~]# etcdctl -h
NAME:
   etcdctl - A simple command line client for etcd.

WARNING:
   Environment variable ETCDCTL_API is not set; defaults to etcdctl v2.
   Set environment variable ETCDCTL_API=3 to use v3 API or ETCDCTL_API=2 to use v2 API.

USAGE:
   etcdctl [global options] command [command options] [arguments...]

VERSION:
   3.3.13

COMMANDS:
     backup          backup an etcd directory
     cluster-health  check the health of the etcd cluster
     mk              make a new key with a given value
     mkdir           make a new directory
     rm              remove a key or a directory
     rmdir           removes the key if it is an empty directory or a key-value pair
     get             retrieve the value of a key
     ls              retrieve a directory
     set             set the value of a key
     setdir          create a new directory or update an existing directory TTL
     update          update an existing key with a given value
     updatedir       update an existing directory
     watch           watch a key for changes
     exec-watch      watch a key for changes and exec an executable
     member          member add, remove and list subcommands
     user            user add, grant and revoke subcommands
     role            role add, grant and revoke subcommands
     auth            overall auth controls
     help, h         Shows a list of commands or help for one command
```

there is not `put` command，So I think it needs to be modified here.
