### PR TITLE
functional/tester: Update cluster_test.go to reflect functional.yaml

### DIFF
--- a/functional/tester/cluster_test.go
+++ b/functional/tester/cluster_test.go
@@ -58,12 +58,13 @@ func Test_read(t *testing.T) {
 					InitialCluster:      "s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381",
 					InitialClusterState: "new",
 					InitialClusterToken: "tkn",
-					SnapshotCount:       10000,
+					SnapshotCount:       2000,
 					QuotaBackendBytes:   10740000000,
 					PreVote:             true,
 					InitialCorruptCheck: true,
 					Logger:              "zap",
 					LogOutputs:          []string{"/tmp/etcd-functional-1/etcd.log"},
+					LogLevel:            "info",
 				},
 				ClientCertData:      "",
 				ClientCertPath:      "",
@@ -110,12 +111,13 @@ func Test_read(t *testing.T) {
 					InitialCluster:      "s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381",
 					InitialClusterState: "new",
 					InitialClusterToken: "tkn",
-					SnapshotCount:       10000,
+					SnapshotCount:       2000,
 					QuotaBackendBytes:   10740000000,
 					PreVote:             true,
 					InitialCorruptCheck: true,
 					Logger:              "zap",
 					LogOutputs:          []string{"/tmp/etcd-functional-2/etcd.log"},
+					LogLevel:            "info",
 				},
 				ClientCertData:      "",
 				ClientCertPath:      "",
@@ -162,12 +164,13 @@ func Test_read(t *testing.T) {
 					InitialCluster:      "s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381",
 					InitialClusterState: "new",
 					InitialClusterToken: "tkn",
-					SnapshotCount:       10000,
+					SnapshotCount:       2000,
 					QuotaBackendBytes:   10740000000,
 					PreVote:             true,
 					InitialCorruptCheck: true,
 					Logger:              "zap",
 					LogOutputs:          []string{"/tmp/etcd-functional-3/etcd.log"},
+					LogLevel:            "info",
 				},
 				ClientCertData:      "",
 				ClientCertPath:      "",
