### PR TITLE
server: use buffered channel to avoid goroutine leak

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -721,7 +721,7 @@ func (s *EtcdServer) start() {
 	s.applyWait = wait.NewTimeList()
 	s.done = make(chan struct{})
 	s.stop = make(chan struct{})
-	s.stopping = make(chan struct{})
+	s.stopping = make(chan struct{}, 1)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.readwaitc = make(chan struct{}, 1)
 	s.readNotifier = newNotifier()


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Reading from s.stopping can timeout at 

```
            if ok {
                 select {
                 case <-time.After(releaseDelayAfterSnapshot):
                 case <-s.stopping:
                 }
             }
```

and 

```
      for i := int64(0); i < int64(waitTime/itv); i++ {
          select {
          case <-time.After(itv):
          case <-s.stopping:
              return
          }
```
which can cause a goroutine leak. To avoid that, this PR converts the s.stopping to a buffered channel.

Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.


