### PR TITLE
Optimize the code for httpproxy

### DIFF
--- a/proxy/httpproxy/reverse.go
+++ b/proxy/httpproxy/reverse.go
@@ -107,7 +107,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 	}
 
 	var requestClosed int32
-	completeCh := make(chan bool, 1)
+	completeCh := make(chan struct{})
 	closeNotifier, ok := rw.(http.CloseNotifier)
 	ctx, cancel := context.WithCancel(context.Background())
 	proxyreq = proxyreq.WithContext(ctx)
@@ -125,7 +125,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 		}()
 
 		defer func() {
-			completeCh <- true
+			close(completeCh)
 		}()
 	}
 

--- a/proxy/httpproxy/reverse.go
+++ b/proxy/httpproxy/reverse.go
@@ -129,12 +129,13 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 		}()
 	}
 
+	if proxybody != nil {
+		proxyreq.Body = ioutil.NopCloser(bytes.NewBuffer(proxybody))
+	}
+
 	var res *http.Response
 
 	for _, ep := range endpoints {
-		if proxybody != nil {
-			proxyreq.Body = ioutil.NopCloser(bytes.NewBuffer(proxybody))
-		}
 		redirectRequest(proxyreq, ep.URL)
 
 		res, err = p.transport.RoundTrip(proxyreq)


### PR DESCRIPTION
There are three optimization points：

1. Change buffer channel to synchronize channel
2. Remove unnecessary assignment
3. Optimize the sending process， add some error checking and  fix a potential bug.
