### PR TITLE
mvcc: fix race in TestKVTxnBlockWriteOperations

### DIFF
--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -410,10 +410,11 @@ func TestKVTxnBlockWriteOperations(t *testing.T) {
 		func() { s.DeleteRange([]byte("foo"), nil) },
 	}
 	for i, tt := range tests {
+		tf := tt
 		txn := s.Write(traceutil.TODO())
 		done := make(chan struct{}, 1)
 		go func() {
-			tt()
+			tf()
 			done <- struct{}{}
 		}()
 		select {


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.

When a go loop launches goroutines, it is a common mistake to assume
that the routines can reference the loop value from their specific loop
iteration. Actually, all goroutines share the same reference to the loop
veriable, and they typically all see the last value. To correct this, the loop variable must be captured as a parameter to the anonymous func.