### PR TITLE
lease:Add Unlock before break in loop

### DIFF
--- a/lease/lessor_bench_test.go
+++ b/lease/lessor_bench_test.go
@@ -201,6 +201,7 @@ func benchmarkLessorFindExpired(benchSize int, b *testing.B) {
 			le.mu.Lock()
 			ls := le.findExpiredLeases(findExpiredLimit)
 			if len(ls) == 0 {
+				le.mu.Unlock()
 				break
 			}
 			le.mu.Unlock()


### PR DESCRIPTION
***Description***
The pair of `le.mu.Lock()` and `le.mu.Unlock()` is called each time when a loop is executed. However, there is a branch between them, leading to a `break`, and there is no `le.mu.Unlock()` before this `break`.

***Buggy code***
https://github.com/etcd-io/etcd/blob/84e2788c2e41937a851ceb9f365b8e3933b59083/lease/lessor_bench_test.go#L200-L206
