### PR TITLE
raft/quorum: fix clobbered size argument

### DIFF
--- a/raft/quorum/quick_test.go
+++ b/raft/quorum/quick_test.go
@@ -45,9 +45,6 @@ func TestQuick(t *testing.T) {
 
 // smallRandIdxMap returns a reasonably sized map of ids to commit indexes.
 func smallRandIdxMap(rand *rand.Rand, size int) map[uint64]Index {
-	// Hard-code a reasonably small size here (quick will hard-code 50, which
-	// is not useful here).
-	size = 10
 
 	n := rand.Intn(size)
 	ids := rand.Perm(2 * n)[:n]


### PR DESCRIPTION
This fixes the size argument to the function smallRandIdxMap(), which was being immediately discarded.

Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>
