### PR TITLE
e2e: only expect cluster's major version is > 3 in release upgrade test

### DIFF
--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -8,10 +8,10 @@ fi
 <<COMMENT
 # amd64-e2e
 tests/semaphore.test.bash
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.2" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.3" make docker-test
 
 # 386-e2e
 sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" make docker-test
 COMMENT
 
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.2" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.3" make docker-test

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -8,10 +8,10 @@ fi
 <<COMMENT
 # amd64-e2e
 tests/semaphore.test.bash
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.0" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.2" make docker-test
 
 # 386-e2e
 sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" make docker-test
 COMMENT
 
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.0" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.2" make docker-test


### PR DESCRIPTION
Fix e2e test `TestReleaseUpgrade`.
The test will skip only when the cluster version is <3.0. 

> === RUN   TestReleaseUpgrade
--- SKIP: TestReleaseUpgrade (9.81s)
    etcd_release_upgrade_test.go:59: #0: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #1: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #2: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #3: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #4: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #5: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:59: #6: v3 is not ready yet (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
    etcd_release_upgrade_test.go:66: cannot pull version (read /dev/ptmx: input/output error (expected "\"etcdcluster\":\"3.5", got ["{\"etcdserver\":\"3.4.0\",\"etcdcluster\":\"3.4.0\"}"]))
Test ignored.
>

