### PR TITLE
integration: fix a data race about `err`

### DIFF
--- a/clientv3/integration/metrics_test.go
+++ b/clientv3/integration/metrics_test.go
@@ -41,12 +41,13 @@ func TestV3ClientMetrics(t *testing.T) {
 	var (
 		addr = "localhost:27989"
 		ln   net.Listener
-		err  error
 	)
 
 	// listen for all Prometheus metrics
 	donec := make(chan struct{})
 	go func() {
+		var err error
+
 		defer close(donec)
 
 		srv := &http.Server{Handler: promhttp.Handler()}
@@ -87,7 +88,7 @@ func TestV3ClientMetrics(t *testing.T) {
 
 	pBefore := sumCountersForMetricAndLabels(t, url, "grpc_client_started_total", "Put", "unary")
 
-	_, err = cli.Put(context.Background(), "foo", "bar")
+	_, err := cli.Put(context.Background(), "foo", "bar")
 	if err != nil {
 		t.Errorf("Error putting value in key store")
 	}


### PR DESCRIPTION
don't share `err` between goroutines

