### PR TITLE
raft: log less during election

### DIFF
--- a/raft/testdata/campaign.txt
+++ b/raft/testdata/campaign.txt
@@ -18,9 +18,7 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
-INFO 1 [logterm: 1, index: 2] sent MsgVote request to 2 at term 1
-INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
+INFO 1 [logterm: 1, index: 2] sent MsgVote request to [2 3] at term 1
 
 stabilize
 ----
@@ -53,8 +51,7 @@ stabilize
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 receiving messages
   2->1 MsgVoteResp Term:1 Log:0/0
-  INFO 1 received MsgVoteResp from 2 at term 1
-  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 received MsgVoteResp from 2 at term 1, now has 2 votes and 0 vote rejections
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready

--- a/raft/testdata/campaign_learner_must_vote.txt
+++ b/raft/testdata/campaign_learner_must_vote.txt
@@ -54,9 +54,7 @@ campaign 2
 ----
 INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
-INFO 2 received MsgVoteResp from 2 at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
+INFO 2 [logterm: 1, index: 4] sent MsgVote request to [1 3] at term 2
 
 # Send out the MsgVote requests.
 process-ready 2
@@ -90,8 +88,7 @@ stabilize 2 3
 ----
 > 2 receiving messages
   3->2 MsgVoteResp Term:2 Log:0/0
-  INFO 2 received MsgVoteResp from 3 at term 2
-  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 received MsgVoteResp from 3 at term 2, now has 2 votes and 0 vote rejections
   INFO 2 became leader at term 2
 > 2 handling Ready
   Ready MustSync=true:

--- a/raft/testdata/confchange_v1_add_single.txt
+++ b/raft/testdata/confchange_v1_add_single.txt
@@ -11,7 +11,6 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
 INFO 1 became leader at term 1
 
 # Add v2 (with an auto transition).

--- a/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/raft/testdata/confchange_v2_add_double_auto.txt
@@ -13,7 +13,6 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
 INFO 1 became leader at term 1
 
 propose-conf-change 1 transition=auto

--- a/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -15,7 +15,6 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
 INFO 1 became leader at term 1
 
 propose-conf-change 1 transition=implicit

--- a/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/raft/testdata/confchange_v2_add_single_auto.txt
@@ -13,7 +13,6 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
 INFO 1 became leader at term 1
 
 # Add v2 (with an auto transition).

--- a/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -13,7 +13,6 @@ campaign 1
 ----
 INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
-INFO 1 received MsgVoteResp from 1 at term 1
 INFO 1 became leader at term 1
 
 # Add v2 with an explicit transition.


### PR DESCRIPTION
For a cluster with 3 members and prevote enabled, a successful election can print 14 logs. It can be too much for the systems that use many raft groups to manage data slice like cockroach and TiKV. This pr reduces the log number to 8 by merging redundant logs and removing a useless log.

Before:
```
[2020/07/02 23:12:16.519 +08:00] [INFO] [raft.go:923] ["d270ec942fe7233a is starting a new election at term 1"]
[2020/07/02 23:12:16.519 +08:00] [INFO] [raft.go:729] ["d270ec942fe7233a became pre-candidate at term 1"]
[2020/07/02 23:12:16.519 +08:00] [INFO] [raft.go:824] ["d270ec942fe7233a received MsgPreVoteResp from d270ec942fe7233a at term 1"]
[2020/07/02 23:12:16.519 +08:00] [INFO] [raft.go:811] ["d270ec942fe7233a [logterm: 1, index: 3] sent MsgPreVote request to 8a5b6495d7a7e783 at term 1"]
[2020/07/02 23:12:16.519 +08:00] [INFO] [raft.go:811] ["d270ec942fe7233a [logterm: 1, index: 3] sent MsgPreVote request to c553da286d59a4a5 at term 1"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:824] ["d270ec942fe7233a received MsgPreVoteResp from c553da286d59a4a5 at term 1"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:1302] ["d270ec942fe7233a has received 2 MsgPreVoteResp votes and 0 vote rejections"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:713] ["d270ec942fe7233a became candidate at term 2"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:824] ["d270ec942fe7233a received MsgVoteResp from d270ec942fe7233a at term 2"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:811] ["d270ec942fe7233a [logterm: 1, index: 3] sent MsgVote request to 8a5b6495d7a7e783 at term 2"]
[2020/07/02 23:12:16.520 +08:00] [INFO] [raft.go:811] ["d270ec942fe7233a [logterm: 1, index: 3] sent MsgVote request to c553da286d59a4a5 at term 2"]
[2020/07/02 23:12:16.521 +08:00] [INFO] [raft.go:824] ["d270ec942fe7233a received MsgVoteResp from 8a5b6495d7a7e783 at term 2"]
[2020/07/02 23:12:16.521 +08:00] [INFO] [raft.go:1302] ["d270ec942fe7233a has received 2 MsgVoteResp votes and 0 vote rejections"]
[2020/07/02 23:12:16.521 +08:00] [INFO] [raft.go:765] ["d270ec942fe7233a became leader at term 2"]
```

After
```
[2020/07/03 00:21:59.403 +08:00] [INFO] [raft.go:938] ["c553da286d59a4a5 is starting a new election at term 5"]
[2020/07/03 00:21:59.403 +08:00] [INFO] [raft.go:729] ["c553da286d59a4a5 became pre-candidate at term 5"]
[2020/07/03 00:21:59.403 +08:00] [INFO] [raft.go:801] ["c553da286d59a4a5 [logterm: 5, index: 107] sent MsgPreVote request to [8a5b6495d7a7e783 d270ec942fe7233a] at term 5"]
[2020/07/03 00:21:59.404 +08:00] [INFO] [raft.go:827] ["c553da286d59a4a5 received MsgPreVoteResp from d270ec942fe7233a at term 5, now has 2 votes and 0 vote rejections"]
[2020/07/03 00:21:59.404 +08:00] [INFO] [raft.go:713] ["c553da286d59a4a5 became candidate at term 6"]
[2020/07/03 00:21:59.404 +08:00] [INFO] [raft.go:801] ["c553da286d59a4a5 [logterm: 5, index: 107] sent MsgVote request to [8a5b6495d7a7e783 c553da286d59a4a5 d270ec942fe7233a] at term 6"]
[2020/07/03 00:21:59.405 +08:00] [INFO] [raft.go:827] ["c553da286d59a4a5 received MsgVoteResp from d270ec942fe7233a at term 6, now has 2 votes and 0 vote rejections"]
[2020/07/03 00:21:59.405 +08:00] [INFO] [raft.go:765] ["c553da286d59a4a5 became leader at term 6"]
```