### PR TITLE
raft/rafttest: simulate async send in node test

### DIFF
--- a/raft/rafttest/node.go
+++ b/raft/rafttest/node.go
@@ -17,6 +17,7 @@ package rafttest
 import (
 	"context"
 	"log"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -79,9 +80,14 @@ func (n *node) start() {
 				}
 				n.storage.Append(rd.Entries)
 				time.Sleep(time.Millisecond)
-				// TODO: make send async, more like real world...
+
+				// simulate async send, more like real world...
 				for _, m := range rd.Messages {
-					n.iface.send(m)
+					mlocal := m
+					go func() {
+						time.Sleep(time.Duration(rand.Int63n(10)) * time.Millisecond)
+						n.iface.send(mlocal)
+					}()
 				}
 				n.Advance()
 			case m := <-n.iface.recv():


### PR DESCRIPTION
In order to cover message can well be received when a node is paused, this commit sends message async using goroutine and random sleep. This change makes recvms is possible to cache message during node.pause is triggered.
