### PR TITLE
Release scripts for modules

### DIFF
--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/json-iterator/go v1.1.10
 	github.com/modern-go/reflect2 v1.0.1
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
 )
 
 replace (

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.5.1
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
 	go.uber.org/zap v1.16.0
 	google.golang.org/grpc v1.29.1
 	sigs.k8s.io/yaml v1.2.0

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/urfave/cli v1.22.4
 	go.etcd.io/bbolt v1.3.5
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v2 v2.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/raft/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/server/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/client/v2 v2.305.0-pre
+	go.etcd.io/etcd/client/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
+	go.etcd.io/etcd/raft/v3 v3.5.0-pre
+	go.etcd.io/etcd/server/v3 v3.5.0-pre
 	go.uber.org/zap v1.16.0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.29.1

--- a/go.mod
+++ b/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spf13/cobra v1.1.1
 	go.etcd.io/bbolt v1.3.5
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v2 v2.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/raft/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/server/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/tests/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/client/v2 v2.305.0-pre
+	go.etcd.io/etcd/client/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
+	go.etcd.io/etcd/raft/v3 v3.5.0-pre
+	go.etcd.io/etcd/server/v3 v3.5.0-pre
+	go.etcd.io/etcd/tests/v3 v3.5.0-pre
 	go.uber.org/zap v1.16.0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.29.1

--- a/raft/go.mod
+++ b/raft/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.5
 	github.com/pkg/errors v0.9.1 // indirect
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
 )
 
 // Bad imports are sometimes causing attempts to pull that code.

