### PR TITLE
Fix import path to fileutils in listener

### DIFF
--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/pkg/tlsutil"
-	"go.etcd.io/etcd/pkg/fileutil"
 )
 
 func NewListener(addr, scheme string, tlsinfo *TLSInfo) (l net.Listener, err error) {


### PR DESCRIPTION
transport/listener: change the import path of fileutil

Version 3.3 still uses the github.com/coreos/etcd prefix, but the transport/listener package
used the go.etcd.io/etcd path prefix.

