### PR TITLE
etcdserver: remove temp files in snap dir when etcdserver starting

### DIFF
--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"go.uber.org/zap/zaptest"
 )
 
 func TestIsDirWriteable(t *testing.T) {
@@ -189,6 +191,48 @@ func TestDirPermission(t *testing.T) {
 	}
 	// check dir permission with mode different than created dir
 	if err = CheckDirPermission(tmpdir2, 0600); err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}
+
+func TestRemoveMatchFile(t *testing.T) {
+	tmpdir := t.TempDir()
+	defer os.RemoveAll(tmpdir)
+	f, err := ioutil.TempFile(tmpdir, "tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	f, err = ioutil.TempFile(tmpdir, "foo.tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	err = RemoveMatchFile(zaptest.NewLogger(t), tmpdir, func(fileName string) bool {
+		return strings.HasPrefix(fileName, "tmp")
+	})
+	if err != nil {
+		t.Errorf("expected nil, got error")
+	}
+	fnames, err := ReadDir(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fnames) != 1 {
+		t.Errorf("expected exist 1 files, got %d", len(fnames))
+	}
+
+	f, err = ioutil.TempFile(tmpdir, "tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	err = RemoveMatchFile(zaptest.NewLogger(t), tmpdir, func(fileName string) bool {
+		os.Remove(filepath.Join(tmpdir, fileName))
+		return strings.HasPrefix(fileName, "tmp")
+	})
+	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
 }

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -338,6 +339,17 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 			zap.Error(err),
 		)
 	}
+
+	if err = fileutil.RemoveMatchFile(cfg.Logger, cfg.SnapDir(), func(fileName string) bool {
+		return strings.HasPrefix(fileName, "tmp")
+	}); err != nil {
+		cfg.Logger.Error(
+			"failed to remove temp file(s) in snapshot directory",
+			zap.String("path", cfg.SnapDir()),
+			zap.Error(err),
+		)
+	}
+
 	ss := snap.New(cfg.Logger, cfg.SnapDir())
 
 	bepath := cfg.BackendPath()


### PR DESCRIPTION

When etcd exits abnormally, tmp files will remain in snap dir, so clean up tmp files in snap dir when etcdserver starting.

Fixes #12837