### PR TITLE
raft: fix a blocking bug in node_test.go

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -848,8 +848,8 @@ func TestNodeProposeAddLearnerNode(t *testing.T) {
 						t.Errorf("add learner should not change the nodes: %v", state.String())
 					}
 					t.Logf("apply raft conf %v changed to: %v", cc, state.String())
-					applyConfChan <- struct{}{}
 				}
+				applyConfChan <- struct{}{}
 				n.Advance()
 			}
 		}


### PR DESCRIPTION
Fixes #11256 

***Description***
In function `TestNodeProposeAddLearnerNode`, there is a potential blocking bug. `applyConfChan` is a local unbuffered channel. It has 1 receive and 1 send, but the send is in a loop. So when this loop is executed multiple times, there may be no receive to synchronize with the send, and then the goroutine will be blocked.

I run this test multiple times and found that in current setting, the send won't be executed more than once, but this is still a bug.

***How it is fixed***
The send operation is moved out of the loop, so it will be executed only once.

***Related code***
The logic is complicated, since 3 channels are involved: `stop`, `done`, `applyConfChan`.
https://github.com/etcd-io/etcd/blob/84e2788c2e41937a851ceb9f365b8e3933b59083/raft/node_test.go#L812-L862