### PR TITLE
scripts: install github.com/myitcv/gobin while gobin doesn't exist.

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -17,8 +17,6 @@ if [[ $(protoc --version | cut -f2 -d' ') != "3.12.3" ]]; then
   exit 255
 fi
 
-run env GO111MODULE=off go get -u github.com/myitcv/gobin
-
 GOFAST_BIN=$(tool_get_bin github.com/gogo/protobuf/protoc-gen-gofast)
 GRPC_GATEWAY_BIN=$(tool_get_bin github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway)
 SWAGGER_BIN=$(tool_get_bin github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger)

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -278,6 +278,11 @@ function tool_exists {
   fi
 }
 
+# Ensure gobin is available, as it runs majority of the tools
+if ! command -v "gobin" >/dev/null; then
+    run env GO111MODULE=off go get github.com/myitcv/gobin || exit 1
+fi
+
 # tool_get_bin [tool] - returns absolute path to a tool binary (or returns error)
 function tool_get_bin {
   tool_exists "gobin" "GO111MODULE=off go get github.com/myitcv/gobin" || return 2
@@ -308,5 +313,3 @@ function run_go_tool {
   run "${cmdbin}" "$@" || return 2
 }
 
-# Ensure gobin is available, as it runs majority of the tools
-run env GO111MODULE=off go get github.com/myitcv/gobin


### PR DESCRIPTION
scripts: install github.com/myitcv/gobin while gobin doesn't exist.

Remove install code from genproto.sh .(line 13 will include test_lib.sh, and will install gobin first.)