### PR TITLE
tools/etcd-dump-logs: Fixed default values for -entry-type flag

### DIFF
--- a/tools/etcd-dump-logs/expectedoutput/decoder_correctoutputformat.output
+++ b/tools/etcd-dump-logs/expectedoutput/decoder_correctoutputformat.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:
@@ -26,7 +26,7 @@ term	     index	type	data	decoder_status	decoded_data
   12	        18	norm	ID:13 auth_enable:<> 	ERROR	jhjdcbcejj
   13	        19	norm	ID:14 auth_disable:<> 	ERROR	jhjeiacfjj
   14	        20	norm	ID:15 authenticate:<name:"myname" password:"password" simple_token:"token" > 	OK	jhjfabcfaijajffdgifefafdfeabjhgjfagcgcggffgbfdaajegdfffbfefe
-  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" > 	OK	jhajebddjejajefefafdfecaabjegjfagcgcca
+  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 	OK	jhajebddajjajefefafdfecaabjegjfagcgccaaajj
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 	OK	jhaaeaddjgjajefefafdfeca
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 	OK	jhabfbddjgjajefefafdfeca
   18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 	OK	jhacfaddjejajefefafdfecaabjegjfagcgccb
@@ -41,4 +41,4 @@ term	     index	type	data	decoder_status	decoded_data
   27	        33	norm	ID:28 auth_role_revoke_permission:<role:"role3" key:"key" range_end:"rangeend" > 	OK	jhacabdbafjajegbfffcfeccabjcfbfegiaajhgbfafefgfefefefd
   27	        34	norm	???	ERROR	cf
 
-Entry types () count is : 34
+Entry types (Normal,ConfigChange) count is : 34

--- a/tools/etcd-dump-logs/expectedoutput/decoder_wrongoutputformat.output
+++ b/tools/etcd-dump-logs/expectedoutput/decoder_wrongoutputformat.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:
@@ -26,7 +26,7 @@ term	     index	type	data	decoder_status	decoded_data
   12	        18	norm	ID:13 auth_enable:<> 	decoder output format is not right, print output anyway	jhjdcbcejj
   13	        19	norm	ID:14 auth_disable:<> 	decoder output format is not right, print output anyway	jhjeiacfjj
   14	        20	norm	ID:15 authenticate:<name:"myname" password:"password" simple_token:"token" > 	decoder output format is not right, print output anyway	jhjfabcfaijajffdgifefafdfeabjhgjfagcgcggffgbfdaajegdfffbfefe
-  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" > 	decoder output format is not right, print output anyway	jhajebddjejajefefafdfecaabjegjfagcgcca
+  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 	decoder output format is not right, print output anyway	jhajebddajjajefefafdfecaabjegjfagcgccaaajj
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 	decoder output format is not right, print output anyway	jhaaeaddjgjajefefafdfeca
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 	decoder output format is not right, print output anyway	jhabfbddjgjajefefafdfeca
   18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 	decoder output format is not right, print output anyway	jhacfaddjejajefefafdfecaabjegjfagcgccb
@@ -41,4 +41,4 @@ term	     index	type	data	decoder_status	decoded_data
   27	        33	norm	ID:28 auth_role_revoke_permission:<role:"role3" key:"key" range_end:"rangeend" > 	decoder output format is not right, print output anyway	jhacabdbafjajegbfffcfeccabjcfbfegiaajhgbfafefgfefefefd
   27	        34	norm	???	decoder output format is not right, print output anyway	cf
 
-Entry types () count is : 34
+Entry types (Normal,ConfigChange) count is : 34

--- a/tools/etcd-dump-logs/expectedoutput/listAll.output
+++ b/tools/etcd-dump-logs/expectedoutput/listAll.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:
@@ -26,7 +26,7 @@ term	     index	type	data
   12	        18	norm	ID:13 auth_enable:<> 
   13	        19	norm	ID:14 auth_disable:<> 
   14	        20	norm	ID:15 authenticate:<name:"myname" password:"password" simple_token:"token" > 
-  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" > 
+  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
   18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 
@@ -41,4 +41,4 @@ term	     index	type	data
   27	        33	norm	ID:28 auth_role_revoke_permission:<role:"role3" key:"key" range_end:"rangeend" > 
   27	        34	norm	???
 
-Entry types () count is : 34
+Entry types (Normal,ConfigChange) count is : 34

