### PR TITLE
tests: prevent cross-test contamination via shared state

### DIFF
--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -36,63 +36,89 @@ const (
 	clientTLSAndNonTLS
 )
 
-var (
-	configNoTLS = etcdProcessClusterConfig{
-		clusterSize:  3,
+func newConfigNoTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{clusterSize: 3,
 		initialToken: "new",
 	}
-	configAutoTLS = etcdProcessClusterConfig{
+}
+
+func newConfigAutoTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:   3,
 		isPeerTLS:     true,
 		isPeerAutoTLS: true,
 		initialToken:  "new",
 	}
-	configTLS = etcdProcessClusterConfig{
+}
+
+func newConfigTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:  3,
 		clientTLS:    clientTLS,
 		isPeerTLS:    true,
 		initialToken: "new",
 	}
-	configClientTLS = etcdProcessClusterConfig{
+}
+
+func newConfigClientTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:  3,
 		clientTLS:    clientTLS,
 		initialToken: "new",
 	}
-	configClientBoth = etcdProcessClusterConfig{
+}
+
+func newConfigClientBoth() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:  1,
 		clientTLS:    clientTLSAndNonTLS,
 		initialToken: "new",
 	}
-	configClientAutoTLS = etcdProcessClusterConfig{
+}
+
+func newConfigClientAutoTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:     1,
 		isClientAutoTLS: true,
 		clientTLS:       clientTLS,
 		initialToken:    "new",
 	}
-	configPeerTLS = etcdProcessClusterConfig{
+}
+
+func newConfigPeerTLS() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:  3,
 		isPeerTLS:    true,
 		initialToken: "new",
 	}
-	configClientTLSCertAuth = etcdProcessClusterConfig{
+}
+
+func newConfigClientTLSCertAuth() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:           1,
 		clientTLS:             clientTLS,
 		initialToken:          "new",
 		clientCertAuthEnabled: true,
 	}
-	configClientTLSCertAuthWithNoCN = etcdProcessClusterConfig{
+}
+
+func newConfigClientTLSCertAuthWithNoCN() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:           1,
 		clientTLS:             clientTLS,
 		initialToken:          "new",
 		clientCertAuthEnabled: true,
 		noCN:                  true,
 	}
