### PR TITLE
Automated cherry pick of #10788 on release-3.3

### DIFF
--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -147,7 +147,7 @@ func (s *simplePrinter) EndpointHealth(hs []epHealth) {
 		if h.Error == "" {
 			fmt.Fprintf(os.Stderr, "%s is healthy: successfully committed proposal: took = %v\n", h.Ep, h.Took)
 		} else {
-			fmt.Fprintf(os.Stderr, "%s is unhealthy: failed to commit proposal: %v", h.Ep, h.Error)
+			fmt.Fprintf(os.Stderr, "%s is unhealthy: failed to commit proposal: %v\n", h.Ep, h.Error)
 		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #10788 on release-3.3.

#10788: ctlv3: add missing newline in EndpointHealth