### PR TITLE
CHANGELOG-3.3: add sigs.k8s.io yaml dependency

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -37,6 +37,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 ### Dependency
 
 - Migrate [`github.com/ugorji/go/codec`](https://github.com/ugorji/go/releases) to [**`github.com/json-iterator/go`**](https://github.com/json-iterator/go) (See [#10667](https://github.com/etcd-io/etcd/pull/10667) for more).
+- Migrate [`github.com/ghodss/yaml`](https://github.com/ghodss/yaml/releases) to [**`sigs.k8s.io/yaml`**](https://github.com/kubernetes-sigs/yaml) (See [#10718](https://github.com/etcd-io/etcd/pull/10718) for more).
 
 ### Go
 


### PR DESCRIPTION
Added the sigs.k8s.io/yaml dependency update in the changelog for release-3.3 : 

The original request came from @gyuho : 

_Originally posted by @gyuho in https://github.com/etcd-io/etcd/pull/10718#issuecomment-497101964_