### PR TITLE
raftexample: New joined node have to start with RestartNode

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -298,14 +298,10 @@ func (rc *raftNode) startRaft() {
 		MaxUncommittedEntriesSize: 1 << 30,
 	}
 
-	if oldwal {
+	if oldwal || rc.join {
 		rc.node = raft.RestartNode(c)
 	} else {
-		startPeers := rpeers
-		if rc.join {
-			startPeers = nil
-		}
-		rc.node = raft.StartNode(c, startPeers)
+		rc.node = raft.StartNode(c, rpeers)
 	}
 
 	rc.transport = &rafthttp.Transport{


### PR DESCRIPTION
Followed [this instruction](https://github.com/etcd-io/etcd/tree/master/contrib/raftexample#dynamic-cluster-reconfiguration) to add new member, but got a below error.

```
$ ./raftexample --id 4 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379,http://127.0.0.1:42379 --port 42380 --join
2021/02/17 16:24:53 replaying WAL of member 4
2021/02/17 16:24:53 loading WAL at term 0 and index 0
panic: no peers given; use RestartNode instead

goroutine 26 [running]:
go.etcd.io/etcd/raft/v3.StartNode(0xc000239f50, 0x0, 0x0, 0x0, 0x0, 0xc00020cb10)
	/Users/mrkm4ntr/go/src/go.etcd.io/etcd/raft/node.go:218 +0x426
main.(*raftNode).startRaft(0xc000182a80)
	/Users/mrkm4ntr/go/src/go.etcd.io/etcd/contrib/raftexample/raft.go:291 +0x5de
created by main.newRaftNode
	/Users/mrkm4ntr/go/src/go.etcd.io/etcd/contrib/raftexample/raft.go:109 +0x39a
```
