### PR TITLE
doc: clarify metrics flag

### DIFF
--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -411,7 +411,7 @@ Follow the instructions when using these flags.
 + env variable: ETCD_ENABLE_PPROF
 
 ### --metrics
-+ Set level of detail for exported metrics, specify 'extensive' to include histogram metrics.
++ Set level of detail for exported metrics, specify 'extensive' to include server side grpc histogram metrics.
 + default: basic
 + env variable: ETCD_METRICS
 

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -240,7 +240,7 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.EnablePprof, "enable-pprof", false, "Enable runtime profiling data via HTTP server. Address is at client URL + \"/debug/pprof/\"")
 
 	// additional metrics
-	fs.StringVar(&cfg.ec.Metrics, "metrics", cfg.ec.Metrics, "Set level of detail for exported metrics, specify 'extensive' to include histogram metrics")
+	fs.StringVar(&cfg.ec.Metrics, "metrics", cfg.ec.Metrics, "Set level of detail for exported metrics, specify 'extensive' to include server side grpc histogram metrics")
 
 	// auth
 	fs.StringVar(&cfg.ec.AuthToken, "auth-token", cfg.ec.AuthToken, "Specify auth token specific options.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -167,7 +167,7 @@ Profiling and Monitoring:
   --enable-pprof 'false'
     Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"
   --metrics 'basic'
-    Set level of detail for exported metrics, specify 'extensive' to include histogram metrics.
+    Set level of detail for exported metrics, specify 'extensive' to include server side grpc histogram metrics.
   --listen-metrics-urls ''
     List of URLs to listen on for the metrics and health endpoints.
 


### PR DESCRIPTION
It appears that `--metrics="extensive"` flag is only enabling grpc related histogram metrics on server side. Other histogram metrics are always enabled despite this flag.

ref: https://github.com/etcd-io/etcd/blob/c55410ccea53bf613f10f6376ef870d3c81e2eec/embed/etcd.go#L758-L760

Related #11177.