### PR TITLE
Cherry pick of #11330 on release-3.4

### DIFF
--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -271,15 +271,15 @@ func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
 }
 
 func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error) {
-	start := time.Now()
-	keep := s.kvindex.Compact(rev)
-	trace.Step("compact in-memory index tree")
 	ch := make(chan struct{})
 	var j = func(ctx context.Context) {
 		if ctx.Err() != nil {
 			s.compactBarrier(ctx, ch)
 			return
 		}
+		start := time.Now()
+		keep := s.kvindex.Compact(rev)
+		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 		if !s.scheduleCompaction(rev, keep) {
 			s.compactBarrier(nil, ch)
 			return
@@ -288,8 +288,6 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 	}
 
 	s.fifoSched.Schedule(j)
-
-	indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 	trace.Step("schedule compaction")
 	return ch, nil
 }

--- a/test
+++ b/test
@@ -581,7 +581,7 @@ function receiver_name_pass {
 }
 
 function commit_title_pass {
-	git log --oneline "$(git merge-base HEAD master)"...HEAD | while read -r l; do
+	git log --oneline "$(git merge-base HEAD "$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}")")"...HEAD | while read -r l; do
 		commitMsg=$(echo "$l" | cut -f2- -d' ')
 		if [[ "$commitMsg" == Merge* ]]; then
 			# ignore "Merge pull" commits


### PR DESCRIPTION
Cherry pick of #11330 on release-3.4.

#11330: mvcc/kvstore:when the number key-value is greater than one

Modified .`/test` to automatically detect branch when finding merge base. (Thanks to @jpbetz)