### PR TITLE
auth: parse to uint instead of int

### DIFF
--- a/auth/simple_token.go
+++ b/auth/simple_token.go
@@ -212,7 +212,7 @@ func (t *tokenSimple) isValidSimpleToken(ctx context.Context, token string) bool
 	if len(splitted) != 2 {
 		return false
 	}
-	index, err := strconv.Atoi(splitted[1])
+	index, err := strconv.ParseUint(splitted[1], 10, 0)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
The strconv.Atoi is equivalent to ParseInt. The index is later used as
uint so we should use strconv.ParseUint.

