### PR TITLE
chore(Dockerfile-release): Update base image to use new debian-base:v2.1.0

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base:v1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image:v2.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-arm64:v1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm64:v2.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-ppc64le:v1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-ppc64le:v2.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-s390x:v1.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-s390x:v2.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Updates the base image for all arch releases to the new location (us.gcr.io/k8s-artifacts-prod/build-image) as well as to the latest version (v2.1.0). This should fix a number of vulnerabilities that are in the 1.0.0 base image release.