--- a/tools/etcd-dump-logs/expectedoutput/listConfigChange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listConfigChange.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listConfigChangeIRRCompaction.output
+++ b/tools/etcd-dump-logs/expectedoutput/listConfigChangeIRRCompaction.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRCompaction.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRCompaction.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRDeleteRange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRDeleteRange.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRLeaseGrant.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRLeaseGrant.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRLeaseRevoke.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRLeaseRevoke.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRPut.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRPut.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRRange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRRange.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listIRRTxn.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRTxn.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/expectedoutput/listInternalRaftRequest.output
+++ b/tools/etcd-dump-logs/expectedoutput/listInternalRaftRequest.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:
@@ -17,7 +17,7 @@ term	     index	type	data
   12	        18	norm	ID:13 auth_enable:<> 
   13	        19	norm	ID:14 auth_disable:<> 
   14	        20	norm	ID:15 authenticate:<name:"myname" password:"password" simple_token:"token" > 
-  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" > 
+  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
   18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 

--- a/tools/etcd-dump-logs/expectedoutput/listNormal.output
+++ b/tools/etcd-dump-logs/expectedoutput/listNormal.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:
@@ -22,7 +22,7 @@ term	     index	type	data
   12	        18	norm	ID:13 auth_enable:<> 
   13	        19	norm	ID:14 auth_disable:<> 
   14	        20	norm	ID:15 authenticate:<name:"myname" password:"password" simple_token:"token" > 
-  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" > 
+  15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
   18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 

--- a/tools/etcd-dump-logs/expectedoutput/listRequest.output
+++ b/tools/etcd-dump-logs/expectedoutput/listRequest.output
@@ -1,6 +1,6 @@
 Snapshot:
 empty
-Start dupmping log entries from snapshot.
+Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
 WAL entries:

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -38,16 +38,21 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultEntryTypes string = "Normal,ConfigChange"
+)
+
 func main() {
 	snapfile := flag.String("start-snap", "", "The base name of snapshot file to start dumping")
 	index := flag.Uint64("start-index", 0, "The index to start dumping")
-	entrytype := flag.String("entry-type", "", `If set, filters output by entry type. Must be one or more than one of:
-	ConfigChange, Normal, Request, InternalRaftRequest,
-	IRRRange, IRRPut, IRRDeleteRange, IRRTxn,
-	IRRCompaction, IRRLeaseGrant, IRRLeaseRevoke, IRRLeaseCheckpoint`)
+	// Default entry types are Normal and ConfigChange
+	entrytype := flag.String("entry-type", defaultEntryTypes, `If set, filters output by entry type. Must be one or more than one of:
+ConfigChange, Normal, Request, InternalRaftRequest,
+IRRRange, IRRPut, IRRDeleteRange, IRRTxn,
+IRRCompaction, IRRLeaseGrant, IRRLeaseRevoke, IRRLeaseCheckpoint`)
 	streamdecoder := flag.String("stream-decoder", "", `The name of an executable decoding tool, the executable must process
-	hex encoded lines of binary input (from etcd-dump-logs)
-	and output a hex encoded line of binary for each input line`)
+hex encoded lines of binary input (from etcd-dump-logs)
+and output a hex encoded line of binary for each input line`)
 
 	flag.Parse()
 
@@ -279,12 +284,6 @@ func evaluateEntrytypeFlag(entrytype string) []EntryFilter {
 		"IRRLeaseCheckpoint":  {passIRRLeaseCheckpoint},
 	}
 	filters := make([]EntryFilter, 0)
-	if len(entrytypelist) == 0 {
-		filters = append(filters, passInternalRaftRequest)
-		filters = append(filters, passRequest)
-		filters = append(filters, passUnknownNormal)
-		filters = append(filters, passConfChange)
-	}
 	for _, et := range entrytypelist {
 		if f, ok := validRequest[et]; ok {
 			filters = append(filters, f...)
@@ -373,7 +372,7 @@ func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry
 		}
 	}
 
-	fmt.Printf("\nEntry types (%s) count is : %d", entrytype, cnt)
+	fmt.Printf("\nEntry types (%s) count is : %d\n", entrytype, cnt)
 }
 
 func parseDecoderOutput(decoderoutput string) (string, string) {


### PR DESCRIPTION
The tool takes default values but it was not visible which default
values were taken. Added default values in proper place, and added a
newline at the end of output.

Fixed failing test case because of this change.

Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
