### PR TITLE
(no)StoreV2 (Part 3): Applying consistency fix: ClusterVersionSet (and co) might get not applied on v2store

### DIFF
--- a/etcdctl/ctlv3/command/migrate_command.go
+++ b/etcdctl/ctlv3/command/migrate_command.go
@@ -208,15 +208,15 @@ func applyConf(cc raftpb.ConfChange, cl *membership.RaftCluster) {
 		if err := json.Unmarshal(cc.Context, m); err != nil {
 			panic(err)
 		}
-		cl.AddMember(m)
+		cl.AddMember(m, true)
 	case raftpb.ConfChangeRemoveNode:
-		cl.RemoveMember(types.ID(cc.NodeID))
+		cl.RemoveMember(types.ID(cc.NodeID), true)
 	case raftpb.ConfChangeUpdateNode:
 		m := new(membership.Member)
 		if err := json.Unmarshal(cc.Context, m); err != nil {
 			panic(err)
 		}
-		cl.UpdateRaftAttributes(m.ID, m.RaftAttributes)
+		cl.UpdateRaftAttributes(m.ID, m.RaftAttributes, true)
 	}
 }
 

--- a/etcdctl/snapshot/v3_snapshot.go
+++ b/etcdctl/snapshot/v3_snapshot.go
@@ -398,7 +398,7 @@ func (s *v3Manager) saveWALAndSnap() error {
 	st := v2store.New(etcdserver.StoreClusterPrefix, etcdserver.StoreKeysPrefix)
 	s.cl.SetStore(st)
 	for _, m := range s.cl.Members() {
-		s.cl.AddMember(m)
+		s.cl.AddMember(m, true)
 	}
 
 	m := s.cl.MemberByName(s.name)

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -72,6 +72,13 @@ type ConfigChangeContext struct {
 	IsPromote bool `json:"isPromote"`
 }
 
+type ShouldApplyV3 bool
+
+const (
+	ApplyBoth        = ShouldApplyV3(true)
+	ApplyV2storeOnly = ShouldApplyV3(false)
+)
+
 // NewClusterFromURLsMap creates a new raft cluster using provided urls map. Currently, it does not support creating
 // cluster with raft learner member.
 func NewClusterFromURLsMap(lg *zap.Logger, token string, urlsmap types.URLsMap) (*RaftCluster, error) {
@@ -371,7 +378,7 @@ func (c *RaftCluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 // AddMember adds a new Member into the cluster, and saves the given member's
 // raftAttributes into the store. The given member should have empty attributes.
 // A Member with a matching id must not exist.
-func (c *RaftCluster) AddMember(m *Member, shouldApplyV3 bool) {
+func (c *RaftCluster) AddMember(m *Member, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 	if c.v2store != nil {
@@ -394,7 +401,7 @@ func (c *RaftCluster) AddMember(m *Member, shouldApplyV3 bool) {
 
 // RemoveMember removes a member from the store.
 // The given id MUST exist, or the function panics.
-func (c *RaftCluster) RemoveMember(id types.ID, shouldApplyV3 bool) {
+func (c *RaftCluster) RemoveMember(id types.ID, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 	if c.v2store != nil {
@@ -426,7 +433,7 @@ func (c *RaftCluster) RemoveMember(id types.ID, shouldApplyV3 bool) {
 	}
 }
 
-func (c *RaftCluster) UpdateAttributes(id types.ID, attr Attributes, shouldApplyV3 bool) {
+func (c *RaftCluster) UpdateAttributes(id types.ID, attr Attributes, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -460,7 +467,7 @@ func (c *RaftCluster) UpdateAttributes(id types.ID, attr Attributes, shouldApply
 }
 
 // PromoteMember marks the member's IsLearner RaftAttributes to false.
-func (c *RaftCluster) PromoteMember(id types.ID, shouldApplyV3 bool) {
+func (c *RaftCluster) PromoteMember(id types.ID, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -479,7 +486,7 @@ func (c *RaftCluster) PromoteMember(id types.ID, shouldApplyV3 bool) {
 	)
 }
 
-func (c *RaftCluster) UpdateRaftAttributes(id types.ID, raftAttr RaftAttributes, shouldApplyV3 bool) {
+func (c *RaftCluster) UpdateRaftAttributes(id types.ID, raftAttr RaftAttributes, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -509,7 +516,7 @@ func (c *RaftCluster) Version() *semver.Version {
 	return semver.Must(semver.NewVersion(c.version.String()))
 }
 
-func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *semver.Version), shouldApplyV3 bool) {
+func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *semver.Version), shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 	if c.version != nil {
@@ -810,7 +817,7 @@ func (c *RaftCluster) DowngradeInfo() *DowngradeInfo {
 	return d
 }
 
-func (c *RaftCluster) SetDowngradeInfo(d *DowngradeInfo, shouldApplyV3 bool) {
+func (c *RaftCluster) SetDowngradeInfo(d *DowngradeInfo, shouldApplyV3 ShouldApplyV3) {
 	c.Lock()
 	defer c.Unlock()
 

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -283,9 +283,9 @@ func TestClusterValidateConfigurationChange(t *testing.T) {
 	cl.SetStore(v2store.New())
 	for i := 1; i <= 4; i++ {
 		attr := RaftAttributes{PeerURLs: []string{fmt.Sprintf("http://127.0.0.1:%d", i)}}
-		cl.AddMember(&Member{ID: types.ID(i), RaftAttributes: attr})
+		cl.AddMember(&Member{ID: types.ID(i), RaftAttributes: attr}, true)
 	}
-	cl.RemoveMember(4)
+	cl.RemoveMember(4, true)
 
 	attr := RaftAttributes{PeerURLs: []string{fmt.Sprintf("http://127.0.0.1:%d", 1)}}
 	ctx, err := json.Marshal(&Member{ID: types.ID(5), RaftAttributes: attr})
@@ -446,7 +446,7 @@ func TestClusterGenID(t *testing.T) {
 	previd := cs.ID()
 
 	cs.SetStore(mockstore.NewNop())
-	cs.AddMember(newTestMember(3, nil, "", nil))
+	cs.AddMember(newTestMember(3, nil, "", nil), true)
 	cs.genID()
 	if cs.ID() == previd {
 		t.Fatalf("cluster.ID = %v, want not %v", cs.ID(), previd)
@@ -489,7 +489,7 @@ func TestClusterAddMember(t *testing.T) {
 	st := mockstore.NewRecorder()
 	c := newTestCluster(t, nil)
 	c.SetStore(st)
-	c.AddMember(newTestMember(1, nil, "node1", nil))
+	c.AddMember(newTestMember(1, nil, "node1", nil), true)
 
 	wactions := []testutil.Action{
 		{
@@ -512,7 +512,7 @@ func TestClusterAddMemberAsLearner(t *testing.T) {
 	st := mockstore.NewRecorder()
 	c := newTestCluster(t, nil)
 	c.SetStore(st)
-	c.AddMember(newTestMemberAsLearner(1, nil, "node1", nil))
+	c.AddMember(newTestMemberAsLearner(1, nil, "node1", nil), true)
 
 	wactions := []testutil.Action{
 		{
@@ -555,7 +555,7 @@ func TestClusterRemoveMember(t *testing.T) {
 	st := mockstore.NewRecorder()
 	c := newTestCluster(t, nil)
 	c.SetStore(st)
-	c.RemoveMember(1)
+	c.RemoveMember(1, true)
 
 	wactions := []testutil.Action{
 		{Name: "Delete", Params: []interface{}{MemberStoreKey(1), true, true}},
@@ -595,7 +595,7 @@ func TestClusterUpdateAttributes(t *testing.T) {
 		c := newTestCluster(t, tt.mems)
 		c.removed = tt.removed
 
-		c.UpdateAttributes(types.ID(1), Attributes{Name: name, ClientURLs: clientURLs})
+		c.UpdateAttributes(types.ID(1), Attributes{Name: name, ClientURLs: clientURLs}, true)
 		if g := c.Members(); !reflect.DeepEqual(g, tt.wmems) {
 			t.Errorf("#%d: members = %+v, want %+v", i, g, tt.wmems)
 		}

--- a/server/etcdserver/apply_auth.go
+++ b/server/etcdserver/apply_auth.go
@@ -41,7 +41,7 @@ func newAuthApplierV3(as auth.AuthStore, base applierV3, lessor lease.Lessor) *a
 	return &authApplierV3{applierV3: base, as: as, lessor: lessor}
 }
 
-func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest) *applyResult {
+func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest, shouldApplyV3 bool) *applyResult {
 	aa.mu.Lock()
 	defer aa.mu.Unlock()
 	if r.Header != nil {
@@ -57,7 +57,7 @@ func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest) *applyResult {
 			return &applyResult{err: err}
 		}
 	}
-	ret := aa.applierV3.Apply(r)
+	ret := aa.applierV3.Apply(r, shouldApplyV3)
 	aa.authInfo.Username = ""
 	aa.authInfo.Revision = 0
 	return ret

--- a/server/etcdserver/apply_auth.go
+++ b/server/etcdserver/apply_auth.go
@@ -21,6 +21,7 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/auth"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/mvcc"
 )
@@ -41,7 +42,7 @@ func newAuthApplierV3(as auth.AuthStore, base applierV3, lessor lease.Lessor) *a
 	return &authApplierV3{applierV3: base, as: as, lessor: lessor}
 }
 
-func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest, shouldApplyV3 bool) *applyResult {
+func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *applyResult {
 	aa.mu.Lock()
 	defer aa.mu.Unlock()
 	if r.Header != nil {

--- a/server/etcdserver/apply_v2.go
+++ b/server/etcdserver/apply_v2.go
@@ -87,7 +87,7 @@ func (a *applierV2store) Put(r *RequestV2) Response {
 				a.lg.Panic("failed to unmarshal", zap.String("value", r.Val), zap.Error(err))
 			}
 			if a.cluster != nil {
-				a.cluster.UpdateAttributes(id, attr)
+				a.cluster.UpdateAttributes(id, attr, true)
 			}
 			// return an empty response since there is no consumer.
 			return Response{}

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -181,7 +181,7 @@ func TestApplyRepeat(t *testing.T) {
 	cl := newTestCluster(nil)
 	st := v2store.New()
 	cl.SetStore(v2store.New())
-	cl.AddMember(&membership.Member{ID: 1234})
+	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          zap.NewExample(),
 		Node:        n,
@@ -509,9 +509,9 @@ func TestApplyConfChangeError(t *testing.T) {
 	cl := membership.NewCluster(zap.NewExample(), "")
 	cl.SetStore(v2store.New())
 	for i := 1; i <= 4; i++ {
-		cl.AddMember(&membership.Member{ID: types.ID(i)})
+		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
-	cl.RemoveMember(4)
+	cl.RemoveMember(4, true)
 
 	attr := membership.RaftAttributes{PeerURLs: []string{fmt.Sprintf("http://127.0.0.1:%d", 1)}}
 	ctx, err := json.Marshal(&membership.Member{ID: types.ID(1), RaftAttributes: attr})
@@ -576,7 +576,7 @@ func TestApplyConfChangeError(t *testing.T) {
 			r:       *newRaftNode(raftNodeConfig{lg: zap.NewExample(), Node: n}),
 			cluster: cl,
 		}
-		_, err := srv.applyConfChange(tt.cc, nil)
+		_, err := srv.applyConfChange(tt.cc, nil, true)
 		if err != tt.werr {
 			t.Errorf("#%d: applyConfChange error = %v, want %v", i, err, tt.werr)
 		}
@@ -597,7 +597,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 	cl := membership.NewCluster(zap.NewExample(), "")
 	cl.SetStore(v2store.New())
 	for i := 1; i <= 3; i++ {
-		cl.AddMember(&membership.Member{ID: types.ID(i)})
+		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
 	r := newRaftNode(raftNodeConfig{
 		lg:        zap.NewExample(),
@@ -616,7 +616,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 		NodeID: 2,
 	}
 	// remove non-local member
-	shouldStop, err := srv.applyConfChange(cc, &raftpb.ConfState{})
+	shouldStop, err := srv.applyConfChange(cc, &raftpb.ConfState{}, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -626,7 +626,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 
 	// remove local member
 	cc.NodeID = 1
-	shouldStop, err = srv.applyConfChange(cc, &raftpb.ConfState{})
+	shouldStop, err = srv.applyConfChange(cc, &raftpb.ConfState{}, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -640,7 +640,7 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 	cl := membership.NewCluster(zap.NewExample(), "")
 	cl.SetStore(v2store.New())
-	cl.AddMember(&membership.Member{ID: types.ID(1)})
+	cl.AddMember(&membership.Member{ID: types.ID(1)}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:        zap.NewExample(),
 		Node:      newNodeNop(),
@@ -688,7 +688,7 @@ func TestApplyMultiConfChangeShouldStop(t *testing.T) {
 	cl := membership.NewCluster(zap.NewExample(), "")
 	cl.SetStore(v2store.New())
 	for i := 1; i <= 5; i++ {
-		cl.AddMember(&membership.Member{ID: types.ID(i)})
+		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
 	r := newRaftNode(raftNodeConfig{
 		lg:        zap.NewExample(),
@@ -1342,7 +1342,7 @@ func TestRemoveMember(t *testing.T) {
 	cl := newTestCluster(nil)
 	st := v2store.New()
 	cl.SetStore(v2store.New())
-	cl.AddMember(&membership.Member{ID: 1234})
+	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          zap.NewExample(),
 		Node:        n,
@@ -1386,7 +1386,7 @@ func TestUpdateMember(t *testing.T) {
 	cl := newTestCluster(nil)
 	st := v2store.New()
 	cl.SetStore(st)
-	cl.AddMember(&membership.Member{ID: 1234})
+	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          zap.NewExample(),
 		Node:        n,
@@ -1874,7 +1874,7 @@ func (n *nodeCommitter) Propose(ctx context.Context, data []byte) error {
 func newTestCluster(membs []*membership.Member) *membership.RaftCluster {
 	c := membership.NewCluster(zap.NewExample(), "")
 	for _, m := range membs {
-		c.AddMember(m)
+		c.AddMember(m, true)
 	}
 	return c
 }

--- a/server/mvcc/kvstore.go
+++ b/server/mvcc/kvstore.go
@@ -43,7 +43,6 @@ var (
 
 	ErrCompacted = errors.New("mvcc: required revision has been compacted")
 	ErrFutureRev = errors.New("mvcc: required revision is a future revision")
-	ErrCanceled  = errors.New("mvcc: watcher is canceled")
 )
 
 const (
@@ -437,6 +436,10 @@ func (s *store) restore() error {
 	}
 
 	tx.Unlock()
+
+	s.lg.Info("kvstore restored",
+		zap.Uint64("consistent-index", s.ConsistentIndex()),
+		zap.Int64("current-rev", s.currentRev))
 
 	if scheduledCompact != 0 {
 		if _, err := s.compactLockfree(scheduledCompact); err != nil {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.5.1
 	go.etcd.io/bbolt v1.3.5
 	go.etcd.io/etcd/api/v3 v3.5.0-alpha.0
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0-alpha.0

--- a/tests/integration/clientv3/ordering_kv_test.go
+++ b/tests/integration/clientv3/ordering_kv_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/ordering"
 	"go.etcd.io/etcd/tests/v3/integration"
 )
 
 func TestDetectKvOrderViolation(t *testing.T) {
-	var errOrderViolation = errors.New("Detected Order Violation")
+	var errOrderViolation = errors.New("DetectedOrderViolation")
 
 	integration.BeforeTest(t)
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
@@ -43,7 +44,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cli.Close()
+	defer func() { assert.NoError(t, cli.Close()) }()
 	ctx := context.TODO()
 
 	if _, err = clus.Client(0).Put(ctx, "foo", "bar"); err != nil {
@@ -69,27 +70,31 @@ func TestDetectKvOrderViolation(t *testing.T) {
 		func(op clientv3.Op, resp clientv3.OpResponse, prevRev int64) error {
 			return errOrderViolation
 		})
-	_, err = orderingKv.Get(ctx, "foo")
+	v, err := orderingKv.Get(ctx, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("Read from the first member: v:%v err:%v", v, err)
+	assert.Equal(t, []byte("buzz"), v.Kvs[0].Value)
 
 	// ensure that only the third member is queried during requests
 	clus.Members[0].Stop(t)
 	clus.Members[1].Stop(t)
-	clus.Members[2].Restart(t)
+	assert.NoError(t, clus.Members[2].Restart(t))
 	// force OrderingKv to query the third member
 	cli.SetEndpoints(clus.Members[2].GRPCAddr())
 	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed
 
-	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
+	t.Logf("Quering m2 after restart")
+	v, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
+	t.Logf("Quering m2 returned: v:%v erro:%v ", v, err)
 	if err != errOrderViolation {
-		t.Fatalf("expected %v, got %v", errOrderViolation, err)
+		t.Fatalf("expected %v, got err:%v v:%v", errOrderViolation, err, v)
 	}
 }
 
 func TestDetectTxnOrderViolation(t *testing.T) {
-	var errOrderViolation = errors.New("Detected Order Violation")
+	var errOrderViolation = errors.New("DetectedOrderViolation")
 
 	integration.BeforeTest(t)
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
@@ -106,7 +111,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cli.Close()
+	defer func() { assert.NoError(t, cli.Close()) }()
 	ctx := context.TODO()
 
 	if _, err = clus.Client(0).Put(ctx, "foo", "bar"); err != nil {
@@ -144,7 +149,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	// ensure that only the third member is queried during requests
 	clus.Members[0].Stop(t)
 	clus.Members[1].Stop(t)
-	clus.Members[2].Restart(t)
+	assert.NoError(t, clus.Members[2].Restart(t))
 	// force OrderingKv to query the third member
 	cli.SetEndpoints(clus.Members[2].GRPCAddr())
 	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed


### PR DESCRIPTION
ClusterVersionSet, ClusterMemberAttrSet, DowngradeInfoSet functions are writing both to V2store and backend. Prior this CL there were in a branch not executed if shouldApplyV3 was false, e.g. during restore when Backend is up-to-date (has high
consistency-index) while v2store requires replay from WAL log.

The most serious consequence of this bug was that v2store after restore could have different index (revision) than the same exact store before restore, so potentially different content between replicas.

Also this change is supressing double-applying of Membership (ClusterConfig) changes on Backend (store v3) - that lackilly are not part of MVCC/KeyValue store, so they didn't caused Revisions to be bumped.

Inspired by @jingyih comment: https://github.com/etcd-io/etcd/pull/12820#issuecomment-815299406


---

For the record, write that was not getting applied and v2store during snapshot restore:

```
go test ./integration --race -run TestForceNewCluster -v --count=1
```
 
    ```
        logger.go:130: 2021-04-10T10:36:15.771+0200 INFO    m2      !!! APPLYING    {"member": "m2", "e.index": 8, "raftReq": "header:<ID:3092698313349819908 > cluster_version_set:<ver:\"3.5.0\" > "}
        logger.go:130: 2021-04-10T10:36:15.788+0200 INFO    m2      set initial cluster version     {"member": "m2", "cluster-id": "6fb40b365bce42fa", "local-member-id": "868613072d7e2aeb", "cluster-version": "3.5"}
    10:36:15.788528 event_history.go:48: adding event to history: {"action":"set","node":{"key":"/0/version","value":"3.5.0","modifiedIndex":7,"createdIndex":7}}
    goroutine 386 [running]:
    runtime/debug.Stack(0x12707ab, 0xc0000e2050, 0x2)
            /usr/lib/google-golang/src/runtime/debug/stack.go:24 +0xab
    runtime/debug.PrintStack()
            /usr/lib/google-golang/src/runtime/debug/stack.go:16 +0x34
    go.etcd.io/etcd/server/v3/etcdserver/api/v2store.(*EventHistory).addEvent(0xc0001061e0, 0xc000295980, 0x0)
            /home/ptab/corp/etcd/server/etcdserver/api/v2store/event_history.go:49 +0x10b
    go.etcd.io/etcd/server/v3/etcdserver/api/v2store.(*watcherHub).notify(0xc000576020, 0xc000295980)
            /home/ptab/corp/etcd/server/etcdserver/api/v2store/watcher_hub.go:127 +0x7e
    go.etcd.io/etcd/server/v3/etcdserver/api/v2store.(*store).Set(0xc000554070, 0xc002fb61c0, 0xa, 0x0, 0xc002fb61ba, 0x5, 0x0, 0x0, 0x0, 0x181f000, ...)
            /home/ptab/corp/etcd/server/etcdserver/api/v2store/store.go:239 +0x3ba
    go.etcd.io/etcd/server/v3/etcdserver/api/membership.mustSaveClusterVersionToStore(0xc000484960, 0x1a0a618, 0xc000554070, 0xc002fa03c0)
            /home/ptab/corp/etcd/server/etcdserver/api/membership/store.go:154 +0x1fb
    go.etcd.io/etcd/server/v3/etcdserver/api/membership.(*RaftCluster).SetVersion(0xc00048f2d0, 0xc002fa03c0, 0x1854410)
            /home/ptab/corp/etcd/server/etcdserver/api/membership/cluster.go:534 +0xcbd
    go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).ClusterVersionSet(0xc00000e0c0, 0xc002573200)
            /home/ptab/corp/etcd/server/etcdserver/apply.go:907 +0xd0
    go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).Apply(0xc00000e150, 0xc0004f1560, 0x0)
            /home/ptab/corp/etcd/server/etcdserver/apply.go:226 +0x2e9e
    go.etcd.io/etcd/server/v3/etcdserver.(*authApplierV3).Apply(0xc0003e02d0, 0xc0004f1560, 0x0)
            /home/ptab/corp/etcd/server/etcdserver/apply_auth.go:60 +0x11d
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntryNormal(0xc000154000, 0xc002545268)
            /home/ptab/corp/etcd/server/etcdserver/server.go:2140 +0xe02
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply(0xc000154000, 0xc00022ea80, 0x1, 0x8, 0xc000574100, 0xc0025453a8, 0x5c917b, 0xc00041f7b0)
            /home/ptab/corp/etcd/server/etcdserver/server.go:2049 +0x725
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries(0xc000154000, 0xc000574100, 0xc000171970)
            /home/ptab/corp/etcd/server/etcdserver/server.go:1305 +0x185
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll(0xc000154000, 0xc000574100, 0xc000171970)

            /home/ptab/corp/etcd/server/etcdserver/server.go:1305 +0x185
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll(0xc000154000, 0xc000574100, 0xc000171970)
            /home/ptab/corp/etcd/server/etcdserver/server.go:1131 +0x9b
    go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func8(0x19f9830, 0xc00011dc80)
            /home/ptab/corp/etcd/server/etcdserver/server.go:1085 +0x54
    go.etcd.io/etcd/pkg/v3/schedule.(*fifo).run(0xc00042c960)
            /home/ptab/corp/etcd/pkg/schedule/schedule.go:157 +0x12b
    created by go.etcd.io/etcd/pkg/v3/schedule.NewFIFOScheduler
            /home/ptab/corp/etcd/pkg/schedule/schedule.go:70 +0x2d9
        logger.go:130: 2021-04-10T10:36:15.789+0200 INFO    m2      cluster version is updated      {"member": "m2", "cluster-version": "3.5"}
  
```