### PR TITLE
*: rename "master" branch references to "main" in source code

### DIFF
--- a/.github/ISSUE_TEMPLATE/distributors-application.md
+++ b/.github/ISSUE_TEMPLATE/distributors-application.md
@@ -20,9 +20,9 @@ meeting the membership criteria.
 **4. Be a participant and active contributor in the community.**
 
 **5. Accept the Embargo Policy.**
-<!-- https://github.com/etcd-io/etcd/blob/master/security/security-release-process.md#disclosures -->
+<!-- https://github.com/etcd-io/etcd/blob/main/security/security-release-process.md#disclosures -->
 
 **6. Be willing to contribute back.**
-<!-- Per https://github.com/etcd-io/etcd/blob/master/security/security-release-process.md#patch-release-and-public-communication -->
+<!-- Per https://github.com/etcd-io/etcd/blob/main/security/security-release-process.md#patch-release-and-public-communication -->
 
 **7. Have someone already on the list vouch for the person requesting membership on behalf of your distribution.**

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,2 +1,2 @@
 
-Please read https://github.com/etcd-io/etcd/blob/master/security/README.md.
+Please read https://github.com/etcd-io/etcd/blob/main/security/README.md.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, release-0.4, release-2.0, release-2.1, release-2.2, release-2.3, release-3.0, release-3.1 ]
+    branches: [ main, release-0.4, release-2.0, release-2.1, release-2.2, release-2.3, release-3.0, release-3.1 ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '20 14 * * 5'
 

--- a/.github/workflows/self-hosted-linux-arm64-graviton2-tests.yml
+++ b/.github/workflows/self-hosted-linux-arm64-graviton2-tests.yml
@@ -2,9 +2,9 @@ name: Linux ARM64 Graviton2
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.0](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.0.md).
+Previous change logs can be found at [CHANGELOG-3.0](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.0.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.1.11+, 3.2.26+, and 3.3.11+.
@@ -21,7 +21,7 @@ The minimum recommended etcd versions to run in **production** are 3.1.11+, 3.2.
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -44,7 +44,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.19...v3.1.20) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -88,7 +88,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.18...v3.1.19) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -130,7 +130,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.17...v3.1.18) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -214,7 +214,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.13...v3.1.14) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -254,7 +254,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.12...v3.1.13) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.1](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.1.md).
+Previous change logs can be found at [CHANGELOG-3.1](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.1.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.
@@ -90,7 +90,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.28...v3.2.29) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 - Add [`etcd_server_client_requests_total` with `"type"` and `"client_api_version"` labels](https://github.com/etcd-io/etcd/pull/11687).
 
@@ -110,7 +110,7 @@ See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -150,7 +150,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -203,7 +203,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.24...v3.2.25) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -247,7 +247,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.23...v3.2.24) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -307,7 +307,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.22...v3.2.23) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -393,7 +393,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.18...v3.2.19) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -442,7 +442,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.17...v3.2.18) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -749,7 +749,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.5...v3.2.6) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -781,7 +781,7 @@ See [security doc](https://etcd.io/docs/latest/op-guide/security/) for more deta
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -900,7 +900,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.0...v3.2.1) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -943,7 +943,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.1.0...v3.2.0) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.2](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.2.md).
+Previous change logs can be found at [CHANGELOG-3.2](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.2.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.
@@ -166,7 +166,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.18...v3.3.19) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 - Add [`etcd_server_client_requests_total` with `"type"` and `"client_api_version"` labels](https://github.com/etcd-io/etcd/pull/11687).
 
@@ -186,7 +186,7 @@ See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -236,7 +236,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.15...v3.3.16) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -348,7 +348,7 @@ NOTE: This patch release had to include some new features from 3.4, while trying
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -377,9 +377,9 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 ### Package `pkg/adt`
 
 - Change [`pkg/adt.IntervalTree` from `struct` to `interface`](https://github.com/etcd-io/etcd/pull/10959).
-  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/master/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
+  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/main/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
 - Improve [`pkg/adt.IntervalTree` test coverage](https://github.com/etcd-io/etcd/pull/10959).
-  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/master/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
+  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/main/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
 - Fix [Red-Black tree to maintain black-height property](https://github.com/etcd-io/etcd/pull/10978).
   - Previously, delete operation violates [black-height property](https://github.com/etcd-io/etcd/issues/10965).
 
@@ -405,7 +405,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.12...v3.3.13) an
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -487,7 +487,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.9...v3.3.10) and
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -534,7 +534,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.8...v3.3.9) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -671,7 +671,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.3...v3.3.4) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -734,7 +734,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.2...v3.3.3) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
@@ -866,7 +866,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.2.0...v3.3.0) and 
 
 ### Metrics, Monitoring
 
