### PR TITLE
clientv3test: fix network partition flaky test

### DIFF
--- a/tests/integration/clientv3/network_partition_test.go
+++ b/tests/integration/clientv3/network_partition_test.go
@@ -74,7 +74,7 @@ func TestBalancerUnderNetworkPartitionTxn(t *testing.T) {
 func TestBalancerUnderNetworkPartitionLinearizableGetWithLongTimeout(t *testing.T) {
 	testBalancerUnderNetworkPartition(t, func(cli *clientv3.Client, ctx context.Context) error {
 		_, err := cli.Get(ctx, "a")
-		if err == rpctypes.ErrTimeout {
+		if isClientTimeout(err) || isServerCtxTimeout(err) || err == rpctypes.ErrTimeout {
 			return errExpected
 		}
 		return err


### PR DESCRIPTION
https://travis-ci.com/github/etcd-io/etcd/jobs/402551406

this test case can ignore "context deadline exceeded" error and will retry five times until successful.

```
"level":"warn","ts":"2020-10-20T14:12:05.885Z","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-30838c61-be53-4f69-b1c6-b37551a49abf/localhost:41839574038523197090","attempt":2,"error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
--- FAIL: TestBalancerUnderNetworkPartitionLinearizableGetWithLongTimeout (14.12s)
network_partition_test.go:143: #0: expected 'expected error', got 'context deadline exceeded'
{"level":"warn","ts":"2020-10-20T14:12:15.409Z","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-b66f9674-48e3-400f-8dba-
```
