### PR TITLE
embed: only log stream error with debug level

### DIFF
--- a/embed/config_logging.go
+++ b/embed/config_logging.go
@@ -17,6 +17,8 @@ package embed
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"sync"
 
 	"go.etcd.io/etcd/pkg/v3/logutil"
@@ -107,10 +109,14 @@ func (cfg *Config) setupLogging() error {
 					grpcLogOnce.Do(func() {
 						// debug true, enable info, warning, error
 						// debug false, only discard info
-						var gl grpclog.LoggerV2
-						gl, err = logutil.NewGRPCLoggerV2(copied)
-						if err == nil {
-							grpclog.SetLoggerV2(gl)
+						if cfg.LogLevel == "debug" {
+							var gl grpclog.LoggerV2
+							gl, err = logutil.NewGRPCLoggerV2(copied)
+							if err == nil {
+								grpclog.SetLoggerV2(gl)
+							}
+						} else {
+							grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
 						}
 					})
 					return nil
@@ -154,7 +160,11 @@ func (cfg *Config) setupLogging() error {
 					c.loggerWriteSyncer = syncer
 
 					grpcLogOnce.Do(func() {
-						grpclog.SetLoggerV2(logutil.NewGRPCLoggerV2FromZapCore(cr, syncer))
+						if cfg.LogLevel == "debug" {
+							grpclog.SetLoggerV2(logutil.NewGRPCLoggerV2FromZapCore(cr, syncer))
+						} else {
+							grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+						}
 					})
 					return nil
 				}


### PR DESCRIPTION
Disable noisy gRPC logs.
```
22:07:55 etcd1 | {"level":"warn","ts":"2020-10-20T22:07:55.500+0800","caller":"grpclog/grpclog.go:66","msg":"transport: http2Server.HandleStreams failed to read frame: read tcp 127.0.0.1:2379->127.0.0.1:62786: read: connection reset by peer"}
22:07:55 etcd1 | {"level":"info","ts":"2020-10-20T22:07:55.500+0800","caller":"grpclog/grpclog.go:51","msg":"transport: loopyWriter.run returning. connection error: desc = \"transport is closing\""}
22:07:56 etcd1 | {"level":"warn","ts":"2020-10-20T22:07:56.135+0800","caller":"grpclog/grpclog.go:66","msg":"transport: http2Server.HandleStreams failed to read frame: read tcp 127.0.0.1:2379->127.0.0.1:62789: read: connection reset by peer"}
22:07:56 etcd1 | {"level":"info","ts":"2020-10-20T22:07:56.136+0800","caller":"grpclog/grpclog.go:51","msg":"transport: loopyWriter.run returning. connection error: desc = \"transport is closing\""}
```