### PR TITLE
proxy: Add critical section to protect wps.watchers and wps.nextWatcherID

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -240,6 +240,7 @@ func (wps *watchProxyStream) recvLoop() error {
 				continue
 			}
 
+			wps.mu.Lock()
 			w := &watcher{
 				wr:  watchRange{string(cr.Key), string(cr.RangeEnd)},
 				id:  wps.nextWatcherID,
@@ -258,6 +259,7 @@ func (wps *watchProxyStream) recvLoop() error {
 			w.nextrev = cr.StartRevision
 			wps.watchers[w.id] = w
 			wps.ranges.add(w)
+			wps.mu.Unlock()
 		case *pb.WatchRequest_CancelRequest:
 			wps.delete(uv.CancelRequest.WatchId)
 		default:


### PR DESCRIPTION
***Description***
Among 6 read/write operations to wps.watchers, 5 of them are protected by wps.mu.Lock(), except the one [at line 259 in file etcd/proxy/grpcproxy/watch.go](https://github.com/etcd-io/etcd/blob/master/proxy/grpcproxy/watch.go#L259)

***What I did***
Add wps.mu.Lock() to protect wps.watchers and wps.nextWatcherID, and then wps.mu.Unlock()

***Why I did this***
It is quite clear that wps.watchers should be protected, since all other 5 usages of it is protected by wps.mu.Lock().  If wps.watchers doesn't need a mutex [at line 259 in function wps.recvLoop()](https://github.com/etcd-io/etcd/blob/master/proxy/grpcproxy/watch.go#L259), then it also doesn't need a mutex [at line 289 and 294 in function wps.delete()](https://github.com/etcd-io/etcd/blob/master/proxy/grpcproxy/watch.go#L289-L294), because wps.delete() is only called in wps.recvLoop()

About wps.nextWatcherID, it is only used 2 times, and both of them are not in critical section. However, I included it in critical section, because it is said that wps.mu protects wps.watchers and wps.nextWatcherID:
https://github.com/etcd-io/etcd/blob/9a2af7378a937a3434dd126e225108c97bef0cdf/proxy/grpcproxy/watch.go#L162-L171

***Is it possible for this patch to introduce other bugs?***
I detected this bug by my static checker, so I can't provide runtime stack to validate my patch. Then I looked into all function calls in the new critical section, and none of them contains wps.mu, so it is not possible to introduce a double lock bug.