@@ -266,7 +269,9 @@ func Test_read(t *testing.T) {
 	cfg.lg = nil
 
 	if !reflect.DeepEqual(exp, cfg) {
-		t.Fatalf("expected %+v, got %+v", exp, cfg)
+		t.Fatalf(`exp != cfg:
+  expected %+v    
+       got %+v`, exp, cfg)
 	}
 
 	cfg.lg = logger


### PR DESCRIPTION
The test seems to be failing in the master branch since: https://github.com/etcd-io/etcd/commit/f1c7fd3d53b028c96bab7b35920bd2927db84f20

Failure before fix with the new formatting that allows to spot the differences:
```
--- FAIL: Test_read (0.00s)
    cluster_test.go:269: exp != cfg:
          expected &{lg:<nil> agentConns:[] agentClients:[] agentStreams:[] agentRequests:[] testerHTTPServer:<nil> Members:[EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:19027" FailpointHTTPAddr:"http://127.0.0.1:7381" BaseDir:"/tmp/etcd-functional-1" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:1379" Etcd:<Name:"s1" DataDir:"/tmp/etcd-functional-1/etcd.data" WALDir:"/tmp/etcd-functional-1/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:1379" AdvertiseClientURLs:"https://127.0.0.1:1379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:1380" AdvertisePeerURLs:"https://127.0.0.1:1381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:10000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-1/etcd.log" > SnapshotPath:"/tmp/etcd-functional-1.snapshot.db"  EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:29027" FailpointHTTPAddr:"http://127.0.0.1:7382" BaseDir:"/tmp/etcd-functional-2" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:2379" Etcd:<Name:"s2" DataDir:"/tmp/etcd-functional-2/etcd.data" WALDir:"/tmp/etcd-functional-2/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:2379" AdvertiseClientURLs:"https://127.0.0.1:2379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:2380" AdvertisePeerURLs:"https://127.0.0.1:2381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:10000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-2/etcd.log" > SnapshotPath:"/tmp/etcd-functional-2.snapshot.db"  EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:39027" FailpointHTTPAddr:"http://127.0.0.1:7383" BaseDir:"/tmp/etcd-functional-3" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:3379" Etcd:<Name:"s3" DataDir:"/tmp/etcd-functional-3/etcd.data" WALDir:"/tmp/etcd-functional-3/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:3379" AdvertiseClientURLs:"https://127.0.0.1:3379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:3380" AdvertisePeerURLs:"https://127.0.0.1:3381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:10000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-3/etcd.log" > SnapshotPath:"/tmp/etcd-functional-3.snapshot.db" ] Tester:DataDir:"/tmp/etcd-tester-data" Network:"tcp" Addr:"127.0.0.1:9028" DelayLatencyMs:5000 DelayLatencyMsRv:500 UpdatedDelayLatencyMs:5000 RoundLimit:1 ExitOnCaseFail:true EnablePprof:true CaseDelayMs:7000 CaseShuffle:true Cases:"SIGTERM_ONE_FOLLOWER" Cases:"SIGTERM_ONE_FOLLOWER_UNTIL_TRIGGER_SNAPSHOT" Cases:"SIGTERM_LEADER" Cases:"SIGTERM_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"SIGTERM_QUORUM" Cases:"SIGTERM_ALL" Cases:"SIGQUIT_AND_REMOVE_ONE_FOLLOWER" Cases:"SIGQUIT_AND_REMOVE_ONE_FOLLOWER_UNTIL_TRIGGER_SNAPSHOT" Cases:"BLACKHOLE_PEER_PORT_TX_RX_LEADER" Cases:"BLACKHOLE_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"BLACKHOLE_PEER_PORT_TX_RX_QUORUM" Cases:"BLACKHOLE_PEER_PORT_TX_RX_ALL" Cases:"DELAY_PEER_PORT_TX_RX_LEADER" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_LEADER" Cases:"DELAY_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"DELAY_PEER_PORT_TX_RX_QUORUM" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_QUORUM" Cases:"DELAY_PEER_PORT_TX_RX_ALL" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_ALL" Cases:"NO_FAIL_WITH_STRESS" Cases:"NO_FAIL_WITH_NO_STRESS_FOR_LIVENESS" FailpointCommands:"panic(\"etcd-tester\")" RunnerExecPath:"./bin/etcd-runner" Stressers:<Type:"KV_WRITE_SMALL" Weight:0.35 > Stressers:<Type:"KV_WRITE_LARGE" Weight:0.002 > Stressers:<Type:"KV_READ_ONE_KEY" Weight:0.07 > Stressers:<Type:"KV_READ_RANGE" Weight:0.07 > Stressers:<Type:"KV_DELETE_ONE_KEY" Weight:0.07 > Stressers:<Type:"KV_DELETE_RANGE" Weight:0.07 > Stressers:<Type:"KV_TXN_WRITE_DELETE" Weight:0.35 > Stressers:<Type:"LEASE" > Checkers:"KV_HASH" Checkers:"LEASE_EXPIRE" StressKeySize:100 StressKeySizeLarge:32769 StressKeySuffixRange:250000 StressKeySuffixRangeTxn:100 StressKeyTxnOps:10 StressClients:100 StressQPS:2000  cases:[] rateLimiter:<nil> stresser:<nil> checkers:[] currentRevision:0 rd:0 cs:0}    
               got &{lg:<nil> agentConns:[] agentClients:[] agentStreams:[] agentRequests:[] testerHTTPServer:<nil> Members:[EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:19027" FailpointHTTPAddr:"http://127.0.0.1:7381" BaseDir:"/tmp/etcd-functional-1" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:1379" Etcd:<Name:"s1" DataDir:"/tmp/etcd-functional-1/etcd.data" WALDir:"/tmp/etcd-functional-1/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:1379" AdvertiseClientURLs:"https://127.0.0.1:1379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:1380" AdvertisePeerURLs:"https://127.0.0.1:1381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:10000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-1/etcd.log" LogLevel:"info" > SnapshotPath:"/tmp/etcd-functional-1.snapshot.db"  EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:29027" FailpointHTTPAddr:"http://127.0.0.1:7382" BaseDir:"/tmp/etcd-functional-2" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:2379" Etcd:<Name:"s2" DataDir:"/tmp/etcd-functional-2/etcd.data" WALDir:"/tmp/etcd-functional-2/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:2379" AdvertiseClientURLs:"https://127.0.0.1:2379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:2380" AdvertisePeerURLs:"https://127.0.0.1:2381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:2000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-2/etcd.log" LogLevel:"info" > SnapshotPath:"/tmp/etcd-functional-2.snapshot.db"  EtcdExec:"./bin/etcd" AgentAddr:"127.0.0.1:39027" FailpointHTTPAddr:"http://127.0.0.1:7383" BaseDir:"/tmp/etcd-functional-3" EtcdPeerProxy:true EtcdClientEndpoint:"127.0.0.1:3379" Etcd:<Name:"s3" DataDir:"/tmp/etcd-functional-3/etcd.data" WALDir:"/tmp/etcd-functional-3/etcd.data/member/wal" HeartbeatIntervalMs:100 ElectionTimeoutMs:1000 ListenClientURLs:"https://127.0.0.1:3379" AdvertiseClientURLs:"https://127.0.0.1:3379" ClientAutoTLS:true ListenPeerURLs:"https://127.0.0.1:3380" AdvertisePeerURLs:"https://127.0.0.1:3381" PeerAutoTLS:true InitialCluster:"s1=https://127.0.0.1:1381,s2=https://127.0.0.1:2381,s3=https://127.0.0.1:3381" InitialClusterState:"new" InitialClusterToken:"tkn" SnapshotCount:2000 QuotaBackendBytes:10740000000 PreVote:true InitialCorruptCheck:true Logger:"zap" LogOutputs:"/tmp/etcd-functional-3/etcd.log" LogLevel:"info" > SnapshotPath:"/tmp/etcd-functional-3.snapshot.db" ] Tester:DataDir:"/tmp/etcd-tester-data" Network:"tcp" Addr:"127.0.0.1:9028" DelayLatencyMs:5000 DelayLatencyMsRv:500 UpdatedDelayLatencyMs:5000 RoundLimit:1 ExitOnCaseFail:true EnablePprof:true CaseDelayMs:7000 CaseShuffle:true Cases:"SIGTERM_ONE_FOLLOWER" Cases:"SIGTERM_ONE_FOLLOWER_UNTIL_TRIGGER_SNAPSHOT" Cases:"SIGTERM_LEADER" Cases:"SIGTERM_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"SIGTERM_QUORUM" Cases:"SIGTERM_ALL" Cases:"SIGQUIT_AND_REMOVE_ONE_FOLLOWER" Cases:"SIGQUIT_AND_REMOVE_ONE_FOLLOWER_UNTIL_TRIGGER_SNAPSHOT" Cases:"BLACKHOLE_PEER_PORT_TX_RX_LEADER" Cases:"BLACKHOLE_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"BLACKHOLE_PEER_PORT_TX_RX_QUORUM" Cases:"BLACKHOLE_PEER_PORT_TX_RX_ALL" Cases:"DELAY_PEER_PORT_TX_RX_LEADER" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_LEADER" Cases:"DELAY_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_LEADER_UNTIL_TRIGGER_SNAPSHOT" Cases:"DELAY_PEER_PORT_TX_RX_QUORUM" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_QUORUM" Cases:"DELAY_PEER_PORT_TX_RX_ALL" Cases:"RANDOM_DELAY_PEER_PORT_TX_RX_ALL" Cases:"NO_FAIL_WITH_STRESS" Cases:"NO_FAIL_WITH_NO_STRESS_FOR_LIVENESS" FailpointCommands:"panic(\"etcd-tester\")" RunnerExecPath:"./bin/etcd-runner" Stressers:<Type:"KV_WRITE_SMALL" Weight:0.35 > Stressers:<Type:"KV_WRITE_LARGE" Weight:0.002 > Stressers:<Type:"KV_READ_ONE_KEY" Weight:0.07 > Stressers:<Type:"KV_READ_RANGE" Weight:0.07 > Stressers:<Type:"KV_DELETE_ONE_KEY" Weight:0.07 > Stressers:<Type:"KV_DELETE_RANGE" Weight:0.07 > Stressers:<Type:"KV_TXN_WRITE_DELETE" Weight:0.35 > Stressers:<Type:"LEASE" > Checkers:"KV_HASH" Checkers:"LEASE_EXPIRE" StressKeySize:100 StressKeySizeLarge:32769 StressKeySuffixRange:250000 StressKeySuffixRangeTxn:100 StressKeyTxnOps:10 StressClients:100 StressQPS:2000  cases:[] rateLimiter:<nil> stresser:<nil> checkers:[] currentRevision:0 rd:0 cs:0}
FAIL

```