### PR TITLE
Raft: Expand raft documentation, in particular point on the godocs

### DIFF
--- a/api/etcdserverpb/rpc.proto
+++ b/api/etcdserverpb/rpc.proto
@@ -238,7 +238,9 @@ service Maintenance {
     };
   }
 
-  // Downgrade requests downgrade, cancel downgrade on the cluster version.
+  // Downgrade requests downgrades, verifies feasibility or cancels downgrade
+  // on the cluster version.
+  // Supported since etcd 3.5.
   rpc Downgrade(DowngradeRequest) returns (DowngradeResponse) {
     option (google.api.http) = {
       post: "/v3/maintenance/downgrade"

--- a/raft/README.md
+++ b/raft/README.md
@@ -195,3 +195,7 @@ This implementation is up to date with the final Raft thesis (https://github.com
 To ensure there is no attempt to commit two membership changes at once by matching log positions (which would be unsafe since they should have different quorum requirements), any proposed membership change is simply disallowed while any uncommitted change appears in the leader's log.
 
 This approach introduces a problem when removing a member from a two-member cluster: If one of the members dies before the other one receives the commit of the confchange entry, then the member cannot be removed any more since the cluster cannot make progress. For this reason it is highly recommended to use three or more nodes in every cluster.
+
+## Go docs
+
+More detailed development documentation can be found in go docs: https://pkg.go.dev/go.etcd.io/etcd/raft/v3.

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -397,7 +397,8 @@ func (r *raft) hardState() pb.HardState {
 	}
 }
 
-// send persists state to stable storage and then sends to its mailbox.
+// send schedules persisting state to a stable storage and AFTER that
+// sending the message (as part of next Ready message processing).
 func (r *raft) send(m pb.Message) {
 	if m.From == None {
 		m.From = r.id

--- a/raft/raftpb/raft.proto
+++ b/raft/raftpb/raft.proto
@@ -33,6 +33,8 @@ message Snapshot {
 	optional SnapshotMetadata metadata = 2 [(gogoproto.nullable) = false];
 }
 
+// For description of different message types, see:
+// https://pkg.go.dev/go.etcd.io/etcd/raft/v3#hdr-MessageType
 enum MessageType {
 	MsgHup             = 0;
 	MsgBeat            = 1;


### PR DESCRIPTION
I was wondering why raft.proto messages are not documented, and finally discovered that the docs are in the package-level doc.go.  Added links for visibility.