### PR TITLE
scripts/build-binary: Added s390x support for binary release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,8 @@ script:
             && GO_BUILD_FLAGS='-v' GOOS=windows GOARCH=amd64 ./build \
             && GO_BUILD_FLAGS='-v' GOARCH=arm ./build \
             && GO_BUILD_FLAGS='-v' GOARCH=arm64 ./build \
-            && GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build"
+            && GO_BUILD_FLAGS='-v' GOARCH=ppc64le ./build \
+            && GO_BUILD_FLAGS='-v' GOARCH=s390x ./build"
         ;;
       linux-amd64-grpcproxy)
         sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build grpcproxy'" make docker-test

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -70,6 +70,7 @@ function main {
 		if [ ${GOOS} == "linux" ]; then
 			TARGET_ARCHS+=("arm64")
 			TARGET_ARCHS+=("ppc64le")
+			TARGET_ARCHS+=("s390x")
 		fi
 
 		for TARGET_ARCH in "${TARGET_ARCHS[@]}"; do


### PR DESCRIPTION
scripts/build-binary: Added TARGET_ARCHS for supporting s390x binary build for release
.travis.yml: Added s390x build in all-build target.
