### PR TITLE
Backport-3.5: seq reset + bucket as object

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -30,6 +30,7 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
@@ -44,10 +45,6 @@ var (
 	authDisabled  = []byte{0}
 
 	revisionKey = []byte("authRevision")
-
-	authBucketName      = []byte("auth")
-	authUsersBucketName = []byte("authUsers")
-	authRolesBucketName = []byte("authRoles")
 
 	ErrRootUserNotExist     = errors.New("auth: root user does not exist")
 	ErrRootRoleNotExist     = errors.New("auth: root user does not have root role")
@@ -240,7 +237,7 @@ func (as *authStore) AuthEnable() error {
 		return ErrRootRoleNotExist
 	}
 
-	tx.UnsafePut(authBucketName, enableFlagKey, authEnabled)
+	tx.UnsafePut(buckets.Auth, enableFlagKey, authEnabled)
 
 	as.enabled = true
 	as.tokenProvider.enable()
@@ -262,7 +259,7 @@ func (as *authStore) AuthDisable() {
 	b := as.be
 	tx := b.BatchTx()
 	tx.Lock()
-	tx.UnsafePut(authBucketName, enableFlagKey, authDisabled)
+	tx.UnsafePut(buckets.Auth, enableFlagKey, authDisabled)
 	as.commitRevision(tx)
 	tx.Unlock()
 	b.ForceCommit()
@@ -357,7 +354,7 @@ func (as *authStore) Recover(be backend.Backend) {
 	as.be = be
 	tx := be.BatchTx()
 	tx.Lock()
-	_, vs := tx.UnsafeRange(authBucketName, enableFlagKey, nil, 0)
+	_, vs := tx.UnsafeRange(buckets.Auth, enableFlagKey, nil, 0)
 	if len(vs) == 1 {
 		if bytes.Equal(vs[0], authEnabled) {
 			enabled = true
@@ -906,7 +903,7 @@ func (as *authStore) IsAdminPermitted(authInfo *AuthInfo) error {
 }
 
 func getUser(lg *zap.Logger, tx backend.BatchTx, username string) *authpb.User {
-	_, vs := tx.UnsafeRange(authUsersBucketName, []byte(username), nil, 0)
+	_, vs := tx.UnsafeRange(buckets.AuthUsers, []byte(username), nil, 0)
 	if len(vs) == 0 {
 		return nil
 	}
@@ -924,7 +921,7 @@ func getUser(lg *zap.Logger, tx backend.BatchTx, username string) *authpb.User {
 }
 
 func getAllUsers(lg *zap.Logger, tx backend.BatchTx) []*authpb.User {
-	_, vs := tx.UnsafeRange(authUsersBucketName, []byte{0}, []byte{0xff}, -1)
+	_, vs := tx.UnsafeRange(buckets.AuthUsers, []byte{0}, []byte{0xff}, -1)
 	if len(vs) == 0 {
 		return nil
 	}
@@ -946,15 +943,15 @@ func putUser(lg *zap.Logger, tx backend.BatchTx, user *authpb.User) {
 	if err != nil {
 		lg.Panic("failed to unmarshal 'authpb.User'", zap.Error(err))
 	}
-	tx.UnsafePut(authUsersBucketName, user.Name, b)
+	tx.UnsafePut(buckets.AuthUsers, user.Name, b)
 }
 
 func delUser(tx backend.BatchTx, username string) {
-	tx.UnsafeDelete(authUsersBucketName, []byte(username))
+	tx.UnsafeDelete(buckets.AuthUsers, []byte(username))
 }
 
 func getRole(lg *zap.Logger, tx backend.BatchTx, rolename string) *authpb.Role {
-	_, vs := tx.UnsafeRange(authRolesBucketName, []byte(rolename), nil, 0)
+	_, vs := tx.UnsafeRange(buckets.AuthRoles, []byte(rolename), nil, 0)
 	if len(vs) == 0 {
 		return nil
 	}
@@ -968,7 +965,7 @@ func getRole(lg *zap.Logger, tx backend.BatchTx, rolename string) *authpb.Role {
 }
 
 func getAllRoles(lg *zap.Logger, tx backend.BatchTx) []*authpb.Role {
-	_, vs := tx.UnsafeRange(authRolesBucketName, []byte{0}, []byte{0xff}, -1)
+	_, vs := tx.UnsafeRange(buckets.AuthRoles, []byte{0}, []byte{0xff}, -1)
 	if len(vs) == 0 {
 		return nil
 	}
@@ -995,11 +992,11 @@ func putRole(lg *zap.Logger, tx backend.BatchTx, role *authpb.Role) {
 		)
 	}
 
-	tx.UnsafePut(authRolesBucketName, role.Name, b)
+	tx.UnsafePut(buckets.AuthRoles, role.Name, b)
 }
 
 func delRole(tx backend.BatchTx, rolename string) {
-	tx.UnsafeDelete(authRolesBucketName, []byte(rolename))
+	tx.UnsafeDelete(buckets.AuthRoles, []byte(rolename))
 }
 
 func (as *authStore) IsAuthEnabled() bool {
@@ -1028,12 +1025,12 @@ func NewAuthStore(lg *zap.Logger, be backend.Backend, tp TokenProvider, bcryptCo
 	tx := be.BatchTx()
 	tx.Lock()
 
-	tx.UnsafeCreateBucket(authBucketName)
-	tx.UnsafeCreateBucket(authUsersBucketName)
-	tx.UnsafeCreateBucket(authRolesBucketName)
+	tx.UnsafeCreateBucket(buckets.Auth)
+	tx.UnsafeCreateBucket(buckets.AuthUsers)
+	tx.UnsafeCreateBucket(buckets.AuthRoles)
 
 	enabled := false
-	_, vs := tx.UnsafeRange(authBucketName, enableFlagKey, nil, 0)
+	_, vs := tx.UnsafeRange(buckets.Auth, enableFlagKey, nil, 0)
 	if len(vs) == 1 {
 		if bytes.Equal(vs[0], authEnabled) {
 			enabled = true
@@ -1076,11 +1073,11 @@ func (as *authStore) commitRevision(tx backend.BatchTx) {
 	atomic.AddUint64(&as.revision, 1)
 	revBytes := make([]byte, revBytesLen)
 	binary.BigEndian.PutUint64(revBytes, as.Revision())
-	tx.UnsafePut(authBucketName, revisionKey, revBytes)
+	tx.UnsafePut(buckets.Auth, revisionKey, revBytes)
 }
 
 func getRevision(tx backend.BatchTx) uint64 {
-	_, vs := tx.UnsafeRange(authBucketName, revisionKey, nil, 0)
+	_, vs := tx.UnsafeRange(buckets.Auth, revisionKey, nil, 0)
 	if len(vs) != 1 {
 		// this can happen in the initialization phase
 		return 0

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -34,6 +34,7 @@ import (
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2store"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/prometheus/client_golang/prometheus"
@@ -700,7 +701,7 @@ func clusterVersionFromBackend(lg *zap.Logger, be backend.Backend) *semver.Versi
 	tx := be.ReadTx()
 	tx.RLock()
 	defer tx.RUnlock()
-	keys, vals := tx.UnsafeRange(clusterBucketName, ckey, nil, 0)
+	keys, vals := tx.UnsafeRange(buckets.Cluster, ckey, nil, 0)
 	if len(keys) == 0 {
 		return nil
 	}
@@ -719,7 +720,7 @@ func downgradeInfoFromBackend(lg *zap.Logger, be backend.Backend) *DowngradeInfo
 	tx := be.ReadTx()
 	tx.Lock()
 	defer tx.Unlock()
-	keys, vals := tx.UnsafeRange(clusterBucketName, dkey, nil, 0)
+	keys, vals := tx.UnsafeRange(buckets.Cluster, dkey, nil, 0)
 	if len(keys) == 0 {
 		return nil
 	}

--- a/server/etcdserver/api/membership/confstate.go
+++ b/server/etcdserver/api/membership/confstate.go
@@ -19,8 +19,8 @@ import (
 	"log"
 
 	"go.etcd.io/etcd/raft/v3/raftpb"
-	"go.etcd.io/etcd/server/v3/mvcc"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 	"go.uber.org/zap"
 )
 
@@ -36,13 +36,13 @@ func MustUnsafeSaveConfStateToBackend(lg *zap.Logger, tx backend.BatchTx, confSt
 		lg.Panic("Cannot marshal raftpb.ConfState", zap.Stringer("conf-state", confState), zap.Error(err))
 	}
 
-	tx.UnsafePut(mvcc.MetaBucketName, confStateKey, confStateBytes)
+	tx.UnsafePut(buckets.Meta, confStateKey, confStateBytes)
 }
 
 // UnsafeConfStateFromBackend retrieves ConfState from the backend.
 // Returns nil if confState in backend is not persisted (e.g. backend writen by <v3.5).
 func UnsafeConfStateFromBackend(lg *zap.Logger, tx backend.ReadTx) *raftpb.ConfState {
-	keys, vals := tx.UnsafeRange(mvcc.MetaBucketName, confStateKey, nil, 0)
+	keys, vals := tx.UnsafeRange(buckets.Meta, confStateKey, nil, 0)
 	if len(keys) == 0 {
 		return nil
 	}

--- a/server/etcdserver/api/v3alarm/alarms.go
+++ b/server/etcdserver/api/v3alarm/alarms.go
@@ -21,12 +21,9 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"go.uber.org/zap"
-)
-
-var (
-	alarmBucketName = []byte("alarm")
 )
 
 type BackendGetter interface {
@@ -69,7 +66,7 @@ func (a *AlarmStore) Activate(id types.ID, at pb.AlarmType) *pb.AlarmMember {
 
 	b := a.bg.Backend()
 	b.BatchTx().Lock()
-	b.BatchTx().UnsafePut(alarmBucketName, v, nil)
+	b.BatchTx().UnsafePut(buckets.Alarm, v, nil)
 	b.BatchTx().Unlock()
 
 	return newAlarm
@@ -98,7 +95,7 @@ func (a *AlarmStore) Deactivate(id types.ID, at pb.AlarmType) *pb.AlarmMember {
 
 	b := a.bg.Backend()
 	b.BatchTx().Lock()
-	b.BatchTx().UnsafeDelete(alarmBucketName, v)
+	b.BatchTx().UnsafeDelete(buckets.Alarm, v)
 	b.BatchTx().Unlock()
 
 	return m
@@ -126,8 +123,8 @@ func (a *AlarmStore) restore() error {
 	tx := b.BatchTx()
 
 	tx.Lock()
-	tx.UnsafeCreateBucket(alarmBucketName)
-	err := tx.UnsafeForEach(alarmBucketName, func(k, v []byte) error {
+	tx.UnsafeCreateBucket(buckets.Alarm)
+	err := tx.UnsafeForEach(buckets.Alarm, func(k, v []byte) error {
 		var m pb.AlarmMember
 		if err := m.Unmarshal(k); err != nil {
 			return err

--- a/server/lease/lessor_test.go
+++ b/server/lease/lessor_test.go
@@ -28,6 +28,7 @@ import (
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 	"go.uber.org/zap"
 )
 
@@ -92,7 +93,7 @@ func TestLessorGrant(t *testing.T) {
 	}
 
 	be.BatchTx().Lock()
-	_, vs := be.BatchTx().UnsafeRange(leaseBucketName, int64ToBytes(int64(l.ID)), nil, 0)
+	_, vs := be.BatchTx().UnsafeRange(buckets.Lease, int64ToBytes(int64(l.ID)), nil, 0)
 	if len(vs) != 1 {
 		t.Errorf("len(vs) = %d, want 1", len(vs))
 	}
@@ -195,7 +196,7 @@ func TestLessorRevoke(t *testing.T) {
 	}
 
 	be.BatchTx().Lock()
-	_, vs := be.BatchTx().UnsafeRange(leaseBucketName, int64ToBytes(int64(l.ID)), nil, 0)
+	_, vs := be.BatchTx().UnsafeRange(buckets.Lease, int64ToBytes(int64(l.ID)), nil, 0)
 	if len(vs) != 0 {
 		t.Errorf("len(vs) = %d, want 0", len(vs))
 	}

--- a/server/mvcc/backend/backend.go
+++ b/server/mvcc/backend/backend.go
@@ -53,7 +53,7 @@ type Backend interface {
 	ConcurrentReadTx() ReadTx
 
 	Snapshot() Snapshot
-	Hash(ignores map[IgnoreKey]struct{}) (uint32, error)
+	Hash(ignores func(bucketName, keyName []byte) bool) (uint32, error)
 	// Size returns the current size of the backend physically allocated.
 	// The backend can hold DB space that is not utilized at the moment,
 	// since it can conduct pre-allocation or spare unused space for recycling.
@@ -194,10 +194,10 @@ func newBackend(bcfg BackendConfig) *backend {
 		readTx: &readTx{
 			baseReadTx: baseReadTx{
 				buf: txReadBuffer{
-					txBuffer:   txBuffer{make(map[string]*bucketBuffer)},
+					txBuffer:   txBuffer{make(map[BucketID]*bucketBuffer)},
 					bufVersion: 0,
 				},
-				buckets: make(map[string]*bolt.Bucket),
+				buckets: make(map[BucketID]*bolt.Bucket),
 				txWg:    new(sync.WaitGroup),
 				txMu:    new(sync.RWMutex),
 			},
@@ -358,12 +358,7 @@ func (b *backend) Snapshot() Snapshot {
 	return &snapshot{tx, stopc, donec}
 }
 
-type IgnoreKey struct {
-	Bucket string
-	Key    string
-}
-
-func (b *backend) Hash(ignores map[IgnoreKey]struct{}) (uint32, error) {
+func (b *backend) Hash(ignores func(bucketName, keyName []byte) bool) (uint32, error) {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 
 	b.mu.RLock()
@@ -377,8 +372,7 @@ func (b *backend) Hash(ignores map[IgnoreKey]struct{}) (uint32, error) {
 			}
 			h.Write(next)
 			b.ForEach(func(k, v []byte) error {
-				bk := IgnoreKey{Bucket: string(next), Key: string(k)}
-				if _, ok := ignores[bk]; !ok {
+				if ignores != nil && !ignores(next, k) {
 					h.Write(k)
 					h.Write(v)
 				}

--- a/server/mvcc/backend/backend.go
+++ b/server/mvcc/backend/backend.go
@@ -587,7 +587,7 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 		if berr != nil {
 			return berr
 		}
-		tmpb.FillPercent = 0.9 // for seq write in for each
+		tmpb.FillPercent = 0.9 // for bucket2seq write in for each
 
 		if err = b.ForEach(func(k, v []byte) error {
 			count++
@@ -601,7 +601,7 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 					return err
 				}
 				tmpb = tmptx.Bucket(next)
-				tmpb.FillPercent = 0.9 // for seq write in for each
+				tmpb.FillPercent = 0.9 // for bucket2seq write in for each
 
 				count = 0
 			}

--- a/server/mvcc/backend/backend_bench_test.go
+++ b/server/mvcc/backend/backend_bench_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	betesting "go.etcd.io/etcd/server/v3/mvcc/backend/testing"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 )
 
 func BenchmarkBackendPut(b *testing.B) {
@@ -41,13 +42,13 @@ func BenchmarkBackendPut(b *testing.B) {
 	batchTx := backend.BatchTx()
 
 	batchTx.Lock()
-	batchTx.UnsafeCreateBucket([]byte("test"))
+	batchTx.UnsafeCreateBucket(buckets.Test)
 	batchTx.Unlock()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		batchTx.Lock()
-		batchTx.UnsafePut([]byte("test"), keys[i], value)
+		batchTx.UnsafePut(buckets.Test, keys[i], value)
 		batchTx.Unlock()
 	}
 }

--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -254,7 +254,7 @@ func newBatchTxBuffered(backend *backend) *batchTxBuffered {
 		batchTx: batchTx{backend: backend},
 		buf: txWriteBuffer{
 			txBuffer: txBuffer{make(map[string]*bucketBuffer)},
-			seq:      true,
+			seq:      make(map[string]bool),
 		},
 	}
 	tx.Commit()

--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -253,8 +253,8 @@ func newBatchTxBuffered(backend *backend) *batchTxBuffered {
 	tx := &batchTxBuffered{
 		batchTx: batchTx{backend: backend},
 		buf: txWriteBuffer{
-			txBuffer: txBuffer{make(map[string]*bucketBuffer)},
-			seq:      make(map[string]bool),
+			txBuffer:   txBuffer{make(map[string]*bucketBuffer)},
+			bucket2seq: make(map[string]bool),
 		},
 	}
 	tx.Commit()

--- a/server/mvcc/backend/batch_tx.go
+++ b/server/mvcc/backend/batch_tx.go
@@ -25,13 +25,30 @@ import (
 	"go.uber.org/zap"
 )
 
+type BucketID int
+
+type Bucket interface {
+	// ID returns a unique identifier of a bucket.
+	// The id must NOT be persisted and can be used as lightweight identificator
+	// in the in-memory maps.
+	ID() BucketID
+	Name() []byte
+	// String implements Stringer (human readable name).
+	String() string
+
+	// IsSafeRangeBucket is a hack to avoid inadvertently reading duplicate keys;
+	// overwrites on a bucket should only fetch with limit=1, but safeRangeBucket
+	// is known to never overwrite any key so range is safe.
+	IsSafeRangeBucket() bool
+}
+
 type BatchTx interface {
 	ReadTx
-	UnsafeCreateBucket(name []byte)
-	UnsafeDeleteBucket(name []byte)
-	UnsafePut(bucketName []byte, key []byte, value []byte)
-	UnsafeSeqPut(bucketName []byte, key []byte, value []byte)
-	UnsafeDelete(bucketName []byte, key []byte)
+	UnsafeCreateBucket(bucket Bucket)
+	UnsafeDeleteBucket(bucket Bucket)
+	UnsafePut(bucket Bucket, key []byte, value []byte)
+	UnsafeSeqPut(bucket Bucket, key []byte, value []byte)
+	UnsafeDelete(bucket Bucket, key []byte)
 	// Commit commits a previous tx and begins a new writable one.
 	Commit()
 	// CommitAndStop commits the previous tx and does not create a new one.
@@ -69,24 +86,24 @@ func (t *batchTx) RUnlock() {
 	panic("unexpected RUnlock")
 }
 
-func (t *batchTx) UnsafeCreateBucket(name []byte) {
-	_, err := t.tx.CreateBucket(name)
+func (t *batchTx) UnsafeCreateBucket(bucket Bucket) {
+	_, err := t.tx.CreateBucket(bucket.Name())
 	if err != nil && err != bolt.ErrBucketExists {
 		t.backend.lg.Fatal(
 			"failed to create a bucket",
-			zap.String("bucket-name", string(name)),
+			zap.Stringer("bucket-name", bucket),
 			zap.Error(err),
 		)
 	}
 	t.pending++
 }
 
-func (t *batchTx) UnsafeDeleteBucket(name []byte) {
-	err := t.tx.DeleteBucket(name)
+func (t *batchTx) UnsafeDeleteBucket(bucket Bucket) {
+	err := t.tx.DeleteBucket(bucket.Name())
 	if err != nil && err != bolt.ErrBucketNotFound {
 		t.backend.lg.Fatal(
 			"failed to delete a bucket",
-			zap.String("bucket-name", string(name)),
+			zap.Stringer("bucket-name", bucket),
 			zap.Error(err),
 		)
 	}
@@ -94,21 +111,21 @@ func (t *batchTx) UnsafeDeleteBucket(name []byte) {
 }
 
 // UnsafePut must be called holding the lock on the tx.
-func (t *batchTx) UnsafePut(bucketName []byte, key []byte, value []byte) {
-	t.unsafePut(bucketName, key, value, false)
+func (t *batchTx) UnsafePut(bucket Bucket, key []byte, value []byte) {
+	t.unsafePut(bucket, key, value, false)
 }
 
 // UnsafeSeqPut must be called holding the lock on the tx.
-func (t *batchTx) UnsafeSeqPut(bucketName []byte, key []byte, value []byte) {
-	t.unsafePut(bucketName, key, value, true)
+func (t *batchTx) UnsafeSeqPut(bucket Bucket, key []byte, value []byte) {
+	t.unsafePut(bucket, key, value, true)
 }
 
-func (t *batchTx) unsafePut(bucketName []byte, key []byte, value []byte, seq bool) {
-	bucket := t.tx.Bucket(bucketName)
+func (t *batchTx) unsafePut(bucketType Bucket, key []byte, value []byte, seq bool) {
+	bucket := t.tx.Bucket(bucketType.Name())
 	if bucket == nil {
 		t.backend.lg.Fatal(
 			"failed to find a bucket",
-			zap.String("bucket-name", string(bucketName)),
+			zap.Stringer("bucket-name", bucketType),
 			zap.Stack("stack"),
 		)
 	}
@@ -120,7 +137,7 @@ func (t *batchTx) unsafePut(bucketName []byte, key []byte, value []byte, seq boo
 	if err := bucket.Put(key, value); err != nil {
 		t.backend.lg.Fatal(
 			"failed to write to a bucket",
-			zap.String("bucket-name", string(bucketName)),
+			zap.Stringer("bucket-name", bucketType),
 			zap.Error(err),
 		)
 	}
@@ -128,12 +145,12 @@ func (t *batchTx) unsafePut(bucketName []byte, key []byte, value []byte, seq boo
 }
 
 // UnsafeRange must be called holding the lock on the tx.
-func (t *batchTx) UnsafeRange(bucketName, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
-	bucket := t.tx.Bucket(bucketName)
+func (t *batchTx) UnsafeRange(bucketType Bucket, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
+	bucket := t.tx.Bucket(bucketType.Name())
 	if bucket == nil {
 		t.backend.lg.Fatal(
 			"failed to find a bucket",
-			zap.String("bucket-name", string(bucketName)),
+			zap.Stringer("bucket-name", bucketType),
 			zap.Stack("stack"),
 		)
 	}
@@ -163,12 +180,12 @@ func unsafeRange(c *bolt.Cursor, key, endKey []byte, limit int64) (keys [][]byte
 }
 
 // UnsafeDelete must be called holding the lock on the tx.
-func (t *batchTx) UnsafeDelete(bucketName []byte, key []byte) {
-	bucket := t.tx.Bucket(bucketName)
+func (t *batchTx) UnsafeDelete(bucketType Bucket, key []byte) {
+	bucket := t.tx.Bucket(bucketType.Name())
 	if bucket == nil {
 		t.backend.lg.Fatal(
 			"failed to find a bucket",
-			zap.String("bucket-name", string(bucketName)),
+			zap.Stringer("bucket-name", bucketType),
 			zap.Stack("stack"),
 		)
 	}
@@ -176,7 +193,7 @@ func (t *batchTx) UnsafeDelete(bucketName []byte, key []byte) {
 	if err != nil {
 		t.backend.lg.Fatal(
 			"failed to delete a key",
-			zap.String("bucket-name", string(bucketName)),
+			zap.Stringer("bucket-name", bucketType),
 			zap.Error(err),
 		)
 	}
@@ -184,12 +201,12 @@ func (t *batchTx) UnsafeDelete(bucketName []byte, key []byte) {
 }
 
 // UnsafeForEach must be called holding the lock on the tx.
-func (t *batchTx) UnsafeForEach(bucketName []byte, visitor func(k, v []byte) error) error {
-	return unsafeForEach(t.tx, bucketName, visitor)
+func (t *batchTx) UnsafeForEach(bucket Bucket, visitor func(k, v []byte) error) error {
+	return unsafeForEach(t.tx, bucket, visitor)
 }
 
-func unsafeForEach(tx *bolt.Tx, bucket []byte, visitor func(k, v []byte) error) error {
-	if b := tx.Bucket(bucket); b != nil {
+func unsafeForEach(tx *bolt.Tx, bucket Bucket, visitor func(k, v []byte) error) error {
+	if b := tx.Bucket(bucket.Name()); b != nil {
 		return b.ForEach(visitor)
 	}
 	return nil
@@ -253,8 +270,8 @@ func newBatchTxBuffered(backend *backend) *batchTxBuffered {
 	tx := &batchTxBuffered{
 		batchTx: batchTx{backend: backend},
 		buf: txWriteBuffer{
-			txBuffer:   txBuffer{make(map[string]*bucketBuffer)},
-			bucket2seq: make(map[string]bool),
+			txBuffer:   txBuffer{make(map[BucketID]*bucketBuffer)},
+			bucket2seq: make(map[BucketID]bool),
 		},
 	}
 	tx.Commit()
@@ -316,12 +333,12 @@ func (t *batchTxBuffered) unsafeCommit(stop bool) {
 	}
 }
 
-func (t *batchTxBuffered) UnsafePut(bucketName []byte, key []byte, value []byte) {
-	t.batchTx.UnsafePut(bucketName, key, value)
-	t.buf.put(bucketName, key, value)
+func (t *batchTxBuffered) UnsafePut(bucket Bucket, key []byte, value []byte) {
+	t.batchTx.UnsafePut(bucket, key, value)
+	t.buf.put(bucket, key, value)
 }
 
-func (t *batchTxBuffered) UnsafeSeqPut(bucketName []byte, key []byte, value []byte) {
-	t.batchTx.UnsafeSeqPut(bucketName, key, value)
-	t.buf.putSeq(bucketName, key, value)
+func (t *batchTxBuffered) UnsafeSeqPut(bucket Bucket, key []byte, value []byte) {
+	t.batchTx.UnsafeSeqPut(bucket, key, value)
+	t.buf.putSeq(bucket, key, value)
 }

--- a/server/mvcc/backend/hooks_test.go
+++ b/server/mvcc/backend/hooks_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
 	betesting "go.etcd.io/etcd/server/v3/mvcc/backend/testing"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 )
 
 var (
-	bucket = []byte("bucket")
+	bucket = buckets.Test
 	key    = []byte("key")
 )
 

--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -39,11 +39,12 @@ func (txb *txBuffer) reset() {
 // txWriteBuffer buffers writes of pending updates that have not yet committed.
 type txWriteBuffer struct {
 	txBuffer
-	seq bool
+	seq map[string]bool
 }
 
+
 func (txw *txWriteBuffer) put(bucket, k, v []byte) {
-	txw.seq = false
+	txw.seq[string(bucket)] = false
 	txw.putSeq(bucket, k, v)
 }
 
@@ -56,6 +57,18 @@ func (txw *txWriteBuffer) putSeq(bucket, k, v []byte) {
 	b.add(k, v)
 }
 
+func (txw *txWriteBuffer) reset() {
+	txw.txBuffer.reset()
+	for k := range txw.seq {
+		v, ok := txw.buckets[k]
+		if !ok {
+			delete(txw.seq, k)
+		} else if v.used == 0 {
+			txw.seq[k] = true
+		}
+	}
+}
+
 func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 	for k, wb := range txw.buckets {
 		rb, ok := txr.buckets[k]
@@ -64,7 +77,7 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 			txr.buckets[k] = wb
 			continue
 		}
-		if !txw.seq && wb.used > 1 {
+		if seq, ok := txw.seq[k]; ok && !seq && wb.used > 1 {
 			// assume no duplicate keys
 			sort.Sort(wb)
 		}

--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -23,7 +23,7 @@ const bucketBufferInitialSize = 512
 
 // txBuffer handles functionality shared between txWriteBuffer and txReadBuffer.
 type txBuffer struct {
-	buckets map[string]*bucketBuffer
+	buckets map[BucketID]*bucketBuffer
 }
 
 func (txb *txBuffer) reset() {
@@ -39,28 +39,26 @@ func (txb *txBuffer) reset() {
 // txWriteBuffer buffers writes of pending updates that have not yet committed.
 type txWriteBuffer struct {
 	txBuffer
-	// Map from bucket name into information whether this bucket is edited
+	// Map from bucket ID into information whether this bucket is edited
 	// sequentially (i.e. keys are growing monotonically).
-	bucket2seq map[string]bool
+	bucket2seq map[BucketID]bool
 }
 
-// TODO: Passing bucket as an (int) enum would avoid a lot of byte[]->string->hash conversions.
-func (txw *txWriteBuffer) put(bucket, k, v []byte) {
-	bucketstr := string(bucket)
-	txw.bucket2seq[bucketstr] = false
-	txw.putInternal(bucketstr, k, v)
+func (txw *txWriteBuffer) put(bucket Bucket, k, v []byte) {
+	txw.bucket2seq[bucket.ID()] = false
+	txw.putInternal(bucket, k, v)
 }
 
-func (txw *txWriteBuffer) putSeq(bucket, k, v []byte) {
+func (txw *txWriteBuffer) putSeq(bucket Bucket, k, v []byte) {
 	// TODO: Add (in tests?) verification whether k>b[len(b)]
-	txw.putInternal(string(bucket), k, v)
+	txw.putInternal(bucket, k, v)
 }
 
-func (txw *txWriteBuffer) putInternal(bucket string, k, v []byte) {
-	b, ok := txw.buckets[bucket]
+func (txw *txWriteBuffer) putInternal(bucket Bucket, k, v []byte) {
+	b, ok := txw.buckets[bucket.ID()]
 	if !ok {
 		b = newBucketBuffer()
-		txw.buckets[bucket] = b
+		txw.buckets[bucket.ID()] = b
 	}
 	b.add(k, v)
 }
@@ -103,15 +101,15 @@ type txReadBuffer struct {
 	bufVersion uint64
 }
 
-func (txr *txReadBuffer) Range(bucketName, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
-	if b := txr.buckets[string(bucketName)]; b != nil {
+func (txr *txReadBuffer) Range(bucket Bucket, key, endKey []byte, limit int64) ([][]byte, [][]byte) {
+	if b := txr.buckets[bucket.ID()]; b != nil {
 		return b.Range(key, endKey, limit)
 	}
 	return nil, nil
 }
 
-func (txr *txReadBuffer) ForEach(bucketName []byte, visitor func(k, v []byte) error) error {
-	if b := txr.buckets[string(bucketName)]; b != nil {
+func (txr *txReadBuffer) ForEach(bucket Bucket, visitor func(k, v []byte) error) error {
+	if b := txr.buckets[bucket.ID()]; b != nil {
 		return b.ForEach(visitor)
 	}
 	return nil
@@ -121,7 +119,7 @@ func (txr *txReadBuffer) ForEach(bucketName []byte, visitor func(k, v []byte) er
 func (txr *txReadBuffer) unsafeCopy() txReadBuffer {
 	txrCopy := txReadBuffer{
 		txBuffer: txBuffer{
-			buckets: make(map[string]*bucketBuffer, len(txr.txBuffer.buckets)),
+			buckets: make(map[BucketID]*bucketBuffer, len(txr.txBuffer.buckets)),
 		},
 		bufVersion: 0,
 	}

--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -41,31 +41,38 @@ type txWriteBuffer struct {
 	txBuffer
 	// Map from bucket name into information whether this bucket is edited
 	// sequentially (i.e. keys are growing monotonically).
-	seq map[string]bool
+	bucket2seq map[string]bool
 }
 
+// TODO: Passing bucket as an (int) enum would avoid a lot of byte[]->string->hash conversions.
 func (txw *txWriteBuffer) put(bucket, k, v []byte) {
-	txw.seq[string(bucket)] = false
-	txw.putSeq(bucket, k, v)
+	bucketstr := string(bucket)
+	txw.bucket2seq[bucketstr] = false
+	txw.putInternal(bucketstr, k, v)
 }
 
 func (txw *txWriteBuffer) putSeq(bucket, k, v []byte) {
-	b, ok := txw.buckets[string(bucket)]
+	// TODO: Add (in tests?) verification whether k>b[len(b)]
+	txw.putInternal(string(bucket), k, v)
+}
+
+func (txw *txWriteBuffer) putInternal(bucket string, k, v []byte) {
+	b, ok := txw.buckets[bucket]
 	if !ok {
 		b = newBucketBuffer()
-		txw.buckets[string(bucket)] = b
+		txw.buckets[bucket] = b
 	}
 	b.add(k, v)
 }
 
 func (txw *txWriteBuffer) reset() {
 	txw.txBuffer.reset()
-	for k := range txw.seq {
+	for k := range txw.bucket2seq {
 		v, ok := txw.buckets[k]
 		if !ok {
-			delete(txw.seq, k)
+			delete(txw.bucket2seq, k)
 		} else if v.used == 0 {
-			txw.seq[k] = true
+			txw.bucket2seq[k] = true
 		}
 	}
 }
@@ -78,7 +85,7 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 			txr.buckets[k] = wb
 			continue
 		}
-		if seq, ok := txw.seq[k]; ok && !seq && wb.used > 1 {
+		if seq, ok := txw.bucket2seq[k]; ok && !seq && wb.used > 1 {
 			// assume no duplicate keys
 			sort.Sort(wb)
 		}

--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -39,9 +39,10 @@ func (txb *txBuffer) reset() {
 // txWriteBuffer buffers writes of pending updates that have not yet committed.
 type txWriteBuffer struct {
 	txBuffer
+	// Map from bucket name into information whether this bucket is edited
+	// sequentially (i.e. keys are growing monotonically).
 	seq map[string]bool
 }
-
 
 func (txw *txWriteBuffer) put(bucket, k, v []byte) {
 	txw.seq[string(bucket)] = false

--- a/server/mvcc/buckets/bucket.go
+++ b/server/mvcc/buckets/bucket.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buckets
+
+import (
+	"bytes"
+
+	"go.etcd.io/etcd/server/v3/mvcc/backend"
+)
+
+var (
+	keyBucketName   = []byte("key")
+	metaBucketName  = []byte("meta")
+	leaseBucketName = []byte("lease")
+	alarmBucketName = []byte("alarm")
+
+	clusterBucketName = []byte("cluster")
+
+	membersBucketName        = []byte("members")
+	membersRemovedBucketName = []byte("members_removed")
+
+	authBucketName      = []byte("auth")
+	authUsersBucketName = []byte("authUsers")
+	authRolesBucketName = []byte("authRoles")
+
+	testBucketName = []byte("test")
+)
+
+var (
+	Key     = backend.Bucket(bucket{id: 1, name: keyBucketName, safeRangeBucket: true})
+	Meta    = backend.Bucket(bucket{id: 2, name: metaBucketName, safeRangeBucket: false})
+	Lease   = backend.Bucket(bucket{id: 3, name: leaseBucketName, safeRangeBucket: false})
+	Alarm   = backend.Bucket(bucket{id: 4, name: alarmBucketName, safeRangeBucket: false})
+	Cluster = backend.Bucket(bucket{id: 5, name: clusterBucketName, safeRangeBucket: false})
+
+	Members        = backend.Bucket(bucket{id: 10, name: membersBucketName, safeRangeBucket: false})
+	MembersRemoved = backend.Bucket(bucket{id: 11, name: membersRemovedBucketName, safeRangeBucket: false})
+
+	Auth      = backend.Bucket(bucket{id: 20, name: authBucketName, safeRangeBucket: false})
+	AuthUsers = backend.Bucket(bucket{id: 21, name: authUsersBucketName, safeRangeBucket: false})
+	AuthRoles = backend.Bucket(bucket{id: 22, name: authRolesBucketName, safeRangeBucket: false})
+
+	Test = backend.Bucket(bucket{id: 100, name: testBucketName, safeRangeBucket: false})
+)
+
+type bucket struct {
+	id              backend.BucketID
+	name            []byte
+	safeRangeBucket bool
+}
+
+func (b bucket) ID() backend.BucketID    { return b.id }
+func (b bucket) Name() []byte            { return b.name }
+func (b bucket) String() string          { return string(b.Name()) }
+func (b bucket) IsSafeRangeBucket() bool { return b.safeRangeBucket }
+
+var (
+	MetaConsistentIndexKeyName = []byte("consistent_index")
+	MetaTermKeyName            = []byte("term")
+)
+
+// DefaultIgnores defines buckets & keys to ignore in hash checking.
+func DefaultIgnores(bucket, key []byte) bool {
+	// consistent index & term might be changed due to v2 internal sync, which
+	// is not controllable by the user.
+	return bytes.Compare(bucket, Meta.Name()) == 0 &&
+		(bytes.Compare(key, MetaTermKeyName) == 0 || bytes.Compare(key, MetaConsistentIndexKeyName) == 0)
+}

--- a/server/mvcc/kvstore.go
+++ b/server/mvcc/kvstore.go
@@ -26,17 +26,14 @@ import (
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/pkg/v3/schedule"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
-	"go.etcd.io/etcd/server/v3/etcdserver/cindex"
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"go.uber.org/zap"
 )
 
 var (
-	keyBucketName  = []byte("key")
-	MetaBucketName = cindex.MetaBucketName
-
 	scheduledCompactKeyName = []byte("scheduledCompactRev")
 	finishedCompactKeyName  = []byte("finishedCompactRev")
 
@@ -123,8 +120,8 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 
 	tx := s.b.BatchTx()
 	tx.Lock()
-	tx.UnsafeCreateBucket(keyBucketName)
-	cindex.UnsafeCreateMetaBucket(tx)
+	tx.UnsafeCreateBucket(buckets.Key)
+	tx.UnsafeCreateBucket(buckets.Meta)
 	tx.Unlock()
 	s.b.ForceCommit()
 
@@ -162,7 +159,7 @@ func (s *store) Hash() (hash uint32, revision int64, err error) {
 	start := time.Now()
 
 	s.b.ForceCommit()
-	h, err := s.b.Hash(DefaultIgnores)
+	h, err := s.b.Hash(buckets.DefaultIgnores)
 
 	hashSec.Observe(time.Since(start).Seconds())
 	return h, s.currentRev, err
@@ -198,8 +195,8 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	lower := revision{main: compactRev + 1}
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 
-	h.Write(keyBucketName)
-	err = tx.UnsafeForEach(keyBucketName, func(k, v []byte) error {
+	h.Write(buckets.Key.Name())
+	err = tx.UnsafeForEach(buckets.Key, func(k, v []byte) error {
 		kr := bytesToRev(k)
 		if !upper.GreaterThan(kr) {
 			return nil
@@ -242,7 +239,7 @@ func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
 
 	tx := s.b.BatchTx()
 	tx.Lock()
-	tx.UnsafePut(MetaBucketName, scheduledCompactKeyName, rbytes)
+	tx.UnsafePut(buckets.Meta, scheduledCompactKeyName, rbytes)
 	tx.Unlock()
 	// ensure that desired compaction is persisted
 	s.b.ForceCommit()
@@ -297,18 +294,6 @@ func (s *store) Compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 	return s.compact(trace, rev)
 }
 
-// DefaultIgnores is a map of keys to ignore in hash checking.
-var DefaultIgnores map[backend.IgnoreKey]struct{}
-
-func init() {
-	DefaultIgnores = map[backend.IgnoreKey]struct{}{
-		// consistent index might be changed due to v2 internal sync, which
-		// is not controllable by the user.
-		{Bucket: string(MetaBucketName), Key: string(cindex.ConsistentIndexKeyName)}: {},
-		{Bucket: string(MetaBucketName), Key: string(cindex.TermKeyName)}:            {},
-	}
-}
-
 func (s *store) Commit() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -352,20 +337,20 @@ func (s *store) restore() error {
 	tx := s.b.BatchTx()
 	tx.Lock()
 
-	_, finishedCompactBytes := tx.UnsafeRange(MetaBucketName, finishedCompactKeyName, nil, 0)
+	_, finishedCompactBytes := tx.UnsafeRange(buckets.Meta, finishedCompactKeyName, nil, 0)
 	if len(finishedCompactBytes) != 0 {
 		s.revMu.Lock()
 		s.compactMainRev = bytesToRev(finishedCompactBytes[0]).main
 
 		s.lg.Info(
 			"restored last compact revision",
-			zap.String("meta-bucket-name", string(MetaBucketName)),
+			zap.Stringer("meta-bucket-name", buckets.Meta),
 			zap.String("meta-bucket-name-key", string(finishedCompactKeyName)),
 			zap.Int64("restored-compact-revision", s.compactMainRev),
 		)
 		s.revMu.Unlock()
 	}
-	_, scheduledCompactBytes := tx.UnsafeRange(MetaBucketName, scheduledCompactKeyName, nil, 0)
+	_, scheduledCompactBytes := tx.UnsafeRange(buckets.Meta, scheduledCompactKeyName, nil, 0)
 	scheduledCompact := int64(0)
 	if len(scheduledCompactBytes) != 0 {
 		scheduledCompact = bytesToRev(scheduledCompactBytes[0]).main
@@ -375,7 +360,7 @@ func (s *store) restore() error {
 	keysGauge.Set(0)
 	rkvc, revc := restoreIntoIndex(s.lg, s.kvindex)
 	for {
-		keys, vals := tx.UnsafeRange(keyBucketName, min, max, int64(restoreChunkKeys))
+		keys, vals := tx.UnsafeRange(buckets.Key, min, max, int64(restoreChunkKeys))
 		if len(keys) == 0 {
 			break
 		}
@@ -436,7 +421,7 @@ func (s *store) restore() error {
 
 		s.lg.Info(
 			"resume scheduled compaction",
-			zap.String("meta-bucket-name", string(MetaBucketName)),
+			zap.Stringer("meta-bucket-name", buckets.Meta),
 			zap.String("meta-bucket-name-key", string(scheduledCompactKeyName)),
 			zap.Int64("scheduled-compact-revision", scheduledCompact),
 		)

--- a/server/mvcc/kvstore_compaction.go
+++ b/server/mvcc/kvstore_compaction.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 	"go.uber.org/zap"
 )
 
@@ -39,11 +40,11 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 
 		tx := s.b.BatchTx()
 		tx.Lock()
-		keys, _ := tx.UnsafeRange(keyBucketName, last, end, int64(s.cfg.CompactionBatchLimit))
+		keys, _ := tx.UnsafeRange(buckets.Key, last, end, int64(s.cfg.CompactionBatchLimit))
 		for _, key := range keys {
 			rev = bytesToRev(key)
 			if _, ok := keep[rev]; !ok {
-				tx.UnsafeDelete(keyBucketName, key)
+				tx.UnsafeDelete(buckets.Key, key)
 				keyCompactions++
 			}
 		}
@@ -51,7 +52,7 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 		if len(keys) < s.cfg.CompactionBatchLimit {
 			rbytes := make([]byte, 8+1+8)
 			revToBytes(revision{main: compactMainRev}, rbytes)
-			tx.UnsafePut(MetaBucketName, finishedCompactKeyName, rbytes)
+			tx.UnsafePut(buckets.Meta, finishedCompactKeyName, rbytes)
 			tx.Unlock()
 			s.lg.Info(
 				"finished scheduled compaction",

--- a/server/mvcc/kvstore_compaction_test.go
+++ b/server/mvcc/kvstore_compaction_test.go
@@ -24,6 +24,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
 	betesting "go.etcd.io/etcd/server/v3/mvcc/backend/testing"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 	"go.uber.org/zap"
 )
 
@@ -74,7 +75,7 @@ func TestScheduleCompaction(t *testing.T) {
 		ibytes := newRevBytes()
 		for _, rev := range revs {
 			revToBytes(rev, ibytes)
-			tx.UnsafePut(keyBucketName, ibytes, []byte("bar"))
+			tx.UnsafePut(buckets.Key, ibytes, []byte("bar"))
 		}
 		tx.Unlock()
 
@@ -83,12 +84,12 @@ func TestScheduleCompaction(t *testing.T) {
 		tx.Lock()
 		for _, rev := range tt.wrevs {
 			revToBytes(rev, ibytes)
-			keys, _ := tx.UnsafeRange(keyBucketName, ibytes, nil, 0)
+			keys, _ := tx.UnsafeRange(buckets.Key, ibytes, nil, 0)
 			if len(keys) != 1 {
 				t.Errorf("#%d: range on %v = %d, want 1", i, rev, len(keys))
 			}
 		}
-		_, vals := tx.UnsafeRange(MetaBucketName, finishedCompactKeyName, nil, 0)
+		_, vals := tx.UnsafeRange(buckets.Meta, finishedCompactKeyName, nil, 0)
 		revToBytes(revision{main: tt.rev}, ibytes)
 		if w := [][]byte{ibytes}; !reflect.DeepEqual(vals, w) {
 			t.Errorf("#%d: vals on %v = %+v, want %+v", i, finishedCompactKeyName, vals, w)

--- a/server/mvcc/util.go
+++ b/server/mvcc/util.go
@@ -19,6 +19,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 )
 
 func WriteKV(be backend.Backend, kv mvccpb.KeyValue) {
@@ -31,6 +32,6 @@ func WriteKV(be backend.Backend, kv mvccpb.KeyValue) {
 	}
 
 	be.BatchTx().Lock()
-	be.BatchTx().UnsafePut(keyBucketName, ibytes, d)
+	be.BatchTx().UnsafePut(buckets.Key, ibytes, d)
 	be.BatchTx().Unlock()
 }

--- a/server/mvcc/watchable_store.go
+++ b/server/mvcc/watchable_store.go
@@ -22,6 +22,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"go.uber.org/zap"
 )
@@ -353,7 +354,7 @@ func (s *watchableStore) syncWatchers() int {
 	// values are actual key-value pairs in backend.
 	tx := s.store.b.ReadTx()
 	tx.RLock()
-	revs, vs := tx.UnsafeRange(keyBucketName, minBytes, maxBytes, 0)
+	revs, vs := tx.UnsafeRange(buckets.Key, minBytes, maxBytes, 0)
 	tx.RUnlock()
 	evs := kvsToEvents(s.store.lg, wg, revs, vs)
 

--- a/tools/etcd-dump-db/backend.go
+++ b/tools/etcd-dump-db/backend.go
@@ -20,10 +20,10 @@ import (
 	"path/filepath"
 
 	"go.etcd.io/etcd/api/v3/authpb"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/server/v3/lease/leasepb"
-	"go.etcd.io/etcd/server/v3/mvcc"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
 
 	bolt "go.etcd.io/bbolt"
@@ -163,7 +163,7 @@ func iterateBucket(dbPath, bucket string, limit uint64, decode bool) (err error)
 
 func getHash(dbPath string) (hash uint32, err error) {
 	b := backend.NewDefaultBackend(dbPath)
-	return b.Hash(mvcc.DefaultIgnores)
+	return b.Hash(buckets.DefaultIgnores)
 }
 
 // TODO: revert by revision and find specified hash value


### PR DESCRIPTION
Backports of: 
  - https://github.com/etcd-io/etcd/pull/12991/commits (Represent bucket as object instead of []byte name.)
  - https://github.com/etcd-io/etcd/pull/12986/commits (Reset 'seq' flags between transactions and track per 'bucket')
that were accompanying: https://github.com/etcd-io/etcd/pull/13036 