### PR TITLE
ci: add drone.io for arm64 verification

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,17 @@
+---
+kind: pipeline
+name: default
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: test
+  image: golang:1.13.1
+  commands:
+  - PASSES='build' ./test
+  - PASSES='unit' ./test
+  - CPU=1 PASSES='integration' ./test
+  - CPU=2 PASSES='integration' ./test
+  - CPU=4 PASSES='integration' ./test

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [![Releases](https://img.shields.io/github/release/etcd-io/etcd/all.svg?style=flat-square)](https://github.com/etcd-io/etcd/releases)
 [![LICENSE](https://img.shields.io/github/license/etcd-io/etcd.svg?style=flat-square)](https://github.com/etcd-io/etcd/blob/master/LICENSE)
 
+Drone CI for Arm64:
+
+[![Build Status Drone](https://cloud.drone.io/api/badges/etcd-io/etcd/status.svg?branch=master)](https://cloud.drone.io/etcd-io/etcd)
+
 **Note**: The `master` branch may be in an *unstable or even broken state* during development. Please use [releases][github-release] instead of the `master` branch in order to get stable binaries.
 
 ![etcd Logo](logos/etcd-horizontal-color.svg)


### PR DESCRIPTION
Enable arm64 CI test by applying drone CI,
Includes build test, unit test and integration test

Signed-off-by: Howard Zhang <howard.zhang@arm.com>


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
