### PR TITLE
[WIP] test: fix commit title check for release 3.4 branch

### DIFF
--- a/test
+++ b/test
@@ -581,7 +581,7 @@ function receiver_name_pass {
 }
 
 function commit_title_pass {
-	git log --oneline "$(git merge-base HEAD master)"...HEAD | while read -r l; do
+	git log --oneline "$(git merge-base HEAD upstream/release-3.4)"...HEAD | while read -r l; do
 		commitMsg=$(echo "$l" | cut -f2- -d' ')
 		if [[ "$commitMsg" == Merge* ]]; then
 			# ignore "Merge pull" commits


### PR DESCRIPTION
I think the commit title check is only meant to be checking the new commits. Currently, new PR in release-3.4 branch fails the commit title check due to a bad commit title of a previously merged commit.