### PR TITLE
Remove unneeded sub-condition

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -279,7 +279,7 @@ func (s *EtcdServer) LeaseRenew(ctx context.Context, id lease.LeaseID) (int64, e
 	defer cancel()
 
 	// renewals don't go through raft; forward to leader manually
-	for cctx.Err() == nil && err != nil {
+	for cctx.Err() == nil {
 		leader, lerr := s.waitLeader(cctx)
 		if lerr != nil {
 			return -1, lerr
@@ -369,7 +369,7 @@ func (s *EtcdServer) waitLeader(ctx context.Context) (*membership.Member, error)
 			return nil, ErrNoLeader
 		}
 	}
-	if leader == nil || len(leader.PeerURLs) == 0 {
+	if len(leader.PeerURLs) == 0 {
 		return nil, ErrNoLeader
 	}
 	return leader, nil


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

This PR removes two sub-conditions whose value doesn't change.
```
        // renewals don't go through raft; forward to leader manually
       for cctx.Err() == nil && err != nil {
```
The err is always not nil.
```
       if leader == nil || len(leader.PeerURLs) == 0 {
```
The leader is always not nil.