### PR TITLE
Fix the mixin.

### DIFF
--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -1292,7 +1292,7 @@
             name: 'cluster',
             options: [],
             query: 'label_values(etcd_server_has_leader, job)',
-            refresh: %(dashboard_var_refresh),
+            refresh: $._config.dashboard_var_refresh,
             regex: '',
             sort: 2,
             tagValuesQuery: '',


### PR DESCRIPTION
https://github.com/etcd-io/etcd/pull/12823 introduced a syntax error in the mixin.

Signed-off-by: Tom Wilkie <tom@grafana.com>
