### PR TITLE
Change interval to 1m for etcdHighNumberOfFailedGRPCRequests critical

### DIFF
--- a/Documentation/etcd-mixin/mixin.libsonnet
+++ b/Documentation/etcd-mixin/mixin.libsonnet
@@ -92,9 +92,9 @@
           {
             alert: 'etcdHighNumberOfFailedGRPCRequests',
             expr: |||
-              100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[5m])) without (grpc_type, grpc_code)
+              100 * sum(rate(grpc_server_handled_total{%(etcd_selector)s, grpc_code!="OK"}[1m])) without (grpc_type, grpc_code)
                 /
-              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[5m])) without (grpc_type, grpc_code)
+              sum(rate(grpc_server_handled_total{%(etcd_selector)s}[1m])) without (grpc_type, grpc_code)
                 > 5
             ||| % $._config,
             'for': '5m',


### PR DESCRIPTION
We've observed an erratic behaviour of this alert during rollouts. On all occasions, we've noticed the alert isn't sustained for more than a few minutes and we flag it as a false positive. I think it's because we're using the 5m rate for 5 minutes the alert only gets to see 1 sample.

We have a couple of options, doubling the alert duration (from 5m to 10m) but that seems unfeasible given the criticality of this, or use the 1m rate for 5m. The latter feels like a minimal change - and it didn't cause the alert to fire (for false positives) on occasions where the current one would.

Apologies for not creating an issue first, given the minimal diff of the change I thought this would be better discussed inside of a pull request. 

current interval (5m)
![Screenshot 2020-07-28 at 11 12 17](https://user-images.githubusercontent.com/231583/88654331-22405e80-d0c5-11ea-8fc2-8049d4c1ca2b.png)

proposed interval (1m)

![Screenshot 2020-07-28 at 11 24 50](https://user-images.githubusercontent.com/231583/88654346-27051280-d0c5-11ea-850a-0a800175e361.png)

Signed-off-by: gotjosh <josue@grafana.com>