### PR TITLE
integration: prevent goroutines leaks in test

### DIFF
--- a/integration/v3_leadership_test.go
+++ b/integration/v3_leadership_test.go
@@ -39,10 +39,16 @@ func testMoveLeader(t *testing.T, auto bool) {
 
 	// ensure followers go through leader transition while learship transfer
 	idc := make(chan uint64)
+	stopc := make(chan struct{})
+	defer close(stopc)
+
 	for i := range clus.Members {
 		if oldLeadIdx != i {
 			go func(m *member) {
-				idc <- checkLeaderTransition(m, oldLeadID)
+				select {
+				case idc <- checkLeaderTransition(m, oldLeadID):
+				case <-stopc:
+				}
 			}(clus.Members[i])
 		}
 	}

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -1188,7 +1188,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		recv := make(chan *pb.WatchResponse)
+		recv := make(chan *pb.WatchResponse, 1)
 		go func() {
 			// check received PUT
 			resp, rerr := ws.Recv()

--- a/integration/v3election_grpc_test.go
+++ b/integration/v3election_grpc_test.go
@@ -97,7 +97,7 @@ func TestV3ElectionObserve(t *testing.T) {
 	lc := toGRPC(clus.Client(0)).Election
 
 	// observe leadership events
-	observec := make(chan struct{})
+	observec := make(chan struct{}, 1)
 	go func() {
 		defer close(observec)
 		s, err := lc.Observe(context.Background(), &epb.LeaderRequest{Name: []byte("foo")})


### PR DESCRIPTION
***Description***

There are 6 test functions sharing a similar problem: some goroutines in these functions will be leaked in certain cases (like timeout). 

Although `t.Fatal()` is often called in these certain cases, it won't stop the leaking, because ["Calling FailNow does not stop those other goroutines." ](https://golang.org/pkg/testing/#T.FailNow)

This patch stops these leaks no matter what happens in test. 

***How they are fixed***

If the channel operations are not in loop, the fix is to add 1 buffer to the channel. So send won't be blocked and receive will still wait for send.

If the channel operations are in loop, the fix is to create a new channel `stopc`, and put the "possibly-blocking" operation in a `select` together with `case <-stopc:`. Before test return or `t.Fatal()`, `close(stopc)` will be called, making sure every child goroutine will not be blocked.