### PR TITLE
Set ETCD_UNSUPPORTED_ARCH to ARM64

### DIFF
--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -4,6 +4,7 @@ ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 ADD var/etcd /var/etcd
 ADD var/lib/etcd /var/lib/etcd
+ENV ETCD_UNSUPPORTED_ARCH=arm64
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION

Resolves #12543 ,

Set the ETCD_UNSUPPORTED_ARCH  environment variable to ARM64 in Docker-release.arm64.

Signed-off-by: odidev <odidev@puresoftware.com>


