### PR TITLE
integration: add WaitGroup to TestV3WatchCurrentPutOverlap

### DIFF
--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -479,8 +479,11 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 	// last mod_revision that will be observed
 	nrRevisions := 32
 	// first revision already allocated as empty revision
+	var wg sync.WaitGroup
 	for i := 1; i < nrRevisions; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			kvc := toGRPC(clus.RandClient()).KV
 			req := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
 			if _, err := kvc.Put(context.TODO(), req); err != nil {
@@ -488,6 +491,7 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 			}
 		}()
 	}
+	wg.Wait()
 
 	// maps watcher to current expected revision
 	progress := make(map[int64]int64)

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -491,7 +491,6 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 			}
 		}()
 	}
-	wg.Wait()
 
 	// maps watcher to current expected revision
 	progress := make(map[int64]int64)
@@ -544,6 +543,8 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 	if rok, nr := waitResponse(wStream, time.Second); !rok {
 		t.Errorf("unexpected pb.WatchResponse is received %+v", nr)
 	}
+
+	wg.Wait()
 }
 
 // TestV3WatchEmptyKey ensures synced watchers see empty key PUTs as PUT events


### PR DESCRIPTION
add WaitGroup to prevent calling t.Fatalf after TestV3WatchCurrentPutOverlap function return. It could cause a panic

Fixes etcd-io#10886