### PR TITLE
clientv3: Fix grpc-go(v1.27.0) incompatible changes to balancer/resolver.

### DIFF
--- a/clientv3/balancer/picker/err.go
+++ b/clientv3/balancer/picker/err.go
@@ -34,6 +34,6 @@ func (ep *errPicker) String() string {
 	return ep.p.String()
 }
 
-func (ep *errPicker) Pick(context.Context, balancer.PickOptions) (balancer.SubConn, func(balancer.DoneInfo), error) {
+func (ep *errPicker) Pick(context.Context, balancer.PickInfo) (balancer.SubConn, func(balancer.DoneInfo), error) {
 	return nil, nil, ep.err
 }

--- a/clientv3/balancer/picker/roundrobin_balanced.go
+++ b/clientv3/balancer/picker/roundrobin_balanced.go
@@ -52,7 +52,7 @@ type rrBalanced struct {
 func (rb *rrBalanced) String() string { return rb.p.String() }
 
 // Pick is called for every client request.
-func (rb *rrBalanced) Pick(ctx context.Context, opts balancer.PickOptions) (balancer.SubConn, func(balancer.DoneInfo), error) {
+func (rb *rrBalanced) Pick(ctx context.Context, opts balancer.PickInfo) (balancer.SubConn, func(balancer.DoneInfo), error) {
 	rb.mu.RLock()
 	n := len(rb.scs)
 	rb.mu.RUnlock()

--- a/clientv3/balancer/resolver/endpoint/endpoint.go
+++ b/clientv3/balancer/resolver/endpoint/endpoint.go
@@ -111,7 +111,7 @@ func (e *ResolverGroup) Close() {
 }
 
 // Build creates or reuses an etcd resolver for the etcd cluster name identified by the authority part of the target.
-func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	if len(target.Authority) < 1 {
 		return nil, fmt.Errorf("'etcd' target scheme requires non-empty authority identifying etcd cluster being routed to")
 	}
@@ -179,7 +179,7 @@ func epsToAddrs(eps ...string) (addrs []resolver.Address) {
 	return addrs
 }
 
-func (*Resolver) ResolveNow(o resolver.ResolveNowOption) {}
+func (*Resolver) ResolveNow(o resolver.ResolveNowOptions) {}
 
 func (r *Resolver) Close() {
 	es, err := bldr.getResolverGroup(r.endpointID)


### PR DESCRIPTION
clientv3: Fix grpc-go (v1.27.0) incompatible modification of balancer/resolver API.

Modify the API changed by balancer / resolver to ensure consistency with grpc-go (v1.27.0), otherwise clientv3 will not be able to be pulled by go mod, which will affect the direct use of users.

References:
1. [balancer/resolver: remove temporary backward-compatibility type aliases](https://github.com/grpc/grpc-go/pull/3309)
2. [Notice: Upcoming Experimental Balancer/Resolver API Changes](https://github.com/grpc/grpc-go/issues/3180)

Fixes https://github.com/etcd-io/etcd/issues/11563