### PR TITLE
tools/benchmark/README.md: Update installation as go get does not work

### DIFF
--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -2,11 +2,13 @@
 
 `etcd/tools/benchmark` is the official benchmarking tool for etcd clusters.
 
-## Download and install
-To get `benchmark` from the `main` branch via `go get`:
+## Install
+
+To install `benchmark` follow these steps.
+
 ```sh
-$ go get go.etcd.io/etcd/tools/benchmark
-# GOPATH should be set
-$ ls $GOPATH/bin
-benchmark
+$ go get go.etcd.io/etcd/v3/tools/benchmark
+$ benchmark --help
 ```
+
+Last command should output of usage of `benchmark`.


### PR DESCRIPTION
I noticed a lot of users mentioning `go get go.etcd.io/etcd/tools/benchmark` does not work for the `benchmark` tool. This updates the instructions to avoid confusion. I am not sure if the goal is to get it to work with `go get`, but I would suggest we open a follow-up issue if we want to.

Fixes https://github.com/etcd-io/etcd/issues/12526 https://github.com/etcd-io/etcd/issues/12851 