### PR TITLE
etcdctl: use appropriate type conversion

### DIFF
--- a/etcdctl/ctlv2/command/exec_watch_command.go
+++ b/etcdctl/ctlv2/command/exec_watch_command.go
@@ -76,10 +76,7 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		cmdArgs = args[:argslen-1]
 	}
 
-	index := 0
-	if c.Int("after-index") != 0 {
-		index = c.Int("after-index")
-	}
+	index := c.Uint64("after-index")
 
 	recursive := c.Bool("recursive")
 


### PR DESCRIPTION
index variable is being passed as uint64 so we shouldn't use Int.
Also the if loop is redundant so remove it.
