### PR TITLE
etcdserver: Fix 64 KB websocket notification message limit

### DIFF
--- a/embed/serve.go
+++ b/embed/serve.go
@@ -275,6 +275,7 @@ func (sctx *serveCtx) createMux(gwmux *gw.ServeMux, handler http.Handler) *http.
 						return outgoing
 					},
 				),
+				wsproxy.WithMaxRespBodyBufferSize(0x7fffffff),
 			),
 		)
 	}


### PR DESCRIPTION
This fixes etcd being unable to send any message longer than 64 KB as a notification over the websocket. This was because the older version of grpc-websocket-proxy was used and WithMaxRespBodyBufferSize option wasn't set.

Same as #12402, but for the master branch.