### PR TITLE
metrics: promote etcd_debugging_mvcc put_total and delete_total

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -241,6 +241,8 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - Change [gRPC proxy to expose etcd server endpoint /metrics](https://github.com/etcd-io/etcd/pull/10618).
   - The metrics that were exposed via the proxy were not etcd server members but instead the proxy itself.
 - Fix bug where [db_compaction_total_duration_milliseconds metric incorrectly measured duration as 0](https://github.com/etcd-io/etcd/pull/10646).
+- Promote [`etcd_debugging_mvcc_put_total`](https://github.com/etcd-io/etcd/pull/10962) Prometheus metric to etcd_mvcc_put_total.
+- Promote [`etcd_debugging_mvcc_delete_total`](https://github.com/etcd-io/etcd/pull/10962) Prometheus metric to etcd_mvcc_delete_total.
 
 ### Security, Authentication
 

--- a/mvcc/metrics.go
+++ b/mvcc/metrics.go
@@ -31,6 +31,15 @@ var (
 
 	putCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
+			Namespace: "etcd",
+			Subsystem: "mvcc",
+			Name:      "put_total",
+			Help:      "Total number of puts seen by this member.",
+		})
+
+	// TODO: remove in 3.5 release
+	putCounterDebug = prometheus.NewCounter(
+		prometheus.CounterOpts{
 			Namespace: "etcd_debugging",
 			Subsystem: "mvcc",
 			Name:      "put_total",
@@ -38,6 +47,15 @@ var (
 		})
 
 	deleteCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "etcd",
+			Subsystem: "mvcc",
+			Name:      "delete_total",
+			Help:      "Total number of deletes seen by this member.",
+		})
+
+	// TODO: remove in 3.5 release
+	deleteCounterDebug = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd_debugging",
 			Subsystem: "mvcc",

--- a/mvcc/metrics_txn.go
+++ b/mvcc/metrics_txn.go
@@ -53,5 +53,9 @@ func (tw *metricsTxnWrite) End() {
 	}
 	rangeCounter.Add(float64(tw.ranges))
 	putCounter.Add(float64(tw.puts))
+	// TODO: remove in 3.5 release
+	putCounterDebug.Add(float64(tw.puts))
 	deleteCounter.Add(float64(tw.deletes))
+	// TODO: remove in 3.5 release
+	deleteCounterDebug.Add(float64(tw.deletes))
 }

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -40,20 +40,32 @@ func metricsTest(cx ctlCtx) {
 	if err := ctlV3Put(cx, "k", "v", ""); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: `etcd_debugging_mvcc_keys_total 1`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
-		cx.t.Fatalf("failed get with curl (%v)", err)
-	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
-		cx.t.Fatalf("failed get with curl (%v)", err)
-	}
 	ver := version.Version
 	if strings.HasSuffix(ver, "+git") {
 		ver = strings.Replace(ver, "+git", "", 1)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, ver), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
-		cx.t.Fatalf("failed get with curl (%v)", err)
-	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health":"true"}`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
-		cx.t.Fatalf("failed get with curl (%v)", err)
+
+	i := 0
+	for _, test := range []struct {
+		endpoint, expected string
+	}{
+		{"/metrics", fmt.Sprintf("etcd_mvcc_put_total 2")},
+		{"/metrics", fmt.Sprintf("etcd_debugging_mvcc_keys_total 1")},
+		{"/metrics", fmt.Sprintf("etcd_mvcc_delete_total 3")},
+		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
+		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, ver)},
+		{"/health", `{"health":"true"}`},
+	} {
+		i++
+		if err := ctlV3Put(cx, fmt.Sprintf("%d", i), "v", ""); err != nil {
+			cx.t.Fatal(err)
+		}
+		if err := ctlV3Del(cx, []string{fmt.Sprintf("%d", i)}, 1); err != nil {
+			cx.t.Fatal(err)
+		}
+
+		if err := cURLGet(cx.epc, cURLReq{endpoint: test.endpoint, expected: test.expected, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+			cx.t.Fatalf("failed get with curl (%v)", err)
+		}
 	}
 }


### PR DESCRIPTION
This PR promotes the following experimental metrics to stable.

- etcd_debugging_mvcc_put_total -> etcd_mvcc_put_total
- etcd_debugging_mvcc_delete_total  -> etcd_mvcc_delete_total

Fixes #10950

/cc @p0lyn0mial
