### PR TITLE
Documentation Content: TOC

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -1,5 +1,6 @@
 ---
 title: etcd version ___
+weight: 1000
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/Documentation/benchmarks/_index.md
+++ b/Documentation/benchmarks/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Benchmarks
+weight: 8000
 ---

--- a/Documentation/benchmarks/etcd-2-1-0-alpha-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-1-0-alpha-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.1.0
+weight: 8875
 ---
 
 ## Physical machines

--- a/Documentation/benchmarks/etcd-2-2-0-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0
+weight: 8750
 ---
 
 ## Physical Machines

--- a/Documentation/benchmarks/etcd-2-2-0-rc-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-rc-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0-rc
+weight: 8625
 ---
 
 ## Physical machine

--- a/Documentation/benchmarks/etcd-2-2-0-rc-memory-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-rc-memory-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0-rc-memory
+weight: 8500
 ---
 
 ## Physical machine

--- a/Documentation/benchmarks/etcd-3-demo-benchmarks.md
+++ b/Documentation/benchmarks/etcd-3-demo-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v3
+weight: 8375
 ---
 
 ## Physical machines

--- a/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
+++ b/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
@@ -1,5 +1,6 @@
 ---
 title: Watch Memory Usage Benchmark
+weight: 8250
 ---
 
 *NOTE*: The watch features are under active development, and their memory usage may change as that development progresses. We do not expect it to significantly increase beyond the figures stated below.

--- a/Documentation/benchmarks/etcd-storage-memory-benchmark.md
+++ b/Documentation/benchmarks/etcd-storage-memory-benchmark.md
@@ -1,5 +1,6 @@
 ---
 title: Storage Memory Usage Benchmark
+weight: 8125
 ---
 
 <!---todo: link storage to storage design doc-->

--- a/Documentation/branch-management.md
+++ b/Documentation/branch-management.md
@@ -1,6 +1,6 @@
 ---
 title: Branch management
-weight: 1
+weight: 1250
 ---
 
 ## Guide

--- a/Documentation/demo.md
+++ b/Documentation/demo.md
@@ -1,6 +1,6 @@
 ---
 title: Demo
-weight: 1
+weight: 1050
 ---
 
 This series of examples shows the basic procedures for working with an etcd cluster.

--- a/Documentation/dev-guide/_index.md
+++ b/Documentation/dev-guide/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Developer guide
+weight: 2000
+description: Guides for developers using ectd
 ---

--- a/Documentation/dev-guide/api_grpc_gateway.md
+++ b/Documentation/dev-guide/api_grpc_gateway.md
@@ -1,5 +1,7 @@
 ---
 title: Why gRPC gateway
+weight: 2375
+description: Why you should consider using the gRPC gateway
 ---
 
 etcd v3 uses [gRPC][grpc] for its messaging protocol. The etcd project includes a gRPC-based [Go client][go-client] and a command line utility, [etcdctl][etcdctl], for communicating with an etcd cluster through gRPC. For languages with no gRPC support, etcd provides a JSON [gRPC gateway][grpc-gateway]. This gateway serves a RESTful proxy that translates HTTP/JSON requests into gRPC messages.

--- a/Documentation/dev-guide/experimental_apis.md
+++ b/Documentation/dev-guide/experimental_apis.md
@@ -1,5 +1,7 @@
 ---
 title: Experimental APIs and features
+weight: 2750
+description: New (and potentially unstable) APIs and features in etcd
 ---
 
 For the most part, the etcd project is stable, but we are still moving fast! We believe in the release fast philosophy. We want to get early feedback on features still in development and stabilizing. Thus, there are, and will be more, experimental features and APIs. We plan to improve these features based on the early feedback from the community, or abandon them if there is little interest, in the next few releases. Please do not rely on any experimental features or APIs in production environment.

--- a/Documentation/dev-guide/grpc_naming.md
+++ b/Documentation/dev-guide/grpc_naming.md
@@ -1,5 +1,7 @@
 ---
 title: gRPC naming and discovery
+weight: 2500
+description: "go-grpc: for resolving gRPC endpoints with an etcd backend"
 ---
 
 etcd provides a gRPC resolver to support an alternative name system that fetches endpoints from etcd for discovering gRPC services. The underlying mechanism is based on watching updates to keys prefixed with the service name.

