### PR TITLE
Documentation Content: TOC — Operation Guides Descriptions

### DIFF
--- a/Documentation/op-guide/_index.md
+++ b/Documentation/op-guide/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Operations guide
+weight: 4000
+description: etcd installation, maintenance, and troubleshooting guides
 ---

--- a/Documentation/op-guide/authentication.md
+++ b/Documentation/op-guide/authentication.md
@@ -1,5 +1,7 @@
 ---
 title: Role-based access control
+weight: 4100
+description: A basic authentication and role-based access control guide
 ---
 
 ## Overview

--- a/Documentation/op-guide/clustering.md
+++ b/Documentation/op-guide/clustering.md
@@ -1,5 +1,7 @@
 ---
 title: Clustering Guide
+weight: 4150
+description: "Bootstrapping an etcd cluster: Static, etcd Discovery, and DNS Discovery"
 ---
 
 ## Overview

--- a/Documentation/op-guide/configuration.md
+++ b/Documentation/op-guide/configuration.md
@@ -1,5 +1,7 @@
 ---
 title: Configuration flags
+weight: 4050
+description: "etcd configuration: files, flags, and environment variables"
 ---
 
 etcd is configurable through a configuration file, various command-line flags, and environment variables.

--- a/Documentation/op-guide/container.md
+++ b/Documentation/op-guide/container.md
@@ -1,5 +1,7 @@
 ---
 title: Run etcd clusters inside containers
