### PR TITLE
Minor test fixes

### DIFF
--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -80,7 +80,7 @@ func TestDialCancel(t *testing.T) {
 }
 
 func TestDialTimeout(t *testing.T) {
-	defer testutil.AfterTest(t)
+	testutil.BeforeTest(t)
 
 	wantError := context.DeadlineExceeded
 

--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -29,7 +29,7 @@ import (
 	"github.com/creack/pty"
 )
 
-const DEBUG_LINES_TAIL=40
+const DEBUG_LINES_TAIL = 40
 
 type ExpectProcess struct {
 	cmd  *exec.Cmd
@@ -111,8 +111,8 @@ func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
 		l := ep.lines[0]
 		ep.lines = ep.lines[1:]
 		lastLinesBuffer = append(lastLinesBuffer, l)
-		if l:=len(lastLinesBuffer); l>DEBUG_LINES_TAIL {
-			lastLinesBuffer = lastLinesBuffer[l-DEBUG_LINES_TAIL:l-1]
+		if l := len(lastLinesBuffer); l > DEBUG_LINES_TAIL {
+			lastLinesBuffer = lastLinesBuffer[l-DEBUG_LINES_TAIL : l-1]
 		}
 		if f(l) {
 			ep.mu.Unlock()
@@ -120,7 +120,7 @@ func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
 		}
 	}
 	ep.mu.Unlock()
-	return "", fmt.Errorf("Match not found." +
+	return "", fmt.Errorf("Match not found."+
 		" Set EXPECT_DEBUG for more info Err: %v, last lines:\n%s\n\n",
 		ep.err, strings.Join(lastLinesBuffer, ""))
 }

--- a/tests/integration/v3_alarm_test.go
+++ b/tests/integration/v3_alarm_test.go
@@ -35,7 +35,7 @@ import (
 
 // TestV3StorageQuotaApply tests the V3 server respects quotas during apply
 func TestV3StorageQuotaApply(t *testing.T) {
-	testutil.AfterTest(t)
+	testutil.BeforeTest(t)
 	quotasize := int64(16 * os.Getpagesize())
 
 	clus := NewClusterV3(t, &ClusterConfig{Size: 2})


### PR DESCRIPTION
- e2e/expect: In case of sut process failure, print last 40lines of logs.
- Fix 2 remaining 'defer AfterTest' calls