### PR TITLE
mvcc: Add Unlock before panic to prevent double lock

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -427,6 +427,7 @@ func (s *store) restore() error {
 
 	for key, lid := range keyToLease {
 		if s.le == nil {
+			tx.Unlock()
 			panic("no lessor to attach lease")
 		}
 		err := s.le.Attach(lid, []lease.LeaseItem{{Key: key}})

--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -159,6 +159,7 @@ func (s *watchableStore) cancelWatcher(wa *watcher) {
 		}
 
 		if !wa.victim {
+			s.mu.Unlock()
 			panic("watcher not victim but not in watch groups")
 		}
 


### PR DESCRIPTION
***Description***
There are 2 places in mvcc where a Mutex is not Unlocked before panic. These 2 problems are similar so I use one patch to fix them both.

***Place 1***
```Go
func (s *watchableStore) cancelWatcher(wa *watcher) {
	for {
		s.mu.Lock()
		if s.unsynced.delete(wa) {
			slowWatcherGauge.Dec()
			break
		} else if ...

		if !wa.victim {
			panic("watcher not victim but not in watch groups")
		}
		...
		s.mu.Unlock()
		time.Sleep(time.Millisecond)
	}
	...
	s.mu.Unlock()
}
```

***Place 2***
```Go
func (s *store) restore() error {
	...
        tx.Lock()
	...
	for key, lid := range keyToLease {
		if s.le == nil {
			panic("no lessor to attach lease")
		}
		...
	}
	tx.Unlock()
	...
}
```