### PR TITLE
embed: support custom fallback handler

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -633,7 +633,11 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 			)
 		}(u)
 		for k := range cfg.UserHandlers {
-			sctx.userHandlers[k] = cfg.UserHandlers[k]
+			if k == "/" {
+				sctx.userFallbackHandler = cfg.UserHandlers[k]
+			} else {
+				sctx.userHandlers[k] = cfg.UserHandlers[k]
+			}
 		}
 		sctx.serviceRegister = cfg.ServiceRegister
 		if cfg.EnablePprof || cfg.LogLevel == "debug" {

--- a/server/etcdserver/api/v2http/client.go
+++ b/server/etcdserver/api/v2http/client.go
@@ -97,7 +97,6 @@ func handleV2(lg *zap.Logger, mux *http.ServeMux, server etcdserver.ServerV2, ti
 		cluster:               server.Cluster(),
 		clientCertAuthEnabled: server.ClientCertAuthEnabled(),
 	}
-	mux.HandleFunc("/", http.NotFound)
 	mux.Handle(keysPrefix, kh)
 	mux.Handle(keysPrefix+"/", kh)
 	mux.HandleFunc(statsPrefix+"/store", sh.serveStore)


### PR DESCRIPTION
Programs that base on etcd may need to customize the fallback logic of http service, i.e. register a handler of pattern `"/"`.
However, under the current implementation, the handler of pattern `"/"` cannot be registered by userHandlers. This PR tries to solve this problem.
