### PR TITLE
client v2: check for empty request from the context

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -521,15 +521,22 @@ type simpleHTTPClient struct {
 	headerTimeout time.Duration
 }
 
+// NoRequestError indicates that the HTTPRequest object could not be found
+// or was nil.  No processing could continue.
+var NoRequestError = errors.New("No HTTPRequest was available")
+
 func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
 	req := act.HTTPRequest(c.endpoint)
+	if req == nil {
+		return nil, nil, NoRequestError
+	}
 
 	if err := printcURL(req); err != nil {
 		return nil, nil, err
 	}
 
 	isWait := false
-	if req != nil && req.URL != nil {
+	if req.URL != nil {
 		ws := req.URL.Query().Get("wait")
 		if len(ws) != 0 {
 			var err error

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -521,14 +521,14 @@ type simpleHTTPClient struct {
 	headerTimeout time.Duration
 }
 
-// NoRequestError indicates that the HTTPRequest object could not be found
+// ErrNoRequest indicates that the HTTPRequest object could not be found
 // or was nil.  No processing could continue.
-var NoRequestError = errors.New("No HTTPRequest was available")
+var ErrNoRequest = errors.New("No HTTPRequest was available")
 
 func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Response, []byte, error) {
 	req := act.HTTPRequest(c.endpoint)
 	if req == nil {
-		return nil, nil, NoRequestError
+		return nil, nil, ErrNoRequest
 	}
 
 	if err := printcURL(req); err != nil {

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -158,6 +158,24 @@ func TestSimpleHTTPClientDoError(t *testing.T) {
 	}
 }
 
+type nilAction struct{}
+
+func (a *nilAction) HTTPRequest(url.URL) *http.Request {
+	return nil
+}
+
+func TestSimpleHTTPClientDoNilRequest(t *testing.T) {
+	tr := newFakeTransport()
+	c := &simpleHTTPClient{transport: tr}
+
+	tr.errchan <- errors.New("fixture")
+
+	_, _, err := c.Do(context.Background(), &nilAction{})
+	if err != NoRequestError {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
 func TestSimpleHTTPClientDoCancelContext(t *testing.T) {
 	tr := newFakeTransport()
 	c := &simpleHTTPClient{transport: tr}

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -171,7 +171,7 @@ func TestSimpleHTTPClientDoNilRequest(t *testing.T) {
 	tr.errchan <- errors.New("fixture")
 
 	_, _, err := c.Do(context.Background(), &nilAction{})
-	if err != NoRequestError {
+	if err != ErrNoRequest {
 		t.Fatalf("expected non-nil error, got nil")
 	}
 }


### PR DESCRIPTION
If the simpleHTTPClient.Do is called and the context has a nil request, return an error early.

Fixes #12718
