### PR TITLE
doc: clarify etcdctl default API version

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -3,7 +3,9 @@ etcdctl
 
 `etcdctl` is a command line client for [etcd][etcd].
 
-The v3 API is used by default. For the v2 API, make sure to set environment variable `ETCDCTL_API=2`. See also [READMEv2][READMEv2].
+The v3 API is used by default on master branch. For the v2 API, make sure to set environment variable `ETCDCTL_API=2`. See also [READMEv2][READMEv2].
+
+If using released versions earlier than v3.4, set `ETCDCTL_API=3` to use v3 API.
 
 Global flags (e.g., `dial-timeout`, `--cacert`, `--cert`, `--key`) can be set with environment variables:
 


### PR DESCRIPTION
Add clarification in etcdctl doc. If using released versions earlier than 3.4, `ETCDCTL_API=3` is needed in order to use v3 API.

This is causing user confusion. Examples: #10740, #10768.