### PR TITLE
github: workflows: add asset-transparency release action

### DIFF
--- a/.github/workflows/asset-transparency.yaml
+++ b/.github/workflows/asset-transparency.yaml
@@ -1,0 +1,18 @@
+name: Publish Release Assets to Asset Transparency Log
+
+on:
+  release:
+    types: [published, created, edited, released]
+
+jobs:
+  github_release_asset_transparency_log_publish_job:
+    runs-on: ubuntu-latest
+    name: Publish GitHub release asset digests to https://beta-asset.transparencylog.net
+    steps:
+    - name: Gather URLs from GitHub release and publish
+      id: asset-transparency
+      uses: transparencylog/github-releases-asset-transparency-verify-action@v11
+    - name: List verified and published URLs
+      run: echo "Verified URLs ${{ steps.asset-transparency.outputs.verified }}"
+    - name: List failed URLs
+      run: echo "Failed URLs ${{ steps.asset-transparency.outputs.failed }}"


### PR DESCRIPTION
From etcd-dev discussion:
https://groups.google.com/u/2/g/etcd-dev/c/oMGSBqs_7sc

I have been working on this system called Asset Transparency[1] which
helps users verify they have received the correct contents from a URL.
If you are familiar with the "download a file, download a SHA256SUM
file, run `sha256sum -c`, etc" process? This tool helps to automate
that for users into something like this[2]:

    $ tl get https://github.com/etcd-io/etcd/releases/download/v3.4.12/etcd-v3.4.12-darwin-amd64.zip

And a best practice for this Asset Transparency system is that URLs
are registered with the log as soon as possible. Why? Well, the sooner
a URL is entered the longer it can protect people consuming a URL from
unexpected content modification from say a GitHub credential
compromise.

To that end I have written a GitHub Action[3] that will automatically
do that on every release. It is easy to activate and should be hands
free after installation. So, before I enable it I want to see if there
are any concerns from maintainers. The only change to our repo will be
a new file in .github/workflows.

[1] https://www.transparencylog.com
[2] https://github.com/transparencylog/tl
[3] https://github.com/transparencylog/publish-releases-asset-transparency-action


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
