### PR TITLE
embed: fix oob panic in zap logger

### DIFF
--- a/embed/config_logging.go
+++ b/embed/config_logging.go
@@ -242,7 +242,7 @@ func (cfg *Config) setupLogging() error {
 			serverName := state.ServerName
 			if len(state.PeerCertificates) > 0 {
 				cert := state.PeerCertificates[0]
-				ips := make([]string, 0, len(cert.IPAddresses))
+				ips := make([]string, len(cert.IPAddresses))
 				for i := range cert.IPAddresses {
 					ips[i] = cert.IPAddresses[i].String()
 				}


### PR DESCRIPTION
This fixes an index out-of-bounds panic caused when using the embed
package and the zap logger. When a TLS handshake error is logged, the
slice for cert ip addresses is allocated with capacity but no length, so
subsequent index access causes the panic, and doesn't surface the TLS
handshake error to the user.

Fixes #10932