### PR TITLE
Documentation Content: TOC — Version Home Sidebar menu order

### DIFF
--- a/Documentation/branch-management.md
+++ b/Documentation/branch-management.md
@@ -1,6 +1,6 @@
 ---
 title: Branch management
-weight: 1
+weight: 1250
 ---
 
 ## Guide

--- a/Documentation/demo.md
+++ b/Documentation/demo.md
@@ -1,6 +1,6 @@
 ---
 title: Demo
-weight: 1
+weight: 1100
 ---
 
 This series of examples shows the basic procedures for working with an etcd cluster.

--- a/Documentation/dev-internal/discovery_protocol.md
+++ b/Documentation/dev-internal/discovery_protocol.md
@@ -1,5 +1,6 @@
 ---
 title: Discovery service protocol
+weight: 1500
 ---
 
 Discovery service protocol helps new etcd member to discover all other members in cluster bootstrap phase using a shared discovery URL.

--- a/Documentation/dev-internal/logging.md
+++ b/Documentation/dev-internal/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging conventions
+weight: 1600
 ---
 
 etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:

--- a/Documentation/dev-internal/modules.md
+++ b/Documentation/dev-internal/modules.md
@@ -1,5 +1,6 @@
 ---
 title: Golang modules
+weight: 1650
 ---
 
 The etcd project (since version 3.5) is organized into multiple 

--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -1,5 +1,6 @@
 ---
 title: etcd release guide
+weight: 1550
 ---
 
 The guide talks about how to release a new version of etcd.

--- a/Documentation/dl-build.md
+++ b/Documentation/dl-build.md
@@ -1,5 +1,6 @@
 ---
 title: Download and build
+weight: 1150
 ---
 
 ## System requirements

--- a/Documentation/faq.md
+++ b/Documentation/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions (FAQ)
+weight: 1200
 ---
 
 ## etcd, general

--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -1,5 +1,6 @@
 ---
 title: Libraries and tools
+weight: 1300
 ---
 
 ## Tools

--- a/Documentation/metrics.md
+++ b/Documentation/metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Metrics
+weight: 1350
 ---
 
 etcd uses [Prometheus][prometheus] for metrics reporting. The metrics can be used for real-time monitoring and debugging. etcd does not persist its metrics; if a member restarts, the metrics will be reset.

--- a/Documentation/reporting-bugs.md
+++ b/Documentation/reporting-bugs.md
@@ -1,5 +1,6 @@
 ---
 title: Reporting bugs
+weight: 1400
 ---
 
 If any part of the etcd project has bugs or documentation mistakes, please let us know by [opening an issue][etcd-issue]. We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check that an issue reporting the same problem does not already exist.

--- a/Documentation/rfc/v3api.md
+++ b/Documentation/rfc/v3api.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+weight: 1050
 ---
 
 The etcd v3 API is designed to give users a more efficient and cleaner abstraction compared to etcd v2. There are a number of semantic and protocol changes in this new API.

--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -1,5 +1,6 @@
 ---
 title: Tuning
+weight: 1450
 ---
 
 The default settings in etcd should work well for installations on a local network where the average network latency is low. However, when using etcd across multiple data centers or over networks with high latency, the heartbeat interval and election timeout settings may need tuning.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509

Updating the Version X.Y.Z home menu order by adding `weight`s to the frontmatter of page that are organized on that sidebar.

Related to issue https://github.com/etcd-io/website/issues/81

| Original order | Updated Order |
| :--- | :--- |
| ![Screen Shot 2020-12-03 at 2 17 57 PM](https://user-images.githubusercontent.com/4453979/101109775-9046e600-35cf-11eb-9cc6-443034c7a324.png) | ![Screenshot_2020-12-07 etcd version ___](https://user-images.githubusercontent.com/4453979/101389298-1f4a4b80-38b9-11eb-82f2-949775c73b20.png) |
| Branch management<br>Demo<br>Discovery service protocol<br>Download and build<br>etcd release guide<br>Frequently Asked Questions (FAQ)<br>Libraries and tools<br>Logging conventions<br>Metrics<br>Overview<br>Reporting bugs<br>Tuning | Overview<br>Demo<br>Download and build<br>Frequently Asked Questions (FAQ)<br>Branch management<br>Libraries and tools<br>Metrics<br>Reporting bugs<br>Tuning<br>Discovery service protocol<br>etcd release guide<br>Logging conventions<br>Golang modules |

This is a first pass on the order. Feedback is welcome!
[edited based on PR feedback]