### PR TITLE
Enhance the root permission, when root role exist, it always return rootPerm.

### DIFF
--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -200,7 +200,7 @@ func (s *simplePrinter) RoleGet(role string, r v3.AuthRoleGetResponse) {
 		} else {
 			fmt.Printf("\t[%s, <open ended>", sKey)
 		}
-		if v3.GetPrefixRangeEnd(sKey) == sRangeEnd {
+		if v3.GetPrefixRangeEnd(sKey) == sRangeEnd && len(sKey) > 0 {
 			fmt.Printf(" (prefix %s)", sKey)
 		}
 		fmt.Printf("\n")

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"reflect"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"sync"
 	"testing"
@@ -384,9 +384,8 @@ func TestGetUser(t *testing.T) {
 		t.Fatal("expect user not nil, got nil")
 	}
 	expected := []string{"role-test"}
-	if !reflect.DeepEqual(expected, u.Roles) {
-		t.Errorf("expected %v, got %v", expected, u.Roles)
-	}
+
+	assert.Equal(t, expected, u.Roles)
 
 	// check non existent user
 	_, err = as.UserGet(&pb.AuthUserGetRequest{Name: "nouser"})
@@ -445,9 +444,40 @@ func TestRoleGrantPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(perm, r.Perm[0]) {
-		t.Errorf("expected %v, got %v", perm, r.Perm[0])
+	assert.Equal(t, perm, r.Perm[0])
+}
+
+func TestRootRoleGrantPermission(t *testing.T) {
+	as, tearDown := setupAuthStore(t)
+	defer tearDown(t)
+
+	perm := &authpb.Permission{
+		PermType: authpb.WRITE,
+		Key:      []byte("Keys"),
+		RangeEnd: []byte("RangeEnd"),
 	}
+	_, err := as.RoleGrantPermission(&pb.AuthRoleGrantPermissionRequest{
+		Name: "root",
+		Perm: perm,
+	})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	r, err := as.RoleGet(&pb.AuthRoleGetRequest{Role: "root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//whatever grant permission to root, it always return root permission.
+	expectPerm := &authpb.Permission{
+		PermType: authpb.READWRITE,
+		Key:      []byte{},
+		RangeEnd: []byte{0},
+	}
+
+	assert.Equal(t, expectPerm, r.Perm[0])
 }
 
 func TestRoleRevokePermission(t *testing.T) {
@@ -522,9 +552,8 @@ func TestUserRevokePermission(t *testing.T) {
 	}
 
 	expected := []string{"role-test", "role-test-1"}
-	if !reflect.DeepEqual(expected, u.Roles) {
-		t.Fatalf("expected %v, got %v", expected, u.Roles)
-	}
+
+	assert.Equal(t, expected, u.Roles)
 
 	_, err = as.UserRevokeRole(&pb.AuthUserRevokeRoleRequest{Name: "foo", Role: "role-test-1"})
 	if err != nil {
@@ -537,9 +566,8 @@ func TestUserRevokePermission(t *testing.T) {
 	}
 
 	expected = []string{"role-test"}
-	if !reflect.DeepEqual(expected, u.Roles) {
-		t.Errorf("expected %v, got %v", expected, u.Roles)
-	}
+
+	assert.Equal(t, expected, u.Roles)
 }
 
 func TestRoleDelete(t *testing.T) {
@@ -555,9 +583,8 @@ func TestRoleDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []string{"root"}
-	if !reflect.DeepEqual(expected, rl.Roles) {
-		t.Errorf("expected %v, got %v", expected, rl.Roles)
-	}
+
+	assert.Equal(t, expected, rl.Roles)
 }
 
 func TestAuthInfoFromCtx(t *testing.T) {

--- a/tests/e2e/ctl_v3_role_test.go
+++ b/tests/e2e/ctl_v3_role_test.go
@@ -76,7 +76,7 @@ func rootRoleGetTest(cx ctlCtx) {
 		},
 		{
 			args:        []string{"get", "root"},
-			expectedStr: []string{"Role root\r\n", "KV Read:\r\n", "\tfoo\r\n", "KV Write:\r\n", "\tfoo\r\n"},
+			expectedStr: []string{"Role root\r\n", "KV Read:\r\n", "\t[, <open ended>\r\n", "KV Write:\r\n", "\t[, <open ended>\r\n"},
 		},
 	}
 


### PR DESCRIPTION
After #12979.
We need make the server-side return "".."\x00" always when asked about the root.
```
$ etcdctl role grant-permission root readwrite foo.
Role root updated
$ etcdctl role get root
Role root
KV Read:
        foo
KV Write:
        foo
```

The `root` role should be 
```
Role root
KV Read:
        [, <open ended>
KV Write:
        [, <open ended>
```

