### PR TITLE
MAINTAINERS: add wenjiaswe@ and ptabor@

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,12 +14,11 @@ Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*
+Piotr Tabor <ptab@google.com> (@ptabor) pkg:*
 Sahdev Zala <spzala@us.ibm.com> (@spzala) pkg:*
 Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
+Wenjia Zhang <wenjiazhang@google.com> (@wenjiaswe) pkg:*
 Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*
 
 Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:go.etcd.io/etcd/raft
 Tobias Grieger <tobias.schottdorf@gmail.com> (@tbg) pkg:go.etcd.io/etcd/raft
-
-# REVIEWERS
-Wenjia Zhang <wenjiazhang@google.com> (@wenjiaswe) pkg:*


### PR DESCRIPTION
Both have shown great initiatives and dedication to the project's long-term health and community engagement.

I strongly support for their recognition and continued work on the project (also endorsed by @xiang90 and @jpbetz).

/cc @wenjiaswe @ptabor 