### PR TITLE
client/v3/README.md: Remove warning

### DIFF
--- a/client/v3/README.md
+++ b/client/v3/README.md
@@ -11,26 +11,23 @@
 go get go.etcd.io/etcd/client/v3
 ```
 
-Warning: As etcd 3.5.0 was not yet released, the command above does not work. 
-After first pre-release of 3.5.0 [#12498](https://github.com/etcd-io/etcd/issues/12498), 
-etcd can be referenced using: 
-```
-go get go.etcd.io/etcd/client/v3@v3.5.0-pre
-```
-
 ## Get started
 
 Create client using `clientv3.New`:
 
 ```go
-cli, err := clientv3.New(clientv3.Config{
-	Endpoints:   []string{"localhost:2379", "localhost:22379", "localhost:32379"},
-	DialTimeout: 5 * time.Second,
-})
-if err != nil {
-	// handle error!
+import clientv3 "go.etcd.io/etcd/client/v3"
+
+func main() {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"localhost:2379", "localhost:22379", "localhost:32379"},
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		// handle error!
+	}
+	defer cli.Close()
 }
-defer cli.Close()
 ```
 
 etcd v3 uses [`gRPC`](https://www.grpc.io) for remote procedure calls. And `clientv3` uses


### PR DESCRIPTION
`go get go.etcd.io/etcd/client/v3` works correctly now and gets the latest beta release, my go.mod after running the command:

```
require go.etcd.io/etcd/client/v3 v3.5.0-beta.4
```
I also added an example with the import path as copy-pasting the client example created a strange import path for me in `vim` -> `"go.etcd.io/etcd/clientv3"`.