### PR TITLE
.travis,Makefile,functional: Bump go 1.12 version to v1.12.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services: docker
 
 go:
-- 1.12.12
+- 1.12.17
 - 1.15.11
 
 notifications:
@@ -28,12 +28,12 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - go: 1.12.12
+  - go: 1.12.17
     env: TARGET=linux-amd64-grpcproxy
-  - go: 1.12.12
+  - go: 1.12.17
     env: TARGET=linux-386-unit
   exclude:
-    - go: 1.15.7
+    - go: 1.15.11
       env: TARGET=linux-amd64-integration-1-cpu
     - go: 1.15.11
       env: TARGET=linux-amd64-integration-2-cpu

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.12.12
+GO_VERSION ?= 1.12.17
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)
@@ -65,11 +65,11 @@ endif
 
 
 # Example:
-#   GO_VERSION=1.12.12 make build-docker-test
+#   GO_VERSION=1.12.17 make build-docker-test
 #   make build-docker-test
 #
 #   gcloud docker -- login -u _json_key -p "$(cat /etc/gcp-key-etcd-development.json)" https://gcr.io
-#   GO_VERSION=1.12.12 make push-docker-test
+#   GO_VERSION=1.12.17 make push-docker-test
 #   make push-docker-test
 #
 #   gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -13,7 +13,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-agent.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.12.12
+  GO_VERSION=1.12.17
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -6,7 +6,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-tester.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.12.12
+  GO_VERSION=1.12.17
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 


### PR DESCRIPTION
This version was already used to build the release v3.4.15.

```
docker run \
          --rm \
          quay.io/coreos/etcd:v3.4.15 \
          /bin/sh -c "/usr/local/bin/etcd --version && /usr/local/bin/etcdctl version"
etcd Version: 3.4.15
Git SHA: aa7126864
Go Version: go1.12.17
Go OS/Arch: linux/amd64
etcdctl version: 3.4.15
API version: 3.4
```