### PR TITLE
mvcc: check the error return in defragdb

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -487,7 +487,7 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 		}
 		tmpb.FillPercent = 0.9 // for seq write in for each
 
-		b.ForEach(func(k, v []byte) error {
+		if pErr := b.ForEach(func(k, v []byte) error {
 			count++
 			if count > limit {
 				err = tmptx.Commit()
@@ -504,7 +504,9 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 				count = 0
 			}
 			return tmpb.Put(k, v)
-		})
+		}); pErr != nil {
+			return pErr
+		}
 	}
 
 	return tmptx.Commit()


### PR DESCRIPTION
In the for loop of defragdb(), we call Bucket.ForEach() but don't check the error return.

This PR adds check for the error return and surfaces it.