### PR TITLE
Avoid potential double lock of tsafeSet

### DIFF
--- a/pkg/types/set.go
+++ b/pkg/types/set.go
@@ -148,6 +148,14 @@ func (ts *tsafeSet) Contains(value string) (exists bool) {
 func (ts *tsafeSet) Equals(other Set) bool {
 	ts.m.RLock()
 	defer ts.m.RUnlock()
+
+	// If ts and other represent the same variable, avoid calling
+	// ts.us.Equals(other), to avoid double RLock bug
+	if _other, ok := other.(*tsafeSet); ok {
+		if _other == ts {
+			return true
+		}
+	}
 	return ts.us.Equals(other)
 }
 
@@ -173,6 +181,15 @@ func (ts *tsafeSet) Copy() Set {
 func (ts *tsafeSet) Sub(other Set) Set {
 	ts.m.RLock()
 	defer ts.m.RUnlock()
+
+	// If ts and other represent the same variable, avoid calling
+	// ts.us.Sub(other), to avoid double RLock bug
+	if _other, ok := other.(*tsafeSet); ok {
+		if _other == ts {
+			usResult := NewUnsafeSet()
+			return &tsafeSet{usResult, sync.RWMutex{}}
+		}
+	}
 	usResult := ts.us.Sub(other).(*unsafeSet)
 	return &tsafeSet{usResult, sync.RWMutex{}}
 }


### PR DESCRIPTION
***Description***
(tsafeSet).Sub and (tsafeSet).Equals can cause double lock bug.
If one goroutine is invoking ts.Add(), and another goroutine is invoking ts.Equals(ts), then these two goroutines may be both blocking.

Fixs #10925 

***How to trigger this bug***
Please use the following test file to trigger this bug:
```Go
package types

import (
	"sync"
	"testing"
)

func TestThreadsafeEqualsSet(t *testing.T) {

	var wg sync.WaitGroup
	s1 := NewThreadsafeSet()
	wg.Add(2)
	go func(){
		for i := 1; i <= 1000; i++ { // On my computer, 1000 is enough to trigger this bug
			s1.Equals(s1)
		}
		wg.Done()
	}()

	go func(){
		for i := 1; i <= 1000; i++ { // On my computer, 1000 is enough to trigger this bug
			s1.Add("abc")
		}
		wg.Done()
	}()

	wg.Wait()

}
```

***How I fixed this bug***
In (tsafeSet).Equals, if `ts` and `other` is the same, return true.
In (tsafeSet).Sub, if `ts` and `other` is the same, return an empty set.
