### PR TITLE
mvcc/backend: remove db.tmp without checking logger presence

### DIFF
--- a/etcdserver/api/snap/snapshotter.go
+++ b/etcdserver/api/snap/snapshotter.go
@@ -240,11 +240,9 @@ func checkSuffix(lg *zap.Logger, names []string) []string {
 func (s *Snapshotter) cleanupSnapdir(filenames []string) error {
 	for _, filename := range filenames {
 		if strings.HasPrefix(filename, "db.tmp") {
-			if s.lg != nil {
-				s.lg.Info("found orphaned defragmentation file; deleting", zap.String("path", filename))
-				if rmErr := os.Remove(filepath.Join(s.dir, filename)); rmErr != nil && !os.IsNotExist(rmErr) {
-					return fmt.Errorf("failed to remove orphaned defragmentation file %s: %v", filename, rmErr)
-				}
+			s.lg.Info("found orphaned defragmentation file; deleting", zap.String("path", filename))
+			if rmErr := os.Remove(filepath.Join(s.dir, filename)); rmErr != nil && !os.IsNotExist(rmErr) {
+				return fmt.Errorf("failed to remove orphaned defragmentation file %s: %v", filename, rmErr)
 			}
 		}
 	}


### PR DESCRIPTION
This is follow on to #11613

The removal of db.tmp should not be contingent upon the presence of logger.