### PR TITLE
Makefile, build.sh: Fix build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 
 UNAME := $(shell uname)
 XARGS = xargs
+ARCH ?= $(shell go env GOARCH)
 
 # -r is only necessary on GNU xargs.
 ifeq ($(UNAME), Linux)
@@ -28,7 +29,7 @@ build:
 clean:
 	rm -f ./codecov
 	rm -rf ./covdir
-	rm -f ./bin/Dockerfile-release
+	rm -f ./bin/Dockerfile-release*
 	rm -rf ./bin/etcd*
 	rm -rf ./default.etcd
 	rm -rf ./tests/e2e/default.etcd
@@ -198,13 +199,13 @@ docker-test-coverage:
 
 build-docker-release-master:
 	$(info ETCD_VERSION: $(ETCD_VERSION))
-	cp ./Dockerfile-release ./bin/Dockerfile-release
+	cp ./Dockerfile-release.$(ARCH) ./bin/Dockerfile-release.$(ARCH)
 	docker build \
 	  --network=host \
 	  --tag gcr.io/etcd-development/etcd:$(ETCD_VERSION) \
-	  --file ./bin/Dockerfile-release \
+	  --file ./bin/Dockerfile-release.$(ARCH) \
 	  ./bin
-	rm -f ./bin/Dockerfile-release
+	rm -f ./bin/Dockerfile-release.$(ARCH)
 
 	docker run \
 	  --rm \

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ etcd_build() {
   # shellcheck disable=SC2086
   (
     cd ./etcdctl
-    run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" go build $GO_BUILD_FLAGS \
+    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcdctl" . || return 2


### PR DESCRIPTION
This fixes `build-docker-release-master` since the Dockerfile files are now per arch, this adjusts to detect ARCH and builds docker release from the Dockerfile.<ARCH> file.

I also ran into an issue while running `make build`, that the `GO_BUILD_ENV` were not taken into account during build of `etcdctl`,  this now fixes so that the `GO_BUILD_ENV` vars are done in the same way as for `etcd` binary build step.
