### PR TITLE
grpc-proxy: add option to allow non empty CN

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -68,6 +68,7 @@ var (
 	grpcProxyCert                  string
 	grpcProxyKey                   string
 	grpcProxyInsecureSkipTLSVerify bool
+	grpcAllowNonEmptyCN            bool
 
 	// tls for clients connecting to proxy
 
@@ -142,6 +143,7 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grpcProxyKey, "key", "", "identify secure connections with etcd servers using this TLS key file")
 	cmd.Flags().StringVar(&grpcProxyCA, "cacert", "", "verify certificates of TLS-enabled secure etcd servers using this CA bundle")
 	cmd.Flags().BoolVar(&grpcProxyInsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip authentication of etcd server TLS certificates (CAUTION: this option should be enabled only for testing purposes)")
+	cmd.Flags().BoolVar(&grpcAllowNonEmptyCN, "allow-non-empty-cn", false, "allow non empty CN when connecting to etcd servers")
 
 	// client TLS for connecting to proxy
 	cmd.Flags().StringVar(&grpcProxyListenCert, "cert-file", "", "identify secure connections to the proxy using this TLS certificate file")
@@ -291,6 +293,7 @@ func newClientCfg(lg *zap.Logger, eps []string) (*clientv3.Config, error) {
 		tls = &transport.TLSInfo{}
 	}
 	if tls != nil {
+		tls.EmptyCN = !grpcAllowNonEmptyCN
 		clientTLS, err := tls.ClientConfig()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In some cases, grpc-proxy can be used with CN based auth.

Fixes #11970

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>