### PR TITLE
removed checks that keep giving false positives.

### DIFF
--- a/Documentation/etcd-mixin/mixin.libsonnet
+++ b/Documentation/etcd-mixin/mixin.libsonnet
@@ -48,38 +48,6 @@
             },
           },
           {
-            alert: 'etcdHighNumberOfFailedGRPCRequests',
-            expr: |||
-              100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-                /
-              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method)
-                > 1
-            ||| % $._config,
-            'for': '10m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.',
-            },
-          },
-          {
-            alert: 'etcdHighNumberOfFailedGRPCRequests',
-            expr: |||
-              100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-                /
-              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) BY (job, instance, grpc_service, grpc_method)
-                > 5
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
-              message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.',
-            },
-          },
-          {
             alert: 'etcdGRPCRequestsSlow',
             expr: |||
               histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{%(etcd_selector)s, grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))

--- a/Documentation/op-guide/etcd3_alert.rules
+++ b/Documentation/op-guide/etcd3_alert.rules
@@ -41,32 +41,6 @@ ANNOTATIONS {
 # gRPC request alerts
 # ===================
 
-# alert if more than 1% of gRPC method calls have failed within the last 5 minutes
-ALERT HighNumberOfFailedGRPCRequests
-IF 100 * (sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 1
-FOR 10m
-LABELS {
-  severity = "warning"
-}
-ANNOTATIONS {
-  summary = "a high number of gRPC requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
-}
-
-# alert if more than 5% of gRPC method calls have failed within the last 5 minutes
-ALERT HighNumberOfFailedGRPCRequests
-IF 100 * (sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="etcd"}[5m]))
-  / sum by(grpc_method) (rate(etcd_grpc_total{job="etcd"}[5m]))) > 5
-FOR 5m
-LABELS {
-  severity = "critical"
-}
-ANNOTATIONS {
-  summary = "a high number of gRPC requests are failing",
-  description = "{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}",
-}
-
 # alert if the 99th percentile of gRPC method calls take more than 150ms
 ALERT GRPCRequestsSlow
 IF histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd",grpc_type="unary"}[5m])) by (grpc_service, grpc_method, le)) > 0.15

--- a/Documentation/op-guide/etcd3_alert.rules.yml
+++ b/Documentation/op-guide/etcd3_alert.rules.yml
@@ -29,30 +29,6 @@ groups:
     for: 15m
     labels:
       severity: warning
-  - alert: etcdHighNumberOfFailedGRPCRequests
-    annotations:
-      message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
-        $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
-    expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        /
-      sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        > 1
-    for: 10m
-    labels:
-      severity: warning
-  - alert: etcdHighNumberOfFailedGRPCRequests
-    annotations:
-      message: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{
-        $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.'
-    expr: |
-      100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        /
-      sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
-        > 5
-    for: 5m
-    labels:
-      severity: critical
   - alert: etcdGRPCRequestsSlow
     annotations:
       message: 'etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method


### PR DESCRIPTION
The purpose of this PR is to remove rules which are known to cause false positives. These rules are propagated to tools like the prometheus-operator which have tools like alertmanager which will continuously emit alerts even when the etcd cluster is in a healthy state with no rpc errors. 

I suggest that when the underlying issues are found, we can add them here again, however, at the moment these have to be manually removed.  