### PR TITLE
clientv3: return "ErrEmptyKey" for empty key watcher

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -665,11 +665,22 @@ func TestKVCompact(t *testing.T) {
 
 	wchan := wcli.Watch(ctx, "foo", clientv3.WithRev(3))
 
-	if wr := <-wchan; wr.CompactRevision != 7 {
+	wr := <-wchan
+	if wr.CompactRevision != 7 {
 		t.Fatalf("wchan CompactRevision got %v, want 7", wr.CompactRevision)
 	}
-	if wr, ok := <-wchan; ok {
+	if !wr.Canceled {
+		t.Fatalf("expected canceled watcher on compacted revision, got %v", wr.Canceled)
+	}
+	if wr.Err() != rpctypes.ErrCompacted {
+		t.Fatalf("watch response error expected %v, got %v", rpctypes.ErrCompacted, wr.Err())
+	}
+	wr, ok := <-wchan
+	if ok {
 		t.Fatalf("wchan got %v, expected closed", wr)
+	}
+	if wr.Err() != nil {
+		t.Fatalf("watch response error expected nil, got %v", wr.Err())
 	}
 
 	_, err = kv.Compact(ctx, 1000)

--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -283,6 +283,13 @@ func (w *watcher) newWatcherGrpcStream(inctx context.Context) *watchGrpcStream {
 
 // Watch posts a watch request to run() and waits for a new watcher channel
 func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) WatchChan {
+	if len(key) == 0 {
+		ch := make(chan WatchResponse, 1)
+		ch <- WatchResponse{Canceled: true, closeErr: v3rpc.ErrEmptyKey}
+		close(ch)
+		return ch
+	}
+
 	ow := opWatch(key, opts...)
 
 	var filters []pb.WatchCreateRequest_FilterType


### PR DESCRIPTION
Both GET and PUT on empty key returns `rpctypes.ErrEmptyKey`.
Watch on an empty key should close immediately.
