### PR TITLE
raftexample: Fix recovery from snapshot

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -50,7 +50,6 @@ type raftNode struct {
 	waldir      string   // path to WAL directory
 	snapdir     string   // path to snapshot directory
 	getSnapshot func() ([]byte, error)
-	lastIndex   uint64 // index of log at start
 
 	confState     raftpb.ConfState
 	snapshotIndex uint64
@@ -175,15 +174,6 @@ func (rc *raftNode) publishEntries(ents []raftpb.Entry) bool {
 
 		// after commit, update appliedIndex
 		rc.appliedIndex = ents[i].Index
-
-		// special nil commit to signal replay has finished
-		if ents[i].Index == rc.lastIndex {
-			select {
-			case rc.commitC <- nil:
-			case <-rc.stopc:
-				return false
-			}
-		}
 	}
 	return true
 }
@@ -240,12 +230,7 @@ func (rc *raftNode) replayWAL() *wal.WAL {
 
 	// append to storage so raft starts at the right place in log
 	rc.raftStorage.Append(ents)
-	// send nil once lastIndex is published so client knows commit channel is current
-	if len(ents) > 0 {
-		rc.lastIndex = ents[len(ents)-1].Index
-	} else {
-		rc.commitC <- nil
-	}
+
 	return w
 }
 
@@ -264,10 +249,12 @@ func (rc *raftNode) startRaft() {
 		}
 	}
 	rc.snapshotter = snap.New(zap.NewExample(), rc.snapdir)
-	rc.snapshotterReady <- rc.snapshotter
 
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
+
+	// signal replay has finished
+	rc.snapshotterReady <- rc.snapshotter
 
 	rpeers := make([]raft.Peer, len(rc.peers))
 	for i := range rpeers {

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -61,17 +61,6 @@ func newCluster(n int) *cluster {
 	return clus
 }
 
-// sinkReplay reads all commits in each node's local log.
-func (clus *cluster) sinkReplay() {
-	for i := range clus.peers {
-		for s := range clus.commitC[i] {
-			if s == nil {
-				break
-			}
-		}
-	}
-}
-
 // Close closes all cluster nodes and returns an error if any failed.
 func (clus *cluster) Close() (err error) {
 	for i := range clus.peers {
@@ -101,8 +90,6 @@ func (clus *cluster) closeNoErrors(t *testing.T) {
 func TestProposeOnCommit(t *testing.T) {
 	clus := newCluster(3)
 	defer clus.closeNoErrors(t)
-
-	clus.sinkReplay()
 
 	donec := make(chan struct{})
 	for i := range clus.peers {
@@ -148,8 +135,6 @@ func TestCloseProposerBeforeReplay(t *testing.T) {
 func TestCloseProposerInflight(t *testing.T) {
 	clus := newCluster(1)
 	defer clus.closeNoErrors(t)
-
-	clus.sinkReplay()
 
 	// some inflight ops
 	go func() {


### PR DESCRIPTION
* If there is a snapshot, HTTP server won't start.
    This function doesn't return. https://github.com/etcd-io/etcd/blob/7cc2f8a4114bbc9ca5fe5381504b9c4096fca1ac/contrib/raftexample/kvstore.go#L43
* Resotring form snapshot occurs after replaying WAL.
* When taking a snapshot, the last change is not applied to the state machine yet.
