### PR TITLE
Documentation/README simplification

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,6 +1,1 @@
-# The etcd documentation
-
-etcd is a distributed key-value store designed to reliably and quickly preserve and provide access to critical data. It enables reliable distributed coordination through distributed locking, leader elections, and write barriers. An etcd cluster is intended for high availability and permanent data storage and retrieval.
-
-These documents have moved to the [etcd-io/website repo](https://github.com/etcd-io/website/), and can be viewed live at [https://etcd.io/docs/latest/](https://etcd.io/docs/latest/).
-
+The etcd docs are hosted at [etcd.io](https://etcd.io/), and so most files formerly in this directory have moved to the [website](https://github.com/etcd-io/website/) repo.


### PR DESCRIPTION
In support of https://github.com/etcd-io/website/issues/65, simply direct the reader to the website (rather than once again defining what etcd is).

/cc @nate-double-u 