### PR TITLE
etcdserver: Missing the cfg.Logger causes panic

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -509,7 +509,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 	}
 	serverID.With(prometheus.Labels{"server_id": id.String()}).Set(1)
 
-	srv.applyV2 = &applierV2store{store: srv.v2store, cluster: srv.cluster}
+	srv.applyV2 = NewApplierV2(cfg.Logger, srv.v2store, srv.cluster)
 
 	srv.be = be
 	minTTL := time.Duration((3*cfg.ElectionTicks)/2) * heartbeat


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.

In **"etcdserver/server.go"**，function **“applyEntryNormal”** calls **“applyV2Request“** ，and **“applyV2Request”** calls **“Put”** when etcd application  starts.

There is log output in this function  (**"Put"**), or log will be added later, but **"a.lg" is nil** when function is executed causes panic.





Test :

You can add  **' fmt.Println(a.lg, "-----------applierV2store Put 67--------") '**  to the 
'func (a *applierV2store) Put(r *RequestV2) Response'



