### PR TITLE
Documentation Content: TOC — Platform Descriptions

### DIFF
--- a/Documentation/platforms/_index.md
+++ b/Documentation/platforms/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Platforms
+weight: 7000
+description: etcd deployments on various platform services
 ---

--- a/Documentation/platforms/aws.md
+++ b/Documentation/platforms/aws.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Web Services
 weight: 7100
+description: etcd deployments on AWS EC2
 ---
 
 This guide assumes operational knowledge of Amazon Web Services (AWS), specifically Amazon Elastic Compute Cloud (EC2). This guide provides an introduction to design considerations when designing an etcd deployment on AWS EC2 and how AWS specific features may be utilized in that context.

--- a/Documentation/platforms/aws.md
+++ b/Documentation/platforms/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Web Services
+weight: 7100
 ---
 
 This guide assumes operational knowledge of Amazon Web Services (AWS), specifically Amazon Elastic Compute Cloud (EC2). This guide provides an introduction to design considerations when designing an etcd deployment on AWS EC2 and how AWS specific features may be utilized in that context.

--- a/Documentation/platforms/container-linux-systemd.md
+++ b/Documentation/platforms/container-linux-systemd.md
@@ -1,5 +1,6 @@
 ---
 title: Container Linux with systemd
+weight: 7200
 ---
 
 The following guide shows how to run etcd with [systemd][systemd-docs] under [Container Linux][container-linux-docs].

--- a/Documentation/platforms/container-linux-systemd.md
+++ b/Documentation/platforms/container-linux-systemd.md
@@ -1,6 +1,7 @@
 ---
 title: Container Linux with systemd
 weight: 7200
+description: etcd deployments with systemd under Container Linux
 ---
 
 The following guide shows how to run etcd with [systemd][systemd-docs] under [Container Linux][container-linux-docs].

--- a/Documentation/platforms/freebsd.md
+++ b/Documentation/platforms/freebsd.md
@@ -1,5 +1,6 @@
 ---
 title: FreeBSD
+weight: 7300
 ---
 
 Starting with version 0.1.2 both etcd and etcdctl have been ported to FreeBSD and can be installed either via packages or ports system. Their versions have been recently updated to 0.2.0 so now etcd and etcdctl can be enjoyed on FreeBSD 10.0 (RC4 as of now) and 9.x, where they have been tested. They might also work when installed from ports on earlier versions of FreeBSD, but it is untested; caveat emptor.

--- a/Documentation/platforms/freebsd.md
+++ b/Documentation/platforms/freebsd.md
@@ -1,6 +1,7 @@
 ---
 title: FreeBSD
 weight: 7300
+description: etcd deployments using FreeBSD 
 ---
 
 Starting with version 0.1.2 both etcd and etcdctl have been ported to FreeBSD and can be installed either via packages or ports system. Their versions have been recently updated to 0.2.0 so now etcd and etcdctl can be enjoyed on FreeBSD 10.0 (RC4 as of now) and 9.x, where they have been tested. They might also work when installed from ports on earlier versions of FreeBSD, but it is untested; caveat emptor.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12515

Adding `description`s to Documentation/platform files' frontmatter so that we can use them as annotations for the TOC

Screenshots of changes
| Section page | Sample page |
| :--- | :--- |
| ![Screenshot_2020-12-09 Platforms](https://user-images.githubusercontent.com/4453979/101704225-2a99a480-3a7c-11eb-8aa4-5b413bd244ea.png) | ![Screenshot_2020-12-09 Amazon Web Services](https://user-images.githubusercontent.com/4453979/101704232-2ec5c200-3a7c-11eb-95ca-06beefbf5386.png) |

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!