### PR TITLE
mvcc: use correct error variable in defragdb

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -492,7 +492,7 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 		}
 		tmpb.FillPercent = 0.9 // for seq write in for each
 
-		if pErr := b.ForEach(func(k, v []byte) error {
+		if err = b.ForEach(func(k, v []byte) error {
 			count++
 			if count > limit {
 				err = tmptx.Commit()
@@ -509,8 +509,8 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 				count = 0
 			}
 			return tmpb.Put(k, v)
-		}); pErr != nil {
-			return pErr
+		}); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
PR #11524 was composed ahead of #11525 and it introduced new error variable.

In light of #11525, we should use the same error variable so that the deferred func can properly rollback tmptx.
