### PR TITLE
raft: makes 'ConnReadTimeout/ConnWriteTimeout' customizable

### DIFF
--- a/server/etcdserver/api/rafthttp/peer.go
+++ b/server/etcdserver/api/rafthttp/peer.go
@@ -37,8 +37,8 @@ const (
 	// to keep the connection alive.
 	// For short term pipeline connections, the connection MUST be killed to avoid it being
 	// put back to http pkg connection pool.
-	ConnReadTimeout  = 5 * time.Second
-	ConnWriteTimeout = 5 * time.Second
+	DefaultConnReadTimeout  = 5 * time.Second
+	DefaultConnWriteTimeout = 5 * time.Second
 
 	recvBufSize = 4096
 	// maxPendingProposals holds the proposals during one leader election process.
@@ -53,6 +53,11 @@ const (
 	streamMsg   = "streamMsg"
 	pipelineMsg = "pipeline"
 	sendSnap    = "sendMsgSnap"
+)
+
+var (
+	ConnReadTimeout  = DefaultConnReadTimeout
+	ConnWriteTimeout = DefaultConnWriteTimeout
 )
 
 type Peer interface {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -85,10 +85,6 @@ const (
 	HealthInterval = 5 * time.Second
 
 	purgeFileInterval = 30 * time.Second
-	// monitorVersionInterval should be smaller than the timeout
-	// on the connection. Or we will not be able to reuse the connection
-	// (since it will timeout).
-	monitorVersionInterval = rafthttp.ConnWriteTimeout - time.Second
 
 	// max number of in-flight snapshot messages etcdserver allows to have
 	// This number is more than enough for most clusters with 5 machines.
@@ -107,6 +103,11 @@ const (
 )
 
 var (
+	// monitorVersionInterval should be smaller than the timeout
+	// on the connection. Or we will not be able to reuse the connection
+	// (since it will timeout).
+	monitorVersionInterval = rafthttp.ConnWriteTimeout - time.Second
+
 	recommendedMaxRequestBytesString = humanize.Bytes(uint64(recommendedMaxRequestBytes))
 	storeMemberAttributeRegexp       = regexp.MustCompile(path.Join(membership.StoreMembersPrefix, "[[:xdigit:]]{1,16}", "attributes"))
 )


### PR DESCRIPTION
There are two timeouts in raft, defined as consts:
https://github.com/etcd-io/etcd/blob/855eeb75c551879fe11b9718bceb8bee9b178905/server/etcdserver/api/rafthttp/peer.go#L40
https://github.com/etcd-io/etcd/blob/855eeb75c551879fe11b9718bceb8bee9b178905/server/etcdserver/api/rafthttp/peer.go#L41

This PR makes them customizable through env/cmdline.
Without that it is pointless to set "store timeouts" (or "dial timeouts" or any other "timeouts") more than this fixed 5s in etcd client - we'll get "context: Deadline exceeded" or "context: Canceled" in any case.
For example, this is necessary for tests in slow configurations. 