### PR TITLE
transport: separate implied client certificate usage with trusted ca

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -361,7 +361,7 @@ func (info TLSInfo) ServerConfig() (*tls.Config, error) {
 	}
 
 	cfg.ClientAuth = tls.NoClientCert
-	if info.TrustedCAFile != "" || info.ClientCertAuth {
+	if info.ClientCertAuth {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 


### PR DESCRIPTION
The trusted CA flag currently implies using client certificates.
However, since the CA is added to the ones we trust, we can now also use it
to validate self-signed certificates between peers for example when only
doing 'simple' TLS without client certificates.
This also makes the 'client-cert-auth' a more explicit boolean flag.

Fixes #11124

This also answers the question at the bottom of #10400
