### PR TITLE
etcdserver: modify a read operation to avoid potential race

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1291,7 +1291,7 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 		plog.Info("finished recovering store v2")
 	}
 
-	s.cluster.SetBackend(s.be)
+	s.cluster.SetBackend(newbe)
 
 	if lg != nil {
 		lg.Info("restoring cluster configuration")


### PR DESCRIPTION
In etcdserver/server.go, s.be is always protected by s.bemu, except one read operation to it at line 1294 that is not in critical section.

Before this commit:
```Go
// line 1112 to 1294:
func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
	...//some irrelevant code

	s.bemu.Lock()
	oldbe := s.be
	go func() {
	...//some code to close oldbe
	}()
	s.be = newbe
	s.bemu.Unlock()

	...//some code to handle error

	s.cluster.SetBackend(s.be)

	...//some irrelevant code
}
```
This commit changes `s.cluster.SetBackend(s.be)` into `s.cluster.SetBackend(newbe)`, so all read operations to s.be are in critical section.

Fix #10871 