### PR TITLE
[Etcd downgrade] Apply downgrade policy to server

### DIFF
--- a/etcdserver/api/capability.go
+++ b/etcdserver/api/capability.go
@@ -17,6 +17,7 @@ package api
 import (
 	"sync"
 
+	"go.etcd.io/etcd/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/v3/version"
 	"go.uber.org/zap"
 
@@ -62,7 +63,7 @@ func UpdateCapability(lg *zap.Logger, v *semver.Version) {
 		return
 	}
 	enableMapMu.Lock()
-	if curVersion != nil && !curVersion.LessThan(*v) {
+	if curVersion != nil && !membership.IsValidVersionChange(v, curVersion) {
 		enableMapMu.Unlock()
 		return
 	}

--- a/etcdserver/api/membership/downgrade.go
+++ b/etcdserver/api/membership/downgrade.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package membership
+
+import (
+	"github.com/coreos/go-semver/semver"
+	"go.etcd.io/etcd/v3/version"
+	"go.uber.org/zap"
+)
+
+type DowngradeInfo struct {
+	// TargetVersion is the target downgrade version, if the cluster is not under downgrading,
+	// the targetVersion will be an empty string
+	TargetVersion string `json:"target-version"`
+	// Enabled indicates whether the cluster is enabled to downgrade
+	Enabled bool `json:"enabled"`
+}
+
+func (d *DowngradeInfo) GetTargetVersion() *semver.Version {
+	return semver.Must(semver.NewVersion(d.TargetVersion))
+}
+
+// isValidDowngrade verifies whether the cluster can be downgraded from verFrom to verTo
+func isValidDowngrade(verFrom *semver.Version, verTo *semver.Version) bool {
+	return verTo.Equal(*AllowedDowngradeVersion(verFrom))
+}
+
+// mustDetectDowngrade will detect unexpected downgrade when the local server is recovered.
+func mustDetectDowngrade(lg *zap.Logger, cv *semver.Version, d *DowngradeInfo) {
+	lv := semver.Must(semver.NewVersion(version.Version))
+	// only keep major.minor version for comparison against cluster version
+	lv = &semver.Version{Major: lv.Major, Minor: lv.Minor}
+
+	// if the cluster enables downgrade, check local version against downgrade target version.
+	if d != nil && d.Enabled && d.TargetVersion != "" {
+		if lv.Equal(*d.GetTargetVersion()) {
+			if cv != nil {
+				lg.Info(
+					"cluster is downgrading to target version",
+					zap.String("target-cluster-version", d.TargetVersion),
+					zap.String("determined-cluster-version", version.Cluster(cv.String())),
+					zap.String("current-server-version", version.Version),
+				)
+			}
+			return
+		}
+		lg.Fatal(
+			"invalid downgrade; server version is not allowed to join when downgrade is enabled",
+			zap.String("current-server-version", version.Version),
+			zap.String("target-cluster-version", d.TargetVersion),
+		)
+	}
+
+	// if the cluster disables downgrade, check local version against determined cluster version.
+	// the validation passes when local version is not less than cluster version
+	if cv != nil && lv.LessThan(*cv) {
+		lg.Fatal(
+			"invalid downgrade; server version is lower than determined cluster version",
+			zap.String("current-server-version", version.Version),
+			zap.String("determined-cluster-version", version.Cluster(cv.String())),
+		)
+	}
+}
+
+func AllowedDowngradeVersion(ver *semver.Version) *semver.Version {
+	// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
+	return &semver.Version{Major: ver.Major, Minor: ver.Minor - 1}
+}

--- a/etcdserver/api/membership/downgrade_test.go
+++ b/etcdserver/api/membership/downgrade_test.go
@@ -1,0 +1,194 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package membership
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/coreos/go-semver/semver"
+	"go.etcd.io/etcd/v3/version"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestMustDetectDowngrade(t *testing.T) {
+	lv := semver.Must(semver.NewVersion(version.Version))
+	lv = &semver.Version{Major: lv.Major, Minor: lv.Minor}
+	oneMinorHigher := &semver.Version{Major: lv.Major, Minor: lv.Minor + 1}
+	oneMinorLower := &semver.Version{Major: lv.Major, Minor: lv.Minor - 1}
+	downgradeEnabledHigherVersion := &DowngradeInfo{Enabled: true, TargetVersion: oneMinorHigher.String()}
+	downgradeEnabledEqualVersion := &DowngradeInfo{Enabled: true, TargetVersion: lv.String()}
+	downgradeEnabledLowerVersion := &DowngradeInfo{Enabled: true, TargetVersion: oneMinorLower.String()}
+	downgradeDisabled := &DowngradeInfo{Enabled: false}
+
+	tests := []struct {
+		name           string
+		clusterVersion *semver.Version
+		downgrade      *DowngradeInfo
+		success        bool
+		message        string
+	}{
+		{
+			"Succeeded when downgrade is disabled and cluster version is nil",
+			nil,
+			downgradeDisabled,
+			true,
+			"",
+		},
+		{
+			"Succeeded when downgrade is disabled and cluster version is one minor lower",
+			oneMinorLower,
+			downgradeDisabled,
+			true,
+			"",
+		},
+		{
+			"Succeeded when downgrade is disabled and cluster version is server version",
+			lv,
+			downgradeDisabled,
+			true,
+			"",
+		},
+		{
+			"Failed when downgrade is disabled and server version is lower than determined cluster version ",
+			oneMinorHigher,
+			downgradeDisabled,
+			false,
+			"invalid downgrade; server version is lower than determined cluster version",
+		},
+		{
+			"Succeeded when downgrade is enabled and cluster version is nil",
+			nil,
+			downgradeEnabledEqualVersion,
+			true,
+			"",
+		},
+		{
+			"Failed when downgrade is enabled and server version is target version",
+			lv,
+			downgradeEnabledEqualVersion,
+			true,
+			"cluster is downgrading to target version",
+		},
+		{
+			"Succeeded when downgrade to lower version and server version is cluster version ",
+			lv,
+			downgradeEnabledLowerVersion,
+			false,
+			"invalid downgrade; server version is not allowed to join when downgrade is enabled",
+		},
+		{
+			"Failed when downgrade is enabled and local version is out of range and cluster version is nil",
+			nil,
+			downgradeEnabledHigherVersion,
+			false,
+			"invalid downgrade; server version is not allowed to join when downgrade is enabled",
+		},
+
+		{
+			"Failed when downgrade is enabled and local version is out of range",
+			lv,
+			downgradeEnabledHigherVersion,
+			false,
+			"invalid downgrade; server version is not allowed to join when downgrade is enabled",
+		},
+	}
+
+	if os.Getenv("DETECT_DOWNGRADE") != "" {
+		i := os.Getenv("DETECT_DOWNGRADE")
+		iint, _ := strconv.Atoi(i)
+		logPath := filepath.Join(os.TempDir(), fmt.Sprintf("test-log-must-detect-downgrade-%v", iint))
+
+		lcfg := zap.NewProductionConfig()
+		lcfg.OutputPaths = []string{logPath}
+		lcfg.ErrorOutputPaths = []string{logPath}
+		lg, _ := lcfg.Build()
+
+		mustDetectDowngrade(lg, tests[iint].clusterVersion, tests[iint].downgrade)
+		return
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logPath := filepath.Join(os.TempDir(), fmt.Sprintf("test-log-must-detect-downgrade-%d", i))
+			t.Log(logPath)
+			defer os.RemoveAll(logPath)
+
+			cmd := exec.Command(os.Args[0], "-test.run=TestMustDetectDowngrade")
+			cmd.Env = append(os.Environ(), fmt.Sprintf("DETECT_DOWNGRADE=%d", i))
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+
+			errCmd := cmd.Wait()
+
+			data, err := ioutil.ReadFile(logPath)
+			if err == nil {
+				if !bytes.Contains(data, []byte(tt.message)) {
+					t.Errorf("Expected to find %v in log", tt.message)
+				}
+			} else {
+				t.Fatal(err)
+			}
+
+			if !tt.success {
+				e, ok := errCmd.(*exec.ExitError)
+				if !ok || e.Success() {
+					t.Errorf("Expected exit with status 1; Got %v", err)
+				}
+			}
+
+			if tt.success && errCmd != nil {
+				t.Errorf("Expected not failure; Got %v", errCmd)
+			}
+		})
+	}
+}
+
+func TestIsValidDowngrade(t *testing.T) {
+	tests := []struct {
+		name    string
+		verFrom string
+		verTo   string
+		result  bool
+	}{
+		{
+			"Valid downgrade",
+			"3.5.0",
+			"3.4.0",
+			true,
+		},
+		{
+			"Invalid downgrade",
+			"3.5.2",
+			"3.3.0",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := isValidDowngrade(
+				semver.Must(semver.NewVersion(tt.verFrom)), semver.Must(semver.NewVersion(tt.verTo)))
+			if res != tt.result {
+				t.Errorf("Expected downgrade valid is %v; Got %v", tt.result, res)
+			}
+		})
+	}
+}

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -198,20 +198,31 @@ func decideClusterVersion(lg *zap.Logger, vers map[string]*version.Versions) *se
 	return cv
 }
 
