### PR TITLE
changelog: Add #11613 backport to 3.2, 3.3 and 3.4 changelogs

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -9,6 +9,9 @@ The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.
 
 ## [v3.2.29](https://github.com/etcd-io/etcd/releases/tag/v3.2.29) (2019-TBD)
 
+### etcd server
+
+- [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
 
 <hr>
 

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -7,6 +7,13 @@ The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.
 
 <hr>
 
+## v3.3.19 (TDB)
+
+### etcd server
+
+- [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
+
+<hr>
 
 ## v3.3.18 (2019-11-26)
 

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -15,6 +15,10 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.3...v3.4.4) and 
 
 **Again, before running upgrades from any previous release, please make sure to read change logs below and [v3.4 upgrade guide](https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_4.md).**
 
+### etcd server
+
+- [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
+
 ### Metrics, Monitoring
 
 See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.


### PR DESCRIPTION
For these backports:

- https://github.com/etcd-io/etcd/pull/11622
- https://github.com/etcd-io/etcd/pull/11623
- https://github.com/etcd-io/etcd/pull/11624