### PR TITLE
update etcd base image to debian-base 1.3.0 for CVEs

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,4 +1,4 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.1.0
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.3.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm64:v2.1.0
+FROM k8s.gcr.io/build-image/debian-base-arm64:buster-v1.3.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-ppc64le:v2.1.0
+FROM k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.3.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,4 +1,4 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-s390x:v2.1.0
+FROM k8s.gcr.io/build-image/debian-base-s390x:buster-v1.3.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/pull/1555

> Addresses:
> 
> * [CVE-2020-29361](https://security-tracker.debian.org/tracker/CVE-2020-29361)
> * [CVE-2020-29362](https://security-tracker.debian.org/tracker/CVE-2020-29362)
> * [CVE-2020-29363](https://security-tracker.debian.org/tracker/CVE-2020-29363)