### PR TITLE
etcdserver: take read lock when cloning store

### DIFF
--- a/etcdserver/api/v2store/store.go
+++ b/etcdserver/api/v2store/store.go
@@ -747,7 +747,7 @@ func (s *store) SaveNoCopy() ([]byte, error) {
 }
 
 func (s *store) Clone() Store {
-	s.worldLock.Lock()
+	s.worldLock.RLock()
 
 	clonedStore := newStore()
 	clonedStore.CurrentIndex = s.CurrentIndex
@@ -756,7 +756,7 @@ func (s *store) Clone() Store {
 	clonedStore.Stats = s.Stats.clone()
 	clonedStore.CurrentVersion = s.CurrentVersion
 
-	s.worldLock.Unlock()
+	s.worldLock.RUnlock()
 	return clonedStore
 }
 


### PR DESCRIPTION
Currently store#Clone() takes write lock.

This is not needed since cloning only involves reading the current store.