### PR TITLE
Documentation Content: TOC — Triage Descriptions

### DIFF
--- a/Documentation/triage/_index.md
+++ b/Documentation/triage/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Triage
+weight: 8000
+description: Managing changes in etcd
 ---

--- a/Documentation/triage/issues.md
+++ b/Documentation/triage/issues.md
@@ -1,5 +1,6 @@
 ---
 title: Issue Triage Guidelines
+weight: 8100
 ---
 
 ## Purpose

--- a/Documentation/triage/issues.md
+++ b/Documentation/triage/issues.md
@@ -1,6 +1,7 @@
 ---
 title: Issue Triage Guidelines
 weight: 8100
+description: Managing incoming issues
 ---
 
 ## Purpose


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12516

Adding `description`s to Documentation/triage files' frontmatter so that we can use them as annotations for the TOC

Screenshots of changes
| Section page | Sample page |
| :--- | :--- |
| ![Screenshot_2020-12-09 Triage](https://user-images.githubusercontent.com/4453979/101701096-223e6b00-3a76-11eb-8d95-14ac839d879e.png) | ![Screenshot_2020-12-09 Issue Triage Guidelines](https://user-images.githubusercontent.com/4453979/101701105-25395b80-3a76-11eb-932b-dddaeba455c9.png) |

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!