### PR TITLE
Documentation/learning/lock/client: add defer Unlock

### DIFF
--- a/Documentation/learning/lock/client/client.go
+++ b/Documentation/learning/lock/client/client.go
@@ -183,6 +183,7 @@ func main() {
 
 	locker := concurrency.NewLocker(session, "/lock")
 	locker.Lock()
+	defer locker.Unlock()
 	version := session.Lease()
 	fmt.Printf("acquired lock, version: %d\n", version)
 


### PR DESCRIPTION
In Documentation/learning/lock/client/client.go,
`func main` forgets `locker.Unlock()` before return.
The fix is to add `defer locker.Unlock()`.