### PR TITLE
github actions: Move e2e to separate workflow and remove semaphoreci

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,35 @@
+name: E2E
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-e2e
+        - linux-386-e2e
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.4
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-e2e)
+            PASSES='build release e2e' MANUAL_VER=v3.4.7 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ;;
+          linux-386-e2e)
+            GOARCH=386 PASSES='build e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,8 +14,6 @@ jobs:
         - linux-amd64-integration-4-cpu
         - linux-amd64-functional
         - linux-amd64-unit-4-cpu-race
-        - linux-amd64-e2e
-        - linux-386-e2e
         - all-build
         - linux-386-unit-1-cpu
     steps:
@@ -63,14 +61,6 @@ jobs:
             ;;
           linux-386-unit-1-cpu)
             GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4
-            ;;
-          linux-amd64-e2e)
-            PASSES='build release e2e' MANUAL_VER=v3.4.7 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
-            ;;
-          linux-386-e2e)
-            GOARCH=386 PASSES='build e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           *)
             echo "Failed to find target"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/etcd-io/etcd?style=flat-square)](https://goreportcard.com/report/github.com/etcd-io/etcd)
 [![Coverage](https://codecov.io/gh/etcd-io/etcd/branch/master/graph/badge.svg)](https://codecov.io/gh/etcd-io/etcd)
 [![Tests](https://github.com/etcd-io/etcd/actions/workflows/tests.yaml/badge.svg)](https://github.com/etcd-io/etcd/actions/workflows/tests.yaml)
-[![Build Status Semaphore](https://semaphoreci.com/api/v1/etcd-io/etcd/branches/master/shields_badge.svg)](https://semaphoreci.com/etcd-io/etcd)
 [![Docs](https://img.shields.io/badge/docs-latest-green.svg)](https://etcd.io/docs)
 [![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/etcd-io/etcd)
 [![Releases](https://img.shields.io/github/release/etcd-io/etcd/all.svg?style=flat-square)](https://github.com/etcd-io/etcd/releases)

--- a/tests/semaphore.test.bash
+++ b/tests/semaphore.test.bash
@@ -1,17 +1,4 @@
 #!/usr/bin/env bash
 
-if ! [[ "$0" =~ "tests/semaphore.test.bash" ]]; then
-  echo "must be run from repository root"
-  exit 255
-fi
-
-<<COMMENT
-# amd64-e2e
-tests/semaphore.test.bash
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7" EXPECT_DEBUG='true' make docker-test
-
-# 386-e2e
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="GOARCH=386 PASSES='build e2e'" EXPECT_DEBUG='true' make docker-test
-COMMENT
-
-sudo HOST_TMP_DIR=/tmp TEST_OPTS="PASSES='build release e2e' MANUAL_VER=v3.4.7 EXPECT_DEBUG='true'" make docker-test
+# Placeholder until SemaphoreCI is disabled
+# E2e tests were migrated to GitHub Actions


### PR DESCRIPTION
Follow up from https://github.com/etcd-io/etcd/pull/12947
cc @ptabor 