### PR TITLE
pkg: Fix dir permission check on Windows

### DIFF
--- a/pkg/fileutil/dir_unix.go
+++ b/pkg/fileutil/dir_unix.go
@@ -18,5 +18,10 @@ package fileutil
 
 import "os"
 
+const (
+	// PrivateDirMode grants owner to make/remove files inside the directory.
+	PrivateDirMode = 0700
+)
+
 // OpenDir opens a directory for syncing.
 func OpenDir(path string) (*os.File, error) { return os.Open(path) }

--- a/pkg/fileutil/dir_windows.go
+++ b/pkg/fileutil/dir_windows.go
@@ -21,6 +21,11 @@ import (
 	"syscall"
 )
 
+const (
+	// PrivateDirMode grants owner to make/remove files inside the directory.
+	PrivateDirMode = 0777
+)
+
 // OpenDir opens a directory in windows with write access for syncing.
 func OpenDir(path string) (*os.File, error) {
 	fd, err := openDir(path)

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -25,8 +25,6 @@ import (
 const (
 	// PrivateFileMode grants owner to read/write a file.
 	PrivateFileMode = 0600
-	// PrivateDirMode grants owner to make/remove files inside the directory.
-	PrivateDirMode = 0700
 )
 
 // IsDirWriteable checks if dir is writable by writing and removing a file


### PR DESCRIPTION
Permissions on Windows is different from *nix. This PR separates them.

@spzala