### PR TITLE
Refine compact in etcd server

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -264,6 +264,20 @@ type IgnoreKey struct {
 	Key    string
 }
 
+func (b *backend) Compact(bucket []byte, keys [][]byte) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucket)
+
+		for _, key := range keys {
+			err := b.Delete(key)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 func (b *backend) Hash(ignores map[IgnoreKey]struct{}) (uint32, error) {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 

--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -264,20 +264,6 @@ type IgnoreKey struct {
 	Key    string
 }
 
-func (b *backend) Compact(bucket []byte, keys [][]byte) error {
-	return b.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucket)
-
-		for _, key := range keys {
-			err := b.Delete(key)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-}
-
 func (b *backend) Hash(ignores map[IgnoreKey]struct{}) (uint32, error) {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 

--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -15,7 +15,6 @@
 package mvcc
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 
@@ -207,7 +206,6 @@ func (ti *treeIndex) Compact(rev int64) map[revision]struct{} {
 		ti.Unlock()
 		return true
 	})
-	fmt.Printf("------available %#v\n", available)
 	return available
 }
 
@@ -215,11 +213,7 @@ func (ti *treeIndex) Compact(rev int64) map[revision]struct{} {
 func (ti *treeIndex) Compact2(rev int64) (map[revision]struct{}, map[revision]struct{}) {
 	unwanted := make(map[revision]struct{})
 	unwantedTomb := make(map[revision]struct{})
-	if ti.lg != nil {
-		ti.lg.Info("compact2 tree index", zap.Int64("revision", rev))
-	} else {
-		plog.Printf("store.index: compact %d", rev)
-	}
+	ti.lg.Info("compact2 tree index", zap.Int64("revision", rev))
 	ti.Lock()
 	clone := ti.tree.Clone()
 	ti.Unlock()
@@ -233,17 +227,12 @@ func (ti *treeIndex) Compact2(rev int64) (map[revision]struct{}, map[revision]st
 		if keyi.isEmpty() {
 			item := ti.tree.Delete(keyi)
 			if item == nil {
-				if ti.lg != nil {
-					ti.lg.Panic("failed to delete during compaction")
-				} else {
-					plog.Panic("store.index: unexpected delete failure during compaction")
-				}
+				ti.lg.Panic("failed to delete during compaction")
 			}
 		}
 		ti.Unlock()
 		return true
 	})
-	fmt.Printf("------unwanted %#v\n", unwanted)
 	return unwanted, unwantedTomb
 }
 

--- a/mvcc/key_index_test.go
+++ b/mvcc/key_index_test.go
@@ -512,6 +512,323 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 	}
 }
 
