### PR TITLE
pkg: consider umask when use MkdirAll

### DIFF
--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -269,16 +269,9 @@ func startProxy(cfg *config) error {
 	}
 
 	cfg.ec.Dir = filepath.Join(cfg.ec.Dir, "proxy")
-	if fileutil.Exist(cfg.ec.Dir) {
-		err := fileutil.CheckDirPermission(cfg.ec.Dir, fileutil.PrivateDirMode)
-		if err != nil {
-			return err
-		}
-	} else {
-		err = os.MkdirAll(cfg.ec.Dir, fileutil.PrivateDirMode)
-		if err != nil {
-			return err
-		}
+	err = fileutil.TouchDirAll(cfg.ec.Dir)
+	if err != nil {
+		return err
 	}
 
 	var peerURLs []string

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -115,17 +115,17 @@ func (info TLSInfo) Empty() bool {
 }
 
 func SelfCert(lg *zap.Logger, dirpath string, hosts []string, additionalUsages ...x509.ExtKeyUsage) (info TLSInfo, err error) {
-	if fileutil.Exist(dirpath) {
-		err = fileutil.CheckDirPermission(dirpath, fileutil.PrivateDirMode)
-		if err != nil {
-			return
-		}
-	} else {
-		if err = os.MkdirAll(dirpath, fileutil.PrivateDirMode); err != nil {
-			return
-		}
-	}
 	info.Logger = lg
+	err = fileutil.TouchDirAll(dirpath)
+	if err != nil {
+		if info.Logger != nil {
+			info.Logger.Warn(
+				"cannot create cert directory",
+				zap.Error(err),
+			)
+		}
+		return
+	}
 
 	certPath := filepath.Join(dirpath, "cert.pem")
 	keyPath := filepath.Join(dirpath, "key.pem")


### PR DESCRIPTION
os.MkdirAll creates directory before umask so make sure that a desired
permission is set after creating a directory with MkdirAll.
Added some additional logging as well.

