### PR TITLE
Fix typo in etcdctl README.md

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -1148,7 +1148,7 @@ Whenever a leader is elected, its proposal is given as output.
 
 ELECT returns a zero exit code only if it is terminated by a signal and can revoke its candidacy or leadership, if any.
 
-If a candidate is abnormally terminated, election rogress may be delayed by up to the default lease length of 60 seconds.
+If a candidate is abnormally terminated, election progress may be delayed by up to the default lease length of 60 seconds.
 
 ## Authentication commands
 


### PR DESCRIPTION
doc: Update etcdctl README

Fixed a typo in the ELECT section of the README.