### PR TITLE
Documentation Content: TOC — Operations guide Section Page Order

### DIFF
--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -1,5 +1,6 @@
 ---
 title: Role-based access control
+weight: 4100
 ---
 
 ## Overview

--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -1,5 +1,6 @@
 ---
 title: Clustering Guide
+weight: 4150
 ---
 
 ## Overview

--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration flags
+weight: 4050
 ---
 
 etcd is configurable through a configuration file, various command-line flags, and environment variables.

--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -1,5 +1,6 @@
 ---
 title: Run etcd clusters inside containers
+weight: 4200
 ---
 
 The following guide shows how to run etcd with rkt and Docker using the [static bootstrap process](clustering.md#static).

--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -1,5 +1,6 @@
 ---
 title: Failure modes
+weight: 4250
 ---
 
 Failures are common in a large deployment of machines. A machine fails when its hardware or software malfunctions. Multiple machines fail together when there are power failures or network issues. Multiple kinds of failures can also happen at once; it is almost impossible to enumerate all possible failure cases. 

--- a/Documentation/op-guide/gateway.md
+++ b/Documentation/op-guide/gateway.md
@@ -1,5 +1,6 @@
 ---
 title: etcd gateway
+weight: 4300
 ---
 
 ## What is etcd gateway

--- a/Documentation/op-guide/grpc_proxy.md
+++ b/Documentation/op-guide/grpc_proxy.md
@@ -1,5 +1,6 @@
 ---
 title: gRPC proxy
+weight: 4350
 ---
 
 The gRPC proxy is a stateless etcd reverse proxy operating at the gRPC layer (L7). The proxy is designed to reduce the total processing load on the core etcd cluster. For horizontal scalability, it coalesces watch and lease API requests. To protect the cluster against abusive clients, it caches key range requests.

--- a/Documentation/op-guide/hardware.md
+++ b/Documentation/op-guide/hardware.md
@@ -1,5 +1,6 @@
 ---
 title: Hardware recommendations
+weight: 4400
 ---
 
 etcd usually runs well with limited resources for development or testing purposes; it’s common to develop with etcd on a  laptop or a cheap cloud machine. However, when running etcd clusters in production, some hardware guidelines are useful for proper administration. These suggestions are not hard rules; they serve as a good starting point for a robust production deployment. As always, deployments should be tested with simulated workloads before running in production.

--- a/Documentation/op-guide/maintenance.md
+++ b/Documentation/op-guide/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: Maintenance
+weight: 4450
 ---
 
 ## Overview

--- a/Documentation/op-guide/monitoring.md
+++ b/Documentation/op-guide/monitoring.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring etcd
+weight: 4500
 ---
 
 Each etcd server provides local monitoring information on its client port through http endpoints. The monitoring data is useful for both system health checking and cluster debugging.

--- a/Documentation/op-guide/performance.md
+++ b/Documentation/op-guide/performance.md
@@ -1,5 +1,6 @@
 ---
 title: Performance
+weight: 4550
 ---
 
 ## Understanding performance

--- a/Documentation/op-guide/recovery.md
+++ b/Documentation/op-guide/recovery.md
@@ -1,5 +1,6 @@
 ---
 title: Disaster recovery
+weight: 4275
 ---
 
 etcd is designed to withstand machine failures. An etcd cluster automatically recovers from temporary failures (e.g., machine reboots) and tolerates up to *(N-1)/2* permanent failures for a cluster of N members. When a member permanently fails, whether due to hardware failure or disk corruption, it loses access to the cluster. If the cluster permanently loses more than *(N-1)/2* members then it disastrously fails, irrevocably losing quorum. Once quorum is lost, the cluster cannot reach consensus and therefore cannot continue accepting updates.

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Runtime reconfiguration
+weight: 4700
 ---
 
 etcd comes with support for incremental runtime reconfiguration, which allows users to update the membership of the cluster at run time.

--- a/Documentation/op-guide/runtime-reconf-design.md
+++ b/Documentation/op-guide/runtime-reconf-design.md
@@ -1,5 +1,6 @@
 ---
 title: Design of runtime reconfiguration
+weight: 4650
 ---
 
 Runtime reconfiguration is one of the hardest and most error prone features in a distributed system, especially in a consensus based system like etcd.

--- a/Documentation/op-guide/security.md
+++ b/Documentation/op-guide/security.md
@@ -1,5 +1,6 @@
 ---
 title: Transport security model
+weight: 4125
 ---
 
 etcd supports automatic TLS as well as authentication through client certificates for both clients to server as well as peer (server to server / cluster) communication. **Note that etcd doesn't enable [RBAC based authentication][auth] or the authentication feature in the transport layer by default to reduce friction for users getting started with the database. Further, changing this default would be a breaking change for the project which was established since 2013. An etcd cluster which doesn't enable security features can expose its data to any clients.**

--- a/Documentation/op-guide/supported-platform.md
+++ b/Documentation/op-guide/supported-platform.md
@@ -1,5 +1,6 @@
 ---
 title: Supported systems
+weight: 4800
 ---
 
 ## Current support

--- a/Documentation/op-guide/v2-migration.md
+++ b/Documentation/op-guide/v2-migration.md
@@ -1,5 +1,6 @@
 ---
 title: Migrate applications from using API v2 to API v3
+weight: 4850
 ---
 
 The data store v2 is still accessible from the API v2 after upgrading to etcd3. Thus, it will work as before and require no application changes. With etcd 3, applications use the new grpc API v3 to access the mvcc store, which provides more features and improved performance. The mvcc store and the old store v2 are separate and isolated; writes to the store v2 will not affect the mvcc store and, similarly, writes to the mvcc store will not affect the store v2.

--- a/Documentation/op-guide/versioning.md
+++ b/Documentation/op-guide/versioning.md
@@ -1,5 +1,6 @@
 ---
 title: Versioning
+weight: 4900
 ---
 
 ## Service versioning


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Operations guide section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 19 01 PM](https://user-images.githubusercontent.com/4453979/101105382-5670e200-35c5-11eb-9755-6be09b72a7d7.png) | ![Screenshot_2020-12-07 Operations guide](https://user-images.githubusercontent.com/4453979/101393748-77844c00-38bf-11eb-82f9-a3d934b4d4fa.png) |
| Clustering Guide<br>Configuration flags<br>Design of runtime reconfiguration<br>Disaster recovery<br>etcd gateway<br>Failure modes<br>gRPC proxy<br>Hardware recommendations<br>Maintenance<br>Migrate applications from using API v2 to API v3<br>Monitoring etcd<br>Performance<br>Role-based access control<br>Run etcd clusters inside containers<br>Runtime reconfiguration<br>Supported systems<br>Transport security model<br>Versioning | Configuration flag<br>Role-based access control<br>Transport security model<br>Clustering Guide<br>Run etcd clusters inside containers<br>Failure modes<br>Disaster recovery<br>etcd gateway<br>gRPC proxy<br>Hardware recommendations<br>Maintenance<br>Monitoring etcd<br>Performance<br>Design of runtime reconfiguration<br>Runtime reconfiguration<br>Supported systems<br>Migrate applications from using API v2 to API v3<br>Versioning  |

This is a first pass on the order. Feedback is welcome!
[Edited based on PR feedback]