### PR TITLE
etcdserver/api: add rtt_name label to peer_round_trip_time_seconds metrics.

### DIFF
--- a/etcdserver/api/rafthttp/metrics.go
+++ b/etcdserver/api/rafthttp/metrics.go
@@ -161,7 +161,7 @@ var (
 		// highest bucket start of 0.0001 sec * 2^15 == 3.2768 sec
 		Buckets: prometheus.ExponentialBuckets(0.0001, 2, 16),
 	},
-		[]string{"To"},
+		[]string{"To", "rtt_name"},
 	)
 )
 

--- a/etcdserver/api/rafthttp/probing_status.go
+++ b/etcdserver/api/rafthttp/probing_status.go
@@ -95,7 +95,7 @@ func monitorProbingStatus(lg *zap.Logger, s probing.Status, id string, roundTrip
 					plog.Warningf("the clock difference against peer %s is too high [%v > %v]", id, s.ClockDiff(), time.Second)
 				}
 			}
-			rttSecProm.WithLabelValues(id).Observe(s.SRTT().Seconds())
+			rttSecProm.WithLabelValues(id, roundTripperName).Observe(s.SRTT().Seconds())
 
 		case <-s.StopNotify():
 			return


### PR DESCRIPTION
Add one more level to metrics `peer_round_trip_time_seconds` to distinguish round tripper type. Since, the network latency between Snapshot` and Raft Message seems are not on the same level (we observed an obvious gap).

Fix: #11100 