### PR TITLE
Automated cherry pick of #11265 on release 3.4

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -786,7 +786,7 @@ func (s *EtcdServer) start() {
 		} else {
 			plog.Infof("starting server... [version: %v, cluster version: %v]", version.Version, version.Cluster(s.ClusterVersion().String()))
 		}
-		membership.ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": s.ClusterVersion().String()}).Set(1)
+		membership.ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(s.ClusterVersion().String())}).Set(1)
 	} else {
 		if lg != nil {
 			lg.Info(


### PR DESCRIPTION
Cherry pick of #11265 on release-3.4.

#11265: etcdserver: strip patch version in metrics