### PR TITLE
scripts: fail explicitly in updatedep.sh when gopath.proto exists

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -38,7 +38,14 @@ SCHWAG_ROOT="${GOPATH}/src/github.com/hexfusion/schwag"
 GOGOPROTO_PATH="${GOGOPROTO_ROOT}:${GOGOPROTO_ROOT}/protobuf"
 GRPC_GATEWAY_ROOT="${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway"
 
-rm -f "${ETCD_ROOT}"
+function cleanup {
+  # Remove the whole fake GOPATH which can really confuse go mod.
+  rm -rf "${PWD}/gopath.proto"
+}
+
+cleanup
+trap cleanup EXIT
+
 mkdir -p "${ETCD_IO_ROOT}"
 ln -s "${PWD}" "${ETCD_ROOT}"
 

--- a/scripts/updatedep.sh
+++ b/scripts/updatedep.sh
@@ -6,6 +6,13 @@ if ! [[ "$0" =~ scripts/updatedep.sh ]]; then
   exit 255
 fi
 
+if [ -d "gopath.proto" ]; then
+  # gopath.proto is created by genproto.sh and it thoroughly messes
+  # with go mod.
+  echo "Remove gopath.proto before running this script"
+  exit 255
+fi
+
 if [[ $(go version) != "go version go1.12"* ]]; then
   echo "expect Go 1.12+, got:" "$(go version)"
   exit 255


### PR DESCRIPTION
I had been dealing with these intermittent failures for a while and
finally figured out why. The real solution is making genproto.sh less
ugly but that won't happen for a while.