### PR TITLE
Process multiple watcherBatch in cancelWatcher

### DIFF
--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -175,13 +175,12 @@ func (s *watchableStore) cancelWatcher(wa *watcher) {
 		for _, wb := range s.victims {
 			if wb[wa] != nil {
 				victimBatch = wb
-				break
+				slowWatcherGauge.Dec()
+				watcherGauge.Dec()
+				delete(victimBatch, wa)
 			}
 		}
 		if victimBatch != nil {
-			slowWatcherGauge.Dec()
-			watcherGauge.Dec()
-			delete(victimBatch, wa)
 			break
 		}
 


### PR DESCRIPTION
This PR loops over all victims for handling watcherBatch in cancelWatcher.
In watchableStore#moveVictims :
```
		s.victims = append(s.victims, newVictim)
```
It seems the new victim is always appended to victims slice.

The complexity of this PR is asymptotically the same as current formation.

Here is code walk through for moveVictims().
Please note that lock is released after the clearing of s.victims:
```
	s.mu.Unlock()
```
See the following code in moveVictims() :
```
			if w.send(WatchResponse{WatchID: w.id, Events: eb.evs, Revision: rev}) {
```
When send returns false, newVictim is filled.
Later on, the new victim would be appended again (line 311) where s.victims may not be empty (due to concurrent activities):
```
	if len(newVictim) > 0 {
		s.mu.Lock()
		s.victims = append(s.victims, newVictim)
		s.mu.Unlock()
```
This is because moveVictims() serves different purpose as that of watcher cancellation.

Without this fix, there is chance for memory leak w.r.t. victimBatch .

Ref #11350