### PR TITLE
grpc-proxy: pass max message size to grpc server

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -372,6 +372,8 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.MaxConcurrentStreams(math.MaxUint32),
+		grpc.MaxRecvMsgSize(grpcMaxCallRecvMsgSize),
+		grpc.MaxSendMsgSize(grpcMaxCallSendMsgSize),
 	}
 	if grpcKeepAliveMinTime > time.Duration(0) {
 		gopts = append(gopts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{


### PR DESCRIPTION
The current implementation for grpc-proxy allows users
to configure the max send and receive message sizes for
the etcd client settings, but neglects to also increase
the grpc proxy server settings.  Messages that are below
the max send/recv size are rejected by the grpc proxy
for hitting the default 4MB limit.

Fixes: #11984

Signed-off-by: Lincoln Thurlow <lincoln@isi.edu>


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
