### PR TITLE
CHANGELOG-3.5: update from #11548 and #11358

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -167,6 +167,10 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 - Upgrade [`google.golang.org/grpc`](https://github.com/grpc/grpc-go/releases) from [**`v1.23.0`**](https://github.com/grpc/grpc-go/releases/tag/v1.23.0) to [**`v1.26.0`**](https://github.com/grpc/grpc-go/releases/tag/v1.26.0).
 
+### Release
+
+- Add s390x build support ([PR#11548](https://github.com/etcd-io/etcd/pull/11548) and [PR#11358](https://github.com/etcd-io/etcd/pull/11358))
+
 ### Go
 
 - Require [*Go 1.13+*](https://github.com/etcd-io/etcd/pull/11110).


### PR DESCRIPTION
Signed-off-by: Nirman Narang <narang@us.ibm.com>


Adding update from PRs #11548 and #11358 to CHANGELOG-3.5.md.
