### PR TITLE
Dockerfile: update to latest debian-base

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base:v1.0.0
+FROM k8s.gcr.io/debian-base:v2.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-arm64:v1.0.0
+FROM k8s.gcr.io/debian-base-arm64:v2.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-ppc64le:v1.0.0
+FROM k8s.gcr.io/debian-base-ppc64le:v2.0.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Kubernetes v1.17.0 shipped using debian-base:v2.0.0, by upgrading to match we can de-dupe base image layer requirements.
