### PR TITLE
raft: internally support joint consensus

### DIFF
--- a/raft/confchange/confchange.go
+++ b/raft/confchange/confchange.go
@@ -1,0 +1,420 @@
+// Copyright 2019 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confchange
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.etcd.io/etcd/raft/quorum"
+	pb "go.etcd.io/etcd/raft/raftpb"
+	"go.etcd.io/etcd/raft/tracker"
+)
+
+// Changer facilitates configuration changes. It exposes methods to handle
+// simple and joint consensus while performing the proper validation that allows
+// refusing invalid configuration changes before they affect the active
+// configuration.
+type Changer struct {
+	Tracker   tracker.ProgressTracker
+	LastIndex uint64
+}
+
+// EnterJoint verifies that the outgoing (=right) majority config of the joint
+// config is empty and initializes it with a copy of the incoming (=left)
+// majority config. That is, it transitions from
+//
+//     (1 2 3)&&()
+// to
+//     (1 2 3)&&(1 2 3).
+//
+// The supplied ConfChanges are then applied to the incoming majority config,
+// resulting in a joint configuration that in terms of the Raft thesis[1]
+// (Section 4.3) corresponds to `C_{new,old}`.
+//
+// [1]: https://github.com/ongardie/dissertation/blob/master/online-trim.pdf
+func (c Changer) EnterJoint(ccs ...pb.ConfChange) (tracker.Config, tracker.ProgressMap, error) {
+	cfg, prs, err := c.checkAndCopy()
+	if err != nil {
+		return c.err(err)
+	}
+	if joint(cfg) {
+		err := errors.New("config is already joint")
+		return c.err(err)
+	}
+	if len(incoming(cfg.Voters)) == 0 {
+		// We allow adding nodes to an empty config for convenience (testing and
+		// bootstrap), but you can't enter a joint state.
+		err := errors.New("can't make a zero-voter config joint")
+		return c.err(err)
+	}
+	// Clear the outgoing config.
+	{
+		*outgoingPtr(&cfg.Voters) = quorum.MajorityConfig{}
+
+	}
+	// Copy incoming to outgoing.
+	for id := range incoming(cfg.Voters) {
+		outgoing(cfg.Voters)[id] = struct{}{}
+	}
+
+	if err := c.apply(&cfg, prs, ccs...); err != nil {
+		return c.err(err)
+	}
+
+	return checkAndReturn(cfg, prs)
+}
+
+// LeaveJoint transitions out of a joint configuration. It is an error to call
+// this method if the configuration is not joint, i.e. if the outgoing majority
+// config Voters[1] is empty.
+//
+// The outgoing majority config of the joint configuration will be removed,
+// that is, the incoming config is promoted as the sole decision maker. In the
+// notation of the Raft thesis[1] (Section 4.3), this method transitions from
+// `C_{new,old}` into `C_new`.
+//
+// At the same time, any staged learners (LearnersNext) the addition of which
+// was held back by an overlapping voter in the former outgoing config will be
+// inserted into Learners.
+//
+// [1]: https://github.com/ongardie/dissertation/blob/master/online-trim.pdf
+func (c Changer) LeaveJoint() (tracker.Config, tracker.ProgressMap, error) {
+	cfg, prs, err := c.checkAndCopy()
+	if err != nil {
+		return c.err(err)
+	}
+	if !joint(cfg) {
+		err := errors.New("can't leave a non-joint config")
+		return c.err(err)
+	}
+	if len(outgoing(cfg.Voters)) == 0 {
+		err := fmt.Errorf("configuration is not joint: %v", cfg)
+		return c.err(err)
+	}
+	for id := range cfg.LearnersNext {
+		nilAwareAdd(&cfg.Learners, id)
+		prs[id].IsLearner = true
+	}
+	cfg.LearnersNext = nil
+
+	for id := range outgoing(cfg.Voters) {
+		_, isVoter := incoming(cfg.Voters)[id]
+		_, isLearner := cfg.Learners[id]
+
+		if !isVoter && !isLearner {
+			delete(prs, id)
+		}
+	}
+	*outgoingPtr(&cfg.Voters) = nil
+
+	return checkAndReturn(cfg, prs)
+}
+
+// Simple carries out a series of configuration changes that (in aggregate)
+// mutates the incoming majority config Voters[0] by at most one. This method
+// will return an error if that is not the case, if the resulting quorum is
+// zero, or if the configuration is in a joint state (i.e. if there is an
+// outgoing configuration).
+func (c Changer) Simple(ccs ...pb.ConfChange) (tracker.Config, tracker.ProgressMap, error) {
+	cfg, prs, err := c.checkAndCopy()
+	if err != nil {
+		return c.err(err)
+	}
+	if joint(cfg) {
+		err := errors.New("can't apply simple config change in joint config")
+		return c.err(err)
+	}
+	if err := c.apply(&cfg, prs, ccs...); err != nil {
+		return c.err(err)
+	}
+	if n := symdiff(incoming(c.Tracker.Voters), incoming(cfg.Voters)); n > 1 {
+		return tracker.Config{}, nil, errors.New("more than voter changed without entering joint config")
+	}
+	if err := checkInvariants(cfg, prs); err != nil {
+		return tracker.Config{}, tracker.ProgressMap{}, nil
+	}
+
+	return checkAndReturn(cfg, prs)
+}
+
+// apply a ConfChange to the configuration. By convention, changes to voters are
+// always made to the incoming majority config Voters[0]. Voters[1] is either
+// empty or preserves the outgoing majority configuration while in a joint state.
+func (c Changer) apply(cfg *tracker.Config, prs tracker.ProgressMap, ccs ...pb.ConfChange) error {
+	for _, cc := range ccs {
+		if cc.NodeID == 0 {
+			// etcd replaces the NodeID with zero if it decides (downstream of
+			// raft) to not apply a ConfChange, so we have to have explicit code
+			// here to ignore these.
+			continue
+		}
+		switch cc.Type {
+		case pb.ConfChangeAddNode:
+			c.makeVoter(cfg, prs, cc.NodeID)
+		case pb.ConfChangeAddLearnerNode:
+			c.makeLearner(cfg, prs, cc.NodeID)
+		case pb.ConfChangeRemoveNode:
+			c.remove(cfg, prs, cc.NodeID)
+		case pb.ConfChangeUpdateNode:
+		default:
+			return fmt.Errorf("unexpected conf type %d", cc.Type)
+		}
+	}
+	if len(incoming(cfg.Voters)) == 0 {
+		return errors.New("removed all voters")
+	}
+	return nil
+}
+
+// makeVoter adds or promotes the given ID to be a voter in the incoming
+// majority config.
+func (c Changer) makeVoter(cfg *tracker.Config, prs tracker.ProgressMap, id uint64) {
+	pr := prs[id]
+	if pr == nil {
+		c.initProgress(cfg, prs, id, false /* isLearner */)
+		return
+	}
+
+	pr.IsLearner = false
+	nilAwareDelete(&cfg.Learners, id)
+	nilAwareDelete(&cfg.LearnersNext, id)
+	incoming(cfg.Voters)[id] = struct{}{}
+	return
+}
+
+// makeLearner makes the given ID a learner or stages it to be a learner once
+// an active joint configuration is exited.
+//
+// The former happens when the peer is not a part of the outgoing config, in
+// which case we either add a new learner or demote a voter in the incoming
+// config.
+//
+// The latter case occurs when the configuration is joint and the peer is a
+// voter in the outgoing config. In that case, we do not want to add the peer
+// as a learner because then we'd have to track a peer as a voter and learner
+// simultaneously. Instead, we add the learner to LearnersNext, so that it will
+// be added to Learners the moment the outgoing config is removed by
+// LeaveJoint().
+func (c Changer) makeLearner(cfg *tracker.Config, prs tracker.ProgressMap, id uint64) {
+	pr := prs[id]
+	if pr == nil {
+		c.initProgress(cfg, prs, id, true /* isLearner */)
+		return
+	}
+	if pr.IsLearner {
+		return
+	}
+	// Remove any existing voter in the incoming config...
+	c.remove(cfg, prs, id)
+	// ... but save the Progress.
+	prs[id] = pr
+	// Use LearnersNext if we can't add the learner to Learners directly, i.e.
+	// if the peer is still tracked as a voter in the outgoing config. It will
+	// be turned into a learner in LeaveJoint().
+	//
+	// Otherwise, add a regular learner right away.
+	if _, onRight := outgoing(cfg.Voters)[id]; onRight {
+		nilAwareAdd(&cfg.LearnersNext, id)
+	} else {
+		pr.IsLearner = true
+		nilAwareAdd(&cfg.Learners, id)
+	}
+}
+
+// remove this peer as a voter or learner from the incoming config.
+func (c Changer) remove(cfg *tracker.Config, prs tracker.ProgressMap, id uint64) {
+	if _, ok := prs[id]; !ok {
+		return
+	}
+
+	delete(incoming(cfg.Voters), id)
+	nilAwareDelete(&cfg.Learners, id)
+	nilAwareDelete(&cfg.LearnersNext, id)
+
+	// If the peer is still a voter in the outgoing config, keep the Progress.
+	if _, onRight := outgoing(cfg.Voters)[id]; !onRight {
+		delete(prs, id)
+	}
+}
+
+// initProgress initializes a new progress for the given node or learner.
+func (c Changer) initProgress(cfg *tracker.Config, prs tracker.ProgressMap, id uint64, isLearner bool) {
+	if !isLearner {
+		incoming(cfg.Voters)[id] = struct{}{}
+	} else {
+		nilAwareAdd(&cfg.Learners, id)
+	}
+	prs[id] = &tracker.Progress{
+		// We initialize Progress.Next with lastIndex+1 so that the peer will be
+		// probed without an index first.
+		//
+		// TODO(tbg): verify that, this is just my best guess.
+		Next:      c.LastIndex + 1,
+		Match:     0,
+		Inflights: tracker.NewInflights(c.Tracker.MaxInflight),
+		IsLearner: isLearner,
+		// When a node is first added, we should mark it as recently active.
+		// Otherwise, CheckQuorum may cause us to step down if it is invoked
+		// before the added node has had a chance to communicate with us.
+		RecentActive: true,
+	}
+}
+
+// checkInvariants makes sure that the config and progress are compatible with
+// each other. This is used to check both what the Changer is initialized with,
+// as well as what it returns.
+func checkInvariants(cfg tracker.Config, prs tracker.ProgressMap) error {
+	// NB: intentionally allow the empty config. In production we'll never see a
+	// non-empty config (we prevent it from being created) but we will need to
+	// be able to *create* an initial config, for example during bootstrap (or
+	// during tests). Instead of having to hand-code this, we allow
+	// transitioning from an empty config into any other legal and non-empty
+	// config.
+	for _, ids := range []map[uint64]struct{}{
+		cfg.Voters.IDs(),
+		cfg.Learners,
+		cfg.LearnersNext,
+	} {
+		for id := range ids {
+			if _, ok := prs[id]; !ok {
+				return fmt.Errorf("no progress for %d", id)
+			}
+		}
+	}
+
+	// Any staged learner was staged because it could not be directly added due
+	// to a conflicting voter in the outgoing config.
+	for id := range cfg.LearnersNext {
+		if _, ok := outgoing(cfg.Voters)[id]; !ok {
+			return fmt.Errorf("%d is in LearnersNext, but not Voters[1]", id)
+		}
+		if prs[id].IsLearner {
+			return fmt.Errorf("%d is in LearnersNext, but is already marked as learner", id)
+		}
+	}
+	// Conversely Learners and Voters doesn't intersect at all.
+	for id := range cfg.Learners {
+		if _, ok := outgoing(cfg.Voters)[id]; ok {
+			return fmt.Errorf("%d is in Learners and Voters[1]", id)
+		}
+		if _, ok := incoming(cfg.Voters)[id]; ok {
+			return fmt.Errorf("%d is in Learners and Voters[0]", id)
+		}
+		if !prs[id].IsLearner {
+			return fmt.Errorf("%d is in Learners, but is not marked as learner", id)
+		}
+	}
+
+	if !joint(cfg) {
+		// We enforce that empty maps are nil instead of zero.
+		if outgoing(cfg.Voters) != nil {
+			return fmt.Errorf("Voters[1] must be nil when not joint")
+		}
+		if cfg.LearnersNext != nil {
+			return fmt.Errorf("LearnersNext must be nil when not joint")
+		}
+	}
+
+	return nil
+}
+
+// checkAndCopy copies the tracker's config and progress map (deeply enough for
+// the purposes of the Changer) and returns those copies. It returns an error
+// if checkInvariants does.
+func (c Changer) checkAndCopy() (tracker.Config, tracker.ProgressMap, error) {
+	cfg := c.Tracker.Config.Clone()
+	prs := tracker.ProgressMap{}
+
+	for id, pr := range c.Tracker.Progress {
+		// A shallow copy is enough because we only mutate the Learner field.
+		ppr := *pr
+		prs[id] = &ppr
+	}
+	return checkAndReturn(cfg, prs)
+}
+
+// checkAndReturn calls checkInvariants on the input and returns either the
+// resulting error or the input.
+func checkAndReturn(cfg tracker.Config, prs tracker.ProgressMap) (tracker.Config, tracker.ProgressMap, error) {
+	if err := checkInvariants(cfg, prs); err != nil {
+		return tracker.Config{}, tracker.ProgressMap{}, err
+	}
+	return cfg, prs, nil
+}
+
+// err returns zero values and an error.
+func (c Changer) err(err error) (tracker.Config, tracker.ProgressMap, error) {
+	return tracker.Config{}, nil, err
+}
+
+// nilAwareAdd populates a map entry, creating the map if necessary.
+func nilAwareAdd(m *map[uint64]struct{}, id uint64) {
+	if *m == nil {
+		*m = map[uint64]struct{}{}
+	}
+	(*m)[id] = struct{}{}
+}
+
+// nilAwareDelete deletes from a map, nil'ing the map itself if it is empty after.
+func nilAwareDelete(m *map[uint64]struct{}, id uint64) {
+	if *m == nil {
+		return
+	}
+	delete(*m, id)
+	if len(*m) == 0 {
+		*m = nil
+	}
+}
+
+// symdiff returns the count of the symmetric difference between the sets of
+// uint64s, i.e. len( (l - r) \union (r - l)).
+func symdiff(l, r map[uint64]struct{}) int {
+	var n int
+	pairs := [][2]quorum.MajorityConfig{
+		{l, r}, // count elems in l but not in r
+		{r, l}, // count elems in r but not in l
+	}
+	for _, p := range pairs {
+		for id := range p[0] {
+			if _, ok := p[1][id]; !ok {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func joint(cfg tracker.Config) bool {
+	return len(outgoing(cfg.Voters)) > 0
+}
+
+func incoming(voters quorum.JointConfig) quorum.MajorityConfig      { return voters[0] }
+func outgoing(voters quorum.JointConfig) quorum.MajorityConfig      { return voters[1] }
+func outgoingPtr(voters *quorum.JointConfig) *quorum.MajorityConfig { return &voters[1] }
+
+// Describe prints the type and NodeID of the configuration changes as a
+// space-delimited string.
+func Describe(ccs ...pb.ConfChange) string {
+	var buf strings.Builder
+	for _, cc := range ccs {
+		if buf.Len() > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%s(%d)", cc.Type, cc.NodeID)
+	}
+	return buf.String()
+}

--- a/raft/confchange/datadriven_test.go
+++ b/raft/confchange/datadriven_test.go
@@ -1,0 +1,105 @@
+// Copyright 2019 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confchange
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/datadriven"
+	pb "go.etcd.io/etcd/raft/raftpb"
+	"go.etcd.io/etcd/raft/tracker"
+)
+
+func TestConfChangeDataDriven(t *testing.T) {
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		tr := tracker.MakeProgressTracker(10)
+		c := Changer{
+			Tracker:   tr,
+			LastIndex: 0, // incremented in this test with each cmd
+		}
+
+		// The test files use the commands
+		// - simple: run a simple conf change (i.e. no joint consensus),
+		// - enter-joint: enter a joint config, and
+		// - leave-joint: leave a joint config.
+		// The first two take a list of config changes, which have the following
+		// syntax:
+		// - vn: make n a voter,
+		// - ln: make n a learner,
+		// - rn: remove n, and
+		// - un: update n.
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			defer func() {
+				c.LastIndex++
+			}()
+			var ccs []pb.ConfChange
+			toks := strings.Split(strings.TrimSpace(d.Input), " ")
+			if toks[0] == "" {
+				toks = nil
+			}
+			for _, tok := range toks {
+				if len(tok) < 2 {
+					return fmt.Sprintf("unknown token %s", tok)
+				}
+				var cc pb.ConfChange
+				switch tok[0] {
+				case 'v':
+					cc.Type = pb.ConfChangeAddNode
+				case 'l':
+					cc.Type = pb.ConfChangeAddLearnerNode
+				case 'r':
+					cc.Type = pb.ConfChangeRemoveNode
+				case 'u':
+					cc.Type = pb.ConfChangeUpdateNode
+				default:
+					return fmt.Sprintf("unknown input: %s", tok)
+				}
+				id, err := strconv.ParseUint(tok[1:], 10, 64)
+				if err != nil {
+					return err.Error()
+				}
+				cc.NodeID = id
+				ccs = append(ccs, cc)
+			}
+
+			var cfg tracker.Config
+			var prs tracker.ProgressMap
+			var err error
+			switch d.Cmd {
+			case "simple":
+				cfg, prs, err = c.Simple(ccs...)
+			case "enter-joint":
+				cfg, prs, err = c.EnterJoint(ccs...)
+			case "leave-joint":
+				if len(ccs) > 0 {
+					err = errors.New("this command takes no input")
+				} else {
+					cfg, prs, err = c.LeaveJoint()
+				}
+			default:
+				return "unknown command"
+			}
+			if err != nil {
+				return err.Error() + "\n"
+			}
+			c.Tracker.Config, c.Tracker.Progress = cfg, prs
+			return fmt.Sprintf("%s\n%s", c.Tracker.Config, c.Tracker.Progress)
+		})
+	})
+}

