### PR TITLE
server/etcdmain and tests: Fix goroutine leaks

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -218,7 +218,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 	httpClient := mustNewHTTPClient(lg)
 
 	srvhttp, httpl := mustHTTPListener(lg, m, tlsinfo, client, proxyClient)
-	errc := make(chan error)
+	errc := make(chan error, 3)
 	go func() { errc <- newGRPCProxyServer(lg, client).Serve(grpcl) }()
 	go func() { errc <- srvhttp.Serve(httpl) }()
 	go func() { errc <- m.Serve() }()

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -260,7 +260,7 @@ func restoreCluster(t *testing.T, clusterN int, dbPath string) (
 		cfgs[i] = cfg
 	}
 
-	sch := make(chan *embed.Etcd)
+	sch := make(chan *embed.Etcd, len(cfgs))
 	for i := range cfgs {
 		go func(idx int) {
 			srv, err := embed.StartEtcd(cfgs[idx])


### PR DESCRIPTION
***Description***
This pull request fixes two simple goroutine leak problems caused by blocking channel operations.

***Problem 1***
The problem in server/etcdmain/grpc_proxy.go is caused by sending 3 messages to `errc` but only receive 1 message from `errc`
https://github.com/etcd-io/etcd/blob/4f34f14830190395e3142ccb19785535631d0fe5/server/etcdmain/grpc_proxy.go#L222-L224
https://github.com/etcd-io/etcd/blob/4f34f14830190395e3142ccb19785535631d0fe5/server/etcdmain/grpc_proxy.go#L248

***Problem 2***
The problem in test/.../v3_snapshot_test.go is caused by the `case <-time.After()`. When this case is chosen, `sch <- srv` at line 272 will be blocked.
https://github.com/etcd-io/etcd/blob/4f34f14830190395e3142ccb19785535631d0fe5/tests/integration/snapshot/v3_snapshot_test.go#L263-L284