### PR TITLE
build: Fix updating 'go.etcd.io/etcd/api/v3/version.GitSHA' + test

### DIFF
--- a/build
+++ b/build
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
-
 source ./scripts/test_lib.sh
-
-# set some environment variables
-ORG_PATH="go.etcd.io"
-REPO_PATH="${ORG_PATH}/etcd/v3"
 
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 if [[ -n "$FAILPOINTS" ]]; then
 	GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
 
+VERSION_SYMBOL="go.etcd.io/etcd/api/v3/version.GitSHA"
+
 # Set GO_LDFLAGS="-s" for building without symbols for debugging.
-GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}"
+# shellcheck disable=SC2206
+GO_LDFLAGS=(${GO_LDFLAGS} "-X=${VERSION_SYMBOL}=${GIT_SHA}")
+GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS}" "GOOS=${GOOS}" "GOARCH=${GOARCH}")
 
 # enable/disable failpoints
 toggle_failpoints() {
@@ -36,17 +35,32 @@ etcd_build() {
 	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
 	toggle_failpoints_default
 
+  run rm -f "${out}/etcd"
 	# Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
 	# shellcheck disable=SC2086
-	CGO_ENABLED=0 run go build $GO_BUILD_FLAGS \
+	run env "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
 		-installsuffix=cgo \
-		"-ldflags='${GO_LDFLAGS}'" \
-		-o="${out}/etcd" . || return
+		"-ldflags=${GO_LDFLAGS[*]}" \
+		-o="${out}/etcd" . || return 2
+
+	run rm -f "${out}/etcdctl"
 	# shellcheck disable=SC2086
-	CGO_ENABLED=0 run go build $GO_BUILD_FLAGS \
+	run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build $GO_BUILD_FLAGS \
 		-installsuffix=cgo \
-		"-ldflags='${GO_LDFLAGS}'" \
-		-o="${out}/etcdctl" ./etcdctl || return
+		"-ldflags=${GO_LDFLAGS[*]}" \
+		-o="${out}/etcdctl" ./etcdctl || return 2
+
+	# Verify whether symbol we overriden exists
+  # For cross-compiling we cannot run: ${out}/etcd --version | grep -q "Git SHA: ${GIT_SHA}"
+
+  # We need symbols to do this check:
+  if [[ "${GO_LDFLAGS[*]}" != *"-s"* ]]; then
+    go tool nm "${out}/etcd" | grep "${VERSION_SYMBOL}" > /dev/null
+    if [[ "${PIPESTATUS[*]}" != "0 0" ]]; then
+      log_error "FAIL: Symbol ${VERSION_SYMBOL} not found in binary: ${out}/etcd"
+      return 2
+    fi
+  fi
 }
 
 tools_build() {
@@ -59,11 +73,12 @@ tools_build() {
 	for tool in ${tools_path}
 	do
 		echo "Building" "'${tool}'"...
+		run rm -f "${out}/${tool}"
 		# shellcheck disable=SC2086
-		CGO_ENABLED=0 run go build ${GO_BUILD_FLAGS} \
+		run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
 		  -installsuffix=cgo \
-		  "-ldflags='${GO_LDFLAGS}'" \
-		  -o="${out}/${tool}" "./${tool}" || return
+		  "-ldflags='${GO_LDFLAGS[*]}'" \
+		  -o="${out}/${tool}" "./${tool}" || return 2
 	done
 	tests_build "${@}"
 }
@@ -80,13 +95,14 @@ tests_build() {
 		cd tests || exit 2
 		for tool in ${tools_path}; do
 			echo "Building" "'${tool}'"...
+			run rm -f "../${out}/${tool}"
 
 			# shellcheck disable=SC2086
-			CGO_ENABLED=0 run go build ${GO_BUILD_FLAGS} \
+			run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build ${GO_BUILD_FLAGS} \
 			  -installsuffix=cgo \
-			  "-ldflags='${GO_LDFLAGS}'" \
-			  -o="../${out}/${tool}" "./${tool}" || return
-    		done
+			  "-ldflags='${GO_LDFLAGS[*]}'" \
+			  -o="../${out}/${tool}" "./${tool}" || return 2
+    done
 	)
 }
 
@@ -94,5 +110,10 @@ toggle_failpoints_default
 
 # only build when called directly, not sourced
 if echo "$0" | grep "build$" >/dev/null; then
-	etcd_build
+	if etcd_build; then
+	  log_success "SUCCESS: etcd_build"
+	else
+	  log_error "FAIL: etcd_build"
+	  exit 2
+  fi
 fi

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -59,14 +59,19 @@ function pkgs_in_module {
 # the test.
 function run {
   local rpath
+  local command
   rpath=$(realpath "--relative-to=${ETCD_ROOT_DIR}" "${PWD}")
-  local repro="$*"
+  # Quoting all components as the commands are fully copy-parsable:
+  command=("${@}")
+  command=("${command[@]@Q}")
   if [ "${rpath}" != "." ]; then
-    repro="(cd ${rpath} && ${repro})"
+    repro="(cd ${rpath} && ${command[*]})"
+  else 
+    repro="${command[*]}"
   fi
 
   log_callout "% ${repro}"
-  "${@}"
+  "${@}" 2> >(while read -r line; do echo -e "\e[01;31m$line\e[0m" >&2; done)
   local error_code=$?
   if [ ${error_code} -ne 0 ]; then
     log_error -e "FAIL: (code:${error_code}):\n  % ${repro}"


### PR DESCRIPTION
During move of code to 'api' (0aab02e7b5ab94ef666392f7a56e0780e7cb27f5), I overlooked that the ./build script is setting the version on the 'symbol'.
I added a code to ./build script that checks whether the symbol's are in sync.