### PR TITLE
fileutil, src: format errors

### DIFF
--- a/pkg/fileutil/lock_windows.go
+++ b/pkg/fileutil/lock_windows.go
@@ -28,7 +28,7 @@ var (
 	modkernel32    = syscall.NewLazyDLL("kernel32.dll")
 	procLockFileEx = modkernel32.NewProc("LockFileEx")
 
-	errLocked = errors.New("The process cannot access the file because another process has locked a portion of the file.")
+	errLocked = errors.New("the process cannot access the file because another process has locked a portion of the file")
 )
 
 const (

--- a/pkg/srv/srv_test.go
+++ b/pkg/srv/srv_test.go
@@ -185,7 +185,7 @@ func TestSRVDiscover(t *testing.T) {
 			if service == "etcd-client" {
 				return "", tt.withoutSSL, nil
 			}
-			return "", nil, errors.New("Unknown service in mock")
+			return "", nil, errors.New("unknown service in mock")
 		}
 
 		srvs, err := GetClient("etcd-client", "example.com", "")


### PR DESCRIPTION
Format errors, according to https://github.com/golang/go/wiki/CodeReviewComments#error-strings