### PR TITLE
MAINTAINERS: add Tobias Grieger as a maintainer to raft

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,3 +16,5 @@ Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
 Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*
 
 Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:go.etcd.io/etcd/raft
+Tobias Grieger <tobias.schottdorf@gmail.com> (@tbg) pkg:go.etcd.io/etcd/raft
+


### PR DESCRIPTION
Tobias has contributed quite a lot to the raft repo. I would like to propose to let him become on of the raft pkg maintainer.

@tbg what do you think?

/cc @bdarnell @gyuho @philips @jpbetz 