### PR TITLE
backend: fix comment for bucketBuffer.merge()

### DIFF
--- a/mvcc/backend/tx_buffer.go
+++ b/mvcc/backend/tx_buffer.go
@@ -162,7 +162,7 @@ func (bb *bucketBuffer) add(k, v []byte) {
 	}
 }
 
-// merge merges data from bb into bbsrc.
+// merge merges data from bbsrc into bb.
 func (bb *bucketBuffer) merge(bbsrc *bucketBuffer) {
 	for i := 0; i < bbsrc.used; i++ {
 		bb.add(bbsrc.buf[i].key, bbsrc.buf[i].val)


### PR DESCRIPTION
IIRC, `bucketBuffer.merge()`'s logic is to merge the data from `bbsrc` into `bb`, therefore a comment fix.