### PR TITLE
benchmark: support encoded output for benchmark result

### DIFF
--- a/tools/benchmark/cmd/encoder.go
+++ b/tools/benchmark/cmd/encoder.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The etcd Authors
+// Copyright 2020 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ func (e jsonEncoder) mustWrite(v interface{}) {
 // returns a restore function for recovering stdout.
 func shouldEncode(format string) (encoder, func(), error) {
 	if len(format) == 0 {
-		return nil, func(){}, nil
+		return nil, func() {}, nil
 	}
 
 	stdout := os.Stdout

--- a/tools/benchmark/cmd/encoder.go
+++ b/tools/benchmark/cmd/encoder.go
@@ -1,0 +1,67 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+type encoder interface {
+	mustWrite(v interface{})
+}
+
+type jsonEncoder struct {
+	enc *json.Encoder
+}
+
+func newJsonEncoder(writer io.Writer) encoder {
+	return jsonEncoder{
+		enc: json.NewEncoder(writer),
+	}
+}
+
+func (e jsonEncoder) mustWrite(v interface{}) {
+	if err := e.enc.Encode(v); err != nil {
+		panic(err)
+	}
+}
+
+// shouldEncode suppresses stdout if output format is set and valid, and
+// returns a restore function for recovering stdout.
+func shouldEncode(format string) (encoder, func(), error) {
+	if len(format) == 0 {
+		return nil, func(){}, nil
+	}
+
+	stdout := os.Stdout
+	restore := func() { os.Stdout = stdout }
+
+	var err error
+	if os.Stdout, err = os.Open(os.DevNull); err != nil {
+		restore()
+		return nil, nil, err
+	}
+
+	switch format {
+	case "json":
+		return newJsonEncoder(stdout), restore, nil
+	}
+
+	restore()
+	return nil, nil, fmt.Errorf("unsupported format %v", format)
+}

--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -55,8 +55,6 @@ var (
 	compactIndexDelta int64
 
 	checkHashkv bool
-
-	putOutputFormat string
 )
 
 func init() {
@@ -71,12 +69,11 @@ func init() {
 	putCmd.Flags().DurationVar(&compactInterval, "compact-interval", 0, `Interval to compact database (do not duplicate this with etcd's 'auto-compaction-retention' flag) (e.g. --compact-interval=5m compacts every 5-minute)`)
 	putCmd.Flags().Int64Var(&compactIndexDelta, "compact-index-delta", 1000, "Delta between current revision and compact revision (e.g. current revision 10000, compact at 9000)")
 	putCmd.Flags().BoolVar(&checkHashkv, "check-hashkv", false, "'true' to check hashkv")
-	putCmd.Flags().StringVar(&putOutputFormat, "output", "", "Output format for benchmark results (only json is currently supported)")
 }
 
 func putFunc(cmd *cobra.Command, args []string) {
 	// Only result will be written in the specified output format if it is set.
-	enc, restore, err := shouldEncode(putOutputFormat)
+	enc, restore, err := shouldEncode(outputFormat)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/benchmark/cmd/range.go
+++ b/tools/benchmark/cmd/range.go
@@ -41,6 +41,7 @@ var (
 	rangeRate        int
 	rangeTotal       int
 	rangeConsistency string
+	rangeJsonPath    string
 )
 
 func init() {
@@ -48,6 +49,7 @@ func init() {
 	rangeCmd.Flags().IntVar(&rangeRate, "rate", 0, "Maximum range requests per second (0 is no limit)")
 	rangeCmd.Flags().IntVar(&rangeTotal, "total", 10000, "Total number of range requests")
 	rangeCmd.Flags().StringVar(&rangeConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
+	rangeCmd.Flags().StringVar(&rangeJsonPath, "jsonpath", "", "json file path for benchmark results output")
 }
 
 func rangeFunc(cmd *cobra.Command, args []string) {
@@ -111,9 +113,26 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 		close(requests)
 	}()
 
-	rc := r.Run()
+	isJsonOutput := len(rangeJsonPath) > 0
+	var sc <-chan report.Stats
+	var rc <-chan string
+
+	// Only one of Stats or Run can be called only one time to get the correct
+	// results since they process results repeatedly.
+	if isJsonOutput {
+		sc = r.Stats()
+	} else {
+		rc = r.Run()
+	}
+
 	wg.Wait()
 	close(r.Results())
 	bar.Finish()
-	fmt.Printf("%s", <-rc)
+
+	if isJsonOutput {
+		mustWriteStatsToJsonFile(rangeJsonPath, <-sc)
+		fmt.Printf("wrote stats to file %s\n", rangeJsonPath)
+	} else {
+		fmt.Printf("%s", <-rc)
+	}
 }

--- a/tools/benchmark/cmd/range.go
+++ b/tools/benchmark/cmd/range.go
@@ -38,10 +38,9 @@ var rangeCmd = &cobra.Command{
 }
 
 var (
-	rangeRate         int
-	rangeTotal        int
-	rangeConsistency  string
-	rangeOutputFormat string
+	rangeRate        int
+	rangeTotal       int
+	rangeConsistency string
 )
 
 func init() {
@@ -49,12 +48,11 @@ func init() {
 	rangeCmd.Flags().IntVar(&rangeRate, "rate", 0, "Maximum range requests per second (0 is no limit)")
 	rangeCmd.Flags().IntVar(&rangeTotal, "total", 10000, "Total number of range requests")
 	rangeCmd.Flags().StringVar(&rangeConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
-	rangeCmd.Flags().StringVar(&rangeOutputFormat, "output", "", "Output format for benchmark results (only json is currently supported)")
 }
 
 func rangeFunc(cmd *cobra.Command, args []string) {
 	// Only result will be written in the specified output format if it is set.
-	enc, restore, err := shouldEncode(rangeOutputFormat)
+	enc, restore, err := shouldEncode(outputFormat)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -54,6 +54,7 @@ var (
 	dialTimeout time.Duration
 
 	targetLeader bool
+	outputFormat string
 )
 
 func init() {
@@ -71,4 +72,5 @@ func init() {
 	RootCmd.PersistentFlags().DurationVar(&dialTimeout, "dial-timeout", 0, "dial timeout for client connections")
 
 	RootCmd.PersistentFlags().BoolVar(&targetLeader, "target-leader", false, "connect only to the leader node")
+	RootCmd.PersistentFlags().StringVar(&outputFormat, "output", "", "Output format for benchmark results (only json is currently supported)")
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -17,9 +17,7 @@ package cmd
 import (
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -178,16 +176,4 @@ func newWeightedReport() report.Report {
 		return report.NewReportSample(p)
 	}
 	return report.NewWeightedReport(report.NewReport(p), p)
-}
-
-func mustWriteStatsToJsonFile(filepath string, stats report.Stats) {
-	out, err := json.Marshal(stats)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to marshal stats: %v\n", err)
-		os.Exit(1)
-	}
-	if err = ioutil.WriteFile(filepath, out, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write file: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -176,4 +178,16 @@ func newWeightedReport() report.Report {
 		return report.NewReportSample(p)
 	}
 	return report.NewWeightedReport(report.NewReport(p), p)
+}
+
+func mustWriteStatsToJsonFile(filepath string, stats report.Stats) {
+	out, err := json.Marshal(stats)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal stats: %v\n", err)
+		os.Exit(1)
+	}
+	if err = ioutil.WriteFile(filepath, out, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write file: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -61,8 +61,6 @@ var (
 	watchKeySize      int
 	watchKeySpaceSize int
 	watchSeqKeys      bool
-
-	watchOutputFormat string
 )
 
 type watchedKeys struct {
@@ -88,12 +86,11 @@ func init() {
 	watchCmd.Flags().IntVar(&watchKeySize, "key-size", 32, "Key size of watch request")
 	watchCmd.Flags().IntVar(&watchKeySpaceSize, "key-space-size", 1, "Maximum possible keys")
 	watchCmd.Flags().BoolVar(&watchSeqKeys, "sequential-keys", false, "Use sequential keys")
-	watchCmd.Flags().StringVar(&watchOutputFormat, "output", "", "Output format for benchmark results (only json is currently supported)")
 }
 
 func watchFunc(cmd *cobra.Command, args []string) {
 	// Only result will be written in the specified output format if it is set.
-	enc, restore, err := shouldEncode(watchOutputFormat)
+	enc, restore, err := shouldEncode(outputFormat)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -40,7 +40,6 @@ var (
 	watchGetTotalStreams  int
 	watchEvents           int
 	firstWatch            sync.Once
-	watchGetOutputFormat  string
 )
 
 func init() {
@@ -48,12 +47,11 @@ func init() {
 	watchGetCmd.Flags().IntVar(&watchGetTotalWatchers, "watchers", 10000, "Total number of watchers")
 	watchGetCmd.Flags().IntVar(&watchGetTotalStreams, "streams", 1, "Total number of watcher streams")
 	watchGetCmd.Flags().IntVar(&watchEvents, "events", 8, "Number of events per watcher")
-	watchGetCmd.Flags().StringVar(&watchGetOutputFormat, "output", "", "Output format for benchmark results output (only json is currently supported)")
 }
 
 func watchGetFunc(cmd *cobra.Command, args []string) {
 	// Only result will be written in the specified output format if it is set.
-	enc, restore, err := shouldEncode(watchGetOutputFormat)
+	enc, restore, err := shouldEncode(outputFormat)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/benchmark/cmd/watch_latency.go
+++ b/tools/benchmark/cmd/watch_latency.go
@@ -44,8 +44,6 @@ var (
 	watchLPutRate   int
 	watchLKeySize   int
 	watchLValueSize int
-
-	watchLOutputFormat string
 )
 
 func init() {
@@ -54,12 +52,11 @@ func init() {
 	watchLatencyCmd.Flags().IntVar(&watchLPutRate, "put-rate", 100, "Number of keys to put per second")
 	watchLatencyCmd.Flags().IntVar(&watchLKeySize, "key-size", 32, "Key size of watch response")
 	watchLatencyCmd.Flags().IntVar(&watchLValueSize, "val-size", 32, "Value size of watch response")
-	watchLatencyCmd.Flags().StringVar(&watchLOutputFormat, "output", "", "Output format for benchmark results (only json is currently supported)")
 }
 
 func watchLatencyFunc(cmd *cobra.Command, args []string) {
 	// Only result will be written in the specified output format if it is set.
-	enc, restore, err := shouldEncode(watchLOutputFormat)
+	enc, restore, err := shouldEncode(outputFormat)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
this PR adds support for encoded output for benchmark results. Only json format is supported currently. If output format is set and valid, only raw objects of benchmark results are written to stdout, anything else written to stdout (e.g. progress bar) is suppressed in order to prevent breaking output parsing. This provides more flexibility: users can redirect the stdout to a file if they wish, instead of forcing the output to a file.

Fixes #11459