--- a/Documentation/dev-guide/interacting_v3.md
+++ b/Documentation/dev-guide/interacting_v3.md
@@ -1,5 +1,7 @@
 ---
 title: Interacting with etcd
+weight: 2250
+description: "etcdctl: a command line tool for interacting with the etcd server"
 ---
 
 Users mostly interact with etcd by putting or getting the value of a key. This section describes how to do that by using etcdctl, a command line tool for interacting with etcd server. The concepts described here should apply to the gRPC APIs or client library APIs.

--- a/Documentation/dev-guide/limit.md
+++ b/Documentation/dev-guide/limit.md
@@ -1,5 +1,7 @@
 ---
 title: System limits
+weight: 2625
+description: "etcd limits: requests and storage"
 ---
 
 ## Request size limit

--- a/Documentation/dev-guide/local_cluster.md
+++ b/Documentation/dev-guide/local_cluster.md
@@ -1,5 +1,7 @@
 ---
 title: Set up a local cluster
+weight: 2125
+description: Configuring local clusters for testing and development 
 ---
 
 For testing and development deployments, the quickest and easiest way is to configure a local cluster. For a production deployment, refer to the [clustering][clustering] section.

--- a/Documentation/dev-internal/discovery_protocol.md
+++ b/Documentation/dev-internal/discovery_protocol.md
@@ -1,5 +1,6 @@
 ---
 title: Discovery service protocol
+weight: 1500
 ---
 
 Discovery service protocol helps new etcd member to discover all other members in cluster bootstrap phase using a shared discovery URL.

--- a/Documentation/dev-internal/logging.md
+++ b/Documentation/dev-internal/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging conventions
+weight: 1600
 ---
 
 etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:

--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -1,5 +1,6 @@
 ---
 title: etcd release guide
+weight: 1550
 ---
 
 The guide talks about how to release a new version of etcd.

--- a/Documentation/dl-build.md
+++ b/Documentation/dl-build.md
@@ -1,5 +1,6 @@
 ---
 title: Download and build
+weight: 1200
 ---
 
 ## System requirements

--- a/Documentation/faq.md
+++ b/Documentation/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions (FAQ)
+weight: 1150
 ---
 
 ## etcd, general

--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Libraries and tools
+weight: 1300
 ---
 
 ## Tools

--- a/Documentation/learning/_index.md
+++ b/Documentation/learning/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Learning
+weight: 3000
 ---

--- a/Documentation/learning/api.md
+++ b/Documentation/learning/api.md
@@ -1,5 +1,6 @@
 ---
 title: etcd3 API
+weight: 3625
 ---
 
 This document is meant to give an overview of the etcd3 API's central design. It is by no means all encompassing, but intended to focus on the basic ideas needed to understand etcd without the distraction of less common API calls. All etcd3 API's are defined in [gRPC services][grpc-service], which categorize remote procedure calls (RPCs) understood by the etcd server. A full listing of all etcd RPCs are documented in markdown in the [gRPC API listing][grpc-api].

--- a/Documentation/learning/api_guarantees.md
+++ b/Documentation/learning/api_guarantees.md
@@ -1,5 +1,6 @@
 ---
 title: KV API guarantees
+weight: 3750
 ---
 
 etcd is a consistent and durable key value store with [mini-transaction][txn] support. The key value store is exposed through the KV APIs. etcd tries to ensure the strongest consistency and durability guarantees for a distributed system. This specification enumerates the KV API guarantees made by etcd.

--- a/Documentation/learning/data_model.md
+++ b/Documentation/learning/data_model.md
@@ -1,5 +1,6 @@
 ---
 title: Data model
+weight: 3125
 ---
 
 etcd is designed to reliably store infrequently updated data and provide reliable watch queries. etcd exposes previous versions of key-value pairs to support inexpensive snapshots and watch history events (“time travel queries”). A persistent, multi-version, concurrency-control data model is a good fit for these use cases.

--- a/Documentation/learning/design-auth-v3.md
+++ b/Documentation/learning/design-auth-v3.md
@@ -1,5 +1,6 @@
 ﻿---
 title: etcd v3 authentication design
