### PR TITLE
mvcc: fix error log typo

### DIFF
--- a/mvcc/index_test.go
+++ b/mvcc/index_test.go
@@ -131,7 +131,7 @@ func TestIndexTombstone(t *testing.T) {
 
 	_, _, _, err = ti.Get([]byte("foo"), 2)
 	if err != ErrRevisionNotFound {
-		t.Errorf("get error = %v, want nil", err)
+		t.Errorf("get error = %v, want ErrRevisionNotFound", err)
 	}
 	err = ti.Tombstone([]byte("foo"), revision{main: 3})
 	if err != ErrRevisionNotFound {


### PR DESCRIPTION
This PR fixes error log typo from `nil` to `ErrRevisionNotFound`.