### PR TITLE
Documentation: change `etcdctl role remove` to `etcdctl role delete`

### DIFF
--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -119,7 +119,7 @@ $ etcdctl role revoke-permission myrolename /foo/bar
 As is removing a role entirely:
 
 ```
-$ etcdctl role remove myrolename
+$ etcdctl role delete myrolename
 ```
 
 ## Enabling authentication


### PR DESCRIPTION
This is a document error. With running `etcdctl role --help`, we can find that it should be delete, not remove.

Fixes #10849


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
