### PR TITLE
grpcproxy: Add an Unlock before continue to prevent double lock

### DIFF
--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -254,6 +254,7 @@ func (wps *watchProxyStream) recvLoop() error {
 			}
 			if !w.wr.valid() {
 				w.post(&pb.WatchResponse{WatchId: -1, Created: true, Canceled: true})
+				wps.mu.Unlock()
 				continue
 			}
 			wps.nextWatcherID++


### PR DESCRIPTION
***Description***
In watchProxyStream.recvLoop of etcd/proxy/grpcproxy/watch.go, `wps.mu.Lock()` is at line 244 and `wps.mu.Unlock()` is at line 263. However, there is a `continue` at line 257. If this `continue` is executed, the loop will be executed again with `wps.mu` locked, which may cause double lock bug.

***How it is fixed***
Add a `wps.mu.Unlock()` before the `continue` at line 257, so no matter what the control flow is, the status of `wps.mu` will be the same.