### PR TITLE
Documentation: Sync etcdMembersDown alert

### DIFF
--- a/Documentation/op-guide/etcd3_alert.rules.yml
+++ b/Documentation/op-guide/etcd3_alert.rules.yml
@@ -2,6 +2,21 @@
 groups:
 - name: etcd
   rules:
+  - alert: etcdMembersDown
+    annotations:
+      message: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).'
+    expr: |
+      max by (job) (
+        sum by (job) (up{job=~".*etcd.*"} == bool 0)
+      or
+        count by (job,endpoint) (
+          sum by (job,endpoint,To) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[3m])) > 0.01
+        )
+      )
+      > 0
+    for: 3m
+    labels:
+      severity: critical
   - alert: etcdInsufficientMembers
     annotations:
       message: 'etcd cluster "{{ $labels.job }}": insufficient members ({{ $value
@@ -23,7 +38,7 @@ groups:
   - alert: etcdHighNumberOfLeaderChanges
     annotations:
       message: 'etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }}
-        has seen {{ $value }} leader changes within the last hour.'
+        has seen {{ $value }} leader changes within the last 30 minutes.'
     expr: |
       rate(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}[15m]) > 3
     for: 15m
@@ -76,7 +91,7 @@ groups:
   - alert: etcdHighNumberOfFailedProposals
     annotations:
       message: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within
-        the last hour on etcd instance {{ $labels.instance }}.'
+        the last 30 minutes on etcd instance {{ $labels.instance }}.'
     expr: |
       rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
     for: 15m


### PR DESCRIPTION
New alert introduced via #10906.
Sync rules to Documentation/etcd-mixin/mixin.libsonnet.
This is prerequisite as described hacks for prometheus-operator
https://github.com/helm/charts/tree/master/stable/prometheus-operator/hack