### PR TITLE
Documentation Content: TOC — Developer Guide Section Descriptions

### DIFF
--- a/Documentation/dev-guide/_index.md
+++ b/Documentation/dev-guide/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Developer guide
+weight: 3000
+description: Guides for developers using ectd
 ---

--- a/Documentation/dev-guide/api_grpc_gateway.md
+++ b/Documentation/dev-guide/api_grpc_gateway.md
@@ -1,5 +1,7 @@
 ---
 title: Why gRPC gateway
+weight: 3375
+description: Why you should consider using the gRPC gateway
 ---
 
 etcd v3 uses [gRPC][grpc] for its messaging protocol. The etcd project includes a gRPC-based [Go client][go-client] and a command line utility, [etcdctl][etcdctl], for communicating with an etcd cluster through gRPC. For languages with no gRPC support, etcd provides a JSON [gRPC gateway][grpc-gateway]. This gateway serves a RESTful proxy that translates HTTP/JSON requests into gRPC messages.

--- a/Documentation/dev-guide/experimental_apis.md
+++ b/Documentation/dev-guide/experimental_apis.md
@@ -1,5 +1,7 @@
 ---
 title: Experimental APIs and features
+weight: 3750
+description: New (and potentially unstable) APIs and features in etcd
 ---
 
 For the most part, the etcd project is stable, but we are still moving fast! We believe in the release fast philosophy. We want to get early feedback on features still in development and stabilizing. Thus, there are, and will be more, experimental features and APIs. We plan to improve these features based on the early feedback from the community, or abandon them if there is little interest, in the next few releases. Please do not rely on any experimental features or APIs in production environment.

--- a/Documentation/dev-guide/grpc_naming.md
+++ b/Documentation/dev-guide/grpc_naming.md
@@ -1,5 +1,7 @@
 ---
 title: gRPC naming and discovery
+weight: 3500
+description: "go-grpc: for resolving gRPC endpoints with an etcd backend"
 ---
 
 etcd provides a gRPC resolver to support an alternative name system that fetches endpoints from etcd for discovering gRPC services. The underlying mechanism is based on watching updates to keys prefixed with the service name.

--- a/Documentation/dev-guide/interacting_v3.md
+++ b/Documentation/dev-guide/interacting_v3.md
@@ -1,5 +1,7 @@
 ---
 title: Interacting with etcd
+weight: 3250
+description: "etcdctl: a command line tool for interacting with the etcd server"
 ---
 
 Users mostly interact with etcd by putting or getting the value of a key. This section describes how to do that by using etcdctl, a command line tool for interacting with etcd server. The concepts described here should apply to the gRPC APIs or client library APIs.

--- a/Documentation/dev-guide/limit.md
+++ b/Documentation/dev-guide/limit.md
@@ -1,5 +1,7 @@
 ---
 title: System limits
+weight: 3625
+description: "etcd limits: requests and storage"
 ---
 
 ## Request size limit

--- a/Documentation/dev-guide/local_cluster.md
+++ b/Documentation/dev-guide/local_cluster.md
@@ -1,5 +1,7 @@
 ---
 title: Set up a local cluster
+weight: 3125
+description: Configuring local clusters for testing and development 
 ---
 
 For testing and development deployments, the quickest and easiest way is to configure a local cluster. For a production deployment, refer to the [clustering][clustering] section.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12510

Adding `description`s to Documentation/dev-guide files' frontmatter so that we can use them as annotations for the TOC 

Page previews for how this may render:
https://deploy-preview-83--etcd.netlify.app/docs/v3.4.z/
https://deploy-preview-83--etcd.netlify.app/docs/v3.4.z/dev-guide/
https://deploy-preview-83--etcd.netlify.app/docs/v3.4.z/dev-guide/local_cluster/

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!