### PR TITLE
in multiple packages: fixed goroutine leak bugs in tests (cont.d)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -285,7 +285,7 @@ func TestSimpleHTTPClientDoHeaderTimeout(t *testing.T) {
 	tr.finishCancel <- struct{}{}
 	c := &simpleHTTPClient{transport: tr, headerTimeout: time.Millisecond}
 
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		_, _, err := c.Do(context.Background(), &fakeAction{})
 		errc <- err
@@ -452,7 +452,7 @@ func TestHTTPClusterClientDoDeadlineExceedContext(t *testing.T) {
 		endpoints:     []url.URL{fakeURL},
 	}
 
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -502,7 +502,7 @@ func TestHTTPClusterClientDoCanceledContext(t *testing.T) {
 		endpoints:     []url.URL{fakeURL},
 	}
 
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		ctx, cancel := withTimeout(fakeCancelContext{}, time.Millisecond)
 		cancel()

--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -99,7 +99,7 @@ func TestDialTimeout(t *testing.T) {
 	}
 
 	for i, cfg := range testCfgs {
-		donec := make(chan error)
+		donec := make(chan error, 1)
 		go func() {
 			// without timeout, dial continues forever on ipv4 black hole
 			c, err := New(cfg)

--- a/clientv3/txn_test.go
+++ b/clientv3/txn_test.go
@@ -26,7 +26,7 @@ func TestTxnPanics(t *testing.T) {
 
 	kv := &kv{}
 
-	errc := make(chan string)
+	errc := make(chan string, 1)
 	df := func() {
 		if s := recover(); s != nil {
 			errc <- s.(string)

--- a/lease/lessor_test.go
+++ b/lease/lessor_test.go
@@ -429,7 +429,7 @@ func TestLessorExpire(t *testing.T) {
 		t.Fatalf("failed to receive expired lease")
 	}
 
-	donec := make(chan struct{})
+	donec := make(chan struct{}, 1)
 	go func() {
 		// expired lease cannot be renewed
 		if _, err := le.Renew(l.ID); err != ErrLeaseNotFound {
@@ -482,7 +482,7 @@ func TestLessorExpireAndDemote(t *testing.T) {
 		t.Fatalf("failed to receive expired lease")
 	}
 
-	donec := make(chan struct{})
+	donec := make(chan struct{}, 1)
 	go func() {
 		// expired lease cannot be renewed
 		if _, err := le.Renew(l.ID); err != ErrNotPrimary {

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -94,7 +94,7 @@ func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 		}
 	}()
 
-	recvc := make(chan []byte)
+	recvc := make(chan []byte, 1)
 	go func() {
 		for i := 0; i < 2; i++ {
 			recvc <- receive(t, ln)
@@ -247,7 +247,7 @@ func TestServer_PauseTx(t *testing.T) {
 	data := []byte("Hello World!")
 	send(t, data, scheme, srcAddr, transport.TLSInfo{})
 
-	recvc := make(chan []byte)
+	recvc := make(chan []byte, 1)
 	go func() {
 		recvc <- receive(t, ln)
 	}()
@@ -364,7 +364,7 @@ func TestServer_BlackholeTx(t *testing.T) {
 	data := []byte("Hello World!")
 	send(t, data, scheme, srcAddr, transport.TLSInfo{})
 
-	recvc := make(chan []byte)
+	recvc := make(chan []byte, 1)
 	go func() {
 		recvc <- receive(t, ln)
 	}()


### PR DESCRIPTION
***Description***

There are 10 test functions with a similar problem - some goroutines in these functions will be leaked in certain cases (e.g., timeout).

`testing.T.Fatal()` is often called in these certain cases to stop the test case when failed, but [it does not stop the goroutines](https://golang.org/pkg/testing/#T.FailNow), which result in goroutine leaks.

This patch stops these leaks no matter what happens in test.

***How they are fixed***

The fixes set the length of the channel buffers as 1 so that goroutines will not be blocked when done.

(This patch is similar to #11318 and #11569 ) 