### PR TITLE
travis: re-enable bom tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
       linux-amd64-fmt)
         docker run --rm \
           --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='fmt dep' ./test"
+          /bin/bash -c "GOARCH=amd64 PASSES='fmt bom dep' ./test"
         ;;
       linux-amd64-integration-1-cpu)
         docker run --rm \


### PR DESCRIPTION
bill-of-materials was fixed for module aware 'go list' as part of https://github.com/coreos/license-bill-of-materials/pull/17
So can re enable bom tests

fixes #11132
