### PR TITLE
Remove unused parameter id from RaftCluster#IsReadyToPromoteMember

### DIFF
--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -607,7 +607,7 @@ func (c *RaftCluster) IsReadyToRemoveVotingMember(id uint64) bool {
 	return true
 }
 
-func (c *RaftCluster) IsReadyToPromoteMember(id uint64) bool {
+func (c *RaftCluster) IsReadyToPromoteMember() bool {
 	nmembers := 1 // We count the learner to be promoted for the future quorum
 	nstarted := 1 // and we also count it as started.
 

--- a/etcdserver/api/membership/cluster_test.go
+++ b/etcdserver/api/membership/cluster_test.go
@@ -939,7 +939,7 @@ func TestIsReadyToPromoteMember(t *testing.T) {
 	}
 	for i, tt := range tests {
 		c := newTestCluster(tt.members)
-		if got := c.IsReadyToPromoteMember(tt.promoteID); got != tt.want {
+		if got := c.IsReadyToPromoteMember(); got != tt.want {
 			t.Errorf("%d: isReadyToPromoteMember returned %t, want %t", i, got, tt.want)
 		}
 	}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1532,7 +1532,7 @@ func (s *EtcdServer) mayPromoteMember(id types.ID) error {
 	if !s.Cfg.StrictReconfigCheck {
 		return nil
 	}
-	if !s.cluster.IsReadyToPromoteMember(uint64(id)) {
+	if !s.cluster.IsReadyToPromoteMember() {
 		lg.Warn(
 			"rejecting member promote request; not enough healthy members",
 			zap.String("local-member-id", s.ID().String()),


### PR DESCRIPTION
RaftCluster#IsReadyToPromoteMember doesn't use id parameter.

This PR removes the parameter.