### PR TITLE
embed: Add `insecure-health-endpoint` flag to enable Kubernetes HTTP probes

### DIFF
--- a/embed/config.go
+++ b/embed/config.go
@@ -330,6 +330,12 @@ type Config struct {
 	// UnsafeNoFsync disables all uses of fsync.
 	// Setting this is unsafe and will cause data loss.
 	UnsafeNoFsync bool `json:"unsafe-no-fsync"`
+
+	// InsecureHealthEndpoint enables an additional /health listener on the specified
+	// address. The listener serves the usual /health endpoint over HTTP. This is
+	// useful for health probes (e.g. Kubernetes) where TLS is an undesirable
+	// complication.
+	InsecureHealthEndpoint string `json:"insecure-health-endpoint"`
 }
 
 // configYAML holds the config suitable for yaml parsing

--- a/etcdmain/config.go
+++ b/etcdmain/config.go
@@ -236,6 +236,7 @@ func newConfig() *config {
 
 	// additional metrics
 	fs.StringVar(&cfg.ec.Metrics, "metrics", cfg.ec.Metrics, "Set level of detail for exported metrics, specify 'extensive' to include server side grpc histogram metrics")
+	fs.StringVar(&cfg.ec.InsecureHealthEndpoint, "insecure-health-endpoint", cfg.ec.InsecureHealthEndpoint, "Create an additional /health HTTP listener on this address")
 
 	// auth
 	fs.StringVar(&cfg.ec.AuthToken, "auth-token", cfg.ec.AuthToken, "Specify auth token specific options.")

--- a/etcdserver/api/etcdhttp/metrics.go
+++ b/etcdserver/api/etcdhttp/metrics.go
@@ -42,10 +42,20 @@ func HandleMetricsHealth(lg *zap.Logger, mux *http.ServeMux, srv etcdserver.Serv
 	mux.Handle(PathHealth, NewHealthHandler(lg, func() Health { return checkV2Health(lg, srv) }))
 }
 
-// HandleMetricsHealthForV3 registers metrics and health handlers. it checks health by using v3 range request
-// and its corresponding timeout.
+// HandleMetricsHealthForV3 registers metrics and health handlers.
 func HandleMetricsHealthForV3(lg *zap.Logger, mux *http.ServeMux, srv *etcdserver.EtcdServer) {
+	HandleMetricsForV3(lg, mux, srv)
+	HandleHealthForV3(lg, mux, srv)
+}
+
+// HandleMetricsForV3 registers a metrics handler.
+func HandleMetricsForV3(lg *zap.Logger, mux *http.ServeMux, srv *etcdserver.EtcdServer) {
 	mux.Handle(PathMetrics, promhttp.Handler())
+}
+
+// HandleHealthForV3 registers a health handler. It checks health by using v3 range request
+// and its corresponding timeout.
+func HandleHealthForV3(lg *zap.Logger, mux *http.ServeMux, srv *etcdserver.EtcdServer) {
 	mux.Handle(PathHealth, NewHealthHandler(lg, func() Health { return checkV3Health(lg, srv) }))
 }
 

--- a/etcdserver/config.go
+++ b/etcdserver/config.go
@@ -162,6 +162,12 @@ type ServerConfig struct {
 	// UnsafeNoFsync disables all uses of fsync.
 	// Setting this is unsafe and will cause data loss.
 	UnsafeNoFsync bool `json:"unsafe-no-fsync"`
+
+	// InsecureHealthEndpoint enables an additional /health listener on the specified
+	// address. The listener serves the usual /health endpoint over HTTP. This is
+	// useful for health probes (e.g. Kubernetes) where TLS is an undesirable
+	// complication.
+	InsecureHealthEndpoint string `json:"insecure-health-endpoint"`
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case

--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -129,13 +129,14 @@ type etcdProcessClusterConfig struct {
 
 	cipherSuites []string
 
-	forceNewCluster     bool
-	initialToken        string
-	quotaBackendBytes   int64
-	noStrictReconfig    bool
-	enableV2            bool
-	initialCorruptCheck bool
-	authTokenOpts       string
+	forceNewCluster               bool
+	initialToken                  string
+	quotaBackendBytes             int64
+	noStrictReconfig              bool
+	enableV2                      bool
+	initialCorruptCheck           bool
+	authTokenOpts                 string
+	insecureHealthEndpointEnabled bool
 
 	rollingStart bool
 }
@@ -269,6 +270,12 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 			args = append(args, "--listen-metrics-urls", murl)
 		}
 
+		var insecureHealthEndpoint string
+		if cfg.insecureHealthEndpointEnabled {
+			insecureHealthEndpoint = fmt.Sprintf("localhost:%d", port+3)
+			args = append(args, "--insecure-health-endpoint", insecureHealthEndpoint)
+		}
+
 		args = append(args, cfg.tlsArgs()...)
 
 		if cfg.authTokenOpts != "" {
@@ -276,16 +283,17 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 		}
 
 		etcdCfgs[i] = &etcdServerProcessConfig{
-			execPath:     cfg.execPath,
-			args:         args,
-			tlsArgs:      cfg.tlsArgs(),
-			dataDirPath:  dataDirPath,
-			keepDataDir:  cfg.keepDataDir,
-			name:         name,
-			purl:         purl,
-			acurl:        curl,
-			murl:         murl,
-			initialToken: cfg.initialToken,
+			execPath:               cfg.execPath,
+			args:                   args,
+			tlsArgs:                cfg.tlsArgs(),
+			dataDirPath:            dataDirPath,
+			keepDataDir:            cfg.keepDataDir,
+			name:                   name,
+			purl:                   purl,
+			acurl:                  curl,
+			murl:                   murl,
+			insecureHealthEndpoint: insecureHealthEndpoint,
+			initialToken:           cfg.initialToken,
 		}
 	}
 

