### PR TITLE
etcdserver: fix watch metrics

### DIFF
--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -35,6 +35,8 @@ var (
 	ErrGRPCLeaseExist       = status.New(codes.FailedPrecondition, "etcdserver: lease already exists").Err()
 	ErrGRPCLeaseTTLTooLarge = status.New(codes.OutOfRange, "etcdserver: too large lease TTL").Err()
 
+	ErrGRPCWatchCanceled = status.New(codes.Canceled, "etcdserver: watch canceled").Err()
+
 	ErrGRPCMemberExist            = status.New(codes.FailedPrecondition, "etcdserver: member ID already exist").Err()
 	ErrGRPCPeerURLExist           = status.New(codes.FailedPrecondition, "etcdserver: Peer URLs already exists").Err()
 	ErrGRPCMemberNotEnoughStarted = status.New(codes.FailedPrecondition, "etcdserver: re-configuration failed due to not enough started members").Err()

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -49,6 +49,7 @@ func metricsTest(cx ctlCtx) {
 		{"/metrics", fmt.Sprintf("etcd_mvcc_delete_total 3")},
 		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
 		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))},
+		{"/metrics", fmt.Sprintf(`grpc_server_handled_total{grpc_code="Canceled",grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"} 6`)},
 		{"/health", `{"health":"true"}`},
 	} {
 		i++
@@ -59,6 +60,9 @@ func metricsTest(cx ctlCtx) {
 			cx.t.Fatal(err)
 		}
 
+		if err := ctlV3Watch(cx, []string{"k", "--rev", "1"}, []kvExec{{key: "k", val: "v"}}...); err != nil {
+			cx.t.Fatal(err)
+		}
 		if err := cURLGet(cx.epc, cURLReq{endpoint: test.endpoint, expected: test.expected, metricsURLScheme: cx.cfg.metricsURLScheme}); err != nil {
 			cx.t.Fatalf("failed get with curl (%v)", err)
 		}


### PR DESCRIPTION
Currently, when a client closes context during watch we pass. `codes.Unavailable` to `status.New()` via `rpctypes.ErrGRPCNoLeader`[1],[2] this inadvertently registers `Unavailable` in Prometheus metrics which causes an issue as `Unavailable` indicates the service is currently unavailable [3]. This PR changes the logic for how we conclude the leader is lost by observing `RaftStatusGetter.Leader()`[4] for `raft.None`. Only then do we return Unavailable (no leader) otherwise Canceled.

Fixes #10289 #9725 #9576 #9166

[1] https://github.com/etcd-io/etcd/pull/11375/files#diff-8a4ebdea7c0a8a8926fca73c3058b0b9L200
[2] - https://github.com/etcd-io/etcd/blob/0fb26df249f1cd4982c49ef125a3b313dfbde7d6/etcdserver/api/v3rpc/rpctypes/error.go#L68
[3] https://github.com/grpc/grpc-go/blob/master/codes/codes.go#L140
[4] -  https://github.com/etcd-io/etcd/blob/bbe1e78e6242a57d54c4b96d8c49ea1e094c3cbb/etcdserver/server.go#L1907