### PR TITLE
update latest tags at remote registries

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -31,6 +31,7 @@ main() {
   RELEASE_VERSION="v${VERSION}"
   MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
   BRANCH="release-${MINOR_VERSION}"
+  STABLE_VERSION="3.3"
 
   if ! command -v docker >/dev/null; then
     echo "cannot find docker"
@@ -196,9 +197,11 @@ main() {
 
     echo "Pushing container images to quay.io ${RELEASE_VERSION}"
     docker push "quay.io/coreos/etcd:${RELEASE_VERSION}"
+    [[ "${MINOR_VERSION}" == "${STABLE_VERSION}" ]] && docker push "quay.io/coreos/etcd:latest"
 
     echo "Pushing container images to gcr.io ${RELEASE_VERSION}"
     gcloud docker -- push "gcr.io/etcd-development/etcd:${RELEASE_VERSION}"
+    [[ "${MINOR_VERSION}" == "${STABLE_VERSION}" ]] && gcloud docker -- push "gcr.io/etcd-development/etcd:latest"
 
     for TARGET_ARCH in "-arm64" "-ppc64le" "-s390x"; do
       echo "Pushing container images to quay.io ${RELEASE_VERSION}${TARGET_ARCH}"


### PR DESCRIPTION
scripts/release: add "STABLE_VERSION" variable, use variable push to remote registries

The **latest** image tags in both remote registries (gcr & quay) are at arbitrary numbers with no published rationale. Being unfamiliar with incorporating the latest tag from the git repository into the release script, and unsure whether that is a wise idea, a stable version variable was set and used to compare to the calculated minor version based on $1 passed in to the release script. This should gate a push of the containers to the remote registry **latest** tag based on this value, which requires manual intervention (editing the release script) to increment.

Fixes [#12477](https://github.com/etcd-io/etcd/issues/12477#issue-745093417)
