### PR TITLE
(no)StoreV2 (Part 2): Prepare to read membership information from backend

### DIFF
--- a/etcdctl/ctlv2/command/backup_command.go
+++ b/etcdctl/ctlv2/command/backup_command.go
@@ -239,6 +239,8 @@ func saveDB(destDB, srcDB string, idx uint64, v3 bool) {
 	}
 
 	// remove membership information; should be clobbered by --force-new-cluster
+	// TODO: Consider refactoring to use backend.Backend instead of bolt
+	// and membership.TrimMembershipFromBackend.
 	for _, bucket := range []string{"members", "members_removed", "cluster"} {
 		tx.DeleteBucket([]byte(bucket))
 	}

--- a/etcdctl/ctlv3/command/migrate_command.go
+++ b/etcdctl/ctlv3/command/migrate_command.go
@@ -128,7 +128,7 @@ func prepareBackend() backend.Backend {
 
 func rebuildStoreV2() (v2store.Store, uint64) {
 	var index uint64
-	cl := membership.NewCluster(zap.NewExample(), "")
+	cl := membership.NewCluster(zap.NewExample())
 
 	waldir := migrateWALdir
 	if len(waldir) == 0 {

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -859,3 +859,20 @@ func (c *RaftCluster) VotingMemberIDs() []types.ID {
 	sort.Sort(types.IDSlice(ids))
 	return ids
 }
+
+// PushMembershipToStorage is overriding storage information about cluster's
+// members, such that they fully reflect internal RaftCluster's storage.
+func (c *RaftCluster) PushMembershipToStorage() {
+	if c.be != nil {
+		TrimMembershipFromBackend(c.lg, c.be)
+		for _, m := range c.members {
+			mustSaveMemberToBackend(c.lg, c.be, m)
+		}
+	}
+	if c.v2store != nil {
+		TrimMembershipFromV2Store(c.lg, c.v2store)
+		for _, m := range c.members {
+			mustSaveMemberToStore(c.lg, c.v2store, m)
+		}
+	}
+}

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -676,6 +676,10 @@ func membersFromStore(lg *zap.Logger, st v2store.Store) (map[types.ID]*Member, m
 	return members, removed
 }
 
+func membersFromBackend(lg *zap.Logger, be backend.Backend) (map[types.ID]*Member, map[types.ID]bool) {
+	return mustReadMembersFromBackend(lg, be)
+}
+
 func clusterVersionFromStore(lg *zap.Logger, st v2store.Store) *semver.Version {
 	e, err := st.Get(path.Join(storePrefix, "version"), false, false)
 	if err != nil {

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -48,7 +48,6 @@ type RaftCluster struct {
 
 	localID types.ID
 	cid     types.ID
-	token   string
 
 	v2store v2store.Store
 	be      backend.Backend
@@ -82,7 +81,7 @@ const (
 // NewClusterFromURLsMap creates a new raft cluster using provided urls map. Currently, it does not support creating
 // cluster with raft learner member.
 func NewClusterFromURLsMap(lg *zap.Logger, token string, urlsmap types.URLsMap) (*RaftCluster, error) {
-	c := NewCluster(lg, token)
+	c := NewCluster(lg)
 	for name, urls := range urlsmap {
 		m := NewMember(name, urls, token, nil)
 		if _, ok := c.members[m.ID]; ok {
@@ -97,8 +96,8 @@ func NewClusterFromURLsMap(lg *zap.Logger, token string, urlsmap types.URLsMap) 
 	return c, nil
 }
 
-func NewClusterFromMembers(lg *zap.Logger, token string, id types.ID, membs []*Member) *RaftCluster {
-	c := NewCluster(lg, token)
+func NewClusterFromMembers(lg *zap.Logger, id types.ID, membs []*Member) *RaftCluster {
+	c := NewCluster(lg)
 	c.cid = id
 	for _, m := range membs {
 		c.members[m.ID] = m
@@ -106,13 +105,12 @@ func NewClusterFromMembers(lg *zap.Logger, token string, id types.ID, membs []*M
 	return c
 }
 
-func NewCluster(lg *zap.Logger, token string) *RaftCluster {
+func NewCluster(lg *zap.Logger) *RaftCluster {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
 	return &RaftCluster{
 		lg:            lg,
-		token:         token,
 		members:       make(map[types.ID]*Member),
 		removed:       make(map[types.ID]bool),
 		downgradeInfo: &DowngradeInfo{Enabled: false},

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -279,7 +279,7 @@ func TestClusterValidateAndAssignIDs(t *testing.T) {
 }
 
 func TestClusterValidateConfigurationChange(t *testing.T) {
-	cl := NewCluster(zap.NewExample(), "")
+	cl := NewCluster(zaptest.NewLogger(t))
 	cl.SetStore(v2store.New())
 	for i := 1; i <= 4; i++ {
 		attr := RaftAttributes{PeerURLs: []string{fmt.Sprintf("http://127.0.0.1:%d", i)}}

--- a/server/etcdserver/api/membership/member.go
+++ b/server/etcdserver/api/membership/member.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -61,12 +62,10 @@ func NewMemberAsLearner(name string, peerURLs types.URLs, clusterName string, no
 }
 
 func computeMemberId(peerURLs types.URLs, clusterName string, now *time.Time) types.ID {
-	var b []byte
 	peerURLstrs := peerURLs.StringSlice()
 	sort.Strings(peerURLstrs)
-	for _, p := range peerURLstrs {
-		b = append(b, []byte(p)...)
-	}
+	joinedPeerUrls := strings.Join(peerURLstrs, "")
+	b := []byte(joinedPeerUrls)
 
 	b = append(b, []byte(clusterName)...)
 	if now != nil {

--- a/server/etcdserver/api/membership/store.go
+++ b/server/etcdserver/api/membership/store.go
@@ -57,6 +57,14 @@ func mustSaveMemberToBackend(lg *zap.Logger, be backend.Backend, m *Member) {
 	tx.UnsafePut(membersBucketName, mkey, mvalue)
 }
 
+func TrimClusterFromBackend(be backend.Backend) error {
+	tx := be.BatchTx()
+	tx.Lock()
+	defer tx.Unlock()
+	tx.UnsafeDeleteBucket(clusterBucketName)
+	return nil
+}
+
 func mustDeleteMemberFromBackend(be backend.Backend, id types.ID) {
 	mkey := backendMemberKey(id)
 

--- a/server/etcdserver/api/membership/store_test.go
+++ b/server/etcdserver/api/membership/store_test.go
@@ -1,0 +1,43 @@
+package membership
+
+import (
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	betesting "go.etcd.io/etcd/server/v3/mvcc/backend/testing"
+
+	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.uber.org/zap"
+)
+
+func TestAddRemoveMember(t *testing.T) {
+	c := newTestCluster(t, nil)
+	be, bepath := betesting.NewDefaultTmpBackend(t)
+	c.SetBackend(be)
+	c.AddMember(newTestMember(17, nil, "node17", nil), true)
+	c.RemoveMember(17, true)
+	c.AddMember(newTestMember(18, nil, "node18", nil), true)
+
+	// Skipping removal of already removed member
+	c.RemoveMember(17, true)
+	err := be.Close()
+	assert.NoError(t, err)
+
+	be2 := backend.NewDefaultBackend(bepath)
+	defer func() {
+		assert.NoError(t, be2.Close())
+	}()
+
+	if false {
+		// TODO: Enable this code when Recover is reading membership from the backend.
+		c2 := newTestCluster(t, nil)
+		c2.SetBackend(be2)
+		c2.Recover(func(*zap.Logger, *semver.Version) {})
+		assert.Equal(t, []*Member{{ID: types.ID(18),
+			Attributes: Attributes{Name: "node18"}}}, c2.Members())
+		assert.Equal(t, true, c2.IsIDRemoved(17))
+		assert.Equal(t, false, c2.IsIDRemoved(18))
+	}
+}

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -113,7 +113,7 @@ func getClusterFromRemotePeers(lg *zap.Logger, urls []string, timeout time.Durat
 		// if membership members are not present then the raft cluster formed will be
 		// an invalid empty cluster hence return failed to get raft cluster member(s) from the given urls error
 		if len(membs) > 0 {
-			return membership.NewClusterFromMembers(lg, "", id, membs), nil
+			return membership.NewClusterFromMembers(lg, id, membs), nil
 		}
 		return nil, fmt.Errorf("failed to get raft cluster member(s) from the given URLs")
 	}

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -487,7 +487,7 @@ func restartNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot) (types.ID, 
 		zap.String("local-member-id", id.String()),
 		zap.Uint64("commit-index", st.Commit),
 	)
-	cl := membership.NewCluster(cfg.Logger, "")
+	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
@@ -565,7 +565,7 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot)
 		zap.Uint64("commit-index", st.Commit),
 	)
 
-	cl := membership.NewCluster(cfg.Logger, "")
+	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -230,7 +230,7 @@ func TestConfigChangeBlocksApply(t *testing.T) {
 
 func TestProcessDuplicatedAppRespMessage(t *testing.T) {
 	n := newNopReadyNode()
-	cl := membership.NewCluster(zap.NewExample(), "abc")
+	cl := membership.NewCluster(zap.NewExample())
 
 	rs := raft.NewMemoryStorage()
 	p := mockstorage.NewStorageRecorder("")

--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -28,6 +28,7 @@ import (
 type BatchTx interface {
 	ReadTx
 	UnsafeCreateBucket(name []byte)
+	UnsafeDeleteBucket(name []byte)
 	UnsafePut(bucketName []byte, key []byte, value []byte)
 	UnsafeSeqPut(bucketName []byte, key []byte, value []byte)
 	UnsafeDelete(bucketName []byte, key []byte)
@@ -73,6 +74,18 @@ func (t *batchTx) UnsafeCreateBucket(name []byte) {
 	if err != nil && err != bolt.ErrBucketExists {
 		t.backend.lg.Fatal(
 			"failed to create a bucket",
+			zap.String("bucket-name", string(name)),
+			zap.Error(err),
+		)
+	}
+	t.pending++
+}
+
+func (t *batchTx) UnsafeDeleteBucket(name []byte) {
+	err := t.tx.DeleteBucket(name)
+	if err != nil && err != bolt.ErrBucketNotFound {
+		t.backend.lg.Fatal(
+			"failed to delete a bucket",
 			zap.String("bucket-name", string(name)),
 			zap.Error(err),
 		)

--- a/server/mvcc/kvstore_test.go
+++ b/server/mvcc/kvstore_test.go
@@ -875,6 +875,7 @@ func (b *fakeBatchTx) Unlock()                        {}
 func (b *fakeBatchTx) RLock()                         {}
 func (b *fakeBatchTx) RUnlock()                       {}
 func (b *fakeBatchTx) UnsafeCreateBucket(name []byte) {}
+func (b *fakeBatchTx) UnsafeDeleteBucket(name []byte) {}
 func (b *fakeBatchTx) UnsafePut(bucketName []byte, key []byte, value []byte) {
 	b.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{bucketName, key, value}})
 }

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -222,15 +222,15 @@ func TestCtlV2BackupV3Snapshot(t *testing.T) { testCtlV2Backup(t, 1, true) }
 func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	BeforeTestV2(t)
 
-	backupDir, err := ioutil.TempDir("", "testbackup0.etcd")
+	backupDir, err := ioutil.TempDir(t.TempDir(), "testbackup0.etcd")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(backupDir)
 
 	etcdCfg := newConfigNoTLS()
 	etcdCfg.snapshotCount = snapCount
 	etcdCfg.enableV2 = true
+	t.Log("Starting etcd-1")
 	epc1 := setupEtcdctlTest(t, etcdCfg, false)
 
 	// v3 put before v2 set so snapshot happens after v3 operations to confirm
@@ -241,23 +241,30 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	}
 	os.Setenv("ETCDCTL_API", "2")
 
+	t.Log("Setting key in etcd-1")
 	if err := etcdctlSet(epc1, "foo1", "bar1"); err != nil {
 		t.Fatal(err)
 	}
 
 	if v3 {
+		t.Log("Stopping etcd-1")
 		// v3 must lock the db to backup, so stop process
 		if err := epc1.Stop(); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := etcdctlBackup(epc1, epc1.procs[0].Config().dataDirPath, backupDir, v3); err != nil {
+	t.Log("Triggering etcd backup")
+	if err := etcdctlBackup(t, epc1, epc1.procs[0].Config().dataDirPath, backupDir, v3); err != nil {
 		t.Fatal(err)
 	}
+	t.Log("Closing etcd-1 backup")
 	if err := epc1.Close(); err != nil {
 		t.Fatalf("error closing etcd processes (%v)", err)
 	}
 
+	t.Logf("Backup directory: %s", backupDir)
+
+	t.Log("Starting etcd-2 (post backup)")
 	// restart from the backup directory
 	cfg2 := newConfigNoTLS()
 	cfg2.dataDirPath = backupDir
@@ -268,6 +275,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	// Make sure a failing test is not leaking resources (running server).
 	defer epc2.Close()
 
+	t.Log("Getting examplar key")
 	// check if backup went through correctly
 	if err := etcdctlGet(epc2, "foo1", "bar1", false); err != nil {
 		t.Fatal(err)
@@ -276,6 +284,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	os.Setenv("ETCDCTL_API", "3")
 	ctx2 := ctlCtx{t: t, epc: epc2}
 	if v3 {
+		t.Log("Getting v3 examplar key")
 		if err := ctlV3Get(ctx2, []string{"v3key"}, kv{"v3key", "123"}); err != nil {
 			t.Fatal(err)
 		}
@@ -286,6 +295,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 	}
 	os.Setenv("ETCDCTL_API", "2")
 
+	t.Log("Getting examplar key foo2")
 	// check if it can serve client requests
 	if err := etcdctlSet(epc2, "foo2", "bar2"); err != nil {
 		t.Fatal(err)
@@ -294,6 +304,7 @@ func testCtlV2Backup(t *testing.T, snapCount int, v3 bool) {
 		t.Fatal(err)
 	}
 
+	t.Log("Closing etcd-2")
 	if err := epc2.Close(); err != nil {
 		t.Fatalf("error closing etcd processes (%v)", err)
 	}
@@ -472,11 +483,12 @@ func etcdctlAuthEnable(clus *etcdProcessCluster) error {
 	return spawnWithExpect(cmdArgs, "Authentication Enabled")
 }
 
-func etcdctlBackup(clus *etcdProcessCluster, dataDir, backupDir string, v3 bool) error {
+func etcdctlBackup(t testing.TB, clus *etcdProcessCluster, dataDir, backupDir string, v3 bool) error {
 	cmdArgs := append(etcdctlPrefixArgs(clus), "backup", "--data-dir", dataDir, "--backup-dir", backupDir)
 	if v3 {
 		cmdArgs = append(cmdArgs, "--with-v3")
 	}
+	t.Logf("Running: %v", cmdArgs)
 	proc, err := spawnCmd(cmdArgs)
 	if err != nil {
 		return err

--- a/tests/e2e/etcd_process.go
+++ b/tests/e2e/etcd_process.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	etcdServerReadyLines = []string{"enabled capabilities for version", "published", "ready to serve client requests"}
+	etcdServerReadyLines = []string{"ready to serve client requests"}
 	binPath              string
 	ctlBinPath           string
 )

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -27,15 +27,13 @@ import (
 )
 
 func waitReadyExpectProc(exproc *expect.ExpectProcess, readyStrs []string) error {
-	c := 0
 	matchSet := func(l string) bool {
 		for _, s := range readyStrs {
 			if strings.Contains(l, s) {
-				c++
-				break
+				return true
 			}
 		}
-		return c == len(readyStrs)
+		return false
 	}
 	_, err := exproc.ExpectFunc(matchSet)
 	return err

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -88,8 +89,12 @@ and output a hex encoded line of binary for each input line`)
 		case nil:
 			walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
 			nodes := genIDSlice(snapshot.Metadata.ConfState.Voters)
-			fmt.Printf("Snapshot:\nterm=%d index=%d nodes=%s\n",
-				walsnap.Term, walsnap.Index, nodes)
+			confstateJson, err := json.Marshal(snapshot.Metadata.ConfState)
+			if err != nil {
+				confstateJson = []byte(fmt.Sprintf("confstate err: %v", err))
+			}
+			fmt.Printf("Snapshot:\nterm=%d index=%d nodes=%s confstate=%s\n",
+				walsnap.Term, walsnap.Index, nodes, confstateJson)
 		case snap.ErrNoSnapshot:
 			fmt.Printf("Snapshot:\nempty\n")
 		default:


### PR DESCRIPTION
Preparation work to read membership information from backend instead of v2store.

This change fixes: 
  - 2 issues with `etcdctl snapshot restore` that was not properly updating membership information in backend. 
  - the fact that we were testing upgrade against 3.3 (instead of 3.4)
  - the fact that V2 etcdctl backup was produciong internally inconsistent membership information between v2 & v2 backend. 

This change does not impacts behavior of etcd binary itself, and the membership information is still read for v2store. 
Separate PR that changes this will follow.