### PR TITLE
Makefile: cleanup all data dirs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ clean:
 	rm -rf ./release
 	rm -f ./snapshot/localhost:*
 	rm -f ./tools/etcd-dump-metrics/localhost:*
-	rm -f ./integration/127.0.0.1:* ./integration/localhost:*
-	rm -f ./clientv3/integration/127.0.0.1:* ./clientv3/integration/localhost:*
-	rm -f ./clientv3/ordering/127.0.0.1:* ./clientv3/ordering/localhost:*
+	find ./ -name "127.0.0.1:*" -o -name "localhost:*" -delete
 
 docker-clean:
 	docker images


### PR DESCRIPTION
Integration tests always generate data dirs but not clean them up if they are failed. Modify the `clean` target in Makefile to address it.
