### PR TITLE
functiona: fix flaky tests

### DIFF
--- a/functional.yaml
+++ b/functional.yaml
@@ -29,7 +29,7 @@ agent-configs:
     initial-cluster: s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381
     initial-cluster-state: new
     initial-cluster-token: tkn
-    snapshot-count: 10000
+    snapshot-count: 2000
     quota-backend-bytes: 10740000000 # 10 GiB
     pre-vote: true
     initial-corrupt-check: true
@@ -80,7 +80,7 @@ agent-configs:
     initial-cluster: s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381
     initial-cluster-state: new
     initial-cluster-token: tkn
-    snapshot-count: 10000
+    snapshot-count: 2000
     quota-backend-bytes: 10740000000 # 10 GiB
     pre-vote: true
     initial-corrupt-check: true
@@ -131,7 +131,7 @@ agent-configs:
     initial-cluster: s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381
     initial-cluster-state: new
     initial-cluster-token: tkn
-    snapshot-count: 10000
+    snapshot-count: 2000
     quota-backend-bytes: 10740000000 # 10 GiB
     pre-vote: true
     initial-corrupt-check: true

--- a/functional/tester/cluster_run.go
+++ b/functional/tester/cluster_run.go
@@ -212,8 +212,8 @@ func (clus *Cluster) doRound() error {
 				)
 
 				// with network delay, some ongoing requests may fail
-				// only return error, if more than 10% of QPS requests fail
-				if cnt > int(clus.Tester.StressQPS)/10 {
+				// only return error, if more than 30% of QPS requests fail
+				if cnt > int(float64(clus.Tester.StressQPS)*0.3) {
 					return fmt.Errorf("expected no error in %q, got %q", fcase.String(), ess)
 				}
 			}


### PR DESCRIPTION
`SIGQUIT_AND_REMOVE_ONE_FOLLOWER_UNTIL_TRIGGER_SNAPSHOT` has been flaky.

Lower snapshot count for slow computes (e.g. CI), and be more generous about error counts during `NO_FAIL_WITH_STRESS`.

Address https://github.com/etcd-io/etcd/issues/10979.