### PR TITLE
Documentation Content: TOC — Triage Section Page weight

### DIFF
--- a/Documentation/triage/issues.md
+++ b/Documentation/triage/issues.md
@@ -1,5 +1,6 @@
 ---
 title: Issue Triage Guidelines
+weight: 8100
 ---
 
 ## Purpose


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Triage section pages by adding `weight`s to the frontmatter. Note, there is only one page in this section.

Related to issue https://github.com/etcd-io/website/issues/81