### PR TITLE
CHANGELOG-3.4: revert invalid gRPC-go dependency bump

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -149,10 +149,6 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.1...v3.4.2) and 
 
 **Again, before running upgrades from any previous release, please make sure to read change logs below and [v3.4 upgrade guide](https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_4.md).**
 
-### Dependency
-
-- Upgrade [`google.golang.org/grpc`](https://github.com/grpc/grpc-go/releases) from [**`v1.23.1`**](https://github.com/grpc/grpc-go/releases/tag/v1.23.1) to [**`v1.24.0`**](https://github.com/grpc/grpc-go/releases/tag/v1.24.0).
-
 ### etcdctl v3
 
 - Fix [`etcdctl member add`](https://github.com/etcd-io/etcd/pull/11194) command to prevent potential timeout.


### PR DESCRIPTION
The gRPC-go bump to 1.24 outlined in changelog for 3.4.2 never actually happened, removing.

ref

https://github.com/etcd-io/etcd/blob/f1eca4e1fa5de962ff8079af836bb390e88d1f4c/vendor/google.golang.org/grpc/version.go#L22