### PR TITLE
embed, etcdmain, etcdserver, integration: adding rate limiting feature

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -17,6 +17,7 @@ package embed
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -56,6 +57,11 @@ const (
 	DefaultGRPCKeepAliveMinTime  = 5 * time.Second
 	DefaultGRPCKeepAliveInterval = 2 * time.Hour
 	DefaultGRPCKeepAliveTimeout  = 20 * time.Second
+
+	// Experimental Rate Limiter Defaults
+	DefaultRequestsPerSecondLimit   = -math.MaxFloat64
+	DefaultEnableRateLimiter        = ""
+	DefaultRateLimiterRequestFilter = ""
 
 	DefaultListenPeerURLs   = "http://localhost:2380"
 	DefaultListenClientURLs = "http://localhost:2379"
@@ -222,6 +228,13 @@ type Config struct {
 	// before closing a non-responsive connection. 0 to disable.
 	GRPCKeepAliveTimeout time.Duration `json:"grpc-keepalive-timeout"`
 
+	// EnableRateLimiter Experimental Rate Limiter rule flag
+	EnableRateLimiter string `json:"experimental-rate-limiter-rules"`
+	// RequestsPerSecondLimit Experimental Rate Limiter Value
+	RequestsPerSecondLimit float64 `json:"experimental-rate-limiter-requests-per-second"`
+	// RateLimiterRequestFilter Experimental Rate Limiter request filter
+	RateLimiterRequestFilter string `json:"experimental-rate-limiter-request-filter"`
+
 	// PreVote is true to enable Raft Pre-Vote.
 	// If enabled, Raft runs an additional election phase
 	// to check whether it would get enough votes to win
@@ -381,6 +394,11 @@ func NewConfig() *Config {
 		GRPCKeepAliveMinTime:  DefaultGRPCKeepAliveMinTime,
 		GRPCKeepAliveInterval: DefaultGRPCKeepAliveInterval,
 		GRPCKeepAliveTimeout:  DefaultGRPCKeepAliveTimeout,
+
+		// Experimental Rate Limiter
+		RequestsPerSecondLimit:   DefaultRequestsPerSecondLimit,
+		EnableRateLimiter:        DefaultEnableRateLimiter,
+		RateLimiterRequestFilter: DefaultRateLimiterRequestFilter,
 
 		TickMs:                     100,
 		ElectionMs:                 1000,

--- a/embed/etcd.go
+++ b/embed/etcd.go
@@ -201,6 +201,9 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		EnableLeaseCheckpoint:       cfg.ExperimentalEnableLeaseCheckpoint,
 		CompactionBatchLimit:        cfg.ExperimentalCompactionBatchLimit,
 		WatchProgressNotifyInterval: cfg.ExperimentalWatchProgressNotifyInterval,
+		EnableRateLimiter:           cfg.EnableRateLimiter,
+		RequestsPerSecondLimit:      cfg.RequestsPerSecondLimit,
+		RateLimiterRequestFilter:    cfg.RateLimiterRequestFilter,
 	}
 	print(e.cfg.logger, *cfg, srvcfg, memberInitialized)
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -252,6 +252,10 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.ExperimentalEnableLeaseCheckpoint, "experimental-enable-lease-checkpoint", false, "Enable to persist lease remaining TTL to prevent indefinite auto-renewal of long lived leases.")
 	fs.IntVar(&cfg.ec.ExperimentalCompactionBatchLimit, "experimental-compaction-batch-limit", cfg.ec.ExperimentalCompactionBatchLimit, "Sets the maximum revisions deleted in each compaction batch.")
 	fs.DurationVar(&cfg.ec.ExperimentalWatchProgressNotifyInterval, "experimental-watch-progress-notify-interval", cfg.ec.ExperimentalWatchProgressNotifyInterval, "Duration of periodic watch progress notifications.")
+	// Experimental Rate Limiter
+	fs.StringVar(&cfg.ec.EnableRateLimiter, "experimental-rate-limiter-rules", cfg.ec.EnableRateLimiter, "Enables the rate limiter with custom ruleset options (if any are passed).")
+	fs.Float64Var(&cfg.ec.RequestsPerSecondLimit, "experimental-rate-limiter-requests-per-second", cfg.ec.RequestsPerSecondLimit, "Sets the limit for requests/second served by the server.")
+	fs.StringVar(&cfg.ec.RateLimiterRequestFilter, "experimental-rate-limiter-request-filter", cfg.ec.RateLimiterRequestFilter, "Sets the type of the requests to be filtered.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -212,6 +212,12 @@ Experimental feature:
     Skip verification of SAN field in client certificate for peer connections.
   --experimental-watch-progress-notify-interval '10m'
     Duration of periodical watch progress notification.
+  --experimental-rate-limiter-rules
+    Enable rate limiter, pass custom rule names as value to the flag to enable rules.
+  --experimental-rate-limiter-requests-per-second
+    Sets the limit for requests/second served by the server.
+  --experimental-rate-limiter-request-filter
+    Sets the type of the requests to be filtered.
 
 Unsafe feature:
   --force-new-cluster 'false'

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -44,8 +44,9 @@ var (
 	ErrGRPCLearnerNotReady        = status.New(codes.FailedPrecondition, "etcdserver: can only promote a learner member which is in sync with leader").Err()
 	ErrGRPCTooManyLearners        = status.New(codes.FailedPrecondition, "etcdserver: too many learner members in cluster").Err()
 
-	ErrGRPCRequestTooLarge        = status.New(codes.InvalidArgument, "etcdserver: request is too large").Err()
-	ErrGRPCRequestTooManyRequests = status.New(codes.ResourceExhausted, "etcdserver: too many requests").Err()
+	ErrGRPCRequestTooLarge             = status.New(codes.InvalidArgument, "etcdserver: request is too large").Err()
+	ErrGRPCRequestTooManyRequests      = status.New(codes.ResourceExhausted, "etcdserver: too many requests").Err()
+	ErrGRPCRequestRequestLimitExceeded = status.New(codes.ResourceExhausted, "etcdserver: request per second limit exceeded").Err()
 
 	ErrGRPCRootUserNotExist     = status.New(codes.FailedPrecondition, "etcdserver: root user does not exist").Err()
 	ErrGRPCRootRoleNotExist     = status.New(codes.FailedPrecondition, "etcdserver: root user does not have root role").Err()
@@ -107,8 +108,9 @@ var (
 		ErrorDesc(ErrGRPCLearnerNotReady):        ErrGRPCLearnerNotReady,
 		ErrorDesc(ErrGRPCTooManyLearners):        ErrGRPCTooManyLearners,
 
-		ErrorDesc(ErrGRPCRequestTooLarge):        ErrGRPCRequestTooLarge,
-		ErrorDesc(ErrGRPCRequestTooManyRequests): ErrGRPCRequestTooManyRequests,
+		ErrorDesc(ErrGRPCRequestTooLarge):             ErrGRPCRequestTooLarge,
+		ErrorDesc(ErrGRPCRequestTooManyRequests):      ErrGRPCRequestTooManyRequests,
+		ErrorDesc(ErrGRPCRequestRequestLimitExceeded): ErrGRPCRequestRequestLimitExceeded,
 
 		ErrorDesc(ErrGRPCRootUserNotExist):     ErrGRPCRootUserNotExist,
 		ErrorDesc(ErrGRPCRootRoleNotExist):     ErrGRPCRootRoleNotExist,
@@ -172,8 +174,9 @@ var (
 	ErrMemberLearnerNotReady  = Error(ErrGRPCLearnerNotReady)
 	ErrTooManyLearners        = Error(ErrGRPCTooManyLearners)
 
-	ErrRequestTooLarge = Error(ErrGRPCRequestTooLarge)
-	ErrTooManyRequests = Error(ErrGRPCRequestTooManyRequests)
+	ErrRequestTooLarge      = Error(ErrGRPCRequestTooLarge)
+	ErrTooManyRequests      = Error(ErrGRPCRequestTooManyRequests)
+	ErrRequestLimitExceeded = Error(ErrGRPCRequestRequestLimitExceeded)
 
 	ErrRootUserNotExist     = Error(ErrGRPCRootUserNotExist)
 	ErrRootRoleNotExist     = Error(ErrGRPCRootRoleNotExist)

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -40,11 +40,12 @@ var toGRPCErrorMap = map[error]error{
 	etcdserver.ErrNotEnoughStartedMembers: rpctypes.ErrMemberNotEnoughStarted,
 	etcdserver.ErrLearnerNotReady:         rpctypes.ErrGRPCLearnerNotReady,
 
-	mvcc.ErrCompacted:             rpctypes.ErrGRPCCompacted,
-	mvcc.ErrFutureRev:             rpctypes.ErrGRPCFutureRev,
-	etcdserver.ErrRequestTooLarge: rpctypes.ErrGRPCRequestTooLarge,
-	etcdserver.ErrNoSpace:         rpctypes.ErrGRPCNoSpace,
-	etcdserver.ErrTooManyRequests: rpctypes.ErrTooManyRequests,
+	mvcc.ErrCompacted:                  rpctypes.ErrGRPCCompacted,
+	mvcc.ErrFutureRev:                  rpctypes.ErrGRPCFutureRev,
+	etcdserver.ErrRequestTooLarge:      rpctypes.ErrGRPCRequestTooLarge,
+	etcdserver.ErrNoSpace:              rpctypes.ErrGRPCNoSpace,
+	etcdserver.ErrTooManyRequests:      rpctypes.ErrTooManyRequests,
+	etcdserver.ErrRequestLimitExceeded: rpctypes.ErrRequestLimitExceeded,
 
 	etcdserver.ErrNoLeader:                   rpctypes.ErrGRPCNoLeader,
 	etcdserver.ErrNotLeader:                  rpctypes.ErrGRPCNotLeader,

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -116,6 +116,11 @@ type ServerConfig struct {
 	QuotaBackendBytes       int64
 	MaxTxnOps               uint
 
+	EnableRateLimiter        string
+	RequestsPerSecondLimit   float64
+	RateLimiterRequestFilter string
+	CustomRuleMap            map[string]RateLimiterRule
+
 	// MaxRequestBytes is the maximum request size to send over raft.
 	MaxRequestBytes uint
 

--- a/etcdserver/errors.go
+++ b/etcdserver/errors.go
@@ -44,6 +44,7 @@ var (
 	ErrInvalidDowngradeTargetVersion = errors.New("etcdserver: invalid downgrade target version")
 	ErrDowngradeInProcess            = errors.New("etcdserver: cluster has a downgrade job in progress")
 	ErrNoInflightDowngrade           = errors.New("etcdserver: no inflight downgrade job")
+	ErrRequestLimitExceeded          = errors.New("etcdserver: request per second limit exceeded")
 )
 
 type DiscoveryError struct {

--- a/etcdserver/rate_limiter.go
+++ b/etcdserver/rate_limiter.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+	"strings"
+)
+
+// RateLimiter defines a rate limiter
+type RateLimiter interface {
+	// Limit decides whether to limit the current request based on the available quota.
+	Limit(reqType string) bool
+}
+
+// allowAllRequests allows all the requests without filtering
+type allowAllRequests struct{}
+
+// Limit does not limit any request in this interface
+func (*allowAllRequests) Limit(string) bool { return false }
+
+const (
+	etcdserverpbkv = "/etcdserverpb.KV/"
+	kvPut          = etcdserverpbkv + "Put"
+	kvRange        = etcdserverpbkv + "Range"
+	kvDelete       = etcdserverpbkv + "Delete"
+	kvCompact      = etcdserverpbkv + "Compact"
+)
+
+// rateLimiter rate limiter object
+type rateLimiter struct {
+	//s Etcd Server
+	s *EtcdServer
+	// maxRequestsPerSecond the max number of allowed requests/second
+	maxRequestsPerSecond float64
+	// ruleSet rate limiter ruleset
+	ruleSet RateLimiterRuleSet
+	// rateLimiterRequestTypeFilter rate limiter request Type filter
+	rateLimiterRequestTypeFilter map[string]bool
+	// rateLimiter rate checker to rate limit
+	rateLimiter *rate.Limiter
+}
+
+// NewRateLimiter returns a new rateLimiter
+func NewRateLimiter(s *EtcdServer, name string) RateLimiter {
+	lg := s.getLogger()
+
+	// rateLimiterRequestTypeFilter Accept from the user as input
+	// compare with this, flip bool values according user input
+	// below configuration represents default prefs which are subject to rate limiting,
+	// type of requests (key) : filter enabled for these kinds of request (value)
+	var rateLimiterRequestTypeFilter = map[string]bool{
+		kvPut:     false,
+		kvRange:   false,
+		kvDelete:  false,
+		kvCompact: false,
+	}
+
+	// Check if any request filters were applied
+	if len(s.Cfg.RateLimiterRequestFilter) > 0 {
+		// Split the user input into each type, for example: Put, Range, Delete, etc
+		requestTypes := strings.Split(s.Cfg.RateLimiterRequestFilter, ",")
+		for _, requestType := range requestTypes {
+			// Check if the "/etcdserverpb.KV/"  requestType exists in our map.
+			current := etcdserverpbkv + strings.Title(strings.ToLower(strings.TrimSpace(requestType)))
+			if _, ok := rateLimiterRequestTypeFilter[current]; ok {
+				// if true, enable rate limiting for that type
+				rateLimiterRequestTypeFilter[current] = true
+			}
+		}
+	}
+
+	// Check if rate limiter is enabled by checking if value is greater than 0
+	if s.Cfg.RequestsPerSecondLimit > 0 {
+		// Check if any rule flags were passed, else enable a simple rate limiter
+		if len(strings.TrimSpace(s.Cfg.EnableRateLimiter)) <= 0 {
+			if lg != nil {
+				lg.Info(
+					"simple rate limiter will be enabled",
+					zap.String("rate-limiter-name", name),
+					zap.Float64("rate-limit", s.Cfg.RequestsPerSecondLimit),
+				)
+			}
+			return &rateLimiter{
+				s,
+				s.Cfg.RequestsPerSecondLimit,
+				nil,
+				rateLimiterRequestTypeFilter,
+				rate.NewLimiter(rate.Limit(s.Cfg.RequestsPerSecondLimit), int(s.Cfg.RequestsPerSecondLimit)),
+			}
+		}
+		// Initialize the rate limiter, custom rule set and return
+		quotaLogOnce.Do(func() {
+			if lg != nil {
+				lg.Info(
+					"custom rate limiter will be enabled",
+					zap.String("rate-limiter-name", name),
+					zap.Float64("rate-limit", s.Cfg.RequestsPerSecondLimit),
+				)
+			}
+		})
+		return &rateLimiter{
+			s,
+			s.Cfg.RequestsPerSecondLimit,
+			NewCustomRuleSet(s),
+			rateLimiterRequestTypeFilter,
+			rate.NewLimiter(rate.Limit(s.Cfg.RequestsPerSecondLimit), int(s.Cfg.RequestsPerSecondLimit)),
+		}
+	}
+
+	// No rate limiters were enabled, will let each request pass through transparently.
+	return &allowAllRequests{}
+}
+
+// Limit decides whether the server is allowed to serve request based on defined rules
+func (r rateLimiter) Limit(reqType string) bool {
+	// Check if this type of request is to be filtered at all, if not, skip
+	if r.rateLimiterRequestTypeFilter[reqType] {
+		// If, ruleset is not available and status does not have any rules enabled, let request
+		// pass through
+		// Else, rate limit (which means, either the simple rate limiter was triggered or a rule was
+		// enabled
+		if r.ruleSet != nil && !r.ruleSet.Status() {
+			// Allow means we're not rate limiting, so flip the condition
+			// and allow everything that passes through
+			return false
+		}
+		return !r.rateLimiter.Allow()
+	}
+	// If disabled or not filtered request type, let the request pass through because we're NOT
+	// rate limiting
+	return false
+}

--- a/etcdserver/rate_limiter_example_rule1.go
+++ b/etcdserver/rate_limiter_example_rule1.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+// customRule1 Defines the custom rule
+type customRule1 struct {
+	// RefreshRate refresh rate in milliseconds
+	RefreshRate int
+	// RuleStatus the status of the rule
+	RuleStatus bool
+}
+
+// NewCustomRule1 prepares custom rule 1
+func NewCustomRule1(s *EtcdServer) RateLimiterRule {
+	// By default the rule set is disabled, will automatically kick in once a rule is activated in the go routine
+	cr1 := &customRule1{
+		RefreshRate: 150000,
+		RuleStatus:  false,
+	}
+	return cr1
+}
+
+// RefreshRateInMs refresh rate in milliseconds for custom rule 1
+func (cr1 *customRule1) RefreshRateInMs() int {
+	return cr1.RefreshRate
+}
+
+// Active defines the rule and returns an bool
+func (cr1 *customRule1) Active() bool {
+	return cr1.RuleStatus
+}

--- a/etcdserver/rate_limiter_example_rule2.go
+++ b/etcdserver/rate_limiter_example_rule2.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+// customRule2 Defines the custom rule
+type customRule2 struct {
+	// RefreshRate refresh rate of rules in milliseconds
+	RefreshRate int
+	// RuleStatus the status of the rule
+	RuleStatus bool
+}
+
+// NewCustomRule2 prepares custom rule 2
+func NewCustomRule2(s *EtcdServer) RateLimiterRule {
+	// By default the rule set is disabled, will automatically kick in once a rule is activated in the go routine
+	cr2 := &customRule2{
+		RefreshRate: 150000,
+		RuleStatus:  true,
+	}
+	return cr2
+}
+
+// RefreshRateInMs refresh rate in milliseconds for custom rule 2
+func (cr2 *customRule2) RefreshRateInMs() int {
+	return cr2.RefreshRate
+}
+
+// Active defines the rule and returns an bool
+func (cr2 *customRule2) Active() bool {
+	return cr2.RuleStatus
+}

--- a/etcdserver/rate_limiter_rule.go
+++ b/etcdserver/rate_limiter_rule.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+// RateLimiterRule rate limiter ruleset
+type RateLimiterRule interface {
+	// RefreshRateInMs refresh rate of the rule in millisecond(s)
+	RefreshRateInMs() int
+	// Active implements the logic of the rule
+	// true = rule is active and requests will be subject to the rate limiter
+	// false = rule is NOT active and will NOT be subject to the rate limiter
+	Active() bool
+}

--- a/etcdserver/rate_limiter_ruleset.go
+++ b/etcdserver/rate_limiter_ruleset.go
@@ -1,0 +1,180 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimiterRuleSet rate limiter rule set
+type RateLimiterRuleSet interface {
+	// Compute Computes the rules
+	Compute()
+	// Status Checks for any rule violations
+	Status() bool
+}
+
+// customRuleSet custom rule set
+type customRuleSet struct {
+	// RuleStatus an atomic bool value is updated at rule updates
+	RuleStatus atomic.Bool
+	// RuleStatusMap a map of statuses of all rules
+	RuleStatusMap *sync.Map
+	// terminationChannel terminates all go routines when server is closed
+	terminationChannel chan bool
+	// updateRuleChannel to communicate rule updates
+	updateRuleChannel chan struct{}
+	// CustomRules map of rules to the rate limiter rule
+	CustomRules map[string]RateLimiterRule
+	// server Etcd server reference
+	server *EtcdServer
+}
+
+// NewCustomRuleSet prepares a custom rule set
+func NewCustomRuleSet(s *EtcdServer) RateLimiterRuleSet {
+	// Check for any custom maps already defined
+	customRuleMap := s.Cfg.CustomRuleMap
+	if customRuleMap == nil {
+		customRuleMap = InitiateRules(s)
+	}
+
+	// By default the rule set is disabled,
+	// will automatically kick in once a rule is activated in the go routine
+	crs := &customRuleSet{
+		RuleStatusMap:      &sync.Map{},
+		CustomRules:        customRuleMap,
+		terminationChannel: s.RulesetRoutine,
+		server:             s,
+		updateRuleChannel:  make(chan struct{}),
+	}
+
+	// Initiate all compute routines, if any
+	crs.Compute()
+	return crs
+}
+
+// InitiateRules initiates all the rules as per user configuration
+func InitiateRules(s *EtcdServer) map[string]RateLimiterRule {
+	lg := s.lg
+	// Build a map of all the rules passed and a map of all rules initiated
+	enabledRuleset := map[string]bool{}
+	customRules := map[string]RateLimiterRule{}
+
+	// Check for all the rules user has enabled and prepare the map
+	for _, currentRule := range strings.Split(s.Cfg.EnableRateLimiter, ",") {
+		enabledRuleset[strings.ToLower(strings.TrimSpace(currentRule))] = true
+	}
+
+	// Go through each rule definition and check what was enabled
+	// Define rule1
+	ruleName1 := "rule1"
+	if _, ok := enabledRuleset[ruleName1]; ok {
+		customRules[ruleName1] = NewCustomRule1(s)
+		if lg != nil {
+			lg.Info("custom rule enabled", zap.String("rule-name", ruleName1))
+		}
+	}
+
+	// Define rule2
+	ruleName2 := "rule2"
+	if _, ok := enabledRuleset[ruleName2]; ok {
+		customRules[ruleName2] = NewCustomRule2(s)
+		if lg != nil {
+			lg.Info("custom rule enabled", zap.String("rule-name", ruleName2))
+		}
+	}
+	return customRules
+}
+
+// Compute rule checker compute
+func (crs *customRuleSet) Compute() {
+	lg := crs.server.lg
+	// Check if no rules are enabled, if so no need to actually run a go routine.
+	if len(crs.CustomRules) == 0 {
+		if lg != nil {
+			lg.Info("none of the custom rules were available")
+		}
+		return
+	}
+
+	// Go through each active rule and initiate the go routine
+	for ruleName := range crs.CustomRules {
+		go crs.ComputeRoutine(ruleName)
+	}
+
+	// Spin up a go routine to compute status at the frequency defined by rule
+	go crs.StatusRoutine()
+}
+
+// ComputeRoutine is running the go routine
+func (crs *customRuleSet) ComputeRoutine(ruleName string) {
+	// Initiate a ticker to refresh the rule periodically
+	ticker := time.NewTicker(time.Duration(crs.CustomRules[ruleName].RefreshRateInMs()) * time.Millisecond)
+	previousValue := false
+
+	// Run forever
+	for {
+		select {
+		case <-ticker.C:
+			// Load the current value of the rule
+			// If value is same as previous value, move on
+			// Else, update the value and channel a change
+			// The change will trigger the statusMap to be recomputed
+			currentValue := crs.CustomRules[ruleName].Active()
+			if currentValue != previousValue {
+				crs.RuleStatusMap.Store(ruleName, currentValue)
+				previousValue = currentValue
+				crs.updateRuleChannel <- struct{}{}
+			}
+		case <-crs.terminationChannel:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// Status check current status of rate limiter
+func (crs *customRuleSet) Status() bool {
+	return crs.RuleStatus.Load()
+}
+
+// StatusRoutine compute the status of the rule every ticker time
+func (crs *customRuleSet) StatusRoutine() {
+	for {
+		select {
+		case <-crs.updateRuleChannel:
+			// Initialise the current result false
+			// Presumes none of the rules are active
+			var currentResult bool
+			// Go through each of the rule statuses and check if any are active
+			crs.RuleStatusMap.Range(func(key, value interface{}) bool {
+				current := value.(bool)
+				if current {
+					// Found an active one, update current result
+					currentResult = true
+				}
+				return true
+			})
+			// Update the RuleStatus accordingly
+			crs.RuleStatus.Store(currentResult)
+		case <-crs.terminationChannel:
+			return
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 	go.etcd.io/bbolt v1.3.5
+	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -141,6 +141,11 @@ type ClusterConfig struct {
 	GRPCKeepAliveInterval time.Duration
 	GRPCKeepAliveTimeout  time.Duration
 
+	EnableRateLimiter        string
+	RequestsPerSecondLimit   float64
+	RateLimiterRequestFilter string
+	CustomRuleMap            map[string]etcdserver.RateLimiterRule
+
 	// SkipCreatingClient to skip creating clients for each member.
 	SkipCreatingClient bool
 
@@ -302,6 +307,10 @@ func (c *cluster) mustNewMember(t testing.TB) *member {
 			enableLeaseCheckpoint:       c.cfg.EnableLeaseCheckpoint,
 			leaseCheckpointInterval:     c.cfg.LeaseCheckpointInterval,
 			WatchProgressNotifyInterval: c.cfg.WatchProgressNotifyInterval,
+			enableRateLimiter:           c.cfg.EnableRateLimiter,
+			requestsPerSecondLimit:      c.cfg.RequestsPerSecondLimit,
+			rateLimiterRequestFilter:    c.cfg.RateLimiterRequestFilter,
+			customRuleMap:               c.cfg.CustomRuleMap,
 		})
 	m.DiscoveryURL = c.cfg.DiscoveryURL
 	if c.cfg.UseGRPC {
@@ -592,6 +601,10 @@ type memberConfig struct {
 	enableLeaseCheckpoint       bool
 	leaseCheckpointInterval     time.Duration
 	WatchProgressNotifyInterval time.Duration
+	requestsPerSecondLimit      float64
+	rateLimiterRequestFilter    string
+	enableRateLimiter           string
+	customRuleMap               map[string]etcdserver.RateLimiterRule
 }
 
 // mustNewMember return an inited member with the given name. If peerTLS is
@@ -679,6 +692,13 @@ func mustNewMember(t testing.TB, mcfg memberConfig) *member {
 			Timeout: mcfg.grpcKeepAliveTimeout,
 		}))
 	}
+
+	// Experimental Rate Limiter
+	m.RequestsPerSecondLimit = mcfg.requestsPerSecondLimit
+	m.RateLimiterRequestFilter = mcfg.rateLimiterRequestFilter
+	m.EnableRateLimiter = mcfg.enableRateLimiter
+	m.CustomRuleMap = mcfg.customRuleMap
+
 	m.clientMaxCallSendMsgSize = mcfg.clientMaxCallSendMsgSize
 	m.clientMaxCallRecvMsgSize = mcfg.clientMaxCallRecvMsgSize
 	m.useIP = mcfg.useIP

--- a/integration/rate_limiter_test_rule.go
+++ b/integration/rate_limiter_test_rule.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import "go.etcd.io/etcd/v3/etcdserver"
+
+// testRule Defines the test rule
+type testRule struct {
+	// RefreshRate refresh rate in milliseconds
+	RefreshRate int
+	// RuleStatus the status of the rule
+	RuleStatus bool
+}
+
+// NewTestRule prepares test rule
+func NewTestRule(refreshRate int) etcdserver.RateLimiterRule {
+	// By default the rule set is disabled, will automatically kick in once a rule is activated in the go routine
+	testRule := &testRule{
+		RefreshRate: refreshRate,
+		RuleStatus:  true,
+	}
+	return testRule
+}
+
+// RefreshRateInMs refresh rate in milliseconds for test rule
+func (tr *testRule) RefreshRateInMs() int {
+	return tr.RefreshRate
+}
+
+// Active defines the rule and returns an bool
+func (tr *testRule) Active() bool {
+	return tr.RuleStatus
+}


### PR DESCRIPTION
This feature enables the user to rate limit requests/sec,
either all the time or as per user defined rules.

Document: https://tinyurl.com/y5yezy4t
Issue: https://github.com/etcd-io/etcd/issues/12164