### PR TITLE
raftExample: Allow closing raftexample node when snapshotting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test:
 	$(TEST_OPTS) ./test.sh 2>&1 | tee test-$(TEST_SUFFIX).log
 	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
-test-small:
+test-smoke:
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	PASSES="fmt build unit" ./test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
 

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -364,9 +364,13 @@ func (rc *raftNode) maybeTriggerSnapshot(applyDoneC <-chan struct{}) {
 		return
 	}
 
-	// wait until all committed entries are applied
+	// wait until all committed entries are applied (or server is closed)
 	if applyDoneC != nil {
-		<-applyDoneC
+		select {
+		case <-applyDoneC:
+		case <-rc.stopc:
+			return
+		}
 	}
 
 	log.Printf("start snapshot [applied index: %d | last snapshot index: %d]", rc.appliedIndex, rc.snapshotIndex)

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -94,9 +94,11 @@ func (clus *cluster) Close() (err error) {
 }
 
 func (clus *cluster) closeNoErrors(t *testing.T) {
+	t.Log("closing cluster...")
 	if err := clus.Close(); err != nil {
 		t.Fatal(err)
 	}
+	t.Log("closing cluster [done]")
 }
 
 // TestProposeOnCommit starts three nodes and feeds commits back into the proposal


### PR DESCRIPTION
Fix race that made the raft_example::TestSnapshot  fail.

@mrkm4ntr FYI