### PR TITLE
etcdserver: don't let InternalAuthenticateRequest have password

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -441,9 +441,10 @@ func (s *EtcdServer) Authenticate(ctx context.Context, r *pb.AuthenticateRequest
 			return nil, err
 		}
 
+		// internalReq doesn't need to have Password because the above s.AuthStore().CheckPassword() already did it.
+		// In addition, it will let a WAL entry not record password as a plain text.
 		internalReq := &pb.InternalAuthenticateRequest{
 			Name:        r.Name,
-			Password:    r.Password,
 			SimpleToken: st,
 		}
 


### PR DESCRIPTION
@xiang90 This is a PR for not recording password in a WAL entry as a plain text. Because of the stateful nature of simple token, making the entire authentication process as a serializable process is difficult. So I think this would be the simplest way. How do you think?