### PR TITLE
raft: avoid data race by not reading raft.lead

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -409,7 +409,7 @@ func (n *node) Tick() {
 	case n.tickc <- struct{}{}:
 	case <-n.done:
 	default:
-		n.rn.raft.logger.Warningf("%x (leader %v) A tick missed to fire. Node blocks too long!", n.rn.raft.id, n.rn.raft.id == n.rn.raft.lead)
+		n.rn.raft.logger.Warningf("%x A tick missed to fire. Node blocks too long!", n.rn.raft.id)
 	}
 }
 


### PR DESCRIPTION
This PR drops the read of raft.lead in node#Tick() so that the following data race is avoided:
```
WARNING: DATA RACE
Write at 0x00c0008af9b0 by goroutine 426:
  go.etcd.io/etcd/v3/raft.(*raft).reset()
      /go/src/go.etcd.io/etcd/raft/raft.go:610 +0x85
  go.etcd.io/etcd/v3/raft.(*raft).becomeCandidate()
      /go/src/go.etcd.io/etcd/raft/raft.go:710 +0xdb
  go.etcd.io/etcd/v3/raft.(*raft).campaign()
      /go/src/go.etcd.io/etcd/raft/raft.go:785 +0xfa
  go.etcd.io/etcd/v3/raft.(*raft).Step()
      /go/src/go.etcd.io/etcd/raft/raft.go:928 +0x1615
  go.etcd.io/etcd/v3/raft.(*raft).tickElection()
      /go/src/go.etcd.io/etcd/raft/raft.go:665 +0x22e
  go.etcd.io/etcd/v3/raft.(*raft).tickElection-fm()
      /go/src/go.etcd.io/etcd/raft/raft.go:660 +0x41
  go.etcd.io/etcd/v3/raft.(*RawNode).Tick()
      /go/src/go.etcd.io/etcd/raft/rawnode.go:59 +0x90a
  go.etcd.io/etcd/v3/raft.(*node).run()
      /go/src/go.etcd.io/etcd/raft/node.go:388 +0x8a2
Previous read at 0x00c0008af9b0 by goroutine 694:
  go.etcd.io/etcd/v3/raft.(*node).Tick()
      /go/src/go.etcd.io/etcd/raft/node.go:412 +0x23f
  go.etcd.io/etcd/v3/etcdserver.(*raftNode).tick()
      /go/src/go.etcd.io/etcd/etcdserver/raft.go:156 +0x82
  go.etcd.io/etcd/v3/etcdserver.(*raftNode).start.func1()
      /go/src/go.etcd.io/etcd/etcdserver/raft.go:172 +0x2078
```
A mutex can be introduced. However, the read in node#Tick() appears in a log. It seems dropping the read is more intuitive.