### PR TITLE
contrib/systemd: add a sysusers entry

### DIFF
--- a/contrib/systemd/sysusers.d/20-etcd.conf
+++ b/contrib/systemd/sysusers.d/20-etcd.conf
@@ -1,0 +1,4 @@
+# etcd - https://github.com/etcd-io/etcd
+
+#Type  Name  ID  GECOS        Home
+u      etcd  -   "etcd user"  /var/lib/etcd


### PR DESCRIPTION
This adds a sysusers.d file, in order to create a system user/group
which matches the one used by the service unit.

Ref: https://www.freedesktop.org/software/systemd/man/sysusers.d.html
