### PR TITLE
use v2 api to update cluster version

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -117,6 +117,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
   - `etcd --experimental-backend-bbolt-freelist-type` has been deprecated.
 - Support [downgrade API](https://github.com/etcd-io/etcd/pull/11715).
 - Deprecate v2 apply on cluster version. [Use v3 request to set cluster version and recover cluster version from v3 backend](https://github.com/etcd-io/etcd/pull/11427).
+- [Use v2 api to update cluster version to support mixed version cluster during upgrade](https://github.com/etcd-io/etcd/pull/12988).
 - [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).
 - Fix [quorum protection logic when promoting a learner](https://github.com/etcd-io/etcd/pull/11640).
 - Improve [peer corruption checker](https://github.com/etcd-io/etcd/pull/11621) to work when peer mTLS is enabled.

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -1714,6 +1715,53 @@ func TestPublishV3Retry(t *testing.T) {
 	srv.publishV3(10 * time.Nanosecond)
 	ch <- struct{}{}
 	<-ch
+}
+
+func TestUpdateVersion(t *testing.T) {
+	n := newNodeRecorder()
+	ch := make(chan interface{}, 1)
+	// simulate that request has gone through consensus
+	ch <- Response{}
+	w := wait.NewWithResponse(ch)
+	ctx, cancel := context.WithCancel(context.TODO())
+	srv := &EtcdServer{
+		lgMu:       new(sync.RWMutex),
+		lg:         zap.NewExample(),
+		id:         1,
+		Cfg:        config.ServerConfig{Logger: zap.NewExample(), TickMs: 1, SnapshotCatchUpEntries: DefaultSnapshotCatchUpEntries},
+		r:          *newRaftNode(raftNodeConfig{lg: zap.NewExample(), Node: n}),
+		attributes: membership.Attributes{Name: "node1", ClientURLs: []string{"http://node1.com"}},
+		cluster:    &membership.RaftCluster{},
+		w:          w,
+		reqIDGen:   idutil.NewGenerator(0, time.Time{}),
+		SyncTicker: &time.Ticker{},
+
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	srv.updateClusterVersionV2("2.0.0")
+
+	action := n.Action()
+	if len(action) != 1 {
+		t.Fatalf("len(action) = %d, want 1", len(action))
+	}
+	if action[0].Name != "Propose" {
+		t.Fatalf("action = %s, want Propose", action[0].Name)
+	}
+	data := action[0].Params[0].([]byte)
+	var r pb.Request
+	if err := r.Unmarshal(data); err != nil {
+		t.Fatalf("unmarshal request error: %v", err)
+	}
+	if r.Method != "PUT" {
+		t.Errorf("method = %s, want PUT", r.Method)
+	}
+	if wpath := path.Join(StoreClusterPrefix, "version"); r.Path != wpath {
+		t.Errorf("path = %s, want %s", r.Path, wpath)
+	}
+	if r.Val != "2.0.0" {
+		t.Errorf("val = %s, want %s", r.Val, "2.0.0")
+	}
 }
 
 func TestStopNotify(t *testing.T) {


### PR DESCRIPTION
Fix #12987

```
{
  "level":"info",
  "ts":"2021-05-17T18:28:27.564Z",
  "caller":"membership/cluster.go:522",
  "msg":"updated cluster version",
  "cluster-id":"ef37ad9dc622a7c4",
  "local-member-id":"6f7e5687e0b95471",
  "from":"3.4",
  "to":"3.5"
}
```

## Testing cluster version upgrade from 3.4 to 3.5
```
rm -rf /home/chaochn/log/etcd/
mkdir -p /home/chaochn/log/etcd

# create 3.4 cluster
~/etcd/release-3.4/etcd --name infra1 \
--listen-client-urls http://127.0.0.1:2379 \
--advertise-client-urls http://127.0.0.1:2379 \
--listen-peer-urls http://127.0.0.1:12380 \
--initial-advertise-peer-urls http://127.0.0.1:12380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra1.log 2>&1 &

~/etcd/release-3.4/etcd --name infra2 \
--listen-client-urls http://127.0.0.1:22379 \
--advertise-client-urls http://127.0.0.1:22379 \
--listen-peer-urls http://127.0.0.1:22380 \
--initial-advertise-peer-urls http://127.0.0.1:22380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra2.log 2>&1 &

~/etcd/release-3.4/etcd --name infra3 \
--listen-client-urls http://127.0.0.1:32379 \
--advertise-client-urls http://127.0.0.1:32379 \
--listen-peer-urls http://127.0.0.1:32380 \
--initial-advertise-peer-urls http://127.0.0.1:32380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra3.log 2>&1 &

# upgrade to 3.5
## first
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:22379 member remove fd422379fda50e48
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:22379 member add infra4 --peer-urls=http://127.0.0.1:32381

~/etcd/3.5.0-alpha.0/etcd --name infra4 \
--listen-client-urls http://127.0.0.1:32379 \
--advertise-client-urls http://127.0.0.1:32379 \
--listen-peer-urls http://127.0.0.1:32381 \
--initial-advertise-peer-urls http://127.0.0.1:32381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra4.log 2>&1 &

## second
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:32379 member remove 91bc3c398fb3c146
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:32379 member add infra5 --peer-urls=http://127.0.0.1:22381

~/etcd/3.5.0-alpha.0/etcd --name infra5 \
--listen-client-urls http://127.0.0.1:22379 \
--advertise-client-urls http://127.0.0.1:22379 \
--listen-peer-urls http://127.0.0.1:22381 \
--initial-advertise-peer-urls http://127.0.0.1:22381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra5=http://127.0.0.1:22381,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra5.log 2>&1 &

## third
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:22379,http://127.0.0.1:32379 member remove 8211f1d0f64f3269
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:22379,http://127.0.0.1:32379 member add infra6 --peer-urls=http://127.0.0.1:12381

~/etcd/3.5.0-alpha.0/etcd --name infra6 \
--listen-client-urls http://127.0.0.1:2379 \
--advertise-client-urls http://127.0.0.1:2379 \
--listen-peer-urls http://127.0.0.1:12381 \
--initial-advertise-peer-urls http://127.0.0.1:12381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra6=http://127.0.0.1:12381,infra5=http://127.0.0.1:22381,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra6.log 2>&1 &

```

## Testing cluster version downgrade from 3.5 to 3.4
```
rm -rf /home/chaochn/log/etcd/
mkdir -p /home/chaochn/log/etcd

# create 3.5 cluster
~/etcd/3.5.0-alpha.0/etcd --name infra1 \
--listen-client-urls http://127.0.0.1:2379 \
--advertise-client-urls http://127.0.0.1:2379 \
--listen-peer-urls http://127.0.0.1:12380 \
--initial-advertise-peer-urls http://127.0.0.1:12380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra1.log 2>&1 &

~/etcd/3.5.0-alpha.0/etcd --name infra2 \
--listen-client-urls http://127.0.0.1:22379 \
--advertise-client-urls http://127.0.0.1:22379 \
--listen-peer-urls http://127.0.0.1:22380 \
--initial-advertise-peer-urls http://127.0.0.1:22380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra2.log 2>&1 &

~/etcd/3.5.0-alpha.0/etcd --name infra3 \
--listen-client-urls http://127.0.0.1:32379 \
--advertise-client-urls http://127.0.0.1:32379 \
--listen-peer-urls http://127.0.0.1:32380 \
--initial-advertise-peer-urls http://127.0.0.1:32380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--enable-pprof > /home/chaochn/log/etcd/infra3.log 2>&1 &

# downgrade to 3.4
## first
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:22379 member remove fd422379fda50e48
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:22379 member add infra4 --peer-urls=http://127.0.0.1:32381

~/etcd/release-3.4-with-rollback/etcd --name infra4 \
--listen-client-urls http://127.0.0.1:32379 \
--advertise-client-urls http://127.0.0.1:32379 \
--listen-peer-urls http://127.0.0.1:32381 \
--initial-advertise-peer-urls http://127.0.0.1:32381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra4.log 2>&1 \
--unsafe-allow-cluster-version-downgrade=true &

## second
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:32379 member remove 91bc3c398fb3c146
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:2379,http://127.0.0.1:32379 member add infra5 --peer-urls=http://127.0.0.1:22381

~/etcd/release-3.4-with-rollback/etcd --name infra5 \
--listen-client-urls http://127.0.0.1:22379 \
--advertise-client-urls http://127.0.0.1:22379 \
--listen-peer-urls http://127.0.0.1:22381 \
--initial-advertise-peer-urls http://127.0.0.1:22381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra5=http://127.0.0.1:22381,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra5.log 2>&1 \
--unsafe-allow-cluster-version-downgrade=true &

## third
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:22379,http://127.0.0.1:32379 member remove 8211f1d0f64f3269
ETCDCTL_API=3 ~/etcd/release-3.4/etcdctl --endpoints http://127.0.0.1:22379,http://127.0.0.1:32379 member add infra6 --peer-urls=http://127.0.0.1:12381

~/etcd/release-3.4-with-rollback/etcd --name infra6 \
--listen-client-urls http://127.0.0.1:2379 \
--advertise-client-urls http://127.0.0.1:2379 \
--listen-peer-urls http://127.0.0.1:12381 \
--initial-advertise-peer-urls http://127.0.0.1:12381 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra6=http://127.0.0.1:12381,infra5=http://127.0.0.1:22381,infra4=http://127.0.0.1:32381' --initial-cluster-state existing \
--enable-pprof > /home/chaochn/log/etcd/infra6.log 2>&1 \
--unsafe-allow-cluster-version-downgrade=true &

# clean up all the process and logs
sudo ps -aef | grep etcd | grep -v grep | awk '{print $2}' | xargs sudo kill
rm -rf ~/infra*
rm -rf /home/chaochn/log/etcd/*.log
```
