### PR TITLE
scripts/release: add sha256sum summary of release assets

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -140,12 +140,23 @@ main() {
   ./release/etcd-${RELEASE_VERSION}-$(go env GOOS)-amd64/etcd --version | grep -q "etcd Version: ${VERSION}" || true
   ./release/etcd-${RELEASE_VERSION}-$(go env GOOS)-amd64/etcdctl version | grep -q "etcdctl version: ${VERSION}" || true
 
+  # Generate SHA256SUM
+  echo -e "Generating sha256sum of release artifacts.\n"
+  ls ./release | grep -E '\.tar.gz$|\.zip$' | xargs shasum -a 256; > ./release/SHA256SUM
+  if [ -s ./release/SHA256SUM ]; then
+    cat ./release/SHA256SUM
+  else
+    echo "sha256sum is not valid. Aborting."
+    exit 1
+  fi
+
   # Upload artifacts.
   if [ "${NO_UPLOAD}" == 1 ]; then
     echo "Skipping artifact upload to gs://etcd. --no-upload flat is set."
   else
     read -p "Upload etcd ${RELEASE_VERSION} release artifacts to gs://etcd [y/N]? " confirm
     [[ "${confirm,,}" == "y" ]] || exit 1
+    gsutil -m cp ./release/SHA256SUM gs://etcd/${RELEASE_VERSION}/
     gsutil -m cp ./release/*.zip gs://etcd/${RELEASE_VERSION}/
     gsutil -m cp ./release/*.tar.gz gs://etcd/${RELEASE_VERSION}/
     gsutil -m acl ch -u allUsers:R -r gs://etcd/${RELEASE_VERSION}/


### PR DESCRIPTION
This PR adds a new file SHA256SUM to the release assets for etcd. The file contains a list of sha2456sum for each release asset. By providing a list of sha256sums we can then validate these in various ways including tools like rget[1] with the added advantage of not requiring an isolated signing key.

[1] https://github.com/merklecounty/rget 

Fixes https://github.com/etcd-io/etcd/issues/11086