### PR TITLE
raft: fix panic when campaign with snapshot

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -167,6 +167,11 @@ func (l *raftLog) hasNextEnts() bool {
 	return l.committed+1 > off
 }
 
+// hasPendingSnapshot returns if there is pending snapshot waiting for applying.
+func (l *raftLog) hasPendingSnapshot() bool {
+	return l.unstable.snapshot != nil && !IsEmptySnap(*l.unstable.snapshot)
+}
+
 func (l *raftLog) snapshot() (pb.Snapshot, error) {
 	if l.unstable.snapshot != nil {
 		return *l.unstable.snapshot, nil

--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -157,7 +157,7 @@ func (rn *RawNode) HasReady() bool {
 	if hardSt := r.hardState(); !IsEmptyHardState(hardSt) && !isHardStateEqual(hardSt, rn.prevHardSt) {
 		return true
 	}
-	if r.raftLog.unstable.snapshot != nil && !IsEmptySnap(*r.raftLog.unstable.snapshot) {
+	if r.raftLog.hasPendingSnapshot() {
 		return true
 	}
 	if len(r.msgs) > 0 || len(r.raftLog.unstableEntries()) > 0 || r.raftLog.hasNextEnts() {


### PR DESCRIPTION
If a node starts campaign without applying the snapshot data, loading entries can fail. This can happen when testing transfer leader after snapshot.

This commit is extracted from #12134. Should also fix the issue reported in [comment](https://github.com/etcd-io/etcd/pull/12134#discussion_r459394987).

@xiang90 PTAL