### PR TITLE
contrib/raftexample: If using the join option, use node.Restart

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -285,12 +285,10 @@ func (rc *raftNode) startRaft() {
 
 	if oldwal {
 		rc.node = raft.RestartNode(c)
+	} else if rc.join {
+		rc.node = raft.RestartNode(nil)
 	} else {
-		startPeers := rpeers
-		if rc.join {
-			startPeers = nil
-		}
-		rc.node = raft.StartNode(c, startPeers)
+		rc.node = raft.StartNode(c, rpeers)
 	}
 
 	rc.transport = &rafthttp.Transport{


### PR DESCRIPTION
When using join flag in raftexample, node.Start becomes panic, so use
node.Restart as shown in the message "no peers given; use RestartNode instead".

```bash
./raftexample --id 4 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379,http://127.0.0.1:42379 --port 42380 --join
2020-01-29 16:42:21.810132 I | replaying WAL of member 4
2020-01-29 16:42:21.894789 I | loading WAL at term 0 and index 0
panic: no peers given; use RestartNode instead

goroutine 55 [running]:
go.etcd.io/etcd/raft.StartNode(0xc0001d7f20, 0x0, 0x0, 0x0, 0x0, 0xc0000b4210)
	/Users/hiromunakamura/hi_dev/etcd/raft/node.go:216 +0x421
main.(*raftNode).startRaft(0xc0001c6000)
	/Users/hiromunakamura/hi_dev/etcd/contrib/raftexample/raft.go:293 +0x6a8
created by main.newRaftNode
	/Users/hiromunakamura/hi_dev/etcd/contrib/raftexample/raft.go:106 +0x35f
```

```go
// in raft/node.go
func StartNode(c *Config, peers []Peer) Node {
	if len(peers) == 0 {
		panic("no peers given; use RestartNode instead") // <- panic here 
	}

        // ...
}
```