### PR TITLE
clientv3: v3Manager#saveDB should always close db file

### DIFF
--- a/clientv3/snapshot/v3_snapshot.go
+++ b/clientv3/snapshot/v3_snapshot.go
@@ -338,6 +338,13 @@ func (s *v3Manager) saveDB() error {
 	if dberr != nil {
 		return dberr
 	}
+	dbClosed := false
+	defer func() {
+		if !dbClosed {
+			db.Close()
+			dbClosed = true
+		}
+	}()
 	if _, err := io.Copy(db, f); err != nil {
 		return err
 	}
@@ -375,6 +382,7 @@ func (s *v3Manager) saveDB() error {
 
 	// db hash is OK, can now modify DB so it can be part of a new cluster
 	db.Close()
+	dbClosed = true
 
 	commit := len(s.cl.Members())
 


### PR DESCRIPTION
In v3Manager#saveDB, db file should always be closed upon return from the method.

Currently if db.Seek() call fails (around line 353), db is not closed.