### PR TITLE
raft: let learners vote

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -378,16 +378,21 @@ func TestLearnerPromotion(t *testing.T) {
 	}
 }
 
-// TestLearnerCannotVote checks that a learner can't vote even it receives a valid Vote request.
-func TestLearnerCannotVote(t *testing.T) {
+// TestLearnerCanVote checks that a learner can vote when it receives a valid Vote request.
+// See (*raft).Step for why this is necessary and correct behavior.
+func TestLearnerCanVote(t *testing.T) {
 	n2 := newTestLearnerRaft(2, []uint64{1}, []uint64{2}, 10, 1, NewMemoryStorage())
 
 	n2.becomeFollower(1, None)
 
 	n2.Step(pb.Message{From: 1, To: 2, Term: 2, Type: pb.MsgVote, LogTerm: 11, Index: 11})
 
-	if len(n2.msgs) != 0 {
-		t.Errorf("expect learner not to vote, but received %v messages", n2.msgs)
+	if len(n2.msgs) != 1 {
+		t.Fatalf("expected exactly one message, not %+v", n2.msgs)
+	}
+	msg := n2.msgs[0]
+	if msg.Type != pb.MsgVoteResp && !msg.Reject {
+		t.Fatal("expected learner to not reject vote")
 	}
 }
 


### PR DESCRIPTION
It turns out that that learners must be allowed to cast votes.

This seems counter- intuitive but is necessary in the situation in which
a learner has been promoted (i.e. is now a voter) but has not learned
about this yet.

For example, consider a group in which id=1 is a learner and id=2 and
id=3 are voters. A configuration change promoting 1 can be committed on
the quorum `{2,3}` without the config change being appended to the
learner's log. If the leader (say 2) fails, there are de facto two
voters remaining. Only 3 can win an election (due to its log containing
all committed entries), but to do so it will need 1 to vote. But 1
considers itself a learner and will continue to do so until 3 has
stepped up as leader, replicates the conf change to 1, and 1 applies it.

Ultimately, by receiving a request to vote, the learner realizes that
the candidate believes it to be a voter, and that it should act
accordingly. The candidate's config may be stale, too; but in that case
it won't win the election, at least in the absence of the bug discussed
in:
https://github.com/etcd-io/etcd/issues/7625#issuecomment-488798263.

PS I have a work-in-progress PR that makes these sorts of interactions
much more testable and I'm planning to add additional test coverage
when it lands.

PS2: note that a similar behavior already holds for considering entries committed.
This decision is made by the leader based on its view of the configuration. If a node
that considers itself a learner acks a log entry, and it is in fact a voter in the leader's
view, then that ack will count for the commit quorum for that index (and always has).
This is necessary, and so is this change.