### PR TITLE
mvcc: allocate victims map before use

### DIFF
--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -379,13 +379,13 @@ func (s *watchableStore) syncWatchers() int {
 		if w.send(WatchResponse{WatchID: w.id, Events: eb.evs, Revision: curRev}) {
 			pendingEventsGauge.Add(float64(len(eb.evs)))
 		} else {
-			if victims == nil {
-				victims = make(watcherBatch)
-			}
 			w.victim = true
 		}
 
 		if w.victim {
+			if victims == nil {
+				victims = make(watcherBatch)
+			}
 			victims[w] = eb
 		} else {
 			if eb.moreRev != 0 {


### PR DESCRIPTION
Currently the allocation of victims map and access are in different if blocks.

This PR moves the allocation to where the map is accessed. This would avoid case where some watcher from wg.watchers had victim flag set (prior to current iteration).
