### PR TITLE
test: bump golang to 1.12.17 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ sudo: required
 services: docker
 
 go:
-- 1.8.7
+- 1.12.17
 
 notifications:
   on_success: never
   on_failure: never
+
+env:
+- GO111MODULE=off
 
 env:
   matrix:
@@ -23,7 +26,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - go: 1.8.7
+  - go: 1.12.17
     env: TARGET=linux-386-unit
   exclude:
   - go: tip

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM ubuntu:16.10
+FROM ubuntu:16.04
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -29,6 +29,7 @@ RUN apt-get -y update \
   && apt-get -y autoremove \
   && apt-get -y autoclean
 
+ENV GO111MODULE=off
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
@@ -46,11 +47,18 @@ ADD ./scripts/install-marker.sh /tmp/install-marker.sh
 
 RUN go get -v -u -tags spell github.com/chzchzchz/goword \
   && go get -v -u github.com/coreos/license-bill-of-materials \
-  && go get -v -u honnef.co/go/tools/cmd/gosimple \
-  && go get -v -u honnef.co/go/tools/cmd/unused \
-  && go get -v -u honnef.co/go/tools/cmd/staticcheck \
   && go get -v -u github.com/wadey/gocovmerge \
   && go get -v -u github.com/gordonklaus/ineffassign \
+  && mkdir -p $GOPATH/src/honnef.co/go/tools \
+  && git clone https://github.com/dominikh/go-tools.git $GOPATH/src/honnef.co/go/tools \
+  && cd $GOPATH/src/honnef.co/go/tools/cmd/staticcheck \
+  && git checkout 2017.2.2 \
+  && go get \
+  && go install \
+  && cd $GOPATH/src/honnef.co/go/tools/cmd/gosimple \
+  && go install \
+  && cd $GOPATH/src/honnef.co/go/tools/cmd/unused \
+  && go install \
   && /tmp/install-marker.sh amd64 \
   && rm -f /tmp/install-marker.sh \
   && curl -s https://codecov.io/bash >/codecov \


### PR DESCRIPTION
This PR bumps Travis testing to align with the intended shipped golang version 1.12.17 for release-3.2. release-3.2 Is the last release that uses the `gcr.io/etcd-development/etcd-test` image. This PR also adds a workaround that allows for older version of go-tools to be built.