### PR TITLE
Add critical section to protect s.currentRev

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -165,6 +165,7 @@ func (s *store) compactBarrier(ctx context.Context, ch chan struct{}) {
 }
 
 func (s *store) Hash() (hash uint32, revision int64, err error) {
+	// TODO: hash and revision could be inconsistent, one possible fix is to add s.revMu.RLock() at the beginning of function, which is costly
 	start := time.Now()
 
 	s.b.ForceCommit()


### PR DESCRIPTION
***Description***
Among 14 read/write operations to s.currentRev, 10 of them are protected by `s.revMu.RLock()` or `s.mu.Lock()`, 3 of them are synchronized by using channel `revc`, but there is one read operation not protect by any Mutex, RWMutex or channel, which is in function `store.Hash()` at line 174 of file etcd/mvcc/kvstore.go:
https://github.com/etcd-io/etcd/blob/9a2af7378a937a3434dd126e225108c97bef0cdf/mvcc/kvstore.go#L167-L175

***What I did***
Add `s.revMu.RLock()` and `defer s.revMu.RUnlock()` to protect s.currentRev

***Why I did this***
In the comment of s.revMu, it is said that s.revMu protects currentRev:
```Go
	// revMuLock protects currentRev and compactMainRev.
	// Locked at end of write txn and released after write txn unlock lock.
	// Locked before locking read txn and released after locking.
	revMu sync.RWMutex
```

***Is it possible for this patch to introduce other bugs?***
I think we only need to consider whether this patch will introduce double lock bug or not (double RLock can also produce deadlock bug if there is another goroutine).  
I detected this bug by my static checker, so I can't provide runtime information to validate my patch. However, the buggy function is `store.Hash()`, and [there is a test function that directly uses `store.Hash()` without using `s.revMu.RLock()`](https://github.com/etcd-io/etcd/blob/master/mvcc/kv_test.go#L590). So I think this patch is safe to use.
