### PR TITLE
rm set startPeers nil when join a peer

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -287,9 +287,6 @@ func (rc *raftNode) startRaft() {
 		rc.node = raft.RestartNode(c)
 	} else {
 		startPeers := rpeers
-		if rc.join {
-			startPeers = nil
-		}
 		rc.node = raft.StartNode(c, startPeers)
 	}
 


### PR DESCRIPTION
hotfix: when join is true, startPeers will set to nil, It can be cause "no peers given; use RestartNode instead" panic.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
