### PR TITLE
default log level to fatal

### DIFF
--- a/pkg/logutil/zap.go
+++ b/pkg/logutil/zap.go
@@ -23,7 +23,7 @@ import (
 
 // DefaultZapLoggerConfig defines default zap logger configuration.
 var DefaultZapLoggerConfig = zap.Config{
-	Level: zap.NewAtomicLevelAt(zap.InfoLevel),
+	Level: zap.NewAtomicLevelAt(zap.FatalLevel),
 
 	Development: false,
 	Sampling: &zap.SamplingConfig{


### PR DESCRIPTION
I think that the default log level should be fatal, was trying to silence output from an embed server with zap but there's no config for that, however with this change the `Debug` flag effectively silence output
