### PR TITLE
in multiple packages: fixed goroutine leak bugs in tests

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -710,7 +710,7 @@ func TestKVGetRetry(t *testing.T) {
 
 	clus.Members[fIdx].Stop(t)
 
-	donec := make(chan struct{})
+	donec := make(chan struct{}, 1)
 	go func() {
 		// Get will fail, but reconnect will trigger
 		gresp, gerr := kv.Get(ctx, "foo")

--- a/clientv3/integration/txn_test.go
+++ b/clientv3/integration/txn_test.go
@@ -119,7 +119,7 @@ func TestTxnReadRetry(t *testing.T) {
 		clus.Members[0].Stop(t)
 		<-clus.Members[0].StopNotify()
 
-		donec := make(chan struct{})
+		donec := make(chan struct{}, 1)
 		go func() {
 			_, err := kv.Txn(context.TODO()).Then(thenOps[i]...).Commit()
 			if err != nil {

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -838,7 +838,7 @@ func TestSync(t *testing.T) {
 	srv.applyV2 = &applierV2store{store: srv.v2store, cluster: srv.cluster}
 
 	// check that sync is non-blocking
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		srv.sync(10 * time.Second)
 		done <- struct{}{}
@@ -883,7 +883,7 @@ func TestSyncTimeout(t *testing.T) {
 	srv.applyV2 = &applierV2store{store: srv.v2store, cluster: srv.cluster}
 
 	// check that sync is non-blocking
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		srv.sync(0)
 		done <- struct{}{}

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -662,7 +662,7 @@ func TestConcurrentReadNotBlockingWrite(t *testing.T) {
 	readTx1 := s.Read(traceutil.TODO())
 
 	// write should not be blocked by reads
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		s.Put([]byte("foo"), []byte("newBar"), lease.NoLease) // this is a write Txn
 		done <- struct{}{}

--- a/mvcc/watcher_test.go
+++ b/mvcc/watcher_test.go
@@ -355,7 +355,7 @@ func TestWatcherWatchWithFilter(t *testing.T) {
 	}
 
 	w.Watch(0, []byte("foo"), nil, 0, filterPut)
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 
 	go func() {
 		<-w.Chan()


### PR DESCRIPTION
***Description***

There are 6 test functions with a similar problem - some goroutines in these functions will be leaked in certain cases (e.g., timeout).

`testing.T.Fatal()` is often called in these certain cases to stop the test case when failed, but [it does not stop the goroutines](https://golang.org/pkg/testing/#T.FailNow), which result in goroutine leaks.

This patch stops these leaks no matter what happens in test.

***How they are fixed***

The fixes set the length of the channel buffers as 1 so that goroutines will not be blocked when done.

(This patch is similar to #11318) 