### PR TITLE
Documentation Content: TOC — Version/Home sidebar Descriptions

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -1,5 +1,6 @@
 ---
 title: etcd version ___
+weight: 1000
 ---
 
 These docs cover everything from setting up and running an etcd cluster to using etcd in applications. Improvements to these docs are encouraged through [pull requests](https://help.github.com/en/articles/about-pull-requests) to the [etcd project](https://github.com/etcd-io/etcd) on GitHub.

--- a/Documentation/branch-management.md
+++ b/Documentation/branch-management.md
@@ -1,6 +1,7 @@
 ---
 title: Branch management
-weight: 1
+weight: 1250
+description: etcd branch management
 ---
 
 ## Guide

--- a/Documentation/demo.md
+++ b/Documentation/demo.md
@@ -1,6 +1,7 @@
 ---
 title: Demo
-weight: 1
+weight: 1100
+description: Procedures for working with an etcd cluster
 ---
 
 This series of examples shows the basic procedures for working with an etcd cluster.

--- a/Documentation/dev-internal/discovery_protocol.md
+++ b/Documentation/dev-internal/discovery_protocol.md
@@ -1,5 +1,7 @@
 ---
 title: Discovery service protocol
+weight: 1500
+description: Discover other etcd members in a cluster bootstrap phase
 ---
 
 Discovery service protocol helps new etcd member to discover all other members in cluster bootstrap phase using a shared discovery URL.

--- a/Documentation/dev-internal/logging.md
+++ b/Documentation/dev-internal/logging.md
@@ -1,5 +1,7 @@
 ---
 title: Logging conventions
+weight: 1600
+description: Logging level categories
 ---
 
 etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:

--- a/Documentation/dev-internal/modules.md
+++ b/Documentation/dev-internal/modules.md
@@ -1,5 +1,7 @@
 ---
 title: Golang modules
+weight: 1650
+description: Organization of the etcd project's golang modules
 ---
 
 The etcd project (since version 3.5) is organized into multiple 

--- a/Documentation/dev-internal/release.md
+++ b/Documentation/dev-internal/release.md
@@ -1,5 +1,7 @@
 ---
 title: etcd release guide
+weight: 1550
+description: How to release a new version of etcd
 ---
 
 The guide talks about how to release a new version of etcd.

--- a/Documentation/dl-build.md
+++ b/Documentation/dl-build.md
@@ -1,5 +1,7 @@
 ---
 title: Download and build
+weight: 1150
+description: Instructions for downloading and building different versions of etcd
 ---
 
 ## System requirements

--- a/Documentation/faq.md
+++ b/Documentation/faq.md
@@ -1,5 +1,7 @@
 ---
-title: Frequently Asked Questions (FAQ)
+title: FAQ
+weight: 1200
+description: Frequently asked questions
 ---
 
 ## etcd, general

--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -1,5 +1,7 @@
 ---
 title: Libraries and tools
+weight: 1300
+description: A listing of etcd tools and client libraries
 ---
 
 ## Tools

--- a/Documentation/metrics.md
+++ b/Documentation/metrics.md
@@ -1,5 +1,7 @@
 ---
 title: Metrics
+weight: 1350
+description: Metrics for real-time monitoring and debugging
 ---
 
 etcd uses [Prometheus][prometheus] for metrics reporting. The metrics can be used for real-time monitoring and debugging. etcd does not persist its metrics; if a member restarts, the metrics will be reset.

--- a/Documentation/reporting-bugs.md
+++ b/Documentation/reporting-bugs.md
@@ -1,5 +1,7 @@
 ---
 title: Reporting bugs
+weight: 1400
+description: How to file issue reports for the etcd project
 ---
 
 If any part of the etcd project has bugs or documentation mistakes, please let us know by [opening an issue][etcd-issue]. We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check that an issue reporting the same problem does not already exist.

--- a/Documentation/rfc/v3api.md
+++ b/Documentation/rfc/v3api.md
@@ -1,5 +1,7 @@
 ---
 title: Overview
+weight: 1050
+description: etcd API design principles
 ---
 
 The etcd v3 API is designed to give users a more efficient and cleaner abstraction compared to etcd v2. There are a number of semantic and protocol changes in this new API.

--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -1,5 +1,7 @@
 ---
 title: Tuning
+weight: 1450
+description: When to update the heartbeat interval and election timeout settings
 ---
 
 The default settings in etcd should work well for installations on a local network where the average network latency is low. However, when using etcd across multiple data centers or over networks with high latency, the heartbeat interval and election timeout settings may need tuning.


### PR DESCRIPTION
This PR builds on https://github.com/etcd-io/etcd/pull/12509 & https://github.com/etcd-io/etcd/pull/12518

Adding `description`s to Documentation version/home sidebar files frontmatter so that we can use them as annotations for the TOC

As there isn't a section overview page for these changes, no screenshots are provided.

Related to issue https://github.com/etcd-io/website/issues/81

This is a first pass on writing descriptions for this section, feedback is welcome!