### PR TITLE
clientv3: Fixed a missing block bug

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -384,6 +384,7 @@ func (w *watcher) RequestProgress(ctx context.Context) (err error) {
 
 	w.mu.Lock()
 	if w.streams == nil {
+		w.mu.Unlock()
 		return fmt.Errorf("no stream found for context")
 	}
 	wgs := w.streams[ctxKey]


### PR DESCRIPTION
Description: `w.mu` is locked at line 385 and unlocked at line 396. Among 5 return statements in this function, `w.mu` is unlocked before 4 return statements, but not unlocked before 1 return statement at line 387.
Fix: Add `w.mu.Unlock()` before that return at line 387.

Fixs [https://github.com/etcd-io/etcd/issues/10863](url)
