### PR TITLE
mvcc: avoid startRev of watcher move back.

### DIFF
--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -365,7 +365,9 @@ func (s *watchableStore) syncWatchers() int {
 	var victims watcherBatch
 	wb := newWatcherBatch(wg, evs)
 	for w := range wg.watchers {
-		w.minRev = curRev + 1
+		if w.minRev <= curRev {
+			w.minRev = curRev + 1
+		}
 
 		eb, ok := wb[w]
 		if !ok {

--- a/mvcc/watchable_store_test.go
+++ b/mvcc/watchable_store_test.go
@@ -358,7 +358,7 @@ func TestWatchRestoreSyncedWatcher(t *testing.T) {
 
 	testKey, testValue := []byte("foo"), []byte("bar")
 	rev := s1.Put(testKey, testValue, lease.NoLease)
-	startRev := rev + 2
+	startRev := rev + 3
 
 	// create a watcher with a future revision
 	// add to "synced" watcher group (startRev > s.store.currentRev)
@@ -379,6 +379,7 @@ func TestWatchRestoreSyncedWatcher(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// trigger events for "startRev"
+	s1.Put(testKey, testValue, lease.NoLease)
 	s1.Put(testKey, testValue, lease.NoLease)
 
 	select {


### PR DESCRIPTION
The startRev of watcher may move back after restore snapshot.
<img width="925" alt="屏幕快照 2020-05-29 下午6 20 14" src="https://user-images.githubusercontent.com/1845842/83253306-5c81a280-a1df-11ea-968e-60ed9b5eece2.png">

Set w.minRev = curRev +1 only if w.minRev <= curRev.
<img width="920" alt="屏幕快照 2020-05-29 下午6 21 09" src="https://user-images.githubusercontent.com/1845842/83253538-b71afe80-a1df-11ea-9ab2-00725aea9a9d.png">
