### PR TITLE
backend: set seq flag for each bucket buffer

### DIFF
--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -238,7 +238,7 @@ func newBatchTxBuffered(backend *backend) *batchTxBuffered {
 		batchTx: batchTx{backend: backend},
 		buf: txWriteBuffer{
 			txBuffer: txBuffer{make(map[string]*bucketBuffer)},
-			seq:      true,
+			seq:      make(map[string]bool),
 		},
 	}
 	tx.Commit()


### PR DESCRIPTION
This PR solves two problems:

1. Reset the `seq` flag to `true` when resetting the whole `txWriteBuffer`, otherwise the `writeback` method always sort the buffer once `seq` set to `false`
2. Give each bucket buffer a `seq` flag to reduce  sort times, as most of the data is stored in the `key` bucket, which grows in sequence.