### PR TITLE
Release scripts: Minor fixes discovered during attempt for release 3.5.0-alpha.0

### DIFF
--- a/scripts/release_mod.sh
+++ b/scripts/release_mod.sh
@@ -68,7 +68,8 @@ function update_versions_cmd() {
 }
 
 function get_gpg_key {
-  keyid=$(gpg --list-keys --with-colons| awk -F: '/^pub:/ { print $5 }')
+  gitemail=$(git config --get user.email)
+  keyid=$(run gpg --list-keys --with-colons "${gitemail}" | awk -F: '/^pub:/ { print $5 }')
   if [[ -z "${keyid}" ]]; then
     log_error "Failed to load gpg key. Is gpg set up correctly for etcd releases?"
     return 2

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -201,7 +201,7 @@ function modules_exp() {
 #  (unless the set is limited using ${PKG} or / ${USERMOD})
 function run_for_modules {
   local pkg="${PKG:-./...}"
-  if [ -z "${USERMOD}" ]; then
+  if [ -z "${USERMOD:-}" ]; then
     for m in $(module_dirs); do
       run_for_module "${m}" "$@" "${pkg}" || return "$?"
     done
@@ -355,7 +355,9 @@ function assert_no_git_modifications {
 #  - no differencing commits in relation to the origin/$branch
 function git_assert_branch_in_sync {
   local branch
-  branch=$(git branch --show-current)
+  branch=$(run git rev-parse --abbrev-ref HEAD)
+  # TODO: When git 2.22 popular, change to:
+  # branch=$(git branch --show-current)
   if [[ $(run git status --porcelain --untracked-files=no) ]]; then
     log_error "The workspace in '$(pwd)' for branch: ${branch} has uncommitted changes"
     log_error "Consider cleaning up / renaming this directory or (cd $(pwd) && git reset --hard)"


### PR DESCRIPTION
- Depending on too new 'git' syntax (`git branch --show-current`)
- gpg is now based on git-configured email (and not on the first key on the list)