### PR TITLE
etcdserver: watch stream got closed if one watch request is not permitted

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -255,9 +255,10 @@ func (sws *serverWatchStream) recvLoop() error {
 
 				select {
 				case sws.ctrlStream <- wr:
+					continue
 				case <-sws.closec:
+					return nil
 				}
-				return nil
 			}
 
 			filters := FiltersFromRequest(creq)


### PR DESCRIPTION
This pr fixes #11708

The issue is easy to fix, but hard to reproduce. It happens only when:
1. Client successfully established a watch stream
2. Client issues another watch request which results in a `permission denied` response
3. After that, every watch request that reuses the same stream will hang forever

@jingyih @gyuho @xiang90 