### PR TITLE
Test flakes: 1 fix + 1 diagnostic

### DIFF
--- a/pkg/testutil/leak.go
+++ b/pkg/testutil/leak.go
@@ -126,7 +126,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "created by text/template/parse.lex") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
 			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") ||
-			strings.Contains(stack, "net.(*netFD).Close(...)") {
+			strings.Contains(stack, "net.(*netFD).Close(") {
 			continue
 		}
 		gs = append(gs, stack)

--- a/test.sh
+++ b/test.sh
@@ -110,7 +110,7 @@ function integration_extra {
 
 function integration_pass {
   local pkgs=${USERPKG:-"./integration/..."}
-  run_for_module "tests" go_test "${pkgs}" "parallel" : -timeout="${TIMEOUT:-30m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
+  run_for_module "tests" go_test "${pkgs}" "parallel" : -timeout="${TIMEOUT:-15m}" "-v" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
   integration_extra "$@"
 }
 


### PR DESCRIPTION
- better classify `net.(*netFD).Close(` leaks
- collect more data about stuck integration tests by running it with `-v`