### PR TITLE
etcdctl: support progress notify option

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -95,6 +95,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 ### etcdctl v3
 
 - Fix [`etcdctl member add`](https://github.com/etcd-io/etcd/pull/11194) command to prevent potential timeout.
+- Add [`etcdctl watch --progress-notify`](https://github.com/etcd-io/etcd/pull/11462) flag.
 
 ### gRPC gateway
 

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -40,6 +40,7 @@ var (
 	watchPrefix      bool
 	watchInteractive bool
 	watchPrevKey     bool
+	progressNotify   bool
 )
 
 // NewWatchCommand returns the cobra command for "watch".
@@ -54,6 +55,7 @@ func NewWatchCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&watchPrefix, "prefix", false, "Watch on a prefix if prefix is set")
 	cmd.Flags().Int64Var(&watchRev, "rev", 0, "Revision to start watching")
 	cmd.Flags().BoolVar(&watchPrevKey, "prev-kv", false, "get the previous key-value pair before the event happens")
+	cmd.Flags().BoolVar(&progressNotify, "progress-notify", false, "get periodic watch progress notification from server")
 
 	return cmd
 }
@@ -153,6 +155,9 @@ func getWatchChan(c *clientv3.Client, args []string) (clientv3.WatchChan, error)
 	}
 	if watchPrevKey {
 		opts = append(opts, clientv3.WithPrevKV())
+	}
+	if progressNotify {
+		opts = append(opts, clientv3.WithProgressNotify())
 	}
 	return c.Watch(clientv3.WithRequireLeader(context.Background()), key, opts...), nil
 }


### PR DESCRIPTION
Add `--progress-notify` to `etcdctl watch` command. Example output:

```
$ etcdctl watch foo --progress-notify
progress notify: 1272
progress notify: 1789
progress notify: 2001
progress notify: 2001
...
```
