### PR TITLE
testutil, clientv3: Add klog and opencensus to gorutine ignore for tests

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -142,6 +142,9 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "go.etcd.io/etcd/client/pkg/v3/testutil.interestingGoroutines") ||
 			strings.Contains(stack, "go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop") ||
 			strings.Contains(stack, "github.com/golang/glog.(*loggingT).flushDaemon") ||
+			strings.Contains(stack, "k8s.io/klog/v2.(*loggingT).flushDaemon") ||
+			strings.Contains(stack, "k8s.io/klog.(*loggingT).flushDaemon") ||
+			strings.Contains(stack, "go.opencensus.io/stats/view.(*worker).start") ||
 			strings.Contains(stack, "created by runtime.gc") ||
 			strings.Contains(stack, "created by text/template/parse.lex") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||


### PR DESCRIPTION
We have some issues with this in k8s, where we have both a klog flushing
daemon and a opencensus worker running in the background when running
tests.

More info here: https://github.com/kubernetes/kubernetes/pull/100488#issuecomment-849375418

Would be nice to get this into the `v3.5` release. :smile: 
