### PR TITLE
test: avoid non existing package for integration test

### DIFF
--- a/test
+++ b/test
@@ -179,8 +179,7 @@ function integration_pass {
 			INTEGTESTPKG=("${REPO_PATH}/integration"
 						  "${REPO_PATH}/client/integration"
 						  "${REPO_PATH}/clientv3/integration"
-						  "${REPO_PATH}/contrib/raftexample"
-						  "${REPO_PATH}/store")
+						  "${REPO_PATH}/contrib/raftexample")
 		else
 			INTEGTESTPKG=("${TEST[@]}")
 		fi


### PR DESCRIPTION
The line makes integration test failed like below:
```
$ PASSES=integration TESTCASE=TestWatchClose USERPKG=1 ./test                                                                                                                                                                  -1- 00:04:01
Running with TEST_CPUS: 1,2,4
Starting 'integration' pass at 2020年  8月  3日 月曜日 00:04:23 JST
Running integration tests...
go: finding module for package go.etcd.io/etcd/v3/store
can't load package: package go.etcd.io/etcd/v3/store: module go.etcd.io/etcd@latest found (v3.3.22+incompatible), but does not contain package go.etcd.io/etcd/v3/store
```
This PR solves the issue.