### PR TITLE
Automated cherry pick of #10987

### DIFF
--- a/functional/Dockerfile
+++ b/functional/Dockerfile
@@ -20,12 +20,12 @@ RUN rm -rf ${GOROOT} \
   && mkdir -p ${GOPATH}/src ${GOPATH}/bin \
   && go version
 
-RUN mkdir -p ${GOPATH}/src/github.com/etcd-io/etcd
-ADD . ${GOPATH}/src/github.com/etcd-io/etcd
+RUN mkdir -p ${GOPATH}/src/go.etcd.io/etcd
+ADD . ${GOPATH}/src/go.etcd.io/etcd
 ADD ./functional.yaml /functional.yaml
 
-RUN go get -v github.com/etcd-io/gofail \
-  && pushd ${GOPATH}/src/github.com/etcd-io/etcd \
+RUN go get -v go.etcd.io/gofail \
+  && pushd ${GOPATH}/src/go.etcd.io/etcd \
   && GO_BUILD_FLAGS="-v" ./build \
   && mkdir -p /bin \
   && cp ./bin/etcd /bin/etcd \
@@ -39,4 +39,4 @@ RUN go get -v github.com/etcd-io/gofail \
   && cp ./bin/etcd-tester /bin/etcd-tester \
   && go build -v -o /bin/benchmark ./tools/benchmark \
   && popd \
-  && rm -rf ${GOPATH}/src/github.com/etcd-io/etcd
+  && rm -rf ${GOPATH}/src/go.etcd.io/etcd

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -38,5 +38,5 @@ docker run \
   --rm \
   --net=host \
   --name ${AGENT_NAME} \
-  gcr.io/etcd-development/etcd-functional-tester:go${GO_VERSION} \
+  gcr.io/etcd-development/etcd-functional:go${GO_VERSION} \
   /bin/bash -c "./bin/etcd-agent ${AGENT_ADDR_FLAG}"

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -14,5 +14,5 @@ docker run \
   --rm \
   --net=host \
   --name tester \
-  gcr.io/etcd-development/etcd-functional-tester:go${GO_VERSION} \
+  gcr.io/etcd-development/etcd-functional:go${GO_VERSION} \
   /bin/bash -c "./bin/etcd-tester --config ./functional.yaml"


### PR DESCRIPTION
Cherry pick of #10987 on release-3.4.

#10987: functional:update go.etcd.io/etcd link and go image registry