### PR TITLE
raft/rafttest: Prune Unused Functions

### DIFF
--- a/raft/rafttest/interaction_env_handler_raft_log.go
+++ b/raft/rafttest/interaction_env_handler_raft_log.go
@@ -23,12 +23,6 @@ import (
 	"go.etcd.io/etcd/raft"
 )
 
-func (env *InteractionEnv) writeErr(err error) {
-	if err != nil {
-		env.Output.WriteString(err.Error())
-	}
-}
-
 func (env *InteractionEnv) handleRaftLog(t *testing.T, d datadriven.TestData) error {
 	idx := firstAsNodeIdx(t, d)
 	return env.RaftLog(idx)

--- a/raft/rafttest/interaction_env_logger.go
+++ b/raft/rafttest/interaction_env_logger.go
@@ -23,15 +23,6 @@ import (
 
 type logLevels [6]string
 
-func (l logLevels) strToLev(s string) int {
-	for i, lvl := range l {
-		if strings.ToUpper(s) == lvl {
-			return i
-		}
-	}
-	panic(fmt.Sprintf("unknown level %q", s))
-}
-
 var lvlNames logLevels = [...]string{"DEBUG", "INFO", "WARN", "ERROR", "FATAL", "NONE"}
 
 type RedirectLogger struct {

--- a/raft/rafttest/network.go
+++ b/raft/rafttest/network.go
@@ -30,19 +30,6 @@ type iface interface {
 	connect()
 }
 
-// a network
-type network interface {
-	// drop message at given rate (1.0 drops all messages)
-	drop(from, to uint64, rate float64)
-	// delay message for (0, d] randomly at given rate (1.0 delay all messages)
-	// do we need rate here?
-	delay(from, to uint64, d time.Duration, rate float64)
-	disconnect(id uint64)
-	connect(id uint64)
-	// heal heals the network
-	heal()
-}
-
 type raftNetwork struct {
 	rand         *rand.Rand
 	mu           sync.Mutex

--- a/raft/rafttest/network.go
+++ b/raft/rafttest/network.go
@@ -131,13 +131,6 @@ func (rn *raftNetwork) delay(from, to uint64, d time.Duration, rate float64) {
 	rn.delaymap[conn{from, to}] = delay{d, rate}
 }
 
-func (rn *raftNetwork) heal() {
-	rn.mu.Lock()
-	defer rn.mu.Unlock()
-	rn.dropmap = make(map[conn]float64)
-	rn.delaymap = make(map[conn]delay)
-}
-
 func (rn *raftNetwork) disconnect(id uint64) {
 	rn.mu.Lock()
 	defer rn.mu.Unlock()


### PR DESCRIPTION
This removes four unused functions from `raft/rafttest`.