### PR TITLE
learner support snapshot RPC

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -237,6 +237,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 - Add [`/v3/auth/status`](https://github.com/etcd-io/etcd/pull/11536) endpoint to check if authentication is enabled
 - [Add `Linearizable` field to `etcdserverpb.MemberListRequest`](https://github.com/etcd-io/etcd/pull/11639).
+- [Learner support Snapshot RPC](https://github.com/etcd-io/etcd/pull/12890/).
 
 ### Package `netutil`
 

--- a/server/etcdserver/api/v3rpc/interceptor.go
+++ b/server/etcdserver/api/v3rpc/interceptor.go
@@ -35,6 +35,7 @@ import (
 const (
 	maxNoLeaderCnt          = 3
 	warnUnaryRequestLatency = 300 * time.Millisecond
+	snapshotMethod          = "/etcdserverpb.Maintenance/Snapshot"
 )
 
 type streamsMap struct {
@@ -214,7 +215,7 @@ func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor
 			return rpctypes.ErrGRPCNotCapable
 		}
 
-		if s.IsMemberExist(s.ID()) && s.IsLearner() { // learner does not support stream RPC
+		if s.IsMemberExist(s.ID()) && s.IsLearner() && info.FullMethod != snapshotMethod { // learner does not support stream RPC except Snapshot
 			return rpctypes.ErrGPRCNotSupportedForLearner
 		}
 


### PR DESCRIPTION
In order to reduce the performance impact on voting member nodes (especially when the node's disk I/O is poor), some users and we want to perform regular snapshot backup on the learner node.