### PR TITLE
mvcc/backend: Optimize etcd compaction

### DIFF
--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -909,6 +909,7 @@ func (b *fakeBackend) Snapshot() backend.Snapshot                               
 func (b *fakeBackend) ForceCommit()                                                {}
 func (b *fakeBackend) Defrag() error                                               { return nil }
 func (b *fakeBackend) Close() error                                                { return nil }
+func (b *fakeBackend) Compact(bucket []byte, keys [][]byte) error                  { return nil }
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
etcd's current compaction batch size is 10k and compactions are executed via mvcc backend write transaction. This can result in severely degraded p99 latency under heavy load each time a compaction occurs, due, in large part, to the batch size.

This PR reduces the batch size to 1k.

Also, the compaction writes are currently accumulated in the mvcc backend write buffer which must later perform a large write while holding the mvcc backend's main read/write lock, preventing new reads from initializing (i.e. ongoing reads may progress concurrently, but new ones cannot begin). But since compaction process removes only boltdb records for revisions that are no longer visible to readers. The main benefit of writing via a mvcc backend write transaction--buffering of writes in a way that ensure they remain visible to readers--is not needed. So this PR change performs compaction writes directly against boltdb. Avoiding lock contention in the mvcc backend and skipping the write buffer. This improves performance significantly.  The kube sig-scalability team tested this against 5k kubemark clusters and validated that it largely eliminates degraded p99 latency.

Even though this is simpler and more efficient. The boltdb writes that perform compaction block the mvcc backend write buffer from performing writeback. When this happens, the writeback will hold the main mvcc backend read/write lock, preventing new reads from initializing. Reducing the batch size to 1k helps minimize this (if the batch size is too low, we risk losing throughput).

Potential future work:
- Find a more optimal batch size)
- Improve how the mvcc backend manages locks to only acquire the main mvcc backend read/write lock once it has acquired the boltdb write lock, to increase concurrency.

There is a potential edge case where writes in the write buffer that are not yet flushed to boltdb become eligible for compaction. By deleting compacted revisions directly from boltdb, these revisions would not be compacted like they should. But this is not a problem because they are not visible to readers, and the next compaction operation after the write buffer is flushed will delete them from boltdb.