### PR TITLE
Fix release script: add `go mod tidy` after go.mod changes

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -42,6 +42,8 @@ help() {
   echo "    --no-upload: skip gs://etcd binary artifact uploads."
   echo "    --no-docker-push: skip docker image pushes."
   echo ""
+  echo "One can perform a (dry-run) test release from any (uncommitted) branch using:"
+  echo "  DRY_RUN=true REPOSITORY=\`pwd\` BRANCH='local-branch-name' ./scripts/release 3.5.0-foobar.2"
 }
 
 main() {

--- a/scripts/release_mod.sh
+++ b/scripts/release_mod.sh
@@ -30,6 +30,7 @@ function update_module_version() {
   local v3version="${1}"
   local v2version="${2}"
   local modules
+  run go mod tidy
   modules=$(run go list -f '{{if not .Main}}{{if not .Indirect}}{{.Path}}{{end}}{{end}}' -m all)
 
   v3deps=$(echo "${modules}" | grep -E "${ROOT_MODULE}/.*/v3")
@@ -41,6 +42,13 @@ function update_module_version() {
   for dep in ${v2deps}; do
     run go mod edit -require "${dep}@${v2version}"
   done
+
+  run go mod tidy
+}
+
+function mod_tidy_fix {
+  run rm ./go.sum
+  run go mod tidy || return 2
 }
 
 # Updates all cross-module versions to ${TARGET_VERSION} in local client.
@@ -65,6 +73,7 @@ function update_versions_cmd() {
   log_info "v2version: ${v2version}"
 
   run_for_modules update_module_version "${v3version}" "${v2version}"
+  run_for_modules mod_tidy_fix || exit 2
 }
 
 function get_gpg_key {


### PR DESCRIPTION
Seems that additinal refresh of go.sum files is needed during the
release process after editing the versions of modules.

Discovered the problem while I was testing whether etcdutl is
properly included in the target binaries using:

```
DRY_RUN=true REPOSITORY=\`pwd\` BRANCH='branch-with-etcdutl' ./scripts/release 3.5.0-foobar.2
```