### PR TITLE
pkg/schedule: TODO: recover from job panic

### DIFF
--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -47,3 +47,43 @@ func TestFIFOSchedule(t *testing.T) {
 		t.Errorf("scheduled = %d, want %d", s.Scheduled(), 100)
 	}
 }
+
+func TestFIFOScheduleJobPanicRecover(t *testing.T) {
+	s := NewFIFOScheduler()
+	defer s.Stop()
+
+	panicJobCreator := func() Job {
+		return func(ctx context.Context) {
+			panic("panic")
+		}
+	}
+
+	next := 0
+	jobCreator := func(i int) Job {
+		return func(ctx context.Context) {
+			if next != i {
+				t.Fatalf("job#%d: got %d, want %d", i, next, i)
+			}
+			next = i + 1
+		}
+	}
+
+	var jobs []Job
+
+	for i := 0; i < 100; i++ {
+		jobs = append(jobs, panicJobCreator())
+	}
+
+	for i := 0; i < 100; i++ {
+		jobs = append(jobs, jobCreator(i))
+	}
+
+	for _, j := range jobs {
+		s.Schedule(j)
+	}
+
+	s.WaitFinish(200)
+	if s.Scheduled() != 200 {
+		t.Errorf("scheduled = %d, want %d", s.Scheduled(), 100)
+	}
+}


### PR DESCRIPTION
This commits adds asynchronous TODO execution ,
record to std by capturing job panic, avoids the entire Scheduler panic caused by a JobPanic