### PR TITLE
etcdserver: check the error return from Write()

### DIFF
--- a/etcdserver/api/v2store/store.go
+++ b/etcdserver/api/v2store/store.go
@@ -311,7 +311,9 @@ func (s *store) CompareAndSwap(nodePath string, prevValue string, prevIndex uint
 	eNode := e.Node
 
 	// if test succeed, write the value
-	n.Write(value, s.CurrentIndex)
+	if err := n.Write(value, s.CurrentIndex); err != nil {
+		return nil, err
+	}
 	n.UpdateTTL(expireOpts.ExpireTime)
 
 	// copy the value for safety
@@ -532,7 +534,9 @@ func (s *store) Update(nodePath string, newValue string, expireOpts TTLOptionSet
 	e.PrevNode = n.Repr(false, false, s.clock)
 	eNode := e.Node
 
-	n.Write(newValue, nextIndex)
+	if err := n.Write(newValue, nextIndex); err != nil {
+		return nil, fmt.Errorf("nodePath %v : %v", nodePath, err)
+	}
 
 	if n.IsDir() {
 		eNode.Dir = true


### PR DESCRIPTION
For store#CompareAndSwap and store#Update, the return value from Write() was ignored.

This PR adds check of the error return.