### PR TITLE
tools/benchmark: exit when txn-ops is larger than key-space-size

### DIFF
--- a/tools/benchmark/cmd/txn_put.go
+++ b/tools/benchmark/cmd/txn_put.go
@@ -61,6 +61,12 @@ func txnPutFunc(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if txnPutOpsPerTxn > keySpaceSize {
+		fmt.Fprintf(os.Stderr, "expected --txn-ops no larger than --key-space-size, "+
+			"got txn-ops(%v) key-space-size(%v)\n", txnPutOpsPerTxn, keySpaceSize)
+		os.Exit(1)
+	}
+
 	requests := make(chan []v3.Op, totalClients)
 	if txnPutRate == 0 {
 		txnPutRate = math.MaxInt32


### PR DESCRIPTION
Running `benchmark txn-put --txn-ops 2` will end up with key duplicated error and it will keeps running until finishing all requests.
```
{"level":"warn","ts":"2020-01-06T15:38:55.524-0800","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker 
failed","target":"endpoint://client-5c2d0b12-54c5-4421-8da7-ea326407b787/127.0.0.1:2379","attempt":0,"error":"rpc error: code 
= InvalidArgument desc = etcdserver: duplicate key given in txn request"}
```
The root cause is that the key is not unique if flag `--txn-ops` is bigger than `--key-space-size.` 
https://github.com/etcd-io/etcd/blob/e6980b1f9fc008837abb9177e87e893e48d565c1/tools/benchmark/cmd/txn_put.go#L95
This PR added exit at the beginning if it happens.
