### PR TITLE
etcdctl: fix member add (again...)

### DIFF
--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -156,30 +156,8 @@ func memberAddCommandFunc(cmd *cobra.Command, args []string) {
 	display.MemberAdd(*resp)
 
 	if _, ok := (display).(*simplePrinter); ok {
-		ctx, cancel = commandCtx(cmd)
-		listResp, err := cli.MemberList(ctx)
-		// make sure the member who served member list request has the latest member list.
-		syncedMemberSet := make(map[uint64]struct{})
-		syncedMemberSet[resp.Header.MemberId] = struct{}{} // the member who served member add is guaranteed to have the latest member list.
-		for {
-			if err != nil {
-				ExitWithError(ExitError, err)
-			}
-			if _, ok := syncedMemberSet[listResp.Header.MemberId]; ok {
-				break
-			}
-			// quorum get to sync cluster list
-			gresp, gerr := cli.Get(ctx, "_")
-			if gerr != nil {
-				ExitWithError(ExitError, err)
-			}
-			syncedMemberSet[gresp.Header.MemberId] = struct{}{}
-			listResp, err = cli.MemberList(ctx)
-		}
-		cancel()
-
 		conf := []string{}
-		for _, memb := range listResp.Members {
+		for _, memb := range resp.Members {
 			for _, u := range memb.PeerURLs {
 				n := memb.Name
 				if memb.ID == newID {


### PR DESCRIPTION
I just realized we could simply use the members information in member add response, which is guaranteed to be up to date.

We tried to fix `etcdctl member add` in #11194. But it does not solve the problem if the client balancer is provided with 2 endpoints and balancer is doing round robin.

Fixes #11554