### PR TITLE
Documentation Content: TOC — Platforms Section Page Order

### DIFF
--- a/Documentation/platforms/aws.md
+++ b/Documentation/platforms/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Web Services
+weight: 7100
 ---
 
 This guide assumes operational knowledge of Amazon Web Services (AWS), specifically Amazon Elastic Compute Cloud (EC2). This guide provides an introduction to design considerations when designing an etcd deployment on AWS EC2 and how AWS specific features may be utilized in that context.

--- a/Documentation/platforms/container-linux-systemd.md
+++ b/Documentation/platforms/container-linux-systemd.md
@@ -1,5 +1,6 @@
 ---
 title: Container Linux with systemd
+weight: 7200
 ---
 
 The following guide shows how to run etcd with [systemd][systemd-docs] under [Container Linux][container-linux-docs].

--- a/Documentation/platforms/freebsd.md
+++ b/Documentation/platforms/freebsd.md
@@ -1,5 +1,6 @@
 ---
 title: FreeBSD
+weight: 7300
 ---
 
 Starting with version 0.1.2 both etcd and etcdctl have been ported to FreeBSD and can be installed either via packages or ports system. Their versions have been recently updated to 0.2.0 so now etcd and etcdctl can be enjoyed on FreeBSD 10.0 (RC4 as of now) and 9.x, where they have been tested. They might also work when installed from ports on earlier versions of FreeBSD, but it is untested; caveat emptor.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Platforms section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 20 06 PM](https://user-images.githubusercontent.com/4453979/101106546-3131a300-35c8-11eb-8102-f86d109e0f45.png) | ![Screen Shot 2020-11-25 at 2 28 10 PM](https://user-images.githubusercontent.com/4453979/100287917-77349a00-2f2a-11eb-8228-38cada7e56b8.png) |
| Amazon Web Services<br>Container Linux with systemd<br>FreeBSD | Amazon Web Services<br>Container Linux with systemd<br>FreeBSD |


Note, I have left the order as it was while adding the `weight`s but I'm not sure if it should be this way or not. Feedback is welcome!