### PR TITLE
mvcc: rollback tmptx in case of error

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -464,6 +464,11 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			tmptx.Rollback()
+		}
+	}()
 
 	// open a tx on old db for read
 	tx, err := odb.Begin(false)


### PR DESCRIPTION
In defragdb(), if there is error and control returns from the func, tmptx is left behind.

This PR rolls back the tmptx in case of err.