### PR TITLE
20210429 etcdctl v2 backup cindex fix

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -110,8 +110,12 @@ func BeforeTest(t TB) {
 // It will detect common goroutine leaks, retrying in case there are goroutines
 // not synchronously torn down, and fail the test if any goroutines are stuck.
 func AfterTest(t TB) {
-	if err := CheckAfterTest(1 * time.Second); err != nil {
-		t.Errorf("Test %v", err)
+	// If test-failed the leaked goroutines list is hidding the real
+	// source of problem.
+	if !t.Failed() {
+		if err := CheckAfterTest(1 * time.Second); err != nil {
+			t.Errorf("Test %v", err)
+		}
 	}
 }
 

--- a/client/pkg/testutil/testutil.go
+++ b/client/pkg/testutil/testutil.go
@@ -53,8 +53,9 @@ func MustNewURL(t *testing.T, s string) *url.URL {
 func FatalStack(t *testing.T, s string) {
 	stackTrace := make([]byte, 1024*1024)
 	n := runtime.Stack(stackTrace, true)
+	t.Errorf("---> Test failed: %s", s)
 	t.Error(string(stackTrace[:n]))
-	t.Fatalf(s)
+	t.Fatal(s)
 }
 
 // ConditionFunc returns true when a condition is met.

--- a/etcdctl/ctlv3/command/migrate_command.go
+++ b/etcdctl/ctlv3/command/migrate_command.go
@@ -36,6 +36,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2error"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2store"
+	"go.etcd.io/etcd/server/v3/etcdserver/cindex"
 	"go.etcd.io/etcd/server/v3/mvcc"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
 	"go.etcd.io/etcd/server/v3/wal"
@@ -91,7 +92,7 @@ func migrateCommandFunc(cmd *cobra.Command, args []string) {
 	}()
 
 	readKeys(reader, be)
-	mvcc.UpdateConsistentIndex(be, index)
+	cindex.UpdateConsistentIndex(be.BatchTx(), index)
 	err := <-errc
 	if err != nil {
 		fmt.Println("failed to transform keys")

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -229,6 +229,9 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		if err = e.Server.CheckInitialHashKV(); err != nil {
 			// set "EtcdServer" to nil, so that it does not block on "EtcdServer.Close()"
 			// (nothing to close since rafthttp transports have not been started)
+
+			e.cfg.logger.Error("checkInitialHashKV failed", zap.Error(err))
+			e.Server.Cleanup()
 			e.Server = nil
 			return e, err
 		}

--- a/server/etcdserver/cindex/cindex_test.go
+++ b/server/etcdserver/cindex/cindex_test.go
@@ -34,7 +34,7 @@ func TestConsistentIndex(t *testing.T) {
 		t.Fatal("batch tx is nil")
 	}
 	tx.Lock()
-	tx.UnsafeCreateBucket(metaBucketName)
+	UnsafeCreateMetaBucket(tx)
 	tx.Unlock()
 	be.ForceCommit()
 	r := rand.Uint64()
@@ -50,6 +50,7 @@ func TestConsistentIndex(t *testing.T) {
 	be.Close()
 
 	b := backend.NewDefaultBackend(tmpPath)
+	defer b.Close()
 	ci.SetConsistentIndex(0)
 	ci.SetBatchTx(b.BatchTx())
 	index = ci.ConsistentIndex()
@@ -62,8 +63,6 @@ func TestConsistentIndex(t *testing.T) {
 	if index != r {
 		t.Errorf("expected %d,got %d", r, index)
 	}
-	b.Close()
-
 }
 
 func TestFakeConsistentIndex(t *testing.T) {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2256,6 +2256,9 @@ func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, confState *raftpb.Con
 func (s *EtcdServer) snapshot(snapi uint64, confState raftpb.ConfState) {
 	clone := s.v2store.Clone()
 	// commit kv to write metadata (for example: consistent index) to disk.
+	//
+	// This guarantees that Backend's consistent_index is >= index of last snapshot.
+	//
 	// KV().commit() updates the consistent index in backend.
 	// All operations that update consistent index must be called sequentially
 	// from applyAll function.

--- a/server/mvcc/kvstore.go
+++ b/server/mvcc/kvstore.go
@@ -35,9 +35,8 @@ import (
 
 var (
 	keyBucketName  = []byte("key")
-	metaBucketName = []byte("meta")
+	metaBucketName = cindex.MetaBucketName
 
-	consistentIndexKeyName  = []byte("consistent_index")
 	scheduledCompactKeyName = []byte("scheduledCompactRev")
 	finishedCompactKeyName  = []byte("finishedCompactRev")
 
@@ -128,7 +127,7 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, ci cindex.Cons
 	tx := s.b.BatchTx()
 	tx.Lock()
 	tx.UnsafeCreateBucket(keyBucketName)
-	tx.UnsafeCreateBucket(metaBucketName)
+	cindex.UnsafeCreateMetaBucket(tx)
 	tx.Unlock()
 	s.b.ForceCommit()
 
@@ -308,7 +307,7 @@ func init() {
 	DefaultIgnores = map[backend.IgnoreKey]struct{}{
 		// consistent index might be changed due to v2 internal sync, which
 		// is not controllable by the user.
-		{Bucket: string(metaBucketName), Key: string(consistentIndexKeyName)}: {},
+		{Bucket: string(metaBucketName), Key: string(cindex.ConsistentIndexKeyName)}: {},
 	}
 }
 

--- a/server/mvcc/util.go
+++ b/server/mvcc/util.go
@@ -15,32 +15,11 @@
 package mvcc
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
 )
-
-func UpdateConsistentIndex(be backend.Backend, index uint64) {
-	tx := be.BatchTx()
-	tx.Lock()
-	defer tx.Unlock()
-
-	var oldi uint64
-	_, vs := tx.UnsafeRange(metaBucketName, consistentIndexKeyName, nil, 0)
-	if len(vs) != 0 {
-		oldi = binary.BigEndian.Uint64(vs[0])
-	}
-
-	if index <= oldi {
-		return
-	}
-
-	bs := make([]byte, 8)
-	binary.BigEndian.PutUint64(bs, index)
-	tx.UnsafePut(metaBucketName, consistentIndexKeyName, bs)
-}
 
 func WriteKV(be backend.Backend, kv mvccpb.KeyValue) {
 	ibytes := newRevBytes()

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -20,17 +20,14 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
 func BeforeTestV2(t testing.TB) {
-	skipInShortMode(t)
+	BeforeTest(t)
 	os.Setenv("ETCDCTL_API", "2")
 	t.Cleanup(func() {
 		os.Unsetenv("ETCDCTL_API")
 	})
-	testutil.BeforeTest(t)
 }
 
 func TestCtlV2Set(t *testing.T)          { testCtlV2Set(t, newConfigNoTLS(), false) }
@@ -493,7 +490,11 @@ func etcdctlBackup(t testing.TB, clus *etcdProcessCluster, dataDir, backupDir st
 	if err != nil {
 		return err
 	}
-	return proc.Close()
+	err = proc.Close()
+	if err != nil {
+		return err
+	}
+	return proc.ProcessError()
 }
 
 func setupEtcdctlTest(t *testing.T, cfg *etcdProcessClusterConfig, quorum bool) *etcdProcessCluster {

--- a/tests/e2e/ctl_v3_migrate_test.go
+++ b/tests/e2e/ctl_v3_migrate_test.go
@@ -23,10 +23,13 @@ import (
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/verify"
 )
 
 func BeforeTest(t testing.TB) {
+	skipInShortMode(t)
 	testutil.BeforeTest(t)
+	os.Setenv(verify.ENV_VERIFY, verify.ENV_VERIFY_ALL_VALUE)
 }
 
 func TestCtlV3Migrate(t *testing.T) {

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -250,6 +250,7 @@ func testCtl(t *testing.T, testFunc func(ctlCtx), opts ...ctlOption) {
 		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
 	case <-donec:
 	}
+	t.Log("---Test logic DONE")
 }
 
 func (cx *ctlCtx) prefixArgs(eps []string) []string {


### PR DESCRIPTION
Fix `ETCDCTL_API=2 etcdctl backup --with-v3` consistent index consistency

Prior to this CL, `ETCDCTL_API=2 etcdctl backup --with-v3` was readacting WAL log
(by removal of some entries), but was NOT updating consistent_index in the backend.
Also the WAL editing logic was buggy, as it didn't took in consideration the fact
that when TERM changes, there can be entries with duplicated indexes in
the log. So its NOT sufficient to subtract number of removed entries to
get accurate log indexes.

The PR replaces removing and shifting of WAL entries with replacing them with an no-op entries.
Thanks to this consistent-index references are staying up to date.

The PR also:
  - updates 'verification' logic to check whether consistent_index does not lag befor last snapshot
  - env-gated execution of verification framework in `etcdctl backup`.

Tested with:
```
(./build.sh && cd tests && EXPECT_DEBUG=TRUE 'env' 'go' 'test' '-timeout=300m' 'go.etcd.io/etcd/tests/v3/e2e' -run=TestCtlV2Backup --count=1000 2>&1 | tee TestCtlV2BackupV3.log)
```

