### PR TITLE
etcdserver: use defer+unlock to avoid potential race

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1210,6 +1210,7 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	// on the backend are finished.
 	// We do not want to wait on closing the old backend.
 	s.bemu.Lock()
+	defer s.bemu.Unlock()
 	oldbe := s.be
 	go func() {
 		if lg != nil {
@@ -1234,7 +1235,6 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	}()
 
 	s.be = newbe
-	s.bemu.Unlock()
 
 	if lg != nil {
 		lg.Info("restoring alarm store")

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1210,7 +1210,6 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	// on the backend are finished.
 	// We do not want to wait on closing the old backend.
 	s.bemu.Lock()
-	defer s.bemu.Unlock()
 	oldbe := s.be
 	go func() {
 		if lg != nil {
@@ -1235,6 +1234,7 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	}()
 
 	s.be = newbe
+	s.bemu.Unlock()
 
 	if lg != nil {
 		lg.Info("restoring alarm store")
@@ -1291,7 +1291,7 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 		plog.Info("finished recovering store v2")
 	}
 
-	s.cluster.SetBackend(s.be)
+	s.cluster.SetBackend(newbe)
 
 	if lg != nil {
 		lg.Info("restoring cluster configuration")


### PR DESCRIPTION
In etcdserver/server.go, `s.be` is always protected by `s.bemu`, except one read operation to it at line 1294 that is not in critical section.

Before this commit:
```Go
// line 1112 to 1294:
func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
	...//some irrelevant code

	s.bemu.Lock()
	oldbe := s.be
	go func() {
	...//some code to close oldbe
	}()
	s.be = newbe
	s.bemu.Unlock()

	...//some code to handle error

	s.cluster.SetBackend(s.be)

	...//some irrelevant code
}
```
This commit changed the position of `s.bemu.Unlock()` and put a `defer` before it, so now `s.cluster.SetBackend(s.be)` is also covered in critical section.

Using `defer` is cumbersome, but I think it will be fine because `s.bemu` is only used twice in the whole etcd project. Besides, it is safer to use `defer` since this function has many branches that can panic.

Fixes #10871 