### PR TITLE
raft: implement fast log rejection

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -141,11 +141,21 @@ func (l *raftLog) findConflict(ents []pb.Entry) uint64 {
 // entry on a leader/follower during an append) and finds the largest index in
 // log l with a term <= `term` and an index <= `index`. If no such index exists
 // in the log, the log's first index is returned.
-// The index provided MUST be equal to or less than l.lastIndex().
+//
+// The index provided MUST be equal to or less than l.lastIndex(). Invalid
+// inputs log a warning and the input index is returned.
 func (l *raftLog) findConflictByTerm(index uint64, term uint64) uint64 {
-	if index > l.lastIndex() {
-		l.logger.Panicf("index(%d) is out of range [lastIndex(%d)] in findConflictByTerm",
-			index, l.lastIndex())
+	if li := l.lastIndex(); index > li {
+		// NB: such calls should not exist, but since there is a straightfoward
+		// way to recover, do it.
+		//
+		// It is tempting to also check something about the first index, but
+		// there is odd behavior with peers that have no log, in which case
+		// lastIndex will return zero and firstIndex will return one, which
+		// leads to calls with an index of zero into this method.
+		l.logger.Warningf("index(%d) is out of range [0, lastIndex(%d)] in findConflictByTerm",
+			index, li)
+		return index
 	}
 	for {
 		logTerm, err := l.term(index)

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1106,32 +1106,127 @@ func stepLeader(r *raft, m pb.Message) error {
 		pr.RecentActive = true
 
 		if m.Reject {
-			r.logger.Debugf("%x received MsgAppResp(MsgApp was rejected, hint: %d) from %x for index %d, log term %d",
-				r.id, m.RejectHint, m.From, m.Index, m.LogTerm)
-			// The reject hint is the suggested next base entry for appending,
-			// i.e. hint+1 would be sent as the next append. 'hint' is usually the
-			// last index of the follower, or the base index (m.Index) from the
-			// append being responsed to.
-			hint := m.RejectHint
+			// RejectHint is the suggested next base entry for appending (i.e.
+			// we try to append entry RejectHint+1 next), and LogTerm is the
+			// term that the follower has at index RejectHint. Older versions
+			// of this library did not populate LogTerm for rejections and it
+			// is zero for followers with an empty log.
+			//
+			// Under normal circumstances, the leader's log is longer than the
+			// follower's and the follower's log is a prefix of the leader's
+			// (i.e. there is no divergent uncommitted suffix of the log on the
+			// follower). In that case, the first probe reveals where the
+			// follower's log ends (RejectHint=follower's last index) and the
+			// subsequent probe succeeds.
+			//
+			// However, when networks are partitioned or systems overloaded,
+			// large divergent log tails can occur. The naive attempt, probing
+			// entry by entry in decreasing order, will be the product of the
+			// length of the diverging tails and the network round-trip latency,
+			// which can easily result in hours of time spent probing and can
+			// even cause outright outages. The probes are thus optimized as
+			// described below.
+			r.logger.Debugf("%x received MsgAppResp(rejected, hint: (index %d, term %d)) from %x for index %d",
+				r.id, m.RejectHint, m.LogTerm, m.From, m.Index)
+			nextProbeIdx := m.RejectHint
 			if m.LogTerm > 0 {
-				// LogTerm is the term that the follower has at index RejectHint. If the
-				// follower has an uncommitted log tail, we would end up probing one by
-				// one until we hit the common prefix.
+				// If the follower has an uncommitted log tail, we would end up
+				// probing one by one until we hit the common prefix.
 				//
 				// For example, if the leader has:
-				//   [...] (idx=1,term=2) (idx=2,term=5)[...](idx=9,term=5)
-				// and the follower has:
-				//   [...] (idx=1,term=2) (idx=2,term=4)[...](idx=6,term=4)
 				//
-				// Then, after sending (idx=9,term=5) we would receive a RejectHint of 6
-				// and LogTerm of 4. Without the code below, we would try an append at
-				// 6, 5, 4 ... until hitting idx=1 which succeeds (as 1 matches).
-				// Instead, the code below skips all indexes at terms >4, and reduces
-				// 'hint' to 1 in one term (meaning we'll successfully append 2 next
-				// time).
-				hint = r.raftLog.findConflictByTerm(hint, m.LogTerm)
+				//   idx        1 2 3 4 5 6 7 8 9
+				//              -----------------
+				//   term (L)   1 3 3 3 5 5 5 5 5
+				//   term (F)   1 1 1 1 2 2
+				//
+				// Then, after sending an append anchored at (idx=9,term=5) we
+				// would receive a RejectHint of 6 and LogTerm of 2. Without the
+				// code below, we would try an append at index 6, which would
+				// fail again.
+				//
+				// However, looking only at what the leader knows about its own
+				// log and the rejection hint, it is clear that a probe at index
+				// 6, 5, 4, 3, and 2 must fail as well:
+				//
+				// For all of these indexes, the leader's log term is larger than
+				// the rejection's log term. If a probe at one of these indexes
+				// succeeded, its log term at that index would match the leader's,
+				// i.e. 3 or 5 in this example. But the follower already told the
+				// leader that it is still at term 2 at index 9, and since the
+				// log term only ever goes up (within a log), this is a contradiction.
+				//
+				// At index 1, however, the leader can draw no such conclusion,
+				// as its term 1 is not larger than the term 2 from the
+				// follower's rejection. We thus probe at 1, which will succeed
+				// in this example. In general, with this approach we probe at
+				// most once per term found in the leader's log.
+				//
+				// There is a similar mechanism on the follower (implemented in
+				// handleAppendEntries via a call to findConflictByTerm) that is
+				// useful if the follower has a large divergent uncommitted log
+				// tail[1], as in this example:
+				//
+				//   idx        1 2 3 4 5 6 7 8 9
+				//              -----------------
+				//   term (L)   1 3 3 3 3 3 3 3 7
+				//   term (F)   1 3 3 4 4 5 5 5 6
+				//
+				// Naively, the leader would probe at idx=9, receive a rejection
+				// revealing the log term of 6 at the follower. Since the leader's
+				// term at the previous index is already smaller than 6, the leader-
+				// side optimization discussed above is ineffective. The leader thus
+				// probes at index 8 and, naively, receives a rejection for the same
+				// index and log term 5. Again, the leader optimization does not improve
+				// over linear probing as term 5 is above the leader's term 3 for that
+				// and many preceding indexes; the leader would have to probe linearly
+				// until it would finally hit index 3, where the probe would succeed.
+				//
+				// Instead, we apply a similar optimization on the follower. When the
+				// follower receives the probe at index 8 (log term 3), it concludes
+				// that all of the leader's log preceding that index has log terms of
+				// 3 or below. The largest index in the follower's log with a log term
+				// of 3 or below is index 3. The follower will thus return a rejection
+				// for index=3, log term=3 instead. The leader's next probe will then
+				// succeed at that index.
+				//
+				// [1]: more precisely, if the log terms in the large uncommitted
+				// tail on the follower are larger than the leader's. At first,
+				// it may seem unintuitive that a follower could even have such
+				// a large tail, but it can happen:
+				//
+				// 1. Leader appends (but does not commit) entries 2 and 3, crashes.
+				//   idx        1 2 3 4 5 6 7 8 9
+				//              -----------------
+				//   term (L)   1 2 2     [crashes]
+				//   term (F)   1
+				//   term (F)   1
+				//
+				// 2. a follower becomes leader and appends entries at term 3.
+				//              -----------------
+				//   term (x)   1 2 2     [down]
+				//   term (F)   1 3 3 3 3
+				//   term (F)   1
+				//
+				// 3. term 3 leader goes down, term 2 leader returns as term 4
+				//    leader. It commits the log & entries at term 4.
+				//
+				//              -----------------
+				//   term (L)   1 2 2 2
+				//   term (x)   1 3 3 3 3 [down]
+				//   term (F)   1
+				//              -----------------
+				//   term (L)   1 2 2 2 4 4 4
+				//   term (F)   1 3 3 3 3 [gets probed]
+				//   term (F)   1 2 2 2 4 4 4
+				//
+				// 4. the leader will now probe the returning follower at index
+				//    7, the rejection points it at the end of the follower's log
+				//    which is at a higher log term than the actually committed
+				//    log.
+				nextProbeIdx = r.raftLog.findConflictByTerm(m.RejectHint, m.LogTerm)
 			}
-			if pr.MaybeDecrTo(m.Index, hint) {
+			if pr.MaybeDecrTo(m.Index, nextProbeIdx) {
 				r.logger.Debugf("%x decreased progress of %x to [%s]", r.id, m.From, pr)
 				if pr.State == tracker.StateReplicate {
 					pr.BecomeProbe()
@@ -1392,15 +1487,8 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		// skip all indexes in the follower's uncommitted tail with terms
 		// greater than the MsgApp's LogTerm.
 		//
-		// For example, if the leader has:
-		//   [...] (idx=1,term=2)[...](idx=5,term=2)
-		// and the follower has:
-		//   [...] (idx=1,term=2) (idx=2,term=4)[...](idx=8,term=4)
-		//
-		// Then, after receiving a MsgApp (idx=5,term=2), the follower would
-		// send a rejected MsgAppRsp with a RejectHint of 1 and a LogTerm of 2.
-		//
-		// There is similar logic on the leader.
+		// See the other caller for findConflictByTerm (in stepLeader) for a much
+		// more detailed explanation of this mechanism.
 		hintIndex := min(m.Index, r.raftLog.lastIndex())
 		hintIndex = r.raftLog.findConflictByTerm(hintIndex, m.LogTerm)
 		hintTerm, err := r.raftLog.term(hintIndex)

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -606,17 +606,18 @@ func TestFollowerCheckMsgApp(t *testing.T) {
 		windex      uint64
 		wreject     bool
 		wrejectHint uint64
+		wlogterm    uint64
 	}{
 		// match with committed entries
-		{0, 0, 1, false, 0},
-		{ents[0].Term, ents[0].Index, 1, false, 0},
+		{0, 0, 1, false, 0, 0},
+		{ents[0].Term, ents[0].Index, 1, false, 0, 0},
 		// match with uncommitted entries
-		{ents[1].Term, ents[1].Index, 2, false, 0},
+		{ents[1].Term, ents[1].Index, 2, false, 0, 0},
 
 		// unmatch with existing entry
-		{ents[0].Term, ents[1].Index, ents[1].Index, true, 2},
+		{ents[0].Term, ents[1].Index, ents[1].Index, true, 1, 1},
 		// unexisting entry
-		{ents[1].Term + 1, ents[1].Index + 1, ents[1].Index + 1, true, 2},
+		{ents[1].Term + 1, ents[1].Index + 1, ents[1].Index + 1, true, 2, 2},
 	}
 	for i, tt := range tests {
 		storage := newTestMemoryStorage(withPeers(1, 2, 3))
@@ -629,7 +630,7 @@ func TestFollowerCheckMsgApp(t *testing.T) {
 
 		msgs := r.readMessages()
 		wmsgs := []pb.Message{
-			{From: 1, To: 2, Type: pb.MsgAppResp, Term: 2, Index: tt.windex, Reject: tt.wreject, RejectHint: tt.wrejectHint},
+			{From: 1, To: 2, Type: pb.MsgAppResp, Term: 2, Index: tt.windex, Reject: tt.wreject, RejectHint: tt.wrejectHint, LogTerm: tt.wlogterm},
 		}
 		if !reflect.DeepEqual(msgs, wmsgs) {
 			t.Errorf("#%d: msgs = %+v, want %+v", i, msgs, wmsgs)

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -4265,6 +4265,289 @@ func TestConfChangeV2CheckBeforeCampaign(t *testing.T) {
 	testConfChangeCheckBeforeCampaign(t, true)
 }
 
+func TestFastLogRejection(t *testing.T) {
+	tests := []struct {
+		leaderLog       []pb.Entry // Logs on the leader
+		followerLog     []pb.Entry // Logs on the follower
+		rejectHintTerm  uint64     // Expected term included in rejected MsgAppResp.
+		rejectHintIndex uint64     // Expected index included in rejected MsgAppResp.
+		nextAppendTerm  uint64     // Expected term when leader appends after rejected.
+		nextAppendIndex uint64     // Expected index when leader appends after rejected.
+	}{
+		// This case tests that leader can find the conflict index quickly.
+		// Firstly leader appends (type=MsgApp,index=7,logTerm=4, entries=...);
+		// After rejected leader appends (type=MsgApp,index=3,logTerm=2).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 4, Index: 4},
+				{Term: 4, Index: 5},
+				{Term: 4, Index: 6},
+				{Term: 4, Index: 7},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 3, Index: 4},
+				{Term: 3, Index: 5},
+				{Term: 3, Index: 6},
+				{Term: 3, Index: 7},
+				{Term: 3, Index: 8},
+				{Term: 3, Index: 9},
+				{Term: 3, Index: 10},
+				{Term: 3, Index: 11},
+			},
+			rejectHintTerm:  3,
+			rejectHintIndex: 7,
+			nextAppendTerm:  2,
+			nextAppendIndex: 3,
+		},
+		// This case tests that leader can find the conflict index quickly.
+		// Firstly leader appends (type=MsgApp,index=8,logTerm=5, entries=...);
+		// After rejected leader appends (type=MsgApp,index=4,logTerm=3).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 3, Index: 4},
+				{Term: 4, Index: 5},
+				{Term: 4, Index: 6},
+				{Term: 4, Index: 7},
+				{Term: 5, Index: 8},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 3, Index: 4},
+				{Term: 3, Index: 5},
+				{Term: 3, Index: 6},
+				{Term: 3, Index: 7},
+				{Term: 3, Index: 8},
+				{Term: 3, Index: 9},
+				{Term: 3, Index: 10},
+				{Term: 3, Index: 11},
+			},
+			rejectHintTerm:  3,
+			rejectHintIndex: 8,
+			nextAppendTerm:  3,
+			nextAppendIndex: 4,
+		},
+		// This case tests that follower can find the conflict index quickly.
+		// Firstly leader appends (type=MsgApp,index=4,logTerm=1, entries=...);
+		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 1, Index: 2},
+				{Term: 1, Index: 3},
+				{Term: 1, Index: 4},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 4, Index: 4},
+			},
+			rejectHintTerm:  1,
+			rejectHintIndex: 1,
+			nextAppendTerm:  1,
+			nextAppendIndex: 1,
+		},
+		// This case is similar to the previous case. However, this time, the
+		// leader has a longer uncommitted log tail than the follower.
+		// Firstly leader appends (type=MsgApp,index=6,logTerm=1, entries=...);
+		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 1, Index: 2},
+				{Term: 1, Index: 3},
+				{Term: 1, Index: 4},
+				{Term: 1, Index: 5},
+				{Term: 1, Index: 6},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 4, Index: 4},
+			},
+			rejectHintTerm:  1,
+			rejectHintIndex: 1,
+			nextAppendTerm:  1,
+			nextAppendIndex: 1,
+		},
+		// This case is similar to the previous case. However, this time, the
+		// follower has a longer uncommitted log tail than the leader.
+		// Firstly leader appends (type=MsgApp,index=4,logTerm=1, entries=...);
+		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 1, Index: 2},
+				{Term: 1, Index: 3},
+				{Term: 1, Index: 4},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 4, Index: 4},
+				{Term: 4, Index: 5},
+				{Term: 4, Index: 6},
+			},
+			rejectHintTerm:  1,
+			rejectHintIndex: 1,
+			nextAppendTerm:  1,
+			nextAppendIndex: 1,
+		},
+		// An normal case that there are no log conflicts.
+		// Firstly leader appends (type=MsgApp,index=5,logTerm=5, entries=...);
+		// After rejected leader appends (type=MsgApp,index=4,logTerm=4).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 1, Index: 2},
+				{Term: 1, Index: 3},
+				{Term: 4, Index: 4},
+				{Term: 5, Index: 5},
+			},
+			followerLog: []pb.Entry{
+				{Term: 1, Index: 1},
+				{Term: 1, Index: 2},
+				{Term: 1, Index: 3},
+				{Term: 4, Index: 4},
+			},
+			rejectHintTerm:  4,
+			rejectHintIndex: 4,
+			nextAppendTerm:  4,
+			nextAppendIndex: 4,
+		},
+		// Test case from example comment in stepLeader (on leader).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 2, Index: 1},
+				{Term: 5, Index: 2},
+				{Term: 5, Index: 3},
+				{Term: 5, Index: 4},
+				{Term: 5, Index: 5},
+				{Term: 5, Index: 6},
+				{Term: 5, Index: 7},
+				{Term: 5, Index: 8},
+				{Term: 5, Index: 9},
+			},
+			followerLog: []pb.Entry{
+				{Term: 2, Index: 1},
+				{Term: 4, Index: 2},
+				{Term: 4, Index: 3},
+				{Term: 4, Index: 4},
+				{Term: 4, Index: 5},
+				{Term: 4, Index: 6},
+			},
+			rejectHintTerm:  4,
+			rejectHintIndex: 6,
+			nextAppendTerm:  2,
+			nextAppendIndex: 1,
+		},
+		// Test case from example comment in handleAppendEntries (on follower).
+		{
+			leaderLog: []pb.Entry{
+				{Term: 2, Index: 1},
+				{Term: 2, Index: 2},
+				{Term: 2, Index: 3},
+				{Term: 2, Index: 4},
+				{Term: 2, Index: 5},
+			},
+			followerLog: []pb.Entry{
+				{Term: 2, Index: 1},
+				{Term: 4, Index: 2},
+				{Term: 4, Index: 3},
+				{Term: 4, Index: 4},
+				{Term: 4, Index: 5},
+				{Term: 4, Index: 6},
+				{Term: 4, Index: 7},
+				{Term: 4, Index: 8},
+			},
+			nextAppendTerm:  2,
+			nextAppendIndex: 1,
+			rejectHintTerm:  2,
+			rejectHintIndex: 1,
+		},
+	}
+
+	for i, test := range tests {
+		s1 := NewMemoryStorage()
+		s1.snapshot.Metadata.ConfState = pb.ConfState{Voters: []uint64{1, 2, 3}}
+		s1.Append(test.leaderLog)
+		s2 := NewMemoryStorage()
+		s2.snapshot.Metadata.ConfState = pb.ConfState{Voters: []uint64{1, 2, 3}}
+		s2.Append(test.followerLog)
+
+		n1 := newTestRaft(1, 10, 1, s1)
+		n2 := newTestRaft(2, 10, 1, s2)
+
+		n1.becomeCandidate()
+		n1.becomeLeader()
+
+		n2.Step(pb.Message{From: 1, To: 1, Type: pb.MsgHeartbeat})
+
+		msgs := n2.readMessages()
+		if len(msgs) != 1 {
+			t.Errorf("can't read 1 message from peer 2")
+		}
+		if msgs[0].Type != pb.MsgHeartbeatResp {
+			t.Errorf("can't read heartbeat response from peer 2")
+		}
+		if n1.Step(msgs[0]) != nil {
+			t.Errorf("peer 1 step heartbeat response fail")
+		}
+
+		msgs = n1.readMessages()
+		if len(msgs) != 1 {
+			t.Errorf("can't read 1 message from peer 1")
+		}
+		if msgs[0].Type != pb.MsgApp {
+			t.Errorf("can't read append from peer 1")
+		}
+
+		if n2.Step(msgs[0]) != nil {
+			t.Errorf("peer 2 step append fail")
+		}
+		msgs = n2.readMessages()
+		if len(msgs) != 1 {
+			t.Errorf("can't read 1 message from peer 2")
+		}
+		if msgs[0].Type != pb.MsgAppResp {
+			t.Errorf("can't read append response from peer 2")
+		}
+		if !msgs[0].Reject {
+			t.Errorf("expected rejected append response from peer 2")
+		}
+		if msgs[0].LogTerm != test.rejectHintTerm {
+			t.Fatalf("#%d expected hint log term = %d, but got %d", i, test.rejectHintTerm, msgs[0].LogTerm)
+		}
+		if msgs[0].RejectHint != test.rejectHintIndex {
+			t.Fatalf("#%d expected hint index = %d, but got %d", i, test.rejectHintIndex, msgs[0].RejectHint)
+		}
+
+		if n1.Step(msgs[0]) != nil {
+			t.Errorf("peer 1 step append fail")
+		}
+		msgs = n1.readMessages()
+		if msgs[0].LogTerm != test.nextAppendTerm {
+			t.Fatalf("#%d expected log term = %d, but got %d", i, test.nextAppendTerm, msgs[0].LogTerm)
+		}
+		if msgs[0].Index != test.nextAppendIndex {
+			t.Fatalf("#%d expected index = %d, but got %d", i, test.nextAppendIndex, msgs[0].Index)
+		}
+	}
+}
+
 func entsWithConfig(configFunc func(*Config), terms ...uint64) *raft {
 	storage := NewMemoryStorage()
 	for i, term := range terms {

--- a/raft/raftpb/raft.proto
+++ b/raft/raftpb/raft.proto
@@ -62,6 +62,11 @@ message Message {
 	optional uint64      to          = 2  [(gogoproto.nullable) = false];
 	optional uint64      from        = 3  [(gogoproto.nullable) = false];
 	optional uint64      term        = 4  [(gogoproto.nullable) = false];
+	// logTerm is generally used for appending Raft logs to followers. For example,
+	// (type=MsgApp,index=100,logTerm=5) means leader appends entries starting at
+	// index=101, and the term of entry at index 100 is 5.
+	// (type=MsgAppResp,reject=true,index=100,logTerm=5) means follower rejects some
+	// entries from its leader as it already has an entry with term 5 at index 100.
 	optional uint64      logTerm     = 5  [(gogoproto.nullable) = false];
 	optional uint64      index       = 6  [(gogoproto.nullable) = false];
 	repeated Entry       entries     = 7  [(gogoproto.nullable) = false];

--- a/raft/rafttest/interaction_env.go
+++ b/raft/rafttest/interaction_env.go
@@ -15,6 +15,7 @@
 package rafttest
 
 import (
+	"bufio"
 	"fmt"
 	"math"
 	"strings"
@@ -58,6 +59,18 @@ func NewInteractionEnv(opts *InteractionOpts) *InteractionEnv {
 			Builder: &strings.Builder{},
 		},
 	}
+}
+
+func (env *InteractionEnv) withIndent(f func()) {
+	orig := env.Output.Builder
+	env.Output.Builder = &strings.Builder{}
+	f()
+
+	scanner := bufio.NewScanner(strings.NewReader(env.Output.Builder.String()))
+	for scanner.Scan() {
+		orig.WriteString("  " + scanner.Text() + "\n")
+	}
+	env.Output.Builder = orig
 }
 
 // Storage is the interface used by InteractionEnv. It is comprised of raft's

--- a/raft/rafttest/interaction_env_handler.go
+++ b/raft/rafttest/interaction_env_handler.go
@@ -160,7 +160,7 @@ func firstAsNodeIdx(t *testing.T, d datadriven.TestData) int {
 	return n - 1
 }
 
-func ints(t *testing.T, d datadriven.TestData) []int {
+func nodeIdxs(t *testing.T, d datadriven.TestData) []int {
 	var ints []int
 	for i := 0; i < len(d.CmdArgs); i++ {
 		if len(d.CmdArgs[i].Vals) != 0 {
@@ -170,7 +170,7 @@ func ints(t *testing.T, d datadriven.TestData) []int {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ints = append(ints, n)
+		ints = append(ints, n-1)
 	}
 	return ints
 }

--- a/raft/rafttest/interaction_env_handler_process_ready.go
+++ b/raft/rafttest/interaction_env_handler_process_ready.go
@@ -15,6 +15,7 @@
 package rafttest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
@@ -23,8 +24,20 @@ import (
 )
 
 func (env *InteractionEnv) handleProcessReady(t *testing.T, d datadriven.TestData) error {
-	idx := firstAsNodeIdx(t, d)
-	return env.ProcessReady(idx)
+	idxs := nodeIdxs(t, d)
+	for _, idx := range idxs {
+		var err error
+		if len(idxs) > 1 {
+			fmt.Fprintf(env.Output, "> %d handling Ready\n", idx+1)
+			env.withIndent(func() { err = env.ProcessReady(idx) })
+		} else {
+			err = env.ProcessReady(idx)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ProcessReady runs Ready handling on the node with the given index.

--- a/raft/testdata/campaign_learner_must_vote.txt
+++ b/raft/testdata/campaign_learner_must_vote.txt
@@ -111,7 +111,7 @@ stabilize 2 3
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
-  DEBUG 2 received MsgAppResp(MsgApp was rejected, hint: 3) from 3 for index 4, log term 1
+  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]
 > 2 handling Ready
   Ready MustSync=false:

--- a/raft/testdata/campaign_learner_must_vote.txt
+++ b/raft/testdata/campaign_learner_must_vote.txt
@@ -108,10 +108,10 @@ stabilize 2 3
   Ready MustSync=false:
   Lead:2 State:StateFollower
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/4 Rejected (Hint: 3)
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/4 Rejected (Hint: 3)
-  DEBUG 2 received MsgAppResp(MsgApp was rejected, lastindex: 3) from 3 for index 4
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
+  DEBUG 2 received MsgAppResp(MsgApp was rejected, hint: 3) from 3 for index 4, log term 1
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]
 > 2 handling Ready
   Ready MustSync=false:

--- a/raft/testdata/confchange_v1_add_single.txt
+++ b/raft/testdata/confchange_v1_add_single.txt
@@ -60,7 +60,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 2 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v1_add_single.txt
+++ b/raft/testdata/confchange_v1_add_single.txt
@@ -60,7 +60,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/raft/testdata/confchange_v2_add_double_auto.txt
@@ -81,7 +81,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 2 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
@@ -155,7 +155,7 @@ stabilize 1 3
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 3 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 3 for index 3, log term 0
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=1 paused pendingSnap=5]

--- a/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/raft/testdata/confchange_v2_add_double_auto.txt
@@ -81,7 +81,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]
@@ -155,7 +155,7 @@ stabilize 1 3
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 3 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=1 paused pendingSnap=5]

--- a/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -66,7 +66,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 2 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -66,7 +66,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/raft/testdata/confchange_v2_add_single_auto.txt
@@ -61,7 +61,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/raft/testdata/confchange_v2_add_single_auto.txt
@@ -61,7 +61,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 2 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -61,7 +61,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -61,7 +61,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(MsgApp was rejected, lastindex: 0) from 2 for index 3
+  DEBUG 1 received MsgAppResp(MsgApp was rejected, hint: 0) from 2 for index 3, log term 0
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=1 paused pendingSnap=4]

--- a/raft/testdata/probe_and_replicate.txt
+++ b/raft/testdata/probe_and_replicate.txt
@@ -1,0 +1,875 @@
+# This test creates a complete Raft log configuration and demonstrates how a
+# leader probes and replicates to each of its followers. The log configuration
+# constructed is almost[*] identical to the one present in Figure 7 of the raft
+# paper (https://raft.github.io/raft.pdf), which looks like:
+#       
+#      1  2  3  4  5  6  7  8  9  10 11 12
+# n1: [1][1][1][4][4][5][5][6][6][6]
+# n2: [1][1][1][4][4][5][5][6][6]
+# n3: [1][1][1][4]
+# n4: [1][1][1][4][4][5][5][6][6][6][6]
+# n5: [1][1][1][4][4][5][5][6][7][7][7][7]
+# n6: [1][1][1][4][4][4][4]
+# n7: [1][1][1][2][2][2][3][3][3][3][3]
+#
+# Once in this state, we then elect node 1 as the leader and stabilize the
+# entire raft group. This demonstrates how a newly elected leader probes for
+# matching indexes, overwrites conflicting entries, and catches up all
+# followers.
+#
+# [*] the only differences are:
+# 1. n5 is given a larger uncommitted log tail, which is used to demonstrate a
+#    follower-side probing optimization.
+# 2. the log indexes are shifted by 10 in this test because add-nodes wants to
+#    start with an index > 1.
+#
+
+
+# Set up the log configuration. This is mostly unintersting, but the order of
+# each leadership change and the nodes that are allowed to hear about them is
+# very important. Most readers of this test can skip this section.
+log-level none
+----
+ok
+
+## Start with seven nodes.
+add-nodes 7 voters=(1,2,3,4,5,6,7) index=10
+----
+ok
+
+## Create term 1 entries.
+campaign 1
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+propose 1 prop_1_12
+----
+ok
+
+propose 1 prop_1_13
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+## Create term 2 entries.
+campaign 2
+----
+ok
+
+stabilize 2
+----
+ok (quiet)
+
+stabilize 6
+----
+ok (quiet)
+
+stabilize 2 5 7
+----
+ok (quiet)
+
+propose 2 prop_2_15
+----
+ok
+
+propose 2 prop_2_16
+----
+ok
+
+stabilize 2 7
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+## Create term 3 entries.
+campaign 7
+----
+ok
+
+stabilize 7
+----
+ok (quiet)
+
+stabilize 1 2 3 4 5 6
+----
+ok (quiet)
+
+stabilize 7
+----
+ok (quiet)
+
+propose 7 prop_3_18
+----
+ok
+
+propose 7 prop_3_19
+----
+ok
+
+propose 7 prop_3_20
+----
+ok
+
+propose 7 prop_3_21
+----
+ok
+
+stabilize 7
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+## Create term 4 entries.
+campaign 6
+----
+ok
+
+stabilize 1 2 3 4 5 6
+----
+ok (quiet)
+
+propose 6 prop_4_15
+----
+ok
+
+stabilize 1 2 4 5 6
+----
+ok (quiet)
+
+propose 6 prop_4_16
+----
+ok
+
+propose 6 prop_4_17
+----
+ok
+
+stabilize 6
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+## Create term 5 entries.
+campaign 5
+----
+ok
+
+stabilize 1 2 4 5
+----
+ok (quiet)
+
+propose 5 prop_5_17
+----
+ok
+
+stabilize 1 2 4 5
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+## Create term 6 entries.
+campaign 4
+----
+ok
+
+stabilize 1 2 4 5
+----
+ok (quiet)
+
+propose 4 prop_6_19
+----
+ok
+
+stabilize 1 2 4
+----
+ok (quiet)
+
+propose 4 prop_6_20
+----
+ok
+
+stabilize 1 4
+----
+ok (quiet)
+
+propose 4 prop_6_21
+----
+ok
+
+stabilize 4
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+## Create term 7 entries.
+campaign 5
+----
+ok
+
+stabilize 5
+----
+ok (quiet)
+
+stabilize 1 3 6 7
+----
+ok (quiet)
+
+stabilize 5
+----
+ok (quiet)
+
+propose 5 prop_7_20
+----
+ok
+
+propose 5 prop_7_21
+----
+ok
+
+propose 5 prop_7_22
+----
+ok
+
+stabilize 5
+----
+ok (quiet)
+
+deliver-msgs drop=(1,2,3,4,5,6,7)
+----
+ok (quiet)
+
+
+# Show the Raft log from each node.
+log-level info
+----
+ok
+
+raft-log 1
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+4/15 EntryNormal "prop_4_15"
+5/16 EntryNormal ""
+5/17 EntryNormal "prop_5_17"
+6/18 EntryNormal ""
+6/19 EntryNormal "prop_6_19"
+6/20 EntryNormal "prop_6_20"
+
+raft-log 2
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+4/15 EntryNormal "prop_4_15"
+5/16 EntryNormal ""
+5/17 EntryNormal "prop_5_17"
+6/18 EntryNormal ""
+6/19 EntryNormal "prop_6_19"
+
+raft-log 3
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+
+raft-log 4
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+4/15 EntryNormal "prop_4_15"
+5/16 EntryNormal ""
+5/17 EntryNormal "prop_5_17"
+6/18 EntryNormal ""
+6/19 EntryNormal "prop_6_19"
+6/20 EntryNormal "prop_6_20"
+6/21 EntryNormal "prop_6_21"
+
+raft-log 5
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+4/15 EntryNormal "prop_4_15"
+5/16 EntryNormal ""
+5/17 EntryNormal "prop_5_17"
+6/18 EntryNormal ""
+7/19 EntryNormal ""
+7/20 EntryNormal "prop_7_20"
+7/21 EntryNormal "prop_7_21"
+7/22 EntryNormal "prop_7_22"
+
+raft-log 6
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+4/14 EntryNormal ""
+4/15 EntryNormal "prop_4_15"
+4/16 EntryNormal "prop_4_16"
+4/17 EntryNormal "prop_4_17"
+
+raft-log 7
+----
+1/11 EntryNormal ""
+1/12 EntryNormal "prop_1_12"
+1/13 EntryNormal "prop_1_13"
+2/14 EntryNormal ""
+2/15 EntryNormal "prop_2_15"
+2/16 EntryNormal "prop_2_16"
+3/17 EntryNormal ""
+3/18 EntryNormal "prop_3_18"
+3/19 EntryNormal "prop_3_19"
+3/20 EntryNormal "prop_3_20"
+3/21 EntryNormal "prop_3_21"
+
+
+# Elect node 1 as leader and stabilize.
+campaign 1
+----
+INFO 1 is starting a new election at term 7
+INFO 1 became candidate at term 8
+INFO 1 received MsgVoteResp from 1 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 2 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 3 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 4 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 5 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 6 at term 8
+INFO 1 [logterm: 6, index: 20] sent MsgVote request to 7 at term 8
+
+## Get elected.
+stabilize 1
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Lead:0 State:StateCandidate
+  HardState Term:8 Vote:1 Commit:18
+  Messages:
+  1->2 MsgVote Term:8 Log:6/20
+  1->3 MsgVote Term:8 Log:6/20
+  1->4 MsgVote Term:8 Log:6/20
+  1->5 MsgVote Term:8 Log:6/20
+  1->6 MsgVote Term:8 Log:6/20
+  1->7 MsgVote Term:8 Log:6/20
+
+stabilize 2 3 4 5 6 7
+----
+> 2 receiving messages
+  1->2 MsgVote Term:8 Log:6/20
+  INFO 2 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 2 became follower at term 8
+  INFO 2 [logterm: 6, index: 19, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+> 3 receiving messages
+  1->3 MsgVote Term:8 Log:6/20
+  INFO 3 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 3 became follower at term 8
+  INFO 3 [logterm: 4, index: 14, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+> 4 receiving messages
+  1->4 MsgVote Term:8 Log:6/20
+  INFO 4 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 4 became follower at term 8
+  INFO 4 [logterm: 6, index: 21, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+> 5 receiving messages
+  1->5 MsgVote Term:8 Log:6/20
+  INFO 5 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 5 became follower at term 8
+  INFO 5 [logterm: 7, index: 22, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+> 6 receiving messages
+  1->6 MsgVote Term:8 Log:6/20
+  INFO 6 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 6 became follower at term 8
+  INFO 6 [logterm: 4, index: 17, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+> 7 receiving messages
+  1->7 MsgVote Term:8 Log:6/20
+  INFO 7 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 7 became follower at term 8
+  INFO 7 [logterm: 3, index: 21, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+> 2 handling Ready
+  Ready MustSync=true:
+  Lead:0 State:StateFollower
+  HardState Term:8 Vote:1 Commit:18
+  Messages:
+  2->1 MsgVoteResp Term:8 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:14
+  Messages:
+  3->1 MsgVoteResp Term:8 Log:0/0
+> 4 handling Ready
+  Ready MustSync=true:
+  Lead:0 State:StateFollower
+  HardState Term:8 Commit:18
+  Messages:
+  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+> 5 handling Ready
+  Ready MustSync=true:
+  Lead:0 State:StateFollower
+  HardState Term:8 Commit:18
+  Messages:
+  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+> 6 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:15
+  Messages:
+  6->1 MsgVoteResp Term:8 Log:0/0
+> 7 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:13
+  Messages:
+  7->1 MsgVoteResp Term:8 Log:0/0
+
+stabilize 1
+----
+> 1 receiving messages
+  2->1 MsgVoteResp Term:8 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 8
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  3->1 MsgVoteResp Term:8 Log:0/0
+  INFO 1 received MsgVoteResp from 3 at term 8
+  INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
+  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  INFO 1 received MsgVoteResp rejection from 4 at term 8
+  INFO 1 has received 3 MsgVoteResp votes and 1 vote rejections
+  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  INFO 1 received MsgVoteResp rejection from 5 at term 8
+  INFO 1 has received 3 MsgVoteResp votes and 2 vote rejections
+  6->1 MsgVoteResp Term:8 Log:0/0
+  INFO 1 received MsgVoteResp from 6 at term 8
+  INFO 1 has received 4 MsgVoteResp votes and 2 vote rejections
+  INFO 1 became leader at term 8
+  7->1 MsgVoteResp Term:8 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  Lead:1 State:StateLeader
+  Entries:
+  8/21 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+
+## Recover each follower, one by one.
+stabilize 1 2
+----
+> 2 receiving messages
+  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=false:
+  Lead:1 State:StateFollower
+  Messages:
+  2->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 19)
+> 1 receiving messages
+  2->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 19)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  2->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:8 Log:8/21 Commit:18
+> 2 receiving messages
+  1->2 MsgApp Term:8 Log:8/21 Commit:18
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  2->1 MsgAppResp Term:8 Log:0/21
+
+stabilize 1 3
+----
+> 3 receiving messages
+  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 3 handling Ready
+  Ready MustSync=false:
+  Lead:1 State:StateFollower
+  Messages:
+  3->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 14)
+> 1 receiving messages
+  3->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 14)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:18
+  Entries:
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  CommittedEntries:
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  3->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:8 Log:8/21 Commit:18
+> 3 receiving messages
+  1->3 MsgApp Term:8 Log:8/21 Commit:18
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  3->1 MsgAppResp Term:8 Log:0/21
+
+stabilize 1 4
+----
+> 4 receiving messages
+  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  INFO found conflict at index 21 [existing term: 6, conflicting term: 8]
+  INFO replace the unstable entries from index 21
+> 4 handling Ready
+  Ready MustSync=true:
+  Lead:1 State:StateFollower
+  Entries:
+  8/21 EntryNormal ""
+  Messages:
+  4->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  4->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  HardState Term:8 Vote:1 Commit:21
+  CommittedEntries:
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:8 Log:8/21 Commit:21
+  1->3 MsgApp Term:8 Log:8/21 Commit:21
+  1->4 MsgApp Term:8 Log:8/21 Commit:21
+> 4 receiving messages
+  1->4 MsgApp Term:8 Log:8/21 Commit:21
+> 4 handling Ready
+  Ready MustSync=false:
+  HardState Term:8 Commit:21
+  CommittedEntries:
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  4->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  4->1 MsgAppResp Term:8 Log:0/21
+
+stabilize 1 5
+----
+> 5 receiving messages
+  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 5 handling Ready
+  Ready MustSync=false:
+  Lead:1 State:StateFollower
+  Messages:
+  5->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 22)
+> 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 22)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->5 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 5 receiving messages
+  1->5 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 5 handling Ready
+  Ready MustSync=false:
+  Messages:
+  5->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 22)
+> 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 22)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 5 receiving messages
+  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  INFO found conflict at index 19 [existing term: 7, conflicting term: 6]
+  INFO replace the unstable entries from index 19
+> 5 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Commit:21
+  Entries:
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  CommittedEntries:
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  5->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->5 MsgApp Term:8 Log:8/21 Commit:21
+> 5 receiving messages
+  1->5 MsgApp Term:8 Log:8/21 Commit:21
+> 5 handling Ready
+  Ready MustSync=false:
+  Messages:
+  5->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:0/21
+
+stabilize 1 6
+----
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 6 handling Ready
+  Ready MustSync=false:
+  Lead:1 State:StateFollower
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 17)
+> 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 17)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->6 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 6 handling Ready
+  Ready MustSync=false:
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 17)
+> 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 17)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->6 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 6 handling Ready
+  Ready MustSync=false:
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 17)
+> 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 17)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  INFO found conflict at index 16 [existing term: 4, conflicting term: 5]
+  INFO replace the unstable entries from index 16
+> 6 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:21
+  Entries:
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  CommittedEntries:
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->6 MsgApp Term:8 Log:8/21 Commit:21
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:8/21 Commit:21
+> 6 handling Ready
+  Ready MustSync=false:
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:0/21
+
+stabilize 1 7
+----
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Lead:1 State:StateFollower
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/18 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/18 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/15 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/15 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:4/14 Commit:21 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:4/14 Commit:21 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/14 Rejected (Hint: 21)
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/14 Rejected (Hint: 21)
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[4/14 EntryNormal "", 4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[4/14 EntryNormal "", 4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
+  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
+  INFO replace the unstable entries from index 14
+> 7 handling Ready
+  Ready MustSync=true:
+  HardState Term:8 Vote:1 Commit:21
+  Entries:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  CommittedEntries:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->7 MsgApp Term:8 Log:8/21 Commit:21
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:8/21 Commit:21
+> 7 handling Ready
+  Ready MustSync=false:
+  Messages:
+  7->1 MsgAppResp Term:8 Log:0/21
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/21

--- a/raft/testdata/probe_and_replicate.txt
+++ b/raft/testdata/probe_and_replicate.txt
@@ -488,9 +488,9 @@ stabilize 1 2
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  2->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -527,9 +527,9 @@ stabilize 1 3
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  3->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -617,21 +617,9 @@ stabilize 1 5
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  5->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 22)
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 22)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->5 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 5 handling Ready
-  Ready MustSync=false:
-  Messages:
-  5->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 22)
-> 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 22)
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -676,33 +664,9 @@ stabilize 1 6
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  6->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 17)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->6 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 6 receiving messages
-  1->6 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 6 handling Ready
-  Ready MustSync=false:
-  Messages:
-  6->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 17)
-> 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 17)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->6 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 6 receiving messages
-  1->6 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 6 handling Ready
-  Ready MustSync=false:
-  Messages:
-  6->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 17)
-> 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -753,81 +717,9 @@ stabilize 1 7
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  7->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 21)
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/20 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:6/19 Commit:21 Entries:[6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/19 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:6/18 Commit:21 Entries:[6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/18 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/18 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:5/17 Commit:21 Entries:[6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/17 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:5/16 Commit:21 Entries:[5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/16 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:4/15 Commit:21 Entries:[5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/15 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/15 Rejected (Hint: 21)
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:4/14 Commit:21 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:4/14 Commit:21 Entries:[4/15 EntryNormal "prop_4_15", 5/16 EntryNormal "", 5/17 EntryNormal "prop_5_17", 6/18 EntryNormal "", 6/19 EntryNormal "prop_6_19", 6/20 EntryNormal "prop_6_20", 8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=false:
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/14 Rejected (Hint: 21)
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/14 Rejected (Hint: 21)
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/raft/tracker/progress.go
+++ b/raft/tracker/progress.go
@@ -157,8 +157,8 @@ func (pr *Progress) MaybeUpdate(n uint64) bool {
 func (pr *Progress) OptimisticUpdate(n uint64) { pr.Next = n + 1 }
 
 // MaybeDecrTo adjusts the Progress to the receipt of a MsgApp rejection. The
-// arguments are the index the follower rejected to append to its log, and its
-// last index.
+// arguments are the index of the append message rejected by the follower, and
+// the hint that we want to decrease to.
 //
 // Rejections can happen spuriously as messages are sent out of order or
 // duplicated. In such cases, the rejection pertains to an index that the
@@ -167,7 +167,7 @@ func (pr *Progress) OptimisticUpdate(n uint64) { pr.Next = n + 1 }
 //
 // If the rejection is genuine, Next is lowered sensibly, and the Progress is
 // cleared for sending log entries.
-func (pr *Progress) MaybeDecrTo(rejected, last uint64) bool {
+func (pr *Progress) MaybeDecrTo(rejected, matchHint uint64) bool {
 	if pr.State == StateReplicate {
 		// The rejection must be stale if the progress has matched and "rejected"
 		// is smaller than "match".
@@ -176,7 +176,7 @@ func (pr *Progress) MaybeDecrTo(rejected, last uint64) bool {
 		}
 		// Directly decrease next to match + 1.
 		//
-		// TODO(tbg): why not use last if it's larger?
+		// TODO(tbg): why not use matchHint if it's larger?
 		pr.Next = pr.Match + 1
 		return true
 	}
@@ -187,7 +187,7 @@ func (pr *Progress) MaybeDecrTo(rejected, last uint64) bool {
 		return false
 	}
 
-	pr.Next = max(min(rejected, last+1), 1)
+	pr.Next = max(min(rejected, matchHint+1), 1)
 	pr.ProbeSent = false
 	return true
 }


### PR DESCRIPTION
The fast log rejection algorithm is descripted in the Raft paper, which can reduce network round trips when peer with less logs becomes leader.

There are 2 cases that the PR can improve:

#### A. The conflict point can be found by leader quickly:
```
leader log   : (idx=100,term=2)(idx=101,term=5)[...](idx=120,term=5)
follower logs: (idx=100,term=2)(idx=101,term=4)[...](idx=110,term=4)
```
When leader appends entries from `index=120`, follower will reject it with `reject=110,term=4`. So leader can found the conflict position and then appends entries from `index=101`.

#### B. The conflict point can be found by follower quickly:
```
leader logs  : (idx=100,term=2)[...](idx=105,term=2)
follower logs: (idx=100,term=2)(idx=101,term=2)(idx=102,term=4)
```
When leader appends entries from `index=105`, follower will reject it with `reject=100,term=2` if it can found the conflict position. After that leader can continue to append entries from `index=101`.

Signed-off-by: qupeng <qupeng@pingcap.com>

Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
