### PR TITLE
 Documentation Content: TOC — Benchmarks Section Page Order

### DIFF
--- a/Documentation/benchmarks/etcd-2-1-0-alpha-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-1-0-alpha-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.1.0
+weight: 5875
 ---
 
 ## Physical machines

--- a/Documentation/benchmarks/etcd-2-2-0-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0
+weight: 5750
 ---
 
 ## Physical Machines

--- a/Documentation/benchmarks/etcd-2-2-0-rc-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-rc-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0-rc
+weight: 5625
 ---
 
 ## Physical machine

--- a/Documentation/benchmarks/etcd-2-2-0-rc-memory-benchmarks.md
+++ b/Documentation/benchmarks/etcd-2-2-0-rc-memory-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v2.2.0-rc-memory
+weight: 5500
 ---
 
 ## Physical machine

--- a/Documentation/benchmarks/etcd-3-demo-benchmarks.md
+++ b/Documentation/benchmarks/etcd-3-demo-benchmarks.md
@@ -1,5 +1,6 @@
 ---
 title: Benchmarking etcd v3
+weight: 5375
 ---
 
 ## Physical machines

--- a/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
+++ b/Documentation/benchmarks/etcd-3-watch-memory-benchmark.md
@@ -1,5 +1,6 @@
 ---
 title: Watch Memory Usage Benchmark
+weight: 5250
 ---
 
 *NOTE*: The watch features are under active development, and their memory usage may change as that development progresses. We do not expect it to significantly increase beyond the figures stated below.

--- a/Documentation/benchmarks/etcd-storage-memory-benchmark.md
+++ b/Documentation/benchmarks/etcd-storage-memory-benchmark.md
@@ -1,5 +1,6 @@
 ---
 title: Storage Memory Usage Benchmark
+weight: 5125
 ---
 
 <!---todo: link storage to storage design doc-->


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Benchmarks section page order by adding `weight`s to the frontmatter.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 20 33 PM](https://user-images.githubusercontent.com/4453979/101108584-c2a31400-35cc-11eb-8482-aa27c6c270d0.png) | ![Screen Shot 2020-11-25 at 2 28 53 PM](https://user-images.githubusercontent.com/4453979/100287978-92070e80-2f2a-11eb-85ff-8d9619a20e7a.png) |
| Benchmarking etcd v2.1.0<br>Benchmarking etcd v2.2.0<br>Benchmarking etcd v2.2.0-rc<br>Benchmarking etcd v2.2.0-rc-memory<br>Benchmarking etcd v3<br>Storage Memory Usage Benchmark<br>Watch Memory Usage Benchmark | Storage Memory Usage Benchmark<br>Watch Memory Usage Benchmark<br>Benchmarking etcd v3<br>Benchmarking etcd v2.2.0-rc-memory<br>Benchmarking etcd v2.2.0-rc<br>Benchmarking etcd v2.2.0<br>Benchmarking etcd v2.1.0 |

This is a first pass on the order. Feedback is welcome!