### PR TITLE
update etcd base image to debian-base 1.4.0 which is now a sane multi-architecture image

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.3.0
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.4.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/build-image/debian-base-arm64:buster-v1.3.0
+FROM k8s.gcr.io/build-image/debian-base-arm64:buster-v1.4.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.3.0
+FROM k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.4.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/build-image/debian-base-s390x:buster-v1.3.0
+FROM k8s.gcr.io/build-image/debian-base-s390x:buster-v1.4.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/pull/1583
https://github.com/kubernetes/kubernetes/pull/98526

Update debian-base to v1.4.0 which is now a sane multi-architecture image.
