### PR TITLE
mvcc/backend: check for nil boltOpenOptions

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -365,7 +365,10 @@ func (b *backend) defrag() error {
 	if err != nil {
 		return err
 	}
-	options := *boltOpenOptions
+	options := bolt.Options{}
+	if boltOpenOptions != nil {
+		options = *boltOpenOptions
+	}
 	options.OpenFile = func(path string, i int, mode os.FileMode) (file *os.File, err error) {
 		return temp, nil
 	}


### PR DESCRIPTION
Check if boltOpenOptions is nil before use it. I believe currently defrag will panic on platforms other than linux.

cc @jpbetz @gyuho @wenjiaswe 
