### PR TITLE
etcdserver: ignore ErrCompacted error

### DIFF
--- a/etcdserver/apply.go
+++ b/etcdserver/apply.go
@@ -133,7 +133,7 @@ func (a *applierV3backend) Apply(r *pb.InternalRaftRequest) *applyResult {
 	ar := &applyResult{}
 	defer func(start time.Time) {
 		warnOfExpensiveRequest(a.s.getLogger(), start, &pb.InternalRaftStringer{Request: r}, ar.resp, ar.err)
-		if ar.err != nil {
+		if ar.err != nil && ar.err != mvcc.ErrCompacted {
 			warnOfFailedRequest(a.s.getLogger(), start, &pb.InternalRaftStringer{Request: r}, ar.resp, ar.err)
 		}
 	}(time.Now())


### PR DESCRIPTION
Fix Issue #12175. 
For the compact RPC Method, returning nil and ErrCompacted are both successful . 