### PR TITLE
raft: simplify the code in progress.go

### DIFF
--- a/raft/tracker/progress.go
+++ b/raft/tracker/progress.go
@@ -148,9 +148,7 @@ func (pr *Progress) MaybeUpdate(n uint64) bool {
 		updated = true
 		pr.ProbeAcked()
 	}
-	if pr.Next < n+1 {
-		pr.Next = n + 1
-	}
+	pr.Next = max(pr.Next, n+1)
 	return updated
 }
 
@@ -189,9 +187,7 @@ func (pr *Progress) MaybeDecrTo(rejected, last uint64) bool {
 		return false
 	}
 
-	if pr.Next = min(rejected, last+1); pr.Next < 1 {
-		pr.Next = 1
-	}
+	pr.Next = max(min(rejected, last+1), 1)
 	pr.ProbeSent = false
 	return true
 }


### PR DESCRIPTION
In raft/tracker/progress.go:

Line 151
```go
if pr.Next < n+1 {
	pr.Next = n + 1
}
```
And line 192
```go
if pr.Next = min(rejected, last+1); pr.Next < 1 {
	pr.Next = 1
}
```

Obviously we can use the  `max`  function instead of  `if`  condition making the code more elegant.

Thanks for your review!