+weight: 3500
 ---
 
 ## Why not reuse the v2 auth system?

--- a/Documentation/learning/design-client.md
+++ b/Documentation/learning/design-client.md
@@ -1,5 +1,6 @@
 ---
 title: etcd client design
+weight: 3250
 ---
 
 etcd Client Design

--- a/Documentation/learning/design-learner.md
+++ b/Documentation/learning/design-learner.md
@@ -1,5 +1,6 @@
 ---
 title: etcd learner design
+weight: 3375
 ---
 
 etcd Learner

--- a/Documentation/learning/glossary.md
+++ b/Documentation/learning/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+weight: 3900
 ---
 
 This document defines the various terms used in etcd documentation, command line and source code.

--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -1,5 +1,6 @@
 ---
 title: etcd versus other key-value stores
+weight: 3875
 ---
 
 The name "etcd" originated from two ideas, the unix "/etc" folder and "d"istributed systems. The "/etc" folder is a place to store configuration data for a single system whereas etcd stores configuration information for large scale distributed systems. Hence, a "d"istributed "/etc" is "etcd".

--- a/Documentation/metrics.md
+++ b/Documentation/metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+weight: 1350
 ---
 
 etcd uses [Prometheus][prometheus] for metrics reporting. The metrics can be used for real-time monitoring and debugging. etcd does not persist its metrics; if a member restarts, the metrics will be reset.

--- a/Documentation/op-guide/_index.md
+++ b/Documentation/op-guide/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Operations guide
+weight: 4000
 ---

--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -1,5 +1,6 @@
 ---
 title: Role-based access control
+weight: 4100
 ---
 
 ## Overview

--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -1,5 +1,6 @@
 ---
 title: Clustering Guide
+weight: 4150
 ---
 
 ## Overview

--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration flags
+weight: 4050
 ---
 
 etcd is configurable through a configuration file, various command-line flags, and environment variables.

--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -1,5 +1,6 @@
 ---
 title: Run etcd clusters inside containers
