### PR TITLE
WatchKey rpc service proposal

### DIFF
--- a/etcdserver/etcdserverpb/rpc.proto
+++ b/etcdserver/etcdserverpb/rpc.proto
@@ -3,6 +3,7 @@ package etcdserverpb;
 
 import "gogoproto/gogo.proto";
 import "etcd/mvcc/mvccpb/kv.proto";
+import "etcd/mvcc/mvccpb/key.proto";
 import "etcd/auth/authpb/auth.proto";
 
 // for grpc-gateway
@@ -71,6 +72,13 @@ service Watch {
   rpc Watch(stream WatchRequest) returns (stream WatchResponse) {
       option (google.api.http) = {
         post: "/v3/watch"
+        body: "*"
+    };
+  }
+
+  rpc WatchKey(stream WatchKeyRequest) returns (stream WatchKeyResponse) {
+      option (google.api.http) = {
+        post: "/v3/watch-key"
         body: "*"
     };
   }
@@ -757,6 +765,100 @@ message WatchResponse {
   bool fragment = 7;
 
   repeated mvccpb.Event events = 11;
+}
+
+message WatchKeyRequest {
+  // request_union is a request to either create a new watcher or cancel an existing watcher.
+  oneof request_union {
+    WatchKeyCreateRequest create_request = 1;
+    WatchKeyCancelRequest cancel_request = 2;
+    WatchKeyProgressRequest progress_request = 3;
+  }
+}
+
+message WatchKeyCreateRequest {
+  // key is the key to register for watching.
+  bytes key = 1;
+
+  // range_end is the end of the range [key, range_end) to watch. If range_end is not given,
+  // only the key argument is watched. If range_end is equal to '\0', all keys greater than
+  // or equal to the key argument are watched.
+  // If the range_end is one bit larger than the given key,
+  // then all keys with the prefix (the given key) will be watched.
+  bytes range_end = 2;
+
+  // start_revision is an optional revision to watch from (inclusive). No start_revision is "now".
+  int64 start_revision = 3;
+
+  // progress_notify is set so that the etcd server will periodically send a WatchResponse with
+  // no events to the new watcher if there are no recent events. It is useful when clients
+  // wish to recover a disconnected watcher starting from a recent known revision.
+  // The etcd server may decide how often it will send notifications based on current load.
+  bool progress_notify = 4;
+
+  enum FilterType {
+    // filter out put event.
+    NOPUT = 0;
+    // filter out delete event.
+    NODELETE = 1;
+  }
+
+  // filters filter the events at server side before it sends back to the watcher.
+  repeated FilterType filters = 5;
+
+  // If watch_id is provided and non-zero, it will be assigned to this watcher.
+  // Since creating a watcher in etcd is not a synchronous operation,
+  // this can be used ensure that ordering is correct when creating multiple
+  // watchers on the same stream. Creating a watcher with an ID already in
+  // use on the stream will cause an error to be returned.
+  int64 watch_id = 6;
+
+  // fragment enables splitting large revisions into multiple watch responses.
+  bool fragment = 7;
+}
+
+message WatchKeyCancelRequest {
+  // watch_id is the watcher id to cancel so that no more events are transmitted.
+  int64 watch_id = 1;
+}
+
+// Requests the a watch stream progress status be sent in the watch response stream as soon as
+// possible.
+message WatchKeyProgressRequest {
+}
+
+message WatchKeyResponse {
+  ResponseHeader header = 1;
+  // watch_id is the ID of the watcher that corresponds to the response.
+  int64 watch_id = 2;
+
+  // created is set to true if the response is for a create watch request.
+  // The client should record the watch_id and expect to receive events for
+  // the created watcher from the same stream.
+  // All events sent to the created watcher will attach with the same watch_id.
+  bool created = 3;
+
+  // canceled is set to true if the response is for a cancel watch request.
+  // No further events will be sent to the canceled watcher.
+  bool canceled = 4;
+
+  // compact_revision is set to the minimum index if a watcher tries to watch
+  // at a compacted index.
+  //
+  // This happens when creating a watcher at a compacted revision or the watcher cannot
+  // catch up with the progress of the key-value store.
+  //
+  // The client should treat the watcher as canceled and should not try to create any
+  // watcher with the same start_revision again.
+  int64 compact_revision = 5;
+
+  // cancel_reason indicates the reason for canceling the watcher.
+  string cancel_reason = 6;
+
+  // framgment is true if large watch response was split over multiple responses.
+  bool fragment = 7;
+
+  repeated mvccpb.KeyEvent events = 8;
 }
 
 message LeaseGrantRequest {

--- a/mvcc/mvccpb/key.proto
+++ b/mvcc/mvccpb/key.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+package mvccpb;
+
+import "gogoproto/gogo.proto";
+
+option (gogoproto.marshaler_all) = true;
+option (gogoproto.sizer_all) = true;
+option (gogoproto.unmarshaler_all) = true;
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.goproto_enum_prefix_all) = false;
+
+message Key {
+    // key is the key in bytes. An empty key is not allowed.
+    bytes key = 1;
+    // create_revision is the revision of last creation on this key.
+    int64 create_revision = 2;
+    // mod_revision is the revision of last modification on this key.
+    int64 mod_revision = 3;
+    // version is the version of the key. A deletion resets
+    // the version to zero and any modification of the key
+    // increases its version.
+    int64 version = 4;
+    // lease is the ID of the lease that attached to key.
+    // When the attached lease expires, the key will be deleted.
+    // If lease is 0, then no lease is attached to the key.
+    int64 lease = 5;
+}
+
+message KeyEvent {
+    enum KeyEventType {
+        PUT = 0;
+        DELETE = 1;
+    }
+    // type is the kind of event. If type is a PUT, it indicates
+    // new data has been stored to the key. If type is a DELETE,
+    // it indicates the key was deleted.
+    KeyEventType type = 1;
+    // key holds the Key for the event.
+    // A PUT event contains current key.
+    // A PUT event with key.Version=1 indicates the creation of a key.
+    // A DELETE/EXPIRE event contains the deleted key with
+    // its modification revision set to the revision of deletion.
+    Key key = 2;
+}


### PR DESCRIPTION
## Purpose

This is only a draft of target api and there is no implementation yet. 
I just want a feedback if this API meets the requirements.

## References

See #11019 

## Background Context

There was a need to introduce a watch API that returns only keys.