### PR TITLE
etcdserver: strip patch version in metrics

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -786,7 +786,7 @@ func (s *EtcdServer) start() {
 		} else {
 			plog.Infof("starting server... [version: %v, cluster version: %v]", version.Version, version.Cluster(s.ClusterVersion().String()))
 		}
-		membership.ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": s.ClusterVersion().String()}).Set(1)
+		membership.ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(s.ClusterVersion().String())}).Set(1)
 	} else {
 		if lg != nil {
 			lg.Info(


### PR DESCRIPTION
This PR completes #11254. 

For example, if node starts / restarts with existing data dir (which stores cluster version), it goes through this code path. Found in #11261.