### PR TITLE
raft: improve commentary on Ready

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -96,7 +96,7 @@ type Ready struct {
 	// TODO(tbg): rearrange these fields in an order reflecting the lists above.
 
 	// Information about the node that is not persisted. This may be nil when
-	// nothing change from the previously emitted SoftState.
+	// there is no change from the most recently emitted SoftState.
 	*SoftState
 
 	// The updated state of the Node to be persisted. If zero, there is no

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -387,6 +387,8 @@ func newRaft(c *Config) *raft {
 
 func (r *raft) hasLeader() bool { return r.lead != None }
 
+// TODO(tbg): it's silly that this allocates. Plenty of callers have this in the
+// hot path to check whether SoftState changes, which it barely ever does.
 func (r *raft) softState() *SoftState { return &SoftState{Lead: r.lead, RaftState: r.state} }
 
 func (r *raft) hardState() pb.HardState {


### PR DESCRIPTION
The correct way to handle a Ready was elusive and comes with a surprising
amount of pitfalls. There are also certain optimizations that need
justification and were previously not documented.

Fix both.