### PR TITLE
*: fix goroutines typos

### DIFF
--- a/etcdserver/api/v2store/store.go
+++ b/etcdserver/api/v2store/store.go
@@ -763,7 +763,7 @@ func (s *store) Clone() Store {
 // Recovery recovers the store system from a static state
 // It needs to recover the parent field of the nodes.
 // It needs to delete the expired nodes since the saved time and also
-// needs to create monitoring go routines.
+// needs to create monitoring goroutines.
 func (s *store) Recovery(state []byte) error {
 	s.worldLock.Lock()
 	defer s.worldLock.Unlock()

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -265,7 +265,7 @@ type EtcdServer struct {
 
 	// wgMu blocks concurrent waitgroup mutation while server stopping
 	wgMu sync.RWMutex
-	// wg is used to wait for the go routines that depends on the server state
+	// wg is used to wait for the goroutines that depends on the server state
 	// to exit when stopping the server.
 	wg sync.WaitGroup
 

--- a/functional/tester/stresser_lease.go
+++ b/functional/tester/stresser_lease.go
@@ -62,7 +62,7 @@ type leaseStresser struct {
 
 type atomicLeases struct {
 	// rwLock is used to protect read/write access of leases map
-	// which are accessed and modified by different go routines.
+	// which are accessed and modified by different goroutines.
 	rwLock sync.RWMutex
 	leases map[int64]time.Time
 }
@@ -217,7 +217,7 @@ func (ls *leaseStresser) createAliveLeases() {
 				return
 			}
 			ls.aliveLeases.add(leaseID, time.Now())
-			// keep track of all the keep lease alive go routines
+			// keep track of all the keep lease alive goroutines
 			ls.aliveWg.Add(1)
 			go ls.keepLeaseAlive(leaseID)
 		}()

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -779,7 +779,7 @@ func TestConcurrentReadTxAndWrite(t *testing.T) {
 		}()
 	}
 
-	// wait until go routines finish or timeout
+	// wait until goroutines finish or timeout
 	doneC := make(chan struct{})
 	go func() {
 		wg.Wait()


### PR DESCRIPTION
To fix the following files of goroutines typos 

etcdserver/api/v2store/store.go
etcdserver/server.go
functional/tester/stresser_lease.go
mvcc/kvstore_test.go

