### PR TITLE
clientv3: fix DialTimeout race condition

### DIFF
--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -100,14 +100,14 @@ func TestDialTimeout(t *testing.T) {
 
 	for i, cfg := range testCfgs {
 		donec := make(chan error, 1)
-		go func() {
+		go func(cfg Config) {
 			// without timeout, dial continues forever on ipv4 black hole
 			c, err := New(cfg)
 			if c != nil || err == nil {
 				t.Errorf("#%d: new client should fail", i)
 			}
 			donec <- err
-		}()
+		}(cfg)
 
 		time.Sleep(10 * time.Millisecond)
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
When a go loop launches goroutines, it is a common mistake to assume
that the routines can reference the loop value from their specific loop
iteration. Actually, all goroutines share the same reference to the loop
veriable, and they typically all see the last value. To correct this, the loop variable must be captured as a parameter to the anonymous func.