### PR TITLE
rafthttp: add 3.4.0,3.5.0 stream type

### DIFF
--- a/etcdserver/api/rafthttp/stream.go
+++ b/etcdserver/api/rafthttp/stream.go
@@ -57,6 +57,8 @@ var (
 		"3.1.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"3.2.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"3.3.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"3.4.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"3.5.0": {streamTypeMsgAppV2, streamTypeMessage},
 	}
 )
 


### PR DESCRIPTION
Fix #11264 
Basically, the bug is due to the failure of `checkStreamSupport`. We need to add stream support to 3.4 and 3.5.
https://github.com/etcd-io/etcd/blob/51b1677d9944e0b28b6b04fab2a64b7a39fe9254/etcdserver/api/rafthttp/stream.go#L635
