### PR TITLE
etcdserver: significantly reduces start-up time

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -102,6 +102,8 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - [Refactor consistentindex](https://github.com/etcd-io/etcd/pull/11699).
 - [Add log when etcdserver failed to apply command](https://github.com/etcd-io/etcd/pull/11670).
 - Improve [count-only range performance](https://github.com/etcd-io/etcd/pull/11771).
+- Remove [redundant storage restore operation to shorten the startup time](https://github.com/etcd-io/etcd/pull/11779).
+  - With 40 million key test data,it can shorten the startup time from 5 min to 2.5 min.
 
 
 ### Package `embed`

--- a/etcdserver/backend.go
+++ b/etcdserver/backend.go
@@ -21,8 +21,6 @@ import (
 
 	"go.etcd.io/etcd/etcdserver/api/snap"
 	"go.etcd.io/etcd/etcdserver/cindex"
-	"go.etcd.io/etcd/lease"
-	"go.etcd.io/etcd/mvcc"
 	"go.etcd.io/etcd/mvcc/backend"
 	"go.etcd.io/etcd/raft/raftpb"
 
@@ -96,9 +94,7 @@ func openBackend(cfg ServerConfig) backend.Backend {
 // case, replace the db with the snapshot db sent by the leader.
 func recoverSnapshotBackend(cfg ServerConfig, oldbe backend.Backend, snapshot raftpb.Snapshot) (backend.Backend, error) {
 	ci := cindex.NewConsistentIndex(oldbe.BatchTx())
-	kv := mvcc.New(cfg.Logger, oldbe, &lease.FakeLessor{}, ci, mvcc.StoreConfig{CompactionBatchLimit: cfg.CompactionBatchLimit})
-	defer kv.Close()
-	if snapshot.Metadata.Index <= kv.ConsistentIndex() {
+	if snapshot.Metadata.Index <= ci.ConsistentIndex() {
 		return oldbe, nil
 	}
 	oldbe.Close()

--- a/etcdserver/backend.go
+++ b/etcdserver/backend.go
@@ -92,9 +92,13 @@ func openBackend(cfg ServerConfig) backend.Backend {
 // before updating the backend db after persisting raft snapshot to disk,
 // violating the invariant snapshot.Metadata.Index < db.consistentIndex. In this
 // case, replace the db with the snapshot db sent by the leader.
-func recoverSnapshotBackend(cfg ServerConfig, oldbe backend.Backend, snapshot raftpb.Snapshot) (backend.Backend, error) {
-	ci := cindex.NewConsistentIndex(oldbe.BatchTx())
-	if snapshot.Metadata.Index <= ci.ConsistentIndex() {
+func recoverSnapshotBackend(cfg ServerConfig, oldbe backend.Backend, snapshot raftpb.Snapshot, beExist bool) (backend.Backend, error) {
+	consistentIndex := uint64(0)
+	if beExist {
+		ci := cindex.NewConsistentIndex(oldbe.BatchTx())
+		consistentIndex = ci.ConsistentIndex()
+	}
+	if snapshot.Metadata.Index <= consistentIndex {
 		return oldbe, nil
 	}
 	oldbe.Close()

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -428,7 +428,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 				zap.String("snapshot-size", humanize.Bytes(uint64(snapshot.Size()))),
 			)
 
-			if be, err = recoverSnapshotBackend(cfg, be, *snapshot); err != nil {
+			if be, err = recoverSnapshotBackend(cfg, be, *snapshot, beExist); err != nil {
 				cfg.Logger.Panic("failed to recover v3 backend from snapshot", zap.Error(err))
 			}
 			s1, s2 := be.Size(), be.SizeInUse()


### PR DESCRIPTION
if there are too much keys(> 1 millions),etcd is slow to start. After my investigation, 90% of the time is spent on mvcc restore(rebuild index tree), 9% is spent on open backend db, and because the index tree has a global lock(idx.Insert), there is no room for optimization. however,restore index is called twice, it is unreasonable.we can benefit from  pr #11699  and cut time in half.


