### PR TITLE
raftexample: Implement ReportUnreachable and ReportSnapshot

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -484,6 +484,8 @@ func (rc *raftNode) serveRaft() {
 func (rc *raftNode) Process(ctx context.Context, m raftpb.Message) error {
 	return rc.node.Step(ctx, m)
 }
-func (rc *raftNode) IsIDRemoved(id uint64) bool                           { return false }
-func (rc *raftNode) ReportUnreachable(id uint64)                          {}
-func (rc *raftNode) ReportSnapshot(id uint64, status raft.SnapshotStatus) {}
+func (rc *raftNode) IsIDRemoved(id uint64) bool  { return false }
+func (rc *raftNode) ReportUnreachable(id uint64) { rc.node.ReportUnreachable(id) }
+func (rc *raftNode) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
+	rc.node.ReportSnapshot(id, status)
+}


### PR DESCRIPTION
The raftexample have to call ReportSnapshot appropriately. See here.
https://github.com/etcd-io/etcd/blob/73c50b869ab7c4676806e4d1f827915f98e6d8f9/raft/node.go#L192-L202

---
Following is the detail.
If sending MsgSnap failed [here](https://github.com/etcd-io/etcd/blob/50ca440c49d85c6b88284af08248a43118b2ae68/server/etcdserver/api/rafthttp/peer.go#L246) due to overloaded network, `ReportSnapshot` of raftexample is invoked. If we call RerportSnapshot of node there, it generates MsgSnapStatus and then state of Progress becomes `StateProbe`.
https://github.com/etcd-io/etcd/blob/719f6ce06fbcaea5ffb0d2b53fc42ab430ddd259/raft/tracker/progress.go#L112-L126
But if we don't do so and state remains `StateSnapshot`, IsPaused always return true. This means no further messages are sent to delayed node.
https://github.com/etcd-io/etcd/blob/719f6ce06fbcaea5ffb0d2b53fc42ab430ddd259/raft/tracker/progress.go#L201-L212
https://github.com/etcd-io/etcd/blob/73c50b869ab7c4676806e4d1f827915f98e6d8f9/raft/raft.go#L426-L430