--- a/scripts/release_mod.sh
+++ b/scripts/release_mod.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Examples:
+
+# Edit go.mod files such that all etcd modules are pointing on given version:
+#
+# % DRY_RUN=false TARGET_VERSION="v3.5.13" ./scripts/release_mod.sh update_versions
+
+# Tag latest commit with current version number for all the modules and push upstream:
+#
+# % DRY_RUN=false REMOTE_REPO="origin" ./scripts/release_mod.sh push_mod_tags
+
+set -e
+
+DRY_RUN=${DRY_RUN:-true}
+
+if ! [[ "$0" =~ scripts/release_mod.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+source ./scripts/test_lib.sh
+
+# _cmd prints help message
+function _cmd() {
+  log_error "Command required: ${0} [cmd]"
+  log_info "Available commands:"
+  log_info "  - update_versions  - Updates all cross-module versions to \${TARGET_VERSION} in the local client."
+  log_info "  - push_mod_tags    - Tags HEAD with all modules versions tags and pushes it to \${REMOTE_REPO}."
+}
+
+# maybe_run [cmd...] runs given command depending on the DRY_RUN flag.
+function maybe_run() {
+  if ${DRY_RUN}; then
+    log_warning -e "# DRY_RUN:\n  % ${*}"
+  else
+    run "${@}"
+  fi
+}
+
+# update_module_version [v2version] [v3version]
+#   Updates versions of cross-references in all internal references in current module.
+function update_module_version() {
+  local v3version="${1}"
+  local v2version="${2}"
+  local modules
+  modules=$(run go list -f '{{if not .Main}}{{if not .Indirect}}{{.Path}}{{end}}{{end}}' -m all)
+
+  v3deps=$(echo "${modules}" | grep -E "${REPO}/.*/v3")
+  for dep in ${v3deps}; do
+    maybe_run go mod edit -require "${dep}@${v3version}"
+  done
+
+  v2deps=$(echo "${modules}" | grep -E "${REPO}/.*/v2")
+  for dep in ${v2deps}; do
+    maybe_run go mod edit -require "${dep}@${v2version}"
+  done
+}
+
+# Updates all cross-module versions to ${TARGET_VERSION} in local client.
+function update_versions_cmd() {
+  assert_no_git_modifications || return 2
+
+  if [ -z "${TARGET_VERSION}" ]; then
+    log_error "TARGET_VERSION environment variable not set. Set it to e.g. v3.5.10-alpha.0"
+    return 2
+  fi
+
+  local v3version="${TARGET_VERSION}"
+  local v2version
+  # converts e.g. v3.5.0-alpha.0 --> v2.305.0-alpha.0
+  # shellcheck disable=SC2001
+  v2version="$(echo "${TARGET_VERSION}" | sed 's|^v3.\([0-9]*\).|v2.30\1.|g')"
+
+  log_info "DRY_RUN       : ${DRY_RUN}"
+  log_info "TARGET_VERSION: ${TARGET_VERSION}"
+  log_info ""
+  log_info "v3version: ${v3version}"
+  log_info "v2version: ${v2version}"
+
+  run_for_modules update_module_version "${v3version}" "${v2version}"
+}
+
+function push_mod_tags_cmd {
+  assert_no_git_modifications || return 2
+
+  if [ -z "${REMOTE_REPO}" ]; then
+    log_error "REMOTE_REPO environment variable not set"
+    return 2
+  fi
+  log_info "REMOTE_REPO:  ${REMOTE_REPO}"
+
+  # Any module ccan be used for this
+  local master_version
+  master_version=$(go list -f '{{.Version}}' -m "${REPO}/api/v3")
+  local tags=()
+
+  for module in $(modules); do
+    local version
+    version=$(go list -f '{{.Version}}' -m "${module}")
+    local path
+    path=$(go list -f '{{.Path}}' -m "${module}")
+    local subdir="${path//${REPO}\//}"
+    local tag
+    if [ -z "${version}" ]; then
+      tag="${master_version}"
+      version="${master_version}"
+    else
+      tag="${subdir///v[23]/}/${version}"
+    fi
+
+    log_info "Tags for: ${module} version:${version} tag:${tag}"
+    maybe_run git tag -f "${tag}"
+    tags=("${tags[@]}" "${tag}")
+  done
+  maybe_run git push -f "${REMOTE_REPO}" "${tags[@]}"
+}
+
+"${1}_cmd"
+
+if "${DRY_RUN}"; then
+  log_info
+  log_warning "WARNING: It was a DRY_RUN. No files were modified."
+fi

--- a/server/go.mod
+++ b/server/go.mod
@@ -27,11 +27,11 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 	go.etcd.io/bbolt v1.3.5
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v2 v2.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/raft/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/client/v2 v2.305.0-pre
+	go.etcd.io/etcd/client/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
+	go.etcd.io/etcd/raft/v3 v3.5.0-pre
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -25,13 +25,13 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/bbolt v1.3.5
-	go.etcd.io/etcd/api/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v2 v2.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/client/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/etcdctl/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/pkg/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/raft/v3 v3.0.0-00010101000000-000000000000
-	go.etcd.io/etcd/server/v3 v3.0.0-00010101000000-000000000000
+	go.etcd.io/etcd/api/v3 v3.5.0-pre
+	go.etcd.io/etcd/client/v2 v2.305.0-pre
+	go.etcd.io/etcd/client/v3 v3.5.0-pre
+	go.etcd.io/etcd/etcdctl/v3 v3.5.0-pre
+	go.etcd.io/etcd/pkg/v3 v3.5.0-pre
+	go.etcd.io/etcd/raft/v3 v3.5.0-pre
+	go.etcd.io/etcd/server/v3 v3.5.0-pre
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e


### PR DESCRIPTION
Release: Scripts to change versions in all go.mod files and push tags upstream.
    
Exemplar invocations:
    
Editing of  go.mod files such that all etcd modules are pointing on given version (e.g. "v3.5.13"):
```
 DRY_RUN=false TARGET_VERSION="v3.5.13" ./scripts/release_mod.sh update_versions
```
    
Tagging latest commit with current version numbers for all the modules and pushing it upstreamt o `origin`:
```
% DRY_RUN=true REMOTE_REPO="origin" ./scripts/release_mod.sh push_mod_tags
```

The arbitrary choice I'm proposing in the PR is how we tag versions for module: 
```
go.etcd.io/etcd/client/v2
```
This is v2 module stored in the repository and kept in-sync with v3 version hierarchy. 
The v2 modules need to have version of v2.x.y . **So I'm proposing to version them as `v2.30x.y` (e.g. v2.305.12)** when the rest of code is versioned as v3.5.12.  This creates very intuitive mapping and is future proof till etcd 3.99.y. 