### PR TITLE
pkg/testutil: Ignore flakes due to "leaked" testing.runTests goroutine

### DIFF
--- a/pkg/testutil/leak.go
+++ b/pkg/testutil/leak.go
@@ -124,6 +124,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "created by os/signal.init") ||
 			strings.Contains(stack, "runtime/panic.go") ||
 			strings.Contains(stack, "created by testing.RunTests") ||
+			strings.Contains(stack, "created by testing.runTests") ||
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "go.etcd.io/etcd/v3/pkg/testutil.interestingGoroutines") ||


### PR DESCRIPTION
The flake happened e.g. in:
https://travis-ci.com/github/etcd-io/etcd/jobs/386607570

```
--- PASS: TestWatchClose (0.37s)
PASS
Unexpected goroutines running after all test(s).
1 instances of:
testing.runTests.func1.1(...)
	/usr/local/go/src/testing/testing.go:1289 +0x60
created by testing.runTests.func1
	/usr/local/go/src/testing/testing.go:1289 +0xdb
FAIL	go.etcd.io/etcd/v3/clientv3/integration	344.389s
FAIL
```