### PR TITLE
auth: fix NoPassWord check when add user

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -388,7 +388,8 @@ func (as *authStore) UserAdd(r *pb.AuthUserAddRequest) (*pb.AuthUserAddResponse,
 	var hashed []byte
 	var err error
 
-	if r.Options != nil && !r.Options.NoPassword {
+	noPassword := r.Options != nil && r.Options.NoPassword
+	if !noPassword {
 		hashed, err = bcrypt.GenerateFromPassword([]byte(r.Password), as.bcryptCost)
 		if err != nil {
 			if as.lg != nil {


### PR DESCRIPTION
fix #11414
There is one more concern about the usage of `NoPassword`. If the user is created like `etcdctl user add user:`, should it be inferred as no password? 
@jingyih PHAL