### PR TITLE
Documentation Content: TOC — Learning Section Page Order

### DIFF
--- a/Documentation/learning/api.md
+++ b/Documentation/learning/api.md
@@ -1,5 +1,6 @@
 ---
 title: etcd3 API
+weight: 2625
 ---
 
 This document is meant to give an overview of the etcd3 API's central design. It is by no means all encompassing, but intended to focus on the basic ideas needed to understand etcd without the distraction of less common API calls. All etcd3 API's are defined in [gRPC services][grpc-service], which categorize remote procedure calls (RPCs) understood by the etcd server. A full listing of all etcd RPCs are documented in markdown in the [gRPC API listing][grpc-api].

--- a/Documentation/learning/api_guarantees.md
+++ b/Documentation/learning/api_guarantees.md
@@ -1,5 +1,6 @@
 ---
 title: KV API guarantees
+weight: 2750
 ---
 
 etcd is a consistent and durable key value store with [mini-transaction][txn] support. The key value store is exposed through the KV APIs. etcd tries to ensure the strongest consistency and durability guarantees for a distributed system. This specification enumerates the KV API guarantees made by etcd.

--- a/Documentation/learning/data_model.md
+++ b/Documentation/learning/data_model.md
@@ -1,5 +1,6 @@
 ---
 title: Data model
+weight: 2125
 ---
 
 etcd is designed to reliably store infrequently updated data and provide reliable watch queries. etcd exposes previous versions of key-value pairs to support inexpensive snapshots and watch history events (“time travel queries”). A persistent, multi-version, concurrency-control data model is a good fit for these use cases.

--- a/Documentation/learning/design-auth-v3.md
+++ b/Documentation/learning/design-auth-v3.md
@@ -1,5 +1,6 @@
 ﻿---
 title: etcd v3 authentication design
+weight: 2500
 ---
 
 ## Why not reuse the v2 auth system?

--- a/Documentation/learning/design-client.md
+++ b/Documentation/learning/design-client.md
@@ -1,5 +1,6 @@
 ---
 title: etcd client design
+weight: 2250
 ---
 
 etcd Client Design

--- a/Documentation/learning/design-learner.md
+++ b/Documentation/learning/design-learner.md
@@ -1,5 +1,6 @@
 ---
 title: etcd learner design
+weight: 2375
 ---
 
 etcd Learner

--- a/Documentation/learning/glossary.md
+++ b/Documentation/learning/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+weight: 2900
 ---
 
 This document defines the various terms used in etcd documentation, command line and source code.

--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -1,5 +1,6 @@
 ---
 title: etcd versus other key-value stores
+weight: 2875
 ---
 
 The name "etcd" originated from two ideas, the unix "/etc" folder and "d"istributed systems. The "/etc" folder is a place to store configuration data for a single system whereas etcd stores configuration information for large scale distributed systems. Hence, a "d"istributed "/etc" is "etcd".


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Learning section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 18 27 PM](https://user-images.githubusercontent.com/4453979/101104623-71425700-35c3-11eb-92e9-71f7e01879a3.png) | ![Screen Shot 2020-11-25 at 2 26 52 PM](https://user-images.githubusercontent.com/4453979/100287833-49e7ec00-2f2a-11eb-820a-9c4819c2a9f5.png) |
| Data model<br>etcd client design<br>etcd learner design<br>etcd v3 authentication design<br>etcd versus other key-value stores<br>etcd3 API<br>Glossary<br>KV API guarantees | Data model<br>etcd client design<br>etcd learner design<br>etcd v3 authentication design<br>etcd3 API<br>KV API guarantees<br>etcd versus other key-value stores<br>Glossary |

This is a first pass on the order. Feedback is welcome!