### PR TITLE
Unify tabs vs. spaces in the shell scripts

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,7 @@ source ./scripts/test_lib.sh
 
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 if [[ -n "$FAILPOINTS" ]]; then
-	GIT_SHA="$GIT_SHA"-FAILPOINTS
+  GIT_SHA="$GIT_SHA"-FAILPOINTS
 fi
 
 VERSION_SYMBOL="go.etcd.io/etcd/api/v3/version.GitSHA"
@@ -16,107 +16,107 @@ GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS}" "GOOS=${GOOS}" 
 
 # enable/disable failpoints
 toggle_failpoints() {
-	mode="$1"
-	if command -v gofail >/dev/null 2>&1; then
-		run gofail "$mode" etcdserver/ mvcc/backend/
-	elif [[ "$mode" != "disable" ]]; then
-		log_error "FAILPOINTS set but gofail not found"
-		exit 1
-	fi
+  mode="$1"
+  if command -v gofail >/dev/null 2>&1; then
+    run gofail "$mode" etcdserver/ mvcc/backend/
+  elif [[ "$mode" != "disable" ]]; then
+    log_error "FAILPOINTS set but gofail not found"
+    exit 1
+  fi
 }
 
 toggle_failpoints_default() {
-	mode="disable"
-	if [[ -n "$FAILPOINTS" ]]; then mode="enable"; fi
-	toggle_failpoints "$mode"
+  mode="disable"
+  if [[ -n "$FAILPOINTS" ]]; then mode="enable"; fi
+  toggle_failpoints "$mode"
 }
 
 etcd_build() {
-	out="bin"
-	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
-	toggle_failpoints_default
+  out="bin"
+  if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
+  toggle_failpoints_default
 
-	run rm -f "${out}/etcd"
-	# Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
-	# shellcheck disable=SC2086
-	run env "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
-		-installsuffix=cgo \
-		"-ldflags=${GO_LDFLAGS[*]}" \
-		-o="${out}/etcd" . || return 2
+  run rm -f "${out}/etcd"
+  # Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
+  # shellcheck disable=SC2086
+  run env "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+    -installsuffix=cgo \
+    "-ldflags=${GO_LDFLAGS[*]}" \
+    -o="${out}/etcd" . || return 2
 
-	run rm -f "${out}/etcdctl"
-	# shellcheck disable=SC2086
-	(
-		cd ./etcdctl
-		run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build $GO_BUILD_FLAGS \
-			-installsuffix=cgo \
-			"-ldflags=${GO_LDFLAGS[*]}" \
-			-o="../${out}/etcdctl" . || return 2
-	) || return 2
-	# Verify whether symbol we overriden exists
-	# For cross-compiling we cannot run: ${out}/etcd --version | grep -q "Git SHA: ${GIT_SHA}"
+  run rm -f "${out}/etcdctl"
+  # shellcheck disable=SC2086
+  (
+    cd ./etcdctl
+    run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build $GO_BUILD_FLAGS \
+      -installsuffix=cgo \
+      "-ldflags=${GO_LDFLAGS[*]}" \
+      -o="../${out}/etcdctl" . || return 2
+  ) || return 2
+  # Verify whether symbol we overriden exists
+  # For cross-compiling we cannot run: ${out}/etcd --version | grep -q "Git SHA: ${GIT_SHA}"
 
-	# We need symbols to do this check:
-	if [[ "${GO_LDFLAGS[*]}" != *"-s"* ]]; then
-		go tool nm "${out}/etcd" | grep "${VERSION_SYMBOL}" > /dev/null
-		if [[ "${PIPESTATUS[*]}" != "0 0" ]]; then
-			log_error "FAIL: Symbol ${VERSION_SYMBOL} not found in binary: ${out}/etcd"
-			return 2
-		fi
-	fi
+  # We need symbols to do this check:
+  if [[ "${GO_LDFLAGS[*]}" != *"-s"* ]]; then
+    go tool nm "${out}/etcd" | grep "${VERSION_SYMBOL}" > /dev/null
+    if [[ "${PIPESTATUS[*]}" != "0 0" ]]; then
+      log_error "FAIL: Symbol ${VERSION_SYMBOL} not found in binary: ${out}/etcd"
+      return 2
+    fi
+  fi
 }
 
 tools_build() {
-	out="bin"
-	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
-	tools_path="tools/benchmark
-		tools/etcd-dump-db
-		tools/etcd-dump-logs
-		tools/local-tester/bridge"
-	for tool in ${tools_path}
-	do
-		echo "Building" "'${tool}'"...
-		run rm -f "${out}/${tool}"
-		# shellcheck disable=SC2086
-		run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
-			-installsuffix=cgo \
-			"-ldflags='${GO_LDFLAGS[*]}'" \
-			-o="${out}/${tool}" "./${tool}" || return 2
-	done
-	tests_build "${@}"
+  out="bin"
+  if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
+  tools_path="tools/benchmark
+    tools/etcd-dump-db
+    tools/etcd-dump-logs
+    tools/local-tester/bridge"
+  for tool in ${tools_path}
+  do
+    echo "Building" "'${tool}'"...
+    run rm -f "${out}/${tool}"
+    # shellcheck disable=SC2086
+    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
+      -installsuffix=cgo \
+      "-ldflags='${GO_LDFLAGS[*]}'" \
+      -o="${out}/${tool}" "./${tool}" || return 2
+  done
+  tests_build "${@}"
 }
 
 tests_build() {
-	out="bin"
-	if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
-	tools_path="
-		functional/cmd/etcd-agent
-		functional/cmd/etcd-proxy
-		functional/cmd/etcd-runner
-		functional/cmd/etcd-tester"
-	(
-		cd tests || exit 2
-		for tool in ${tools_path}; do
-			echo "Building" "'${tool}'"...
-			run rm -f "../${out}/${tool}"
+  out="bin"
+  if [[ -n "${BINDIR}" ]]; then out="${BINDIR}"; fi
+  tools_path="
+    functional/cmd/etcd-agent
+    functional/cmd/etcd-proxy
+    functional/cmd/etcd-runner
+    functional/cmd/etcd-tester"
+  (
+    cd tests || exit 2
+    for tool in ${tools_path}; do
+      echo "Building" "'${tool}'"...
+      run rm -f "../${out}/${tool}"
 
-			# shellcheck disable=SC2086
-			run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build ${GO_BUILD_FLAGS} \
-				-installsuffix=cgo \
-				"-ldflags='${GO_LDFLAGS[*]}'" \
-				-o="../${out}/${tool}" "./${tool}" || return 2
-		done
-	) || return 2
+      # shellcheck disable=SC2086
+      run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build ${GO_BUILD_FLAGS} \
+        -installsuffix=cgo \
+        "-ldflags='${GO_LDFLAGS[*]}'" \
+        -o="../${out}/${tool}" "./${tool}" || return 2
+    done
+  ) || return 2
 }
 
 toggle_failpoints_default
 
 # only build when called directly, not sourced
 if echo "$0" | grep "build$" >/dev/null; then
