### PR TITLE
CHANGELOG: update from #11621

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -18,6 +18,8 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.3...v3.4.4) and 
 ### etcd server
 
 - [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
+- Fix [quorum protection logic when promoting a learner](https://github.com/etcd-io/etcd/pull/11640).
+- Improve [peer corruption checker](https://github.com/etcd-io/etcd/pull/11621) to work when peer mTLS is enabled.
 
 ### Metrics, Monitoring
 
@@ -515,7 +517,6 @@ See [security doc](https://github.com/etcd-io/etcd/blob/master/Documentation/op-
 - Fix [server crash from creating an empty role](https://github.com/etcd-io/etcd/pull/10907).
   - Previously, creating a role with an empty name crashed etcd server with an error code `Unavailable`.
   - Now, creating a role with an empty name is not allowed with an error code `InvalidArgument`.
-- Fix [quorum protection logic when promoting a learner](https://github.com/etcd-io/etcd/pull/11640).
 
 ### API
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -90,6 +90,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - Deprecate v2 apply on cluster version. [Use v3 request to set cluster version and recover cluster version from v3 backend](https://github.com/etcd-io/etcd/pull/11427).
 - [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
 - Fix [quorum protection logic when promoting a learner](https://github.com/etcd-io/etcd/pull/11640).
+- Improve [peer corruption checker](https://github.com/etcd-io/etcd/pull/11621) to work when peer mTLS is enabled.
 
 ### Package `embed`
 


### PR DESCRIPTION
#11621 was backported and released in 3.4.4. Adding the corresponding log entry to CHANGELOG. Also moving an previous log in CHANGELOG-3.4 to the right spot.
