### PR TITLE
mvcc/kvstore: Optimize compaction, slove conflict for #11150

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -272,15 +272,15 @@ func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
 }
 
 func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error) {
-	start := time.Now()
-	keep := s.kvindex.Compact(rev)
-	trace.Step("compact in-memory index tree")
 	ch := make(chan struct{})
 	var j = func(ctx context.Context) {
 		if ctx.Err() != nil {
 			s.compactBarrier(ctx, ch)
 			return
 		}
+		start := time.Now()
+		keep := s.kvindex.Compact(rev)
+		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 		if !s.scheduleCompaction(rev, keep) {
 			s.compactBarrier(nil, ch)
 			return
@@ -289,8 +289,6 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 	}
 
 	s.fifoSched.Schedule(j)
-
-	indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 	trace.Step("schedule compaction")
 	return ch, nil
 }


### PR DESCRIPTION
mvcc/kvstore: Optimize compaction

when the number of key-value index is greater than one million, compact take too long and blocks other requests.
Move the “kvindex.Compact” to “fifoSched.Schedule” func

slove conflict for  https://github.com/etcd-io/etcd/pull/11150