-	configJWT = etcdProcessClusterConfig{
+}
+
+func newConfigJWT() *etcdProcessClusterConfig {
+	return &etcdProcessClusterConfig{
 		clusterSize:   1,
 		initialToken:  "new",
 		authTokenOpts: "jwt,pub-key=../fixtures/server.crt,priv-key=../fixtures/server.key.insecure,sign-method=RS256,ttl=1s",
 	}
-)
+}
 
 func configStandalone(cfg etcdProcessClusterConfig) *etcdProcessClusterConfig {
 	ret := cfg

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -24,11 +24,11 @@ import (
 	"go.etcd.io/etcd/pkg/v3/testutil"
 )
 
-func TestCtlV2Set(t *testing.T)          { testCtlV2Set(t, &configNoTLS, false) }
-func TestCtlV2SetQuorum(t *testing.T)    { testCtlV2Set(t, &configNoTLS, true) }
-func TestCtlV2SetClientTLS(t *testing.T) { testCtlV2Set(t, &configClientTLS, false) }
-func TestCtlV2SetPeerTLS(t *testing.T)   { testCtlV2Set(t, &configPeerTLS, false) }
-func TestCtlV2SetTLS(t *testing.T)       { testCtlV2Set(t, &configTLS, false) }
+func TestCtlV2Set(t *testing.T)          { testCtlV2Set(t, newConfigNoTLS(), false) }
+func TestCtlV2SetQuorum(t *testing.T)    { testCtlV2Set(t, newConfigNoTLS(), true) }
+func TestCtlV2SetClientTLS(t *testing.T) { testCtlV2Set(t, newConfigClientTLS(), false) }
+func TestCtlV2SetPeerTLS(t *testing.T)   { testCtlV2Set(t, newConfigPeerTLS(), false) }
+func TestCtlV2SetTLS(t *testing.T)       { testCtlV2Set(t, newConfigTLS(), false) }
 func testCtlV2Set(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	os.Setenv("ETCDCTL_API", "2")
 	defer os.Unsetenv("ETCDCTL_API")
@@ -49,9 +49,9 @@ func testCtlV2Set(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	}
 }
 
-func TestCtlV2Mk(t *testing.T)       { testCtlV2Mk(t, &configNoTLS, false) }
-func TestCtlV2MkQuorum(t *testing.T) { testCtlV2Mk(t, &configNoTLS, true) }
-func TestCtlV2MkTLS(t *testing.T)    { testCtlV2Mk(t, &configTLS, false) }
+func TestCtlV2Mk(t *testing.T)       { testCtlV2Mk(t, newConfigNoTLS(), false) }
+func TestCtlV2MkQuorum(t *testing.T) { testCtlV2Mk(t, newConfigNoTLS(), true) }
+func TestCtlV2MkTLS(t *testing.T)    { testCtlV2Mk(t, newConfigTLS(), false) }
 func testCtlV2Mk(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	os.Setenv("ETCDCTL_API", "2")
 	defer os.Unsetenv("ETCDCTL_API")
@@ -75,8 +75,8 @@ func testCtlV2Mk(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	}
 }
 
-func TestCtlV2Rm(t *testing.T)    { testCtlV2Rm(t, &configNoTLS) }
-func TestCtlV2RmTLS(t *testing.T) { testCtlV2Rm(t, &configTLS) }
+func TestCtlV2Rm(t *testing.T)    { testCtlV2Rm(t, newConfigNoTLS()) }
+func TestCtlV2RmTLS(t *testing.T) { testCtlV2Rm(t, newConfigTLS()) }
 func testCtlV2Rm(t *testing.T, cfg *etcdProcessClusterConfig) {
 	os.Setenv("ETCDCTL_API", "2")
 	defer os.Unsetenv("ETCDCTL_API")
@@ -100,9 +100,9 @@ func testCtlV2Rm(t *testing.T, cfg *etcdProcessClusterConfig) {
 	}
 }
 
-func TestCtlV2Ls(t *testing.T)       { testCtlV2Ls(t, &configNoTLS, false) }
-func TestCtlV2LsQuorum(t *testing.T) { testCtlV2Ls(t, &configNoTLS, true) }
-func TestCtlV2LsTLS(t *testing.T)    { testCtlV2Ls(t, &configTLS, false) }
+func TestCtlV2Ls(t *testing.T)       { testCtlV2Ls(t, newConfigNoTLS(), false) }
+func TestCtlV2LsQuorum(t *testing.T) { testCtlV2Ls(t, newConfigNoTLS(), true) }
+func TestCtlV2LsTLS(t *testing.T)    { testCtlV2Ls(t, newConfigTLS(), false) }
 func testCtlV2Ls(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	os.Setenv("ETCDCTL_API", "2")
 	defer os.Unsetenv("ETCDCTL_API")
@@ -123,8 +123,8 @@ func testCtlV2Ls(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) {
 	}
 }
 
-func TestCtlV2Watch(t *testing.T)    { testCtlV2Watch(t, &configNoTLS, false) }
-func TestCtlV2WatchTLS(t *testing.T) { testCtlV2Watch(t, &configTLS, false) }
+func TestCtlV2Watch(t *testing.T)    { testCtlV2Watch(t, newConfigNoTLS(), false) }
+func TestCtlV2WatchTLS(t *testing.T) { testCtlV2Watch(t, newConfigTLS(), false) }
 
 func testCtlV2Watch(t *testing.T, cfg *etcdProcessClusterConfig, noSync bool) {
 	os.Setenv("ETCDCTL_API", "2")
@@ -156,9 +156,9 @@ func TestCtlV2GetRoleUser(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copied := configNoTLS
+	copied := newConfigNoTLS()
 	copied.enableV2 = true
-	epc := setupEtcdctlTest(t, &copied, false)
+	epc := setupEtcdctlTest(t, copied, false)
 	defer cleanupEtcdProcessCluster(epc, t)
 
 	if err := etcdctlRoleAdd(epc, "foo"); err != nil {
@@ -189,9 +189,9 @@ func testCtlV2UserList(t *testing.T, username string) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copied := configNoTLS
+	copied := newConfigNoTLS()
 	copied.enableV2 = true
-	epc := setupEtcdctlTest(t, &copied, false)
+	epc := setupEtcdctlTest(t, copied, false)
 	defer cleanupEtcdProcessCluster(epc, t)
 
 	if err := etcdctlUserAdd(epc, username, "password"); err != nil {
@@ -207,9 +207,9 @@ func TestCtlV2RoleList(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copied := configNoTLS
+	copied := newConfigNoTLS()
 	copied.enableV2 = true
-	epc := setupEtcdctlTest(t, &copied, false)
+	epc := setupEtcdctlTest(t, copied, false)
 	defer cleanupEtcdProcessCluster(epc, t)
 
 	if err := etcdctlRoleAdd(epc, "foo"); err != nil {
@@ -237,10 +237,10 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	}
 	defer os.RemoveAll(backupDir)
 
-	etcdCfg := configNoTLS
+	etcdCfg := newConfigNoTLS()
 	etcdCfg.snapshotCount = snapCount
 	etcdCfg.enableV2 = true
-	epc1 := setupEtcdctlTest(t, &etcdCfg, false)
+	epc1 := setupEtcdctlTest(t, etcdCfg, false)
 
 	// v3 put before v2 set so snapshot happens after v3 operations to confirm
 	// v3 data is preserved after snapshot.
@@ -268,12 +268,12 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	}
 
 	// restart from the backup directory
-	cfg2 := configNoTLS
+	cfg2 := newConfigNoTLS()
 	cfg2.dataDirPath = backupDir
 	cfg2.keepDataDir = true
 	cfg2.forceNewCluster = true
 	cfg2.enableV2 = true
-	epc2 := setupEtcdctlTest(t, &cfg2, false)
+	epc2 := setupEtcdctlTest(t, cfg2, false)
 	// Make sure a failing test is not leaking resources (running server).
 	defer epc2.Close()
 
@@ -313,10 +313,10 @@ func TestCtlV2AuthWithCommonName(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copiedCfg := configClientTLS
+	copiedCfg := newConfigClientTLS()
 	copiedCfg.clientCertAuthEnabled = true
 	copiedCfg.enableV2 = true
-	epc := setupEtcdctlTest(t, &copiedCfg, false)
+	epc := setupEtcdctlTest(t, copiedCfg, false)
 	defer cleanupEtcdProcessCluster(epc, t)
 
 	if err := etcdctlRoleAdd(epc, "testrole"); err != nil {
@@ -347,9 +347,9 @@ func TestCtlV2ClusterHealth(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copied := configNoTLS
+	copied := newConfigNoTLS()
 	copied.enableV2 = true
-	epc := setupEtcdctlTest(t, &copied, true)
+	epc := setupEtcdctlTest(t, copied, true)
 	defer cleanupEtcdProcessCluster(epc, t)
 
 	// all members available

--- a/tests/e2e/ctl_v3_auth_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_auth_no_proxy_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 )
 
-func TestCtlV3AuthCertCN(t *testing.T) { testCtl(t, authTestCertCN, withCfg(configClientTLSCertAuth)) }
+func TestCtlV3AuthCertCN(t *testing.T) {
+	testCtl(t, authTestCertCN, withCfg(*newConfigClientTLSCertAuth()))
+}
 func TestCtlV3AuthCertCNAndUsername(t *testing.T) {
-	testCtl(t, authTestCertCNAndUsername, withCfg(configClientTLSCertAuth))
+	testCtl(t, authTestCertCNAndUsername, withCfg(*newConfigClientTLSCertAuth()))
 }
 func TestCtlV3AuthCertCNAndUsernameNoPassword(t *testing.T) {
-	testCtl(t, authTestCertCNAndUsernameNoPassword, withCfg(configClientTLSCertAuth))
+	testCtl(t, authTestCertCNAndUsernameNoPassword, withCfg(*newConfigClientTLSCertAuth()))
 }

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -33,7 +33,7 @@ func TestCtlV3AuthRoleUpdate(t *testing.T)          { testCtl(t, authRoleUpdateT
 func TestCtlV3AuthUserDeleteDuringOps(t *testing.T) { testCtl(t, authUserDeleteDuringOpsTest) }
 func TestCtlV3AuthRoleRevokeDuringOps(t *testing.T) { testCtl(t, authRoleRevokeDuringOpsTest) }
 func TestCtlV3AuthTxn(t *testing.T)                 { testCtl(t, authTestTxn) }
-func TestCtlV3AuthTxnJWT(t *testing.T)              { testCtl(t, authTestTxn, withCfg(configJWT)) }
+func TestCtlV3AuthTxnJWT(t *testing.T)              { testCtl(t, authTestTxn, withCfg(*newConfigJWT())) }
 func TestCtlV3AuthPrefixPerm(t *testing.T)          { testCtl(t, authTestPrefixPerm) }
 func TestCtlV3AuthMemberAdd(t *testing.T)           { testCtl(t, authTestMemberAdd) }
 func TestCtlV3AuthMemberRemove(t *testing.T) {
@@ -44,7 +44,7 @@ func TestCtlV3AuthRevokeWithDelete(t *testing.T) { testCtl(t, authTestRevokeWith
 func TestCtlV3AuthInvalidMgmt(t *testing.T)      { testCtl(t, authTestInvalidMgmt) }
 func TestCtlV3AuthFromKeyPerm(t *testing.T)      { testCtl(t, authTestFromKeyPerm) }
 func TestCtlV3AuthAndWatch(t *testing.T)         { testCtl(t, authTestWatch) }
-func TestCtlV3AuthAndWatchJWT(t *testing.T)      { testCtl(t, authTestWatch, withCfg(configJWT)) }
+func TestCtlV3AuthAndWatchJWT(t *testing.T)      { testCtl(t, authTestWatch, withCfg(*newConfigJWT())) }
 
 func TestCtlV3AuthLeaseTestKeepAlive(t *testing.T) { testCtl(t, authLeaseTestKeepAlive) }
 func TestCtlV3AuthLeaseTestTimeToLiveExpired(t *testing.T) {
@@ -52,7 +52,7 @@ func TestCtlV3AuthLeaseTestTimeToLiveExpired(t *testing.T) {
 }
 func TestCtlV3AuthLeaseGrantLeases(t *testing.T) { testCtl(t, authLeaseTestLeaseGrantLeases) }
 func TestCtlV3AuthLeaseGrantLeasesJWT(t *testing.T) {
-	testCtl(t, authLeaseTestLeaseGrantLeases, withCfg(configJWT))
+	testCtl(t, authLeaseTestLeaseGrantLeases, withCfg(*newConfigJWT()))
 }
 func TestCtlV3AuthLeaseRevoke(t *testing.T) { testCtl(t, authLeaseTestLeaseRevoke) }
 
@@ -65,8 +65,8 @@ func TestCtlV3AuthEndpointHealth(t *testing.T) {
 	testCtl(t, authTestEndpointHealth, withQuorum())
 }
 func TestCtlV3AuthSnapshot(t *testing.T)            { testCtl(t, authTestSnapshot) }
-func TestCtlV3AuthSnapshotJWT(t *testing.T)         { testCtl(t, authTestSnapshot, withCfg(configJWT)) }
-func TestCtlV3AuthJWTExpire(t *testing.T)           { testCtl(t, authTestJWTExpire, withCfg(configJWT)) }
+func TestCtlV3AuthSnapshotJWT(t *testing.T)         { testCtl(t, authTestSnapshot, withCfg(*newConfigJWT())) }
+func TestCtlV3AuthJWTExpire(t *testing.T)           { testCtl(t, authTestJWTExpire, withCfg(*newConfigJWT())) }
 func TestCtlV3AuthRevisionConsistency(t *testing.T) { testCtl(t, authTestRevisionConsistency) }
 
 func authEnableTest(cx ctlCtx) {

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -22,22 +22,22 @@ import (
 )
 
 func TestCtlV3Put(t *testing.T)              { testCtl(t, putTest, withDialTimeout(7*time.Second)) }
-func TestCtlV3PutNoTLS(t *testing.T)         { testCtl(t, putTest, withCfg(configNoTLS)) }
-func TestCtlV3PutClientTLS(t *testing.T)     { testCtl(t, putTest, withCfg(configClientTLS)) }
-func TestCtlV3PutClientAutoTLS(t *testing.T) { testCtl(t, putTest, withCfg(configClientAutoTLS)) }
-func TestCtlV3PutPeerTLS(t *testing.T)       { testCtl(t, putTest, withCfg(configPeerTLS)) }
+func TestCtlV3PutNoTLS(t *testing.T)         { testCtl(t, putTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3PutClientTLS(t *testing.T)     { testCtl(t, putTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3PutClientAutoTLS(t *testing.T) { testCtl(t, putTest, withCfg(*newConfigClientAutoTLS())) }
+func TestCtlV3PutPeerTLS(t *testing.T)       { testCtl(t, putTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3PutTimeout(t *testing.T)       { testCtl(t, putTest, withDialTimeout(0)) }
 func TestCtlV3PutClientTLSFlagByEnv(t *testing.T) {
-	testCtl(t, putTest, withCfg(configClientTLS), withFlagByEnv())
+	testCtl(t, putTest, withCfg(*newConfigClientTLS()), withFlagByEnv())
 }
 func TestCtlV3PutIgnoreValue(t *testing.T) { testCtl(t, putTestIgnoreValue) }
 func TestCtlV3PutIgnoreLease(t *testing.T) { testCtl(t, putTestIgnoreLease) }
 
 func TestCtlV3Get(t *testing.T)              { testCtl(t, getTest) }
-func TestCtlV3GetNoTLS(t *testing.T)         { testCtl(t, getTest, withCfg(configNoTLS)) }
-func TestCtlV3GetClientTLS(t *testing.T)     { testCtl(t, getTest, withCfg(configClientTLS)) }
-func TestCtlV3GetClientAutoTLS(t *testing.T) { testCtl(t, getTest, withCfg(configClientAutoTLS)) }
-func TestCtlV3GetPeerTLS(t *testing.T)       { testCtl(t, getTest, withCfg(configPeerTLS)) }
+func TestCtlV3GetNoTLS(t *testing.T)         { testCtl(t, getTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3GetClientTLS(t *testing.T)     { testCtl(t, getTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3GetClientAutoTLS(t *testing.T) { testCtl(t, getTest, withCfg(*newConfigClientAutoTLS())) }
+func TestCtlV3GetPeerTLS(t *testing.T)       { testCtl(t, getTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3GetTimeout(t *testing.T)       { testCtl(t, getTest, withDialTimeout(0)) }
 func TestCtlV3GetQuorum(t *testing.T)        { testCtl(t, getTest, withQuorum()) }
 
@@ -47,9 +47,9 @@ func TestCtlV3GetKeysOnly(t *testing.T)  { testCtl(t, getKeysOnlyTest) }
 func TestCtlV3GetCountOnly(t *testing.T) { testCtl(t, getCountOnlyTest) }
 
 func TestCtlV3Del(t *testing.T)          { testCtl(t, delTest) }
-func TestCtlV3DelNoTLS(t *testing.T)     { testCtl(t, delTest, withCfg(configNoTLS)) }
-func TestCtlV3DelClientTLS(t *testing.T) { testCtl(t, delTest, withCfg(configClientTLS)) }
-func TestCtlV3DelPeerTLS(t *testing.T)   { testCtl(t, delTest, withCfg(configPeerTLS)) }
+func TestCtlV3DelNoTLS(t *testing.T)     { testCtl(t, delTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3DelClientTLS(t *testing.T) { testCtl(t, delTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3DelPeerTLS(t *testing.T)   { testCtl(t, delTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3DelTimeout(t *testing.T)   { testCtl(t, delTest, withDialTimeout(0)) }
 
 func TestCtlV3GetRevokedCRL(t *testing.T) {

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -24,81 +24,87 @@ import (
 
 func TestCtlV3LeaseGrantTimeToLive(t *testing.T) { testCtl(t, leaseTestGrantTimeToLive) }
 func TestCtlV3LeaseGrantTimeToLiveNoTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantTimeToLive, withCfg(configNoTLS))
+	testCtl(t, leaseTestGrantTimeToLive, withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3LeaseGrantTimeToLiveClientTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantTimeToLive, withCfg(configClientTLS))
+	testCtl(t, leaseTestGrantTimeToLive, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseGrantTimeToLiveClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantTimeToLive, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestGrantTimeToLive, withCfg(*newConfigClientAutoTLS()))
 }
 func TestCtlV3LeaseGrantTimeToLivePeerTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantTimeToLive, withCfg(configPeerTLS))
+	testCtl(t, leaseTestGrantTimeToLive, withCfg(*newConfigPeerTLS()))
 }
 
 func TestCtlV3LeaseGrantLeases(t *testing.T) { testCtl(t, leaseTestGrantLeaseListed) }
 func TestCtlV3LeaseGrantLeasesNoTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantLeaseListed, withCfg(configNoTLS))
+	testCtl(t, leaseTestGrantLeaseListed, withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3LeaseGrantLeasesClientTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantLeaseListed, withCfg(configClientTLS))
+	testCtl(t, leaseTestGrantLeaseListed, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseGrantLeasesClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantLeaseListed, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestGrantLeaseListed, withCfg(*newConfigClientAutoTLS()))
 }
 func TestCtlV3LeaseGrantLeasesPeerTLS(t *testing.T) {
-	testCtl(t, leaseTestGrantLeaseListed, withCfg(configPeerTLS))
+	testCtl(t, leaseTestGrantLeaseListed, withCfg(*newConfigPeerTLS()))
 }
 
 func TestCtlV3LeaseTestTimeToLiveExpired(t *testing.T) { testCtl(t, leaseTestTimeToLiveExpired) }
 func TestCtlV3LeaseTestTimeToLiveExpiredNoTLS(t *testing.T) {
-	testCtl(t, leaseTestTimeToLiveExpired, withCfg(configNoTLS))
+	testCtl(t, leaseTestTimeToLiveExpired, withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3LeaseTestTimeToLiveExpiredClientTLS(t *testing.T) {
-	testCtl(t, leaseTestTimeToLiveExpired, withCfg(configClientTLS))
+	testCtl(t, leaseTestTimeToLiveExpired, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseTestTimeToLiveExpiredClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestTimeToLiveExpired, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestTimeToLiveExpired, withCfg(*newConfigClientAutoTLS()))
 }
 func TestCtlV3LeaseTestTimeToLiveExpiredPeerTLS(t *testing.T) {
-	testCtl(t, leaseTestTimeToLiveExpired, withCfg(configPeerTLS))
+	testCtl(t, leaseTestTimeToLiveExpired, withCfg(*newConfigPeerTLS()))
 }
 
-func TestCtlV3LeaseKeepAlive(t *testing.T)      { testCtl(t, leaseTestKeepAlive) }
-func TestCtlV3LeaseKeepAliveNoTLS(t *testing.T) { testCtl(t, leaseTestKeepAlive, withCfg(configNoTLS)) }
+func TestCtlV3LeaseKeepAlive(t *testing.T) { testCtl(t, leaseTestKeepAlive) }
+func TestCtlV3LeaseKeepAliveNoTLS(t *testing.T) {
+	testCtl(t, leaseTestKeepAlive, withCfg(*newConfigNoTLS()))
+}
 func TestCtlV3LeaseKeepAliveClientTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(configClientTLS))
+	testCtl(t, leaseTestKeepAlive, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseKeepAliveClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestKeepAlive, withCfg(*newConfigClientAutoTLS()))
 }
 func TestCtlV3LeaseKeepAlivePeerTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(configPeerTLS))
+	testCtl(t, leaseTestKeepAlive, withCfg(*newConfigPeerTLS()))
 }
 
 func TestCtlV3LeaseKeepAliveOnce(t *testing.T) { testCtl(t, leaseTestKeepAliveOnce) }
 func TestCtlV3LeaseKeepAliveOnceNoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAliveOnce, withCfg(configNoTLS))
+	testCtl(t, leaseTestKeepAliveOnce, withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3LeaseKeepAliveOnceClientTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAliveOnce, withCfg(configClientTLS))
+	testCtl(t, leaseTestKeepAliveOnce, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseKeepAliveOnceClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAliveOnce, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestKeepAliveOnce, withCfg(*newConfigClientAutoTLS()))
 }
 func TestCtlV3LeaseKeepAliveOncePeerTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAliveOnce, withCfg(configPeerTLS))
+	testCtl(t, leaseTestKeepAliveOnce, withCfg(*newConfigPeerTLS()))
 }
 
-func TestCtlV3LeaseRevoke(t *testing.T)      { testCtl(t, leaseTestRevoked) }
-func TestCtlV3LeaseRevokeNoTLS(t *testing.T) { testCtl(t, leaseTestRevoked, withCfg(configNoTLS)) }
+func TestCtlV3LeaseRevoke(t *testing.T) { testCtl(t, leaseTestRevoked) }
+func TestCtlV3LeaseRevokeNoTLS(t *testing.T) {
+	testCtl(t, leaseTestRevoked, withCfg(*newConfigNoTLS()))
+}
 func TestCtlV3LeaseRevokeClientTLS(t *testing.T) {
-	testCtl(t, leaseTestRevoked, withCfg(configClientTLS))
+	testCtl(t, leaseTestRevoked, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3LeaseRevokeClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestRevoked, withCfg(configClientAutoTLS))
+	testCtl(t, leaseTestRevoked, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3LeaseRevokePeerTLS(t *testing.T) { testCtl(t, leaseTestRevoked, withCfg(configPeerTLS)) }
+func TestCtlV3LeaseRevokePeerTLS(t *testing.T) {
+	testCtl(t, leaseTestRevoked, withCfg(*newConfigPeerTLS()))
+}
 
 func leaseTestGrantTimeToLive(cx ctlCtx) {
 	id, err := ctlV3LeaseGrant(cx, 10)

--- a/tests/e2e/ctl_v3_make_mirror_test.go
+++ b/tests/e2e/ctl_v3_make_mirror_test.go
@@ -59,12 +59,12 @@ func makeMirrorNoDestPrefixTest(cx ctlCtx) {
 
 func testMirrorCommand(cx ctlCtx, flags []string, sourcekvs []kv, destkvs []kvExec, srcprefix, destprefix string) {
 	// set up another cluster to mirror with
-	mirrorcfg := configAutoTLS
+	mirrorcfg := newConfigAutoTLS()
 	mirrorcfg.clusterSize = 1
 	mirrorcfg.basePort = 10000
 	mirrorctx := ctlCtx{
 		t:           cx.t,
-		cfg:         mirrorcfg,
+		cfg:         *mirrorcfg,
 		dialTimeout: 7 * time.Second,
 	}
 

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -25,22 +25,26 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
-func TestCtlV3MemberList(t *testing.T)          { testCtl(t, memberListTest) }
-func TestCtlV3MemberListWithHex(t *testing.T)   { testCtl(t, memberListWithHexTest) }
-func TestCtlV3MemberListNoTLS(t *testing.T)     { testCtl(t, memberListTest, withCfg(configNoTLS)) }
-func TestCtlV3MemberListClientTLS(t *testing.T) { testCtl(t, memberListTest, withCfg(configClientTLS)) }
-func TestCtlV3MemberListClientAutoTLS(t *testing.T) {
-	testCtl(t, memberListTest, withCfg(configClientAutoTLS))
+func TestCtlV3MemberList(t *testing.T)        { testCtl(t, memberListTest) }
+func TestCtlV3MemberListWithHex(t *testing.T) { testCtl(t, memberListWithHexTest) }
+func TestCtlV3MemberListNoTLS(t *testing.T)   { testCtl(t, memberListTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3MemberListClientTLS(t *testing.T) {
+	testCtl(t, memberListTest, withCfg(*newConfigClientTLS()))
 }
-func TestCtlV3MemberListPeerTLS(t *testing.T) { testCtl(t, memberListTest, withCfg(configPeerTLS)) }
+func TestCtlV3MemberListClientAutoTLS(t *testing.T) {
+	testCtl(t, memberListTest, withCfg(*newConfigClientAutoTLS()))
+}
+func TestCtlV3MemberListPeerTLS(t *testing.T) {
+	testCtl(t, memberListTest, withCfg(*newConfigPeerTLS()))
+}
 func TestCtlV3MemberRemove(t *testing.T) {
 	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig())
 }
 func TestCtlV3MemberRemoveNoTLS(t *testing.T) {
-	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(configNoTLS))
+	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3MemberRemoveClientTLS(t *testing.T) {
-	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(configClientTLS))
+	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3MemberRemoveClientAutoTLS(t *testing.T) {
 	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(
@@ -53,25 +57,31 @@ func TestCtlV3MemberRemoveClientAutoTLS(t *testing.T) {
 		}))
 }
 func TestCtlV3MemberRemovePeerTLS(t *testing.T) {
-	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(configPeerTLS))
+	testCtl(t, memberRemoveTest, withQuorum(), withNoStrictReconfig(), withCfg(*newConfigPeerTLS()))
 }
-func TestCtlV3MemberAdd(t *testing.T)          { testCtl(t, memberAddTest) }
-func TestCtlV3MemberAddNoTLS(t *testing.T)     { testCtl(t, memberAddTest, withCfg(configNoTLS)) }
-func TestCtlV3MemberAddClientTLS(t *testing.T) { testCtl(t, memberAddTest, withCfg(configClientTLS)) }
+func TestCtlV3MemberAdd(t *testing.T)      { testCtl(t, memberAddTest) }
+func TestCtlV3MemberAddNoTLS(t *testing.T) { testCtl(t, memberAddTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3MemberAddClientTLS(t *testing.T) {
+	testCtl(t, memberAddTest, withCfg(*newConfigClientTLS()))
+}
 func TestCtlV3MemberAddClientAutoTLS(t *testing.T) {
-	testCtl(t, memberAddTest, withCfg(configClientAutoTLS))
+	testCtl(t, memberAddTest, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3MemberAddPeerTLS(t *testing.T)    { testCtl(t, memberAddTest, withCfg(configPeerTLS)) }
+func TestCtlV3MemberAddPeerTLS(t *testing.T)    { testCtl(t, memberAddTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3MemberAddForLearner(t *testing.T) { testCtl(t, memberAddForLearnerTest) }
 func TestCtlV3MemberUpdate(t *testing.T)        { testCtl(t, memberUpdateTest) }
-func TestCtlV3MemberUpdateNoTLS(t *testing.T)   { testCtl(t, memberUpdateTest, withCfg(configNoTLS)) }
+func TestCtlV3MemberUpdateNoTLS(t *testing.T) {
+	testCtl(t, memberUpdateTest, withCfg(*newConfigNoTLS()))
+}
 func TestCtlV3MemberUpdateClientTLS(t *testing.T) {
-	testCtl(t, memberUpdateTest, withCfg(configClientTLS))
+	testCtl(t, memberUpdateTest, withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3MemberUpdateClientAutoTLS(t *testing.T) {
-	testCtl(t, memberUpdateTest, withCfg(configClientAutoTLS))
+	testCtl(t, memberUpdateTest, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3MemberUpdatePeerTLS(t *testing.T) { testCtl(t, memberUpdateTest, withCfg(configPeerTLS)) }
+func TestCtlV3MemberUpdatePeerTLS(t *testing.T) {
+	testCtl(t, memberUpdateTest, withCfg(*newConfigPeerTLS()))
+}
 
 func memberListTest(cx ctlCtx) {
 	if err := ctlV3MemberList(cx); err != nil {

--- a/tests/e2e/ctl_v3_migrate_test.go
+++ b/tests/e2e/ctl_v3_migrate_test.go
@@ -28,9 +28,9 @@ import (
 func TestCtlV3Migrate(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	cfg := configNoTLS
+	cfg := newConfigNoTLS()
 	cfg.enableV2 = true
-	epc := setupEtcdctlTest(t, &cfg, false)
+	epc := setupEtcdctlTest(t, cfg, false)
 	defer func() {
 		if errC := epc.Close(); errC != nil {
 			t.Fatalf("error closing etcd processes (%v)", errC)
@@ -58,7 +58,7 @@ func TestCtlV3Migrate(t *testing.T) {
 	os.Unsetenv("ETCDCTL_API")
 	cx := ctlCtx{
 		t:           t,
-		cfg:         configNoTLS,
+		cfg:         *newConfigNoTLS(),
 		dialTimeout: 7 * time.Second,
 		epc:         epc,
 	}

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -29,11 +29,11 @@ import (
 )
 
 func TestCtlV3MoveLeaderSecure(t *testing.T) {
-	testCtlV3MoveLeader(t, configTLS)
+	testCtlV3MoveLeader(t, *newConfigTLS())
 }
 
 func TestCtlV3MoveLeaderInsecure(t *testing.T) {
-	testCtlV3MoveLeader(t, configNoTLS)
+	testCtlV3MoveLeader(t, *newConfigNoTLS())
 }
 
 func testCtlV3MoveLeader(t *testing.T, cfg etcdProcessClusterConfig) {
@@ -92,7 +92,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg etcdProcessClusterConfig) {
 	defer os.Unsetenv("ETCDCTL_API")
 	cx := ctlCtx{
 		t:           t,
-		cfg:         configNoTLS,
+		cfg:         *newConfigNoTLS(),
 		dialTimeout: 7 * time.Second,
 		epc:         epc,
 	}

--- a/tests/e2e/ctl_v3_role_test.go
+++ b/tests/e2e/ctl_v3_role_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func TestCtlV3RoleAdd(t *testing.T)          { testCtl(t, roleAddTest) }
-func TestCtlV3RoleAddNoTLS(t *testing.T)     { testCtl(t, roleAddTest, withCfg(configNoTLS)) }
-func TestCtlV3RoleAddClientTLS(t *testing.T) { testCtl(t, roleAddTest, withCfg(configClientTLS)) }
-func TestCtlV3RoleAddPeerTLS(t *testing.T)   { testCtl(t, roleAddTest, withCfg(configPeerTLS)) }
+func TestCtlV3RoleAddNoTLS(t *testing.T)     { testCtl(t, roleAddTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3RoleAddClientTLS(t *testing.T) { testCtl(t, roleAddTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3RoleAddPeerTLS(t *testing.T)   { testCtl(t, roleAddTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3RoleAddTimeout(t *testing.T)   { testCtl(t, roleAddTest, withDialTimeout(0)) }
 
 func TestCtlV3RoleGrant(t *testing.T) { testCtl(t, roleGrantTest) }

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -53,13 +53,13 @@ func TestClusterVersion(t *testing.T) {
 				t.Skipf("%q does not exist", binary)
 			}
 			defer testutil.AfterTest(t)
-			cfg := configNoTLS
+			cfg := newConfigNoTLS()
 			cfg.execPath = binary
 			cfg.snapshotCount = 3
 			cfg.baseScheme = "unix" // to avoid port conflict
 			cfg.rollingStart = tt.rollingStart
 
-			epc, err := newEtcdProcessCluster(t, &cfg)
+			epc, err := newEtcdProcessCluster(t, cfg)
 			if err != nil {
 				t.Fatalf("could not start etcd process cluster (%v)", err)
 			}
@@ -71,7 +71,7 @@ func TestClusterVersion(t *testing.T) {
 
 			ctx := ctlCtx{
 				t:   t,
-				cfg: cfg,
+				cfg: *cfg,
 				epc: epc,
 			}
 			cv := version.Cluster(version.Version)
@@ -108,7 +108,7 @@ func ctlV3Version(cx ctlCtx) error {
 
 // TestCtlV3DialWithHTTPScheme ensures that client handles endpoints with HTTPS scheme.
 func TestCtlV3DialWithHTTPScheme(t *testing.T) {
-	testCtl(t, dialWithSchemeTest, withCfg(configClientTLS))
+	testCtl(t, dialWithSchemeTest, withCfg(*newConfigClientTLS()))
 }
 
 func dialWithSchemeTest(cx ctlCtx) {
@@ -202,7 +202,7 @@ func testCtl(t *testing.T, testFunc func(ctlCtx), opts ...ctlOption) {
 
 	ret := ctlCtx{
 		t:           t,
-		cfg:         configAutoTLS,
+		cfg:         *newConfigAutoTLS(),
 		dialTimeout: 7 * time.Second,
 	}
 	ret.applyOpts(opts)

--- a/tests/e2e/ctl_v3_txn_test.go
+++ b/tests/e2e/ctl_v3_txn_test.go
@@ -20,13 +20,13 @@ func TestCtlV3TxnInteractiveSuccess(t *testing.T) {
 	testCtl(t, txnTestSuccess, withInteractive())
 }
 func TestCtlV3TxnInteractiveSuccessNoTLS(t *testing.T) {
-	testCtl(t, txnTestSuccess, withInteractive(), withCfg(configNoTLS))
+	testCtl(t, txnTestSuccess, withInteractive(), withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3TxnInteractiveSuccessClientTLS(t *testing.T) {
-	testCtl(t, txnTestSuccess, withInteractive(), withCfg(configClientTLS))
+	testCtl(t, txnTestSuccess, withInteractive(), withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3TxnInteractiveSuccessPeerTLS(t *testing.T) {
-	testCtl(t, txnTestSuccess, withInteractive(), withCfg(configPeerTLS))
+	testCtl(t, txnTestSuccess, withInteractive(), withCfg(*newConfigPeerTLS()))
 }
 func TestCtlV3TxnInteractiveFail(t *testing.T) {
 	testCtl(t, txnTestFail, withInteractive())

--- a/tests/e2e/ctl_v3_user_test.go
+++ b/tests/e2e/ctl_v3_user_test.go
@@ -17,33 +17,41 @@ package e2e
 import "testing"
 
 func TestCtlV3UserAdd(t *testing.T)          { testCtl(t, userAddTest) }
-func TestCtlV3UserAddNoTLS(t *testing.T)     { testCtl(t, userAddTest, withCfg(configNoTLS)) }
-func TestCtlV3UserAddClientTLS(t *testing.T) { testCtl(t, userAddTest, withCfg(configClientTLS)) }
-func TestCtlV3UserAddPeerTLS(t *testing.T)   { testCtl(t, userAddTest, withCfg(configPeerTLS)) }
+func TestCtlV3UserAddNoTLS(t *testing.T)     { testCtl(t, userAddTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3UserAddClientTLS(t *testing.T) { testCtl(t, userAddTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3UserAddPeerTLS(t *testing.T)   { testCtl(t, userAddTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3UserAddTimeout(t *testing.T)   { testCtl(t, userAddTest, withDialTimeout(0)) }
 func TestCtlV3UserAddClientAutoTLS(t *testing.T) {
-	testCtl(t, userAddTest, withCfg(configClientAutoTLS))
+	testCtl(t, userAddTest, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3UserList(t *testing.T)          { testCtl(t, userListTest) }
-func TestCtlV3UserListNoTLS(t *testing.T)     { testCtl(t, userListTest, withCfg(configNoTLS)) }
-func TestCtlV3UserListClientTLS(t *testing.T) { testCtl(t, userListTest, withCfg(configClientTLS)) }
-func TestCtlV3UserListPeerTLS(t *testing.T)   { testCtl(t, userListTest, withCfg(configPeerTLS)) }
+func TestCtlV3UserList(t *testing.T)      { testCtl(t, userListTest) }
+func TestCtlV3UserListNoTLS(t *testing.T) { testCtl(t, userListTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3UserListClientTLS(t *testing.T) {
+	testCtl(t, userListTest, withCfg(*newConfigClientTLS()))
+}
+func TestCtlV3UserListPeerTLS(t *testing.T) { testCtl(t, userListTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3UserListClientAutoTLS(t *testing.T) {
-	testCtl(t, userListTest, withCfg(configClientAutoTLS))
+	testCtl(t, userListTest, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3UserDelete(t *testing.T)          { testCtl(t, userDelTest) }
-func TestCtlV3UserDeleteNoTLS(t *testing.T)     { testCtl(t, userDelTest, withCfg(configNoTLS)) }
-func TestCtlV3UserDeleteClientTLS(t *testing.T) { testCtl(t, userDelTest, withCfg(configClientTLS)) }
-func TestCtlV3UserDeletePeerTLS(t *testing.T)   { testCtl(t, userDelTest, withCfg(configPeerTLS)) }
+func TestCtlV3UserDelete(t *testing.T)      { testCtl(t, userDelTest) }
+func TestCtlV3UserDeleteNoTLS(t *testing.T) { testCtl(t, userDelTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3UserDeleteClientTLS(t *testing.T) {
+	testCtl(t, userDelTest, withCfg(*newConfigClientTLS()))
+}
+func TestCtlV3UserDeletePeerTLS(t *testing.T) { testCtl(t, userDelTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3UserDeleteClientAutoTLS(t *testing.T) {
-	testCtl(t, userDelTest, withCfg(configClientAutoTLS))
+	testCtl(t, userDelTest, withCfg(*newConfigClientAutoTLS()))
 }
-func TestCtlV3UserPasswd(t *testing.T)          { testCtl(t, userPasswdTest) }
-func TestCtlV3UserPasswdNoTLS(t *testing.T)     { testCtl(t, userPasswdTest, withCfg(configNoTLS)) }
-func TestCtlV3UserPasswdClientTLS(t *testing.T) { testCtl(t, userPasswdTest, withCfg(configClientTLS)) }
-func TestCtlV3UserPasswdPeerTLS(t *testing.T)   { testCtl(t, userPasswdTest, withCfg(configPeerTLS)) }
+func TestCtlV3UserPasswd(t *testing.T)      { testCtl(t, userPasswdTest) }
+func TestCtlV3UserPasswdNoTLS(t *testing.T) { testCtl(t, userPasswdTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3UserPasswdClientTLS(t *testing.T) {
+	testCtl(t, userPasswdTest, withCfg(*newConfigClientTLS()))
+}
+func TestCtlV3UserPasswdPeerTLS(t *testing.T) {
+	testCtl(t, userPasswdTest, withCfg(*newConfigPeerTLS()))
+}
 func TestCtlV3UserPasswdClientAutoTLS(t *testing.T) {
-	testCtl(t, userPasswdTest, withCfg(configClientAutoTLS))
+	testCtl(t, userPasswdTest, withCfg(*newConfigClientAutoTLS()))
 }
 
 type userCmdDesc struct {

--- a/tests/e2e/ctl_v3_watch_cov_test.go
+++ b/tests/e2e/ctl_v3_watch_cov_test.go
@@ -22,22 +22,22 @@ import (
 )
 
 func TestCtlV3Watch(t *testing.T)          { testCtl(t, watchTest) }
-func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(configNoTLS)) }
-func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(configClientTLS)) }
-func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(configPeerTLS)) }
+func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3WatchTimeout(t *testing.T)   { testCtl(t, watchTest, withDialTimeout(0)) }
 
 func TestCtlV3WatchInteractive(t *testing.T) {
 	testCtl(t, watchTest, withInteractive())
 }
 func TestCtlV3WatchInteractiveNoTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configNoTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3WatchInteractiveClientTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configClientTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3WatchInteractivePeerTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configPeerTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigPeerTLS()))
 }
 
 func watchTest(cx ctlCtx) {

--- a/tests/e2e/ctl_v3_watch_no_cov_test.go
+++ b/tests/e2e/ctl_v3_watch_no_cov_test.go
@@ -22,22 +22,22 @@ import (
 )
 
 func TestCtlV3Watch(t *testing.T)          { testCtl(t, watchTest) }
-func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(configNoTLS)) }
-func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(configClientTLS)) }
-func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(configPeerTLS)) }
+func TestCtlV3WatchNoTLS(t *testing.T)     { testCtl(t, watchTest, withCfg(*newConfigNoTLS())) }
+func TestCtlV3WatchClientTLS(t *testing.T) { testCtl(t, watchTest, withCfg(*newConfigClientTLS())) }
+func TestCtlV3WatchPeerTLS(t *testing.T)   { testCtl(t, watchTest, withCfg(*newConfigPeerTLS())) }
 func TestCtlV3WatchTimeout(t *testing.T)   { testCtl(t, watchTest, withDialTimeout(0)) }
 
 func TestCtlV3WatchInteractive(t *testing.T) {
 	testCtl(t, watchTest, withInteractive())
 }
 func TestCtlV3WatchInteractiveNoTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configNoTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigNoTLS()))
 }
 func TestCtlV3WatchInteractiveClientTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configClientTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigClientTLS()))
 }
 func TestCtlV3WatchInteractivePeerTLS(t *testing.T) {
-	testCtl(t, watchTest, withInteractive(), withCfg(configPeerTLS))
+	testCtl(t, watchTest, withInteractive(), withCfg(*newConfigPeerTLS()))
 }
 
 func watchTest(cx ctlCtx) {

--- a/tests/e2e/etcd_corrupt_test.go
+++ b/tests/e2e/etcd_corrupt_test.go
@@ -36,13 +36,13 @@ func TestEtcdCorruptHash(t *testing.T) {
 	// defer os.Setenv("EXPECT_DEBUG", oldenv)
 	// os.Setenv("EXPECT_DEBUG", "1")
 
-	cfg := configNoTLS
+	cfg := newConfigNoTLS()
 
 	// trigger snapshot so that restart member can load peers from disk
 	cfg.snapshotCount = 3
 
 	testCtl(t, corruptTest, withQuorum(),
-		withCfg(cfg),
+		withCfg(*cfg),
 		withInitialCorruptCheck(),
 		withCorruptFunc(corruptHash),
 	)

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -36,12 +36,12 @@ func TestReleaseUpgrade(t *testing.T) {
 
 	defer testutil.AfterTest(t)
 
-	copiedCfg := configNoTLS
+	copiedCfg := newConfigNoTLS()
 	copiedCfg.execPath = lastReleaseBinary
 	copiedCfg.snapshotCount = 3
 	copiedCfg.baseScheme = "unix" // to avoid port conflict
 
-	epc, err := newEtcdProcessCluster(t, &copiedCfg)
+	epc, err := newEtcdProcessCluster(t, copiedCfg)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -69,7 +69,7 @@ func TestReleaseUpgrade(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	cx := ctlCtx{
 		t:           t,
-		cfg:         configNoTLS,
+		cfg:         *newConfigNoTLS(),
 		dialTimeout: 7 * time.Second,
 		quorum:      true,
 		epc:         epc,
@@ -127,12 +127,12 @@ func TestReleaseUpgradeWithRestart(t *testing.T) {
 
 	defer testutil.AfterTest(t)
 
-	copiedCfg := configNoTLS
+	copiedCfg := newConfigNoTLS()
 	copiedCfg.execPath = lastReleaseBinary
 	copiedCfg.snapshotCount = 10
 	copiedCfg.baseScheme = "unix"
 
-	epc, err := newEtcdProcessCluster(t, &copiedCfg)
+	epc, err := newEtcdProcessCluster(t, copiedCfg)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -146,7 +146,7 @@ func TestReleaseUpgradeWithRestart(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	cx := ctlCtx{
 		t:           t,
-		cfg:         configNoTLS,
+		cfg:         *newConfigNoTLS(),
 		dialTimeout: 7 * time.Second,
 		quorum:      true,
 		epc:         epc,

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestGateway(t *testing.T) {
-	ec, err := newEtcdProcessCluster(t, &configNoTLS)
+	ec, err := newEtcdProcessCluster(t, newConfigNoTLS())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 func TestV3MetricsSecure(t *testing.T) {
-	cfg := configTLS
+	cfg := newConfigTLS()
 	cfg.clusterSize = 1
 	cfg.metricsURLScheme = "https"
 	testCtl(t, metricsTest)
 }
 
 func TestV3MetricsInsecure(t *testing.T) {
-	cfg := configTLS
+	cfg := newConfigTLS()
 	cfg.clusterSize = 1
 	cfg.metricsURLScheme = "http"
 	testCtl(t, metricsTest)

--- a/tests/e2e/v2_curl_test.go
+++ b/tests/e2e/v2_curl_test.go
@@ -24,12 +24,12 @@ import (
 	"go.etcd.io/etcd/pkg/v3/testutil"
 )
 
-func TestV2CurlNoTLS(t *testing.T)      { testCurlPutGet(t, &configNoTLS) }
-func TestV2CurlAutoTLS(t *testing.T)    { testCurlPutGet(t, &configAutoTLS) }
-func TestV2CurlAllTLS(t *testing.T)     { testCurlPutGet(t, &configTLS) }
-func TestV2CurlPeerTLS(t *testing.T)    { testCurlPutGet(t, &configPeerTLS) }
-func TestV2CurlClientTLS(t *testing.T)  { testCurlPutGet(t, &configClientTLS) }
-func TestV2CurlClientBoth(t *testing.T) { testCurlPutGet(t, &configClientBoth) }
+func TestV2CurlNoTLS(t *testing.T)      { testCurlPutGet(t, newConfigNoTLS()) }
+func TestV2CurlAutoTLS(t *testing.T)    { testCurlPutGet(t, newConfigAutoTLS()) }
+func TestV2CurlAllTLS(t *testing.T)     { testCurlPutGet(t, newConfigTLS()) }
+func TestV2CurlPeerTLS(t *testing.T)    { testCurlPutGet(t, newConfigPeerTLS()) }
+func TestV2CurlClientTLS(t *testing.T)  { testCurlPutGet(t, newConfigClientTLS()) }
+func TestV2CurlClientBoth(t *testing.T) { testCurlPutGet(t, newConfigClientBoth()) }
 func testCurlPutGet(t *testing.T, cfg *etcdProcessClusterConfig) {
 	defer testutil.AfterTest(t)
 
@@ -70,9 +70,9 @@ func TestV2CurlIssue5182(t *testing.T) {
 	defer os.Unsetenv("ETCDCTL_API")
 	defer testutil.AfterTest(t)
 
-	copied := configNoTLS
+	copied := newConfigNoTLS()
 	copied.enableV2 = true
-	epc := setupEtcdctlTest(t, &copied, false)
+	epc := setupEtcdctlTest(t, copied, false)
 	defer func() {
 		if err := epc.Close(); err != nil {
 			t.Fatalf("error closing etcd processes (%v)", err)

--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -26,7 +26,7 @@ import (
 func TestV3CurlCipherSuitesValid(t *testing.T)    { testV3CurlCipherSuites(t, true) }
 func TestV3CurlCipherSuitesMismatch(t *testing.T) { testV3CurlCipherSuites(t, false) }
 func testV3CurlCipherSuites(t *testing.T, valid bool) {
-	cc := configClientTLS
+	cc := newConfigClientTLS()
 	cc.clusterSize = 1
 	cc.cipherSuites = []string{
 		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -40,7 +40,7 @@ func testV3CurlCipherSuites(t *testing.T, valid bool) {
 	if !valid {
 		testFunc = cipherSuiteTestMismatch
 	}
-	testCtl(t, testFunc, withCfg(cc))
+	testCtl(t, testFunc, withCfg(*cc))
 }
 
 func cipherSuiteTestValid(cx ctlCtx) {

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -23,22 +23,22 @@ import (
 
 func TestV3CurlLeaseGrantNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseGrant, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlLeaseGrant, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 func TestV3CurlLeaseRevokeNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseRevoke, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlLeaseRevoke, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 func TestV3CurlLeaseLeasesNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseLeases, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlLeaseLeases, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 func TestV3CurlLeaseKeepAliveNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseKeepAlive, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlLeaseKeepAlive, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -36,27 +36,27 @@ var apiPrefix = []string{"/v3", "/v3beta"}
 
 func TestV3CurlPutGetNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 func TestV3CurlPutGetAutoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(configAutoTLS))
+		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(*newConfigAutoTLS()))
 	}
 }
 func TestV3CurlPutGetAllTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(configTLS))
+		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(*newConfigTLS()))
 	}
 }
 func TestV3CurlPutGetPeerTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(configPeerTLS))
+		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(*newConfigPeerTLS()))
 	}
 }
 func TestV3CurlPutGetClientTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(configClientTLS))
+		testCtl(t, testV3CurlPutGet, withApiPrefix(p), withCfg(*newConfigClientTLS()))
 	}
 }
 func TestV3CurlWatch(t *testing.T) {
@@ -76,7 +76,7 @@ func TestV3CurlAuth(t *testing.T) {
 }
 func TestV3CurlAuthClientTLSCertAuth(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlAuth, withApiPrefix(p), withCfg(configClientTLSCertAuthWithNoCN))
+		testCtl(t, testV3CurlAuth, withApiPrefix(p), withCfg(*newConfigClientTLSCertAuthWithNoCN()))
 	}
 }
 
@@ -269,7 +269,7 @@ func testV3CurlAuth(cx ctlCtx) {
 
 func TestV3CurlCampaignNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlCampaign, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlCampaign, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 
@@ -331,7 +331,7 @@ func testV3CurlCampaign(cx ctlCtx) {
 
 func TestV3CurlProclaimMissiongLeaderKeyNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlProclaimMissiongLeaderKey, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlProclaimMissiongLeaderKey, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 
@@ -351,7 +351,7 @@ func testV3CurlProclaimMissiongLeaderKey(cx ctlCtx) {
 
 func TestV3CurlResignMissiongLeaderKeyNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlResignMissiongLeaderKey, withApiPrefix(p), withCfg(configNoTLS))
+		testCtl(t, testV3CurlResignMissiongLeaderKey, withApiPrefix(p), withCfg(*newConfigNoTLS()))
 	}
 }
 


### PR DESCRIPTION
The e2e tests can be flaky due to various tests mutating shared mutable
fixtures, causing non-deterministic behavior depending on the test set, order,
etc.

For example, `configTLS` is mutated in at least two tests in such a way that the
config is potentially invalidated for any subsequent test running in the same
process (e.g. by setting the `enableV2` field). This particular example caused
a substantial amount of confusion diagnosing the new test introduced for
https://github.com/etcd-io/etcd/pull/12370.

Independent tests should not share mutable state unless deliberately. This patch
refactors the e2e test config fixtures to safeguard against these problems by
replacing the package variables (which cannot easily be made immutable) with
functions that return new instances.
