### PR TITLE
clientv3: add nil checks in Client.Close()

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -129,8 +129,12 @@ func NewFromURLs(urls []string) (*Client, error) {
 // Close shuts down the client's etcd connections.
 func (c *Client) Close() error {
 	c.cancel()
-	c.Watcher.Close()
-	c.Lease.Close()
+	if c.Watcher != nil {
+		c.Watcher.Close()
+	}
+	if c.Lease != nil {
+		c.Lease.Close()
+	}
 	if c.resolverGroup != nil {
 		c.resolverGroup.Close()
 	}

--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -156,3 +156,13 @@ func TestIsHaltErr(t *testing.T) {
 		t.Errorf("cancel on context should be Halted")
 	}
 }
+
+func TestCloseCtxClient(t *testing.T) {
+	ctx := context.Background()
+	c := NewCtxClient(ctx)
+	err := c.Close()
+	// Close returns ctx.toErr, a nil error means an open Done channel
+	if err == nil {
+		t.Errorf("failed to Close the client. %v", err)
+	}
+}


### PR DESCRIPTION
Added nil checks in Close() for Watcher and Lease fields
Added test case


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
