### PR TITLE
pkg/fileutil: fix constant for linux locking

### DIFF
--- a/pkg/fileutil/lock_linux.go
+++ b/pkg/fileutil/lock_linux.go
@@ -30,7 +30,7 @@ import (
 //
 // constants from /usr/include/bits/fcntl-linux.h
 const (
-	F_OFD_GETLK  = 37
+	F_OFD_GETLK  = 36
 	F_OFD_SETLK  = 37
 	F_OFD_SETLKW = 38
 )


### PR DESCRIPTION
The constant F_OFD_GETLK is 36, not 37, according to
/usr/include/bits/fcntl-linux.h
Credits go to joakim-tjernlund who digged deep enough
to find this.

Fixes #31182
