### PR TITLE
mvcc: no need to hold tx lock when converting kvs to watch events

### DIFF
--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -358,9 +358,9 @@ func (s *watchableStore) syncWatchers() int {
 	tx := s.store.b.ReadTx()
 	tx.RLock()
 	revs, vs := tx.UnsafeRange(keyBucketName, minBytes, maxBytes, 0)
+	tx.RUnlock()
 	var evs []mvccpb.Event
 	evs = kvsToEvents(s.store.lg, wg, revs, vs)
-	tx.RUnlock()
 
 	var victims watcherBatch
 	wb := newWatcherBatch(wg, evs)


### PR DESCRIPTION
Method `kvsToEvents` can take a long time if a large number of events need to be synchronized. However, this method does not access any shared resources, so it no need to hold the tx lock when executing. So we can move it outside to reduce lock holding time.

