### PR TITLE
etcdserver: populate ResponseHeader in Alarm method

### DIFF
--- a/etcdserver/api/v3rpc/maintenance.go
+++ b/etcdserver/api/v3rpc/maintenance.go
@@ -169,7 +169,15 @@ func (ms *maintenanceServer) HashKV(ctx context.Context, r *pb.HashKVRequest) (*
 }
 
 func (ms *maintenanceServer) Alarm(ctx context.Context, ar *pb.AlarmRequest) (*pb.AlarmResponse, error) {
-	return ms.a.Alarm(ctx, ar)
+	resp, err := ms.a.Alarm(ctx, ar)
+	if err != nil {
+		return nil, togRPCError(err)
+	}
+	if resp.Header == nil {
+		resp.Header = &pb.ResponseHeader{}
+	}
+	ms.hdr.fill(resp.Header)
+	return resp, nil
 }
 
 func (ms *maintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (*pb.StatusResponse, error) {


### PR DESCRIPTION
When no Alarms are found, the response has no header. The header should always
be populated. Some components, like fields printer used by etcdctl, break when
the header is not populated.

Fixes #11581

Signed-off-by: Daniel Lipovetsky <dlipovetsky@d2iq.com>