### PR TITLE
Allow commandline overrides

### DIFF
--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -82,8 +82,7 @@ func verifyEnv(lg *zap.Logger, prefix string, usedEnvKey, alreadySet map[string]
 		}
 		if alreadySet[kv[0]] {
 			if lg != nil {
-				// TODO: exit with error in v3.4
-				lg.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", zap.String("environment-variable", kv[0]))
+				lg.Info("recognized environment variable %s overriden by commandline", zap.String("environment-variable", kv[0]))
 			}
 			continue
 		}

--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -82,11 +82,10 @@ func verifyEnv(lg *zap.Logger, prefix string, usedEnvKey, alreadySet map[string]
 		}
 		if alreadySet[kv[0]] {
 			if lg != nil {
-				lg.Fatal(
-					"conflicting environment variable is shadowed by corresponding command-line flag (either unset environment variable or disable flag))",
-					zap.String("environment-variable", kv[0]),
-				)
+				// TODO: exit with error in v3.4
+				lg.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", zap.String("environment-variable", kv[0]))
 			}
+			continue
 		}
 		if strings.HasPrefix(env, prefix+"_") {
 			if lg != nil {

--- a/pkg/flags/flag_test.go
+++ b/pkg/flags/flag_test.go
@@ -37,11 +37,17 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	if err := fs.Set("b", "bar"); err != nil {
 		t.Fatal(err)
 	}
+	// command-line flags take precedence over env vars
+	os.Setenv("ETCD_C", "woof")
+	if err := fs.Set("c", "quack"); err != nil {
+		t.Fatal(err)
+	}
 
 	// first verify that flags are as expected before reading the env
 	for f, want := range map[string]string{
 		"a": "",
 		"b": "bar",
+		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Fatalf("flag %q=%q, want %q", f, got, want)
@@ -56,6 +62,7 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	for f, want := range map[string]string{
 		"a": "foo",
 		"b": "bar",
+		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Errorf("flag %q=%q, want %q", f, got, want)


### PR DESCRIPTION
Addressing issue https://github.com/etcd-io/etcd/issues/12222 see https://github.com/etcd-io/etcd/issues/12222#issuecomment-686060536

It is a valid workflow to to have defaults in your environmental variables, and then override them on-demand with commandline parameters. The existing change unnecessarily breaks existing clusters when upgrading to 3.4+. I will also do a PR for release-3.4 cherry-pick.