### PR TITLE
tests: fix test case panic error

### DIFF
--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -305,8 +305,13 @@ func TestGrpcproxyAndCommonName(t *testing.T) {
 	}
 
 	p, err := spawnCmd(argsWithEmptyCN)
+	defer func() {
+		if p != nil {
+			p.Stop()
+		}
+	}()
+
 	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
+		t.Fatal(err)
 	}
-	p.Stop()
 }


### PR DESCRIPTION
Fix test case in tests/e2e/etcd_config_test.go:311, here should
check if it is nil. As the following errors:

--- FAIL: TestGrpcproxyAndCommonName (0.00s)
    etcd_config_test.go:304: Unexpected error: fork/exec ../../bin/etcd: no such file or directory
    etcd_config_test.go:309: Unexpected error: fork/exec ../../bin/etcd: no such file or directory
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56bd96]


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
