### PR TITLE
server/etcdmain: officially supports "arm64"

### DIFF
--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -463,8 +463,11 @@ func identifyDataDirOrDie(lg *zap.Logger, dir string) dirType {
 }
 
 func checkSupportArch() {
-	// TODO qualify arm64
-	if runtime.GOARCH == "amd64" || runtime.GOARCH == "ppc64le" || runtime.GOARCH == "s390x" {
+	// to add a new platform, check https://github.com/etcd-io/website/blob/master/content/en/docs/next/op-guide/supported-platform.md
+	if runtime.GOARCH == "amd64" ||
+		runtime.GOARCH == "arm64" ||
+		runtime.GOARCH == "ppc64le" ||
+		runtime.GOARCH == "s390x" {
 		return
 	}
 	// unsupported arch only configured via environment variable


### PR DESCRIPTION
- Integration and end-to-end tests are passing (ref. https://github.com/etcd-io/etcd/pull/12928)
- I've been extensively testing etcd on arm64 and so far, haven't faced any critical issue.
- I am proposing to have tiered support system https://github.com/etcd-io/website/pull/273, listing myself as a maintainer. arm64 will be tier-2 for now, until we run more functional tests. But, it should be now marked as officially supported since it's the only platform other than amd64, that runs and passes all integration tests.