### PR TITLE
if rev is not specified, choose recent revision of the specified key.

### DIFF
--- a/client/v3/mirror/syncer.go
+++ b/client/v3/mirror/syncer.go
@@ -36,14 +36,15 @@ type Syncer interface {
 }
 
 // NewSyncer creates a Syncer.
-func NewSyncer(c *clientv3.Client, prefix string, rev int64) Syncer {
-	return &syncer{c: c, prefix: prefix, rev: rev}
+func NewSyncer(c *clientv3.Client, prefix string, rev int64, key string) Syncer {
+	return &syncer{c: c, prefix: prefix, rev: rev, key: key}
 }
 
 type syncer struct {
 	c      *clientv3.Client
 	rev    int64
 	prefix string
+	key    string
 }
 
 func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, chan error) {
@@ -52,7 +53,11 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 
 	// if rev is not specified, we will choose the most recent revision.
 	if s.rev == 0 {
-		resp, err := s.c.Get(ctx, "foo")
+		key := "foo"
+		if len(s.key) > 0 {
+		        key = s.key
+		}
+		resp, err := s.c.Get(ctx, key)
 		if err != nil {
 			errchan <- err
 			close(respchan)

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -137,7 +137,7 @@ func makeMirror(ctx context.Context, c *clientv3.Client, dc *clientv3.Client) er
 		}
 	}()
 
-	s := mirror.NewSyncer(c, mmprefix, 0)
+	s := mirror.NewSyncer(c, mmprefix, 0, "")
 
 	rc, errc := s.SyncBase(ctx)
 

--- a/tests/integration/clientv3/mirror_test.go
+++ b/tests/integration/clientv3/mirror_test.go
@@ -39,7 +39,7 @@ func TestMirrorSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	syncer := mirror.NewSyncer(c, "", 0)
+	syncer := mirror.NewSyncer(c, "", 0, "")
 	gch, ech := syncer.SyncBase(context.TODO())
 	wkvs := []*mvccpb.KeyValue{{Key: []byte("foo"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}}
 
@@ -104,7 +104,7 @@ func TestMirrorSyncBase(t *testing.T) {
 	close(keyCh)
 	wg.Wait()
 
-	syncer := mirror.NewSyncer(cli, "test", 0)
+	syncer := mirror.NewSyncer(cli, "test", 0, "")
 	respCh, errCh := syncer.SyncBase(ctx)
 
 	count := 0


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Problem:  production etcd may not have the 'foo' key.