### PR TITLE
Documentation Content: TOC — Sections Order

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -1,5 +1,6 @@
 ---
 title: etcd version ___
+weight: 1000
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/Documentation/benchmarks/_index.md
+++ b/Documentation/benchmarks/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Benchmarks
+weight: 5000
 ---

--- a/Documentation/dev-guide/_index.md
+++ b/Documentation/dev-guide/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Developer guide
+weight: 3000
 ---

--- a/Documentation/learning/_index.md
+++ b/Documentation/learning/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Learning
+weight: 2000
 ---

--- a/Documentation/op-guide/_index.md
+++ b/Documentation/op-guide/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Operations guide
+weight: 4000
 ---

--- a/Documentation/platforms/_index.md
+++ b/Documentation/platforms/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Platforms
+weight: 7000
 ---

--- a/Documentation/triage/_index.md
+++ b/Documentation/triage/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Triage
+weight: 8000
 ---

--- a/Documentation/upgrades/_index.md
+++ b/Documentation/upgrades/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Upgrading
+weight: 6000
 ---


### PR DESCRIPTION
Updating the primary sections order by adding `weight`s to main section `.md` files.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 17 57 PM](https://user-images.githubusercontent.com/4453979/101097842-d5601d80-35b9-11eb-8b5a-4df7cdb27b07.png) | ![Screenshot_2020-12-09 etcd version ___](https://user-images.githubusercontent.com/4453979/101557723-7897a500-39b5-11eb-9851-9f44505c9e5a.png) |
|  Documentation sections<br>* Benchmarks<br>* Developer guide<br>* Learning<br>* Operations guide<br>* Platforms<br>* Triage<br>* Upgrading |  Documentation sections<br>* Learning<br>* Developer guide<br>* Operations guide<br>* Benchmarks<br>* Upgrading<br>* Platforms<br>* Triage  |

This is a first pass on the order. Feedback is welcome!