### PR TITLE
Documentation Content: TOC — Learning Section Descriptions

### DIFF
--- a/Documentation/learning/_index.md
+++ b/Documentation/learning/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Learning
+weight: 2000
+description: Learning resources
 ---

--- a/Documentation/learning/api.md
+++ b/Documentation/learning/api.md
@@ -1,5 +1,6 @@
 ---
 title: etcd3 API
+weight: 3625
 ---
 
 This document is meant to give an overview of the etcd3 API's central design. It is by no means all encompassing, but intended to focus on the basic ideas needed to understand etcd without the distraction of less common API calls. All etcd3 API's are defined in [gRPC services][grpc-service], which categorize remote procedure calls (RPCs) understood by the etcd server. A full listing of all etcd RPCs are documented in markdown in the [gRPC API listing][grpc-api].

--- a/Documentation/learning/api.md
+++ b/Documentation/learning/api.md
@@ -1,6 +1,7 @@
 ---
 title: etcd3 API
-weight: 3625
+weight: 2625
+description: etcd3 API central design overview
 ---
 
 This document is meant to give an overview of the etcd3 API's central design. It is by no means all encompassing, but intended to focus on the basic ideas needed to understand etcd without the distraction of less common API calls. All etcd3 API's are defined in [gRPC services][grpc-service], which categorize remote procedure calls (RPCs) understood by the etcd server. A full listing of all etcd RPCs are documented in markdown in the [gRPC API listing][grpc-api].

--- a/Documentation/learning/api_guarantees.md
+++ b/Documentation/learning/api_guarantees.md
@@ -1,6 +1,7 @@
 ---
 title: KV API guarantees
-weight: 3750
+weight: 2750
+description: KV API guarantees made by etcd
 ---
 
 etcd is a consistent and durable key value store with [mini-transaction][txn] support. The key value store is exposed through the KV APIs. etcd tries to ensure the strongest consistency and durability guarantees for a distributed system. This specification enumerates the KV API guarantees made by etcd.

--- a/Documentation/learning/api_guarantees.md
+++ b/Documentation/learning/api_guarantees.md
@@ -1,5 +1,6 @@
 ---
 title: KV API guarantees
+weight: 3750
 ---
 
 etcd is a consistent and durable key value store with [mini-transaction][txn] support. The key value store is exposed through the KV APIs. etcd tries to ensure the strongest consistency and durability guarantees for a distributed system. This specification enumerates the KV API guarantees made by etcd.

--- a/Documentation/learning/data_model.md
+++ b/Documentation/learning/data_model.md
@@ -1,5 +1,6 @@
 ---
 title: Data model
+weight: 3125
 ---
 
 etcd is designed to reliably store infrequently updated data and provide reliable watch queries. etcd exposes previous versions of key-value pairs to support inexpensive snapshots and watch history events (“time travel queries”). A persistent, multi-version, concurrency-control data model is a good fit for these use cases.

--- a/Documentation/learning/data_model.md
+++ b/Documentation/learning/data_model.md
@@ -1,6 +1,7 @@
 ---
 title: Data model
-weight: 3125
+weight: 2125
+description: etcd data storage methodologies
 ---
 
 etcd is designed to reliably store infrequently updated data and provide reliable watch queries. etcd exposes previous versions of key-value pairs to support inexpensive snapshots and watch history events (“time travel queries”). A persistent, multi-version, concurrency-control data model is a good fit for these use cases.

--- a/Documentation/learning/design-auth-v3.md
+++ b/Documentation/learning/design-auth-v3.md
@@ -1,6 +1,7 @@
 ﻿---
 title: etcd v3 authentication design
-weight: 3500
+weight: 2500
+description: etcd v3 authentication
 ---
 
 ## Why not reuse the v2 auth system?

--- a/Documentation/learning/design-auth-v3.md
+++ b/Documentation/learning/design-auth-v3.md
@@ -1,5 +1,6 @@
 ﻿---
 title: etcd v3 authentication design
+weight: 3500
 ---
 
 ## Why not reuse the v2 auth system?

--- a/Documentation/learning/design-client.md
+++ b/Documentation/learning/design-client.md
@@ -1,6 +1,7 @@
 ---
 title: etcd client design
-weight: 3250
+weight: 2250
+description: Client architectural decisions & their implementation details
 ---
 
 etcd Client Design

--- a/Documentation/learning/design-client.md
+++ b/Documentation/learning/design-client.md
@@ -1,5 +1,6 @@
 ---
 title: etcd client design
+weight: 3250
 ---
 
 etcd Client Design

--- a/Documentation/learning/design-learner.md
+++ b/Documentation/learning/design-learner.md
@@ -1,6 +1,7 @@
 ---
 title: etcd learner design
-weight: 3375
+weight: 2375
+description: Mitigating common challenges with membership reconfiguration
 ---
 
 etcd Learner

--- a/Documentation/learning/design-learner.md
+++ b/Documentation/learning/design-learner.md
@@ -1,5 +1,6 @@
 ---
 title: etcd learner design
+weight: 3375
 ---
 
 etcd Learner

--- a/Documentation/learning/glossary.md
+++ b/Documentation/learning/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+weight: 3900
 ---
 
 This document defines the various terms used in etcd documentation, command line and source code.

--- a/Documentation/learning/glossary.md
+++ b/Documentation/learning/glossary.md
@@ -1,6 +1,7 @@
 ---
 title: Glossary
-weight: 3900
+weight: 2900
+description: Terms used in etcd documentation, command line, and source code
 ---
 
 This document defines the various terms used in etcd documentation, command line and source code.

--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -1,6 +1,7 @@
 ---
 title: etcd versus other key-value stores
-weight: 3875
+weight: 2875
+description: History and use of etcd & comparison with other tools
 ---
 
 The name "etcd" originated from two ideas, the unix "/etc" folder and "d"istributed systems. The "/etc" folder is a place to store configuration data for a single system whereas etcd stores configuration information for large scale distributed systems. Hence, a "d"istributed "/etc" is "etcd".

--- a/Documentation/learning/why.md
+++ b/Documentation/learning/why.md
@@ -1,5 +1,6 @@
 ---
 title: etcd versus other key-value stores
+weight: 3875
 ---
 
 The name "etcd" originated from two ideas, the unix "/etc" folder and "d"istributed systems. The "/etc" folder is a place to store configuration data for a single system whereas etcd stores configuration information for large scale distributed systems. Hence, a "d"istributed "/etc" is "etcd".


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12512

Adding `description`s to Documentation/learning files' frontmatter so that we can use them as annotations for the TOC

Screenshots of changes
| Section page | Sample page |
| :--- | :--- |
| ![Screenshot_2020-12-04 Learning](https://user-images.githubusercontent.com/4453979/101225728-1cb5df00-368a-11eb-864a-a3f934a3c860.png) | ![Screenshot_2020-12-04 Glossary](https://user-images.githubusercontent.com/4453979/101226040-0e1bf780-368b-11eb-834b-1a6c21ab0573.png) |

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!