### PR TITLE
compile in module mode

### DIFF
--- a/build
+++ b/build
@@ -54,11 +54,13 @@ etcd_build() {
 	# Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
 	# shellcheck disable=SC2086
 	CGO_ENABLED=0 go build $GO_BUILD_FLAGS \
+		-mod=vendor \
 		-installsuffix cgo \
 		-ldflags "$GO_LDFLAGS" \
 		-o "${out}/etcd" ${REPO_PATH} || return
 	# shellcheck disable=SC2086
 	CGO_ENABLED=0 go build $GO_BUILD_FLAGS \
+		-mod=vendor \
 		-installsuffix cgo \
 		-ldflags "$GO_LDFLAGS" \
 		-o "${out}/etcdctl" ${REPO_PATH}/etcdctl || return


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
As you know, because of the FW block I cannot compile the latest source with the build file and now that the the mod tool was used in the new version, I think it is a good way to compile in module mode. And it do well for me on Mac OS.