### PR TITLE
Fixes to CI configs

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,0 +1,29 @@
+name: functional-tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-functional
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "^1.16"
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-functional)
+            GO_BUILD_FLAGS='-v -mod=readonly' ./build && GOARCH=amd64 PASSES='functional' ./test
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -1,0 +1,30 @@
+name: grpcProxy-tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-grpcproxy
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "^1.16"
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-grpcproxy)
+            PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,15 +4,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target:
         - linux-amd64-fmt
-        - linux-amd64-grpcproxy
         - linux-amd64-integration-1-cpu
         - linux-amd64-integration-2-cpu
         - linux-amd64-integration-4-cpu
-        - linux-amd64-functional
         - linux-amd64-unit-4-cpu-race
         - all-build
         - linux-386-unit-1-cpu
@@ -39,9 +37,6 @@ jobs:
           linux-amd64-integration-4-cpu)
             GOARCH=amd64 CPU=4 PASSES='integration' RACE='false' ./test.sh
             ;;
-          linux-amd64-functional)
-            GO_BUILD_FLAGS='-v -mod=readonly' ./build && GOARCH=amd64 PASSES='functional' ./test
-            ;;
           linux-amd64-unit-4-cpu-race)
             GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test.sh -p=2
             ;;
@@ -54,10 +49,6 @@ jobs:
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm64 ./build.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=ppc64le ./build.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=s390x ./build.sh
-            ;;
-          linux-amd64-grpcproxy)
-            PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
-            ! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           linux-386-unit-1-cpu)
             GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services: docker
 
 go:
-  - "1.16"
+  - "1.16.3"
   - tip
 
 notifications:
@@ -21,14 +21,14 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - go: "1.16"
+    - go: "1.16.3"
       env: TARGET=linux-amd64-coverage
     - go: tip
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
   exclude:
     - go: tip
       env: TARGET=linux-amd64-coverage
-    - go: "1.16"
+    - go: "1.16.3"
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
 
 before_install:


### PR DESCRIPTION
- Moves grpcproxy & functional tests to a separate workflows such thay can get restarted independently.
- Configures travis to run 1.16.3 go version (as travis cannot resolve 1.16 to the default).