### PR TITLE
etcdmain: fix shadow error

### DIFF
--- a/etcdmain/gateway.go
+++ b/etcdmain/gateway.go
@@ -136,7 +136,8 @@ func startGateway(cmd *cobra.Command, args []string) {
 	}
 
 	for _, srv := range srvs.SRVs {
-		eaddrs, err := net.LookupHost(srv.Target)
+		var eaddrs []string
+		eaddrs, err = net.LookupHost(srv.Target)
 		if err != nil {
 			fmt.Println("failed to resolve endpoint host:", srv.Target)
 			os.Exit(1)


### PR DESCRIPTION
release-3.4 is failed to pass fmt/govet test. 
```
etcdmain/gateway.go:139:11: declaration of "err" shadows declaration at line 96
The command "case "${TARGET}" in
```
https://travis-ci.com/github/etcd-io/etcd/jobs/352631586