### PR TITLE
raft: never remove the last voter

### DIFF
--- a/raft/tracker/tracker.go
+++ b/raft/tracker/tracker.go
@@ -157,6 +157,11 @@ func (p *ProgressTracker) RemoveAny(id uint64) {
 		panic(fmt.Sprintf("peer %x is both voter and learner", id))
 	}
 
+	if okV1 && len(p.Voters[0]) == 1 {
+		// Never remove the last voter.
+		return
+	}
+
 	delete(p.Voters[0], id)
 	delete(p.Voters[1], id)
 	delete(p.Learners, id)


### PR DESCRIPTION
Before this change, it was possible for a Raft group to apply a
configuration change that removes the last voter. Such a group
is stuck and it's unclear that this operation is ever useful.
On the flip side, it makes an awkward edge case to allow, one
that will be more awkward in the context of joint consensus.

Remove it and thereby reduce the mental overhead of reasoning
about configuration changes.

@xiang90 do you know of any reason to keep this functionality around?