### PR TITLE
scripts: add missing etcdutl to release pipeline

### DIFF
--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -30,7 +30,7 @@ IMAGEDIR=${BUILDDIR}/image-docker
 
 mkdir -p "${IMAGEDIR}"/var/etcd
 mkdir -p "${IMAGEDIR}"/var/lib/etcd
-cp "${BINARYDIR}"/etcd "${BINARYDIR}"/etcdctl "${IMAGEDIR}"
+cp "${BINARYDIR}"/etcd "${BINARYDIR}"/etcdctl "${BINARYDIR}"/etcdutl "${IMAGEDIR}"
 
 cat ./"${DOCKERFILE}" > "${IMAGEDIR}"/Dockerfile
 

--- a/scripts/release
+++ b/scripts/release
@@ -191,6 +191,7 @@ main() {
   # Sanity checks.
   "./release/etcd-${RELEASE_VERSION}-$(go env GOOS)-amd64/etcd" --version | grep -q "etcd Version: ${VERSION}" || true
   "./release/etcd-${RELEASE_VERSION}-$(go env GOOS)-amd64/etcdctl" version | grep -q "etcdctl version: ${VERSION}" || true
+  "./release/etcd-${RELEASE_VERSION}-$(go env GOOS)-amd64/etcdutl" version | grep -q "etcdutl version: ${VERSION}" || true
 
   # Generate SHA256SUMS
   log_callout "Generating sha256sums of release artifacts."


### PR DESCRIPTION
This PR fixes a few missing etcdutl references in release scripts.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
