### PR TITLE
pkg, clientv3: etcdctl can snaprestore when data-dir exits but empty

### DIFF
--- a/clientv3/snapshot/v3_snapshot.go
+++ b/clientv3/snapshot/v3_snapshot.go
@@ -268,8 +268,8 @@ func (s *v3Manager) Restore(cfg RestoreConfig) error {
 	if dataDir == "" {
 		dataDir = cfg.Name + ".etcd"
 	}
-	if fileutil.Exist(dataDir) {
-		return fmt.Errorf("data-dir %q exists", dataDir)
+	if fileutil.Exist(dataDir) && !fileutil.DirEmpty(dataDir) {
+		return fmt.Errorf("data-dir %q not empty or could not be read", dataDir)
 	}
 
 	walDir := cfg.OutputWALDir

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -76,6 +76,12 @@ func Exist(name string) bool {
 	return err == nil
 }
 
+// DirEmpty returns true if a directory empty and can access.
+func DirEmpty(name string) bool {
+	ns, err := ReadDir(name)
+	return len(ns) == 0 && err == nil
+}
+
 // ZeroToEnd zeros a file starting from SEEK_CUR to its SEEK_END. May temporarily
 // shorten the length of the file.
 func ZeroToEnd(f *os.File) error {

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -105,6 +105,31 @@ func TestExist(t *testing.T) {
 	}
 }
 
+func TestDirEmpty(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "empty_dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if !DirEmpty(dir) {
+		t.Fatalf("expected DirEmpty true, got %v", DirEmpty(dir))
+	}
+
+	file, err := ioutil.TempFile(dir, "new_file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	if DirEmpty(dir) {
+		t.Fatalf("expected DirEmpty false, got %v", DirEmpty(dir))
+	}
+	if DirEmpty(file.Name()) {
+		t.Fatalf("expected DirEmpty false, got %v", DirEmpty(file.Name()))
+	}
+}
+
 func TestZeroToEnd(t *testing.T) {
 	f, err := ioutil.TempFile(os.TempDir(), "fileutil")
 	if err != nil {


### PR DESCRIPTION
Fix #11618