### PR TITLE
MAINTAINERS: update @philips email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,7 +9,7 @@
 # Please keep the list sorted.
 
 # MAINTAINERS
-Brandon Philips <bphilips@redhat.com> (@philips) pkg:*
+Brandon Philips <brandon@ifup.org> (@philips) pkg:*
 Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*


### PR DESCRIPTION
Brandon is no longer at Red Hat. Use a different email.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
