### PR TITLE
clientv3: use Mutex for watcher lock

### DIFF
--- a/clientv3/watch.go
+++ b/clientv3/watch.go
@@ -139,7 +139,7 @@ type watcher struct {
 	callOpts []grpc.CallOption
 
 	// mu protects the grpc streams map
-	mu sync.RWMutex
+	mu sync.Mutex
 
 	// streams holds all the active grpc streams keyed by ctx value.
 	streams map[string]*watchGrpcStream


### PR DESCRIPTION
Currently watcher.mu is declared as RWMutex.
However, read lock is never taken.

This PR changes its type to Mutex.