### PR TITLE
Metrics example 404s - fix url

### DIFF
--- a/client/v3/README.md
+++ b/client/v3/README.md
@@ -77,7 +77,7 @@ if err != nil {
 
 ## Metrics
 
-The etcd client optionally exposes RPC metrics through [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus). See the [examples](https://github.com/etcd-io/etcd/blob/master/clientv3/example_metrics_test.go).
+The etcd client optionally exposes RPC metrics through [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus). See the [examples](https://github.com/etcd-io/etcd/blob/master/tests/integration/clientv3/examples/example_metrics_test.go).
 
 ## Namespacing
 


### PR DESCRIPTION
The metrics example link points to a file that appears to have moved. This change points it to what I think is the right place.


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
