### PR TITLE
clientv3: fix racy writes to context key

### DIFF
--- a/.words
+++ b/.words
@@ -46,6 +46,7 @@ mutex
 prefetching
 protobuf
 prometheus
+racey
 rafthttp
 repin
 rpc

--- a/clientv3/ctx.go
+++ b/clientv3/ctx.go
@@ -30,9 +30,10 @@ func WithRequireLeader(ctx context.Context) context.Context {
 		md = metadata.Pairs(rpctypes.MetadataRequireLeaderKey, rpctypes.MetadataHasLeader)
 		return metadata.NewOutgoingContext(ctx, md)
 	}
+	copied := md.Copy() // avoid racey updates
 	// overwrite/add 'hasleader' key/value
-	md.Set(rpctypes.MetadataRequireLeaderKey, rpctypes.MetadataHasLeader)
-	return metadata.NewOutgoingContext(ctx, md)
+	copied.Set(rpctypes.MetadataRequireLeaderKey, rpctypes.MetadataHasLeader)
+	return metadata.NewOutgoingContext(ctx, copied)
 }
 
 // embeds client version
@@ -42,7 +43,8 @@ func withVersion(ctx context.Context) context.Context {
 		md = metadata.Pairs(rpctypes.MetadataClientAPIVersionKey, version.APIVersion)
 		return metadata.NewOutgoingContext(ctx, md)
 	}
+	copied := md.Copy() // avoid racey updates
 	// overwrite/add version key/value
-	md.Set(rpctypes.MetadataClientAPIVersionKey, version.APIVersion)
-	return metadata.NewOutgoingContext(ctx, md)
+	copied.Set(rpctypes.MetadataClientAPIVersionKey, version.APIVersion)
+	return metadata.NewOutgoingContext(ctx, copied)
 }


### PR DESCRIPTION
```
=== RUN   TestWatchOverlapContextCancel
==================
WARNING: DATA RACE
Write at 0x00c42110dd40 by goroutine 99:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:485 +0x0
  github.com/coreos/etcd/clientv3.metadataSet()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/ctx.go:61 +0x8c
  github.com/coreos/etcd/clientv3.withVersion()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/ctx.go:47 +0x137
  github.com/coreos/etcd/clientv3.newStreamClientInterceptor.func1()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/client.go:309 +0x81
  google.golang.org/grpc.NewClientStream()
      /go/src/github.com/coreos/etcd/gopath/src/google.golang.org/grpc/stream.go:101 +0x10e
  github.com/coreos/etcd/etcdserver/etcdserverpb.(*watchClient).Watch()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/etcdserver/etcdserverpb/rpc.pb.go:3193 +0xe9
  github.com/coreos/etcd/clientv3.(*watchGrpcStream).openWatchClient()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:788 +0x143
  github.com/coreos/etcd/clientv3.(*watchGrpcStream).newWatchClient()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:700 +0x5c3
  github.com/coreos/etcd/clientv3.(*watchGrpcStream).run()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:431 +0x12b

Previous read at 0x00c42110dd40 by goroutine 130:
  reflect.maplen()
      /usr/local/go/src/runtime/hashmap.go:1165 +0x0
  reflect.Value.MapKeys()
      /usr/local/go/src/reflect/value.go:1090 +0x43b
  fmt.(*pp).printValue()
      /usr/local/go/src/fmt/print.go:741 +0x1885
  fmt.(*pp).printArg()
      /usr/local/go/src/fmt/print.go:682 +0x1b1
  fmt.(*pp).doPrintf()
      /usr/local/go/src/fmt/print.go:998 +0x1cad
  fmt.Sprintf()
      /usr/local/go/src/fmt/print.go:196 +0x77
  github.com/coreos/etcd/clientv3.streamKeyFromCtx()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:825 +0xc8
  github.com/coreos/etcd/clientv3.(*watcher).Watch()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:265 +0x426
  github.com/coreos/etcd/clientv3/integration.testWatchOverlapContextCancel.func1()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:959 +0x23e

Goroutine 99 (running) created at:
  github.com/coreos/etcd/clientv3.(*watcher).newWatcherGrpcStream()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:236 +0x59d
  github.com/coreos/etcd/clientv3.(*watcher).Watch()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/watch.go:278 +0xbb6
  github.com/coreos/etcd/clientv3/integration.testWatchOverlapContextCancel.func1()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:959 +0x23e

Goroutine 130 (running) created at:
  github.com/coreos/etcd/clientv3/integration.testWatchOverlapContextCancel()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:979 +0x76d
  github.com/coreos/etcd/clientv3/integration.TestWatchOverlapContextCancel()
      /go/src/github.com/coreos/etcd/gopath/src/github.com/coreos/etcd/clientv3/integration/watch_test.go:922 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:657 +0x107


```