### PR TITLE
integration/clientv3: fix 4 API misusage in test functions

### DIFF
--- a/integration/v3_election_test.go
+++ b/integration/v3_election_test.go
@@ -140,13 +140,11 @@ func TestElectionFailover(t *testing.T) {
 	}
 
 	// next leader
-	electedc := make(chan struct{})
+	electedErrC := make(chan error, 1)
 	go func() {
 		ee := concurrency.NewElection(ss[1], "test-election")
-		if eer := ee.Campaign(context.TODO(), "bar"); eer != nil {
-			t.Fatal(eer)
-		}
-		electedc <- struct{}{}
+		eer := ee.Campaign(context.TODO(), "bar")
+		electedErrC <- eer // If eer != nil, the test will fail by calling t.Fatal(eer)
 	}()
 
 	// invoke leader failover
@@ -166,7 +164,10 @@ func TestElectionFailover(t *testing.T) {
 	}
 
 	// leader must ack election (otherwise, Campaign may see closed conn)
-	<-electedc
+	eer := <-electedErrC
+	if eer != nil {
+		t.Fatal(eer)
+	}
 }
 
 // TestElectionSessionRelock ensures that campaigning twice on the same election


### PR DESCRIPTION
***Description***

There are four test functions having the same mistake: using `t.Fatal()`or `t.Fatalf()` in a spawned goroutine. This is a misusage because ["FailNow (called by Fatal and Fatalf) must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test."](https://golang.org/pkg/testing/#B.FailNow)

***How they are fixed***
Use a local channel to pass the error or error string. I make channels with buffer or use a select with default, so the concurrency behavior of these test functions won't change after this patch.