### PR TITLE
Documentation Content: TOC — Upgrading Section Page Order

### DIFF
--- a/Documentation/upgrades/upgrade_3_0.md
+++ b/Documentation/upgrades/upgrade_3_0.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 2.3 to 3.0
+weight: 6900
 ---
 
 In the general case, upgrading from etcd 2.3 to 3.0 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_1.md
+++ b/Documentation/upgrades/upgrade_3_1.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.0 to 3.1
+weight: 6850
 ---
 
 In the general case, upgrading from etcd 3.0 to 3.1 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_2.md
+++ b/Documentation/upgrades/upgrade_3_2.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.1 to 3.2
+weight: 6800
 ---
 
 In the general case, upgrading from etcd 3.1 to 3.2 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_3.md
+++ b/Documentation/upgrades/upgrade_3_3.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.2 to 3.3
+weight: 6750
 ---
 
 In the general case, upgrading from etcd 3.2 to 3.3 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_4.md
+++ b/Documentation/upgrades/upgrade_3_4.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.3 to 3.4
+weight: 6700
 ---
 
 In the general case, upgrading from etcd 3.3 to 3.4 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrade_3_5.md
+++ b/Documentation/upgrades/upgrade_3_5.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrade etcd from 3.4 to 3.5
+weight: 6650
 ---
 
 In the general case, upgrading from etcd 3.4 to 3.5 can be a zero-downtime, rolling upgrade:

--- a/Documentation/upgrades/upgrading-etcd.md
+++ b/Documentation/upgrades/upgrading-etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading etcd clusters and applications
+weight: 6500
 ---
 
 This section contains documents specific to upgrading etcd clusters and applications.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Upgrading section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 19 19 PM](https://user-images.githubusercontent.com/4453979/101105874-997f8500-35c6-11eb-9b51-e215f55b2879.png) | ![Screenshot_2020-12-09 Upgrading](https://user-images.githubusercontent.com/4453979/101683349-bd2a4b80-3a5c-11eb-9e07-ce3191ff8c12.png) |
| Upgrade etcd from 2.3 to 3.0<br>Upgrade etcd from 3.0 to 3.1<br>Upgrade etcd from 3.1 to 3.2<br>Upgrade etcd from 3.2 to 3.3<br>Upgrade etcd from 3.3 to 3.4<br>Upgrade etcd from 3.4 to 3.5<br>Upgrading etcd clusters and applications | Upgrading etcd clusters and applications<br>Upgrade etcd from 3.4 to 3.5<br>Upgrade etcd from 3.3 to 3.4<br>Upgrade etcd from 3.2 to 3.3<br>Upgrade etcd from 3.1 to 3.2<br>Upgrade etcd from 3.0 to 3.1<br>Upgrade etcd from 2.3 to 3.0 |

This is a first pass on the order. Feedback is welcome!