### PR TITLE
raft: advance commit index by MsgReadIndexResp 

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1364,6 +1364,10 @@ func stepFollower(r *raft, m pb.Message) error {
 			return nil
 		}
 		r.readStates = append(r.readStates, ReadState{Index: m.Index, RequestCtx: m.Entries[0].Data})
+		// `index` and `term` in MsgReadIndexResp is the leader's commit index and its current term,
+		// the log entry in the leader's commit index will always have the leader's current term,
+		// because the leader only handle MsgReadIndex after it has committed log entry in its term.
+		r.raftLog.maybeCommit(m.Index, m.Term)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>
When a follower/learner requests a read index, it's possible that it has new enough logs but its commit index is smaller than this read index. If there is no proposal, the follower/learner's commit index is advanced by the leader's heartbeat, which is too slow and increases the latency time. Instead we can advance the  follower/learner's commit index with the `index` and `term` in `MsgReadIndexResp`, because the `index` and `term` in `MsgReadIndexResp` is the leader's commit index and its current term, and log entry in the leader's commit index will always have the leader's current term, because the leader only handle `MsgReadIndex` after it has committed log entry in its term.

also see: https://github.com/tikv/raft-rs/issues/343 https://github.com/tikv/raft-rs/pull/346
