### PR TITLE
Automated cherry pick of #11233 #11254 on release 3.4

### DIFF
--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -575,9 +575,9 @@ func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *s
 		mustSaveClusterVersionToBackend(c.be, ver)
 	}
 	if oldVer != nil {
-		ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": oldVer.String()}).Set(0)
+		ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(oldVer.String())}).Set(0)
 	}
-	ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": ver.String()}).Set(1)
+	ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(ver.String())}).Set(1)
 	onSet(c.lg, ver)
 }
 

--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -565,6 +565,7 @@ func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *s
 			plog.Noticef("set the initial cluster version to %v", version.Cluster(ver.String()))
 		}
 	}
+	oldVer := c.version
 	c.version = ver
 	mustDetectDowngrade(c.lg, c.version)
 	if c.v2store != nil {
@@ -572,6 +573,9 @@ func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *s
 	}
 	if c.be != nil {
 		mustSaveClusterVersionToBackend(c.be, ver)
+	}
+	if oldVer != nil {
+		ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": oldVer.String()}).Set(0)
 	}
 	ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": ver.String()}).Set(1)
 	onSet(c.lg, ver)

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -48,7 +48,7 @@ func metricsTest(cx ctlCtx) {
 		{"/metrics", fmt.Sprintf("etcd_debugging_mvcc_keys_total 1")},
 		{"/metrics", fmt.Sprintf("etcd_mvcc_delete_total 3")},
 		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
-		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version)+".0")},
+		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))},
 		{"/health", `{"health":"true"}`},
 	} {
 		i++


### PR DESCRIPTION
Cherry pick of #11233 #11254 on release-3.4.

#11233: etcdserver: unset old cluster version in metrics
#11254: etcdserver: strip patch version in cluster version