### PR TITLE
etcdserver/api/etcdhttp: log successful etcd server side health check in debug level

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -115,6 +115,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - Fix [quorum protection logic when promoting a learner](https://github.com/etcd-io/etcd/pull/11640).
 - Improve [peer corruption checker](https://github.com/etcd-io/etcd/pull/11621) to work when peer mTLS is enabled.
 - Log [`[CLIENT-PORT]/health` check in server side](https://github.com/etcd-io/etcd/pull/11704).
+- Log [successful etcd server-side health check in debug level](https://github.com/etcd-io/etcd/pull/12677).
 - Improve [compaction performance when latest index is greater than 1-million](https://github.com/etcd-io/etcd/pull/11734).
 - [Refactor consistentindex](https://github.com/etcd-io/etcd/pull/11699).
 - [Add log when etcdserver failed to apply command](https://github.com/etcd-io/etcd/pull/11670).

--- a/server/etcdserver/api/etcdhttp/metrics.go
+++ b/server/etcdserver/api/etcdhttp/metrics.go
@@ -79,7 +79,7 @@ func NewHealthHandler(lg *zap.Logger, hfunc func() Health) http.HandlerFunc {
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Write(d)
-		lg.Info("/health OK", zap.Int("status-code", http.StatusOK))
+		lg.Debug("/health OK", zap.Int("status-code", http.StatusOK))
 	}
 }
 
@@ -154,7 +154,7 @@ func checkV2Health(lg *zap.Logger, srv etcdserver.ServerV2) (h Health) {
 		lg.Warn("serving /health false; QGET fails", zap.Error(err))
 		return
 	}
-	lg.Info("serving /health true")
+	lg.Debug("serving /health true")
 	return
 }
 
@@ -171,6 +171,6 @@ func checkV3Health(lg *zap.Logger, srv *etcdserver.EtcdServer) (h Health) {
 		lg.Warn("serving /health false; Range fails", zap.Error(err))
 		return
 	}
-	lg.Info("serving /health true")
+	lg.Debug("serving /health true")
 	return
 }


### PR DESCRIPTION
When we have an external component that checks /health periodically, the
etcd server logs can be quite verbose (e.g., DDOS-ing against insure
etcd health check can lead to disk space full due to large log files).

This change was introduced in #11704.

While we keep the warning logs for etcd health check failures, the
success (or OK) log level should be set to DEBUG.

Fixes #12676 
