### PR TITLE
go mod: script to get a usable mod version from a tag to use in a go.mod

### DIFF
--- a/hack/get-usable-mod-version-from-tag/README.md
+++ b/hack/get-usable-mod-version-from-tag/README.md
@@ -1,0 +1,14 @@
+# get-usable-mod-version-from-tag.sh
+
+Tags like `v3.X.Y` do not work with `go.mod` files.
+This tiny script will compute a usable go module version to import from a tag (until the situation gets fixed).
+
+## Usage
+Get the usable version from a tag:
+```
+get-usable-mod-version-from-tag.sh -t tag_name
+```
+You can now use it in `go.mod` (the version here is for tag `v3.4.3`).
+```
+require go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+```

--- a/hack/get-usable-mod-version-from-tag/README.md
+++ b/hack/get-usable-mod-version-from-tag/README.md
@@ -16,7 +16,7 @@ require go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 
 If you're using go get, fetch the package with:
 ```
-go get v0.0.0-20191023171146-3cf2f69b5738
+go get go.etcd.io/etcd@v0.0.0-20191023171146-3cf2f69b5738
 ```
 And when it's done, add this line at the end of go.mod:
 ```

--- a/hack/get-usable-mod-version-from-tag/README.md
+++ b/hack/get-usable-mod-version-from-tag/README.md
@@ -12,3 +12,13 @@ You can now use it in `go.mod` (the version here is for tag `v3.4.3`).
 ```
 require go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 ```
+## go get
+
+If you're using go get, fetch the package with:
+```
+go get v0.0.0-20191023171146-3cf2f69b5738
+```
+And when it's done, add this line at the end of go.mod:
+```
+replace go.etcd.io/etcd => go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+```

--- a/hack/get-usable-mod-version-from-tag/get-usable-mod-version-from-tag.sh
+++ b/hack/get-usable-mod-version-from-tag/get-usable-mod-version-from-tag.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+
+function usage {
+  echo "${0} -t tag_name"
+}
+
+function tag_exists {
+  local tag="${1}"
+  git --no-pager tag | grep -q "${tag}"'$'
+  return $?
+}
+
+while getopts "t:h" option; do
+  case "${option}" in
+    t)
+      tag=${OPTARG}
+    ;;
+    h)
+      usage
+      exit 0
+    ;;
+    \?)
+      usage
+      exit 1
+    ;;
+  esac
+done
+
+
+if [ -z "${tag}" ]; then
+  usage
+  exit 1
+fi
+
+
+REPO_ROOT=$(git -C "$(dirname $( readlink -f ${BASH_SOURCE[0]}))" rev-parse --show-toplevel)
+pushd ${REPO_ROOT} > /dev/null 2>&1
+if ! tag_exists "${tag}"; then
+  echo "tag ${tag} does not exist"
+  echo "use 'git tag' to list available ones"
+  exit 1
+else
+  git checkout tags/$tag > /dev/null 2>&1
+  echo -n v0.0.0-
+  TZ=UTC git --no-pager show \
+    --quiet \
+    --abbrev=12 \
+    --date='format-local:%Y%m%d%H%M%S' \
+    --format="%cd-%h"
+  git checkout - > /dev/null 2>&1
+fi
+popd > /dev/null 2>&1


### PR DESCRIPTION
Right now it is impossible to import `go.etcd.io/etc v3.X.Y`. This script finds the corresponding `v0.0.0-...-...` from a tag so that it can be included in a project's `go.mod`.

Fixes #11154 #11336 #11472 