--- a/raft/confchange/quick_test.go
+++ b/raft/confchange/quick_test.go
@@ -1,0 +1,168 @@
+// Copyright 2019 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confchange
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	pb "go.etcd.io/etcd/raft/raftpb"
+	"go.etcd.io/etcd/raft/tracker"
+)
+
+// TestConfChangeQuick uses quickcheck to verify that simple and joint config
+// changes arrive at the same result.
+func TestConfChangeQuick(t *testing.T) {
+	cfg := &quick.Config{
+		MaxCount: 1000,
+	}
+
+	// Log the first couple of runs to give some indication of things working
+	// as intended.
+	const infoCount = 5
+
+	runWithJoint := func(c *Changer, ccs []pb.ConfChange) error {
+		cfg, prs, err := c.EnterJoint(ccs...)
+		if err != nil {
+			return err
+		}
+		c.Tracker.Config = cfg
+		c.Tracker.Progress = prs
+		cfg, prs, err = c.LeaveJoint()
+		if err != nil {
+			return err
+		}
+		c.Tracker.Config = cfg
+		c.Tracker.Progress = prs
+		return nil
+	}
+
+	runWithSimple := func(c *Changer, ccs []pb.ConfChange) error {
+		for _, cc := range ccs {
+			cfg, prs, err := c.Simple(cc)
+			if err != nil {
+				return err
+			}
+			c.Tracker.Config, c.Tracker.Progress = cfg, prs
+		}
+		return nil
+	}
+
+	type testFunc func(*Changer, []pb.ConfChange) error
+
+	wrapper := func(invoke testFunc) func(setup initialChanges, ccs confChanges) (*Changer, error) {
+		return func(setup initialChanges, ccs confChanges) (*Changer, error) {
+			tr := tracker.MakeProgressTracker(10)
+			c := &Changer{
+				Tracker:   tr,
+				LastIndex: 10,
+			}
+
+			if err := runWithSimple(c, setup); err != nil {
+				return nil, err
+			}
+
+			err := invoke(c, ccs)
+			return c, err
+		}
+	}
+
+	var n int
+	f1 := func(setup initialChanges, ccs confChanges) *Changer {
+		c, err := wrapper(runWithSimple)(setup, ccs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n < infoCount {
+			t.Log("initial setup:", Describe(setup...))
+			t.Log("changes:", Describe(ccs...))
+			t.Log(c.Tracker.Config)
+			t.Log(c.Tracker.Progress)
+		}
+		n++
+		return c
+	}
+	f2 := func(setup initialChanges, ccs confChanges) *Changer {
+		c, err := wrapper(runWithJoint)(setup, ccs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	err := quick.CheckEqual(f1, f2, cfg)
+	if err == nil {
+		return
+	}
+	cErr, ok := err.(*quick.CheckEqualError)
+	if !ok {
+		t.Fatal(err)
+	}
+
+	t.Error("setup:", Describe(cErr.In[0].([]pb.ConfChange)...))
+	t.Error("ccs:", Describe(cErr.In[1].([]pb.ConfChange)...))
+	t.Errorf("out1: %+v\nout2: %+v", cErr.Out1, cErr.Out2)
+}
+
+type confChangeTyp pb.ConfChangeType
+
+func (confChangeTyp) Generate(rand *rand.Rand, _ int) reflect.Value {
+	return reflect.ValueOf(confChangeTyp(rand.Intn(4)))
+}
+
+type confChanges []pb.ConfChange
+
+func genCC(num func() int, id func() uint64, typ func() pb.ConfChangeType) []pb.ConfChange {
+	var ccs []pb.ConfChange
+	n := num()
+	for i := 0; i < n; i++ {
+		ccs = append(ccs, pb.ConfChange{Type: typ(), NodeID: id()})
+	}
+	return ccs
+}
+
+func (confChanges) Generate(rand *rand.Rand, _ int) reflect.Value {
+	num := func() int {
+		return 1 + rand.Intn(9)
+	}
+	id := func() uint64 {
+		// Note that num() >= 1, so we're never returning 1 from this method,
+		// meaning that we'll never touch NodeID one, which is special to avoid
+		// voterless configs altogether in this test.
+		return 1 + uint64(num())
+	}
+	typ := func() pb.ConfChangeType {
+		return pb.ConfChangeType(rand.Intn(len(pb.ConfChangeType_name)))
+	}
+	return reflect.ValueOf(genCC(num, id, typ))
+}
+
+type initialChanges []pb.ConfChange
+
+func (initialChanges) Generate(rand *rand.Rand, _ int) reflect.Value {
+	num := func() int {
+		return 1 + rand.Intn(5)
+	}
+	id := func() uint64 { return uint64(num()) }
+	typ := func() pb.ConfChangeType {
+		return pb.ConfChangeAddNode
+	}
+	// NodeID one is special - it's in the initial config and will be a voter
+	// always (this is to avoid uninteresting edge cases where the simple conf
+	// changes can't easily make progress).
+	ccs := append([]pb.ConfChange{{Type: pb.ConfChangeAddNode, NodeID: 1}}, genCC(num, id, typ)...)
+	return reflect.ValueOf(ccs)
+}

--- a/raft/confchange/testdata/joint_idempotency.txt
+++ b/raft/confchange/testdata/joint_idempotency.txt
@@ -1,0 +1,23 @@
+# Verify that operations upon entering the joint state are idempotent, i.e.
+# removing an absent node is fine, etc.
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+enter-joint
+r1 r2 r9 v2 v3 v4 v2 v3 v4 l2 l2 r4 r4 l1 l1
+----
+voters=(3)&&(1) learners=(2) learners_next=(1)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2 learner
+3: StateProbe match=0 next=2
+
+leave-joint
+----
+voters=(3) learners=(1 2)
+1: StateProbe match=0 next=1 learner
+2: StateProbe match=0 next=2 learner
+3: StateProbe match=0 next=2

--- a/raft/confchange/testdata/joint_learners_next.txt
+++ b/raft/confchange/testdata/joint_learners_next.txt
@@ -1,0 +1,24 @@
+# Verify that when a voter is demoted in a joint config, it will show up in
+# learners_next until the joint config is left, and only then will the progress
+# turn into that of a learner, without resetting the progress. Note that this
+# last fact is verified by `next`, which can tell us which "round" the progress
+# was originally created in.
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+enter-joint
+v2 l1
+----
+voters=(2)&&(1) learners_next=(1)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+
+leave-joint
+----
+voters=(2) learners=(1)
+1: StateProbe match=0 next=1 learner
+2: StateProbe match=0 next=2

--- a/raft/confchange/testdata/joint_safety.txt
+++ b/raft/confchange/testdata/joint_safety.txt
@@ -1,0 +1,81 @@
+leave-joint
+----
+can't leave a non-joint config
+
+enter-joint
+----
+can't make a zero-voter config joint
+
+enter-joint
+v1
+----
+can't make a zero-voter config joint
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=4
+
+leave-joint
+----
+can't leave a non-joint config
+
+# Can enter into joint config.
+enter-joint
+----
+voters=(1)&&(1)
+1: StateProbe match=0 next=4
+
+enter-joint
+----
+config is already joint
+
+leave-joint
+----
+voters=(1)
+1: StateProbe match=0 next=4
+
+leave-joint
+----
+can't leave a non-joint config
+
+# Can enter again, this time with some ops.
+enter-joint
+r1 v2 v3 l4
+----
+voters=(2 3)&&(1) learners=(4)
+1: StateProbe match=0 next=4
+2: StateProbe match=0 next=10
+3: StateProbe match=0 next=10
+4: StateProbe match=0 next=10 learner
+
+enter-joint
+----
+config is already joint
+
+enter-joint
+v12
+----
+config is already joint
+
+simple
+l15
+----
+can't apply simple config change in joint config
+
+leave-joint
+----
+voters=(2 3) learners=(4)
+2: StateProbe match=0 next=10
+3: StateProbe match=0 next=10
+4: StateProbe match=0 next=10 learner
+
+simple
+l9
+----
+voters=(2 3) learners=(4 9)
+2: StateProbe match=0 next=10
+3: StateProbe match=0 next=10
+4: StateProbe match=0 next=10 learner
+9: StateProbe match=0 next=15 learner

--- a/raft/confchange/testdata/simple_idempotency.txt
+++ b/raft/confchange/testdata/simple_idempotency.txt
@@ -1,0 +1,69 @@
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+simple
+v2
+----
+voters=(1 2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=3
+
+simple
+l1
+----
+voters=(2) learners=(1)
+1: StateProbe match=0 next=1 learner
+2: StateProbe match=0 next=3
+
+simple
+l1
+----
+voters=(2) learners=(1)
+1: StateProbe match=0 next=1 learner
+2: StateProbe match=0 next=3
+
+simple
+r1
+----
+voters=(2)
+2: StateProbe match=0 next=3
+
+simple
+r1
+----
+voters=(2)
+2: StateProbe match=0 next=3
+
+simple
+v3
+----
+voters=(2 3)
+2: StateProbe match=0 next=3
+3: StateProbe match=0 next=8
+
+simple
+r3
+----
+voters=(2)
+2: StateProbe match=0 next=3
+
+simple
+r3
+----
+voters=(2)
+2: StateProbe match=0 next=3
+
+simple
+r4
+----
+voters=(2)
+2: StateProbe match=0 next=3

--- a/raft/confchange/testdata/simple_promote_demote.txt
+++ b/raft/confchange/testdata/simple_promote_demote.txt
@@ -1,0 +1,60 @@
+# Set up three voters for this test.
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+simple
+v2
+----
+voters=(1 2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+
+simple
+v3
+----
+voters=(1 2 3)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+3: StateProbe match=0 next=3
+
+# Can atomically demote and promote without a hitch.
+# This is pointless, but possible.
+simple
+l1 v1
+----
+voters=(1 2 3)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+3: StateProbe match=0 next=3
+
+# Can demote a voter.
+simple
+l2
+----
+voters=(1 3) learners=(2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2 learner
+3: StateProbe match=0 next=3
+
+# Can atomically promote and demote the same voter.
+# This is pointless, but possible.
+simple
+v2 l2
+----
+voters=(1 3) learners=(2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2 learner
+3: StateProbe match=0 next=3
+
+# Can promote a voter.
+simple
+v2
+----
+voters=(1 2 3)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+3: StateProbe match=0 next=3

--- a/raft/confchange/testdata/simple_safety.txt
+++ b/raft/confchange/testdata/simple_safety.txt
@@ -1,0 +1,64 @@
+simple
+l1
+----
+removed all voters
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=2
+
+simple
+v2 l3
+----
+voters=(1 2) learners=(3)
+1: StateProbe match=0 next=2
+2: StateProbe match=0 next=3
+3: StateProbe match=0 next=3 learner
+
+simple
+r1 v5
+----
+more than voter changed without entering joint config
+
+simple
+r1 r2
+----
+removed all voters
+
+simple
+v3 v4
+----
+more than voter changed without entering joint config
+
+simple
+l1 v5
+----
+more than voter changed without entering joint config
+
+simple
+l1 l2
+----
+removed all voters
+
+simple
+l2 l3 l4 l5
+----
+voters=(1) learners=(2 3 4 5)
+1: StateProbe match=0 next=2
+2: StateProbe match=0 next=3 learner
+3: StateProbe match=0 next=3 learner
+4: StateProbe match=0 next=9 learner
+5: StateProbe match=0 next=9 learner
+
+simple
+r1
+----
+removed all voters
+
+simple
+r2 r3 r4 r5
+----
+voters=(1)
+1: StateProbe match=0 next=2

--- a/raft/confchange/testdata/update.txt
+++ b/raft/confchange/testdata/update.txt
@@ -1,0 +1,23 @@
+# Nobody cares about ConfChangeUpdateNode, but at least use it once. It is used
+# by etcd as a convenient way to pass a blob through their conf change machinery
+# that updates information tracked outside of raft.
+
+simple
+v1
+----
+voters=(1)
+1: StateProbe match=0 next=1
+
+simple
+v2 u1
+----
+voters=(1 2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2
+
+simple
+u1 u2 u3 u1 u2 u3
+----
+voters=(1 2)
+1: StateProbe match=0 next=1
+2: StateProbe match=0 next=2

--- a/raft/confchange/testdata/zero.txt
+++ b/raft/confchange/testdata/zero.txt
@@ -1,0 +1,6 @@
+# NodeID zero is ignored.
+simple
+v1 r0 v0 l0
+----
+voters=(1)
+1: StateProbe match=0 next=1

--- a/raft/tracker/progress.go
+++ b/raft/tracker/progress.go
@@ -16,6 +16,7 @@ package tracker
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -232,6 +233,25 @@ func (pr *Progress) String() string {
 		if pr.Inflights.Full() {
 			fmt.Fprint(&buf, "[full]")
 		}
+	}
+	return buf.String()
+}
+
+// ProgressMap is a map of *Progress.
+type ProgressMap map[uint64]*Progress
+
+// String prints the ProgressMap in sorted key order, one Progress per line.
+func (m ProgressMap) String() string {
+	ids := make([]uint64, 0, len(m))
+	for k := range m {
+		ids = append(ids, k)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+	var buf strings.Builder
+	for _, id := range ids {
+		fmt.Fprintf(&buf, "%d: %s\n", id, m[id])
 	}
 	return buf.String()
 }


### PR DESCRIPTION
This commit introduces machinery to safely apply joint consensus
configuration changes to Raft.

The main contribution is the new package, `confchange`, which offers
the primitives `Simple`, `EnterJoint`, and `LeaveJoint`.

The first two take a list of configuration changes. `Simple` only
declares success if these configuration changes (applied atomically)
change the set of voters by at most one (i.e. it's fine to add or
remove any number of learners, but change only one voter). `EnterJoint`
makes the configuration joint and then applies the changes to it, in
preparation of the caller returning later and transitioning out of the
joint config into the final desired configuration via `LeaveJoint()`.

This commit streamlines the conversion between voters and learners, which
is now generally allowed whenever the above conditions are upheld (i.e.
it's not possible to demote a voter and add a new voter in the context
of a Simple configuration change, but it is possible via EnterJoint).
Previously, we had the artificial restriction that a voter could not be
demoted to a learner, but had to be removed first.
Even though demoting a learner is generally less useful than promoting
a learner (the latter is used to catch up future voters), demotions
could see use in improved handling of temporary node unavailability,
where it is desired to remove voting power from a down node, but to
preserve its data should it return.

An additional change that was made in this commit is to prevent the use
of empty commit quorums, which was previously possible but for no good
reason; this:

Closes #10884.

The work left to do in a future PR is to actually expose joint
configurations to the applications using Raft. This will entail mostly
API design and the addition of suitable testing, which to be carried
out ergonomically is likely to motivate a larger refactor.

Touches #7625.