### PR TITLE
*: add "--unsafe-allow-cluster-version-downgrade" for not failing cluster version downgrade

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -116,6 +116,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - [`etcd --backend-bbolt-freelist-type`] flag is now stable.
   - `etcd --experimental-backend-bbolt-freelist-type` has been deprecated.
 - Support [downgrade API](https://github.com/etcd-io/etcd/pull/11715).
+- Add [`etcd --unsafe-allow-cluster-version-downgrade`](https://github.com/etcd-io/etcd/pull/13022) for not failing cluster version downgrade.
 - Deprecate v2 apply on cluster version. [Use v3 request to set cluster version and recover cluster version from v3 backend](https://github.com/etcd-io/etcd/pull/11427).
 - [Use v2 api to update cluster version to support mixed version cluster during upgrade](https://github.com/etcd-io/etcd/pull/12988).
 - [Fix corruption bug in defrag](https://github.com/etcd-io/etcd/pull/11613).

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -183,6 +183,12 @@ type ServerConfig struct {
 	// consider running defrag during bootstrap. Needs to be set to non-zero value to take effect.
 	ExperimentalBootstrapDefragThresholdMegabytes uint `json:"experimental-bootstrap-defrag-threshold-megabytes"`
 
+	// UnsafeAllowClusterVersionDowngrade is "true" to allow cluster version downgrade.
+	// "false" by default, since newer minor versions may introduce incompatible feature changes.
+	// For instance, lease checkpointer request to 3.4 will fail the remaining 3.3 nodes.
+	// But, if one does not use "lease checkpointer" feature, it can be safe to run 3.3 along with 3.4.
+	UnsafeAllowClusterVersionDowngrade bool `json:"unsafe-allow-cluster-version-downgrade"`
+
 	// V2Deprecation defines a phase of v2store deprecation process.
 	V2Deprecation V2DeprecationEnum `json:"v2-deprecation"`
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -89,6 +89,10 @@ const (
 	// v2 API is disabled by default.
 	DefaultEnableV2 = false
 
+	// DefaultUnsafeAllowClusterVersionDowngrade is the default value for "unsafe-allow-cluster-version-downgrade" flag.
+	// unsafe allow cluster version downgrade is disabled by default
+	DefaultUnsafeAllowClusterVersionDowngrade = false
+
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed in ../Documentation/tuning.md#time-parameters.
 	maxElectionMs = 50000
@@ -392,6 +396,12 @@ type Config struct {
 	// ExperimentalTxnModeWriteWithSharedBuffer enables write transaction to use a shared buffer in its readonly check operations.
 	ExperimentalTxnModeWriteWithSharedBuffer bool `json:"experimental-txn-mode-write-with-shared-buffer"`
 
+	// UnsafeAllowClusterVersionDowngrade is "true" to allow cluster version downgrade.
+	// "false" by default, since newer minor versions may introduce incompatible feature changes.
+	// For instance, lease checkpointer request to 3.4 will fail the remaining 3.3 nodes.
+	// But, if one does not use "lease checkpointer" feature, it can be safe to run 3.3 along with 3.4.
+	UnsafeAllowClusterVersionDowngrade bool `json:"unsafe-allow-cluster-version-downgrade"`
+
 	// V2Deprecation describes phase of API & Storage V2 support
 	V2Deprecation config.V2DeprecationEnum `json:"v2-deprecation"`
 }
@@ -488,6 +498,8 @@ func NewConfig() *Config {
 		ExperimentalDowngradeCheckTime:           DefaultDowngradeCheckTime,
 		ExperimentalMemoryMlock:                  false,
 		ExperimentalTxnModeWriteWithSharedBuffer: true,
+
+		UnsafeAllowClusterVersionDowngrade: DefaultUnsafeAllowClusterVersionDowngrade,
 
 		V2Deprecation: config.V2_DEPR_DEFAULT,
 	}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -223,7 +223,8 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		ExperimentalMemoryMlock:                  cfg.ExperimentalMemoryMlock,
 		ExperimentalTxnModeWriteWithSharedBuffer: cfg.ExperimentalTxnModeWriteWithSharedBuffer,
 		ExperimentalBootstrapDefragThresholdMegabytes: cfg.ExperimentalBootstrapDefragThresholdMegabytes,
-		V2Deprecation: cfg.V2DeprecationEffective(),
+		UnsafeAllowClusterVersionDowngrade:            cfg.UnsafeAllowClusterVersionDowngrade,
+		V2Deprecation:                                 cfg.V2DeprecationEffective(),
 	}
 
 	if srvcfg.ExperimentalEnableDistributedTracing {

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -291,6 +291,7 @@ func newConfig() *config {
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")
+	fs.BoolVar(&cfg.ec.UnsafeAllowClusterVersionDowngrade, "unsafe-allow-cluster-version-downgrade", embed.DefaultUnsafeAllowClusterVersionDowngrade, "true to allow cluster version downgrade, because newer minor versions may introduce incompatible feature changes like lease checkpointer introduced in v3.4")
 	fs.BoolVar(&cfg.ec.ForceNewCluster, "force-new-cluster", false, "Force to create a new one member cluster.")
 
 	// ignored

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -252,6 +252,9 @@ Unsafe feature:
     Force to create a new one-member cluster.
   --unsafe-no-fsync 'false'
     Disables fsync, unsafe, will cause data loss.
+  --unsafe-allow-cluster-version-downgrade 'false'
+    Allow cluster version downgrade, unsafe, newer minor versions may introduce incompatible feature changes.
+    For instance, experimental lease checkpointer is enabled in 3.4 and downgrade to 3.3 will fail. 
 
 CAUTIOUS with unsafe flag! It may break the guarantees given by the consensus protocol!
 `

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -488,6 +488,9 @@ func restartNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot) (types.ID, 
 	)
 	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
+	if cfg.UnsafeAllowClusterVersionDowngrade {
+		cl.AllowUnsafeDowngrade()
+	}
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)
@@ -562,6 +565,9 @@ func restartAsStandaloneNode(cfg config.ServerConfig, snapshot *raftpb.Snapshot)
 
 	cl := membership.NewCluster(cfg.Logger)
 	cl.SetID(id, cid)
+	if cfg.UnsafeAllowClusterVersionDowngrade {
+		cl.AllowUnsafeDowngrade()
+	}
 	s := raft.NewMemoryStorage()
 	if snapshot != nil {
 		s.ApplySnapshot(*snapshot)

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -421,7 +421,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		if err = membership.ValidateClusterAndAssignIDs(cfg.Logger, cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
-		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt) {
+		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt, cfg.UnsafeAllowClusterVersionDowngrade) {
 			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 
@@ -429,6 +429,9 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		cl.SetID(types.ID(0), existingCluster.ID())
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.UnsafeAllowClusterVersionDowngrade {
+			cl.AllowUnsafeDowngrade()
+		}
 		id, n, s, w = startNode(cfg, cl, nil)
 		cl.SetID(id, existingCluster.ID())
 
@@ -464,6 +467,9 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		}
 		cl.SetStore(st)
 		cl.SetBackend(be)
+		if cfg.UnsafeAllowClusterVersionDowngrade {
+			cl.AllowUnsafeDowngrade()
+		}
 		id, n, s, w = startNode(cfg, cl, cl.MemberIDs())
 		cl.SetID(id, cl.ID())
 


### PR DESCRIPTION
Compared to the [public etcd downgrade design](https://docs.google.com/document/d/1mSihXRJz8ROhXf4r5WrBGc8aka-b8HKjo2VDllOc6ac/edit#heading=h.e4jdx621yd8s), I am trying to simplify the manual "whitelisting target downgrade version" process and it doesn't require any server/client side API changes. Once the new `--unsafe-allow-cluster-version-downgrade` flag is enabled, only one minor version downgrade is allowed (e.g. v3.6 to v3.5). We can cherry-pick the same change to v3.4 and v3.3 if this feature is useful. 

However, if a user is already using `--experimental-enable-lease-checkpoint` flag to bootstrap a v3.4 cluster, the version downgrade is not possible due to the  [MustUnmarshal](https://github.com/etcd-io/etcd/blob/release-3.3/etcdserver/server.go#L1436-L1442) will panic on `LeaseCheckpoint` internal raft message which doesn't exist in v3.3. Not to mention there is no corresponding apply method. As a result, the new added etcd v3.3 flag `--unsafe-allow-cluster-version-downgrade` is not expected to set to `true` in this case. 

I've excessively tested v3.5 to v3.4 and v3.4 to v3.3 downgrade in two environments and the results look good. I will publish the backport PRs once the community agree on the approach. 

1. Tested locally first bootstrap with 3 etcd v3.4 servers and then downgrade to v3.3 one by one. It aims to test when the v2 store cluster version request replicate from v3.4 to new v3.3 server, it can be replaced by local 3.3 cluster version. 
2. Tested in a 1.17 kubernetes cluster which by default have 3 etcd v3.4 servers. It amis to test new v3.3 server can recover from the snapshot and replace the cluster version. At the same time when downgrading starts, I ran the sonobuoy e2e conformance test to verify it won't cause k8s functionality regression. 

I understand this is a risky operation without controlling the set of APIs used by the etcd client. But, I would like to put it here for reference, as others may find it useful.

Any feedback is welcome, Thanks! 
