### PR TITLE
raft: break out of nested loop when raft id is found

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -367,10 +367,12 @@ func (n *node) run() {
 			// very sound and likely has bugs.
 			if _, okAfter := r.prs.Progress[r.id]; okBefore && !okAfter {
 				var found bool
+			outer:
 				for _, sl := range [][]uint64{cs.Voters, cs.VotersOutgoing} {
 					for _, id := range sl {
 						if id == r.id {
 							found = true
+							break outer
 						}
 					}
 				}


### PR DESCRIPTION
In  node#run(), the nested loop is used to find matching id:
```
				for _, sl := range [][]uint64{cs.Voters, cs.VotersOutgoing} {
					for _, id := range sl {
```
When id is found, we can come out of the loop.