### PR TITLE
Run e2e tests with: EXPECT_DEBUG='true'

### DIFF
--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -8,10 +8,10 @@ fi
 <<COMMENT
 # amd64-e2e
 tests/semaphore.test.bash
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7" EXPECT_DEBUG='true' make docker-test
 
 # 386-e2e
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" EXPECT_DEBUG='true' make docker-test
 COMMENT
 
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7" make docker-test
+sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7 EXPECT_DEBUG='true'" make docker-test


### PR DESCRIPTION
The motivation is need to diagnose flakes like:
https://semaphoreci.com/etcd-io/etcd/branches/pull-request-12940/builds/2.

Now - when the logs are streamed through testing.T logger, the verbosity is not that significant concern.