### PR TITLE
wal: fix panic when decoder not set

### DIFF
--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -979,3 +979,24 @@ func TestRenameFail(t *testing.T) {
 		t.Fatalf("expected error, got %v", werr)
 	}
 }
+
+// TestReadAllFail ensure ReadAll error if used without opening the WAL
+func TestReadAllFail(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "waltest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// create initial WAL
+	f, err := Create(zap.NewExample(), dir, []byte("metadata"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	// try to read without opening the WAL
+	_, _, _, err = f.ReadAll()
+	if err == nil || err != ErrDecoderNotFound {
+		t.Fatalf("err = %v, want ErrDecoderNotFound", err)
+	}
+}


### PR DESCRIPTION
The Create function doc says a WAL is ready to read right after but it results in a panic. A returned WAL from call to Open is ready to read which is correctly mentioned in the Open func. 


