### PR TITLE
[3.2 backport] pkg/fileutil: fix constant for linux locking

### DIFF
--- a/pkg/fileutil/lock_linux.go
+++ b/pkg/fileutil/lock_linux.go
@@ -29,7 +29,7 @@ import (
 //
 // constants from /usr/include/bits/fcntl-linux.h
 const (
-	F_OFD_GETLK  = 37
+	F_OFD_GETLK  = 36
 	F_OFD_SETLK  = 37
 	F_OFD_SETLKW = 38
 )


### PR DESCRIPTION
This is a backport of #12440 to release-3.3 branch, fixing the critical bug in pkg/fileutil. All credits to @moritzboth and @joakim-tjernlund. Original description follows.

----

The constant F_OFD_GETLK is 36, not 37, according to
/usr/include/bits/fcntl-linux.h
Credits go to @joakim-tjernlund who digged deep enough
to find this.