+weight: 4200
+description: Running etcd with rkt and Docker using static bootstrapping
 ---
 
 The following guide shows how to run etcd with rkt and Docker using the [static bootstrap process](clustering.md#static).

--- a/Documentation/op-guide/failures.md
+++ b/Documentation/op-guide/failures.md
@@ -1,5 +1,7 @@
 ---
 title: Failure modes
+weight: 4250
+description: Kinds of failures and ectd's tolerance for them
 ---
 
 Failures are common in a large deployment of machines. A machine fails when its hardware or software malfunctions. Multiple machines fail together when there are power failures or network issues. Multiple kinds of failures can also happen at once; it is almost impossible to enumerate all possible failure cases. 

--- a/Documentation/op-guide/gateway.md
+++ b/Documentation/op-guide/gateway.md
@@ -1,5 +1,7 @@
 ---
 title: etcd gateway
+weight: 4300
+description: etcd gateway, when to use it, and how to set it up
 ---
 
 ## What is etcd gateway

--- a/Documentation/op-guide/grpc_proxy.md
+++ b/Documentation/op-guide/grpc_proxy.md
@@ -1,5 +1,7 @@
 ---
 title: gRPC proxy
+weight: 4350
+description: A stateless etcd reverse proxy operating at the gRPC layer
 ---
 
 The gRPC proxy is a stateless etcd reverse proxy operating at the gRPC layer (L7). The proxy is designed to reduce the total processing load on the core etcd cluster. For horizontal scalability, it coalesces watch and lease API requests. To protect the cluster against abusive clients, it caches key range requests.

--- a/Documentation/op-guide/hardware.md
+++ b/Documentation/op-guide/hardware.md
@@ -1,5 +1,7 @@
 ---
 title: Hardware recommendations
+weight: 4400
+description: Hardware guidelines for administering etcd clusters
 ---
 
 etcd usually runs well with limited resources for development or testing purposes; it’s common to develop with etcd on a  laptop or a cheap cloud machine. However, when running etcd clusters in production, some hardware guidelines are useful for proper administration. These suggestions are not hard rules; they serve as a good starting point for a robust production deployment. As always, deployments should be tested with simulated workloads before running in production.

--- a/Documentation/op-guide/maintenance.md
+++ b/Documentation/op-guide/maintenance.md
@@ -1,5 +1,7 @@
 ---
 title: Maintenance
+weight: 4450
+description: Periodic etcd cluster maintenance guide
 ---
 
 ## Overview

--- a/Documentation/op-guide/monitoring.md
+++ b/Documentation/op-guide/monitoring.md
@@ -1,5 +1,7 @@
 ---
 title: Monitoring etcd
+weight: 4500
+description: Monitoring etcd for system health & cluster debugging
 ---
 
 Each etcd server provides local monitoring information on its client port through http endpoints. The monitoring data is useful for both system health checking and cluster debugging.

--- a/Documentation/op-guide/performance.md
+++ b/Documentation/op-guide/performance.md
@@ -1,5 +1,7 @@
 ---
 title: Performance
+weight: 4550
+description: "Understanding performance: latency & throughput"
 ---
 
 ## Understanding performance

--- a/Documentation/op-guide/recovery.md
+++ b/Documentation/op-guide/recovery.md
@@ -1,5 +1,7 @@
 ---
 title: Disaster recovery
+weight: 4275
+description: etcd v3 snapshot & restore facilities
 ---
 
 etcd is designed to withstand machine failures. An etcd cluster automatically recovers from temporary failures (e.g., machine reboots) and tolerates up to *(N-1)/2* permanent failures for a cluster of N members. When a member permanently fails, whether due to hardware failure or disk corruption, it loses access to the cluster. If the cluster permanently loses more than *(N-1)/2* members then it disastrously fails, irrevocably losing quorum. Once quorum is lost, the cluster cannot reach consensus and therefore cannot continue accepting updates.

--- a/Documentation/op-guide/runtime-configuration.md
+++ b/Documentation/op-guide/runtime-configuration.md
@@ -1,5 +1,7 @@
 ---
 title: Runtime reconfiguration
+weight: 4700
+description: etcd incremental runtime reconfiguration support
 ---
 
 etcd comes with support for incremental runtime reconfiguration, which allows users to update the membership of the cluster at run time.

--- a/Documentation/op-guide/runtime-reconf-design.md
+++ b/Documentation/op-guide/runtime-reconf-design.md
@@ -1,5 +1,7 @@
 ---
 title: Design of runtime reconfiguration
+weight: 4650
+description: The design of etcd’s runtime reconfiguration commands
 ---
 
 Runtime reconfiguration is one of the hardest and most error prone features in a distributed system, especially in a consensus based system like etcd.

--- a/Documentation/op-guide/security.md
+++ b/Documentation/op-guide/security.md
@@ -1,5 +1,7 @@
 ---
 title: Transport security model
+weight: 4125
+description: Securing data in transit
 ---
 
 etcd supports automatic TLS as well as authentication through client certificates for both clients to server as well as peer (server to server / cluster) communication. **Note that etcd doesn't enable [RBAC based authentication][auth] or the authentication feature in the transport layer by default to reduce friction for users getting started with the database. Further, changing this default would be a breaking change for the project which was established since 2013. An etcd cluster which doesn't enable security features can expose its data to any clients.**

--- a/Documentation/op-guide/supported-platform.md
+++ b/Documentation/op-guide/supported-platform.md
@@ -1,5 +1,7 @@
 ---
 title: Supported systems
+weight: 4800
+description: etcd support status for common architectures & operating systems
 ---
 
 ## Current support

--- a/Documentation/op-guide/v2-migration.md
+++ b/Documentation/op-guide/v2-migration.md
@@ -1,5 +1,7 @@
 ---
 title: Migrate applications from using API v2 to API v3
+weight: 4850
+description: A guide for migrating from API v2 to API v3
 ---
 
 The data store v2 is still accessible from the API v2 after upgrading to etcd3. Thus, it will work as before and require no application changes. With etcd 3, applications use the new grpc API v3 to access the mvcc store, which provides more features and improved performance. The mvcc store and the old store v2 are separate and isolated; writes to the store v2 will not affect the mvcc store and, similarly, writes to the mvcc store will not affect the store v2.

--- a/Documentation/op-guide/versioning.md
+++ b/Documentation/op-guide/versioning.md
@@ -1,5 +1,7 @@
 ---
 title: Versioning
+weight: 4900
+description: Semantic versioning with etcd
 ---
 
 ## Service versioning


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12513

Adding `description`s to Documentation/op-guide files' frontmatter so that we can use them as annotations for the TOC

Screenshots of changes
| Section page | Sample page |
| :--- | :--- |
| ![Screenshot_2020-12-05 Operations guide](https://user-images.githubusercontent.com/4453979/101230726-e2a30800-369e-11eb-86c0-bbcba40dec68.png) | ![Screenshot_2020-12-05 Run etcd clusters inside containers](https://user-images.githubusercontent.com/4453979/101230719-da4acd00-369e-11eb-9f8b-eb1cd684c69d.png) |

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!