### PR TITLE
etcdserver: mark AuthStatus as no side effect request

### DIFF
--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -1036,7 +1036,7 @@ func mkGteRange(rangeEnd []byte) []byte {
 }
 
 func noSideEffect(r *pb.InternalRaftRequest) bool {
-	return r.Range != nil || r.AuthUserGet != nil || r.AuthRoleGet != nil
+	return r.Range != nil || r.AuthUserGet != nil || r.AuthRoleGet != nil || r.AuthStatus != nil
 }
 
 func removeNeedlessRangeReqs(txn *pb.TxnRequest) {


### PR DESCRIPTION
This is a follow up change of https://github.com/etcd-io/etcd/pull/11536
The newly added `AuthStatus()` RPC doesn't have side effect against the state machine so we should mark it as no side effect request for avoiding replay overhead.

cc @tarcinil 