### PR TITLE
readme: fix `go get` command

### DIFF
--- a/clientv3/README.md
+++ b/clientv3/README.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```bash
-go get go.etcd.io/etcd/clientv3
+go get go.etcd.io/etcd/v3/clientv3@master
 ```
 
 ## Get started


### PR DESCRIPTION
Since 96cce208c2cb9e70ac3573b3f76eed7c84d262d1 the `go get` command is wrong.

`master` is necessary because this commit is not yet in a release.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
