### PR TITLE
wal: remove redundant war tmp dirs if create wal failed

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -114,6 +114,8 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 			return nil, err
 		}
 	}
+	defer os.RemoveAll(tmpdirpath)
+
 	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
 		lg.Warn(
 			"failed to create a temporary WAL directory",


### PR DESCRIPTION
If we create 000000000-0000000.war failed in war tmp dir(XXX.tmp) and we should
remove the tmp dirs. If create war successfully in tmp dir and it will
be renamed to common dir and remove tmp dir(XXX.tmp) will also be ok.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
