### PR TITLE
etcdserver: v3compactor should use proper clock for latency (took) reporting

### DIFF
--- a/etcdserver/api/v3compactor/periodic.go
+++ b/etcdserver/api/v3compactor/periodic.go
@@ -136,13 +136,14 @@ func (pc *Periodic) Run() {
 				zap.Int64("revision", rev),
 				zap.Duration("compact-period", pc.period),
 			)
+			startTime := pc.clock.Now()
 			_, err := pc.c.Compact(pc.ctx, &pb.CompactionRequest{Revision: rev})
 			if err == nil || err == mvcc.ErrCompacted {
 				pc.lg.Info(
 					"completed auto periodic compaction",
 					zap.Int64("revision", rev),
 					zap.Duration("compact-period", pc.period),
-					zap.Duration("took", time.Since(lastSuccess)),
+					zap.Duration("took", pc.clock.Now().Sub(startTime)),
 				)
 				lastSuccess = pc.clock.Now()
 			} else {


### PR DESCRIPTION
The code used to:
  - report time since previous compaction success as a 'duration' of compaction process itself.
  - mix real clock with 'injected' clock. This led to strange log-lines
in tests in order of 234543543h of duration.