### PR TITLE
Bring back original NewZapCoreLoggerBuilder api.

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -70,8 +70,10 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.0...v3.5.0) and 
 - Turned on [--pre-vote by default](https://github.com/etcd-io/etcd/pull/12770). Should prevent disrupting RAFT leader by an individual member.
 - [ETCD_CLIENT_DEBUG env](https://github.com/etcd-io/etcd/pull/12786): Now supports log levels (debug, info, warn, error, dpanic, panic, fatal). Only when set, overrides application-wide grpc logging settings.
 - [Embed Etcd.Close()](https://github.com/etcd-io/etcd/pull/12828) needs to called exactly once and closes Etcd.Err() stream.
-- [Embed Etcd does not override global/grpc logger](https://github.com/etcd-io/etcd/pull/12861) be default any longer. If desired, please call `embed.Config::SetupGlobalLoggers()` explicitly.
+- [Embed Etcd does not override global/grpc logger](https://github.com/etcd-io/etcd/pull/12861) be default any longer. If desired, please call `embed.Config::SetupGlobalLoggers()` explicitly. 
+- [Embed Etcd custom logger should be configured using simpler builder `NewZapLoggerBuilder`](https://github.com/etcd-io/etcd/pull/12973).
 - Client errors of `context cancelled` or `context deadline exceeded` are exposed as `codes.Canceled` and `codes.DeadlineExceeded`, instead of `codes.Unknown`.
+
 
 ### Storage format changes
 - [WAL log's snapshots persists raftpb.ConfState](https://github.com/etcd-io/etcd/pull/12735)

--- a/tests/integration/testing.go
+++ b/tests/integration/testing.go
@@ -67,7 +67,7 @@ func NewEmbedConfig(t testing.TB, name string) *embed.Config {
 	cfg := embed.NewConfig()
 	cfg.Name = name
 	lg := zaptest.NewLogger(t, zaptest.Level(zapcore.InfoLevel)).Named(cfg.Name)
-	cfg.ZapLoggerBuilder = embed.NewZapCoreLoggerBuilder(lg)
+	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(lg)
 	cfg.Dir = t.TempDir()
 	return cfg
 }


### PR DESCRIPTION
The funcion signature has been changed in:
eafbc8c57efc716644c328f63677ca7eadeebdfe .
Instead we should have added new method `NewZapLoggerBuilder()`.