### PR TITLE
fix: pass argument url in defer to avoid loopclosure

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -589,7 +589,7 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 			}
 		}
 
-		defer func() {
+		defer func(u url.URL) {
 			if err == nil {
 				return
 			}
@@ -599,7 +599,7 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 				zap.String("address", u.Host),
 				zap.Error(err),
 			)
-		}()
+		}(u)
 		for k := range cfg.UserHandlers {
 			sctx.userHandlers[k] = cfg.UserHandlers[k]
 		}


### PR DESCRIPTION
Because of the well-known range loop closure issue, the value of `u` may
have changed by the time the anonymous function mentioned in the `defer`
is run. To address this, the simplest fix is to pass the url used in the
loop as an argument to the function run in the `defer`.

Found this via an automated analysis of Go repos on GitHub.
