### PR TITLE
etcdserver: fix log info error

### DIFF
--- a/etcdserver/util.go
+++ b/etcdserver/util.go
@@ -141,7 +141,7 @@ func warnOfExpensiveReadOnlyTxnRequest(lg *zap.Logger, now time.Time, r *pb.TxnR
 		}
 		resp = fmt.Sprintf("responses:<%s> size:%d", strings.Join(resps, " "), proto.Size(txnResponse))
 	}
-	warnOfExpensiveGenericRequest(lg, now, reqStringer, "read-only range ", resp, err)
+	warnOfExpensiveGenericRequest(lg, now, reqStringer, "read-only txn ", resp, err)
 }
 
 func warnOfExpensiveReadOnlyRangeRequest(lg *zap.Logger, now time.Time, reqStringer fmt.Stringer, rangeResponse *pb.RangeResponse, err error) {


### PR DESCRIPTION

etcdserver#util.go#warnOfExpensiveReadOnlyTxnRequest logs with wrong prefix "read-only range ".
It has to be "read-only txn ".

Fixes #12295
