### PR TITLE
raft: optimize string representation of Progress

### DIFF
--- a/raft/tracker/progress_test.go
+++ b/raft/tracker/progress_test.go
@@ -18,6 +18,25 @@ import (
 	"testing"
 )
 
+func TestProgressString(t *testing.T) {
+	ins := NewInflights(1)
+	ins.Add(123)
+	pr := &Progress{
+		Match:           1,
+		Next:            2,
+		State:           StateSnapshot,
+		PendingSnapshot: 123,
+		RecentActive:    false,
+		ProbeSent:       true,
+		IsLearner:       true,
+		Inflights:       ins,
+	}
+	const exp = `StateSnapshot match=1 next=2 learner paused pendingSnap=123 inactive inflight=1[full]`
+	if act := pr.String(); act != exp {
+		t.Errorf("exp: %s\nact: %s", exp, act)
+	}
+}
+
 func TestProgressIsPaused(t *testing.T) {
 	tests := []struct {
 		state  StateType


### PR DESCRIPTION
Make it less verbose by omitting the values for the steady state.
Also rearrange the order so that information that is typically more
relevant is printed first.