### PR TITLE
doc: Fix broken links referring to redhatdocs.io

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -53,7 +53,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.12...v3.3.13) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://etcd.readthedocs.io/en/latest/operate.html#v3-3) for all metrics per release.
+See [List of metrics](https://etcd.io/docs/v3.3.12/metrics/) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -126,10 +126,7 @@ If adding multiple members the best practice is to configure a single member at 
 #### Add a new member as learner
 
 Starting from v3.4, etcd supports adding a new member as learner / non-voting member.
-The motivation and design can be found in [design doc](https://etcd.io/docs/v3.3.12/learning/learner/#raft-learner).
-In order to make the process of adding a new member safer,
-and to reduce cluster downtime when the new member is added, it is recommended that the new member is added to cluster
-as a learner until it catches up. This can be described as a three step process:
+The motivation and design can be found in [design doc][design-learner]. In order to make the process of adding a new member safer, and to reduce cluster downtime when the new member is added, it is recommended that the new member is added to cluster as a learner until it catches up. This can be described as a three step process:
 
  * Add the new member as learner via [gRPC members API][member-api-grpc] or the `etcdctl member add --learner` command.
 
@@ -243,3 +240,4 @@ It is enabled by default.
 [remove member]: #remove-a-member
 [runtime-reconf]: runtime-reconf-design.md
 [error cases when promoting a member]: #error-cases-when-promoting-a-learner-member
+[design-learner]: ../learning/design-learner.md

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -126,7 +126,10 @@ If adding multiple members the best practice is to configure a single member at 
 #### Add a new member as learner
 
 Starting from v3.4, etcd supports adding a new member as learner / non-voting member.
-The motivation and design can be found in [design doc][design-learner]. In order to make the process of adding a new member safer, and to reduce cluster downtime when the new member is added, it is recommended that the new member is added to cluster as a learner until it catches up. This can be described as a three step process:
+The motivation and design can be found in [design doc][design-learner].
+In order to make the process of adding a new member safer,
+and to reduce cluster downtime when the new member is added, it is recommended that the new member is added to cluster
+as a learner until it catches up. This can be described as a three step process:
 
  * Add the new member as learner via [gRPC members API][member-api-grpc] or the `etcdctl member add --learner` command.
 

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -126,7 +126,7 @@ If adding multiple members the best practice is to configure a single member at 
 #### Add a new member as learner
 
 Starting from v3.4, etcd supports adding a new member as learner / non-voting member.
-The motivation and design can be found in [design doc](https://etcd.readthedocs.io/en/latest/server-learner.html).
+The motivation and design can be found in [design doc](https://etcd.io/docs/v3.3.12/learning/learner/#raft-learner).
 In order to make the process of adding a new member safer,
 and to reduce cluster downtime when the new member is added, it is recommended that the new member is added to cluster
 as a learner until it catches up. This can be described as a three step process:


### PR DESCRIPTION
Instead use links to the Documentation in the internal repo. 