### PR TITLE
raft/log: Get rid of the junk code

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -327,11 +327,6 @@ func (l *raftLog) slice(lo, hi, maxSize uint64) ([]pb.Entry, error) {
 			panic(err) // TODO(bdarnell)
 		}
 
-		// check if ents has reached the size limitation
-		if uint64(len(storedEnts)) < min(hi, l.unstable.offset)-lo {
-			return storedEnts, nil
-		}
-
 		ents = storedEnts
 	}
 	if hi > l.unstable.offset {


### PR DESCRIPTION
in raft/log, func slice(), the min of len of soredEnts is equal to
`min(hi, l.unstable.offset)-lo`, so we cloud remove this code.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
