### PR TITLE
raft: only redirect a msg when `from` is not None

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -293,10 +293,11 @@ func TestNodeReadIndexToOldLeader(t *testing.T) {
 	if len(r1.msgs) != 2 {
 		t.Fatalf("len(r1.msgs) expected 1, got %d", len(r1.msgs))
 	}
-	readIndxMsg3 := raftpb.Message{From: 1, To: 3, Type: raftpb.MsgReadIndex, Entries: testEntries}
+	readIndxMsg3 := raftpb.Message{From: 2, To: 3, Type: raftpb.MsgReadIndex, Entries: testEntries}
 	if !reflect.DeepEqual(r1.msgs[0], readIndxMsg3) {
 		t.Fatalf("r1.msgs[0] expected %+v, got %+v", readIndxMsg3, r1.msgs[0])
 	}
+	readIndxMsg3 = raftpb.Message{From: 3, To: 3, Type: raftpb.MsgReadIndex, Entries: testEntries}
 	if !reflect.DeepEqual(r1.msgs[1], readIndxMsg3) {
 		t.Fatalf("r1.msgs[1] expected %+v, got %+v", readIndxMsg3, r1.msgs[1])
 	}

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -399,7 +399,9 @@ func (r *raft) hardState() pb.HardState {
 
 // send persists state to stable storage and then sends to its mailbox.
 func (r *raft) send(m pb.Message) {
-	m.From = r.id
+	if m.From == None {
+		m.From = r.id
+	}
 	if m.Type == pb.MsgVote || m.Type == pb.MsgVoteResp || m.Type == pb.MsgPreVote || m.Type == pb.MsgPreVoteResp {
 		if m.Term == 0 {
 			// All {pre-,}campaign messages need to have the term set when


### PR DESCRIPTION
Signed-off-by: Fullstop000 <fullstop1005@gmail.com>

In current raft implementation, `from` in a message will be overwritten to `r.id` when `r.send(msg)`  is called which might cause some issues. 
For example, assuming establishing a raft cluster with three nodes ABC where C is the Leader. A client sends a `MsgReadIndex` to node A and A redirects the msg to B (`m.From = A`). However, B is a stale leader in the view of A so that B also redirects the msg to C with `m.From = B`. In this case, when `ReadIndex` finishes in C, only B has a chance to receive a `MsgReadIndexResp` because of `m.From` in the `MsgReadIndex`. And the client might be waiting for the read response from A forever since A never receives a `MsgReadIndexResp`.