--- a/tests/e2e/etcd_process.go
+++ b/tests/e2e/etcd_process.go
@@ -61,8 +61,9 @@ type etcdServerProcessConfig struct {
 
 	purl url.URL
 
-	acurl string
-	murl  string
+	acurl                  string
+	murl                   string
+	insecureHealthEndpoint string
 
 	initialToken   string
 	initialCluster string

--- a/tests/integration/cluster.go
+++ b/tests/integration/cluster.go
@@ -601,6 +601,7 @@ type memberConfig struct {
 	enableLeaseCheckpoint       bool
 	leaseCheckpointInterval     time.Duration
 	WatchProgressNotifyInterval time.Duration
+	InsecureHealthEndpoint      string
 }
 
 // mustNewMember return an inited member with the given name. If peerTLS is
@@ -697,6 +698,8 @@ func mustNewMember(t testing.TB, mcfg memberConfig) *member {
 	m.WatchProgressNotifyInterval = mcfg.WatchProgressNotifyInterval
 
 	m.InitialCorruptCheck = true
+
+	m.InsecureHealthEndpoint = mcfg.InsecureHealthEndpoint
 
 	lcfg := logutil.DefaultZapLoggerConfig
 	m.LoggerConfig = &lcfg


### PR DESCRIPTION
Before this patch, Kubernetes users deploying etcd who configure mTLS
authentication for client and metrics endpoints are unable to leverage etcd's
`/health` endpoint for liveness or readiness probes because Kubernetes HTTP
probes don't support mTLS. Users must work around this limitation with
strategies like weak health checks using custom `exec` probes. Bypassing the
`/health` endpoint for this purpose can lead to false positive probe results and
quorum loss if a member is falsely determined to be ready during a rollout.

This patch introduces an `--insecure-health-endpoint` flag which, if specified,
enables an insecure HTTP `/health` endpoint which is functionally equivalent to
other `/health` endpoints. This enables etcd pods to specify reliable HTTP GET
probes for readiness and liveness checking.

This approach stands as an alternative to introducing a parallel TLS
configuration and listener just for the `/health` endpoint. The typical use case
is probably a non-exposed port used only by a container orchestration component
(e.g. the Kubelet).

Fixes https://github.com/etcd-io/etcd/issues/11993.
