### PR TITLE
backport-3.5: integration.BeforeTest can be run without leak-detection in k8s 

### DIFF
--- a/client/pkg/testutil/leak_test.go
+++ b/client/pkg/testutil/leak_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 
 func TestSample(t *testing.T) {
 	SkipTestIfShortMode(t, "Counting leaked routines is disabled in --short tests")
-	defer AfterTest(t)
+	defer afterTest(t)
 	ranSample = true
 	for range make([]struct{}, 100) {
 		go func() {

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -35,7 +35,7 @@ func NewClient(t *testing.T, cfg Config) (*Client, error) {
 }
 
 func TestDialCancel(t *testing.T) {
-	testutil.BeforeTest(t)
+	testutil.RegisterLeakDetection(t)
 
 	// accept first connection so client is created with dial timeout
 	ln, err := net.Listen("unix", "dialcancel:12345")
@@ -87,7 +87,7 @@ func TestDialCancel(t *testing.T) {
 }
 
 func TestDialTimeout(t *testing.T) {
-	testutil.BeforeTest(t)
+	testutil.RegisterLeakDetection(t)
 
 	wantError := context.DeadlineExceeded
 

--- a/client/v3/txn_test.go
+++ b/client/v3/txn_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestTxnPanics(t *testing.T) {
-	testutil.BeforeTest(t)
+	testutil.RegisterLeakDetection(t)
 
 	kv := &kv{}
 

--- a/server/etcdserver/api/rafthttp/stream_test.go
+++ b/server/etcdserver/api/rafthttp/stream_test.go
@@ -187,7 +187,7 @@ func TestStreamReaderDialResult(t *testing.T) {
 
 // TestStreamReaderStopOnDial tests a stream reader closes the connection on stop.
 func TestStreamReaderStopOnDial(t *testing.T) {
-	testutil.BeforeTest(t)
+	testutil.RegisterLeakDetection(t)
 	h := http.Header{}
 	h.Add("X-Server-Version", version.Version)
 	tr := &respWaitRoundTripper{rrt: &respRoundTripper{code: http.StatusOK, header: h}}

--- a/tests/integration/clientv3/connectivity/server_shutdown_test.go
+++ b/tests/integration/clientv3/connectivity/server_shutdown_test.go
@@ -17,6 +17,7 @@ package connectivity_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -243,8 +244,10 @@ func TestBalancerUnderServerStopInflightLinearizableGetOnRestart(t *testing.T) {
 		{pinLeader: false, stopPinFirst: true},
 		{pinLeader: false, stopPinFirst: false},
 	}
-	for i := range tt {
-		testBalancerUnderServerStopInflightRangeOnRestart(t, true, tt[i])
+	for _, w := range tt {
+		t.Run(fmt.Sprintf("%#v", w), func(t *testing.T) {
+			testBalancerUnderServerStopInflightRangeOnRestart(t, true, w)
+		})
 	}
 }
 
@@ -255,8 +258,10 @@ func TestBalancerUnderServerStopInflightSerializableGetOnRestart(t *testing.T) {
 		{pinLeader: false, stopPinFirst: true},
 		{pinLeader: false, stopPinFirst: false},
 	}
-	for i := range tt {
-		testBalancerUnderServerStopInflightRangeOnRestart(t, false, tt[i])
+	for _, w := range tt {
+		t.Run(fmt.Sprintf("%#v", w), func(t *testing.T) {
+			testBalancerUnderServerStopInflightRangeOnRestart(t, false, w)
+		})
 	}
 }
 

--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -611,8 +611,6 @@ func TestConfigurableWatchProgressNotifyInterval(t *testing.T) {
 }
 
 func TestWatchRequestProgress(t *testing.T) {
-	integration.BeforeTest(t)
-
 	if integration.ThroughProxy {
 		t.Skipf("grpc-proxy does not support WatchProgress yet")
 	}

--- a/tests/integration/cluster.go
+++ b/tests/integration/cluster.go
@@ -1288,16 +1288,8 @@ type ClusterV3 struct {
 // for each cluster member.
 func NewClusterV3(t testutil.TB, cfg *ClusterConfig) *ClusterV3 {
 	t.Helper()
-	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(wd, os.TempDir()) {
-		t.Errorf("Working directory '%s' expected to be in temp-dir ('%s')."+
-			"Have you executed integration.BeforeTest(t) ?", wd, os.TempDir())
-	}
+	assertInTestContext(t)
 
 	cfg.UseGRPC = true
 

--- a/tests/integration/testing_test.go
+++ b/tests/integration/testing_test.go
@@ -12,27 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package integration_test
 
 import (
-	"os"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
-	"go.etcd.io/etcd/server/v3/verify"
+	"go.etcd.io/etcd/tests/v3/integration"
 )
 
-func BeforeTest(t testing.TB) {
-	skipInShortMode(t)
-	testutil.RegisterLeakDetection(t)
-	os.Setenv(verify.ENV_VERIFY, verify.ENV_VERIFY_ALL_VALUE)
-
-	path, err := os.Getwd()
-	assert.NoError(t, err)
-	tempDir := t.TempDir()
-	assert.NoError(t, os.Chdir(tempDir))
-	t.Logf("Changing working directory to: %s", tempDir)
-
-	t.Cleanup(func() { assert.NoError(t, os.Chdir(path)) })
+func TestBeforeTestWithoutLeakDetection(t *testing.T) {
+	integration.BeforeTest(t, integration.WithoutGoLeakDetection(), integration.WithoutSkipInShort())
+	// Intentional leak that should get ignored
+	go time.Sleep(2 * time.Second)
 }

--- a/tests/integration/v2store/store_tag_not_v2v3_test.go
+++ b/tests/integration/v2store/store_tag_not_v2v3_test.go
@@ -32,7 +32,6 @@ type v2TestStore struct {
 func (s *v2TestStore) Close() {}
 
 func newTestStore(t *testing.T, ns ...string) StoreCloser {
-	integration.BeforeTest(t)
 	if len(ns) == 0 {
 		t.Logf("new v2 store with no namespace")
 	}
@@ -41,6 +40,7 @@ func newTestStore(t *testing.T, ns ...string) StoreCloser {
 
 // Ensure that the store can recover from a previously saved state.
 func TestStoreRecover(t *testing.T) {
+	integration.BeforeTest(t)
 	s := newTestStore(t)
 	defer s.Close()
 	var eidx uint64 = 4

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -233,7 +233,6 @@ func TestV3LeaseCheckpoint(t *testing.T) {
 
 	var ttl int64 = 300
 	leaseInterval := 2 * time.Second
-	BeforeTest(t)
 	clus := NewClusterV3(t, &ClusterConfig{
 		Size:                    3,
 		EnableLeaseCheckpoint:   true,


### PR DESCRIPTION
Backport of: https://github.com/etcd-io/etcd/pull/13052 to unblock k8s integration with 3.5