### PR TITLE
etcdserver: Check memb against nil before dereferencing

### DIFF
--- a/clientv3/snapshot/v3_snapshot.go
+++ b/clientv3/snapshot/v3_snapshot.go
@@ -425,6 +425,9 @@ func (s *v3Manager) saveWALAndSnap() error {
 	}
 
 	m := s.cl.MemberByName(s.name)
+	if m == nil {
+		return fmt.Errorf("unable to retrieve member for %q", s.name)
+	}
 	md := &etcdserverpb.Metadata{NodeID: uint64(m.ID), ClusterID: uint64(s.cl.ID())}
 	metadata, merr := md.Marshal()
 	if merr != nil {

--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -166,6 +166,9 @@ func (c *RaftCluster) MemberByName(name string) *Member {
 			memb = m
 		}
 	}
+	if memb == nil {
+		return nil
+	}
 	return memb.Clone()
 }
 

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -39,7 +39,11 @@ func isMemberBootstrapped(lg *zap.Logger, cl *membership.RaftCluster, member str
 	if err != nil {
 		return false
 	}
-	id := cl.MemberByName(member).ID
+	mbr := cl.MemberByName(member)
+	if mbr == nil {
+		return false
+	}
+	id := mbr.ID
 	m := rcl.Member(id)
 	if m == nil {
 		return false

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -400,6 +400,9 @@ func (r *raftNode) advanceTicks(ticks int) {
 func startNode(cfg ServerConfig, cl *membership.RaftCluster, ids []types.ID) (id types.ID, n raft.Node, s *raft.MemoryStorage, w *wal.WAL) {
 	var err error
 	member := cl.MemberByName(cfg.Name)
+	if member == nil {
+		cfg.Logger.Panic("failed to retrieve member")
+	}
 	metadata := pbutil.MustMarshal(
 		&pb.Metadata{
 			NodeID:    uint64(member.ID),

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -352,7 +352,11 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		if err = membership.ValidateClusterAndAssignIDs(cfg.Logger, cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
-		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt) {
+		mbr := cl.MemberByName(cfg.Name)
+		if mbr == nil {
+			return nil, fmt.Errorf("unable to retrieve member for %q", cfg.Name)
+		}
+		if !isCompatibleWithCluster(cfg.Logger, cl, mbr.ID, prt) {
 			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 
@@ -372,6 +376,9 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 			return nil, err
 		}
 		m := cl.MemberByName(cfg.Name)
+		if m == nil {
+			return nil, fmt.Errorf("unable to retrieve member for %q", cfg.Name)
+		}
 		if isMemberBootstrapped(cfg.Logger, cl, cfg.Name, prt, cfg.bootstrapTimeout()) {
 			return nil, fmt.Errorf("member %s has already been bootstrapped", m.ID)
 		}


### PR DESCRIPTION
In RaftCluster#MemberByName, memb is initially un-assigned.

If the loop doesn't find the named Member, the return statement would panic.

This PR adds nil check.

