### PR TITLE
etcd-raft-zap logger fixes.

### DIFF
--- a/server/etcdserver/apply_v2.go
+++ b/server/etcdserver/apply_v2.go
@@ -120,7 +120,7 @@ func (s *EtcdServer) applyV2Request(r *RequestV2) (resp Response) {
 	defer func(start time.Time) {
 		success := resp.Err == nil
 		applySec.WithLabelValues(v2Version, r.Method, strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		warnOfExpensiveRequest(s.getLogger(), s.Cfg.WarningApplyDuration, start, stringer, nil, nil)
+		warnOfExpensiveRequest(s.Logger(), s.Cfg.WarningApplyDuration, start, stringer, nil, nil)
 	}(time.Now())
 
 	switch r.Method {

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -41,7 +41,7 @@ func (s *EtcdServer) CheckInitialHashKV() error {
 		return nil
 	}
 
-	lg := s.getLogger()
+	lg := s.Logger()
 
 	lg.Info(
 		"starting initial corruption check",
@@ -126,7 +126,7 @@ func (s *EtcdServer) monitorKVHash() {
 		return
 	}
 
-	lg := s.getLogger()
+	lg := s.Logger()
 	lg.Info(
 		"enabled corruption checking",
 		zap.String("local-member-id", s.ID().String()),
@@ -149,7 +149,7 @@ func (s *EtcdServer) monitorKVHash() {
 }
 
 func (s *EtcdServer) checkHashKV() error {
-	lg := s.getLogger()
+	lg := s.Logger()
 
 	h, rev, crev, err := s.kv.HashByRev(0)
 	if err != nil {
@@ -268,7 +268,7 @@ func (s *EtcdServer) getPeerHashKVs(rev int64) []*peerHashKVResp {
 		peers = append(peers, peerInfo{id: m.ID, eps: m.PeerURLs})
 	}
 
-	lg := s.getLogger()
+	lg := s.Logger()
 
 	var resps []*peerHashKVResp
 	for _, p := range peers {
@@ -345,7 +345,7 @@ type hashKVHandler struct {
 }
 
 func (s *EtcdServer) HashKVHandler() http.Handler {
-	return &hashKVHandler{lg: s.getLogger(), server: s}
+	return &hashKVHandler{lg: s.Logger(), server: s}
 }
 
 func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/server/etcdserver/quota.go
+++ b/server/etcdserver/quota.go
@@ -72,7 +72,7 @@ var (
 
 // NewBackendQuota creates a quota layer with the given storage limit.
 func NewBackendQuota(s *EtcdServer, name string) Quota {
-	lg := s.getLogger()
+	lg := s.Logger()
 	quotaBackendBytes.Set(float64(s.Cfg.QuotaBackendBytes))
 
 	if s.Cfg.QuotaBackendBytes < 0 {

--- a/server/etcdserver/snapshot_merge.go
+++ b/server/etcdserver/snapshot_merge.go
@@ -29,7 +29,7 @@ import (
 // a snapshot of v2 store inside raft.Snapshot as []byte, a snapshot of v3 KV in the top level message
 // as ReadCloser.
 func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapt, snapi uint64, confState raftpb.ConfState) snap.Message {
-	lg := s.getLogger()
+	lg := s.Logger()
 	// get a snapshot of v2 store as []byte
 	clone := s.v2store.Clone()
 	d, err := clone.SaveNoCopy()


### PR DESCRIPTION
    Unify logic of building raft-loggers for etcd.
    
    1. We had the same code copied 3 times.
    2. The code was not reusing existing logger if this one is given.

The benefit of this change is that all integration tests are using the same logger.