### PR TITLE
Doc: fix inconsistency and broken path

### DIFF
--- a/client/v3/README.md
+++ b/client/v3/README.md
@@ -55,7 +55,7 @@ For full compatibility, it is recommended to install released versions of client
 etcd client returns 2 types of errors:
 
 1. context error: canceled or deadline exceeded.
-2. gRPC error: see [api/v3rpc/rpctypes](https://godoc.org/go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes).
+2. gRPC error: see [api/v3rpc/rpctypes](https://godoc.org/go.etcd.io/etcd/api/v3rpc/rpctypes).
 
 Here is the example code to handle client errors:
 

--- a/client/v3/doc.go
+++ b/client/v3/doc.go
@@ -57,11 +57,11 @@
 // The Client has internal state (watchers and leases), so Clients should be reused instead of created as needed.
 // Clients are safe for concurrent use by multiple goroutines.
 //
-// etcd client returns 3 types of errors:
+// etcd client returns 2 types of errors:
 //
 //  1. context error: canceled or deadline exceeded.
-//  2. gRPC status error: e.g. when clock drifts in server-side before client's context deadline exceeded.
-//  3. gRPC error: see https://github.com/etcd-io/etcd/blob/master/etcdserver/api/v3rpc/rpctypes/error.go
+//  2. gRPC error: e.g. when clock drifts in server-side before client's context deadline exceeded.
+//  See https://github.com/etcd-io/etcd/blob/master/api/v3rpc/rpctypes/error.go
 //
 // Here is the example code to handle client errors:
 //


### PR DESCRIPTION
1) Fix the path for rpc errors
2) The README says 2 types of client errors vs doc mentioning 3
types of client errors. grpc erros should be considered single time
as covered in the README.

