### PR TITLE
Update cert generation Makefile to include configurable cert file names

### DIFF
--- a/hack/tls-setup/Makefile
+++ b/hack/tls-setup/Makefile
@@ -19,32 +19,32 @@ req:
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/9.145.89.120
+	  config/req-csr.json | $(JSON) -bare certs/${infra0}
 	$(CFSSL) gencert \
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/9.145.89.173
+	  config/req-csr.json | $(JSON) -bare certs/${infra1}
 	$(CFSSL) gencert \
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/9.145.89.225
+	  config/req-csr.json | $(JSON) -bare certs/${infra2}
 	$(CFSSL) gencert \
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/peer-9.145.89.120
+	  config/req-csr.json | $(JSON) -bare certs/peer-${infra0}
 	$(CFSSL) gencert \
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/peer-9.145.89.173
+	  config/req-csr.json | $(JSON) -bare certs/peer-${infra1}
 	$(CFSSL) gencert \
 	  -ca certs/ca.pem \
 	  -ca-key certs/ca-key.pem \
 	  -config config/ca-config.json \
-	  config/req-csr.json | $(JSON) -bare certs/peer-9.145.89.225
+	  config/req-csr.json | $(JSON) -bare certs/peer-${infra2}
 
 clean:
 	rm -rf certs

--- a/hack/tls-setup/README.md
+++ b/hack/tls-setup/README.md
@@ -28,4 +28,10 @@ Example:
   ]
 }
 ```
-3. Run `make` to generate the certs
+3. Set the following environment variables subsituting your IP address:
+```bash
+export infra0={IP-0}
+export infra1={IP-1}
+export infra2={IP-2}
+```
+4. Run `make` to generate the certs


### PR DESCRIPTION
The example for using cfssl tool runs a Makefile to generate certs for the nodes whose IP addresses are provided in req-csr.json
Makefile generates the certs with names containing hardcoded IP addresses. This commit  changes the Makefile to read the address from environment variables 