### PR TITLE
Fix issue with command in guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This will bring up etcd listening on port 2379 for client communication and on p
 Next, let's set a single key, and then retrieve it:
 
 ```
-etcdctl put mykey "this is awesome"
+etcdctl set mykey "this is awesome"
 etcdctl get mykey
 ```
 


### PR DESCRIPTION
The documentation (i.e the README guide) is misleading since the command is now `set` and not `put`