### PR TITLE
Remove test files that have invalid go code within the file

### DIFF
--- a/client/example_keys_test.go
+++ b/client/example_keys_test.go
@@ -1,1 +1,0 @@
-../tests/integration/client/examples/example_keys_test.go

--- a/clientv3/concurrency/example_election_test.go
+++ b/clientv3/concurrency/example_election_test.go
@@ -1,1 +1,0 @@
-../../tests/integration/clientv3/concurrency/example_election_test.go

--- a/clientv3/concurrency/example_mutex_test.go
+++ b/clientv3/concurrency/example_mutex_test.go
@@ -1,1 +1,0 @@
-../../tests/integration/clientv3/concurrency/example_mutex_test.go

--- a/clientv3/concurrency/example_stm_test.go
+++ b/clientv3/concurrency/example_stm_test.go
@@ -1,1 +1,0 @@
-../../tests/integration/clientv3/concurrency/example_stm_test.go

--- a/clientv3/example_auth_test.go
+++ b/clientv3/example_auth_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_auth_test.go

--- a/clientv3/example_cluster_test.go
+++ b/clientv3/example_cluster_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_cluster_test.go

--- a/clientv3/example_kv_test.go
+++ b/clientv3/example_kv_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_kv_test.go

--- a/clientv3/example_lease_test.go
+++ b/clientv3/example_lease_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_lease_test.go

--- a/clientv3/example_maintenance_test.go
+++ b/clientv3/example_maintenance_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_maintenance_test.go

--- a/clientv3/example_metrics_test.go
+++ b/clientv3/example_metrics_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_metrics_test.go

--- a/clientv3/example_test.go
+++ b/clientv3/example_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_test.go

--- a/clientv3/example_watch_test.go
+++ b/clientv3/example_watch_test.go
@@ -1,1 +1,0 @@
-../tests/integration/clientv3/examples/example_watch_test.go


### PR DESCRIPTION
as per what in the commit message said, rather than filling the content of old test files with the path of the new test file, better to remove it completely.

... Or, we can keep the file,s but make it into a valid go test file, by putting the package name there.

This PR contains changes to the 1st option (completely remove the test files).
but let me know if keeping the file with the package name looks better, I'll happy to make the changes.