### PR TITLE
do not use grpc/naming package

### DIFF
--- a/client/v3/naming/doc.go
+++ b/client/v3/naming/doc.go
@@ -21,14 +21,13 @@
 //		etcdnaming "go.etcd.io/etcd/client/v3/naming"
 //
 //		"google.golang.org/grpc"
-//		"google.golang.org/grpc/naming"
 //	)
 //
 // First, register new endpoint addresses for a service:
 //
 //	func etcdAdd(c *clientv3.Client, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Add, Addr: addr})
+//		return r.Update(c.Ctx(), service, etcdnaming.Update{Op: etcdnaming.Add, Addr: addr})
 //	}
 //
 // Dial an RPC service using the etcd gRPC resolver and a gRPC Balancer:
@@ -43,14 +42,14 @@
 //
 //	func etcdDelete(c *clientv3, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Delete, Addr: "1.2.3.4"})
+//		return r.Update(c.Ctx(), service, etcdnaming.Update{Op: etcdnaming.Delete, Addr: "1.2.3.4"})
 //	}
 //
 // Or register an expiring endpoint with a lease:
 //
 //	func etcdLeaseAdd(c *clientv3.Client, lid clientv3.LeaseID, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Add, Addr: addr}, clientv3.WithLease(lid))
+//		return r.Update(c.Ctx(), service, etcdnaming.Update{Op: etcdnaming.Add, Addr: addr}, clientv3.WithLease(lid))
 //	}
 //
 package naming

--- a/client/v3/naming/grpc.go
+++ b/client/v3/naming/grpc.go
@@ -12,19 +12,68 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// DEPRECATION NOTICE
+// This package is deprecated and must be implemented as part of grpcproxy package
+
 package naming
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	etcd "go.etcd.io/etcd/client/v3"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/naming"
 	"google.golang.org/grpc/status"
 )
+
+// Code at 31-75 based on deprecated google.golang.org/grpc/naming
+
+// Operation defines the corresponding operations for a name resolution change.
+//
+// Deprecated: please use package resolver.
+type Operation uint8
+
+const (
+	// Add indicates a new address is added.
+	Add Operation = iota
+	// Delete indicates an existing address is deleted.
+	Delete
+)
+
+// Update defines a name resolution update. Notice that it is not valid having both
+// empty string Addr and nil Metadata in an Update.
+//
+// Deprecated: please use package resolver.
+type Update struct {
+	// Op indicates the operation of the update.
+	Op Operation
+	// Addr is the updated address. It is empty string if there is no address update.
+	Addr string
+	// Metadata is the updated metadata. It is nil if there is no metadata update.
+	// Metadata is not required for a custom naming implementation.
+	Metadata interface{}
+}
+
+// Resolver creates a Watcher for a target to track its resolution changes.
+//
+// Deprecated: please use package resolver.
+type Resolver interface {
+	// Resolve creates a Watcher for target.
+	Resolve(target string) (Watcher, error)
+}
+
+// Watcher watches for the updates on the specified target.
+//
+// Deprecated: please use package resolver.
+type Watcher interface {
+	// Next blocks until an update or error happens. It may return one or more
+	// updates. The first call should get the full set of the results. It should
+	// return an error if and only if Watcher cannot recover.
+	Next() ([]*Update, error)
+	// Close closes the Watcher.
+	Close()
+}
 
 var ErrWatcherClosed = fmt.Errorf("naming: watch closed")
 
@@ -34,15 +83,15 @@ type GRPCResolver struct {
 	Client *etcd.Client
 }
 
