### PR TITLE
concurrency: Improve distributed locking by adding support for cancel…

### DIFF
--- a/client/v3/concurrency/key.go
+++ b/client/v3/concurrency/key.go
@@ -17,7 +17,6 @@ package concurrency
 import (
 	"context"
 	"fmt"
-
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	v3 "go.etcd.io/etcd/client/v3"
@@ -59,6 +58,65 @@ func waitDeletes(ctx context.Context, client *v3.Client, pfx string, maxCreateRe
 		}
 		lastKey := string(resp.Kvs[0].Key)
 		if err = waitDelete(ctx, client, lastKey, resp.Header.Revision); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func waitDeleteWithCancel(ctx context.Context, client *v3.Client, key string, rev int64, ch chan bool) error {
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	quit := make(chan bool, 1)
+	defer func() { quit <- true }()
+
+	go func() {
+		for {
+			select {
+			case <-quit:
+				return
+			case <-ch:
+				cancel()
+				return
+			}
+		}
+	}()
+
+	var wr v3.WatchResponse
+	wch := client.Watch(cctx, key, v3.WithRev(rev))
+	for wr = range wch {
+		for _, ev := range wr.Events {
+			if ev.Type == mvccpb.DELETE {
+				return nil
+			}
+		}
+	}
+
+	if err := wr.Err(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("lost watcher waiting for delete")
+}
+
+// waitDeletes efficiently waits until all keys matching the prefix and no greater
+// than the create revision.
+func waitDeletesWithCancel(ctx context.Context, client *v3.Client, pfx string, maxCreateRev int64, ch chan bool) (*pb.ResponseHeader, error) {
+	getOpts := append(v3.WithLastCreate(), v3.WithMaxCreateRev(maxCreateRev))
+	for {
+		resp, err := client.Get(ctx, pfx, getOpts...)
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Kvs) == 0 {
+			ch <- true
+			return resp.Header, nil
+		}
+		lastKey := string(resp.Kvs[0].Key)
+		if err = waitDeleteWithCancel(ctx, client, lastKey, resp.Header.Revision, ch); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
concurrency: Improve distributed locking by adding support for cancellation

Problem:
Client continues to wait for lock even if underlying session key has been deleted

Solution:
Add an additional watch on session key (in addition to already existing watches on previous keys through waitDeletes() function)
Report ErrSessionExpired if session key is deleted
If either of session key/ all previous keys are deleted, cancel the other watch
Once previous keys are deleted (and session key has not been deleted), no need to check for presence of key again since there is now an explicit watch

References:
https://jepsen.io/analyses/etcd-3.4.3
https://github.com/etcd-io/etcd/issues/11456