### PR TITLE
scripts: avoid release builds on darwin machine.

### DIFF
--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -57,6 +57,11 @@ function main {
 	cd release
 	setup_env "${PROJ}" "${VER}"
 
+	if [[ $(go env GOOS) == "darwin" ]]; then
+		echo "Please use linux machine for release builds."
+		exit 1
+	fi
+
 	for os in darwin windows linux; do
 		export GOOS=${os}
 		TARGET_ARCHS=("amd64")


### PR DESCRIPTION
Backport to release-3.3.
