### PR TITLE
proxy/grpcproxy: fix grpc proxy hang when broadcast failed to cancel a watcher

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -177,6 +177,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 - Fix [`panic on error`](https://github.com/etcd-io/etcd/pull/11694) for metrics handler.
 - Add [gRPC keepalive related flags](https://github.com/etcd-io/etcd/pull/11711) `grpc-keepalive-min-time`, `grpc-keepalive-interval` and `grpc-keepalive-timeout`.
+- [Fix grpc watch proxy hangs when failed to cancel a watcher](https://github.com/etcd-io/etcd/pull/12030) .
 
 ### Auth
 

--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -357,7 +357,7 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 	}
 
 	kvp, _ := grpcproxy.NewKvProxy(client)
-	watchp, _ := grpcproxy.NewWatchProxy(client)
+	watchp, _ := grpcproxy.NewWatchProxy(lg, client)
 	if grpcProxyResolverPrefix != "" {
 		grpcproxy.Register(lg, client, grpcProxyResolverPrefix, grpcProxyAdvertiseClientURL, grpcProxyResolverTTL)
 	}

--- a/proxy/grpcproxy/watch_broadcast.go
+++ b/proxy/grpcproxy/watch_broadcast.go
@@ -21,6 +21,8 @@ import (
 
 	"go.etcd.io/etcd/v3/clientv3"
 	pb "go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
+
+	"go.uber.org/zap"
 )
 
 // watchBroadcast broadcasts a server watcher to many client watchers.
@@ -37,15 +39,17 @@ type watchBroadcast struct {
 	receivers map[*watcher]struct{}
 	// responses counts the number of responses
 	responses int
+	lg        *zap.Logger
 }
 
-func newWatchBroadcast(wp *watchProxy, w *watcher, update func(*watchBroadcast)) *watchBroadcast {
+func newWatchBroadcast(lg *zap.Logger, wp *watchProxy, w *watcher, update func(*watchBroadcast)) *watchBroadcast {
 	cctx, cancel := context.WithCancel(wp.ctx)
 	wb := &watchBroadcast{
 		cancel:    cancel,
 		nextrev:   w.nextrev,
 		receivers: make(map[*watcher]struct{}),
 		donec:     make(chan struct{}),
+		lg:        lg,
 	}
 	wb.add(w)
 	go func() {
@@ -62,6 +66,7 @@ func newWatchBroadcast(wp *watchProxy, w *watcher, update func(*watchBroadcast))
 		cctx = withClientAuthToken(cctx, w.wps.stream.Context())
 
 		wch := wp.cw.Watch(cctx, w.wr.key, opts...)
+		wp.lg.Debug("watch", zap.String("key", w.wr.key))
 
 		for wr := range wch {
 			wb.bcast(wr)
@@ -156,5 +161,6 @@ func (wb *watchBroadcast) stop() {
 		// and it will cause the watch proxy to not work.
 		// please see pr https://github.com/etcd-io/etcd/pull/12030 to get more detail info.
 	case <-time.After(time.Second):
+		wb.lg.Error("failed to cancel etcd watcher")
 	}
 }

--- a/proxy/grpcproxy/watch_broadcasts.go
+++ b/proxy/grpcproxy/watch_broadcasts.go
@@ -93,7 +93,7 @@ func (wbs *watchBroadcasts) add(w *watcher) {
 		}
 	}
 	// no fit; create a bcast
-	wb := newWatchBroadcast(wbs.wp, w, wbs.update)
+	wb := newWatchBroadcast(wbs.wp.lg, wbs.wp, w, wbs.update)
 	wbs.watchers[w] = wb
 	wbs.bcasts[wb] = struct{}{}
 }

--- a/proxy/grpcproxy/watcher.go
+++ b/proxy/grpcproxy/watcher.go
@@ -123,6 +123,7 @@ func (w *watcher) post(wr *pb.WatchResponse) bool {
 	case w.wps.watchCh <- wr:
 	case <-time.After(50 * time.Millisecond):
 		w.wps.cancel()
+		w.wps.lg.Error("failed to put a watch response on the watcher's proxy stream channel,err is timeout")
 		return false
 	}
 	return true


### PR DESCRIPTION
etcd version 3.4.9,recently we met a grpc proxy hang bug when broadcast failed to cancel a watcher. 
watchProxyStream will hold watchRanges global mutex lock all the time if client failed to cancel etcd watchers and it will cause the watch proxy to not work.
it is very difficult to troubleshooting when grpc proxy does not work,so I also add a zap logger for watch proxy.

```
1327935-goroutine 701608 [chan receive, 11 minutes]:
1327936-go.etcd.io/etcd/proxy/grpcproxy.(*watchBroadcast).stop(0xc069bdd200)
1327937-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch_broadcast.go:151 +0x60
1327938-go.etcd.io/etcd/proxy/grpcproxy.(*watchBroadcasts).delete(0xc089d2f9b0, 0xc0d1534300, 0x0)
1327939-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch_broadcasts.go:114 +0x164
1327940-go.etcd.io/etcd/proxy/grpcproxy.(*watchRanges).delete(0xc000210080, 0xc0d1534300)
1327941:	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch_ranges.go:56 +0xb5
1327942-go.etcd.io/etcd/proxy/grpcproxy.(*watchProxyStream).delete(0xc093096540, 0x2)
1327943-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch.go:294 +0xba
1327944-go.etcd.io/etcd/proxy/grpcproxy.(*watchProxyStream).recvLoop(0xc093096540, 0x10e7098, 0xc0615e9a40)
1327945-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch.go:263 +0x4e1
1327946-go.etcd.io/etcd/proxy/grpcproxy.(*watchProxy).Watch.func1(0xc0615e9a40, 0xc093096540)
1327947-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch.go:125 +0x51
1327948-created by go.etcd.io/etcd/proxy/grpcproxy.(*watchProxy).Watch
1327949-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch.go:123 +0x383

1034015-goroutine 740631 [select, 13 minutes]:
1034016-go.etcd.io/etcd/clientv3.(*watcher).Watch(0xc00054e140, 0x1287720, 0xc0d25d5900, 0xc0d25bb870, 0xd, 0xc0d24ed110, 0x5, 0x5, 0xc00022ba70)
1034017-	/tmp/etcd-release-3.4.9/etcd/release/etcd/clientv3/watch.go:346 +0x5d9
1034018-go.etcd.io/etcd/proxy/grpcproxy.newWatchBroadcast.func1(0xc0d25d5940, 0xc02dc6d280, 0xc0d25b7080, 0xc000214060, 0xc0d25b7070)
1034019:	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch_broadcast.go:63 +0x212
1034020-created by go.etcd.io/etcd/proxy/grpcproxy.newWatchBroadcast
1034021-	/tmp/etcd-release-3.4.9/etcd/release/etcd/proxy/grpcproxy/watch_broadcast.go:50 +0x16a

```