+// allowedVersionRange decides the available version range of the cluster that local server can join in;
+// if the downgrade enabled status is true, the version window is [oneMinorHigher, oneMinorHigher]
+// if the downgrade is not enabled, the version window is [MinClusterVersion, localVersion]
+func allowedVersionRange(downgradeEnabled bool) (minV *semver.Version, maxV *semver.Version) {
+	minV = semver.Must(semver.NewVersion(version.MinClusterVersion))
+	maxV = semver.Must(semver.NewVersion(version.Version))
+	maxV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
+
+	if downgradeEnabled {
+		// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
+		maxV.Minor = maxV.Minor + 1
+		minV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
+	}
+	return minV, maxV
+}
+
 // isCompatibleWithCluster return true if the local member has a compatible version with
 // the current running cluster.
 // The version is considered as compatible when at least one of the other members in the cluster has a
-// cluster version in the range of [MinClusterVersion, Version] and no known members has a cluster version
+// cluster version in the range of [MinV, MaxV] and no known members has a cluster version
 // out of the range.
 // We set this rule since when the local member joins, another member might be offline.
 func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper) bool {
 	vers := getVersions(lg, cl, local, rt)
-	minV := semver.Must(semver.NewVersion(version.MinClusterVersion))
-	maxV := semver.Must(semver.NewVersion(version.Version))
-	maxV = &semver.Version{
-		Major: maxV.Major,
-		Minor: maxV.Minor,
-	}
+	minV, maxV := allowedVersionRange(getDowngradeEnabledFromRemotePeers(lg, cl, local, rt))
 	return isCompatibleWithVers(lg, vers, local, minV, maxV)
 }
 
