### PR TITLE
raft: correctly pass arguments to Logger.Panic

### DIFF
--- a/raft/logger.go
+++ b/raft/logger.go
@@ -114,7 +114,7 @@ func (l *DefaultLogger) Fatalf(format string, v ...interface{}) {
 }
 
 func (l *DefaultLogger) Panic(v ...interface{}) {
-	l.Logger.Panic(v)
+	l.Logger.Panic(v...)
 }
 
 func (l *DefaultLogger) Panicf(format string, v ...interface{}) {


### PR DESCRIPTION
This CI failure was flushed while trying to bump golang for Travis tests[1],[2].

[1] https://github.com/etcd-io/etcd/pull/12802
[2] https://travis-ci.com/github/etcd-io/etcd/jobs/494343959#L625

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
