### PR TITLE
clientv3: Declare auth variable inside the loop

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -272,10 +272,10 @@ func (c *Client) Dial(ep string) (*grpc.ClientConn, error) {
 
 func (c *Client) getToken(ctx context.Context) error {
 	var err error // return last error in a case of fail
-	var auth *authenticator
 
 	eps := c.Endpoints()
 	for _, ep := range eps {
+		var auth *authenticator
 		// use dial options without dopts to avoid reusing the client balancer
 		var dOpts []grpc.DialOption
 		_, host, _ := endpoint.ParseEndpoint(ep)


### PR DESCRIPTION
In Client#getToken(), the auth variable is declared outside the loop.
This would affect the closing, resulting in resource leak :
```
		defer auth.close()
```
This PR moves the variable declaration inside the loop.

Please see the following for demonstration: the two increments on field c were on the same instance. Note the close() is not called at the end of each iteration.

https://play.golang.org/p/kNoi618goai