### PR TITLE
Remove redundant fsync for WAL

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -251,14 +251,6 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 				// gofail: var raftAfterSave struct{}
 
 				if !raft.IsEmptySnap(rd.Snapshot) {
-					// Force WAL to fsync its hard state before Release() releases
-					// old data from the WAL. Otherwise could get an error like:
-					// panic: tocommit(107) is out of range [lastIndex(84)]. Was the raft log corrupted, truncated, or lost?
-					// See https://github.com/etcd-io/etcd/issues/10219 for more details.
-					if err := r.storage.Sync(); err != nil {
-						r.lg.Fatal("failed to sync Raft snapshot", zap.Error(err))
-					}
-
 					// etcdserver now claim the snapshot has been persisted onto the disk
 					notifyc <- struct{}{}
 

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1158,11 +1158,6 @@ func TestSnapshotOrdering(t *testing.T) {
 		t.Fatalf("expected file %q, got missing", snapPath)
 	}
 
-	// unblock SaveSnapshot, etcdserver now permitted to move snapshot file
-	if ac := <-p.Chan(); ac.Name != "Sync" {
-		t.Fatalf("expected Sync, got %+v", ac)
-	}
-
 	if ac := <-p.Chan(); ac.Name != "Release" {
 		t.Fatalf("expected Release, got %+v", ac)
 	}


### PR DESCRIPTION
Because the hard state is already on disk after invocation of wal.Save.

https://github.com/etcd-io/etcd/blob/71934ff244ca4e06f4c60e8a0eb27f4889e5cc77/server/wal/wal.go#L937-L944
https://github.com/etcd-io/etcd/blob/71934ff244ca4e06f4c60e8a0eb27f4889e5cc77/server/wal/wal.go#L713

I've already checked with steps to reproduce of https://github.com/etcd-io/etcd/issues/10219 and there is no problem.


<!--Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.-->
