### PR TITLE
Fix code coverage measurement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ docker-test-coverage:
 	  $(TMP_DIR_MOUNT_FLAG) \
 	  --mount type=bind,source=`pwd`,destination=/go/src/go.etcd.io/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(GO_VERSION) \
-	  /bin/bash -c "COVERDIR=covdir PASSES='build build_cov cov' ./test.sh 2>&1 | tee docker-test-coverage-$(TEST_SUFFIX).log && /codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1"
+	  /bin/bash -c "set -o pipefail; (COVERDIR=covdir PASSES='build build_cov cov' ./test.sh 2>&1 | tee docker-test-coverage-$(TEST_SUFFIX).log) && /codecov -t 6040de41-c073-4d6f-bbf8-d89256ef31e1"
 	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 docker-test-coverage-$(TEST_SUFFIX).log
 
 

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -158,6 +158,10 @@ function run_for_module {
   )
 }
 
+function module_dirs() {
+  echo "api pkg raft client/v2 client/v3 server etcdctl tests ."
+}
+
 function modules() {
   modules=(
     "${ROOT_MODULE}/api/v3"
@@ -184,15 +188,9 @@ function modules_exp() {
 function run_for_modules {
   local pkg="${PKG:-./...}"
   if [ -z "${USERMOD}" ]; then
-    run_for_module "api" "$@" "${pkg}" || return "$?"
-    run_for_module "pkg" "$@" "${pkg}" || return "$?"
-    run_for_module "raft" "$@" "${pkg}" || return "$?"
-    run_for_module "client/v2" "$@" "${pkg}" || return "$?"
-    run_for_module "client/v3" "$@" "${pkg}" || return "$?"
-    run_for_module "server" "$@" "${pkg}" || return "$?"
-    run_for_module "etcdctl" "$@" "${pkg}" || return "$?"
-    run_for_module "tests" "$@" "${pkg}" || return "$?"
-    run_for_module "." "$@" "${pkg}" || return "$?"
+    for m in $(module_dirs); do
+      run_for_module "${m}" "$@" "${pkg}" || return "$?"
+    done
   else
     run_for_module "${USERMOD}" "$@" "${pkg}" || return "$?"
   fi
@@ -265,7 +263,6 @@ function go_test {
         failures=("${failures[@]}" "${pkg}")
       fi
     fi
-    echo
   done
 
   if [ -n "${failures[*]}" ] ; then


### PR DESCRIPTION
After code moves/modularization, the coverage information generation process stopped working. 

See https://codecov.io/gh/etcd-io/etcd -> last report from October
Failed measurement in Travis CI, reported as passed: 
  https://travis-ci.com/github/etcd-io/etcd/jobs/472812130

The PR fixes it