### PR TITLE
Fixed a bug blocking node.Status()

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -514,7 +514,7 @@ func (n *node) ApplyConfChange(cc pb.ConfChangeI) *pb.ConfState {
 func (n *node) Status() Status {
 	c := make(chan Status)
 	select {
-	case n.status <- c:
+	case c <- n.status:
 		return <-c
 	case <-n.done:
 		return Status{}


### PR DESCRIPTION
***Description***
In function (node).Status, a new channel c is allocated, but the next select statement receives from c, which will never happen. So this select statement will always block until n.done is not empty, and then return an empty structure Status{}.

***Buggy code***
```Go
func (n *node) Status() Status {
	c := make(chan Status)
	select {
	case n.status <- c:
		return <-c
	case <-n.done:
		return Status{}
	}
}
```

***About my patch***
I found this bug by my static checker, so I don't know what will happen if `Status` is always blocked until node is done. However I believe what the developer wanted to write here is 
```Go
select {
case c <- n.status:
	return <-c
case <-n.done:
	return Status{}
}
```