### PR TITLE
Migrate PR testing from travis to GitHub actions

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,78 @@
+name: Unit Tests
+on: [push]
+jobs:
+  test:
+    # TODO: Remove continue-on-error after migrating from Travis to GitHub Actions
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        # TODO: Add tip when https://github.com/actions/setup-go/issues/21 is resolved
+        go: [1.16.3]
+        target:
+        - linux-amd64-fmt
+        - linux-amd64-grpcproxy
+        - linux-amd64-coverage
+        - linux-amd64-integration-1-cpu
+        - linux-amd64-integration-2-cpu
+        - linux-amd64-integration-4-cpu
+        - linux-amd64-functional
+        - linux-amd64-unit-4-cpu-race
+        - all-build
+        - linux-amd64-fmt-unit-go-tip-2-cpu
+        - linux-386-unit-1-cpu
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-fmt)
+            GOARCH=amd64 PASSES='fmt bom dep' ./test.sh
+            ;;
+          linux-amd64-integration-1-cpu)
+            GOARCH=amd64 CPU=1 PASSES='integration' RACE='false' ./test.sh
+            ;;
+          linux-amd64-integration-2-cpu)
+            GOARCH=amd64 CPU=2 PASSES='integration' RACE='false' ./test.sh
+            ;;
+          linux-amd64-integration-4-cpu)
+            GOARCH=amd64 CPU=4 PASSES='integration' RACE='false' ./test.sh
+            ;;
+          linux-amd64-functional)
+            GO_BUILD_FLAGS='-v -mod=readonly' ./build && GOARCH=amd64 PASSES='functional' ./test
+            ;;
+          linux-amd64-unit-4-cpu-race)
+            GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test.sh -p=2
+            ;;
+          all-build)
+            GOARCH=amd64 PASSES='build' ./test.sh
+            GOARCH=386 PASSES='build' ./test.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=amd64 ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOOS=windows GOARCH=amd64 ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm64 ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=ppc64le ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=s390x ./build.sh
+            ;;
+          linux-amd64-grpcproxy)
+            PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ;;
+          linux-amd64-coverage)
+            ./scripts/codecov_upload.sh test-coverage.log \
+            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-coverage.log
+            ;;
+          linux-amd64-fmt-unit-go-tip-2-cpu)
+            GOARCH=amd64 PASSES='fmt unit' CPU='2' RACE='false' ./test.sh -p=2
+            ;;
+          linux-386-unit-1-cpu)
+            GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4
+            ;;
+        esac


### PR DESCRIPTION
This PR executes on first stage of plan presented in https://github.com/etcd-io/etcd/issues/12921
It adds GitHub actions to run unit tests that will shadow [Travis configuration](https://github.com/etcd-io/etcd/blob/master/.travis.yml).

Differences from travis config:
* Removed executing docker to run tests in container - this simplifies setup 
* Tests are not executed against Go tip version as this not supported https://github.com/actions/setup-go/issues/21
* Tests have "continue-on-error" enabled which means they are allowed to fail - We should not block ongoing PRs until we stabilize new configuration

Proposed configuration shadows existing Travis CI config as much as possible. There are multiple possible improvements/simplifications to be done, but those should be postponed to avoid too cost of managing two totally different configs.