### PR TITLE
etcdctl/ctlv3: do not modify db file on "restore"

### DIFF
--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -407,7 +407,7 @@ func dbStatus(p string) dbstatus {
 
 	ds := dbstatus{}
 
-	db, err := bolt.Open(p, 0400, nil)
+	db, err := bolt.Open(p, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		ExitWithError(ExitError, err)
 	}


### PR DESCRIPTION
This can break production rollback/downgrade process:

For example,

1. start etcd v3.3.10
2. write some data
3. use etcdctl v3.3.10 to save snapshot
4. somehow, upgrading Kubernetes fails, thus rolling back to previous version etcd v3.2.24
5. run etcdctl v3.2.24 snapshot status against the snapshot file saved from v3.3.10 server
6. run etcdctl v3.2.24 snapshot restore fails with `"expected sha256 [12..."`

/cc @wenjiaswe @jingyih 