### PR TITLE
wal: fix check valid sequence bug.

### DIFF
--- a/wal/util.go
+++ b/wal/util.go
@@ -59,8 +59,8 @@ func searchIndex(lg *zap.Logger, names []string, index uint64) (int, bool) {
 // names should have been sorted based on sequence number.
 // isValidSeq checks whether seq increases continuously.
 func isValidSeq(lg *zap.Logger, names []string) bool {
-	var lastSeq uint64
-	for _, name := range names {
+	var prevSeq uint64
+	for i, name := range names {
 		curSeq, _, err := parseWALName(name)
 		if err != nil {
 			if lg != nil {
@@ -69,10 +69,10 @@ func isValidSeq(lg *zap.Logger, names []string) bool {
 				plog.Panicf("parse correct name should never fail: %v", err)
 			}
 		}
-		if lastSeq != 0 && lastSeq != curSeq-1 {
+		if i > 0 && curSeq != prevSeq+1 {
 			return false
 		}
-		lastSeq = curSeq
+		prevSeq = curSeq
 	}
 	return true
 }

--- a/wal/util_test.go
+++ b/wal/util_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func makeFilesName(seq []int) []string {
+	filesName := make([]string, len(seq))
+	for i, s := range seq {
+		filesName[i] = fmt.Sprintf("%016x-0000000000000000.wal", s)
+	}
+	return filesName
+}
+
+func TestIsValidSeq(t *testing.T) {
+	tests := []struct {
+		seq  []int
+		want bool
+	}{
+		{[]int{0, 1, 2, 3, 4}, true},
+		{[]int{1, 2, 3, 4}, true},
+		{[]int{0, 2, 3, 4}, false},
+		{[]int{0, 1, 2, 3, 4, 6}, false},
+		{[]int{4, 0, 2, 3, 4, 6}, false},
+	}
+	for i, tt := range tests {
+		filesName := makeFilesName(tt.seq)
+		got := isValidSeq(zap.NewExample(), filesName)
+		if got != tt.want {
+			t.Fatalf("#%d: want=%#v, got=%#v", i, tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
To fix bug: when names has sequence [0-lastIndex1.wal,2-lastIndex2.wal],original
function will report this is a valid sequence.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
