### PR TITLE
Adding `clientv3` import alias to match usage in `register_test.go`.

### DIFF
--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -30,7 +30,6 @@ replace (
 	go.etcd.io/etcd/pkg/v3 => ../pkg
 	go.etcd.io/etcd/raft/v3 => ../raft
 	go.etcd.io/etcd/server/v3 => ../server
-//	go.etcd.io/etcd/v3 => ../
 )
 
 // Bad imports are sometimes causing attempts to pull that code.

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -36,5 +36,6 @@ replace (
 // This makes the error more explicit.
 replace (
 	go.etcd.io/etcd => ./FORBIDDEN_DEPENDENCY
+	go.etcd.io/etcd/v3 => ./FORBIDDEN_DEPENDENCY
 	go.etcd.io/tests/v3 => ./FORBIDDEN_DEPENDENCY
 )

--- a/tests/integration/proxy/grpcproxy/register_test.go
+++ b/tests/integration/proxy/grpcproxy/register_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/naming"
 	"go.etcd.io/etcd/pkg/v3/testutil"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy"


### PR DESCRIPTION
<!-- Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow. -->