### PR TITLE
auth: remove unnecessary code

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -1221,9 +1221,7 @@ func NewTokenProvider(
 
 	switch tokenType {
 	case tokenTypeSimple:
-		if lg != nil {
-			lg.Warn("simple token is not cryptographically signed")
-		}
+		lg.Warn("simple token is not cryptographically signed")
 		return newTokenProviderSimple(lg, indexWaiter), nil
 
 	case tokenTypeJWT:
@@ -1233,13 +1231,11 @@ func NewTokenProvider(
 		return newTokenProviderNop()
 
 	default:
-		if lg != nil {
-			lg.Warn(
-				"unknown token type",
-				zap.String("type", tokenType),
-				zap.Error(ErrInvalidAuthOpts),
-			)
-		}
+		lg.Warn(
+			"unknown token type",
+			zap.String("type", tokenType),
+			zap.Error(ErrInvalidAuthOpts),
+		)
 		return nil, ErrInvalidAuthOpts
 	}
 }


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.

<br/>

NewTokenProvider is only called by  NewServer (etcdserver/server.go)，and "cfg.Logger != nil" is default.

It's not necessary to add this judgment(if lg!=nil) to all functions,especially the parameter of those functions have determined "logger != nil".
