### PR TITLE
Automated cherry pick of #11754 on release-3.3

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -230,9 +230,10 @@ func (sws *serverWatchStream) recvLoop() error {
 
 				select {
 				case sws.ctrlStream <- wr:
+					continue
 				case <-sws.closec:
+					return nil
 				}
-				return nil
 			}
 
 			filters := FiltersFromRequest(creq)


### PR DESCRIPTION
Cherry pick of #11754 on release-3.3.

#11754: etcdserver: watch stream got closed once one request is not