### PR TITLE
Update failures.md to clarify no “split-brain”

### DIFF
--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -30,7 +30,7 @@ Once a majority of members works, the etcd cluster elects a new leader automatic
 
 ## Network partition
 
-A network partition is similar to a minor followers failure or a leader failure. A network partition divides the etcd cluster into two parts; one with a member majority and the other with a member minority. The majority side becomes the available cluster and the minority side is unavailable; there is no “split-brain” in etcd. 
+A network partition is similar to a minor followers failure or a leader failure. A network partition divides the etcd cluster into two parts; one with a member majority and the other with a member minority. The majority side becomes the available cluster and the minority side is unavailable. There is no “split-brain” in etcd because cluster members are explicitly added/removed with each such change is approved by the current majority of members.
 
 If the leader is on the majority side, then from the majority point of view the failure is a minority follower failure. If the leader is on the minority side, then it is a leader failure. The leader on the minority side steps down and the majority side elects a new leader.
 


### PR DESCRIPTION
Update failures.md: Adding a clarifying sentence, because it was not immediately obvious why "split-brain" is not possible.

The intent is to help users coming from alternative clustering technologies where the cluster membership is more dynamic.
