### PR TITLE
transport: add check trusted-ca-file when open client-cert-auth

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -246,6 +246,7 @@ func (info TLSInfo) baseConfig() (*tls.Config, error) {
 	if info.KeyFile == "" || info.CertFile == "" {
 		return nil, fmt.Errorf("KeyFile and CertFile must both be present[key: %v, cert: %v]", info.KeyFile, info.CertFile)
 	}
+
 	if info.Logger == nil {
 		info.Logger = zap.NewNop()
 	}
@@ -360,8 +361,12 @@ func (info TLSInfo) ServerConfig() (*tls.Config, error) {
 		return nil, err
 	}
 
+	if info.ClientCertAuth && info.TrustedCAFile == "" {
+		return nil, fmt.Errorf("ClientCertAuth and TrustedCAFile must both be present[key: %v, cert: %v]", info.ClientCertAuth, info.TrustedCAFile)
+	}
+
 	cfg.ClientAuth = tls.NoClientCert
-	if info.TrustedCAFile != "" || info.ClientCertAuth {
+	if info.ClientCertAuth {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 


### PR DESCRIPTION
When you have set trusted-ca-file ,the client-cert-auth is useless.
So add a check ,the trusted-ca-file must be set,when you open client-cert-auth.
Just only set trusted-ca-file is useless.

Fixes #11124


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
