### PR TITLE
transport: simple fix in test functions to prevent goroutine leak

### DIFF
--- a/pkg/transport/listener_test.go
+++ b/pkg/transport/listener_test.go
@@ -146,14 +146,14 @@ func testNewListenerTLSInfoClientCheck(t *testing.T, skipClientSANVerify, goodCl
 
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	cli := &http.Client{Transport: tr}
-	chClientErr := make(chan error)
+	chClientErr := make(chan error, 1)
 	go func() {
 		_, err := cli.Get("https://" + ln.Addr().String())
 		chClientErr <- err
 	}()
 
-	chAcceptErr := make(chan error)
-	chAcceptConn := make(chan net.Conn)
+	chAcceptErr := make(chan error, 1)
+	chAcceptConn := make(chan net.Conn, 1)
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {

--- a/pkg/transport/timeout_dialer_test.go
+++ b/pkg/transport/timeout_dialer_test.go
@@ -22,6 +22,9 @@ import (
 
 func TestReadWriteTimeoutDialer(t *testing.T) {
 	stop := make(chan struct{})
+	defer func() {
+		stop <- struct{}{}
+	}()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -42,7 +45,7 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 
 	// fill the socket buffer
 	data := make([]byte, 5*1024*1024)
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		_, err = conn.Write(data)
 		done <- struct{}{}
@@ -81,8 +84,6 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 	if operr, ok := err.(*net.OpError); !ok || operr.Op != "read" || !operr.Timeout() {
 		t.Errorf("err = %v, want write i/o timeout error", err)
 	}
-
-	stop <- struct{}{}
 }
 
 type testBlockingServer struct {

--- a/pkg/transport/timeout_listener_test.go
+++ b/pkg/transport/timeout_listener_test.go
@@ -47,7 +47,7 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 		wtimeoutd:  10 * time.Millisecond,
 		rdtimeoutd: 10 * time.Millisecond,
 	}
-	stop := make(chan struct{})
+	stop := make(chan struct{}, 1)
 
 	blocker := func() {
 		conn, derr := net.Dial("tcp", ln.Addr().String())
@@ -62,13 +62,14 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 
 	conn, err := wln.Accept()
 	if err != nil {
+		stop <- struct{}{}
 		t.Fatalf("unexpected accept error: %v", err)
 	}
 	defer conn.Close()
 
 	// fill the socket buffer
 	data := make([]byte, 5*1024*1024)
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		_, err = conn.Write(data)
 		done <- struct{}{}
@@ -78,6 +79,7 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 	case <-done:
 	// It waits 1s more to avoid delay in low-end system.
 	case <-time.After(wln.wtimeoutd*10 + time.Second):
+		stop <- struct{}{}
 		t.Fatal("wait timeout")
 	}
 
@@ -90,6 +92,7 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 
 	conn, err = wln.Accept()
 	if err != nil {
+		stop <- struct{}{}
 		t.Fatalf("unexpected accept error: %v", err)
 	}
 	buf := make([]byte, 10)
@@ -102,6 +105,7 @@ func TestWriteReadTimeoutListener(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(wln.rdtimeoutd * 10):
+		stop <- struct{}{}
 		t.Fatal("wait timeout")
 	}
 


### PR DESCRIPTION
***Description***

This is a very simple patch. There are 3 test functions with similar problems: some spawned goroutines will be leaked in certain cases (like timeout). 

Although `t.Fatal()` is often called in these certain cases, it won't stop the leaking, because ["Calling FailNow does not stop those other goroutines." ](https://golang.org/pkg/testing/#T.FailNow) This patch stops these leaks no matter what happens in test. 

This patch is similar to #11318

***How they are fixed***

For most blocking channels, adding 1 buffer to them is enough. This can make send operations unblockable. Semantics are not influenced, because there is no instruction after send.

For the last instruction `stop <- struct{}{}` at line 85 of timeout_dialer_test.go, I moved it into a deferred function, so it will be executed even if `t.Fatal()` is called.

For `stop` created at line 50 of timeout_listener_test.go, I send to it to unblock the child goroutine before each `t.Fatalf()`. I also add 1 buffer to it so the send itself won't block.