### PR TITLE
agent: add 1 buffer to errc to prevent goroutine leak

### DIFF
--- a/functional/agent/handler.go
+++ b/functional/agent/handler.go
@@ -121,7 +121,7 @@ func (srv *Server) creatEtcd(fromSnapshot bool) error {
 
 // start but do not wait for it to complete
 func (srv *Server) runEtcd() error {
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		time.Sleep(5 * time.Second)
 		// server advertise client/peer listener had to start first


### PR DESCRIPTION
***Description***
In function `(*Server).runEtcd()`, if `select` at line 150 chooses `case <-time.After(time.Minute):`, then the goroutine created at line 125 will be blocked forever, because there is no receive to synchronize with `errc <- srv.startProxy()` at line 129
https://github.com/etcd-io/etcd/blob/84e2788c2e41937a851ceb9f365b8e3933b59083/functional/agent/handler.go#L123-L158

***How it is fixed***
This patch is similar to line 210 in file lease/leasehttp/http.go of #7015
We add 1 buffer to the channel `errc`, and then the send `errc <- srv.startProxy()` will not be blocked and no goroutine will be leaked, but all receives will still be waiting for sent. So this patch is very safe.