### PR TITLE
Prepar to upgrade grpc version: grpc naming packge is moved in v1.30.0

### DIFF
--- a/client/v3/naming/doc.go
+++ b/client/v3/naming/doc.go
@@ -19,16 +19,16 @@
 //	import (
 //		"go.etcd.io/etcd/client/v3"
 //		etcdnaming "go.etcd.io/etcd/client/v3/naming"
+//		gnaming "go.etcd.io/etcd/client/v3/naming/grpcnaming"
 //
 //		"google.golang.org/grpc"
-//		"google.golang.org/grpc/naming"
 //	)
 //
 // First, register new endpoint addresses for a service:
 //
 //	func etcdAdd(c *clientv3.Client, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Add, Addr: addr})
+//		return r.Update(c.Ctx(), service, gnaming.Update{Op: gnaming.Add, Addr: addr})
 //	}
 //
 // Dial an RPC service using the etcd gRPC resolver and a gRPC Balancer:
@@ -43,14 +43,15 @@
 //
 //	func etcdDelete(c *clientv3, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Delete, Addr: "1.2.3.4"})
+//		return r.Update(c.Ctx(), service, gnaming.Update{Op: gnaming.Delete, Addr: "1.2.3.4"})
 //	}
 //
 // Or register an expiring endpoint with a lease:
 //
 //	func etcdLeaseAdd(c *clientv3.Client, lid clientv3.LeaseID, service, addr string) error {
 //		r := &etcdnaming.GRPCResolver{Client: c}
-//		return r.Update(c.Ctx(), service, naming.Update{Op: naming.Add, Addr: addr}, clientv3.WithLease(lid))
+//		return r.Update(c.Ctx(), service, gnaming.Update{Op: gnaming.Add, Addr: addr}, clientv3.WithLease(lid))
 //	}
 //
+// This package is deprecated: grpc naming package is removed in grpc version v1.30.0
 package naming

--- a/client/v3/naming/grpcnaming/doc.go
+++ b/client/v3/naming/grpcnaming/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2017 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package grpcnaming is copied from grpc naming package, which is removed in grpc version v1.30.0
+//
+// This package is deprecated: please use package resolver instead.
+package grpcnaming

