### PR TITLE
pkg/pbutil: fix Errorf format

### DIFF
--- a/pkg/pbutil/pbutil_test.go
+++ b/pkg/pbutil/pbutil_test.go
@@ -24,7 +24,7 @@ func TestMarshaler(t *testing.T) {
 	data := []byte("test data")
 	m := &fakeMarshaler{data: data}
 	if g := MustMarshal(m); !reflect.DeepEqual(g, data) {
-		t.Errorf("data = %s, want %s", g, m)
+		t.Errorf("data = %s, want %v", g, m)
 	}
 }
 
@@ -43,7 +43,7 @@ func TestUnmarshaler(t *testing.T) {
 	m := &fakeUnmarshaler{}
 	MustUnmarshal(m, data)
 	if !reflect.DeepEqual(m.data, data) {
-		t.Errorf("data = %s, want %s", m.data, m)
+		t.Errorf("data = %s, want %v", m.data, m)
 	}
 }
 


### PR DESCRIPTION
More cleanup.. m is pbutil.fakeUnmarshaler not a string..

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>


Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
