### PR TITLE
pkg/fileutil: optimize file stats error

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -60,6 +60,9 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.0...v3.5.0) and 
 - Changed `pkg/flags` function signature to [support structured logger](https://github.com/etcd-io/etcd/pull/11616).
   - Previously, `SetFlagsFromEnv(prefix string, fs *flag.FlagSet) error`, now `SetFlagsFromEnv(lg *zap.Logger, prefix string, fs *flag.FlagSet) error`.
   - Previously, `SetPflagsFromEnv(prefix string, fs *pflag.FlagSet) error`, now `SetPflagsFromEnv(lg *zap.Logger, prefix string, fs *pflag.FlagSet) error`.
+- Changed behavior on [existing dir permission](https://github.com/etcd-io/etcd/pull/11798).
+  - Previously, the permission was not checked on existing data directory and the directory used for automatically generating self-signed certificates for TLS connections with clients. Now a check is added to make sure those directories, if already exist, has a desired permission of 700 on Linux and 777 on Windows.
+
 
 ### `etcdctl`
 

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -124,7 +124,7 @@ func CheckDirPermission(dir string, perm os.FileMode) error {
 	}
 	dirMode := dirInfo.Mode().Perm()
 	if dirMode != perm {
-		err = fmt.Errorf("directory %q exist without desired file permission. %q", dir, dirInfo.Mode())
+		err = fmt.Errorf("directory %q,%q exist without desired file permission %q.", dir, dirInfo.Mode(), os.FileMode(PrivateDirMode))
 		return err
 	}
 	return nil


### PR DESCRIPTION
when I try to upgrade etcd cluster from v3.4 to v3.5, I failed to start etcd etcd process.  I have to find solution from code, pr #11798 introduces this issue.  it is better if we can print detail desired file permission in error log and add breaking change doc for it. thanks. @spzala 
```
Jun 10 13:50:45 VM-test-ubuntu bash[11974]: {"level":"fatal","ts":"2020-06-10T13:50:45.510+0800","caller":"etcdmain/etcd.go:197","msg":"discovery failed","error":"cannot access data directory: directory \"/data/etcd.data\" exist without desired file permission. \"drwxr-xr-x\"","
```