### PR TITLE
proxy/grpcproxy: add return on error for metrics handler

### DIFF
--- a/proxy/grpcproxy/metrics.go
+++ b/proxy/grpcproxy/metrics.go
@@ -89,6 +89,7 @@ func HandleMetrics(mux *http.ServeMux, c *http.Client, eps []string) {
 		resp, err := c.Get(target)
 		if err != nil {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
 		}
 		defer resp.Body.Close()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")


### PR DESCRIPTION
The gRPC proxy metrics handler will panic on error, return instead.