### PR TITLE
proxy/tcpproxy: fix dup unweighted remotes

### DIFF
--- a/proxy/tcpproxy/userspace.go
+++ b/proxy/tcpproxy/userspace.go
@@ -117,7 +117,7 @@ func (tp *TCPProxy) pick() *remote {
 			bestPr = r.srv.Priority
 			w = 0
 			weighted = nil
-			unweighted = []*remote{r}
+			unweighted = nil
 			fallthrough
 		case r.srv.Priority == bestPr:
 			if r.srv.Weight > 0 {


### PR DESCRIPTION
This PR fixes dup unweighted remote by assigning `nil` to `unweighted` first when the remote srv priority is smaller than the `bestPr`. This is because the `fallthrough` directive will make the adding of remote to weighted or unweighted logic done in the next `case`.