-See [List of metrics](https://github.com/etcd-io/etcd/tree/master/Documentation/metrics) for all metrics per release.
+See [List of metrics](https://github.com/etcd-io/etcd/tree/main/Documentation/metrics) for all metrics per release.
 
 Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md).
+Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.3.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.
@@ -498,7 +498,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.0...v3.4.0) and 
 - Make etcd server return `raft.ErrProposalDropped` on internal Raft proposal drop in [v3 applier](https://github.com/etcd-io/etcd/pull/9549) and [v2 applier](https://github.com/etcd-io/etcd/pull/9558).
   - e.g. a node is removed from cluster, or [`raftpb.MsgProp` arrives at current leader while there is an ongoing leadership transfer](https://github.com/etcd-io/etcd/issues/8975).
 - Add [`snapshot`](https://github.com/etcd-io/etcd/pull/9118) package for easier snapshot workflow (see [`godoc.org/github.com/etcd/clientv3/snapshot`](https://godoc.org/github.com/etcd-io/etcd/clientv3/snapshot) for more).
-- Improve [functional tester](https://github.com/etcd-io/etcd/tree/master/functional) coverage: [proxy layer to run network fault tests in CI](https://github.com/etcd-io/etcd/pull/9081), [TLS is enabled both for server and client](https://github.com/etcd-io/etcd/pull/9534), [liveness mode](https://github.com/etcd-io/etcd/issues/9230), [shuffle test sequence](https://github.com/etcd-io/etcd/issues/9381), [membership reconfiguration failure cases](https://github.com/etcd-io/etcd/pull/9564), [disastrous quorum loss and snapshot recover from a seed member](https://github.com/etcd-io/etcd/pull/9565), [embedded etcd](https://github.com/etcd-io/etcd/pull/9572).
+- Improve [functional tester](https://github.com/etcd-io/etcd/tree/main/functional) coverage: [proxy layer to run network fault tests in CI](https://github.com/etcd-io/etcd/pull/9081), [TLS is enabled both for server and client](https://github.com/etcd-io/etcd/pull/9534), [liveness mode](https://github.com/etcd-io/etcd/issues/9230), [shuffle test sequence](https://github.com/etcd-io/etcd/issues/9381), [membership reconfiguration failure cases](https://github.com/etcd-io/etcd/pull/9564), [disastrous quorum loss and snapshot recover from a seed member](https://github.com/etcd-io/etcd/pull/9565), [embedded etcd](https://github.com/etcd-io/etcd/pull/9572).
 - Improve [index compaction blocking](https://github.com/etcd-io/etcd/pull/9511) by using a copy on write clone to avoid holding the lock for the traversal of the entire index.
 - Update [JWT methods](https://github.com/etcd-io/etcd/pull/9883) to allow for use of any supported signature method/algorithm.
 - Add [Lease checkpointing](https://github.com/etcd-io/etcd/pull/9924) to persist remaining TTLs to the consensus log periodically so that long lived leases progress toward expiry in the presence of leader elections and server restarts.
@@ -605,7 +605,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.3.0...v3.4.0) and 
   - `"github.com/coreos/etcd/store"` to `"go.etcd.io/etcd/etcdserver/api/v2store"`.
 - Change [snapshot file permissions](https://github.com/etcd-io/etcd/pull/9977): On Linux, the snapshot file changes from readable by all (mode 0644) to readable by the user only (mode 0600).
 - Change [`pkg/adt.IntervalTree` from `struct` to `interface`](https://github.com/etcd-io/etcd/pull/10959).
-  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/master/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
+  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/main/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
 - Release branch `/version` defines version `3.4.x-pre`, instead of `3.4.y+git`.
   - Use `3.4.5-pre`, instead of `3.4.4+git`.
 
@@ -875,9 +875,9 @@ Note: **v3.5 will deprecate `etcd --log-package-levels` flag for `capnslog`**; `
 ### Package `pkg/adt`
 
 - Change [`pkg/adt.IntervalTree` from `struct` to `interface`](https://github.com/etcd-io/etcd/pull/10959).
-  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/master/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
+  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/main/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
 - Improve [`pkg/adt.IntervalTree` test coverage](https://github.com/etcd-io/etcd/pull/10959).
-  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/master/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
+  - See [`pkg/adt` README](https://github.com/etcd-io/etcd/tree/main/pkg/adt) and [`pkg/adt` godoc](https://godoc.org/go.etcd.io/etcd/pkg/adt).
 - Fix [Red-Black tree to maintain black-height property](https://github.com/etcd-io/etcd/pull/10978).
   - Previously, delete operation violates [black-height property](https://github.com/etcd-io/etcd/issues/10965).
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.4.md).
+Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.4.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.
@@ -64,9 +64,9 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.0...v3.5.0) and 
 - Changed `pkg/flags` function signature to [support structured logger](https://github.com/etcd-io/etcd/pull/11616).
   - Previously, `SetFlagsFromEnv(prefix string, fs *flag.FlagSet) error`, now `SetFlagsFromEnv(lg *zap.Logger, prefix string, fs *flag.FlagSet) error`.
   - Previously, `SetPflagsFromEnv(prefix string, fs *pflag.FlagSet) error`, now `SetPflagsFromEnv(lg *zap.Logger, prefix string, fs *pflag.FlagSet) error`.
-- ClientV3 supports [grpc resolver API](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/resolver/resolver.go).
-  - Endpoints can be managed using [endpoints.Manager](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/endpoints/endpoints.go)
-  - Previously supported [GRPCResolver was decomissioned](https://github.com/etcd-io/etcd/pull/12675). Use [resolver](https://github.com/etcd-io/etcd/blob/master/client/v3/naming/resolver/resolver.go) instead.
+- ClientV3 supports [grpc resolver API](https://github.com/etcd-io/etcd/blob/main/client/v3/naming/resolver/resolver.go).
+  - Endpoints can be managed using [endpoints.Manager](https://github.com/etcd-io/etcd/blob/main/client/v3/naming/endpoints/endpoints.go)
+  - Previously supported [GRPCResolver was decomissioned](https://github.com/etcd-io/etcd/pull/12675). Use [resolver](https://github.com/etcd-io/etcd/blob/main/client/v3/naming/resolver/resolver.go) instead.
 - Turned on [--pre-vote by default](https://github.com/etcd-io/etcd/pull/12770). Should prevent disrupting RAFT leader by an individual member. 
 - [ETCD_CLIENT_DEBUG env](https://github.com/etcd-io/etcd/pull/12786): Now supports log levels (debug, info, warn, error, dpanic, panic, fatal). Only when set, overrides application-wide grpc logging settings.
 - [Embed Etcd.Close()](https://github.com/etcd-io/etcd/pull/12828) needs to called exactly once and closes Etcd.Err() stream.

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,6 @@
 
 
-Previous change logs can be found at [CHANGELOG-3.x](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.x.md).
+Previous change logs can be found at [CHANGELOG-3.x](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.x.md).
 
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Reporting bugs is one of the best ways to contribute. However, a good bug report
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a topic branch from where to base the contribution. This is usually master.
+- Create a topic branch from where to base the contribution. This is usually main.
 - Make commits of logical units.
 - Make sure commit messages are in the proper format (see below).
 - Push changes in a topic branch to a personal fork of the repository.

--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,11 @@ docker-test-coverage:
 
 # Example:
 #   make compile-with-docker-test
-#   ETCD_VERSION=v3-test make build-docker-release-master
-#   ETCD_VERSION=v3-test make push-docker-release-master
+#   ETCD_VERSION=v3-test make build-docker-release-main
+#   ETCD_VERSION=v3-test make push-docker-release-main
 #   gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
 
-build-docker-release-master:
+build-docker-release-main:
 	$(info ETCD_VERSION: $(ETCD_VERSION))
 	cp ./Dockerfile-release.$(ARCH) ./bin/Dockerfile-release.$(ARCH)
 	docker build \
@@ -212,7 +212,7 @@ build-docker-release-master:
 	  gcr.io/etcd-development/etcd:$(ETCD_VERSION) \
 	  /bin/sh -c "/usr/local/bin/etcd --version && /usr/local/bin/etcdctl version"
 
-push-docker-release-master:
+push-docker-release-main:
 	$(info ETCD_VERSION: $(ETCD_VERSION))
 	docker push gcr.io/etcd-development/etcd:$(ETCD_VERSION)
 

--- a/client/v3/README.md
+++ b/client/v3/README.md
@@ -77,7 +77,7 @@ if err != nil {
 
 ## Metrics
 
-The etcd client optionally exposes RPC metrics through [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus). See the [examples](https://github.com/etcd-io/etcd/blob/master/tests/integration/clientv3/examples/example_metrics_test.go).
+The etcd client optionally exposes RPC metrics through [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus). See the [examples](https://github.com/etcd-io/etcd/blob/main/tests/integration/clientv3/examples/example_metrics_test.go).
 
 ## Namespacing
 
@@ -89,4 +89,4 @@ Client request size limit is configurable via `clientv3.Config.MaxCallSendMsgSiz
 
 ## Examples
 
-More code [examples](https://github.com/etcd-io/etcd/tree/master/tests/integration/clientv3/examples) can be found at [GoDoc](https://pkg.go.dev/go.etcd.io/etcd/client/v3).
+More code [examples](https://github.com/etcd-io/etcd/tree/main/tests/integration/clientv3/examples) can be found at [GoDoc](https://pkg.go.dev/go.etcd.io/etcd/client/v3).

--- a/client/v3/doc.go
+++ b/client/v3/doc.go
@@ -61,7 +61,7 @@
 //
 //  1. context error: canceled or deadline exceeded.
 //  2. gRPC error: e.g. when clock drifts in server-side before client's context deadline exceeded.
-//  See https://github.com/etcd-io/etcd/blob/master/api/v3rpc/rpctypes/error.go
+//  See https://github.com/etcd-io/etcd/blob/main/api/v3rpc/rpctypes/error.go
 //
 // Here is the example code to handle client errors:
 //

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -3,7 +3,7 @@ etcdctl
 
 `etcdctl` is a command line client for [etcd][etcd].
 
-The v3 API is used by default on master branch. For the v2 API, make sure to set environment variable `ETCDCTL_API=2`. See also [READMEv2][READMEv2].
+The v3 API is used by default on main branch. For the v2 API, make sure to set environment variable `ETCDCTL_API=2`. See also [READMEv2][READMEv2].
 
 If using released versions earlier than v3.4, set `ETCDCTL_API=3` to use v3 API.
 

--- a/etcdctl/READMEv2.md
+++ b/etcdctl/READMEv2.md
@@ -328,7 +328,7 @@ Releases will follow lockstep with the etcd release cycle.
 
 etcdctl is under the Apache 2.0 license. See the [LICENSE][license] file for details.
 
-[authentication]: https://github.com/etcd-io/website/blob/master/content/docs/v2/authentication.md
+[authentication]: https://github.com/etcd-io/website/blob/main/content/docs/v2/authentication.md
 [etcd]: https://github.com/coreos/etcd
 [github-release]: https://github.com/coreos/etcd/releases/
 [license]: ../LICENSE

--- a/etcdctl/ctlv2/command/member_commands.go
+++ b/etcdctl/ctlv2/command/member_commands.go
@@ -164,7 +164,7 @@ func actionMemberRemove(c *cli.Context) error {
 		if m.Name == removalID {
 			// Note that, so long as it's not ambiguous, we *could* do the right thing by name here.
 			fmt.Fprintf(os.Stderr, "Found a member named %s; if this is correct, please use its ID, eg:\n\tetcdctl member remove %s\n", m.Name, m.ID)
-			fmt.Fprintf(os.Stderr, "For more details, read the documentation at https://github.com/etcd-io/etcd/blob/master/Documentation/runtime-configuration.md#remove-a-member\n\n")
+			fmt.Fprintf(os.Stderr, "For more details, read the documentation at https://github.com/etcd-io/etcd/blob/main/Documentation/runtime-configuration.md#remove-a-member\n\n")
 		}
 	}
 	if !foundID {

--- a/hack/patch/README.md
+++ b/hack/patch/README.md
@@ -1,6 +1,6 @@
 # ./hack/patch/cherrypick.sh
 
-Handles cherry-picks of PR(s) from etcd master to a stable etcd release branch automatically.
+Handles cherry-picks of PR(s) from etcd main to a stable etcd release branch automatically.
 
 ## Setup
 

--- a/hack/tls-setup/README.md
+++ b/hack/tls-setup/README.md
@@ -5,7 +5,7 @@ Defaults generate an ECDSA-384 root and leaf certificates for `localhost`. etcd 
 **Instructions**
 
 1. Install git, go, and make
-2. Amend https://github.com/etcd-io/etcd/blob/master/hack/tls-setup/config/req-csr.json - IP's currently in the config should be replaced/added with IP addresses of each cluster node, please note 127.0.0.1 is always required for loopback purposes:
+2. Amend https://github.com/etcd-io/etcd/blob/main/hack/tls-setup/config/req-csr.json - IP's currently in the config should be replaced/added with IP addresses of each cluster node, please note 127.0.0.1 is always required for loopback purposes:
 ```json
 Example:
 {

--- a/raft/README.md
+++ b/raft/README.md
@@ -13,7 +13,7 @@ To keep the codebase small as well as provide flexibility, the library only impl
 
 In order to easily test the Raft library, its behavior should be deterministic. To achieve this determinism, the library models Raft as a state machine.  The state machine takes a `Message` as input. A message can either be a local timer update or a network message sent from a remote peer. The state machine's output is a 3-tuple `{[]Messages, []LogEntries, NextState}` consisting of an array of `Messages`, `log entries`, and `Raft state changes`. For state machines with the same state, the same state machine input should always generate the same state machine output.
 
-A simple example application, _raftexample_, is also available to help illustrate how to use this package in practice: https://github.com/etcd-io/etcd/tree/master/contrib/raftexample
+A simple example application, _raftexample_, is also available to help illustrate how to use this package in practice: https://github.com/etcd-io/etcd/tree/main/contrib/raftexample
 
 # Features
 

--- a/raft/doc.go
+++ b/raft/doc.go
@@ -23,7 +23,7 @@ For more details on Raft, see "In Search of an Understandable Consensus Algorith
 
 A simple example application, _raftexample_, is also available to help illustrate
 how to use this package in practice:
-https://github.com/etcd-io/etcd/tree/master/contrib/raftexample
+https://github.com/etcd-io/etcd/tree/main/contrib/raftexample
 
 Usage
 

--- a/scripts/release_mod.sh
+++ b/scripts/release_mod.sh
@@ -87,8 +87,8 @@ function push_mod_tags_cmd {
   log_info "REMOTE_REPO:  ${REMOTE_REPO}"
 
   # Any module ccan be used for this
-  local master_version
-  master_version=$(go list -f '{{.Version}}' -m "${ROOT_MODULE}/api/v3")
+  local main_version
+  main_version=$(go list -f '{{.Version}}' -m "${ROOT_MODULE}/api/v3")
   local tags=()
 
   keyid=$(get_gpg_key) || return 2
@@ -101,8 +101,8 @@ function push_mod_tags_cmd {
     local subdir="${path//${ROOT_MODULE}\//}"
     local tag
     if [ -z "${version}" ]; then
-      tag="${master_version}"
-      version="${master_version}"
+      tag="${main_version}"
+      version="${main_version}"
     else
       tag="${subdir///v[23]/}/${version}"
     fi

--- a/security/security-release-process.md
+++ b/security/security-release-process.md
@@ -102,7 +102,7 @@ With the Fix Development underway, the PSC needs to come up with an overall comm
 
 **Fix Release Day** (Completed within 1-21 days of Disclosure)
 
-- The PSC will cherry-pick the patches onto the master branch and all relevant release branches. The Fix Team will `lgtm` and `approve`.
+- The PSC will cherry-pick the patches onto the main branch and all relevant release branches. The Fix Team will `lgtm` and `approve`.
 - The etcd maintainers will merge these PRs as quickly as possible.
 - The PSC will ensure all the binaries are built, publicly available, and functional.
 - The PSC will announce the new releases, the CVE number, severity, and impact, and the location of the binaries to get wide distribution and user action. As much as possible this announcement should be actionable, and include any mitigating steps users can take prior to upgrading to a fixed version. The recommended target time is 4pm UTC on a non-Friday weekday. This means the announcement will be seen morning Pacific, early evening Europe, and late evening Asia. The announcement will be sent via the following channels:

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -463,7 +463,7 @@ func identifyDataDirOrDie(lg *zap.Logger, dir string) dirType {
 }
 
 func checkSupportArch() {
-	// to add a new platform, check https://github.com/etcd-io/website/blob/master/content/en/docs/next/op-guide/supported-platform.md
+	// to add a new platform, check https://github.com/etcd-io/website/blob/main/content/en/docs/next/op-guide/supported-platform.md
 	if runtime.GOARCH == "amd64" ||
 		runtime.GOARCH == "arm64" ||
 		runtime.GOARCH == "ppc64le" ||

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -563,7 +563,7 @@ func (c *RaftCluster) IsReadyToAddVotingMember() bool {
 
 	if nstarted == 1 && nmembers == 2 {
 		// a case of adding a new node to 1-member cluster for restoring cluster data
-		// https://github.com/etcd-io/website/blob/master/content/docs/v2/admin_guide.md#restoring-the-cluster
+		// https://github.com/etcd-io/website/blob/main/content/docs/v2/admin_guide.md#restoring-the-cluster
 		c.lg.Debug("number of started member is 1; can accept add member request")
 		return true
 	}

--- a/server/etcdserver/api/v2error/error.go
+++ b/server/etcdserver/api/v2error/error.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package v2error describes errors in etcd project. When any change happens,
-// https://github.com/etcd-io/website/blob/master/content/docs/v2/errorcode.md
+// https://github.com/etcd-io/website/blob/main/content/docs/v2/errorcode.md
 // needs to be updated correspondingly.
 // To be deprecated in favor of v3 APIs.
 package v2error

--- a/tests/docker-dns-srv/named.conf
+++ b/tests/docker-dns-srv/named.conf
@@ -13,11 +13,11 @@ options {
 };
 
 zone "etcd.local" IN {
-      type master;
+      type main;
       file "/etc/bind/etcd.zone";
 };
 
 zone "0.0.127.in-addr.arpa" {
-      type master;
+      type main;
       file "/etc/bind/rdns.zone";
 };

--- a/tests/docker-dns/named.conf
+++ b/tests/docker-dns/named.conf
@@ -13,11 +13,11 @@ options {
 };
 
 zone "etcd.local" IN {
-      type master;
+      type main;
       file "/etc/bind/etcd.zone";
 };
 
 zone "0.0.127.in-addr.arpa" {
-      type master;
+      type main;
       file "/etc/bind/rdns.zone";
 };

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -4,7 +4,7 @@
 
 See [`rpcpb.Case`](https://godoc.org/github.com/coreos/etcd/functional/rpcpb#Case) for all failure cases.
 
-See [functional.yaml](https://github.com/etcd-io/etcd/blob/master/tests/functional/functional.yaml) for an example configuration.
+See [functional.yaml](https://github.com/etcd-io/etcd/blob/main/tests/functional/functional.yaml) for an example configuration.
 
 ### Run locally
 

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -3,7 +3,7 @@
 `etcd/tools/benchmark` is the official benchmarking tool for etcd clusters.
 
 ## Download and install
-To get `benchmark` from the `master` branch via `go get`:
+To get `benchmark` from the `main` branch via `go get`:
 ```sh
 $ go get go.etcd.io/etcd/tools/benchmark
 # GOPATH should be set

--- a/tools/etcd-dump-metrics/README
+++ b/tools/etcd-dump-metrics/README
@@ -1,7 +1,7 @@
 
 go install -v ./tools/etcd-dump-metrics
 
-# for latest master branch
+# for latest main branch
 etcd-dump-metrics > Documentation/metrics/latest
 
 # Or download etcd v3.3.9 to ./bin


### PR DESCRIPTION
Renaming to "main" across our source code first, and I will make the change in GitHub setting to actually rename the git branch from "master" to "main".

- https://github.com/etcd-io/website/issues/149#issuecomment-839804288
- https://github.com/etcd-io/website/pull/282
- https://github.com/github/renaming

Address https://github.com/etcd-io/etcd/issues/12949

@ptabor @xiang90 @spzala @hexfusion @lilic @chalin @nate-double-u 