### PR TITLE
Fix "race" - auth unit tests leaking goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
         sudo HOST_TMP_DIR=/tmp TEST_OPTS="VERBOSE='1'" make docker-test-coverage
         ;;
       linux-amd64-fmt-unit-go-tip-2-cpu)
-        GOARCH=amd64 PASSES='fmt unit' 'CPU=2' ./test -p=2
+        GOARCH=amd64 PASSES='fmt unit' CPU='2' RACE='false' ./test -p=2
         ;;
       linux-386-unit-1-cpu)
         docker run --rm \

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package integration
+package auth
 
 import (
 	"testing"

--- a/auth/simple_token.go
+++ b/auth/simple_token.go
@@ -36,6 +36,7 @@ const (
 )
 
 // var for testing purposes
+// TODO: Remove this mutable global state - as it's race-prone.
 var (
 	simpleTokenTTLDefault    = 300 * time.Second
 	simpleTokenTTLResolution = 1 * time.Second

--- a/auth/simple_token_test.go
+++ b/auth/simple_token_test.go
@@ -50,6 +50,7 @@ func TestSimpleTokenDisabled(t *testing.T) {
 func TestSimpleTokenAssign(t *testing.T) {
 	tp := newTokenProviderSimple(zap.NewExample(), dummyIndexWaiter, simpleTokenTTLDefault)
 	tp.enable()
+	defer tp.disable()
 	ctx := context.WithValue(context.WithValue(context.TODO(), AuthenticateParamIndex{}, uint64(1)), AuthenticateParamSimpleTokenPrefix{}, "dummy")
 	token, err := tp.assign(ctx, "user1", 0)
 	if err != nil {

--- a/client/integration/main_test.go
+++ b/client/integration/main_test.go
@@ -5,16 +5,11 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"go.etcd.io/etcd/v3/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {
-	v := m.Run()
-	if v == 0 && testutil.CheckLeakedGoroutine() {
-		os.Exit(1)
-	}
-	os.Exit(v)
+	testutil.MustTestMainWithLeakDetection(m)
 }

--- a/clientv3/integration/main_test.go
+++ b/clientv3/integration/main_test.go
@@ -5,16 +5,11 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"go.etcd.io/etcd/v3/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {
-	v := m.Run()
-	if v == 0 && testutil.CheckLeakedGoroutine() {
-		os.Exit(1)
-	}
-	os.Exit(v)
+	testutil.MustTestMainWithLeakDetection(m)
 }

--- a/etcdserver/api/v3rpc/interceptor.go
+++ b/etcdserver/api/v3rpc/interceptor.go
@@ -264,13 +264,13 @@ func monitorLeader(s *etcdserver.EtcdServer) *streamsMap {
 		streams: make(map[grpc.ServerStream]struct{}),
 	}
 
-	go func() {
+	s.GoAttach(func() {
 		election := time.Duration(s.Cfg.TickMs) * time.Duration(s.Cfg.ElectionTicks) * time.Millisecond
 		noLeaderCnt := 0
 
 		for {
 			select {
-			case <-s.StopNotify():
+			case <-s.StoppingNotify():
 				return
 			case <-time.After(election):
 				if s.Leader() == types.ID(raft.None) {
@@ -295,7 +295,7 @@ func monitorLeader(s *etcdserver.EtcdServer) *streamsMap {
 				}
 			}
 		}
-	}()
+	})
 
 	return smap
 }

--- a/etcdserver/corrupt.go
+++ b/etcdserver/corrupt.go
@@ -180,7 +180,7 @@ func (s *EtcdServer) checkHashKV() error {
 			Action:   pb.AlarmRequest_ACTIVATE,
 			Alarm:    pb.AlarmType_CORRUPT,
 		}
-		s.goAttach(func() {
+		s.GoAttach(func() {
 			s.raftRequest(s.ctx, pb.InternalRaftRequest{Alarm: a})
 		})
 	}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -429,9 +429,11 @@ func (c *cluster) waitMembersMatch(t testing.TB, membs []client.Member) {
 	}
 }
 
+// WaitLeader returns index of the member in c.Members that is leader (or -1).
 func (c *cluster) WaitLeader(t testing.TB) int { return c.waitLeader(t, c.Members) }
 
-// waitLeader waits until given members agree on the same leader.
+// waitLeader waits until given members agree on the same leader,
+// and returns its 'index' in the 'membs' list (or -1).
 func (c *cluster) waitLeader(t testing.TB, membs []*member) int {
 	possibleLead := make(map[uint64]bool)
 	var lead uint64

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -72,7 +72,7 @@ function run {
   log_callout "% ${repro}"
   "${@}"
   local error_code=$?
-  if [ ${error_code} != 0 ]; then
+  if [ ${error_code} -ne 0 ]; then
     log_error -e "FAIL: (code:${error_code}):\n  % ${repro}"
     return ${error_code}
   fi


### PR DESCRIPTION
Fixes leaked goroutines in 'auth' module that are reported as unit test flakes due to 'race detection'. 

With this PR: 
  - We turn on detection of leaked go routines in auth test
  - Fix all the 'detected' cases
  - Make it simpler to turn on leak detection for other tests.

In particular fixes issue: https://github.com/etcd-io/etcd/issues/12353

https://travis-ci.com/github/etcd-io/etcd/jobs/393026994

Detected by following command:

`% env go test -short -timeout=3m -cpu=4 --race=true ./... -p=2`

```
==================
WARNING: DATA RACE
Write at 0x0000014685b0 by goroutine 62:
  go.etcd.io/etcd/v3/auth.TestHammerSimpleAuthenticate()
      /go/src/go.etcd.io/etcd/auth/store_test.go:770 +0x104
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
Previous read at 0x0000014685b0 by goroutine 48:
  go.etcd.io/etcd/v3/auth.(*simpleTokenTTLKeeper).run()
      /go/src/go.etcd.io/etcd/auth/simple_token.go:76 +0x52
Goroutine 62 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1042 +0x660
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1284 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1282 +0x527
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1199 +0x2ff
  main.main()
      _testmain.go:114 +0x223
Goroutine 48 (running) created at:
  go.etcd.io/etcd/v3/auth.(*tokenSimple).enable()
      /go/src/go.etcd.io/etcd/auth/simple_token.go:180 +0x2c6
  go.etcd.io/etcd/v3/auth.TestSimpleTokenAssign()
      /go/src/go.etcd.io/etcd/auth/simple_token_test.go:52 +0xad
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:991 +0x1eb
==================
```

Also fixes following races: 
```
==================
WARNING: DATA RACE
Write at 0x00c000905f78 by goroutine 764:
  go.etcd.io/etcd/v3/mvcc.(*store).restore()
      /go/src/go.etcd.io/etcd/mvcc/kvstore.go:397 +0x773
  go.etcd.io/etcd/v3/mvcc.(*store).Restore()
      /go/src/go.etcd.io/etcd/mvcc/kvstore.go:343 +0x5f1
  go.etcd.io/etcd/v3/mvcc.(*watchableStore).Restore()
      /go/src/go.etcd.io/etcd/mvcc/watchable_store.go:199 +0xe2
  go.etcd.io/etcd/v3/etcdserver.(*EtcdServer).applySnapshot()
      /go/src/go.etcd.io/etcd/etcdserver/server.go:1107 +0xa49
  go.etcd.io/etcd/v3/etcdserver.(*EtcdServer).applyAll()
      /go/src/go.etcd.io/etcd/etcdserver/server.go:1031 +0x6d
  go.etcd.io/etcd/v3/etcdserver.(*EtcdServer).run.func8()
      /go/src/go.etcd.io/etcd/etcdserver/server.go:986 +0x53
  go.etcd.io/etcd/v3/pkg/schedule.(*fifo).run()
      /go/src/go.etcd.io/etcd/pkg/schedule/schedule.go:157 +0x11e
Previous read at 0x00c000905f78 by goroutine 180:
  [failed to restore the stack]
Goroutine 764 (running) created at:
  go.etcd.io/etcd/v3/pkg/schedule.NewFIFOScheduler()
      /go/src/go.etcd.io/etcd/pkg/schedule/schedule.go:70 +0x2b1
  go.etcd.io/etcd/v3/etcdserver.(*EtcdServer).run()
      /go/src/go.etcd.io/etcd/etcdserver/server.go:871 +0x32c
Goroutine 180 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2933 +0x5b6
  net/http/httptest.(*Server).goServe.func1()
      /usr/local/go/src/net/http/httptest/server.go:308 +0xd3
==================
--- FAIL: TestV3WatchRestoreSnapshotUnsync (6.74s)
    testing.go:906: race detected during execution of test
FAIL
```
That used to be observed for: 
`go test -timeout=30m -cpu=1 --race --cover=true go.etcd.io/etcd/v3/integration`