### PR TITLE
pkg/schedule: recover from job panic

### DIFF
--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -30,6 +30,9 @@ func TestFIFOSchedule(t *testing.T) {
 				t.Fatalf("job#%d: got %d, want %d", i, next, i)
 			}
 			next = i + 1
+			if next%2 == 0 { // prevent panic all jobs
+				panic("panic job")
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR prevents job panic in pkg/scheduler.

In case that the recovered task error is not reported at the moment. However, the newly introduced function `exec` allows reporting the error by its return value.