### PR TITLE
pkg/traceutil: skip subTraceStart/subTraceEnd steps when logging steps

### DIFF
--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -192,6 +192,9 @@ func (t *Trace) logInfo(threshold time.Duration) (string, []zap.Field) {
 	}
 	for i := 0; i < len(t.steps); i++ {
 		step := t.steps[i]
+		if step.isSubTraceStart || step.isSubTraceEnd {
+			continue
+		}
 		stepDuration := step.time.Sub(lastStepTime)
 		if stepDuration > threshold {
 			steps = append(steps, fmt.Sprintf("trace[%d] '%v' %s (duration: %v)",


### PR DESCRIPTION
SubTraceStart and SubTraceEnd steps are only placeholders, not really steps, we should skip them when logging the long duration steps, otherwise these steps will lead to incorrect start time and duration of subsequent steps.