### PR TITLE
*: register metrics handler for grpcproxy self

### DIFF
--- a/etcdmain/grpc_proxy.go
+++ b/etcdmain/grpc_proxy.go
@@ -215,6 +215,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 			mux := http.NewServeMux()
 			grpcproxy.HandleMetrics(mux, httpClient, client.Endpoints())
 			grpcproxy.HandleHealth(lg, mux, client)
+			grpcproxy.HandleProxyMetrics(mux)
 			lg.Info("gRPC proxy server metrics URL serving")
 			herr := http.Serve(mhttpl, mux)
 			if herr != nil {
@@ -407,6 +408,7 @@ func mustHTTPListener(lg *zap.Logger, m cmux.CMux, tlsinfo *transport.TLSInfo, c
 	httpmux.HandleFunc("/", http.NotFound)
 	grpcproxy.HandleMetrics(httpmux, httpClient, c.Endpoints())
 	grpcproxy.HandleHealth(lg, httpmux, c)
+	grpcproxy.HandleProxyMetrics(httpmux)
 	if grpcProxyEnablePprof {
 		for p, h := range debugutil.PProfHandlers() {
 			httpmux.Handle(p, h)

--- a/etcdserver/api/etcdhttp/metrics.go
+++ b/etcdserver/api/etcdhttp/metrics.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	PathMetrics = "/metrics"
-	PathHealth  = "/health"
+	PathMetrics      = "/metrics"
+	PathHealth       = "/health"
+	PathProxyMetrics = "/proxy/metrics"
 )
 
 // HandleMetricsHealth registers metrics and health handlers.

--- a/proxy/grpcproxy/metrics.go
+++ b/proxy/grpcproxy/metrics.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.etcd.io/etcd/v3/etcdserver/api/etcdhttp"
 )
 
@@ -96,6 +97,11 @@ func HandleMetrics(mux *http.ServeMux, c *http.Client, eps []string) {
 		body, _ := ioutil.ReadAll(resp.Body)
 		fmt.Fprintf(w, "%s", body)
 	})
+}
+
+// HandleProxyMetrics registers metrics handler on '/proxy/metrics'.
+func HandleProxyMetrics(mux *http.ServeMux) {
+	mux.Handle(etcdhttp.PathProxyMetrics, promhttp.Handler())
 }
 
 func shuffleEndpoints(r *rand.Rand, eps []string) []string {


### PR DESCRIPTION
grpcproxy does not register self metrics handler, there is no way to get eventsCoalescing/cacheKeys,etc metrics.
this pr registers metrics handler on '/proxy/metrics'.