### PR TITLE
logging: create logger to prevent nil pointer

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -57,6 +57,15 @@ func startEtcdOrProxyV2() {
 
 	err := cfg.parse(os.Args[1:])
 	lg := cfg.ec.GetLogger()
+	if lg == nil {
+		var zapError error
+		// use this logger
+		lg, zapError = zap.NewProduction()
+		if zapError != nil {
+			fmt.Printf("error creating zap logger %v", zapError)
+			os.Exit(1)
+		}
+	}
 	if err != nil {
 		lg.Warn("failed to verify flags", zap.Error(err))
 		switch err {


### PR DESCRIPTION
Create a new logger if one not found.

If an incorrect flag is provided on command line, e.g. #etcd help, it throws a nil pointer. 
