### PR TITLE
client: Allow setting zap logger in config

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -99,6 +99,9 @@ func NewFromURLs(urls []string) (*Client, error) {
 }
 
 // WithLogger overrides the logger.
+//
+// Deprecated: Please use Logger field in clientv3.Config
+//
 // Does not changes grpcLogger, that can be explicitly configured
 // using grpc_zap.ReplaceGrpcLoggerV2(..) method.
 func (c *Client) WithLogger(lg *zap.Logger) *Client {
@@ -331,7 +334,9 @@ func newClient(cfg *Config) (*Client, error) {
 	}
 
 	var err error
-	if cfg.LogConfig != nil {
+	if cfg.Logger != nil {
+		client.lg = cfg.Logger
+	} else if cfg.LogConfig != nil {
 		client.lg, err = cfg.LogConfig.Build()
 	} else {
 		client.lg, err = createDefaultZapLogger()

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -29,11 +29,8 @@ import (
 )
 
 func NewClient(t *testing.T, cfg Config) (*Client, error) {
-	client, err := New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return client.WithLogger(zaptest.NewLogger(t)), nil
+	cfg.Logger = zaptest.NewLogger(t)
+	return New(cfg)
 }
 
 func TestDialCancel(t *testing.T) {

--- a/client/v3/config.go
+++ b/client/v3/config.go
@@ -76,6 +76,10 @@ type Config struct {
 	// other operations that do not have an explicit context.
 	Context context.Context
 
+	// Logger sets client-side logger.
+	// If nil, fallback to building LogConfig.
+	Logger *zap.Logger
+
 	// LogConfig configures client-side logger.
 	// If nil, use the default logger.
 	// TODO: configure gRPC logger

--- a/client/v3/snapshot/v3_snapshot.go
+++ b/client/v3/snapshot/v3_snapshot.go
@@ -47,6 +47,7 @@ func Save(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, dbPath strin
 	if lg == nil {
 		lg = zap.NewExample()
 	}
+	cfg.Logger = lg.Named("client")
 	if len(cfg.Endpoints) != 1 {
 		return fmt.Errorf("snapshot must be requested to one selected node, not multiple %v", cfg.Endpoints)
 	}
@@ -55,8 +56,6 @@ func Save(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, dbPath strin
 		return err
 	}
 	defer cli.Close()
-
-	cli = cli.WithLogger(lg.Named("client"))
 
 	partpath := dbPath + ".part"
 	defer os.RemoveAll(partpath)

--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -115,12 +115,12 @@ func epHealthCommandFunc(cmd *cobra.Command, args []string) {
 		go func(cfg *v3.Config) {
 			defer wg.Done()
 			ep := cfg.Endpoints[0]
+			cfg.Logger = lg.Named("client")
 			cli, err := v3.New(*cfg)
 			if err != nil {
 				hch <- epHealth{Ep: ep, Health: false, Error: err.Error()}
 				return
 			}
-			cli = cli.WithLogger(lg.Named("client"))
 			st := time.Now()
 			// get a random key. As long as we can get the response without an error, the
 			// endpoint is health.

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -119,13 +119,13 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 		Endpoints:   []string{eps[0]},
 		DialTimeout: 3 * time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		Logger:      zaptest.NewLogger(t).Named("client"),
 	}
 	cli, err := integration.NewClient(t, ccfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cli.Close()
-	cli = cli.WithLogger(zaptest.NewLogger(t).Named("client"))
 	// wait for eps[0] to be pinned
 	clientv3test.MustWaitPinReady(t, cli)
 

--- a/tests/integration/cluster_direct.go
+++ b/tests/integration/cluster_direct.go
@@ -41,9 +41,6 @@ func toGRPC(c *clientv3.Client) grpcAPI {
 }
 
 func newClientV3(cfg clientv3.Config, lg *zap.Logger) (*clientv3.Client, error) {
-	c, err := clientv3.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return c.WithLogger(lg), nil
+	cfg.Logger = lg
+	return clientv3.New(cfg)
 }

--- a/tests/integration/cluster_proxy.go
+++ b/tests/integration/cluster_proxy.go
@@ -109,11 +109,11 @@ func (pc *proxyCloser) Close() error {
 }
 
 func newClientV3(cfg clientv3.Config, lg *zap.Logger) (*clientv3.Client, error) {
+	cfg.Logger = lg
 	c, err := clientv3.New(cfg)
 	if err != nil {
 		return nil, err
 	}
-	c = c.WithLogger(lg)
 	rpc := toGRPC(c)
 	c.KV = clientv3.NewKVFromKVClient(rpc.KV, c)
 	pmu.Lock()

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -35,7 +35,6 @@ import (
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/tests/v3/integration"
-	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -166,8 +165,6 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 		t.Fatal(err)
 	}
 	defer cli.Close()
-
-	cli = cli.WithLogger(zaptest.NewLogger(t))
 
 	// open watch connection
 	cli.Watch(context.Background(), "foo")

--- a/tests/integration/testing.go
+++ b/tests/integration/testing.go
@@ -73,9 +73,8 @@ func NewEmbedConfig(t testing.TB, name string) *embed.Config {
 }
 
 func NewClient(t testing.TB, cfg clientv3.Config) (*clientv3.Client, error) {
-	client, err := clientv3.New(cfg)
-	if err != nil {
-		return nil, err
+	if cfg.Logger != nil {
+		cfg.Logger = zaptest.NewLogger(t)
 	}
-	return client.WithLogger(zaptest.NewLogger(t)), nil
+	return clientv3.New(cfg)
 }


### PR DESCRIPTION
Support direct passing logger to clientv3. 
Ref https://github.com/etcd-io/etcd/issues/12326

clientv3 technically allows to achieve this by using `c := c.WIthLogger(logger)`, but this is error prone as some objects take logger before wrapping. 

cc @ptabor 