### PR TITLE
etcdserver: prevent crash using expvars when server is not running

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -61,6 +61,9 @@ func init() {
 	expvar.Publish("raft.status", expvar.Func(func() interface{} {
 		raftStatusMu.Lock()
 		defer raftStatusMu.Unlock()
+		if raftStatus == nil {
+			return nil
+		}
 		return raftStatus()
 	}))
 }

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"encoding/json"
+	"expvar"
 	"reflect"
 	"sync"
 	"testing"
@@ -266,4 +267,18 @@ func TestProcessDuplicatedAppRespMessage(t *testing.T) {
 	if got != want {
 		t.Errorf("count = %d, want %d", got, want)
 	}
+}
+
+// Test that none of the expvars that get added during init panic.
+// This matters if another package imports etcdserver,
+// doesn't use it, but does use expvars.
+func TestExpvarWithNoRaftStatus(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	expvar.Do(func(kv expvar.KeyValue) {
+		_ = kv.Value.String()
+	})
 }


### PR DESCRIPTION
The raft.status expvar is added at init time.
This change ensures that evaluating that expvar variable
doesn't panic during evaluation, even when there is
no server running.
