### PR TITLE
Automated cherry pick of #11630 to release-3.4

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -376,7 +376,10 @@ func (b *backend) defrag() error {
 	if err != nil {
 		return err
 	}
-	options := *boltOpenOptions
+	options := bolt.Options{}
+	if boltOpenOptions != nil {
+		options = *boltOpenOptions
+	}
 	options.OpenFile = func(path string, i int, mode os.FileMode) (file *os.File, err error) {
 		return temp, nil
 	}


### PR DESCRIPTION
Cherry pick of #11630 on release-3.4.

#11630: mvcc/backend: check for nil boltOpenOptions