### PR TITLE
clientv3/concurrency: Mutex blocking

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -378,6 +378,15 @@
 		]
 	},
 	{
+		"project": "golang.org/x/sync/semaphore",
+		"licenses": [
+			{
+				"type": "BSD 3-clause \"New\" or \"Revised\" License",
+				"confidence": 0.9663865546218487
+			}
+		]
+	},
+	{
 		"project": "golang.org/x/sys/unix",
 		"licenses": [
 			{

--- a/clientv3/concurrency/mutex.go
+++ b/clientv3/concurrency/mutex.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/sync/semaphore"
+
 	v3 "go.etcd.io/etcd/clientv3"
 	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 )
@@ -31,6 +33,7 @@ var ErrLocked = errors.New("mutex: Locked by another session")
 type Mutex struct {
 	s *Session
 
+	w     *semaphore.Weighted
 	pfx   string
 	myKey string
 	myRev int64
@@ -38,15 +41,21 @@ type Mutex struct {
 }
 
 func NewMutex(s *Session, pfx string) *Mutex {
-	return &Mutex{s, pfx + "/", "", -1, nil}
+	w := semaphore.NewWeighted(1)
+	return &Mutex{s, w, pfx + "/", "", -1, nil}
 }
 
 // TryLock locks the mutex if not already locked by another session.
-// If lock is held by another session, return immediately after attempting necessary cleanup
+// If lock is held by another, return immediately after attempting necessary cleanup.
 // The ctx argument is used for the sending/receiving Txn RPC.
 func (m *Mutex) TryLock(ctx context.Context) error {
+	if !m.w.TryAcquire(1) {
+		return ErrLocked
+	}
+
 	resp, err := m.tryAcquire(ctx)
 	if err != nil {
+		m.w.Release(1)
 		return err
 	}
 	// if no key on prefix / the minimum rev is key, already hold the lock
@@ -55,21 +64,24 @@ func (m *Mutex) TryLock(ctx context.Context) error {
 		m.hdr = resp.Header
 		return nil
 	}
-	client := m.s.Client()
-	// Cannot lock, so delete the key
-	if _, err := client.Delete(ctx, m.myKey); err != nil {
+
+	// Cannot lock so unlock
+	if err := m.Unlock(ctx); err != nil {
 		return err
 	}
-	m.myKey = "\x00"
-	m.myRev = -1
 	return ErrLocked
 }
 
 // Lock locks the mutex with a cancelable context. If the context is canceled
 // while trying to acquire the lock, the mutex tries to clean its stale lock entry.
 func (m *Mutex) Lock(ctx context.Context) error {
+	if err := m.w.Acquire(ctx, 1); err != nil {
+		return err
+	}
+
 	resp, err := m.tryAcquire(ctx)
 	if err != nil {
+		m.w.Release(1)
 		return err
 	}
 	// if no key on prefix / the minimum rev is key, already hold the lock
@@ -80,14 +92,14 @@ func (m *Mutex) Lock(ctx context.Context) error {
 	}
 	client := m.s.Client()
 	// wait for deletion revisions prior to myKey
-	hdr, werr := waitDeletes(ctx, client, m.pfx, m.myRev-1)
+	hdr, err := waitDeletes(ctx, client, m.pfx, m.myRev-1)
 	// release lock key if wait failed
-	if werr != nil {
+	if err != nil {
 		m.Unlock(client.Ctx())
-	} else {
-		m.hdr = hdr
+		return err
 	}
-	return werr
+	m.hdr = hdr
+	return nil
 }
 
 func (m *Mutex) tryAcquire(ctx context.Context) (*v3.TxnResponse, error) {
@@ -113,7 +125,9 @@ func (m *Mutex) tryAcquire(ctx context.Context) (*v3.TxnResponse, error) {
 	return resp, nil
 }
 
+// Unlock unlocks m.
 func (m *Mutex) Unlock(ctx context.Context) error {
+	defer m.w.Release(1)
 	client := m.s.Client()
 	if _, err := client.Delete(ctx, m.myKey); err != nil {
 		return err

--- a/clientv3/concurrency/mutex_test.go
+++ b/clientv3/concurrency/mutex_test.go
@@ -1,0 +1,98 @@
+package concurrency_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
+)
+
+func BenchmarkMutex(b *testing.B) {
+	cli, err := clientv3.New(clientv3.Config{Endpoints: endpoints})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cli.Close()
+
+	ctx := context.Background()
+
+	var berr error
+	var once sync.Once
+
+	b.SetParallelism(64)
+	b.RunParallel(func(pb *testing.PB) {
+		foo := 0
+		for pb.Next() {
+			s, err := concurrency.NewSession(cli)
+			if err != nil {
+				once.Do(func() { berr = err })
+				return
+			}
+
+			m := concurrency.NewMutex(s, "/bench-lock")
+
+			if err := m.Lock(ctx); err != nil {
+				once.Do(func() { berr = err })
+				s.Close()
+				return
+			}
+			foo += 1
+			if err := m.Unlock(ctx); err != nil {
+				once.Do(func() { berr = err })
+				s.Close()
+				return
+			}
+			s.Close()
+		}
+		_ = foo
+	})
+
+	if berr != nil {
+		b.Fatal(berr)
+	}
+}
+
+func BenchmarkMutexMulti(b *testing.B) {
+	cli, err := clientv3.New(clientv3.Config{Endpoints: endpoints})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cli.Close()
+
+	s, err := concurrency.NewSession(cli)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+
+	var berr error
+	var once sync.Once
+
+	b.SetParallelism(64)
+	b.RunParallel(func(pb *testing.PB) {
+		foo := 0
+
+		for pb.Next() {
+			m := concurrency.NewMutex(s, "/bench-lock2")
+
+			if err := m.Lock(ctx); err != nil {
+				once.Do(func() { berr = err })
+				return
+			}
+			foo += 1
+			if err := m.Unlock(ctx); err != nil {
+				once.Do(func() { berr = err })
+				return
+			}
+		}
+		_ = foo
+	})
+
+	if berr != nil {
+		b.Fatal(berr)
+	}
+}

--- a/clientv3/concurrency/session.go
+++ b/clientv3/concurrency/session.go
@@ -72,9 +72,7 @@ func NewSession(client *v3.Client, opts ...SessionOption) (*Session, error) {
 }
 
 // Client is the etcd client that is attached to the session.
-func (s *Session) Client() *v3.Client {
-	return s.client
-}
+func (s *Session) Client() *v3.Client { return s.client }
 
 // Lease is the lease ID for keys bound to the session.
 func (s *Session) Lease() v3.LeaseID { return s.id }

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
 	google.golang.org/grpc v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Implements concurrency.Mutex as a blocking Lock rather than reentrant. Removes race conditions with multiple goroutines for a single concurrent.Mutex. Previous behaviour with multiple sessions remains the same. Fixes #11360

Single mutex can be used for local locking. The session per lock cost is greatly reduced.
Before:
```
go test -bench=BenchmarkMutex -benchtime=20s -benchmem
goos: darwin
goarch: amd64
pkg: go.etcd.io/etcd/clientv3/concurrency
BenchmarkMutex-8             547          47679065 ns/op          338555 B/op       1505 allocs/op
PASS
```

After:
```
go test -bench=BenchmarkMutex -benchtime=20s -benchmem
goos: darwin
goarch: amd64
pkg: go.etcd.io/etcd/clientv3/concurrency
BenchmarkMutex-8                     990          38539089 ns/op         1126085 B/op       8984 allocs/op
BenchmarkMutexMulti-8             120577            199765 ns/op          113982 B/op        599 allocs/op
PASS
```

Related: https://github.com/etcd-io/etcd/pull/11364
