### PR TITLE
raft: return error for unapplied entries

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -914,7 +914,9 @@ func (r *raft) Step(m pb.Message) error {
 			}
 			ents, err := r.raftLog.slice(r.raftLog.applied+1, r.raftLog.committed+1, noLimit)
 			if err != nil {
-				r.logger.Panicf("unexpected error getting unapplied entries (%v)", err)
+				errRet := fmt.Errorf("unexpected error getting unapplied entries (%v)", err)
+				r.logger.Error(errRet)
+				return errRet
 			}
 			if n := numOfPendingConf(ents); n != 0 && r.raftLog.committed > r.raftLog.applied {
 				r.logger.Warningf("%x cannot campaign at term %d since there are still %d pending configuration changes to apply", r.id, r.Term, n)


### PR DESCRIPTION
In raft#Step, this PR replaces panic with returning an error.