### PR TITLE
Automated cherry pick of #11987

### DIFF
--- a/mvcc/watchable_store.go
+++ b/mvcc/watchable_store.go
@@ -30,9 +30,8 @@ import (
 var (
 	// chanBufLen is the length of the buffered chan
 	// for sending out watched events.
-	// TODO: find a good buf value. 1024 is just a random one that
-	// seems to be reasonable.
-	chanBufLen = 1024
+	// See https://github.com/etcd-io/etcd/issues/11906 for more detail.
+	chanBufLen = 128
 
 	// maxWatchersPerSync is the number of watchers to sync in a single batch
 	maxWatchersPerSync = 512


### PR DESCRIPTION
Cherry pick of #11987 on release-3.4.

#11987: mvcc: chanLen 1024 is to biger,and it used more memory. 128