### PR TITLE
etcdserver/mvcc: update tw.trace.Step condition

### DIFF
--- a/server/mvcc/kvstore_txn.go
+++ b/server/mvcc/kvstore_txn.go
@@ -182,8 +182,8 @@ func (tw *storeTxnWrite) put(key, value []byte, leaseID lease.LeaseID) {
 	if err == nil {
 		c = created.main
 		oldLease = tw.s.le.GetLease(lease.LeaseItem{Key: string(key)})
+		tw.trace.Step("get key's previous created_revision and leaseID")
 	}
-	tw.trace.Step("get key's previous created_revision and leaseID")
 	ibytes := newRevBytes()
 	idxRev := revision{main: rev, sub: int64(len(tw.changes))}
 	revToBytes(idxRev, ibytes)


### PR DESCRIPTION
It seems that `tw.trace.Step("get key's previous created_revision and leaseID")` is not in the right position.
When `err != nil` , which means we can not get key's previous created_revision and leaseID,
the tracer would still `Step("get key's previous created_revision and leaseID")`, making it not so accurate.
So i move it into the `if` condition so it would trace when `err == nil` condition hit.