### PR TITLE
etcdserver: fix a bug which append object to a new allocated sized slice

### DIFF
--- a/etcdserver/corrupt.go
+++ b/etcdserver/corrupt.go
@@ -313,7 +313,7 @@ func (s *EtcdServer) getPeerHashKVs(rev int64) (resps []*peerHashKVResp) {
 	// TODO: handle the case when "s.cluster.Members" have not
 	// been populated (e.g. no snapshot to load from disk)
 	mbs := s.cluster.Members()
-	pss := make([]peerHashKVResp, len(mbs))
+	pss := make([]peerHashKVResp, 0, len(mbs))
 	for _, m := range mbs {
 		if m.ID == s.ID() {
 			continue


### PR DESCRIPTION
etcdserver: fix a bug which append object to a new allocated sized slice


https://github.com/etcd-io/etcd/blob/bbe1e78e6242a57d54c4b96d8c49ea1e094c3cbb/etcdserver/corrupt.go#L316
```go
mbs := s.cluster.Members()
	pss := make([]peerHashKVResp, len(mbs))
	for _, m := range mbs {
		if m.ID == s.ID() {
			continue
		}
		pss = append(pss, peerHashKVResp{id: m.ID, eps: m.PeerURLs})
	}
```
pss is a new slice with size len(mbs) and append to this slice make the [0:len(mbs)-1] elements are empty and useless. pss := make([]peerHashKVResp, len(mbs)) should be pss := make([]peerHashKVResp, 0, len(mbs))


Fixes #11320