### PR TITLE
functional: update go.etcd.io/etcd link and go image registry for func…

### DIFF
--- a/functional/Dockerfile
+++ b/functional/Dockerfile
@@ -20,12 +20,12 @@ RUN rm -rf ${GOROOT} \
   && mkdir -p ${GOPATH}/src ${GOPATH}/bin \
   && go version
 
-RUN mkdir -p ${GOPATH}/src/github.com/etcd-io/etcd
-ADD . ${GOPATH}/src/github.com/etcd-io/etcd
+RUN mkdir -p ${GOPATH}/src/go.etcd.io/etcd
+ADD . ${GOPATH}/src/go.etcd.io/etcd
 ADD ./functional.yaml /functional.yaml
 
-RUN go get -v github.com/etcd-io/gofail \
-  && pushd ${GOPATH}/src/github.com/etcd-io/etcd \
+RUN go get -v go.etcd.io/gofail \
+  && pushd ${GOPATH}/src/go.etcd.io/etcd \
   && GO_BUILD_FLAGS="-v" ./build \
   && mkdir -p /bin \
   && cp ./bin/etcd /bin/etcd \
@@ -39,4 +39,4 @@ RUN go get -v github.com/etcd-io/gofail \
   && cp ./bin/etcd-tester /bin/etcd-tester \
   && go build -v -o /bin/benchmark ./tools/benchmark \
   && popd \
-  && rm -rf ${GOPATH}/src/github.com/etcd-io/etcd
+  && rm -rf ${GOPATH}/src/go.etcd.io/etcd

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -38,5 +38,5 @@ docker run \
   --rm \
   --net=host \
   --name ${AGENT_NAME} \
-  gcr.io/etcd-development/etcd-functional-tester:go${GO_VERSION} \
+  gcr.io/etcd-development/etcd-functional:go${GO_VERSION} \
   /bin/bash -c "./bin/etcd-agent ${AGENT_ADDR_FLAG}"

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -14,5 +14,5 @@ docker run \
   --rm \
   --net=host \
   --name tester \
-  gcr.io/etcd-development/etcd-functional-tester:go${GO_VERSION} \
+  gcr.io/etcd-development/etcd-functional:go${GO_VERSION} \
   /bin/bash -c "./bin/etcd-tester --config ./functional.yaml"


### PR DESCRIPTION
Fix some bugs when running functional docker test:
1. update "go.etcd.io/etcd" link in functional/scripts
2. update go image registry to match https://github.com/etcd-io/etcd/blob/4bf584893c74a00b34a563cfa154b14f55e01436/Makefile#L493

I will backport to release-3.4 once merged.