### PR TITLE
etcdserver/api/etcdhttp: add reason field for /health response

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -122,6 +122,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
   - See https://github.com/etcd-io/etcd/issues/11918.
 - Improve logging around snapshot send and receive.
 - [Push down RangeOptions.limit argv into index tree to reduce memory overhead](https://github.com/etcd-io/etcd/pull/11990).
+- Add [reason field for /health response](https://github.com/etcd-io/etcd/pull/11983).
 
 ### Package `embed`
 

--- a/tests/e2e/ctl_v3_alarm_test.go
+++ b/tests/e2e/ctl_v3_alarm_test.go
@@ -53,7 +53,7 @@ func alarmTest(cx ctlCtx) {
 	}
 
 	// '/health' handler should return 'false'
-	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health":"false"}`}); err != nil {
+	if err := cURLGet(cx.epc, cURLReq{endpoint: "/health", expected: `{"health":"false","reason":"ALARM NOSPACE"}`}); err != nil {
 		cx.t.Fatalf("failed get with curl (%v)", err)
 	}
 

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -49,7 +49,7 @@ func metricsTest(cx ctlCtx) {
 		{"/metrics", fmt.Sprintf("etcd_mvcc_delete_total 3")},
 		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
 		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))},
-		{"/health", `{"health":"true"}`},
+		{"/health", `{"health":"true","reason":""}`},
 	} {
 		i++
 		if err := ctlV3Put(cx, fmt.Sprintf("%d", i), "v", ""); err != nil {


### PR DESCRIPTION
Fix issue #11599 . @gyuho 

```
{"health":"false","reason":"NOSPACE"}
```