### PR TITLE
Documentation: Further improve etcdMembersDown alert

### DIFF
--- a/Documentation/etcd-mixin/test.yaml
+++ b/Documentation/etcd-mixin/test.yaml
@@ -17,16 +17,16 @@ tests:
         alertname: etcdInsufficientMembers
       - eval_time: 5m
         alertname: etcdInsufficientMembers
-      - eval_time: 5m
+      - eval_time: 12m
         alertname: etcdMembersDown
-      - eval_time: 7m
+      - eval_time: 14m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:
               job: etcd
               severity: critical
             exp_annotations:
-              message: 'etcd cluster "etcd": members are down (1).'
+              message: 'etcd cluster "etcd": members are down (3).'
       - eval_time: 7m
         alertname: etcdInsufficientMembers
       - eval_time: 11m
@@ -49,33 +49,31 @@ tests:
   - interval: 1m
     input_series:
       - series: 'up{job="etcd",instance="10.10.10.0"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
       - series: 'up{job="etcd",instance="10.10.10.1"}'
-        values: '1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
+        values: '1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0'
       - series: 'up{job="etcd",instance="10.10.10.2"}'
-        values: '1 1 1 1 0 0 0 0'
+        values: '1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 14m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:
               job: etcd
               severity: critical
             exp_annotations:
-              message: 'etcd cluster "etcd": members are down (2).'
+              message: 'etcd cluster "etcd": members are down (3).'
 
   - interval: 1m
     input_series:
       - series: 'up{job="etcd",instance="10.10.10.0"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0'
       - series: 'up{job="etcd",instance="10.10.10.1"}'
-        values: '1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0'
       - series: 'etcd_network_peer_sent_failures_total{To="member-1",job="etcd",endpoint="test"}'
-        values: '0 0 1 2 3 4 5 6 7 8 9 10'
+        values: '0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18'
     alert_rule_test:
-      - eval_time: 4m
-        alertname: etcdMembersDown
-      - eval_time: 6m
+      - eval_time: 13m
         alertname: etcdMembersDown
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
Before this change, the default window for the etcdMembersDown network failure
rate function was recently changed to 1 minute. While this helps detect a etcd
recovery more quickly, it depends on scrape intervals of <= 15s to collect
sufficient data points for the rate function. In practice, an interval of >= 30s
is more typical, which causes the rate function to be less accurate.

This patch increases the window to 2m, which is a compromise between the
original value of 3m and the 1m change introuced with 2aa5684, and should
accomodate more typical scrape intervals.

To offset the window change and to further improve the chance that the alert
will only fire when etcd is truly dead, this patch changes the `for` clause from
3m to 10m. The rationale is as follows:

1. There can be significant variance in durations following a reboot before etcd
is scraped and detected as available.

2. A conservative trigger like 10m seems less likely to produce a false alarm in
the face of such variance.

3. In this alerting situation, if the outage is real, it seems unlikely that an
additional 7 minutes of delay before (for example) paging somebody will make a
significant impact on the overall response.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
