### PR TITLE
clientv3: remove ineffective nil check

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -23,7 +23,7 @@ import (
 
 	v3rpc "go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
-	mvccpb "go.etcd.io/etcd/mvcc/mvccpb"
+	"go.etcd.io/etcd/mvcc/mvccpb"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -402,10 +402,7 @@ func (w *watcher) RequestProgress(ctx context.Context) (err error) {
 	case reqc <- pr:
 		return nil
 	case <-ctx.Done():
-		if err == nil {
-			return ctx.Err()
-		}
-		return err
+		return ctx.Err()
 	case <-donec:
 		if wgs.closeErr != nil {
 			return wgs.closeErr


### PR DESCRIPTION
The check for nil in watcher#RequestProgress is not useful: err has not been assigned.

This PR removes the nil check.
