### PR TITLE
etcdctl: Add table format support to get command

### DIFF
--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -17,6 +17,7 @@ package command
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -162,6 +163,47 @@ func (p *printerUnsupported) EndpointHashKV([]epHashKV) { p.p(nil) }
 func (p *printerUnsupported) DBStatus(snapshot.Status)  { p.p(nil) }
 
 func (p *printerUnsupported) MoveLeader(leader, target uint64, r v3.MoveLeaderResponse) { p.p(nil) }
+
+func makeHeaderTable(h *pb.ResponseHeader) (hdr []string, rows [][]string) {
+	hdr = []string{"Cluster ID", "Member ID", "Revision", "Raft Term"}
+
+	rows = append(rows, []string{
+		strconv.FormatUint(h.ClusterId, 10),
+		strconv.FormatUint(h.MemberId, 10),
+		strconv.FormatInt(h.Revision, 10),
+		strconv.FormatUint(h.RaftTerm, 10),
+	})
+
+	return hdr, rows
+}
+
+func makeGetTable(r v3.GetResponse) (hdr []string, rows [][]string) {
+	hdr = []string{"Key", "Create Revision", "Mod Revision", "Version", "Value", "Lease"}
+
+	for _, kv := range r.Kvs {
+		rows = append(rows, []string{
+			string(kv.Key),
+			strconv.FormatInt(kv.CreateRevision, 10),
+			strconv.FormatInt(kv.ModRevision, 10),
+			strconv.FormatInt(kv.Version, 10),
+			string(kv.Value),
+			strconv.FormatInt(kv.Lease, 10),
+		})
+	}
+
+	return hdr, rows
+}
+
+func makeGetFooterTable(r v3.GetResponse) (hdr []string, rows [][]string) {
+	hdr = []string{"More", "Count"}
+
+	rows = append(rows, []string{
+		strconv.FormatBool(r.More),
+		strconv.FormatInt(r.Count, 10),
+	})
+
+	return hdr, rows
+}
 
 func makeMemberListTable(r v3.MemberListResponse) (hdr []string, rows [][]string) {
 	hdr = []string{"ID", "Status", "Name", "Peer Addrs", "Client Addrs", "Is Learner"}

--- a/etcdctl/ctlv3/command/printer_table.go
+++ b/etcdctl/ctlv3/command/printer_table.go
@@ -25,6 +25,35 @@ import (
 
 type tablePrinter struct{ printer }
 
+func (tp *tablePrinter) Get(r v3.GetResponse) {
+	hdr, rows := makeHeaderTable(r.Header)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(hdr)
+	for _, row := range rows {
+		table.Append(row)
+	}
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
+	table.Render()
+
+	hdr, rows = makeGetTable(r)
+	table = tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(hdr)
+	for _, row := range rows {
+		table.Append(row)
+	}
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
+	table.Render()
+
+	hdr, rows = makeGetFooterTable(r)
+	table = tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(hdr)
+	for _, row := range rows {
+		table.Append(row)
+	}
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
+	table.Render()
+}
+
 func (tp *tablePrinter) MemberList(r v3.MemberListResponse) {
 	hdr, rows := makeMemberListTable(r)
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
etcdctl: Add table format support to get command

Currently, following command option with 'table' is not supported.

```
etcdctl --write-out=table get foo
Error: table not supported as output format
```
Sample output from new implementation:

![image](https://user-images.githubusercontent.com/11611178/103461213-b0f77e00-4cea-11eb-9e82-b5fab7695868.png)

This PR adds the support for table for 'get' command.

Fixes [12592](https://github.com/etcd-io/etcd/issues/12592)