### PR TITLE
integration: relax leader timeout from 3s to 4s

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -63,7 +63,7 @@ import (
 
 const (
 	// RequestWaitTimeout is the time duration to wait for a request to go through or detect leader loss.
-	RequestWaitTimeout = 3 * time.Second
+	RequestWaitTimeout = 4 * time.Second
 	tickDuration       = 10 * time.Millisecond
 	requestTimeout     = 20 * time.Second
 


### PR DESCRIPTION
The integration jobs fail with timeouts slightly over 3s, increase
this marginally so false failures are less prevalent.