### PR TITLE
mvcc: revert change made by #10526 and #10699

### DIFF
--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -91,11 +91,10 @@ func (ti *treeIndex) keyIndex(keyi *keyIndex) *keyIndex {
 func (ti *treeIndex) visit(key, end []byte, f func(ki *keyIndex)) {
 	keyi, endi := &keyIndex{key: key}, &keyIndex{key: end}
 
-	ti.Lock()
-	clone := ti.tree.Clone()
-	ti.Unlock()
+	ti.RLock()
+	defer ti.RUnlock()
 
-	clone.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
+	ti.tree.AscendGreaterOrEqual(keyi, func(item btree.Item) bool {
 		if len(endi.key) > 0 && !item.Less(endi) {
 			return false
 		}


### PR DESCRIPTION
Revert #10526 and its followup #10699. To fix data race in the following tests:

- TestLeasingDeleteRangeContendTxn
- TestBarrierSingleNode
- TestBarrierMultiNode

`&keyIndex{}` is not deep copied in `tree.Clone()`.
https://github.com/etcd-io/etcd/blob/e1ca3b4434945e57e8e3a451cdbde74a903cc8e1/mvcc/index.go#L94-L96
