### PR TITLE
contrib/raftexample: to be compatible with the container environment.

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -460,7 +460,8 @@ func (rc *raftNode) serveRaft() {
 		log.Fatalf("raftexample: Failed parsing URL (%v)", err)
 	}
 
-	ln, err := newStoppableListener(url.Host, rc.httpstopc)
+	addr := fmt.Sprintf(":%s", url.Port())
+	ln, err := newStoppableListener(addr, rc.httpstopc)
 	if err != nil {
 		log.Fatalf("raftexample: Failed to listen rafthttp (%v)", err)
 	}


### PR DESCRIPTION
To be compatible with the container environment.

There is a limitation to using the cluster parameter directly：When running in cluster mode, if the cluster parameter USES the service name (k8s service), the listener will fail. As an example, direct listening :port should also work.