### PR TITLE
Convert number to string without using Sprintf()

### DIFF
--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -312,7 +313,7 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	cc := &http.Client{Transport: peerRt}
 	// TODO: refactor member http handler code
 	// cannot import etcdhttp, so manually construct url
-	requestUrl := url + "/members/promote/" + fmt.Sprintf("%d", id)
+	requestUrl := url + "/members/promote/" + strconv.FormatInt(int64(id), 10)
 	req, err := http.NewRequest("POST", requestUrl, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In promoteMemberHTTP(), Sprintf() is used to convert number.

* fmt.Sprintf needs to parse its first argument to understand what to do. But we only want to convert a number
* fmt.Sprintf needs to marshal its variable arguments into a slice of interface{}. this could cause unnecessary allocations.

This PR converts the number directly.