### PR TITLE
Allow commandline overrides 3.4

### DIFF
--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -81,7 +81,9 @@ func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
 			continue
 		}
 		if alreadySet[kv[0]] {
-			plog.Fatalf("conflicting environment variable %q is shadowed by corresponding command-line flag (either unset environment variable or disable flag)", kv[0])
+			// TODO: exit with error in v3.4
+			plog.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", kv[0])
+			continue
 		}
 		if strings.HasPrefix(env, prefix+"_") {
 			plog.Warningf("unrecognized environment variable %s", env)

--- a/pkg/flags/flag.go
+++ b/pkg/flags/flag.go
@@ -81,8 +81,7 @@ func verifyEnv(prefix string, usedEnvKey, alreadySet map[string]bool) {
 			continue
 		}
 		if alreadySet[kv[0]] {
-			// TODO: exit with error in v3.4
-			plog.Warningf("recognized environment variable %s, but unused: shadowed by corresponding flag", kv[0])
+			plog.Infof("recognized environment variable %s overriden by commandline", kv[0])
 			continue
 		}
 		if strings.HasPrefix(env, prefix+"_") {

--- a/pkg/flags/flag_test.go
+++ b/pkg/flags/flag_test.go
@@ -35,11 +35,17 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	if err := fs.Set("b", "bar"); err != nil {
 		t.Fatal(err)
 	}
+	// command-line flags take precedence over env vars
+	os.Setenv("ETCD_C", "woof")
+	if err := fs.Set("c", "quack"); err != nil {
+		t.Fatal(err)
+	}
 
 	// first verify that flags are as expected before reading the env
 	for f, want := range map[string]string{
 		"a": "",
 		"b": "bar",
+		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Fatalf("flag %q=%q, want %q", f, got, want)
@@ -54,6 +60,7 @@ func TestSetFlagsFromEnv(t *testing.T) {
 	for f, want := range map[string]string{
 		"a": "foo",
 		"b": "bar",
+		"c": "quack",
 	} {
 		if got := fs.Lookup(f).Value.String(); got != want {
 			t.Errorf("flag %q=%q, want %q", f, got, want)


### PR DESCRIPTION
Cherry-pick of https://github.com/etcd-io/etcd/pull/12268 from master

Addressing issue #12222 see #12222 (comment)

It is a valid workflow to to have defaults in your environmental variables, and then override them on-demand with commandline parameters. The existing change unnecessarily breaks existing clusters when upgrading to 3.4+. I will also do a PR for release-3.4 cherry-pick.