### PR TITLE
client, raft: Log unhandled errors

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -439,6 +439,9 @@ func (l *lessor) recvKeepAliveLoop() (gerr error) {
 	for {
 		stream, err := l.resetRecv()
 		if err != nil {
+			l.lg.Warn("error occurred during lease keep alive loop",
+				zap.Error(err),
+			)
 			if canceledByCaller(l.stopCtx, err) {
 				return err
 			}
@@ -571,7 +574,9 @@ func (l *lessor) sendKeepAliveLoop(stream pb.Lease_LeaseKeepAliveClient) {
 		for _, id := range tosend {
 			r := &pb.LeaseKeepAliveRequest{ID: int64(id)}
 			if err := stream.Send(r); err != nil {
-				// TODO do something with this error?
+				l.lg.Warn("error occurred during lease keep alive request sending",
+					zap.Error(err),
+				)
 				return
 			}
 		}

--- a/raft/node.go
+++ b/raft/node.go
@@ -223,7 +223,10 @@ func StartNode(c *Config, peers []Peer) Node {
 	if err != nil {
 		panic(err)
 	}
-	rn.Bootstrap(peers)
+	err = rn.Bootstrap(peers)
+	if err != nil {
+		c.Logger.Warningf("error occurred during starting a new node: %v", err)
+	}
 
 	n := newNode(rn)
 

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -647,7 +647,9 @@ func (r *raft) tickElection() {
 
 	if r.promotable() && r.pastElectionTimeout() {
 		r.electionElapsed = 0
-		r.Step(pb.Message{From: r.id, Type: pb.MsgHup})
+		if err := r.Step(pb.Message{From: r.id, Type: pb.MsgHup}); err != nil {
+			r.logger.Debugf("error occurred during election: %v", err)
+		}
 	}
 }
 
@@ -659,7 +661,9 @@ func (r *raft) tickHeartbeat() {
 	if r.electionElapsed >= r.electionTimeout {
 		r.electionElapsed = 0
 		if r.checkQuorum {
-			r.Step(pb.Message{From: r.id, Type: pb.MsgCheckQuorum})
+			if err := r.Step(pb.Message{From: r.id, Type: pb.MsgCheckQuorum}); err != nil {
+				r.logger.Debugf("error occurred during checking sending hearbeat: %v", err)
+			}
 		}
 		// If current leader cannot transfer leadership in electionTimeout, it becomes leader again.
 		if r.state == StateLeader && r.leadTransferee != None {
@@ -673,7 +677,9 @@ func (r *raft) tickHeartbeat() {
 
 	if r.heartbeatElapsed >= r.heartbeatTimeout {
 		r.heartbeatElapsed = 0
-		r.Step(pb.Message{From: r.id, Type: pb.MsgBeat})
+		if err := r.Step(pb.Message{From: r.id, Type: pb.MsgBeat}); err != nil {
+			r.logger.Debugf("error occurred during checking sending hearbeat: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
While exploring codebase I found some errors that are never handled, neither logged nor returned. I now log errors, but happy to do something different as well!

Fixes https://github.com/etcd-io/etcd/issues/12884.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
