### PR TITLE
hack: fix cherrypick instruction

### DIFF
--- a/hack/patch/README.md
+++ b/hack/patch/README.md
@@ -7,14 +7,14 @@ Handles cherry-picks of PR(s) from etcd master to a stable etcd release branch a
 Set the `UPSTREAM_REMOTE` and `FORK_REMOTE` environment variables.
 `UPSTREAM_REMOTE` should be set to git remote name of `github.com/etcd-io/etcd`,
 and `FORK_REMOTE` should be set to the git remote name of the forked etcd
-repo (`github.com/${github-username}/etcd`). Use `git remotes -v` to
+repo (`github.com/${github-username}/etcd`). Use `git remote -v` to
 look up the git remote names. If etcd has not been forked, create
 one on github.com and register it locally with `git remote add ...`.
 
 
 ```
-export UPSTREAM_REMOTE=origin
-export FORK_REMOTE=${github-username}
+export UPSTREAM_REMOTE=upstream
+export FORK_REMOTE=origin
 export GITHUB_USER=${github-username}
 ```
 


### PR DESCRIPTION
`remotes` is not a valid git command. Also, set the environmental variable
correctly.

