### PR TITLE
etcdserver: add check for nil options

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -388,7 +388,7 @@ func (as *authStore) UserAdd(r *pb.AuthUserAddRequest) (*pb.AuthUserAddResponse,
 	var hashed []byte
 	var err error
 
-	if !r.Options.NoPassword {
+	if r.Options != nil && !r.Options.NoPassword {
 		hashed, err = bcrypt.GenerateFromPassword([]byte(r.Password), as.bcryptCost)
 		if err != nil {
 			if as.lg != nil {


### PR DESCRIPTION
r.Options is not checked against nil before usage. It can cause panic in case Options is not defined