### PR TITLE
Fix coverage tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -325,14 +325,14 @@ function cov_pass {
   log_callout "[$(date)] Collecting coverage from e2e tests ..."
   # We don't pass 'gocov_build_flags' nor 'pkg_to_coverprofileflag' here,
   # as the coverage is collected from the ./bin/etcd_test & ./bin/etcdctl_test internally spawned.
-  mkdir -p "${COVERDIR}/e2e"
-  COVERDIR="${COVERDIR}/e2e" run_for_module "tests" go_test "./e2e/..." "keep_going" : -tags=cov -timeout 30m "$@" || failed="$failed tests_e2e"
-  split_dir "${COVERDIR}/e2e" 10
+  mkdir -p "${coverdir}/e2e"
+  COVERDIR="${coverdir}/e2e" run_for_module "tests" go_test "./e2e/..." "keep_going" : -tags=cov -timeout 30m "$@" || failed="$failed tests_e2e"
+  split_dir "${coverdir}/e2e" 10
 
   log_callout "[$(date)] Collecting coverage from e2e tests with proxy ..."
-  mkdir -p "${COVERDIR}/e2e_proxy"
-  COVERDIR="${COVERDIR}/e2e_proxy" run_for_module "tests" go_test "./e2e/..." "keep_going" : -tags="cov cluster_proxy" -timeout 30m "$@" || failed="$failed tests_e2e_proxy"
-  split_dir "${COVERDIR}/e2e_proxy" 10
+  mkdir -p "${coverdir}/e2e_proxy"
+  COVERDIR="${coverdir}/e2e_proxy" run_for_module "tests" go_test "./e2e/..." "keep_going" : -tags="cov cluster_proxy" -timeout 30m "$@" || failed="$failed tests_e2e_proxy"
+  split_dir "${coverdir}/e2e_proxy" 10
 
   local cover_out_file="${coverdir}/all.coverprofile"
   merge_cov "${coverdir}"

--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -25,6 +25,7 @@ import (
 
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/integration"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -134,6 +135,7 @@ func configStandalone(cfg etcdProcessClusterConfig) *etcdProcessClusterConfig {
 }
 
 type etcdProcessCluster struct {
+	lg    *zap.Logger
 	cfg   *etcdProcessClusterConfig
 	procs []etcdProcess
 }
@@ -182,6 +184,7 @@ func newEtcdProcessCluster(t testing.TB, cfg *etcdProcessClusterConfig) (*etcdPr
 	etcdCfgs := cfg.etcdServerProcessConfigs(t)
 	epc := &etcdProcessCluster{
 		cfg:   cfg,
+		lg:    zaptest.NewLogger(t),
 		procs: make([]etcdProcess, cfg.clusterSize),
 	}
 
@@ -451,6 +454,7 @@ func (epc *etcdProcessCluster) Stop() (err error) {
 }
 
 func (epc *etcdProcessCluster) Close() error {
+	epc.lg.Info("closing test cluster...")
 	err := epc.Stop()
 	for _, p := range epc.procs {
 		// p is nil when newEtcdProcess fails in the middle
@@ -462,6 +466,7 @@ func (epc *etcdProcessCluster) Close() error {
 			err = cerr
 		}
 	}
+	epc.lg.Info("closed test cluster.")
 	return err
 }
 

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -193,7 +193,6 @@ func TestIssue6361(t *testing.T) {
 	}
 
 	fpath := filepath.Join(t.TempDir(), "test.snapshot")
-	defer os.RemoveAll(fpath)
 
 	t.Log("etcdctl saving snapshot...")
 	if err = spawnWithExpect(append(prefixArgs, "snapshot", "save", fpath), fmt.Sprintf("Snapshot saved at %s", fpath)); err != nil {
@@ -206,7 +205,6 @@ func TestIssue6361(t *testing.T) {
 	}
 
 	newDataDir := filepath.Join(t.TempDir(), "test.data")
-	defer os.RemoveAll(newDataDir)
 
 	t.Log("etcdctl restoring the snapshot...")
 	err = spawnWithExpect([]string{ctlBinPath, "snapshot", "restore", fpath, "--name", epc.procs[0].Config().name, "--initial-cluster", epc.procs[0].Config().initialCluster, "--initial-cluster-token", epc.procs[0].Config().initialToken, "--initial-advertise-peer-urls", epc.procs[0].Config().purl.String(), "--data-dir", newDataDir}, "added member")
@@ -273,4 +271,5 @@ func TestIssue6361(t *testing.T) {
 	if err = nepc.Stop(); err != nil {
 		t.Fatal(err)
 	}
+	t.Log("Test logic done")
 }

--- a/tests/e2e/etcd_process.go
+++ b/tests/e2e/etcd_process.go
@@ -90,23 +90,34 @@ func (ep *etcdServerProcess) Start() error {
 	if ep.proc != nil {
 		panic("already started")
 	}
+	ep.cfg.lg.Info("starting server...", zap.String("name", ep.cfg.name))
 	proc, err := spawnCmdWithLogger(ep.cfg.lg, append([]string{ep.cfg.execPath}, ep.cfg.args...))
 	if err != nil {
 		return err
 	}
 	ep.proc = proc
-	return ep.waitReady()
+	err = ep.waitReady()
+	if err == nil {
+		ep.cfg.lg.Info("started server.", zap.String("name", ep.cfg.name))
+	}
+	return err
 }
 
 func (ep *etcdServerProcess) Restart() error {
+	ep.cfg.lg.Info("restaring server...", zap.String("name", ep.cfg.name))
 	if err := ep.Stop(); err != nil {
 		return err
 	}
 	ep.donec = make(chan struct{})
-	return ep.Start()
+	err := ep.Start()
+	if err == nil {
+		ep.cfg.lg.Info("restared server", zap.String("name", ep.cfg.name))
+	}
+	return err
 }
 
 func (ep *etcdServerProcess) Stop() (err error) {
+	ep.cfg.lg.Info("stoping server...", zap.String("name", ep.cfg.name))
 	if ep == nil || ep.proc == nil {
 		return nil
 	}
@@ -123,13 +134,16 @@ func (ep *etcdServerProcess) Stop() (err error) {
 			return err
 		}
 	}
+	ep.cfg.lg.Info("stopped server.", zap.String("name", ep.cfg.name))
 	return nil
 }
 
 func (ep *etcdServerProcess) Close() error {
+	ep.cfg.lg.Info("closing server...", zap.String("name", ep.cfg.name))
 	if err := ep.Stop(); err != nil {
 		return err
 	}
+	ep.cfg.lg.Info("removing directory", zap.String("data-dir", ep.cfg.dataDirPath))
 	return os.RemoveAll(ep.cfg.dataDirPath)
 }
 

--- a/tests/e2e/etcd_spawn_cov.go
+++ b/tests/e2e/etcd_spawn_cov.go
@@ -19,29 +19,39 @@ package e2e
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/pkg/v3/expect"
+	"go.uber.org/zap"
 )
 
 const noOutputLineCount = 2 // cov-enabled binaries emit PASS and coverage count lines
 
 func spawnCmd(args []string) (*expect.ExpectProcess, error) {
+	return spawnCmdWithLogger(zap.NewNop(), args)
+}
+
+func spawnCmdWithLogger(lg *zap.Logger, args []string) (*expect.ExpectProcess, error) {
 	cmd := args[0]
 	env := make([]string, 0)
-	switch cmd {
-	case binPath:
-		cmd = "../../bin/etcd_test"
-	case ctlBinPath:
-		cmd = "../../bin/etcdctl_test"
-	case ctlBinPath + "3":
-		cmd = "../../bin/etcdctl_test"
+	switch {
+	case strings.HasSuffix(cmd, "/etcd"):
+		cmd = cmd + "_test"
+	case strings.HasSuffix(cmd, "/etcdctl"):
+		cmd = cmd + "_test"
+	case strings.HasSuffix(cmd, "/etcdctl3"):
+		cmd = ctlBinPath + "_test"
 		env = append(env, "ETCDCTL_API=3")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
 	}
 
 	covArgs, err := getCovArgs()
@@ -52,7 +62,7 @@ func spawnCmd(args []string) (*expect.ExpectProcess, error) {
 	// they must be included in ctl_cov_env.
 	env = append(env, os.Environ()...)
 	all_args := append(args[1:], covArgs...)
-	log.Printf("Executing %v %v", cmd, all_args)
+	lg.Info("spawning process", zap.Strings("args", all_args), zap.String("working-dir", wd))
 	ep, err := expect.NewExpectWithEnv(cmd, all_args, env)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
3 problems:
  - spawnCmdWithLogger was not implemented (when built with 'cov' tag)
  - the logic was depending on relative paths. We change it to absolute
to be able to run in the test-specific temporary directories.
   - In `TestIssue6361` data directory was deleted too early. 