--- a/client/v3/naming/grpcnaming/naming.go
+++ b/client/v3/naming/grpcnaming/naming.go
@@ -1,0 +1,68 @@
+/*
+ *
+ * Copyright 2014 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package grpcnaming is copied from grpc naming package, which is removed in grpc version v1.30.0
+//
+// This package is deprecated: please use package resolver instead.
+package grpcnaming
+
+// Operation defines the corresponding operations for a name resolution change.
+//
+// Deprecated: please use package resolver.
+type Operation uint8
+
+const (
+	// Add indicates a new address is added.
+	Add Operation = iota
+	// Delete indicates an existing address is deleted.
+	Delete
+)
+
+// Update defines a name resolution update. Notice that it is not valid having both
+// empty string Addr and nil Metadata in an Update.
+//
+// Deprecated: please use package resolver.
+type Update struct {
+	// Op indicates the operation of the update.
+	Op Operation
+	// Addr is the updated address. It is empty string if there is no address update.
+	Addr string
+	// Metadata is the updated metadata. It is nil if there is no metadata update.
+	// Metadata is not required for a custom naming implementation.
+	Metadata interface{}
+}
+
+// Resolver creates a Watcher for a target to track its resolution changes.
+//
+// Deprecated: please use package resolver.
+type Resolver interface {
+	// Resolve creates a Watcher for target.
+	Resolve(target string) (Watcher, error)
+}
+
+// Watcher watches for the updates on the specified target.
+//
+// Deprecated: please use package resolver.
+type Watcher interface {
+	// Next blocks until an update or error happens. It may return one or more
+	// updates. The first call should get the full set of the results. It should
+	// return an error if and only if Watcher cannot recover.
+	Next() ([]*Update, error)
+	// Close closes the Watcher.
+	Close()
+}

--- a/server/proxy/grpcproxy/cluster.go
+++ b/server/proxy/grpcproxy/cluster.go
@@ -25,10 +25,10 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/naming"
+	gnaming "go.etcd.io/etcd/client/v3/naming/grpcnaming"
 
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 // allow maximum 1 retry per second

--- a/server/proxy/grpcproxy/register.go
+++ b/server/proxy/grpcproxy/register.go
@@ -21,10 +21,10 @@ import (
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/client/v3/naming"
+	gnaming "go.etcd.io/etcd/client/v3/naming/grpcnaming"
 
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 // allow maximum 1 retry per second

--- a/tests/integration/clientv3/grpc_test.go
+++ b/tests/integration/clientv3/grpc_test.go
@@ -22,10 +22,10 @@ import (
 
 	etcd "go.etcd.io/etcd/client/v3"
 	namingv3 "go.etcd.io/etcd/client/v3/naming"
+	gnaming "go.etcd.io/etcd/client/v3/naming/grpcnaming"
+
 	"go.etcd.io/etcd/pkg/v3/testutil"
 	"go.etcd.io/etcd/tests/v3/integration"
-
-	"google.golang.org/grpc/naming"
 )
 
 func TestGRPCResolver(t *testing.T) {
@@ -44,7 +44,7 @@ func TestGRPCResolver(t *testing.T) {
 	}
 	defer w.Close()
 
-	addOp := naming.Update{Op: naming.Add, Addr: "127.0.0.1", Metadata: "metadata"}
+	addOp := gnaming.Update{Op: gnaming.Add, Addr: "127.0.0.1", Metadata: "metadata"}
 	err = r.Update(context.TODO(), "foo", addOp)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
@@ -55,8 +55,8 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatal("failed to get udpate", err)
 	}
 
-	wu := &naming.Update{
-		Op:       naming.Add,
+	wu := &gnaming.Update{
+		Op:       gnaming.Add,
 		Addr:     "127.0.0.1",
 		Metadata: "metadata",
 	}
@@ -65,7 +65,7 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatalf("up = %#v, want %#v", us[0], wu)
 	}
 
-	delOp := naming.Update{Op: naming.Delete, Addr: "127.0.0.1"}
+	delOp := gnaming.Update{Op: gnaming.Delete, Addr: "127.0.0.1"}
 	err = r.Update(context.TODO(), "foo", delOp)
 	if err != nil {
 		t.Fatalf("failed to udpate %v", err)
@@ -76,8 +76,8 @@ func TestGRPCResolver(t *testing.T) {
 		t.Fatalf("failed to get udpate %v", err)
 	}
 
-	wu = &naming.Update{
-		Op:       naming.Delete,
+	wu = &gnaming.Update{
+		Op:       gnaming.Delete,
 		Addr:     "127.0.0.1",
 		Metadata: "metadata",
 	}
@@ -97,7 +97,7 @@ func TestGRPCResolverMulti(t *testing.T) {
 	defer clus.Terminate(t)
 	c := clus.RandClient()
 
-	v, verr := json.Marshal(naming.Update{Addr: "127.0.0.1", Metadata: "md"})
+	v, verr := json.Marshal(gnaming.Update{Addr: "127.0.0.1", Metadata: "md"})
 	if verr != nil {
 		t.Fatal(verr)
 	}
@@ -133,7 +133,7 @@ func TestGRPCResolverMulti(t *testing.T) {
 	if nerr != nil {
 		t.Fatal(nerr)
 	}
-	if len(updates) != 2 || (updates[0].Op != naming.Delete && updates[1].Op != naming.Delete) {
+	if len(updates) != 2 || (updates[0].Op != gnaming.Delete && updates[1].Op != gnaming.Delete) {
 		t.Fatalf("expected two updates, got %+v", updates)
 	}
 }

--- a/tests/integration/proxy/grpcproxy/register_test.go
+++ b/tests/integration/proxy/grpcproxy/register_test.go
@@ -20,12 +20,12 @@ import (
 
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/naming"
+	gnaming "go.etcd.io/etcd/client/v3/naming/grpcnaming"
 	"go.etcd.io/etcd/pkg/v3/testutil"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy"
 	"go.etcd.io/etcd/tests/v3/integration"
 
 	"go.uber.org/zap"
-	gnaming "google.golang.org/grpc/naming"
 )
 
 func TestRegister(t *testing.T) {


### PR DESCRIPTION
Target: we want to upgrade grpc version from current v1.29.1 to new version (like v1.32.0)

Background: in grpc version v1.30.0, the grpc naming package is removed, which is used by ectd naming package and grpcproxy package

More information, please refrence to:

https://github.com/etcd-io/etcd/pull/12398


