### PR TITLE
clientv3: close file handle in case of file operation error

### DIFF
--- a/clientv3/snapshot/v3_snapshot.go
+++ b/clientv3/snapshot/v3_snapshot.go
@@ -123,9 +123,17 @@ func (s *v3Manager) Save(ctx context.Context, cfg clientv3.Config, dbPath string
 		zap.String("endpoint", cfg.Endpoints[0]),
 	)
 	if _, err = io.Copy(f, rd); err != nil {
+		if closeerr := f.Close(); closeerr != nil {
+			s.lg.Warn("encountered err when closing",
+				zap.String("path", partpath), zap.String("err", closeerr.Error()))
+		}
 		return err
 	}
 	if err = fileutil.Fsync(f); err != nil {
+		if closeerr := f.Close(); closeerr != nil {
+			s.lg.Warn("encountered err when closing",
+				zap.String("path", partpath), zap.String("err", closeerr.Error()))
+		}
 		return err
 	}
 	if err = f.Close(); err != nil {


### PR DESCRIPTION
In v3Manager#Save, when file copy or fsync encounters error, we should close the file handle.