-	if etcd_build; then
-		log_success "SUCCESS: etcd_build"
-	else
-		log_error "FAIL: etcd_build"
-		exit 2
+  if etcd_build; then
+    log_success "SUCCESS: etcd_build"
+  else
+    log_error "FAIL: etcd_build"
+    exit 2
   fi
 fi

--- a/pkg/proxy/fixtures/gencerts.sh
+++ b/pkg/proxy/fixtures/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -7,8 +7,8 @@ set -e
 
 VERSION=$1
 if [ -z "${VERSION}" ]; then
-	echo "Usage: ${0} VERSION" >> /dev/stderr
-	exit 255
+  echo "Usage: ${0} VERSION" >> /dev/stderr
+  exit 255
 fi
 
 if ! command -v docker >/dev/null; then
@@ -19,11 +19,11 @@ fi
 ETCD_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 pushd "${ETCD_ROOT}" >/dev/null
-	echo Building etcd binary...
-	./scripts/build-binary "${VERSION}"
+  echo Building etcd binary...
+  ./scripts/build-binary "${VERSION}"
 
-	for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
-		echo Building ${TARGET_ARCH} docker image...
-		GOOS=linux GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-docker "${VERSION}"
-	done
+  for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
+    echo Building ${TARGET_ARCH} docker image...
+    GOOS=linux GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-docker "${VERSION}"
+  done
 popd >/dev/null

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -10,10 +10,18 @@ function mod_tidy_fix {
   run go mod tidy || return 2
 }
 
