### PR TITLE
tests: Fixes a few recently spotted test-flakes

### DIFF
--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -52,6 +52,7 @@ func TestServer_Unix_Insecure_DelayTx(t *testing.T) { testServer(t, "unix", fals
 func TestServer_TCP_Insecure_DelayTx(t *testing.T)  { testServer(t, "tcp", false, true) }
 func TestServer_Unix_Secure_DelayTx(t *testing.T)   { testServer(t, "unix", true, true) }
 func TestServer_TCP_Secure_DelayTx(t *testing.T)    { testServer(t, "tcp", true, true) }
+
 func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 	srcAddr, dstAddr := newUnixAddr(), newUnixAddr()
 	if scheme == "tcp" {
@@ -122,15 +123,15 @@ func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 	}
 	took2 := time.Since(now)
 	if delayTx {
-		t.Logf("took %v with latency %v±%v", took2, lat, rv)
+		t.Logf("took %v with latency %v+-%v", took2, lat, rv)
 	} else {
 		t.Logf("took %v with no latency", took2)
 	}
 
 	if delayTx {
 		p.UndelayTx()
-		if took1 >= took2 {
-			t.Fatalf("expected took1 %v < took2 %v (with latency)", took1, took2)
+		if took2 < lat-rv {
+			t.Fatalf("expected took2 %v (with latency) > delay: %v", took2, lat-rv)
 		}
 	}
 

--- a/pkg/testutil/leak.go
+++ b/pkg/testutil/leak.go
@@ -125,7 +125,8 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "created by runtime.gc") ||
 			strings.Contains(stack, "created by text/template/parse.lex") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
-			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") {
+			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") ||
+			strings.Contains(stack, "net.(*netFD).Close(...)") {
 			continue
 		}
 		gs = append(gs, stack)

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -234,10 +234,12 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("watchCli created to: %v", target)
 	defer watchCli.Close()
 
-	// wait for eps[target] to be pinned
+	// wait for eps[target] to be connected
 	clientv3test.MustWaitPinReady(t, watchCli)
+	t.Logf("successful connection with server: %v", target)
 
 	// add all eps to list, so that when the original pined one fails
 	// the client can switch to other available eps
@@ -249,6 +251,8 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 	case <-time.After(integration.RequestWaitTimeout):
 		t.Fatal("took too long to create watch")
 	}
+
+	t.Logf("watch established")
 
 	// isolate eps[target]
 	clus.Members[target].InjectPartition(t,

--- a/tests/integration/cluster.go
+++ b/tests/integration/cluster.go
@@ -110,6 +110,7 @@ var (
 
 	defaultTokenJWT = "jwt,pub-key=../fixtures/server.crt,priv-key=../fixtures/server.key.insecure,sign-method=RS256,ttl=1s"
 
+	// Replace with just usage of testing.TB instead of zap
 	lg = zap.NewNop()
 )
 
@@ -1202,6 +1203,7 @@ func (m *member) InjectPartition(t testing.TB, others ...*member) {
 	for _, other := range others {
 		m.s.CutPeer(other.s.ID())
 		other.s.CutPeer(m.s.ID())
+		t.Logf("network partition injected between: %v <-> %v", m.s.ID(), other.s.ID())
 	}
 }
 
@@ -1210,6 +1212,7 @@ func (m *member) RecoverPartition(t testing.TB, others ...*member) {
 	for _, other := range others {
 		m.s.MendPeer(other.s.ID())
 		other.s.MendPeer(m.s.ID())
+		t.Logf("network partition between: %v <-> %v", m.s.ID(), other.s.ID())
 	}
 }
 


### PR DESCRIPTION
```
Unexpected goroutines running after all test(s).
1 instances of:
syscall.Syscall(...)
	/usr/local/go/src/syscall/asm_linux_386.s:19 +0x5
syscall.Close(...)
	/usr/local/go/src/syscall/zsyscall_linux_386.go:285 +0x3d
internal/poll.(*FD).destroy(...)
	/usr/local/go/src/internal/poll/fd_unix.go:77 +0x30
internal/poll.(*FD).decref(...)
	/usr/local/go/src/internal/poll/fd_mutex.go:213 +0x38
internal/poll.(*FD).Close(...)
	/usr/local/go/src/internal/poll/fd_unix.go:99 +0x43
net.(*netFD).Close(...)
	/usr/local/go/src/net/fd_posix.go:37 +0x49
FAIL	go.etcd.io/etcd/tests/v3/integration/client	0.039s
```

```
--- FAIL: TestServer_TCP_Secure_DelayTx (0.20s)
    server_test.go:110: took 128.026085ms with no latency
    server_test.go:125: took 62.980988ms with latency 50ms+-5ms
    server_test.go:133: expected took1 128.026085ms < took2 62.980988ms (with latency)
```

https://github.com/etcd-io/etcd/issues/12372
