### PR TITLE
Add @jingyih to MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,6 +9,7 @@
 Brandon Philips <bphilips@redhat.com> (@philips) pkg:*
 Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
+Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*
 Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
 Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*


### PR DESCRIPTION
@jingyih has become increasingly involved in etcd over the last year, the most notable being his recent contributions to the implementation of the Learner feature in 3.4. Equally important is his daily activity reviewing PRs and issues, his bug fixes and backports to ensure etcd is stable and operable, and his contributions to performance enhancements efforts like the fully concurrent reads.