### PR TITLE
server: make raft read only option configurable

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -59,6 +59,7 @@ const (
 	DefaultGRPCKeepAliveInterval = 2 * time.Hour
 	DefaultGRPCKeepAliveTimeout  = 20 * time.Second
 	DefaultDowngradeCheckTime    = 5 * time.Second
+	DefaultLinearizableReadMode  = "Safe"
 
 	DefaultListenPeerURLs   = "http://localhost:2380"
 	DefaultListenClientURLs = "http://localhost:2379"
@@ -345,6 +346,8 @@ type Config struct {
 	UnsafeNoFsync bool `json:"unsafe-no-fsync"`
 
 	ExperimentalDowngradeCheckTime time.Duration `json:"experimental-downgrade-check-time"`
+
+	ExperimentalLinearizableReadMode string `json:"experimental-linearizable-read-mode"`
 }
 
 // configYAML holds the config suitable for yaml parsing
@@ -431,6 +434,8 @@ func NewConfig() *Config {
 		EnableGRPCGateway: true,
 
 		ExperimentalDowngradeCheckTime: DefaultDowngradeCheckTime,
+
+		ExperimentalLinearizableReadMode: DefaultLinearizableReadMode,
 	}
 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 	return cfg

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -203,6 +203,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		WatchProgressNotifyInterval: cfg.ExperimentalWatchProgressNotifyInterval,
 		DowngradeCheckTime:          cfg.ExperimentalDowngradeCheckTime,
 		WarningApplyDuration:        cfg.ExperimentalWarningApplyDuration,
+		LinearizableReadMode:        cfg.ExperimentalLinearizableReadMode,
 	}
 	print(e.cfg.logger, *cfg, srvcfg, memberInitialized)
 	if e.Server, err = etcdserver.NewServer(srvcfg); err != nil {

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -261,6 +261,8 @@ func newConfig() *config {
 	fs.DurationVar(&cfg.ec.ExperimentalDowngradeCheckTime, "experimental-downgrade-check-time", cfg.ec.ExperimentalDowngradeCheckTime, "Duration of time between two downgrade status check.")
 	fs.DurationVar(&cfg.ec.ExperimentalWarningApplyDuration, "experimental-warning-apply-duration", cfg.ec.ExperimentalWarningApplyDuration, "Time duration after which a warning is generated if request takes more time.")
 
+	fs.StringVar(&cfg.ec.ExperimentalLinearizableReadMode, "experimental-linearizable-read-mode", cfg.ec.ExperimentalLinearizableReadMode, "Safe guarantees the linearizability of the read only request by communicating with the quorum. LeaseBased ensures linearizability of the read only request by relying on the leader lease. It can be affected by clock drift.")
+
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")
 	fs.BoolVar(&cfg.ec.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -216,6 +216,15 @@ Experimental feature:
     Duration of periodical watch progress notification.
   --experimental-warning-apply-duration '100ms'
 	Warning is generated if requests take more than this duration.
+  --experimental-linearizable-read-mode 'Safe'
+    Specifies how the read only request is processed.
+    Safe guarantees the linearizability of the read only request by
+    communicating with the quorum. It is the default and suggested option.
+    LeaseBased ensures linearizability of the read only request by
+    relying on the leader lease. It can be affected by clock drift.
+    If the clock drift is unbounded, leader might keep the lease longer than it
+    should (clock can move backward/pause without any bound). ReadIndex is not safe
+    in that case.
 
 Unsafe feature:
   --force-new-cluster 'false'

--- a/server/etcdserver/config.go
+++ b/server/etcdserver/config.go
@@ -166,6 +166,8 @@ type ServerConfig struct {
 	UnsafeNoFsync bool `json:"unsafe-no-fsync"`
 
 	DowngradeCheckTime time.Duration
+
+	LinearizableReadMode string
 }
 
 // VerifyBootstrap sanity-checks the initial config for bootstrap case


### PR DESCRIPTION
Currently the raft library supports two options to ensure linearizability of read only requests, but there are no command line flags to config this option. This PR adds a parameter to allow the user to configure this option.