+weight: 4200
 ---
 
 The following guide shows how to run etcd with rkt and Docker using the [static bootstrap process](clustering.md#static).

--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -1,5 +1,6 @@
 ---
 title: Failure modes
+weight: 4250
 ---
 
 Failures are common in a large deployment of machines. A machine fails when its hardware or software malfunctions. Multiple machines fail together when there are power failures or network issues. Multiple kinds of failures can also happen at once; it is almost impossible to enumerate all possible failure cases. 

--- a/Documentation/op-guide/gateway.md
+++ b/Documentation/op-guide/gateway.md
@@ -1,5 +1,6 @@
 ---
 title: etcd gateway
+weight: 4300
 ---
 
 ## What is etcd gateway

--- a/Documentation/op-guide/grpc_proxy.md
+++ b/Documentation/op-guide/grpc_proxy.md
@@ -1,5 +1,6 @@
 ---
 title: gRPC proxy
+weight: 4350
 ---
 
 The gRPC proxy is a stateless etcd reverse proxy operating at the gRPC layer (L7). The proxy is designed to reduce the total processing load on the core etcd cluster. For horizontal scalability, it coalesces watch and lease API requests. To protect the cluster against abusive clients, it caches key range requests.

--- a/Documentation/op-guide/hardware.md
+++ b/Documentation/op-guide/hardware.md
@@ -1,5 +1,6 @@
 ---
 title: Hardware recommendations
+weight: 4400
 ---
 
 etcd usually runs well with limited resources for development or testing purposes; it’s common to develop with etcd on a  laptop or a cheap cloud machine. However, when running etcd clusters in production, some hardware guidelines are useful for proper administration. These suggestions are not hard rules; they serve as a good starting point for a robust production deployment. As always, deployments should be tested with simulated workloads before running in production.

--- a/Documentation/op-guide/maintenance.md
+++ b/Documentation/op-guide/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: Maintenance
+weight: 4450
 ---
 
 ## Overview

--- a/Documentation/op-guide/monitoring.md
+++ b/Documentation/op-guide/monitoring.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring etcd
+weight: 4500
 ---
 
 Each etcd server provides local monitoring information on its client port through http endpoints. The monitoring data is useful for both system health checking and cluster debugging.

--- a/Documentation/op-guide/performance.md
+++ b/Documentation/op-guide/performance.md
@@ -1,5 +1,6 @@
 ---
 title: Performance
+weight: 4550
 ---
 
 ## Understanding performance

--- a/Documentation/op-guide/recovery.md
+++ b/Documentation/op-guide/recovery.md
@@ -1,5 +1,6 @@
 ---
 title: Disaster recovery
+weight: 4600
 ---
 
 etcd is designed to withstand machine failures. An etcd cluster automatically recovers from temporary failures (e.g., machine reboots) and tolerates up to *(N-1)/2* permanent failures for a cluster of N members. When a member permanently fails, whether due to hardware failure or disk corruption, it loses access to the cluster. If the cluster permanently loses more than *(N-1)/2* members then it disastrously fails, irrevocably losing quorum. Once quorum is lost, the cluster cannot reach consensus and therefore cannot continue accepting updates.

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Runtime reconfiguration
+weight: 4650
 ---
 
 etcd comes with support for incremental runtime reconfiguration, which allows users to update the membership of the cluster at run time.

--- a/Documentation/op-guide/runtime-reconf-design.md
+++ b/Documentation/op-guide/runtime-reconf-design.md
@@ -1,5 +1,6 @@
 ---
 title: Design of runtime reconfiguration
+weight: 4700
 ---
 
 Runtime reconfiguration is one of the hardest and most error prone features in a distributed system, especially in a consensus based system like etcd.

--- a/Documentation/op-guide/security.md
+++ b/Documentation/op-guide/security.md
@@ -1,5 +1,6 @@
 ---
 title: Transport security model
+weight: 4750
 ---
 
 etcd supports automatic TLS as well as authentication through client certificates for both clients to server as well as peer (server to server / cluster) communication. **Note that etcd doesn't enable [RBAC based authentication][auth] or the authentication feature in the transport layer by default to reduce friction for users getting started with the database. Further, changing this default would be a breaking change for the project which was established since 2013. An etcd cluster which doesn't enable security features can expose its data to any clients.**

--- a/Documentation/op-guide/supported-platform.md
+++ b/Documentation/op-guide/supported-platform.md
@@ -1,5 +1,6 @@
 ---
 title: Supported systems
+weight: 4800
 ---
 
 ## Current support

--- a/Documentation/op-guide/v2-migration.md
+++ b/Documentation/op-guide/v2-migration.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate applications from using API v2 to API v3
+weight: 4850
 ---
 
 The data store v2 is still accessible from the API v2 after upgrading to etcd3. Thus, it will work as before and require no application changes. With etcd 3, applications use the new grpc API v3 to access the mvcc store, which provides more features and improved performance. The mvcc store and the old store v2 are separate and isolated; writes to the store v2 will not affect the mvcc store and, similarly, writes to the mvcc store will not affect the store v2.

--- a/Documentation/op-guide/versioning.md
+++ b/Documentation/op-guide/versioning.md
@@ -1,5 +1,6 @@
 ---
 title: Versioning
+weight: 4900
 ---
 
 ## Service versioning

--- a/Documentation/platforms/_index.md
+++ b/Documentation/platforms/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Platforms
+weight: 6000
 ---

--- a/Documentation/platforms/aws.md
+++ b/Documentation/platforms/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Web Services
+weight: 6100
 ---
 
 This guide assumes operational knowledge of Amazon Web Services (AWS), specifically Amazon Elastic Compute Cloud (EC2). This guide provides an introduction to design considerations when designing an etcd deployment on AWS EC2 and how AWS specific features may be utilized in that context.

--- a/Documentation/platforms/container-linux-systemd.md
+++ b/Documentation/platforms/container-linux-systemd.md
@@ -1,5 +1,6 @@
 ---
 title: Container Linux with systemd
+weight: 6200
 ---
 
 The following guide shows how to run etcd with [systemd][systemd-docs] under [Container Linux][container-linux-docs].

--- a/Documentation/platforms/freebsd.md
+++ b/Documentation/platforms/freebsd.md
@@ -1,5 +1,6 @@
 ---
 title: FreeBSD
+weight: 6300
 ---
 
 Starting with version 0.1.2 both etcd and etcdctl have been ported to FreeBSD and can be installed either via packages or ports system. Their versions have been recently updated to 0.2.0 so now etcd and etcdctl can be enjoyed on FreeBSD 10.0 (RC4 as of now) and 9.x, where they have been tested. They might also work when installed from ports on earlier versions of FreeBSD, but it is untested; caveat emptor.

--- a/Documentation/reporting-bugs.md
+++ b/Documentation/reporting-bugs.md
@@ -1,5 +1,6 @@
 ---
 title: Reporting bugs
+weight: 1400
 ---
 
 If any part of the etcd project has bugs or documentation mistakes, please let us know by [opening an issue][etcd-issue]. We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check that an issue reporting the same problem does not already exist.

--- a/Documentation/rfc/v3api.md
+++ b/Documentation/rfc/v3api.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+weight: 1100
 ---
 
 The etcd v3 API is designed to give users a more efficient and cleaner abstraction compared to etcd v2. There are a number of semantic and protocol changes in this new API.

--- a/Documentation/triage/_index.md
+++ b/Documentation/triage/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Triage
+weight: 7000
 ---

--- a/Documentation/triage/issues.md
+++ b/Documentation/triage/issues.md
@@ -1,5 +1,6 @@
 ---
 title: Issue Triage Guidelines
+weight: 7100
 ---
 
 ## Purpose

--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -1,5 +1,6 @@
 ---
 title: Tuning
+weight: 1450
 ---
 
 The default settings in etcd should work well for installations on a local network where the average network latency is low. However, when using etcd across multiple data centers or over networks with high latency, the heartbeat interval and election timeout settings may need tuning.

--- a/Documentation/upgrades/_index.md
+++ b/Documentation/upgrades/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Upgrading
+weight: 5000
 ---

--- a/Documentation/upgrades/upgrade_3_0.md
+++ b/Documentation/upgrades/upgrade_3_0.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 2.3 to 3.0
+weight: 5900
 ---
 
 In the general case, upgrading from etcd 2.3 to 3.0 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_1.md
+++ b/Documentation/upgrades/upgrade_3_1.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.0 to 3.1
+weight: 5850
 ---
 
 In the general case, upgrading from etcd 3.0 to 3.1 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_2.md
+++ b/Documentation/upgrades/upgrade_3_2.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.1 to 3.2
+weight: 5800
 ---
 
 In the general case, upgrading from etcd 3.1 to 3.2 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_3.md
+++ b/Documentation/upgrades/upgrade_3_3.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.2 to 3.3
+weight: 5750
 ---
 
 In the general case, upgrading from etcd 3.2 to 3.3 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_4.md
+++ b/Documentation/upgrades/upgrade_3_4.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.3 to 3.4
+weight: 5700
 ---
 
 In the general case, upgrading from etcd 3.3 to 3.4 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_5.md
+++ b/Documentation/upgrades/upgrade_3_5.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.4 to 3.5
+weight: 5650
 ---
 
 In the general case, upgrading from etcd 3.4 to 3.5 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrading-etcd.md
+++ b/Documentation/upgrades/upgrading-etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading etcd clusters and applications
+weight: 5950
 ---
 
 This section contains documents specific to upgrading etcd clusters and applications.


### PR DESCRIPTION
Package: Documentation

As this repo's `Documentation/` folder is the basis for the https://etcd.io/docs/ pages, this PR is one of two PRs working on the [Documentation Content: TOC](https://github.com/etcd-io/website/issues/81). The other PR being: https://github.com/etcd-io/website/pull/83

Locally, during development the Documentation folder is being treated as the primary source of truth, and to ensure that there are no differences, content edits are being made in this repo, and are being synchronized between the repos using:

```bash
while inotifywait -r -e modify,create,delete,move ~/Repos/etcd-io-etcd/Documentation; do
    rsync -avz ~/Repos/etcd-io-etcd/Documentation/ ~/Repos/etcd-io-website/content/docs/v3.4.z
done
# based on https://stackoverflow.com/a/40525217
```
Deploy preview: https://deploy-preview-83--etcd.netlify.app/docs/v3.4.z/

fixes (partly): https://github.com/etcd-io/website/issues/81