### PR TITLE
e2e test: remove metricsURLScheme from e2e tests

### DIFF
--- a/e2e/etcd_release_upgrade_test.go
+++ b/e2e/etcd_release_upgrade_test.go
@@ -103,7 +103,7 @@ func TestReleaseUpgrade(t *testing.T) {
 	}
 
 	// expect upgraded cluster version
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version)), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
 }

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -22,17 +22,9 @@ import (
 	"github.com/coreos/etcd/version"
 )
 
-func TestV3MetricsSecure(t *testing.T) {
+func TestV3Metrics(t *testing.T) {
 	cfg := configTLS
 	cfg.clusterSize = 1
-	cfg.metricsURLScheme = "https"
-	testCtl(t, metricsTest)
-}
-
-func TestV3MetricsInsecure(t *testing.T) {
-	cfg := configTLS
-	cfg.clusterSize = 1
-	cfg.metricsURLScheme = "http"
 	testCtl(t, metricsTest)
 }
 
@@ -40,20 +32,20 @@ func metricsTest(cx ctlCtx) {
 	if err := ctlV3Put(cx, "k", "v", ""); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: `etcd_debugging_mvcc_keys_total 1`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: `etcd_debugging_mvcc_keys_total 1`}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
 	ver := version.Version
 	if strings.HasSuffix(ver, "+git") {
 		ver = strings.Replace(ver, "+git", "", 1)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version)), metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/metrics", expected: fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health":"true"}`, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health": "true"}`}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
 }


### PR DESCRIPTION
Cherry pick PR #11271 instroduced new e2e test failure since "metricsURLScheme" is added when adding "*: support additional '/metrics' endpoints (https://github.com/etcd-io/etcd/pull/8242", which is not in 3.2. Now e2e tests all pass.

cc @jingyih @gyuho 