### PR TITLE
[Draft] etcd: Support configuring zap console log format with --log-format flag

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -350,6 +350,8 @@ type Config struct {
 	// Logger is logger options: currently only supports "zap".
 	// "capnslog" is removed in v3.5.
 	Logger string `json:"logger"`
+	// LogFormat configures format of logs. Only supports json, console. Default 'json'.
+	LogFormat string `json:"log-format"`
 	// LogLevel configures log level. Only supports debug, info, warn, error, panic, or fatal. Default 'info'.
 	LogLevel string `json:"log-level"`
 	// LogOutputs is either:
@@ -485,6 +487,7 @@ func NewConfig() *Config {
 		loggerMu:              new(sync.RWMutex),
 		logger:                nil,
 		Logger:                "zap",
+		LogFormat:             "json",
 		LogOutputs:            []string{DefaultLogOutput},
 		LogLevel:              logutil.DefaultLogLevel,
 		EnableLogRotation:     false,
@@ -619,6 +622,11 @@ func updateCipherSuites(tls *transport.TLSInfo, ss []string) error {
 
 // Validate ensures that '*embed.Config' fields are properly configured.
 func (cfg *Config) Validate() error {
+	switch cfg.LogFormat {
+	case "json", "console":
+	default:
+		return fmt.Errorf("--log-format=%s is not supported", cfg.LogFormat)
+	}
 	if err := cfg.setupLogging(); err != nil {
 		return err
 	}

--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -98,7 +98,7 @@ func (cfg *Config) setupLogging() error {
 
 		if !isJournal {
 			copied := logutil.DefaultZapLoggerConfig
-			copied.OutputPaths = outputPaths
+			copied.Encoding = cfg.LogFormat
 			copied.ErrorOutputPaths = errOutputPaths
 			copied = logutil.MergeOutputPaths(copied)
 			copied.Level = zap.NewAtomicLevelAt(logutil.ConvertToZapLevel(cfg.LogLevel))
@@ -124,6 +124,9 @@ func (cfg *Config) setupLogging() error {
 						return fmt.Errorf("running with systemd/journal but other '--log-outputs' values (%q) are configured with 'default'; override 'default' value with something else", cfg.LogOutputs)
 					}
 				}
+			}
+			if cfg.LogFormat != logutil.DefaultLogLevel {
+				return fmt.Errorf("--log-format=%q with systemd/journal is not supported", cfg.LogFormat)
 			}
 
 			// use stderr as fallback

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -364,3 +364,48 @@ func TestLogRotation(t *testing.T) {
 		})
 	}
 }
+
+func TestLogFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		LogFormat  string
+		wantErr    bool
+		wantErrMsg error
+	}{
+		{
+			name: "default",
+		},
+		{
+			name:      "json",
+			LogFormat: "json",
+		},
+		{
+			name:      "console",
+			LogFormat: "console",
+		},
+		{
+			name:       "unsupported",
+			LogFormat:  "xml",
+			wantErr:    true,
+			wantErrMsg: errors.New("--log-format=xml is not supported"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			if tt.LogFormat != "" {
+				cfg.LogFormat = tt.LogFormat
+			}
+			err := cfg.Validate()
+			if err != nil && !tt.wantErr {
+				t.Errorf("test %q, unexpected error %v", tt.name, err)
+			}
+			if err != nil && tt.wantErr && tt.wantErrMsg.Error() != err.Error() {
+				t.Errorf("test %q, expected error: %+v, got: %+v", tt.name, tt.wantErrMsg, err)
+			}
+			if err == nil && tt.wantErr {
+				t.Errorf("test %q, expected error, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -234,6 +234,7 @@ func newConfig() *config {
 
 	// logging
 	fs.StringVar(&cfg.ec.Logger, "logger", "zap", "Currently only supports 'zap' for structured logging.")
+	fs.StringVar(&cfg.ec.LogFormat, "log-format", "json", "Configures format of logs. Only supports json, console. Default 'json'.")
 	fs.Var(flags.NewUniqueStringsValue(embed.DefaultLogOutput), "log-outputs", "Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd, or list of comma separated output targets.")
 	fs.StringVar(&cfg.ec.LogLevel, "log-level", logutil.DefaultLogLevel, "Configures log level. Only supports debug, info, warn, error, panic, or fatal. Default 'info'.")
 	fs.BoolVar(&cfg.ec.EnableLogRotation, "enable-log-rotation", false, "Enable log rotation of a single log-outputs file target.")

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -184,6 +184,8 @@ Profiling and Monitoring:
 Logging:
   --logger 'zap'
     Currently only supports 'zap' for structured logging.
+  --log-format 'json'
+    LogFormat configures format of logs. Only supports json, console.
   --log-outputs 'default'
     Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd, or list of comma separated output targets.
   --log-level 'info'

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -73,6 +73,7 @@ func TestEmbedEtcd(t *testing.T) {
 	for i := range tests {
 		tests[i].cfg = *embed.NewConfig()
 		tests[i].cfg.Logger = "zap"
+		tests[i].cfg.LogFormat = "json"
 		tests[i].cfg.LogOutputs = []string{"/dev/null"}
 	}
 
@@ -199,6 +200,7 @@ func newEmbedURLs(secure bool, n int) (urls []url.URL) {
 
 func setupEmbedCfg(cfg *embed.Config, curls []url.URL, purls []url.URL) {
 	cfg.Logger = "zap"
+	cfg.LogFormat = "json"
 	cfg.LogOutputs = []string{"/dev/null"}
 
 	cfg.ClusterState = "new"

--- a/tools/etcd-dump-metrics/etcd.go
+++ b/tools/etcd-dump-metrics/etcd.go
@@ -40,6 +40,7 @@ func newEmbedURLs(n int) (urls []url.URL) {
 
 func setupEmbedCfg(cfg *embed.Config, curls, purls, ics []url.URL) {
 	cfg.Logger = "zap"
+	cfg.LogFormat = "json"
 	cfg.LogOutputs = []string{"/dev/null"}
 	// []string{"stderr"} to enable server logging
 


### PR DESCRIPTION
Console format is much easier to read during development when compared
to json.

Example: 
```
2021-05-14T12:11:46.513+0200    info    etcdmain/etcd.go:72     Running:        {"args": ["./bin/etcd", "--log-format=console"]}
2021-05-14T12:11:46.514+0200    warn    etcdmain/etcd.go:104    'data-dir' was empty; using default     {"data-dir": "default.etcd"}
2021-05-14T12:11:46.514+0200    info    etcdmain/etcd.go:115    server has been already initialized     {"data-dir": "default.etcd", "dir-type": "member"}
2021-05-14T12:11:46.514+0200    info    embed/etcd.go:131       configuring peer listeners      {"listen-peer-urls": ["http://localhost:2380"]}
2021-05-14T12:11:46.515+0200    info    embed/etcd.go:139       configuring client listeners    {"listen-client-urls": ["http://localhost:2379"]}
```

Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
