### PR TITLE
Continue with the loop after writing to ctrlStream

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -214,6 +214,7 @@ func (sws *serverWatchStream) isWatchPermitted(wcr *pb.WatchCreateRequest) bool 
 }
 
 func (sws *serverWatchStream) recvLoop() error {
+	outer:
 	for {
 		req, err := sws.gRPCStream.Recv()
 		if err == io.EOF {
@@ -255,7 +256,7 @@ func (sws *serverWatchStream) recvLoop() error {
 
 				select {
 				case sws.ctrlStream <- wr:
-					continue
+					continue outer
 				case <-sws.closec:
 					return nil
 				}


### PR DESCRIPTION
#11754 fixed a bug where watch stream was prematurely closed.

However, when the write to sws.ctrlStream succeeds, we should continue with the for loop. The existing code doesn't achieve this purpose.

This PR makes the continue effective by introducing label.

/cc @polyrabbit @xiang90 @jingyih 