### PR TITLE
raft: centralize configuration change application

### DIFF
--- a/raft/quorum/joint.go
+++ b/raft/quorum/joint.go
@@ -18,6 +18,13 @@ package quorum
 // majority configurations. Decisions require the support of both majorities.
 type JointConfig [2]MajorityConfig
 
+func (c JointConfig) String() string {
+	if len(c[1]) > 0 {
+		return c[0].String() + "&&" + c[1].String()
+	}
+	return c[0].String()
+}
+
 // IDs returns a newly initialized map representing the set of voters present
 // in the joint configuration.
 func (c JointConfig) IDs() map[uint64]struct{} {

--- a/raft/quorum/majority.go
+++ b/raft/quorum/majority.go
@@ -24,6 +24,24 @@ import (
 // MajorityConfig is a set of IDs that uses majority quorums to make decisions.
 type MajorityConfig map[uint64]struct{}
 
+func (c MajorityConfig) String() string {
+	sl := make([]uint64, 0, len(c))
+	for id := range c {
+		sl = append(sl, id)
+	}
+	sort.Slice(sl, func(i, j int) bool { return sl[i] < sl[j] })
+	var buf strings.Builder
+	buf.WriteByte('(')
+	for i := range sl {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, sl[i])
+	}
+	buf.WriteByte(')')
+	return buf.String()
+}
+
 // Describe returns a (multi-line) representation of the commit indexes for the
 // given lookuper.
 func (c MajorityConfig) Describe(l AckedIndexer) string {

--- a/raft/quorum/quorum.go
+++ b/raft/quorum/quorum.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 )
 
+// Index is a Raft log position.
 type Index uint64
 
 func (i Index) String() string {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1461,6 +1461,7 @@ func (r *raft) applyConfChange(cc pb.ConfChange) pb.ConfState {
 		}
 	}
 
+	r.logger.Infof("%x switched to configuration %s", r.id, r.prs.Config)
 	// Now that the configuration is updated, handle any side effects.
 
 	cs := pb.ConfState{Nodes: r.prs.VoterNodes(), Learners: r.prs.LearnerNodes()}


### PR DESCRIPTION
Put all the logic related to applying a configuration change in one
place in preparation for adding joint consensus.

This inspired various TODOs.

I had to rewrite TestSnapshotSucceedViaAppResp since it was relying
on a snapshot applied to the leader, which is now prevented.