### PR TITLE
Errors: `context cancelled` or `context deadline exceeded` are exposed as codes.Canceled, codes.DeadlineExceeded instead of 'codes.Unknown'

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -70,6 +70,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.0...v3.5.0) and 
 - [ETCD_CLIENT_DEBUG env](https://github.com/etcd-io/etcd/pull/12786): Now supports log levels (debug, info, warn, error, dpanic, panic, fatal). Only when set, overrides application-wide grpc logging settings.
 - [Embed Etcd.Close()](https://github.com/etcd-io/etcd/pull/12828) needs to called exactly once and closes Etcd.Err() stream.
 - [Embed Etcd does not override global/grpc logger](https://github.com/etcd-io/etcd/pull/12861) be default any longer. If desired, please call `embed.Config::SetupGlobalLoggers()` explicitly. 
+- Errors: `context cancelled` or `context deadline exceeded` are exposed as codes.Canceled, codes.DeadlineExceeded instead of 'codes.Unknown'.
 ###
 
 - Make sure [save snapshot downloads checksum for integrity checks](https://github.com/etcd-io/etcd/pull/11896).

--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -84,6 +84,9 @@ var (
 	ErrGRPCDowngradeInProcess            = status.New(codes.FailedPrecondition, "etcdserver: cluster has a downgrade job in progress").Err()
 	ErrGRPCNoInflightDowngrade           = status.New(codes.FailedPrecondition, "etcdserver: no inflight downgrade job").Err()
 
+	ErrGRPCCanceled         = status.New(codes.Canceled, "etcdserver: request canceled").Err()
+	ErrGRPCDeadlineExceeded = status.New(codes.DeadlineExceeded, "etcdserver: context deadline exceeded").Err()
+
 	errStringToError = map[string]error{
 		ErrorDesc(ErrGRPCEmptyKey):      ErrGRPCEmptyKey,
 		ErrorDesc(ErrGRPCKeyNotFound):   ErrGRPCKeyNotFound,

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -83,6 +83,10 @@ var toGRPCErrorMap = map[error]error{
 	auth.ErrAuthNotEnabled:       rpctypes.ErrGRPCAuthNotEnabled,
 	auth.ErrInvalidAuthToken:     rpctypes.ErrGRPCInvalidAuthToken,
 	auth.ErrInvalidAuthMgmt:      rpctypes.ErrGRPCInvalidAuthMgmt,
+
+	// In sync with status.FromContextError
+	context.Canceled:         rpctypes.ErrGRPCCanceled,
+	context.DeadlineExceeded: rpctypes.ErrGRPCDeadlineExceeded,
 }
 
 func togRPCError(err error) error {

--- a/tests/integration/clientv3/util.go
+++ b/tests/integration/clientv3/util.go
@@ -50,7 +50,8 @@ func IsServerCtxTimeout(err error) bool {
 		return false
 	}
 	code := ev.Code()
-	return code == codes.DeadlineExceeded && strings.Contains(err.Error(), "context deadline exceeded")
+	return (code == codes.DeadlineExceeded /*3.5+"*/ || code == codes.Unknown /*<=3.4*/) &&
+		strings.Contains(err.Error(), "context deadline exceeded")
 }
 
 // IsClientTimeout checks reason of the error.


### PR DESCRIPTION
The reason for this PR are test flakes like: https://travis-ci.com/github/etcd-io/etcd/jobs/500367259

```
    logger.go:130: 2021-04-22T07:56:30.190Z	WARN	m0	apply request took too long	{"member": "m0", "took": "898.215659ms", "expected-duration": "100ms", "prefix": "read-only range ", "request": "key:\"a\" ", "response": "", "error": "context deadline exceeded"}
    logger.go:130: 2021-04-22T07:56:30.190Z	INFO	m0	trace[566305530] range	{"member": "m0", "detail": "{range_begin:a; range_end:; }", "duration": "898.32003ms", "start": "2021-04-22T07:56:29.292Z", "end": "2021-04-22T07:56:30.190Z", "steps": ["trace[566305530] 'agreement among raft nodes before linearized reading'  (duration: 898.212117ms)"], "step_count": 1}
    logger.go:130: 2021-04-22T07:56:30.190Z	WARN	m0	request stats	{"member": "m0", "start time": "2021-04-22T07:56:29.292Z", "time spent": "898.37779ms", "remote": "@", "response type": "/etcdserverpb.KV/Range", "request count": 0, "request size": 3, "response count": 0, "response size": 0, "request content": "key:\"a\" "}
    network_partition_test.go:140: Op returned error: rpc error: code = Unknown desc = context deadline exceeded
    network_partition_test.go:141: Cancelling...
    network_partition_test.go:147: #0: expected 'expected error', got 'rpc error: code = Unknown desc = context deadline exceeded'
```

