### PR TITLE
 etcdserver: add more detailed traces on linearized reading

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"strconv"
 	"time"
 
 	"go.etcd.io/etcd/v3/auth"
@@ -715,6 +716,9 @@ func (s *EtcdServer) linearizableReadLoop() {
 			return
 		}
 
+		// as a single loop is can unlock multiple reads, it is not very useful
+		// to propagate the trace from Txn or Range.
+		trace := traceutil.New("linearizableReadLoop", s.getLogger())
 		nextnr := newNotifier()
 
 		s.readMu.Lock()
@@ -775,16 +779,26 @@ func (s *EtcdServer) linearizableReadLoop() {
 		if !done {
 			continue
 		}
+		trace.Step("read index received")
 
-		if ai := s.getAppliedIndex(); ai < rs.Index {
+		index := rs.Index
+		trace.AddField(traceutil.Field{Key: "readStateIndex", Value: index})
+
+		ai := s.getAppliedIndex()
+		trace.AddField(traceutil.Field{Key: "appliedIndex", Value: strconv.FormatUint(ai, 10)})
+
+		if ai < index {
 			select {
-			case <-s.applyWait.Wait(rs.Index):
+			case <-s.applyWait.Wait(index):
 			case <-s.stopping:
 				return
 			}
 		}
 		// unblock all l-reads requested at indices before rs.Index
 		nr.notify(nil)
+		trace.Step("applied index is now lower than readState.Index")
+
+		trace.LogAllStepsIfLong(traceThreshold)
 	}
 }
 

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -157,6 +157,13 @@ func (t *Trace) LogIfLong(threshold time.Duration) {
 	}
 }
 
+// LogAllStepsIfLong dumps all logs if the duration is longer than threshold
+func (t *Trace) LogAllStepsIfLong(threshold time.Duration) {
+	if time.Since(t.startTime) > threshold {
+		t.LogWithStepThreshold(0)
+	}
+}
+
 // LogWithStepThreshold only dumps step whose duration is longer than step threshold
 func (t *Trace) LogWithStepThreshold(threshold time.Duration) {
 	msg, fs := t.logInfo(threshold)


### PR DESCRIPTION
This PR is related to #11884 

## Why

To improve debuggability of `agreement among raft nodes before linearized reading`, we added some tracing inside `linearizableReadLoop`.

This will allow us to know the timing of `s.r.ReadIndex` vs `s.applyWait.Wait(rs.Index)`.

## Results

The patch has been deployed on clusters running v3.4.9, here's some traces:

```json
{
  "level": "info",
  "ts": "2020-09-22T12:54:01.021Z",
  "caller": "traceutil/trace.go:152",
  "msg": "trace[2138445431] linearizableReadLoop",
  "detail": "",
  "duration": "855.447896ms",
  "start": "2020-09-22T12:54:00.166Z",
  "end": "2020-09-22T12:54:01.021Z",
  "steps": [
    "trace[2138445431] read index received  (duration: 824.408µs)",
    "trace[2138445431] applied index is now lower than readState.Index  (duration: 854.622058ms)"
  ]
}
```