### PR TITLE
clientv3/integration: Reduce flakines of TestGetTokenWithoutAuth

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -337,7 +337,13 @@ func (c *Client) dial(target string, creds grpccredentials.TransportCredentials,
 
 		err = c.getToken(ctx)
 		if err != nil {
+			// TODO: Consider retrying transient errors like:
+			// "error":"rpc error: code = Unavailable desc = etcdserver: leader changed"
+
+			// Ignore rpctypes.ErrAuthNotEnabled error.
 			if toErr(ctx, err) != rpctypes.ErrAuthNotEnabled {
+				// This logic originates from 62d7bae496 and is not clear why we cannot just return err
+				// without looking into parent's context.
 				if err == ctx.Err() && ctx.Err() != c.ctx.Err() {
 					err = context.DeadlineExceeded
 				}


### PR DESCRIPTION
The test is vary flaky on Travis.

Seems that since (https://github.com/etcd-io/etcd/issues/7724) the
client is expected to simply ignore whether server is in AuthDisabled
mode even if the user supplies credentials.

The tests used to:
  * use very large cluster (10 nodes)
  * set very low timeout (1 sec)

Such setup led to frequent deadlineExceed errors or following failures:

    === RUN   TestGetTokenWithoutAuth
    {"level":"warn","ts":"2020-08-04T16:50:48.686+0200","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-35573307-1ee5-441b-acc7-d073f0bd7de5/localhost:69820396562031027440","attempt":0,"error":"rpc error: code = Unavailable desc = etcdserver: leader changed"}
        user_test.go:151: other errors:etcdserver: leader changed
    --- FAIL: TestGetTokenWithoutAuth (10.91s)

The flakiness is hard to spot when executing isolated: 
```
GOARCH=amd64 CPU=1 PASSES='integration' ./test -v --run TestGetTokenWithoutAuth -count=10
```
But is visible when all tests are executed: 
GOARCH=amd64 CPU=1 PASSES='integration' ./test --count=3

I believe its due to slowness coming from CPU utilization when multiple tests are executed.