### PR TITLE
backend: do not copy buffer when creating read tx

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -704,8 +704,6 @@ func clusterVersionFromBackend(lg *zap.Logger, be backend.Backend) *semver.Versi
 func downgradeInfoFromBackend(lg *zap.Logger, be backend.Backend) *DowngradeInfo {
 	dkey := backendDowngradeKey()
 	tx := be.ReadTx()
-	tx.Lock()
-	defer tx.Unlock()
 	keys, vals := tx.UnsafeRange(clusterBucketName, dkey, nil, 0)
 	if len(keys) == 0 {
 		return nil

--- a/server/mvcc/backend/backend.go
+++ b/server/mvcc/backend/backend.go
@@ -171,7 +171,8 @@ func newBackend(bcfg BackendConfig) *backend {
 
 		readTx: &readTx{
 			baseReadTx: baseReadTx{
-				buf: txReadBuffer{
+				mu: &sync.RWMutex{},
+				buf: &txReadBuffer{
 					txBuffer: txBuffer{make(map[string]*bucketBuffer)},
 				},
 				buckets: make(map[string]*bolt.Bucket),
@@ -210,7 +211,8 @@ func (b *backend) ConcurrentReadTx() ReadTx {
 	// TODO: might want to copy the read buffer lazily - create copy when A) end of a write transaction B) end of a batch interval.
 	return &concurrentReadTx{
 		baseReadTx: baseReadTx{
-			buf:     b.readTx.buf.unsafeCopy(),
+			mu:      b.readTx.mu,
+			buf:     b.readTx.buf,
 			txMu:    b.readTx.txMu,
 			tx:      b.readTx.tx,
 			buckets: b.readTx.buckets,

--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -248,7 +248,7 @@ func newBatchTxBuffered(backend *backend) *batchTxBuffered {
 func (t *batchTxBuffered) Unlock() {
 	if t.pending != 0 {
 		t.backend.readTx.Lock() // blocks txReadBuffer for writing.
-		t.buf.writeback(&t.backend.readTx.buf)
+		t.buf.writeback(t.backend.readTx.buf)
 		t.backend.readTx.Unlock()
 		if t.pending >= t.backend.batchLimit {
 			t.commit(false)


### PR DESCRIPTION
Currently, the backend buffer is copied once for [each read request](https://github.com/etcd-io/etcd/blob/ca866c02422ff3f3d1f0876898a30c33dd7bcccf/server/mvcc/backend/backend.go#L213), which may brings significant additional overhead. For example, in a Kubernetes cluster, all write requests are `Txn`, which triggers a read request to check the `Comapre` assertion. What's more, kube-apiserver watches etcd with previous kv required, so each watch event also triggers a [read request](https://github.com/etcd-io/etcd/blob/ca866c02422ff3f3d1f0876898a30c33dd7bcccf/server/etcdserver/api/v3rpc/watch.go#L386). In a busy Kubernetes cluster, there will be many read and write requests at the same time, resulting in a large buffer and a large number of buffer copy operations.

However, as the buffer is managed as a sorted array, the overhead of a read operation is less than that of copying the entire buffer, so we can remove the buffer copy operation and just hold the read lock when invoke the buffer's range operation.

I developed a simple test tool, which can generate concurrent read and write requests at the same time, and tested the version before and after optimization. Below is a preliminary test result: the size of key is set to 64, concurrency of read and write operation is 500, read and write requests are executed 10W times and 30W times respectively. It seems that this optimization can significantly improve the performance of read operations.

| value size | read qps | optimized read qps | write qps | optimized write qps |
| ---------- | ---------  | ---------- | ---------- | ---------- |
| 128 | 11313 | 24093 | 6276 | 13118 |
| 256 | 11538 | 24229 | 6405 | 12997 |
| 512 | 11669 | 23000 | 6447 | 12062 |
| 1024 | 10999 | 19594 | 6285 | 10036 |
| 2048 | 10354 | 13780 | 5595 | 6157 |
| 3072 | 10202 | 12112 | 5197 | 5297 |
| 4096 | 8217 | 9351 | 3773 | 3794 |
| 5120 | 7507 | 8564 | 3448 | 3462 |