### PR TITLE
backend: fix buffer range bug

### DIFF
--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -120,7 +120,7 @@ func newBucketBuffer() *bucketBuffer {
 func (bb *bucketBuffer) Range(key, endKey []byte, limit int64) (keys [][]byte, vals [][]byte) {
 	f := func(i int) bool { return bytes.Compare(bb.buf[i].key, key) >= 0 }
 	idx := sort.Search(bb.used, f)
-	if idx < 0 {
+	if idx < 0 || idx >= bb.used {
 		return nil, nil
 	}
 	if len(endKey) == 0 {


### PR DESCRIPTION
The [sort.Search](https://golang.org/pkg/sort/#Search) method returns `n` instead of `-1` if no such index satisfied the assertion. So we need to compare whether the return `idx` is equal to `bb.used` to determine whether we have found a value that meets the condition.