-func (gr *GRPCResolver) Update(ctx context.Context, target string, nm naming.Update, opts ...etcd.OpOption) (err error) {
+func (gr *GRPCResolver) Update(ctx context.Context, target string, nm Update, opts ...etcd.OpOption) (err error) {
 	switch nm.Op {
-	case naming.Add:
+	case Add:
 		var v []byte
 		if v, err = json.Marshal(nm); err != nil {
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
 		_, err = gr.Client.KV.Put(ctx, target+"/"+nm.Addr, string(v), opts...)
-	case naming.Delete:
+	case Delete:
 		_, err = gr.Client.Delete(ctx, target+"/"+nm.Addr, opts...)
 	default:
 		return status.Error(codes.InvalidArgument, "naming: bad naming op")
@@ -50,7 +99,7 @@ func (gr *GRPCResolver) Update(ctx context.Context, target string, nm naming.Upd
 	return err
 }
 
-func (gr *GRPCResolver) Resolve(target string) (naming.Watcher, error) {
+func (gr *GRPCResolver) Resolve(target string) (Watcher, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &gRPCWatcher{c: gr.Client, target: target + "/", ctx: ctx, cancel: cancel}
 	return w, nil
@@ -68,7 +117,7 @@ type gRPCWatcher struct {
 // Next gets the next set of updates from the etcd resolver.
 // Calls to Next should be serialized; concurrent calls are not safe since
 // there is no way to reconcile the update ordering.
-func (gw *gRPCWatcher) Next() ([]*naming.Update, error) {
+func (gw *gRPCWatcher) Next() ([]*Update, error) {
 	if gw.wch == nil {
 		// first Next() returns all addresses
 		return gw.firstNext()
@@ -87,17 +136,17 @@ func (gw *gRPCWatcher) Next() ([]*naming.Update, error) {
 		return nil, gw.err
 	}
 
-	updates := make([]*naming.Update, 0, len(wr.Events))
+	updates := make([]*Update, 0, len(wr.Events))
 	for _, e := range wr.Events {
-		var jupdate naming.Update
+		var jupdate Update
 		var err error
 		switch e.Type {
 		case etcd.EventTypePut:
 			err = json.Unmarshal(e.Kv.Value, &jupdate)
-			jupdate.Op = naming.Add
+			jupdate.Op = Add
 		case etcd.EventTypeDelete:
 			err = json.Unmarshal(e.PrevKv.Value, &jupdate)
-			jupdate.Op = naming.Delete
+			jupdate.Op = Delete
 		default:
 			continue
 		}
@@ -108,7 +157,7 @@ func (gw *gRPCWatcher) Next() ([]*naming.Update, error) {
 	return updates, nil
 }
 
-func (gw *gRPCWatcher) firstNext() ([]*naming.Update, error) {
+func (gw *gRPCWatcher) firstNext() ([]*Update, error) {
 	// Use serialized request so resolution still works if the target etcd
 	// server is partitioned away from the quorum.
 	resp, err := gw.c.Get(gw.ctx, gw.target, etcd.WithPrefix(), etcd.WithSerializable())
@@ -116,9 +165,9 @@ func (gw *gRPCWatcher) firstNext() ([]*naming.Update, error) {
 		return nil, err
 	}
 
-	updates := make([]*naming.Update, 0, len(resp.Kvs))
+	updates := make([]*Update, 0, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
-		var jupdate naming.Update
+		var jupdate Update
 		if err := json.Unmarshal(kv.Value, &jupdate); err != nil {
 			continue
 		}

--- a/server/proxy/grpcproxy/cluster.go
+++ b/server/proxy/grpcproxy/cluster.go
@@ -28,7 +28,6 @@ import (
 
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 // allow maximum 1 retry per second
@@ -45,7 +44,7 @@ type clusterProxy struct {
 	prefix  string
 
 	umu  sync.RWMutex
-	umap map[string]gnaming.Update
+	umap map[string]naming.Update
 }
 
 // NewClusterProxy takes optional prefix to fetch grpc-proxy member endpoints.
@@ -63,7 +62,7 @@ func NewClusterProxy(lg *zap.Logger, c *clientv3.Client, advaddr string, prefix 
 
 		advaddr: advaddr,
 		prefix:  prefix,
-		umap:    make(map[string]gnaming.Update),
+		umap:    make(map[string]naming.Update),
 	}
 
 	donec := make(chan struct{})
@@ -91,7 +90,7 @@ func (cp *clusterProxy) resolve(prefix string) {
 	}
 }
 
-func (cp *clusterProxy) monitor(wa gnaming.Watcher) {
+func (cp *clusterProxy) monitor(wa naming.Watcher) {
 	for cp.ctx.Err() == nil {
 		ups, err := wa.Next()
 		if err != nil {
@@ -104,9 +103,9 @@ func (cp *clusterProxy) monitor(wa gnaming.Watcher) {
 		cp.umu.Lock()
 		for i := range ups {
 			switch ups[i].Op {
-			case gnaming.Add:
+			case naming.Add:
 				cp.umap[ups[i].Addr] = *ups[i]
-			case gnaming.Delete:
+			case naming.Delete:
 				delete(cp.umap, ups[i].Addr)
 			}
 		}

--- a/server/proxy/grpcproxy/register.go
+++ b/server/proxy/grpcproxy/register.go
@@ -21,10 +21,8 @@ import (
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/client/v3/naming"
-
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 // allow maximum 1 retry per second
@@ -69,7 +67,7 @@ func registerSession(lg *zap.Logger, c *clientv3.Client, prefix string, addr str
 	}
 
 	gr := &naming.GRPCResolver{Client: c}
-	if err = gr.Update(c.Ctx(), prefix, gnaming.Update{Op: gnaming.Add, Addr: addr, Metadata: getMeta()}, clientv3.WithLease(ss.Lease())); err != nil {
+	if err = gr.Update(c.Ctx(), prefix, naming.Update{Op: naming.Add, Addr: addr, Metadata: getMeta()}, clientv3.WithLease(ss.Lease())); err != nil {
 		return nil, err
 	}
 

--- a/tests/integration/clientv3/grpc_test.go
+++ b/tests/integration/clientv3/grpc_test.go
@@ -24,8 +24,6 @@ import (
 	namingv3 "go.etcd.io/etcd/client/v3/naming"
 	"go.etcd.io/etcd/pkg/v3/testutil"
 	"go.etcd.io/etcd/tests/v3/integration"
-
-	"google.golang.org/grpc/naming"
 )
 
 func TestGRPCResolver(t *testing.T) {
@@ -44,7 +42,7 @@ func TestGRPCResolver(t *testing.T) {
 	}
 	defer w.Close()
 
-	addOp := naming.Update{Op: naming.Add, Addr: "127.0.0.1", Metadata: "metadata"}
+	addOp := namingv3.Update{Op: namingv3.Add, Addr: "127.0.0.1", Metadata: "metadata"}
 	err = r.Update(context.TODO(), "foo", addOp)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
@@ -55,8 +53,8 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatal("failed to get udpate", err)
 	}
 
-	wu := &naming.Update{
-		Op:       naming.Add,
+	wu := &namingv3.Update{
+		Op:       namingv3.Add,
 		Addr:     "127.0.0.1",
 		Metadata: "metadata",
 	}
@@ -65,7 +63,7 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatalf("up = %#v, want %#v", us[0], wu)
 	}
 
-	delOp := naming.Update{Op: naming.Delete, Addr: "127.0.0.1"}
+	delOp := namingv3.Update{Op: namingv3.Delete, Addr: "127.0.0.1"}
 	err = r.Update(context.TODO(), "foo", delOp)
 	if err != nil {
 		t.Fatalf("failed to udpate %v", err)
@@ -76,8 +74,8 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatalf("failed to get udpate %v", err)
 	}
 
-	wu = &naming.Update{
-		Op:       naming.Delete,
+	wu = &namingv3.Update{
+		Op:       namingv3.Delete,
 		Addr:     "127.0.0.1",
 		Metadata: "metadata",
 	}
@@ -97,7 +95,7 @@ func TestGRPCResolverMulti(t *testing.T) {
 	defer clus.Terminate(t)
 	c := clus.RandClient()
 
-	v, verr := json.Marshal(naming.Update{Addr: "127.0.0.1", Metadata: "md"})
+	v, verr := json.Marshal(namingv3.Update{Addr: "127.0.0.1", Metadata: "md"})
 	if verr != nil {
 		t.Fatal(verr)
 	}
@@ -133,7 +131,7 @@ func TestGRPCResolverMulti(t *testing.T) {
 	if nerr != nil {
 		t.Fatal(nerr)
 	}
-	if len(updates) != 2 || (updates[0].Op != naming.Delete && updates[1].Op != naming.Delete) {
+	if len(updates) != 2 || (updates[0].Op != namingv3.Delete && updates[1].Op != namingv3.Delete) {
 		t.Fatalf("expected two updates, got %+v", updates)
 	}
 }

--- a/tests/integration/proxy/grpcproxy/register_test.go
+++ b/tests/integration/proxy/grpcproxy/register_test.go
@@ -25,7 +25,6 @@ import (
 	"go.etcd.io/etcd/tests/v3/integration"
 
 	"go.uber.org/zap"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 func TestRegister(t *testing.T) {
@@ -68,7 +67,7 @@ func TestRegister(t *testing.T) {
 	}
 }
 
-func createWatcher(t *testing.T, c *clientv3.Client, prefix string) gnaming.Watcher {
+func createWatcher(t *testing.T, c *clientv3.Client, prefix string) naming.Watcher {
 	gr := &naming.GRPCResolver{Client: c}
 	watcher, err := gr.Resolve(prefix)
 	if err != nil {


### PR DESCRIPTION
so due lessons learned with #12597 and #12398 at first we are moving grpc/naming as part of internal naming package

also refers to #12124 as a part of solution