### PR TITLE
TODO's 3.5: Decommission metrics, PreVote=true. 

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -66,6 +66,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.0...v3.5.0) and 
 - ClientV3 supports [grpc resolver API](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/resolver/resolver.go).
   - Endpoints can be managed using [endpoints.Manager](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/endpoints/endpoints.go)
   - Previously supported [GRPCResolver was decomissioned](https://github.com/etcd-io/etcd/pull/12675). Use [resolver](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/resolver/resolver.go) instead.
+- Turned on [--pre-vote by default](https://github.com/etcd-io/etcd/pull/). Should prevent disrupting RAFT leader by an individual member. 
 
 ### `etcdctl`
 

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -239,7 +239,6 @@ type Config struct {
 	// If enabled, Raft runs an additional election phase
 	// to check whether it would get enough votes to win
 	// an election, thus minimizing disruptions.
-	// TODO: enable by default in 3.5.
 	PreVote bool `json:"pre-vote"`
 
 	CORS map[string]struct{}
@@ -436,7 +435,7 @@ func NewConfig() *Config {
 		BcryptCost:   uint(bcrypt.DefaultCost),
 		AuthTokenTTL: 300,
 
-		PreVote: false, // TODO: enable by default in v3.5
+		PreVote: true,
 
 		loggerMu:          new(sync.RWMutex),
 		logger:            nil,

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -116,7 +116,7 @@ Clustering:
     Suffix to the dns srv name queried when bootstrapping.
   --strict-reconfig-check '` + strconv.FormatBool(embed.DefaultStrictReconfigCheck) + `'
     Reject reconfiguration requests that would cause quorum loss.
-  --pre-vote 'false'
+  --pre-vote 'true'
     Enable to run an additional Raft election phase.
   --auto-compaction-retention '0'
     Auto compaction retention length. 0 means disable auto compaction.

--- a/server/mvcc/metrics.go
+++ b/server/mvcc/metrics.go
@@ -43,14 +43,6 @@ var (
 			Name:      "put_total",
 			Help:      "Total number of puts seen by this member.",
 		})
-	// TODO: remove in 3.5 release
-	putCounterDebug = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "etcd_debugging",
-			Subsystem: "mvcc",
-			Name:      "put_total",
-			Help:      "Total number of puts seen by this member.",
-		})
 
 	deleteCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -59,25 +51,10 @@ var (
 			Name:      "delete_total",
 			Help:      "Total number of deletes seen by this member.",
 		})
-	// TODO: remove in 3.5 release
-	deleteCounterDebug = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "etcd_debugging",
-			Subsystem: "mvcc",
-			Name:      "delete_total",
-			Help:      "Total number of deletes seen by this member.",
-		})
 
 	txnCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "etcd",
-			Subsystem: "mvcc",
-			Name:      "txn_total",
-			Help:      "Total number of txns seen by this member.",
-		})
-	txnCounterDebug = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "etcd_debugging",
 			Subsystem: "mvcc",
 			Name:      "txn_total",
 			Help:      "Total number of txns seen by this member.",
@@ -199,19 +176,6 @@ var (
 	reportDbTotalSizeInBytesMu sync.RWMutex
 	reportDbTotalSizeInBytes   = func() float64 { return 0 }
 
-	// TODO: remove this in v3.5
-	dbTotalSizeDebug = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: "etcd_debugging",
-		Subsystem: "mvcc",
-		Name:      "db_total_size_in_bytes",
-		Help:      "Total size of the underlying database physically allocated in bytes.",
-	},
-		func() float64 {
-			reportDbTotalSizeInBytesDebugMu.RLock()
-			defer reportDbTotalSizeInBytesDebugMu.RUnlock()
-			return reportDbTotalSizeInBytesDebug()
-		},
-	)
 	// overridden by mvcc initialization
 	reportDbTotalSizeInBytesDebugMu sync.RWMutex
 	reportDbTotalSizeInBytesDebug   = func() float64 { return 0 }
@@ -318,11 +282,8 @@ func init() {
 	prometheus.MustRegister(rangeCounter)
 	prometheus.MustRegister(rangeCounterDebug)
 	prometheus.MustRegister(putCounter)
-	prometheus.MustRegister(putCounterDebug)
 	prometheus.MustRegister(deleteCounter)
-	prometheus.MustRegister(deleteCounterDebug)
 	prometheus.MustRegister(txnCounter)
-	prometheus.MustRegister(txnCounterDebug)
 	prometheus.MustRegister(keysGauge)
 	prometheus.MustRegister(watchStreamGauge)
 	prometheus.MustRegister(watcherGauge)
@@ -335,7 +296,6 @@ func init() {
 	prometheus.MustRegister(dbCompactionLast)
 	prometheus.MustRegister(dbCompactionKeysCounter)
 	prometheus.MustRegister(dbTotalSize)
-	prometheus.MustRegister(dbTotalSizeDebug)
 	prometheus.MustRegister(dbTotalSizeInUse)
 	prometheus.MustRegister(dbOpenReadTxN)
 	prometheus.MustRegister(hashSec)

--- a/server/mvcc/metrics_txn.go
+++ b/server/mvcc/metrics_txn.go
@@ -57,7 +57,6 @@ func (tw *metricsTxnWrite) End() {
 	defer tw.TxnWrite.End()
 	if sum := tw.ranges + tw.puts + tw.deletes; sum > 1 {
 		txnCounter.Inc()
-		txnCounterDebug.Inc() // TODO: remove in 3.5 release
 	}
 
 	ranges := float64(tw.ranges)
@@ -66,10 +65,8 @@ func (tw *metricsTxnWrite) End() {
 
 	puts := float64(tw.puts)
 	putCounter.Add(puts)
-	putCounterDebug.Add(puts) // TODO: remove in 3.5 release
 	totalPutSizeGauge.Add(float64(tw.putSize))
 
 	deletes := float64(tw.deletes)
 	deleteCounter.Add(deletes)
-	deleteCounterDebug.Add(deletes) // TODO: remove in 3.5 release
 }


### PR DESCRIPTION
Enabled --pre-vote by default. 
Delete etcd-debug metrics. 