### PR TITLE
github actions: Make github actions go1.16.3 tests blocking and remove them from travis

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,9 +1,7 @@
-name: Unit Tests
+name: Tests
 on: [push, pull_request]
 jobs:
   test:
-    # TODO: Remove continue-on-error after migrating from Travis to GitHub Actions
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -13,14 +11,12 @@ jobs:
         target:
         - linux-amd64-fmt
         - linux-amd64-grpcproxy
-        - linux-amd64-coverage
         - linux-amd64-integration-1-cpu
         - linux-amd64-integration-2-cpu
         - linux-amd64-integration-4-cpu
         - linux-amd64-functional
         - linux-amd64-unit-4-cpu-race
         - all-build
-        - linux-amd64-fmt-unit-go-tip-2-cpu
         - linux-386-unit-1-cpu
     steps:
     - uses: actions/checkout@v2
@@ -64,13 +60,6 @@ jobs:
           linux-amd64-grpcproxy)
             PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
             ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
-            ;;
-          linux-amd64-coverage)
-            ./scripts/codecov_upload.sh test-coverage.log \
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-coverage.log
-            ;;
-          linux-amd64-fmt-unit-go-tip-2-cpu)
-            GOARCH=amd64 PASSES='fmt unit' CPU='2' RACE='false' ./test.sh -p=2
             ;;
           linux-386-unit-1-cpu)
             GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,8 @@ notifications:
 
 env:
   matrix:
-    - TARGET=linux-amd64-fmt
-    - TARGET=linux-amd64-integration-1-cpu
-    - TARGET=linux-amd64-integration-2-cpu
-    - TARGET=linux-amd64-integration-4-cpu
-    - TARGET=linux-amd64-functional
-    - TARGET=linux-amd64-unit-4-cpu-race
-    - TARGET=all-build
-    - TARGET=linux-amd64-grpcproxy
     - TARGET=linux-amd64-coverage
     - TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
-    - TARGET=linux-386-unit-1-cpu
 
 matrix:
   fast_finish: true
@@ -36,27 +27,9 @@ matrix:
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
   exclude:
     - go: tip
-      env: TARGET=linux-amd64-fmt
-    - go: tip
-      env: TARGET=linux-amd64-integration-1-cpu
-    - go: tip
-      env: TARGET=linux-amd64-integration-2-cpu
-    - go: tip
-      env: TARGET=linux-amd64-integration-4-cpu
-    - go: tip
-      env: TARGET=linux-amd64-functional
-    - go: tip
-      env: TARGET=linux-amd64-unit-4-cpu-race
-    - go: tip
-      env: TARGET=all-build
-    - go: tip
-      env: TARGET=linux-amd64-grpcproxy
-    - go: tip
       env: TARGET=linux-amd64-coverage
-    - go: 1.14.3
+    - go: 1.16.3
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
-    - go: tip
-      env: TARGET=linux-386-unit-1-cpu
 
 before_install:
   - if [[ $TRAVIS_GO_VERSION == 1.* ]]; then docker pull gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION}; fi
@@ -69,60 +42,10 @@ script:
   - echo "TRAVIS_GO_VERSION=${TRAVIS_GO_VERSION}"
   - >
     case "${TARGET}" in
-      linux-amd64-fmt)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='fmt bom dep' ./test.sh"
-        ;;
-      linux-amd64-integration-1-cpu)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 CPU=1 PASSES='integration' RACE='false' ./test.sh"
-        ;;
-      linux-amd64-integration-2-cpu)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 CPU=2 PASSES='integration' RACE='false' ./test.sh"
-        ;;
-      linux-amd64-integration-4-cpu)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 CPU=4 PASSES='integration' RACE='true' ./test.sh"
-        ;;
-      linux-amd64-functional)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GO_BUILD_FLAGS='-v -mod=readonly' ./build && GOARCH=amd64 PASSES='functional' ./test"
-        ;;
-      linux-amd64-unit-4-cpu-race)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test.sh -p=2"
-        ;;
-      all-build)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=amd64 PASSES='build' ./test.sh \
-            && GOARCH=386 PASSES='build' ./test.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=amd64 ./build.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOOS=windows GOARCH=amd64 ./build.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm ./build.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm64 ./build.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=ppc64le ./build.sh \
-            && GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=s390x ./build.sh"
-        ;;
-      linux-amd64-grpcproxy)
-        sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true'" make docker-test
-        ;;
       linux-amd64-coverage)
         sudo HOST_TMP_DIR=/tmp TEST_OPTS="VERBOSE='1'" make docker-test-coverage
         ;;
       linux-amd64-fmt-unit-go-tip-2-cpu)
         GOARCH=amd64 PASSES='fmt unit' CPU='2' RACE='false' ./test.sh -p=2
-        ;;
-      linux-386-unit-1-cpu)
-        docker run --rm \
-          --volume=`pwd`:/go/src/go.etcd.io/etcd gcr.io/etcd-development/etcd-test:go${TRAVIS_GO_VERSION} \
-          /bin/bash -c "GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4"
         ;;
     esac


### PR DESCRIPTION
Implements stage 2 and 3a of https://github.com/etcd-io/etcd/issues/12921. As discussed on https://github.com/etcd-io/etcd/pull/12936 we will want to wait to collect more data from runs and merge it tomorrow. 

Changes
* Move coverage to separate job with "continue-on-error" to allow it to fail
* Leave GO tip tests in travis as they are not yet supported

@ptabor 
@xiang90 
@gyuho 


