### PR TITLE
Remove type network interface unused from raft/rafttest/network.go:34…

### DIFF
--- a/raft/rafttest/network.go
+++ b/raft/rafttest/network.go
@@ -30,19 +30,6 @@ type iface interface {
 	connect()
 }
 
-// a network
-type network interface {
-	// drop message at given rate (1.0 drops all messages)
-	drop(from, to uint64, rate float64)
-	// delay message for (0, d] randomly at given rate (1.0 delay all messages)
-	// do we need rate here?
-	delay(from, to uint64, d time.Duration, rate float64)
-	disconnect(id uint64)
-	connect(id uint64)
-	// heal heals the network
-	heal()
-}
-
 type raftNetwork struct {
 	mu           sync.Mutex
 	disconnected map[uint64]bool


### PR DESCRIPTION
…:6 (deadcode) https://github.com/etcd-io/etcd/issues/10836


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