+func TestKeyIndexCompact2(t *testing.T) {
+	tests := []struct {
+		compact int64
+
+		wki          *keyIndex
+		unwanted     map[revision]struct{}
+		unwantedTomb map[revision]struct{}
+	}{
+		{
+			1,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{2, 0}, ver: 3, revs: []revision{{main: 2}, {main: 4}, {main: 6}}},
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			2,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{2, 0}, ver: 3, revs: []revision{{main: 2}, {main: 4}, {main: 6}}},
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			3,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{2, 0}, ver: 3, revs: []revision{{main: 2}, {main: 4}, {main: 6}}},
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			4,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{2, 0}, ver: 3, revs: []revision{{main: 4}, {main: 6}}},
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 2}: {},
+			},
+			map[revision]struct{}{},
+		},
+		{
+			5,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{2, 0}, ver: 3, revs: []revision{{main: 4}, {main: 6}}},
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			6,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 4}: {},
+			},
+			map[revision]struct{}{
+				{main: 6}: {},
+			},
+		},
+		{
+			7,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			8,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			9,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 8}, {main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			10,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 8}: {},
+			},
+			map[revision]struct{}{},
+		},
+		{
+			11,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{8, 0}, ver: 3, revs: []revision{{main: 10}, {main: 12}}},
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			12,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 10}: {},
+			},
+			map[revision]struct{}{
+				{main: 12}: {},
+			},
+		},
+		{
+			13,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14}, {main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			14,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 14}: {},
+			},
+			map[revision]struct{}{},
+		},
+		{
+			15,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{created: revision{14, 0}, ver: 3, revs: []revision{{main: 14, sub: 1}, {main: 16}}},
+					{},
+				},
+			},
+			map[revision]struct{}{},
+			map[revision]struct{}{},
+		},
+		{
+			16,
+			&keyIndex{
+				key:      []byte("foo"),
+				modified: revision{16, 0},
+				generations: []generation{
+					{},
+				},
+			},
+			map[revision]struct{}{
+				{main: 14, sub: 1}: {},
+			},
+			map[revision]struct{}{
+				{main: 16}: {},
+			},
+		},
+	}
+
+	// Continuous Compaction
+	ki := newTestKeyIndex()
+
+	for i, tt := range tests {
+		//fmt.Printf("----nimei i:%v %#v\n", i, ki)
+		am := make(map[revision]struct{})
+		am2 := make(map[revision]struct{})
+		ki.compact2(zap.NewExample(), tt.compact, am, am2)
+		if !reflect.DeepEqual(ki, tt.wki) {
+			t.Errorf("#%d: ki = %+v, want %+v", i, ki, tt.wki)
+		}
+		if !reflect.DeepEqual(am, tt.unwanted) {
+			t.Errorf("#%d: am = %+v, want %+v", i, am, tt.unwanted)
+		}
+		if !reflect.DeepEqual(am2, tt.unwantedTomb) {
+			t.Errorf("#%d: am = %+v, want %+v", i, am, tt.unwantedTomb)
+		}
+	}
+
+	// // Jump Compaction and finding Keep
+	// ki = newTestKeyIndex()
+	// for i, tt := range tests {
+	// 	if (i%2 == 0 && i < 6) || (i%2 == 1 && i > 6) {
+	// 		am := make(map[revision]struct{})
+	// 		kiclone := cloneKeyIndex(ki)
+	// 		ki.keep(tt.compact, am)
+	// 		if !reflect.DeepEqual(ki, kiclone) {
+	// 			t.Errorf("#%d: ki = %+v, want %+v", i, ki, kiclone)
+	// 		}
+	// 		if !reflect.DeepEqual(am, tt.wam) {
+	// 			t.Errorf("#%d: am = %+v, want %+v", i, am, tt.wam)
+	// 		}
+	// 		am = make(map[revision]struct{})
+	// 		ki.compact(zap.NewExample(), tt.compact, am)
+	// 		if !reflect.DeepEqual(ki, tt.wki) {
+	// 			t.Errorf("#%d: ki = %+v, want %+v", i, ki, tt.wki)
+	// 		}
+	// 		if !reflect.DeepEqual(am, tt.wam) {
+	// 			t.Errorf("#%d: am = %+v, want %+v", i, am, tt.wam)
+	// 		}
+	// 	}
+	// }
+
+	// kiClone := newTestKeyIndex()
+	// // Once Compaction and finding Keep
+	// for i, tt := range tests {
+	// 	ki := newTestKeyIndex()
+	// 	am := make(map[revision]struct{})
+	// 	ki.keep(tt.compact, am)
+	// 	if !reflect.DeepEqual(ki, kiClone) {
+	// 		t.Errorf("#%d: ki = %+v, want %+v", i, ki, kiClone)
+	// 	}
+	// 	if !reflect.DeepEqual(am, tt.wam) {
+	// 		t.Errorf("#%d: am = %+v, want %+v", i, am, tt.wam)
+	// 	}
+	// 	am = make(map[revision]struct{})
+	// 	ki.compact(zap.NewExample(), tt.compact, am)
+	// 	if !reflect.DeepEqual(ki, tt.wki) {
+	// 		t.Errorf("#%d: ki = %+v, want %+v", i, ki, tt.wki)
+	// 	}
+	// 	if !reflect.DeepEqual(am, tt.wam) {
+	// 		t.Errorf("#%d: am = %+v, want %+v", i, am, tt.wam)
+	// 	}
+	// }
+}
+
 func cloneKeyIndex(ki *keyIndex) *keyIndex {
 	generations := make([]generation, len(ki.generations))
 	for i, gen := range ki.generations {
@@ -697,4 +1014,97 @@ func newTestKeyIndex() *keyIndex {
 	ki.put(zap.NewExample(), 14, 1)
 	ki.tombstone(zap.NewExample(), 16, 0)
 	return ki
+}
+
+func Test_findFirstSE(t *testing.T) {
+	revs := []revision{{main: 2}, {main: 4}, {main: 6}}
+	type args struct {
+		start     int
+		end       int
+		num       int64
+		revisions []revision
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "test1",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       3,
+				revisions: revs,
+			},
+			want: 0,
+		},
+		{
+			name: "test2",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       2,
+				revisions: revs,
+			},
+			want: 0,
+		},
+		{
+			name: "test3",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       1,
+				revisions: revs,
+			},
+			want: -1,
+		},
+		{
+			name: "test5",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       4,
+				revisions: revs,
+			},
+			want: 1,
+		},
+		{
+			name: "test6",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       5,
+				revisions: revs,
+			},
+			want: 1,
+		},
+		{
+			name: "test7",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       6,
+				revisions: revs,
+			},
+			want: 2,
+		},
+		{
+			name: "test8",
+			args: args{
+				start:     0,
+				end:       3,
+				num:       7,
+				revisions: revs,
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findFirstSE(tt.args.start, tt.args.end, tt.args.num, tt.args.revisions); got != tt.want {
+				t.Errorf("findFirstSE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -280,7 +280,7 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 		start := time.Now()
 		unwanted, unwantedTomb := s.kvindex.Compact2(rev)
 		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
-		if !s.scheduleCompaction(rev, keep) {
+		if !s.scheduleCompaction(rev, unwanted, unwantedTomb) {
 			s.compactBarrier(nil, ch)
 			return
 		}

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -278,7 +278,7 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 			return
 		}
 		start := time.Now()
-		keep := s.kvindex.Compact(rev)
+		unwanted, unwantedTomb := s.kvindex.Compact2(rev)
 		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 		if !s.scheduleCompaction(rev, keep) {
 			s.compactBarrier(nil, ch)

--- a/mvcc/kvstore_compaction.go
+++ b/mvcc/kvstore_compaction.go
@@ -31,6 +31,7 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 	binary.BigEndian.PutUint64(end, uint64(compactMainRev+1))
 
 	last := make([]byte, 8+1+8)
+	//compactKeys := make([][]byte, 0, s.cfg.CompactionBatchLimit)
 	for {
 		var rev revision
 

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -967,6 +967,10 @@ func (i *fakeIndex) Compact(rev int64) map[revision]struct{} {
 	i.Recorder.Record(testutil.Action{Name: "compact", Params: []interface{}{rev}})
 	return <-i.indexCompactRespc
 }
+func (i *fakeIndex) Compact2(rev int64) (map[revision]struct{}, map[revision]struct{}) {
+	i.Recorder.Record(testutil.Action{Name: "compact2", Params: []interface{}{rev}})
+	return <-i.indexCompactRespc, <-i.indexCompactRespc
+}
 func (i *fakeIndex) Keep(rev int64) map[revision]struct{} {
 	i.Recorder.Record(testutil.Action{Name: "keep", Params: []interface{}{rev}})
 	return <-i.indexCompactRespc


### PR DESCRIPTION
Now etcd do the index compaction first and use the index compaction to get the keys(revisions) we want to keep(in this case we call it keepSet), and then range the boltdb to get the whole revisions under compaction revision and minus the keepSet to get the keys we want to delete in the boltdb. I come up with another way. We can directly get the old revisions(two kinds: 1 normal revision 2 tomb revision) from index compact phase, and directly use it to delete the old revisions we don't want to keep. In this new way, we don't need the boltdb range anymore which costs time.

This pr implements this new approach.
