### PR TITLE
raft/raft: remove redundant state setting in progress

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1152,7 +1152,6 @@ func stepLeader(r *raft, m pb.Message) error {
 					// move to replicating state, that would only happen with
 					// the next round of appends (but there may not be a next
 					// round for a while, exposing an inconsistent RaftStatus).
-					pr.BecomeProbe()
 					pr.BecomeReplicate()
 				case pr.State == tracker.StateReplicate:
 					pr.Inflights.FreeLE(m.Index)


### PR DESCRIPTION
raft/raft,  in Line 1155, remove `pr.BecomeProbe()` but use `pr.BecomeReplicate()` last.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
