### PR TITLE
 integration: Fix 'go test --tags cluster_proxy --timeout=30m -v ./integration/...'

### DIFF
--- a/integration/cluster_direct.go
+++ b/integration/cluster_direct.go
@@ -23,6 +23,8 @@ import (
 	pb "go.etcd.io/etcd/v3/etcdserver/etcdserverpb"
 )
 
+const throughProxy = false
+
 func toGRPC(c *clientv3.Client) grpcAPI {
 	return grpcAPI{
 		pb.NewClusterClient(c.ActiveConnection()),

--- a/integration/cluster_proxy.go
+++ b/integration/cluster_proxy.go
@@ -45,6 +45,8 @@ func toGRPC(c *clientv3.Client) grpcAPI {
 	pmu.Lock()
 	defer pmu.Unlock()
 
+	lg := zap.NewExample()
+
 	if v, ok := proxies[c]; ok {
 		return v.grpc
 	}
@@ -55,10 +57,10 @@ func toGRPC(c *clientv3.Client) grpcAPI {
 	c.Lease = namespace.NewLease(c.Lease, proxyNamespace)
 	// test coalescing/caching proxy
 	kvp, kvpch := grpcproxy.NewKvProxy(c)
-	wp, wpch := grpcproxy.NewWatchProxy(c)
+	wp, wpch := grpcproxy.NewWatchProxy(lg, c)
 	lp, lpch := grpcproxy.NewLeaseProxy(c)
 	mp := grpcproxy.NewMaintenanceProxy(c)
-	clp, _ := grpcproxy.NewClusterProxy(zap.NewExample(), c, "", "") // without registering proxy URLs
+	clp, _ := grpcproxy.NewClusterProxy(lg, c, "", "") // without registering proxy URLs
 	authp := grpcproxy.NewAuthProxy(c)
 	lockp := grpcproxy.NewLockProxy(c)
 	electp := grpcproxy.NewElectionProxy(c)

--- a/integration/cluster_proxy.go
+++ b/integration/cluster_proxy.go
@@ -27,6 +27,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const throughProxy = true
+
 var (
 	pmu     sync.Mutex
 	proxies map[*clientv3.Client]grpcClientProxy = make(map[*clientv3.Client]grpcClientProxy)

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -1241,8 +1241,16 @@ func TestV3WatchCancellation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if minWatches != "1" {
-		t.Fatalf("expected one watch, got %s", minWatches)
+	var expected string
+	if throughProxy {
+		// grpc proxy has additional 2 watches open
+		expected = "3"
+	} else {
+		expected = "1"
+	}
+
+	if minWatches != expected {
+		t.Fatalf("expected %s watch, got %s", expected, minWatches)
 	}
 }
 
@@ -1270,7 +1278,15 @@ func TestV3WatchCloseCancelRace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if minWatches != "0" {
-		t.Fatalf("expected zero watches, got %s", minWatches)
+	var expected string
+	if throughProxy {
+		// grpc proxy has additional 2 watches open
+		expected = "2"
+	} else {
+		expected = "0"
+	}
+
+	if minWatches != expected {
+		t.Fatalf("expected %s watch, got %s", expected, minWatches)
 	}
 }


### PR DESCRIPTION
Fixes:   
> go test --tags cluster_proxy --timeout=30m -v ./integration/... ./clientv3/integration/...

this contains 3 aspects: 

-----

**fixing broken build:**  (trivial)

 integration/cluster_proxy.go:58:37: not enough arguments in call to grpcproxy.NewWatchProxy
       have (*clientv3.Client)
       want (*zap.Logger, *clientv3.Client)
    FAIL    go.etcd.io/etcd/v3/integration [build failed]

-----

**fixing 2 failing tests: (TestV3WatchCloseCancelRace, TestV3WatchCancellation) **

grpc proxy opens additional 2 watching channels. The metric is shared between etcd-server & grpc_proxy, so all assertions on number of open watch channels need to take in consideration the additional "2" channels.

-----
** fixing clientv3/integration: TestLeasingTxtOwnerGet **     
    
Fixes:
>      go test --tags cluster_proxy --timeout=30m -run TestLeasingTxnOwnerGet -v ./clientv3/integration/...
   
The explicit code to close client is needed due to: 

https://github.com/etcd-io/etcd/blob/76e769ce95ca0d4d0e3486712d96956260db04b8/clientv3/watch.go#L72

as just ctx close by LeasingKeyValue store does not interrupts opened Watches.
The only way to interrupt open Watch is to close the 'whole' Watcher / Client.