+function bash_ws_fix {
+  log_callout "Fixing whitespaces in the bash scripts"
+  # Makes sure all bash scripts do use '  ' (double space) for indention. 
+  log_cmd "% find ./ -name '*.sh' | xargs sed --follow-symlinks -i 's|\t|  |g'"
+  find ./ -print0 -name '*.sh' | xargs -0 sed --follow-symlinks -i 's|\t|  |g'
+}
+
 log_callout -e "\nFixing etcd code for you...\n"
 
 run_for_modules run go fmt || exit 2
 run_for_modules mod_tidy_fix || exit 2
 run_for_module tests bom_fix || exit 2
+bash_ws_fix || exit 2
 
 log_success -e "\nSUCCESS: etcd code is fixed :)"

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [[ "$(go list)" != "go.etcd.io/etcd/v3" ]]; then
-	echo "must be run from 'go.etcd.io/etcd/v3' module directory"
-	exit 255
+  echo "must be run from 'go.etcd.io/etcd/v3' module directory"
+  exit 255
 fi
 
 ETCD_ROOT_DIR=$(go list -f '{{.Dir}}' "go.etcd.io/etcd/v3")
@@ -107,12 +107,12 @@ function run_for_module {
 function modules() {
   echo "go.etcd.io/etcd/api/v3
         go.etcd.io/etcd/pkg/v3
-	go.etcd.io/etcd/raft/v3
-	go.etcd.io/etcd/client/v2
-	go.etcd.io/etcd/client/v3
-	go.etcd.io/etcd/v3
-	go.etcd.io/etcd/etcdctl/v3
-	go.etcd.io/etcd/tests/v3"
+  go.etcd.io/etcd/raft/v3
+  go.etcd.io/etcd/client/v2
+  go.etcd.io/etcd/client/v3
+  go.etcd.io/etcd/v3
+  go.etcd.io/etcd/etcdctl/v3
+  go.etcd.io/etcd/tests/v3"
 }
 
 function modules_exp() {

--- a/test
+++ b/test
@@ -306,6 +306,8 @@ function fmt_pass {
       commit_title \
       mod_tidy \
       dep \
+      shellcheck \
+      shellws \
       ; do
     run_pass "${p}" "${@}"
   done
@@ -314,6 +316,21 @@ function fmt_pass {
 function shellcheck_pass {
   if tool_exists "shellcheck" "https://github.com/koalaman/shellcheck#installing"; then
     generic_checker run shellcheck -fgcc build test scripts/*.sh
+  fi
+}
+
+function shellws_pass {
+  log_callout "Ensuring no tab-based indention in shell scripts"
+  local files
+  files=$(find ./ -name '*.sh' -print0 | xargs -0 )
+  log_cmd "grep -E -n $'^ *\t' ${files}"
+  # shellcheck disable=SC2086
+  if grep -E -n $'^ *\t' ${files} | sed -s $'s|\t|[\\\\tab]|g'; then
+    log_error "FAIL: found tab-based indention in bash scripts. Use '  ' (double space)."
+    return 1
+  else
+    log_success "SUCCESS: no tabulators found."
+    return 0
   fi
 }
 

--- a/tests/docker-dns-srv/certs-gateway/gencerts.sh
+++ b/tests/docker-dns-srv/certs-gateway/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns-srv/certs-wildcard/gencerts.sh
+++ b/tests/docker-dns-srv/certs-wildcard/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns-srv/certs/gencerts.sh
+++ b/tests/docker-dns-srv/certs/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs-common-name-auth/gencerts.sh
+++ b/tests/docker-dns/certs-common-name-auth/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs-common-name-multi/gencerts.sh
+++ b/tests/docker-dns/certs-common-name-multi/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs-gateway/gencerts.sh
+++ b/tests/docker-dns/certs-gateway/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs-san-dns/gencerts.sh
+++ b/tests/docker-dns/certs-san-dns/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs-wildcard/gencerts.sh
+++ b/tests/docker-dns/certs-wildcard/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-dns/certs/gencerts.sh
+++ b/tests/docker-dns/certs/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-static-ip/certs-metrics-proxy/gencerts.sh
+++ b/tests/docker-static-ip/certs-metrics-proxy/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tests/docker-static-ip/certs/gencerts.sh
+++ b/tests/docker-static-ip/certs/gencerts.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if ! [[ "$0" =~ "./gencerts.sh" ]]; then
-	echo "must be run from 'fixtures'"
-	exit 255
+  echo "must be run from 'fixtures'"
+  exit 255
 fi
 
 if ! which cfssl; then
-	echo "cfssl is not installed"
-	exit 255
+  echo "cfssl is not installed"
+  exit 255
 fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca

--- a/tools/etcd-dump-logs/testdecoder/decoder_correctoutputformat.sh
+++ b/tools/etcd-dump-logs/testdecoder/decoder_correctoutputformat.sh
@@ -3,8 +3,8 @@ while read line
 do
   LEN=$(echo ${#line})
   if [ $LEN -ge 20 ]; then
-  	echo "OK|$line" | tr 1234567890 abcdefghij
+    echo "OK|$line" | tr 1234567890 abcdefghij
   else
-  	echo "ERROR|$line" | tr 1234567890 abcdefghij
+    echo "ERROR|$line" | tr 1234567890 abcdefghij
   fi
 done < "${1:-/dev/stdin}"

--- a/tools/local-tester/bridge.sh
+++ b/tools/local-tester/bridge.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 exec tools/local-tester/bridge/bridge \
-	-delay-accept		\
-	-reset-listen		\
-	-conn-fault-rate=0.25	\
-	-immediate-close	\
-	-blackhole		\
-	-time-close		\
-	-write-remote-only	\
-	-read-remote-only	\
-	-random-blackhole	\
-	-corrupt-receive	\
-	-corrupt-send		\
-	-reorder		\
-	$@
+  -delay-accept    \
+  -reset-listen    \
+  -conn-fault-rate=0.25  \
+  -immediate-close  \
+  -blackhole    \
+  -time-close    \
+  -write-remote-only  \
+  -read-remote-only  \
+  -random-blackhole  \
+  -corrupt-receive  \
+  -corrupt-send    \
+  -reorder    \
+  $@

--- a/tools/local-tester/faults.sh
+++ b/tools/local-tester/faults.sh
@@ -4,88 +4,88 @@ PROCFILE="tools/local-tester/Procfile"
 HTTPFAIL=(127.0.0.1:11180 127.0.0.1:22280 127.0.0.1:33380)
 
 function wait_time {
-	expr $RANDOM % 10 + 1
+  expr $RANDOM % 10 + 1
 }
 
 function cycle {
-	for a; do
-		echo "cycling $a"
-		goreman -f $PROCFILE run stop $a || echo "could not stop $a"
-		sleep `wait_time`s
-		goreman -f $PROCFILE run restart $a || echo "could not restart $a"
-	done
+  for a; do
+    echo "cycling $a"
+    goreman -f $PROCFILE run stop $a || echo "could not stop $a"
+    sleep `wait_time`s
+    goreman -f $PROCFILE run restart $a || echo "could not restart $a"
+  done
 }
 
 function cycle_members {
-	cycle etcd1 etcd2 etcd3
+  cycle etcd1 etcd2 etcd3
 }
 function cycle_pbridge {
-	cycle pbridge1 pbridge2 pbridge3
+  cycle pbridge1 pbridge2 pbridge3
 }
 function cycle_cbridge {
-	cycle cbridge1 cbridge2 cbridge3
+  cycle cbridge1 cbridge2 cbridge3
 }
 function cycle_stresser {
-	cycle stress-put
+  cycle stress-put
 }
 
 function kill_maj {
-	idx="etcd"`expr $RANDOM % 3 + 1`
-	idx2="$idx"
-	while [ "$idx" == "$idx2" ]; do
-		idx2="etcd"`expr $RANDOM % 3 + 1`
-	done
-	echo "kill majority $idx $idx2"
-	goreman -f $PROCFILE run stop $idx || echo "could not stop $idx"
-	goreman -f $PROCFILE run stop $idx2 || echo "could not stop $idx2"
-	sleep `wait_time`s
-	goreman -f $PROCFILE run restart $idx || echo "could not restart $idx"
-	goreman -f $PROCFILE run restart $idx2 || echo "could not restart $idx2"
+  idx="etcd"`expr $RANDOM % 3 + 1`
+  idx2="$idx"
+  while [ "$idx" == "$idx2" ]; do
+    idx2="etcd"`expr $RANDOM % 3 + 1`
+  done
+  echo "kill majority $idx $idx2"
+  goreman -f $PROCFILE run stop $idx || echo "could not stop $idx"
+  goreman -f $PROCFILE run stop $idx2 || echo "could not stop $idx2"
+  sleep `wait_time`s
+  goreman -f $PROCFILE run restart $idx || echo "could not restart $idx"
+  goreman -f $PROCFILE run restart $idx2 || echo "could not restart $idx2"
 }
 
 function kill_all {
-	for a in etcd1 etcd2 etcd3; do
-		goreman -f $PROCFILE run stop $a || echo "could not stop $a"
-	done
-	sleep `wait_time`s
-	for a in etcd1 etcd2 etcd3; do
-		goreman -f $PROCFILE run restart $a || echo "could not restart $a"
-	done
+  for a in etcd1 etcd2 etcd3; do
+    goreman -f $PROCFILE run stop $a || echo "could not stop $a"
+  done
+  sleep `wait_time`s
+  for a in etcd1 etcd2 etcd3; do
+    goreman -f $PROCFILE run restart $a || echo "could not restart $a"
+  done
 }
 
 function rand_fp {
-	echo "$FAILPOINTS" | sed `expr $RANDOM % $NUMFPS + 1`"q;d"
+  echo "$FAILPOINTS" | sed `expr $RANDOM % $NUMFPS + 1`"q;d"
 }
 
 # fp_activate <http> <fppath> <value>
 function fp_activate {
-	curl "$1"/"$2" -XPUT -d "$3" >/dev/null 2>&1
+  curl "$1"/"$2" -XPUT -d "$3" >/dev/null 2>&1
 }
 
 function fp_rand_single {
-	fp=`rand_fp`
-	fp_activate ${HTTPFAIL[`expr $RANDOM % ${#HTTPFAIL[@]}`]} $fp 'panic("'$fp'")'
-	sleep `wait_time`s
+  fp=`rand_fp`
+  fp_activate ${HTTPFAIL[`expr $RANDOM % ${#HTTPFAIL[@]}`]} $fp 'panic("'$fp'")'
+  sleep `wait_time`s
 }
 
 function fp_rand_all {
-	fp=`rand_fp`
-	for a in `seq ${#HTTPFAIL[@]}`; do fp_activate ${HTTPFAIL[$a]} "$fp" 'panic("'$fp'")'; done
-	sleep `wait_time`s
+  fp=`rand_fp`
+  for a in `seq ${#HTTPFAIL[@]}`; do fp_activate ${HTTPFAIL[$a]} "$fp" 'panic("'$fp'")'; done
+  sleep `wait_time`s
 }
 
 function fp_all_rand_fire {
-	for fp in $FAILPOINTS; do
-		for url in "${HTTPFAIL[@]}"; do
-			fp_activate "$url" "$fp" '0.5%panic("0.5%'$fp'")'
-		done
-	done
+  for fp in $FAILPOINTS; do
+    for url in "${HTTPFAIL[@]}"; do
+      fp_activate "$url" "$fp" '0.5%panic("0.5%'$fp'")'
+    done
+  done
 }
 
 function choose {
-	fault=${FAULTS[`expr $RANDOM % ${#FAULTS[@]}`]}
-	echo $fault
-	$fault || echo "failed: $fault"
+  fault=${FAULTS[`expr $RANDOM % ${#FAULTS[@]}`]}
+  echo $fault
+  $fault || echo "failed: $fault"
 }
 
 sleep 2s
@@ -96,13 +96,13 @@ FAULTS=(cycle_members kill_maj kill_all cycle_pbridge cycle_cbridge cycle_stress
 FAILPOINTS=`curl http://"${HTTPFAIL[0]}" 2>/dev/null | cut -f1 -d'=' | grep -v "^$"`
 NUMFPS=`echo $(echo "$FAILPOINTS" | wc -l)`
 if [ "$NUMFPS" != "0" ]; then
-	FAULTS+=(fp_rand_single)
-	FAULTS+=(fp_rand_all)
+  FAULTS+=(fp_rand_single)
+  FAULTS+=(fp_rand_all)
 fi
 
 while [ 1 ]; do
-	choose
-	# start any nodes that have been killed by failpoints
-	for a in etcd1 etcd2 etcd3; do goreman -f $PROCFILE run start $a; done
-	fp_all_rand_fire
+  choose
+  # start any nodes that have been killed by failpoints
+  for a in etcd1 etcd2 etcd3; do goreman -f $PROCFILE run start $a; done
+  fp_all_rand_fire
 done


### PR DESCRIPTION
As frequently I got comments about wrong 'indention' in bash scripts, caused by 
different length of '\tab' in different editors, in the PR: 
 - I add a PASSES="shellws" ./test  that makes sure indention is made using 'spaces' (no tabs) 
 -Converted existing shell scripts. 

I picked tab=2spaces for compliance with: https://google.github.io/styleguide/shellguide.html#s5.1-indentation