### PR TITLE
etcdctl: document how to give permissions for locks

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -1082,6 +1082,12 @@ echo ${transferee_id}
 
 LOCK acquires a distributed mutex with a given name. Once the lock is acquired, it will be held until etcdctl is terminated.
 
+#### Example
+
+```bash
+etcdctl role grant-permission my_rw_locks --prefix=true readwrite _locks//my_service_locks/
+```
+
 #### Options
 
 - ttl - time out in seconds of lock session.


### PR DESCRIPTION
Added an example to the documentation to help in how to give
permissions for locks

Fixes #10544

Signed-off-by: Alwin Doss <alwindoss84@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
