### PR TITLE
20201103 no commit title check

### DIFF
--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -13,8 +13,8 @@ function mod_tidy_fix {
 function bash_ws_fix {
   log_callout "Fixing whitespaces in the bash scripts"
   # Makes sure all bash scripts do use '  ' (double space) for indention. 
-  log_cmd "% find ./ -name '*.sh' | xargs sed --follow-symlinks -i 's|\t|  |g'"
-  find ./ -print0 -name '*.sh' | xargs -0 sed --follow-symlinks -i 's|\t|  |g'
+  log_cmd "find ./ -name '*.sh' -print0 | xargs -0 sed --follow-symlinks -i 's|\t|  |g'"
+  find ./ -name '*.sh' -print0 | xargs -0 sed --follow-symlinks -i 's|\t|  |g'
 }
 
 log_callout -e "\nFixing etcd code for you...\n"

--- a/test
+++ b/test
@@ -303,7 +303,6 @@ function fmt_pass {
       revive \
       license_header \
       receiver_name \
-      commit_title \
       mod_tidy \
       dep \
       shellcheck \
@@ -419,30 +418,6 @@ function receiver_name_for_package {
 
 function receiver_name_pass {
   run_for_modules receiver_name_for_package
-}
-
-function commit_title_pass {
-  git log --oneline "$(git merge-base HEAD master)"...HEAD | while read -r l; do
-    commitMsg=$(echo "$l" | cut -f2- -d' ')
-    if [[ "$commitMsg" == Merge* ]]; then
-      # ignore "Merge pull" commits
-      continue
-    fi
-    if [[ "$commitMsg" == Revert* ]]; then
-      # ignore revert commits
-      continue
-    fi
-
-    pkgPrefix=$(echo "$commitMsg" | cut -f1 -d':')
-    spaceCommas=$(echo "$commitMsg" | sed 's/ /\n/g' | grep -c ',$' || echo 0)
-    commaSpaces=$(echo "$commitMsg" | sed 's/,/\n/g' | grep -c '^ ' || echo 0)
-    if [[ $(echo "$commitMsg" | grep -c ":..*") == 0 || "$commitMsg" == "$pkgPrefix" || "$spaceCommas" != "$commaSpaces" ]]; then
-      log_error "$l"...
-      log_error "Expected commit title format '<package>{\", \"<package>}: <description>'"
-      log_error "Got: $l"
-      return 255
-    fi
-  done
 }
 
 # goword_for_package package


### PR DESCRIPTION
1. Turns off validation of commits titles as requested in: 
https://github.com/etcd-io/etcd/pull/12430#issuecomment-7182973641

2. Fixes ./scripts/fix.sh command to find *.sh files.

3. Fixes static-code analysis error: 
    https://travis-ci.com/github/etcd-io/etcd/jobs/425920416
    ```
    % (cd server && go vet ./...)
    stderr: # go.etcd.io/etcd/server/v3/etcdserver
    stderr: etcdserver/server_test.go:1002:4: call to (*T).Fatalf from a non-test goroutine
    stderr: etcdserver/server_test.go:1166:4: call to (*T).Fatalf from a non-test goroutine
    FAIL: (code:2):
      % (cd server && go vet ./...)
    FAIL: 'run go vet ./...' checking failed (!=0 return code)
    FAIL: 'govet' failed at Tue Nov  3 04:07:47 UTC 2020
    ```
