### PR TITLE
Changes made to CreateSnapshot method

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -358,7 +358,7 @@ func (rc *raftNode) maybeTriggerSnapshot() {
 	if err != nil {
 		log.Panic(err)
 	}
-	snap, err := rc.raftStorage.CreateSnapshot(rc.appliedIndex, &rc.confState, data)
+	snap, err := rc.raftStorage.CreateSnapshot(rc.appliedIndex-1, &rc.confState, data)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
raftexample -Changes made to CreateSnapshort method

 CreateSnapshot is missing the immediate value after the snapshort is triggered,So to avoid this problem rc.appliedIndex-1 should be passed as parameter


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
