### PR TITLE
Documentation Content: TOC — Developer Guide Section

### DIFF
--- a/Documentation/dev-guide/api_grpc_gateway.md
+++ b/Documentation/dev-guide/api_grpc_gateway.md
@@ -1,5 +1,6 @@
 ---
 title: Why gRPC gateway
+weight: 3375
 ---
 
 etcd v3 uses [gRPC][grpc] for its messaging protocol. The etcd project includes a gRPC-based [Go client][go-client] and a command line utility, [etcdctl][etcdctl], for communicating with an etcd cluster through gRPC. For languages with no gRPC support, etcd provides a JSON [gRPC gateway][grpc-gateway]. This gateway serves a RESTful proxy that translates HTTP/JSON requests into gRPC messages.

--- a/Documentation/dev-guide/experimental_apis.md
+++ b/Documentation/dev-guide/experimental_apis.md
@@ -1,5 +1,6 @@
 ---
 title: Experimental APIs and features
+weight: 3750
 ---
 
 For the most part, the etcd project is stable, but we are still moving fast! We believe in the release fast philosophy. We want to get early feedback on features still in development and stabilizing. Thus, there are, and will be more, experimental features and APIs. We plan to improve these features based on the early feedback from the community, or abandon them if there is little interest, in the next few releases. Please do not rely on any experimental features or APIs in production environment.

--- a/Documentation/dev-guide/grpc_naming.md
+++ b/Documentation/dev-guide/grpc_naming.md
@@ -1,5 +1,6 @@
 ---
 title: gRPC naming and discovery
+weight: 3500
 ---
 
 etcd provides a gRPC resolver to support an alternative name system that fetches endpoints from etcd for discovering gRPC services. The underlying mechanism is based on watching updates to keys prefixed with the service name.

--- a/Documentation/dev-guide/interacting_v3.md
+++ b/Documentation/dev-guide/interacting_v3.md
@@ -1,5 +1,6 @@
 ---
 title: Interacting with etcd
+weight: 3250
 ---
 
 Users mostly interact with etcd by putting or getting the value of a key. This section describes how to do that by using etcdctl, a command line tool for interacting with etcd server. The concepts described here should apply to the gRPC APIs or client library APIs.

--- a/Documentation/dev-guide/limit.md
+++ b/Documentation/dev-guide/limit.md
@@ -1,5 +1,6 @@
 ---
 title: System limits
+weight: 3625
 ---
 
 ## Request size limit

--- a/Documentation/dev-guide/local_cluster.md
+++ b/Documentation/dev-guide/local_cluster.md
@@ -1,5 +1,6 @@
 ---
 title: Set up a local cluster
+weight: 3125
 ---
 
 For testing and development deployments, the quickest and easiest way is to configure a local cluster. For a production deployment, refer to the [clustering][clustering] section.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Developer Guide section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 18 17 PM](https://user-images.githubusercontent.com/4453979/101103074-04c65880-35c1-11eb-9800-44d0159b52a2.png) | ![Screen Shot 2020-11-25 at 2 26 23 PM](https://user-images.githubusercontent.com/4453979/100287809-3a68a300-2f2a-11eb-88f4-e99171d73116.png) |
| Experimental APIs and features<br>gRPC naming and discovery<br>Interacting with etcd<br>Set up a local cluster<br>System limits<br>Why gRPC gateway | Set up a local cluster<br>Interacting with etcd<br>Why gRPC gateway<br>gRPC naming and discovery<br>System limits<br>Experimental APIs and features |

This is a first pass on the order. Feedback is welcome!