### PR TITLE
Dockerfile: Rebase etcd image to debian

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM k8s.gcr.io/debian-base:v1.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:16.04
+FROM k8s.gcr.io/debian-base-arm64:v1.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/alpine:latest
+FROM k8s.gcr.io/debian-base-ppc64le:v1.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
To improve security and maintenance effort for etcd releases, it would 
be ideal to rebase etcd base image from Alpine to Distroless. However, 
note that distroless images by default do not contain a shell, etcd still has
shell scripts in https://github.com/etcd-io/etcd/tree/master/hack, I will
first rebase to Debian in v3.4.

This work is still in progress, open now to unveil any unexpected errors 
from testing.

Fixes #10804 

/cc @yuwenma