### PR TITLE
raft : remove unnecessary, if check

### DIFF
--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -45,9 +45,6 @@ type RawNode struct {
 // state manually by setting up a Storage that has a first index > 1 and which
 // stores the desired ConfState as its InitialState.
 func NewRawNode(config *Config) (*RawNode, error) {
-	if config.ID == 0 {
-		panic("config.ID must not be zero")
-	}
 	r := newRaft(config)
 	rn := &RawNode{
 		raft: r,


### PR DESCRIPTION
`newRaft()` does check for validity of `Config` object.