### PR TITLE
auth: ensure RoleGrantPermission is compatible with older versions

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -800,16 +800,6 @@ func (as *authStore) RoleGrantPermission(r *pb.AuthRoleGrantPermissionRequest) (
 	})
 
 	if idx < len(role.KeyPermission) && bytes.Equal(role.KeyPermission[idx].Key, r.Perm.Key) && bytes.Equal(role.KeyPermission[idx].RangeEnd, r.Perm.RangeEnd) {
-		if role.KeyPermission[idx].PermType == r.Perm.PermType {
-			as.lg.Warn(
-				"ignored grant permission request to a role, existing permission",
-				zap.String("role-name", r.Name),
-				zap.ByteString("key", r.Perm.Key),
-				zap.ByteString("range-end", r.Perm.RangeEnd),
-				zap.String("permission-type", authpb.Permission_Type_name[int32(r.Perm.PermType)]),
-			)
-			return &pb.AuthRoleGrantPermissionResponse{}, nil
-		}
 		// update existing permission
 		role.KeyPermission[idx].PermType = r.Perm.PermType
 	} else {

--- a/auth/store_test.go
+++ b/auth/store_test.go
@@ -414,55 +414,6 @@ func TestListUsers(t *testing.T) {
 	}
 }
 
-func TestRoleGrantPermissionRevision(t *testing.T) {
-	as, tearDown := setupAuthStore(t)
-	defer tearDown(t)
-
-	_, err := as.RoleAdd(&pb.AuthRoleAddRequest{Name: "role-test-1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	perm := &authpb.Permission{
-		PermType: authpb.WRITE,
-		Key:      []byte("Keys"),
-		RangeEnd: []byte("RangeEnd"),
-	}
-	_, err = as.RoleGrantPermission(&pb.AuthRoleGrantPermissionRequest{
-		Name: "role-test-1",
-		Perm: perm,
-	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r, err := as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(perm, r.Perm[0]) {
-		t.Errorf("expected %v, got %v", perm, r.Perm[0])
-	}
-
-	oldRevision := as.Revision()
-
-	_, err = as.RoleGrantPermission(&pb.AuthRoleGrantPermissionRequest{
-		Name: "role-test-1",
-		Perm: perm,
-	})
-
-	if err != nil {
-		t.Error(err)
-	}
-	newRevision := as.Revision()
-
-	if oldRevision != newRevision {
-		t.Errorf("expected revision diff is 0, got %d", newRevision-oldRevision)
-	}
-}
-
 func TestRoleGrantPermission(t *testing.T) {
 	as, tearDown := setupAuthStore(t)
 	defer tearDown(t)


### PR DESCRIPTION
we learn lessons from issue #11689, if a feature that may update auth-revision or revision is not compatible with older versions, it is possible to cause data inconsistency. so we have to ensure RoleGrantPermission is compatible with older versions, just revert it to old versions. 

@mitake @jingyih 