### PR TITLE
transaction logic improvement

### DIFF
--- a/server/mvcc/kvstore_txn.go
+++ b/server/mvcc/kvstore_txn.go
@@ -68,10 +68,13 @@ type storeTxnWrite struct {
 
 func (s *store) Write(trace *traceutil.Trace) TxnWrite {
 	s.mu.RLock()
+	s.revMu.RLock()
+	firstRev, rev := s.compactMainRev, s.currentRev
+	s.revMu.RUnlock()
 	tx := s.b.BatchTx()
 	tx.Lock()
 	tw := &storeTxnWrite{
-		storeTxnRead: storeTxnRead{s, tx, 0, 0, trace},
+		storeTxnRead: storeTxnRead{s, tx, firstRev, rev, trace},
 		tx:           tx,
 		beginRev:     s.currentRev,
 		changes:      make([]mvccpb.KeyValue, 0, 4),


### PR DESCRIPTION
server: change Txn() to use one transaction to avoid txn.End() extra overhead.

based on our observations, txn operation is taking a lot of cpu time compared with normal put operations. with some profiling, we found it is because of txn.End() operation. To avoid extra overhead, we should use one transaction inside Txn(). With this change, the benchmark txn-put operation performance can get a significant improvement.