### PR TITLE
server: proper cancellation for range request

### DIFF
--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -383,7 +383,7 @@ func (sws *serverWatchStream) sendLoop() {
 				events[i] = &evs[i]
 				if needPrevKV {
 					opt := mvcc.RangeOptions{Rev: evs[i].Kv.ModRevision - 1}
-					r, err := sws.watchable.Range(evs[i].Kv.Key, nil, opt)
+					r, err := sws.watchable.Range(context.TODO(), evs[i].Kv.Key, nil, opt)
 					if err == nil && len(r.KVs) != 0 {
 						events[i].PrevKv = &(r.KVs[0])
 					}

--- a/server/etcdserver/apply.go
+++ b/server/etcdserver/apply.go
@@ -230,7 +230,7 @@ func (a *applierV3backend) Put(ctx context.Context, txn mvcc.TxnWrite, p *pb.Put
 	var rr *mvcc.RangeResult
 	if p.IgnoreValue || p.IgnoreLease || p.PrevKv {
 		trace.StepWithFunction(func() {
-			rr, err = txn.Range(p.Key, nil, mvcc.RangeOptions{})
+			rr, err = txn.Range(context.TODO(), p.Key, nil, mvcc.RangeOptions{})
 		}, "get previous kv pair")
 
 		if err != nil {
@@ -271,7 +271,7 @@ func (a *applierV3backend) DeleteRange(txn mvcc.TxnWrite, dr *pb.DeleteRangeRequ
 	}
 
 	if dr.PrevKv {
-		rr, err := txn.Range(dr.Key, end, mvcc.RangeOptions{})
+		rr, err := txn.Range(context.TODO(), dr.Key, end, mvcc.RangeOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -316,7 +316,7 @@ func (a *applierV3backend) Range(ctx context.Context, txn mvcc.TxnRead, r *pb.Ra
 		Count: r.CountOnly,
 	}
 
-	rr, err := txn.Range(r.Key, mkGteRange(r.RangeEnd), ro)
+	rr, err := txn.Range(ctx, r.Key, mkGteRange(r.RangeEnd), ro)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +503,7 @@ func applyCompare(rv mvcc.ReadView, c *pb.Compare) bool {
 	// * rewrite rules for common patterns:
 	//	ex. "[a, b) createrev > 0" => "limit 1 /\ kvs > 0"
 	// * caching
-	rr, err := rv.Range(c.Key, mkGteRange(c.RangeEnd), mvcc.RangeOptions{})
+	rr, err := rv.Range(context.TODO(), c.Key, mkGteRange(c.RangeEnd), mvcc.RangeOptions{})
 	if err != nil {
 		return false
 	}
@@ -631,7 +631,7 @@ func (a *applierV3backend) Compaction(compaction *pb.CompactionRequest) (*pb.Com
 		return nil, ch, nil, err
 	}
 	// get the current revision. which key to get is not important.
-	rr, _ := a.s.KV().Range([]byte("compaction"), nil, mvcc.RangeOptions{})
+	rr, _ := a.s.KV().Range(context.TODO(), []byte("compaction"), nil, mvcc.RangeOptions{})
 	resp.Header.Revision = rr.Rev
 	return resp, ch, trace, err
 }
@@ -999,7 +999,7 @@ func (a *applierV3backend) checkRequestPut(rv mvcc.ReadView, reqOp *pb.RequestOp
 	req := tv.RequestPut
 	if req.IgnoreValue || req.IgnoreLease {
 		// expects previous key-value, error if not exist
-		rr, err := rv.Range(req.Key, nil, mvcc.RangeOptions{})
+		rr, err := rv.Range(context.TODO(), req.Key, nil, mvcc.RangeOptions{})
 		if err != nil {
 			return err
 		}

--- a/server/mvcc/kv.go
+++ b/server/mvcc/kv.go
@@ -15,6 +15,8 @@
 package mvcc
 
 import (
+	"context"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
@@ -50,7 +52,7 @@ type ReadView interface {
 	// If `end` is not nil and empty, it gets the keys greater than or equal to key.
 	// Limit limits the number of keys returned.
 	// If the required rev is compacted, ErrCompacted will be returned.
-	Range(key, end []byte, ro RangeOptions) (r *RangeResult, err error)
+	Range(ctx context.Context, key, end []byte, ro RangeOptions) (r *RangeResult, err error)
 }
 
 // TxnRead represents a read-only transaction with operations that will not

--- a/server/mvcc/kv_view.go
+++ b/server/mvcc/kv_view.go
@@ -15,6 +15,8 @@
 package mvcc
 
 import (
+	"context"
+
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
 )
@@ -33,10 +35,10 @@ func (rv *readView) Rev() int64 {
 	return tr.Rev()
 }
 
-func (rv *readView) Range(key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
+func (rv *readView) Range(ctx context.Context, key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
 	tr := rv.kv.Read(traceutil.TODO())
 	defer tr.End()
-	return tr.Range(key, end, ro)
+	return tr.Range(ctx, key, end, ro)
 }
 
 type writeView struct{ kv KV }

--- a/server/mvcc/kvstore_bench_test.go
+++ b/server/mvcc/kvstore_bench_test.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"context"
 	"testing"
 
 	"go.etcd.io/etcd/pkg/v3/traceutil"
@@ -67,7 +68,7 @@ func benchmarkStoreRange(b *testing.B, n int) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Range(begin, end, RangeOptions{})
+		s.Range(context.TODO(), begin, end, RangeOptions{})
 	}
 }
 

--- a/server/mvcc/kvstore_compaction_test.go
+++ b/server/mvcc/kvstore_compaction_test.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"context"
 	"os"
 	"reflect"
 	"testing"
@@ -130,7 +131,7 @@ func TestCompactAllAndRestore(t *testing.T) {
 	if s1.Rev() != rev {
 		t.Errorf("rev = %v, want %v", s1.Rev(), rev)
 	}
-	_, err = s1.Range([]byte("foo"), nil, RangeOptions{})
+	_, err = s1.Range(context.TODO(), []byte("foo"), nil, RangeOptions{})
 	if err != nil {
 		t.Errorf("unexpect range error %v", err)
 	}

--- a/server/mvcc/kvstore_test.go
+++ b/server/mvcc/kvstore_test.go
@@ -16,6 +16,7 @@ package mvcc
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -213,7 +214,7 @@ func TestStoreRange(t *testing.T) {
 		b.tx.rangeRespc <- tt.r
 		fi.indexRangeRespc <- tt.idxr
 
-		ret, err := s.Range([]byte("foo"), []byte("goo"), ro)
+		ret, err := s.Range(context.TODO(), []byte("foo"), []byte("goo"), ro)
 		if err != nil {
 			t.Errorf("#%d: err = %v, want nil", i, err)
 		}
@@ -455,7 +456,7 @@ func TestRestoreDelete(t *testing.T) {
 	defer s.Close()
 	for i := 0; i < 20; i++ {
 		ks := fmt.Sprintf("foo-%d", i)
-		r, err := s.Range([]byte(ks), nil, RangeOptions{})
+		r, err := s.Range(context.TODO(), []byte(ks), nil, RangeOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -502,7 +503,7 @@ func TestRestoreContinueUnfinishedCompaction(t *testing.T) {
 		// wait for scheduled compaction to be finished
 		time.Sleep(100 * time.Millisecond)
 
-		if _, err := s.Range([]byte("foo"), nil, RangeOptions{Rev: 1}); err != ErrCompacted {
+		if _, err := s.Range(context.TODO(), []byte("foo"), nil, RangeOptions{Rev: 1}); err != ErrCompacted {
 			t.Errorf("range on compacted rev error = %v, want %v", err, ErrCompacted)
 		}
 		// check the key in backend is deleted
@@ -676,7 +677,7 @@ func TestConcurrentReadNotBlockingWrite(t *testing.T) {
 	// readTx2 simulates a short read request
 	readTx2 := s.Read(traceutil.TODO())
 	ro := RangeOptions{Limit: 1, Rev: 0, Count: false}
-	ret, err := readTx2.Range([]byte("foo"), nil, ro)
+	ret, err := readTx2.Range(context.TODO(), []byte("foo"), nil, ro)
 	if err != nil {
 		t.Fatalf("failed to range: %v", err)
 	}
@@ -693,7 +694,7 @@ func TestConcurrentReadNotBlockingWrite(t *testing.T) {
 	}
 	readTx2.End()
 
-	ret, err = readTx1.Range([]byte("foo"), nil, ro)
+	ret, err = readTx1.Range(context.TODO(), []byte("foo"), nil, ro)
 	if err != nil {
 		t.Fatalf("failed to range: %v", err)
 	}
@@ -760,7 +761,7 @@ func TestConcurrentReadTxAndWrite(t *testing.T) {
 			tx := s.Read(traceutil.TODO())
 			mu.Unlock()
 			// get all keys in backend store, and compare with wKVs
-			ret, err := tx.Range([]byte("\x00000000"), []byte("\xffffffff"), RangeOptions{})
+			ret, err := tx.Range(context.TODO(), []byte("\x00000000"), []byte("\xffffffff"), RangeOptions{})
 			tx.End()
 			if err != nil {
 				t.Errorf("failed to range keys: %v", err)

--- a/server/mvcc/kvstore_txn.go
+++ b/server/mvcc/kvstore_txn.go
@@ -15,6 +15,8 @@
 package mvcc
 
 import (
+	"context"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
@@ -47,8 +49,8 @@ func (s *store) Read(trace *traceutil.Trace) TxnRead {
 func (tr *storeTxnRead) FirstRev() int64 { return tr.firstRev }
 func (tr *storeTxnRead) Rev() int64      { return tr.rev }
 
-func (tr *storeTxnRead) Range(key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
-	return tr.rangeKeys(key, end, tr.Rev(), ro)
+func (tr *storeTxnRead) Range(ctx context.Context, key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
+	return tr.rangeKeys(ctx, key, end, tr.Rev(), ro)
 }
 
 func (tr *storeTxnRead) End() {
@@ -79,12 +81,12 @@ func (s *store) Write(trace *traceutil.Trace) TxnWrite {
 
 func (tw *storeTxnWrite) Rev() int64 { return tw.beginRev }
 
-func (tw *storeTxnWrite) Range(key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
+func (tw *storeTxnWrite) Range(ctx context.Context, key, end []byte, ro RangeOptions) (r *RangeResult, err error) {
 	rev := tw.beginRev
 	if len(tw.changes) > 0 {
 		rev++
 	}
-	return tw.rangeKeys(key, end, rev, ro)
+	return tw.rangeKeys(ctx, key, end, rev, ro)
 }
 
 func (tw *storeTxnWrite) DeleteRange(key, end []byte) (int64, int64) {
@@ -114,7 +116,7 @@ func (tw *storeTxnWrite) End() {
 	tw.s.mu.RUnlock()
 }
 
-func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions) (*RangeResult, error) {
+func (tr *storeTxnRead) rangeKeys(ctx context.Context, key, end []byte, curRev int64, ro RangeOptions) (*RangeResult, error) {
 	rev := ro.Rev
 	if rev > curRev {
 		return &RangeResult{KVs: nil, Count: -1, Rev: curRev}, ErrFutureRev
@@ -144,6 +146,11 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 	kvs := make([]mvccpb.KeyValue, limit)
 	revBytes := newRevBytes()
 	for i, revpair := range revpairs[:len(kvs)] {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		revToBytes(revpair, revBytes)
 		_, vs := tr.tx.UnsafeRange(keyBucketName, revBytes, nil, 0)
 		if len(vs) != 1 {

--- a/server/mvcc/metrics_txn.go
+++ b/server/mvcc/metrics_txn.go
@@ -14,7 +14,11 @@
 
 package mvcc
 
-import "go.etcd.io/etcd/server/v3/lease"
+import (
+	"context"
+
+	"go.etcd.io/etcd/server/v3/lease"
+)
 
 type metricsTxnWrite struct {
 	TxnWrite
@@ -32,9 +36,9 @@ func newMetricsTxnWrite(tw TxnWrite) TxnWrite {
 	return &metricsTxnWrite{tw, 0, 0, 0, 0}
 }
 
-func (tw *metricsTxnWrite) Range(key, end []byte, ro RangeOptions) (*RangeResult, error) {
+func (tw *metricsTxnWrite) Range(ctx context.Context, key, end []byte, ro RangeOptions) (*RangeResult, error) {
 	tw.ranges++
-	return tw.TxnWrite.Range(key, end, ro)
+	return tw.TxnWrite.Range(ctx, key, end, ro)
 }
 
 func (tw *metricsTxnWrite) DeleteRange(key, end []byte) (n, rev int64) {


### PR DESCRIPTION
If a range request is timed out or canceled by client, server could stop serving this request in order to save resource. Note we cannot do similar things for mutating requests - once they passed raft and were appended to the WAL log, they must be finished applying to the database.

This PR wires the context to range function in apply. Ranging from database is stopped once context is canceled or timed out.

fix: #12458

Using the same example provided in the original issue. Client issues an expensive range request which timed out after 2 sec.
```
$ time etcdctl --command-timeout=2s get "" --prefix
{"level":"warn","ts":"2020-11-06T01:19:45.943+0800","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-3e579972-3aa2-4942-a9f7-3d7fbd36e380/127.0.0.1:2379","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
Error: context deadline exceeded

real    0m2.040s
user    0m0.023s
sys     0m0.028s
```

Server stopped serving the range request upon context time out.
```
{"level":"warn","ts":"2020-11-06T01:19:45.944+0800","caller":"etcdserver/util.go:158","msg":"apply request took too long","took":"1.998370669s","expected-duration":"100ms","prefix":"read-only range ","request":"key:\"\\000\" range_end:\"\\000\" ","response":"","error":"context canceled"}
{"level":"info","ts":"2020-11-06T01:19:45.944+0800","caller":"traceutil/trace.go:171","msg":"trace[1039134524] range","detail":"{range_begin:\u0000; range_end:\u0000; }","duration":"1.998720987s","start":"2020-11-06T01:19:43.945+0800","end":"2020-11-06T01:19:45.944+0800","steps":["trace[1039134524] 'range keys from in-memory index tree'  (duration: 170.321926ms)"],"step_count":1}
```