### PR TITLE
12125: panic: zap.Logger is nil in Embed client

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -112,7 +112,7 @@ func New(cfg Config) (*Client, error) {
 // service interface implementations and do not need connection management.
 func NewCtxClient(ctx context.Context) *Client {
 	cctx, cancel := context.WithCancel(ctx)
-	return &Client{ctx: cctx, cancel: cancel}
+	return &Client{ctx: cctx, cancel: cancel, lg: zap.NewNop()}
 }
 
 // NewFromURL creates a new etcdv3 client from a URL.
@@ -123,6 +123,12 @@ func NewFromURL(url string) (*Client, error) {
 // NewFromURLs creates a new etcdv3 client from URLs.
 func NewFromURLs(urls []string) (*Client, error) {
 	return New(Config{Endpoints: urls})
+}
+
+// WithLogger sets a logger
+func (c *Client) WithLogger(lg *zap.Logger) *Client {
+	c.lg = lg
+	return c
 }
 
 // Close shuts down the client's etcd connections.

--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -166,3 +166,16 @@ func TestCloseCtxClient(t *testing.T) {
 		t.Errorf("failed to Close the client. %v", err)
 	}
 }
+
+func TestWithLogger(t *testing.T) {
+	ctx := context.Background()
+	c := NewCtxClient(ctx)
+	if c.lg == nil {
+		t.Errorf("unexpected nil in *zap.Logger")
+	}
+
+	c.WithLogger(nil)
+	if c.lg != nil {
+		t.Errorf("WithLogger should modify *zap.Logger")
+	}
+}

--- a/etcdserver/api/v3client/v3client.go
+++ b/etcdserver/api/v3client/v3client.go
@@ -29,6 +29,10 @@ import (
 // to the etcd server through its api/v3rpc function interfaces.
 func New(s *etcdserver.EtcdServer) *clientv3.Client {
 	c := clientv3.NewCtxClient(context.Background())
+	lg := s.Logger()
+	if lg != nil {
+		c.WithLogger(lg)
+	}
 
 	kvc := adapter.KvServerToKvClient(v3rpc.NewQuotaKVServer(s))
 	c.KV = clientv3.NewKVFromKVClient(kvc, c)


### PR DESCRIPTION
Fix for: https://github.com/etcd-io/etcd/issues/12125

`NewCtxClient` is used with Embedded server. This constructor does not create Logger, which is used by other packages, which causes a panic in `func New(s *etcdserver.EtcdServer) *clientv3.Client`

The fix introduces a default no-op logger and allows to copy the logger from the Embed Server, if specified.

