### PR TITLE
raft: postpone MsgReadIndex until first commit in the term

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -183,6 +183,8 @@ type Node interface {
 	// Read state has a read index. Once the application advances further than the read
 	// index, any linearizable read requests issued before the read request can be
 	// processed safely. The read state will have the same rctx attached.
+	// Note that request can be lost without notice, therefore it is user's job
+	// to ensure read index retries.
 	ReadIndex(ctx context.Context, rctx []byte) error
 
 	// Status returns the current status of the raft state machine.


### PR DESCRIPTION
This PR tries to address #12680. Instead of dropping requests while Leader didn't committed first log in the term, it records them and process afer commit (1).

#12680 could be also fixed by another approach: retry mechanism in the following code (2)

https://github.com/etcd-io/etcd/blob/3ead91ca3edf66112d56c453169343515bba71c3/server/etcdserver/v3_server.go#L752-L783 

While this PR is proposal for (1), I'd like to introduce PR for (2) as well. In my opinion implementing (1) alone, (2) alone and both seems reasonable and I'd love to hear what you think.

Edit: 
Implementation of (2) can be found in #12780