### PR TITLE
Add critical section to protect a read operation s.compactMainRev

### DIFF
--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -119,7 +119,10 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 	if rev <= 0 {
 		rev = curRev
 	}
-	if rev < tr.s.compactMainRev {
+	tr.s.revMu.RLock()
+	compactMainRev := tr.s.compactMainRev
+	tr.s.revMu.RUnlock()
+	if rev < compactMainRev {
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
 


### PR DESCRIPTION
***Description***
This PR is related to #10975 
A read operation to s.compactMainRev at line 122 of file etcd/mvcc/kvstore_txn.go that is not protected by RWMutex.

***What I did***
Add `s.revMu.RLock()` and `s.revMu.RUnlock()` to protect s.compactMainRev

***Why I did this***
In the comment of s.revMu, it is said that s.revMu protects compactMainRev:
```Go
	// revMuLock protects currentRev and compactMainRev.
	// Locked at end of write txn and released after write txn unlock lock.
	// Locked before locking read txn and released after locking.
	revMu sync.RWMutex
```

***Is it possible for this patch to introduce other bugs?***
I think we only need to consider whether this patch will introduce double lock bug or not. It is hard to find all functions calling this function or its caller, but I briefly go through these code and don't think double lock bug can happen.