### PR TITLE
raft: merge MsgAppResp and use binary search when free Inflights

### DIFF
--- a/raft/node_bench_test.go
+++ b/raft/node_bench_test.go
@@ -65,7 +65,12 @@ func BenchmarkCluster(b *testing.B) {
 	nodes := make(map[uint64]*tNode)
 	for _, peer := range peers {
 		s := NewMemoryStorage()
-		rn := newTestRawNode(peer, peers, 10, 1, s)
+		cfg := newTestConfig(peer, peers, 10, 1, s)
+		cfg.Logger = discardLogger
+		rn, err := NewRawNode(cfg)
+		if err != nil {
+			panic(err)
+		}
 		n := newNode(rn)
 		nodes[peer] = &tNode{
 			node: &n,
@@ -94,7 +99,7 @@ func BenchmarkCluster(b *testing.B) {
 				}
 				n.s.Append(rd.Entries)
 				// a reasonable disk sync latency
-				time.Sleep(1 * time.Millisecond)
+				// time.Sleep(1 * time.Millisecond)
 				n.node.Advance()
 				if rd.HardState.Commit == uint64(b.N+1) {
 					wg.Done()

--- a/raft/node_bench_test.go
+++ b/raft/node_bench_test.go
@@ -22,12 +22,42 @@ import (
 	"time"
 )
 
+func BenchmarkOneNode(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewMemoryStorage()
+	rn := newTestRawNode(1, []uint64{1}, 10, 1, s)
+	n := newNode(rn)
+	go n.run()
+
+	defer n.Stop()
+
+	n.Campaign(ctx)
+	go func() {
+		for i := 0; i < b.N; i++ {
+			n.Propose(ctx, []byte("foo"))
+		}
+	}()
+
+	for {
+		rd := <-n.Ready()
+		s.Append(rd.Entries)
+		// a reasonable disk sync latency
+		time.Sleep(1 * time.Millisecond)
+		n.Advance()
+		if rd.HardState.Commit == uint64(b.N+1) {
+			return
+		}
+	}
+}
+
 type tNode struct {
 	node *node
 	s    *MemoryStorage
 }
 
-func BenchmarkOneNode(b *testing.B) {
+func BenchmarkCluster(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/raft/tracker/inflights_test.go
+++ b/raft/tracker/inflights_test.go
@@ -105,7 +105,7 @@ func TestInflightFreeTo(t *testing.T) {
 		in.Add(uint64(i))
 	}
 
-	in.FreeLE(4)
+	in.FreeLE(4, false)
 
 	wantIn := &Inflights{
 		start: 5,
@@ -119,7 +119,7 @@ func TestInflightFreeTo(t *testing.T) {
 		t.Fatalf("in = %+v, want %+v", in, wantIn)
 	}
 
-	in.FreeLE(8)
+	in.FreeLE(8, false)
 
 	wantIn2 := &Inflights{
 		start: 9,
@@ -138,7 +138,7 @@ func TestInflightFreeTo(t *testing.T) {
 		in.Add(uint64(i))
 	}
 
-	in.FreeLE(12)
+	in.FreeLE(12, false)
 
 	wantIn3 := &Inflights{
 		start: 3,
@@ -152,7 +152,7 @@ func TestInflightFreeTo(t *testing.T) {
 		t.Fatalf("in = %+v, want %+v", in, wantIn3)
 	}
 
-	in.FreeLE(14)
+	in.FreeLE(14, false)
 
 	wantIn4 := &Inflights{
 		start: 0,


### PR DESCRIPTION
For now, the leader frees the item of `Inflights` in a FIFO style with linear iterating because message ack comes with the order the message sent. Such an approach is sufficient when the cluster is kind of idle (without tons of log replication). But when the message ack arrives out of the order, the `FreeLe` could take extra cost to evict the items and the stale message is just useless.  Furthermore, it seems unnecessary to call `FreeLe` every time the `MsgAppResp` arriving in the leader and the follower can just merge all the `MsgAppResp` into a single one to reduce the network transferring cost. So here comes the basic idea:
1. follower can merge all the `MsgAppResp` into a single one with latest `index` to reduce the network cost
2. the leader can just use binary search when invoking `FreeLe` to reduce the CPU cost if necessary

I've added a cluster benchmark to testing whether the idea is work. In my machine, with the merging `MsgAppResp`, we could gain a 10% increment of proposing speed on average. 

Some benchmark results:
```
~/dev/etcd/raft(merge_append_response ✗) go test -bench ^BenchmarkCluster --run ^$ -v -benchmem
goos: linux
goarch: amd64
pkg: go.etcd.io/etcd/v3/raft
BenchmarkCluster
BenchmarkCluster/merge_append_response
BenchmarkCluster/merge_append_response-8                  104875             10577 ns/op          7084 B/op         12 allocs/op
BenchmarkCluster/no_merge_append_response
BenchmarkCluster/no_merge_append_response-8                86439             12660 ns/op         10039 B/op         14 allocs/op
PASS
ok      go.etcd.io/etcd/v3/raft 3.543s
~/dev/etcd/raft(merge_append_response ✗) go test -bench ^BenchmarkCluster --run ^$ -v -benchmem
goos: linux
goarch: amd64
pkg: go.etcd.io/etcd/v3/raft
BenchmarkCluster
BenchmarkCluster/merge_append_response
BenchmarkCluster/merge_append_response-8                  104830             14533 ns/op            7252 B/op         12 allocs/op
BenchmarkCluster/no_merge_append_response
BenchmarkCluster/no_merge_append_response-8                66547             17860 ns/op           10275 B/op         14 allocs/op
PASS
ok      go.etcd.io/etcd/v3/raft 4.107s
~/dev/etcd/raft(merge_append_response ✗) go test -bench ^BenchmarkCluster --run ^$ -v -benchmem
goos: linux
goarch: amd64
pkg: go.etcd.io/etcd/v3/raft
BenchmarkCluster
BenchmarkCluster/merge_append_response
BenchmarkCluster/merge_append_response-8                   89022             12588 ns/op            7225 B/op         12 allocs/op
BenchmarkCluster/no_merge_append_response
BenchmarkCluster/no_merge_append_response-8                67036             19870 ns/op           10410 B/op         14 allocs/op
PASS
ok      go.etcd.io/etcd/v3/raft 2.820s
```

### NOTE
- The data driven test cases are not fixed for now
- This is an unmatured idea without considering the correctness guarantee in complex scenarios as the follower merges `MsgAppResp`

/cc @tbg @xiang90 @gyuho 
