### PR TITLE
test: fix metric name typo

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -206,11 +206,11 @@ func TestMetricsHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hv, err := clus.Members[0].Metric("etcd_server_health_failure")
+	hv, err := clus.Members[0].Metric("etcd_server_health_failures")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if hv != "0" {
-		t.Fatalf("expected '0' from etcd_server_health_failure, got %q", hv)
+		t.Fatalf("expected '0' from etcd_server_health_failures, got %q", hv)
 	}
 }


### PR DESCRIPTION
From the definition, we have a trailing `s` here.

https://github.com/etcd-io/etcd/blob/9c5426830b1b8728af14e069acfdc2a64dea768c/etcdserver/api/etcdhttp/metrics.go#L76

Currently, we only match the prefix of metric name. So we don't find this problem.

https://github.com/etcd-io/etcd/blob/800e7235ebcd99087f084d6afc8521cc35a03c14/integration/cluster.go#L1149-L1153

It seems split at ` ` or `{` to get full metric name will be better.(or just using Prometheus `TextParser`). If it looks good, I can pull request.
