### PR TITLE
v3rpc: fix a typo `err`

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -179,7 +179,7 @@ func (ws *watchServer) Watch(stream pb.Watch_WatchServer) (err error) {
 				}
 			} else {
 				if sws.lg != nil {
-					sws.lg.Warn("failed to receive watch request from gRPC stream", zap.Error(err))
+					sws.lg.Warn("failed to receive watch request from gRPC stream", zap.Error(rerr))
 				} else {
 					plog.Warningf("failed to receive watch request from gRPC stream (%q)", rerr.Error())
 				}


### PR DESCRIPTION

don't read return value in child goroutine which causes data race.



