### PR TITLE
CHANGELOG : Update CHANGELOG-3.5.md for Mutex.TryLock

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -81,6 +81,11 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - Remove [`embed.Config.Debug`](https://github.com/etcd-io/etcd/pull/10947).
   - Use `embed.Config.LogLevel` instead.
 
+### Package `clientv3`
+
+- Add [TryLock](https://github.com/etcd-io/etcd/pull/11104) method to `clientv3/concurrency/Mutex`. A non-blocking method on `Mutex` which does not wait to get lock on the Mutex, returns immediately if Mutex is locked by another session.
+
+
 ### gRPC gateway
 
 - [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway) only supports [`/v3`](TODO) endpoint.


### PR DESCRIPTION
Added https://github.com/etcd-io/etcd/pull/11104 to CHANGELOG for 3.5


