### PR TITLE
embed: don't compare uint to any negative number

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -561,10 +561,10 @@ func (cfg *Config) Validate() error {
 		return ErrConflictBootstrapFlags
 	}
 
-	if cfg.TickMs <= 0 {
+	if cfg.TickMs == 0 {
 		return fmt.Errorf("--heartbeat-interval must be >0 (set to %dms)", cfg.TickMs)
 	}
-	if cfg.ElectionMs <= 0 {
+	if cfg.ElectionMs == 0 {
 		return fmt.Errorf("--election-timeout must be >0 (set to %dms)", cfg.ElectionMs)
 	}
 	if 5*cfg.TickMs > cfg.ElectionMs {


### PR DESCRIPTION
`uint` variables should not be compared to a negative number. 