@@ -356,6 +367,11 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	return membs, nil
 }
 
+// getDowngradeEnabledFromRemotePeers will get the downgrade enabled status of the cluster.
+func getDowngradeEnabledFromRemotePeers(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper) bool {
+	return false
+}
+
 func convertToClusterVersion(v string) (*semver.Version, error) {
 	ver, err := semver.NewVersion(v)
 	if err != nil {
@@ -368,9 +384,4 @@ func convertToClusterVersion(v string) (*semver.Version, error) {
 	// cluster version only keeps major.minor, remove patch version
 	ver = &semver.Version{Major: ver.Major, Minor: ver.Minor}
 	return ver, nil
-}
-
-// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
-func allowedDowngradeVersion(ver *semver.Version) *semver.Version {
-	return &semver.Version{Major: ver.Major, Minor: ver.Minor - 1}
 }

--- a/etcdserver/cluster_util_test.go
+++ b/etcdserver/cluster_util_test.go
@@ -176,3 +176,42 @@ func TestConvertToClusterVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestDecideAllowedVersionRange(t *testing.T) {
+	minClusterV := semver.Must(semver.NewVersion(version.MinClusterVersion))
+	localV := semver.Must(semver.NewVersion(version.Version))
+	localV = &semver.Version{Major: localV.Major, Minor: localV.Minor}
+
+	tests := []struct {
+		name             string
+		downgradeEnabled bool
+		expectedMinV     *semver.Version
+		expectedMaxV     *semver.Version
+	}{
+		{
+			"When cluster enables downgrade",
+			true,
+			&semver.Version{Major: localV.Major, Minor: localV.Minor + 1},
+			&semver.Version{Major: localV.Major, Minor: localV.Minor + 1},
+		},
+		{
+			"When cluster disables downgrade",
+			false,
+			minClusterV,
+			localV,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minV, maxV := allowedVersionRange(tt.downgradeEnabled)
+			if !minV.Equal(*tt.expectedMinV) {
+				t.Errorf("Expected minV is %v; Got %v", tt.expectedMinV.String(), minV.String())
+			}
+
+			if !maxV.Equal(*tt.expectedMaxV) {
+				t.Errorf("Expected maxV is %v; Got %v", tt.expectedMaxV.String(), maxV.String())
+			}
+		})
+	}
+}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2272,9 +2272,7 @@ func (s *EtcdServer) monitorVersions() {
 			continue
 		}
 
-		// update cluster version only if the decided version is greater than
-		// the current cluster version
-		if v != nil && s.cluster.Version().LessThan(*v) {
+		if v != nil && membership.IsValidVersionChange(s.cluster.Version(), v) {
 			s.goAttach(func() { s.updateClusterVersion(v.String()) })
 		}
 	}

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -840,7 +840,7 @@ func (s *EtcdServer) downgradeValidate(ctx context.Context, v string) (*pb.Downg
 	}
 	resp.Version = cv.String()
 
-	allowedTargetVersion := allowedDowngradeVersion(cv)
+	allowedTargetVersion := membership.AllowedDowngradeVersion(cv)
 	if !targetVersion.Equal(*allowedTargetVersion) {
 		return nil, ErrInvalidDowngradeTargetVersion
 	}


### PR DESCRIPTION
4th step of #11716.
The PR adjusted downgrade version latch to server. Previously, cluster will not allow lower version member to join in. With downgrade, the cluster can open such latch if downgrade is enabled.

Based on the discussion [here](https://github.com/etcd-io/etcd/issues/11385), the cluster only allows member with downgrade target version to join in during downgrading.

