### PR TITLE
integration : fix TestTLSClientCipherSuitesMismatch in go1.13

### DIFF
--- a/integration/v3_tls_test.go
+++ b/integration/v3_tls_test.go
@@ -56,6 +56,9 @@ func testTLSCipherSuites(t *testing.T, valid bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// go1.13 enables TLS13 by default, and in TLS13, cipher suites are not configurable
+	// setting Max TLS version to TLS12 for go1.13
+	cc.MaxVersion = tls.VersionTLS12
 	cli, cerr := clientv3.New(clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCAddr()},
 		DialTimeout: time.Second,


### PR DESCRIPTION
In go1.13, the TLS13 is enablled by default, and as per go1.13 release notes :
TLS 1.3 cipher suites are not configurable. All supported cipher suites are safe,
and if PreferServerCipherSuites is set in Config the preference order is based
on the available hardware.

Fixing the test case for go1.13 by limiting the TLS version to TLS12


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
