### PR TITLE
config: grpc gateway

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -323,7 +323,8 @@ type Config struct {
 	loggerCore        zapcore.Core
 	loggerWriteSyncer zapcore.WriteSyncer
 
-	// EnableGRPCGateway is false to disable grpc gateway.
+	// EnableGRPCGateway enables grpc gateway.
+	// The gateway translates a RESTful HTTP API into gRPC.
 	EnableGRPCGateway bool `json:"enable-grpc-gateway"`
 
 	// UnsafeNoFsync disables all uses of fsync.
@@ -406,11 +407,12 @@ func NewConfig() *Config {
 
 		PreVote: false, // TODO: enable by default in v3.5
 
-		loggerMu:   new(sync.RWMutex),
-		logger:     nil,
-		Logger:     "zap",
-		LogOutputs: []string{DefaultLogOutput},
-		LogLevel:   logutil.DefaultLogLevel,
+		loggerMu:          new(sync.RWMutex),
+		logger:            nil,
+		Logger:            "zap",
+		LogOutputs:        []string{DefaultLogOutput},
+		LogLevel:          logutil.DefaultLogLevel,
+		EnableGRPCGateway: true,
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -243,7 +243,7 @@ func newConfig() *config {
 	fs.UintVar(&cfg.ec.AuthTokenTTL, "auth-token-ttl", cfg.ec.AuthTokenTTL, "The lifetime in seconds of the auth token.")
 
 	// gateway
-	fs.BoolVar(&cfg.ec.EnableGRPCGateway, "enable-grpc-gateway", true, "Enable GRPC gateway.")
+	fs.BoolVar(&cfg.ec.EnableGRPCGateway, "enable-grpc-gateway", cfg.ec.EnableGRPCGateway, "Enable GRPC gateway.")
 
 	// experimental
 	fs.BoolVar(&cfg.ec.ExperimentalInitialCorruptCheck, "experimental-initial-corrupt-check", cfg.ec.ExperimentalInitialCorruptCheck, "Enable to check data corruption before serving any client/peer traffic.")


### PR DESCRIPTION
Currently, the grpc gateway is enabled by default when run the etcd server
using command line configuration. However, when provide config through
config file, the grpc gateway is disabled by default. We should either use
the same approach or at least document this.

related #https://github.com/etcd-io/etcd/issues/12093



