### PR TITLE
 mvcc: push down RangeOptions.limit argv into index tree to reduce memory overhead

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -121,6 +121,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
   - Add [missing CRC checksum check in WAL validate method otherwise causes panic](https://github.com/etcd-io/etcd/pull/11924).
   - See https://github.com/etcd-io/etcd/issues/11918.
 - Improve logging around snapshot send and receive.
+- [Push down RangeOptions.limit argv into index tree to reduce memory overhead](https://github.com/etcd-io/etcd/pull/11990).
 
 ### Package `embed`
 

--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -242,8 +242,12 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 		if r.Rev != wrev {
 			t.Errorf("#%d: rev = %d, want %d", i, r.Rev, wrev)
 		}
-		if r.Count != len(kvs) {
-			t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
+		if tt.limit <= 0 || int(tt.limit) > len(kvs) {
+			if r.Count != len(kvs) {
+				t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
+			}
+		} else if r.Count != int(tt.limit) {
+			t.Errorf("#%d: count = %d, want %d", i, r.Count, tt.limit)
 		}
 	}
 }

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -936,12 +936,12 @@ type fakeIndex struct {
 	indexCompactRespc     chan map[revision]struct{}
 }
 
-func (i *fakeIndex) Revisions(key, end []byte, atRev int64) []revision {
+func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int) []revision {
 	_, rev := i.Range(key, end, atRev)
 	return rev
 }
 
-func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
+func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64, limit int) int {
 	_, rev := i.Range(key, end, atRev)
 	return len(rev)
 }

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -126,11 +126,11 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
 	if ro.Count {
-		total := tr.s.kvindex.CountRevisions(key, end, rev)
+		total := tr.s.kvindex.CountRevisions(key, end, rev, int(ro.Limit))
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
-	revpairs := tr.s.kvindex.Revisions(key, end, rev)
+	revpairs := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit))
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil


### PR DESCRIPTION
if there are too many keys(key,rangeEnd), even if we set RangeOptions.limit to 1,range request is very expensive and it will result in oom. this pr will push down RangeOptions.limit argv into index tree to reduce memory overhead. @gyuho 
![image](https://user-images.githubusercontent.com/2403673/83998563-78313980-a993-11ea-81f5-adc9a8bf1a6a.png)
