### PR TITLE
check read tx is nil

### DIFF
--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -282,8 +282,10 @@ func (t *batchTxBuffered) unsafeCommit(stop bool) {
 		// then close the boltdb tx
 		go func(tx *bolt.Tx, wg *sync.WaitGroup) {
 			wg.Wait()
-			if err := tx.Rollback(); err != nil {
-				t.backend.lg.Fatal("failed to rollback tx", zap.Error(err))
+			if tx != nil {
+				if err := tx.Rollback(); err != nil {
+					t.backend.lg.Fatal("failed to rollback tx", zap.Error(err))
+				}
 			}
 		}(t.backend.readTx.tx, t.backend.readTx.txWg)
 		t.backend.readTx.reset()


### PR DESCRIPTION
func (t *batchTxBuffered) unsafeCommit(stop bool)
readTx.tx will try to Rollback(), but this invoke in go func(), 
next line will invoke t.backend.readTx.reset(),
but in reset() block will run "readTx.tx = nil",
I suspect whether there is an nil pointer???

So I add a check avoid unsafe thread.

```go
if t.backend.readTx.tx != nil {
		// wait all store read transactions using the current boltdb tx to finish,
		// then close the boltdb tx
		go func(tx *bolt.Tx, wg *sync.WaitGroup) {
			wg.Wait()
			if err := tx.Rollback(); err != nil {
				t.backend.lg.Fatal("failed to rollback tx", zap.Error(err))
			}
		}(t.backend.readTx.tx, t.backend.readTx.txWg)
		t.backend.readTx.reset()
	}
```

```go
func (rt *readTx) reset() {
	rt.buf.reset()
	rt.buckets = make(map[string]*bolt.Bucket)
	rt.tx = nil  //this is not safe I think if other goroutine invoke rt.tx.XXX().
	rt.txWg = new(sync.WaitGroup)
}

```
