### PR TITLE
etcdserver: don't activate alarm w/missing AlarmType

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -111,6 +111,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 ### etcd server
 
+  - Add [don't activate alarms w/missing AlarmType](https://github.com/etcd-io/etcd/pull/13084).
   - Add [`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256` and `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` to `etcd --cipher-suites`](https://github.com/etcd-io/etcd/pull/11864).
   - Automatically [create parent directory if it does not exist](https://github.com/etcd-io/etcd/pull/9626) (fix [issue#9609](https://github.com/etcd-io/etcd/issues/9609)).
   - v4.0 will configure `etcd --enable-v2=true --enable-v2v3=/aaa` to enable v2 API server that is backed by **v3 storage**.

--- a/server/etcdserver/apply.go
+++ b/server/etcdserver/apply.go
@@ -721,6 +721,9 @@ func (a *applierV3backend) Alarm(ar *pb.AlarmRequest) (*pb.AlarmResponse, error)
 	case pb.AlarmRequest_GET:
 		resp.Alarms = a.s.alarmStore.Get(ar.Alarm)
 	case pb.AlarmRequest_ACTIVATE:
+		if ar.Alarm == pb.AlarmType_NONE {
+			break
+		}
 		m := a.s.alarmStore.Activate(types.ID(ar.MemberID), ar.Alarm)
 		if m == nil {
 			break
@@ -738,7 +741,7 @@ func (a *applierV3backend) Alarm(ar *pb.AlarmRequest) (*pb.AlarmResponse, error)
 		case pb.AlarmType_NOSPACE:
 			a.s.applyV3 = newApplierV3Capped(a)
 		default:
-			lg.Warn("unimplemented alarm activation", zap.String("alarm", fmt.Sprintf("%+v", m)))
+			lg.Panic("unimplemented alarm activation", zap.String("alarm", fmt.Sprintf("%+v", m)))
 		}
 	case pb.AlarmRequest_DEACTIVATE:
 		m := a.s.alarmStore.Deactivate(types.ID(ar.MemberID), ar.Alarm)

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -366,6 +366,21 @@ func testV3CurlResignMissiongLeaderKey(cx ctlCtx) {
 	}
 }
 
+func TestV3CurlMaintenanceAlarmMissiongAlarm(t *testing.T) {
+	for _, p := range apiPrefix {
+		testCtl(t, testV3CurlMaintenanceAlarmMissiongAlarm, withApiPrefix(p), withCfg(*newConfigNoTLS()))
+	}
+}
+
+func testV3CurlMaintenanceAlarmMissiongAlarm(cx ctlCtx) {
+	if err := cURLPost(cx.epc, cURLReq{
+		endpoint: path.Join(cx.apiPrefix, "/maintenance/alarm"),
+		value:    `{"action": "ACTIVATE"}`,
+	}); err != nil {
+		cx.t.Fatalf("failed post maintenance alarm (%s) (%v)", cx.apiPrefix, err)
+	}
+}
+
 // to manually decode; JSON marshals integer fields with
 // string types, so can't unmarshal with epb.CampaignResponse
 type campaignResponse struct {


### PR DESCRIPTION
This is a crashing bug I found while fuzzing etcd under [Mayhem for API](https://mayhem4api.forallsecure.com/). Full disclosure: working on this is my day job!

On a fresh-out-of-the-box `bin/etcd`:

```
$ curl -d "{\"action\":\"ACTIVATE\"}" localhost:2379/v3/maintenance/alarm
curl: (52) Empty reply from server
```

The server has crashed hard, with:

```
go.etcd.io/etcd/server/v3/mvcc/backend.(*batchTx).unsafePut
	etcd/release/etcd/server/mvcc/backend/batch_tx.go:138
go.etcd.io/etcd/server/v3/mvcc/backend.(*batchTx).UnsafePut
	etcd/release/etcd/server/mvcc/backend/batch_tx.go:115
go.etcd.io/etcd/server/v3/mvcc/backend.(*batchTxBuffered).UnsafePut
	etcd/release/etcd/server/mvcc/backend/batch_tx.go:337
go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm.(*AlarmStore).Activate
	etcd/release/etcd/server/etcdserver/api/v3alarm/alarms.go:69
go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).Alarm
	etcd/release/etcd/server/etcdserver/apply.go:724
go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).Apply
	etcd/release/etcd/server/etcdserver/apply.go:192
go.etcd.io/etcd/server/v3/etcdserver.(*authApplierV3).Apply
	etcd/release/etcd/server/etcdserver/apply_auth.go:61
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntryNormal
	etcd/release/etcd/server/etcdserver/server.go:2206
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply
	etcd/release/etcd/server/etcdserver/server.go:2116
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries
	etcd/release/etcd/server/etcdserver/server.go:1357
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll
	etcd/release/etcd/server/etcdserver/server.go:1179
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func8
	etcd/release/etcd/server/etcdserver/server.go:1111
go.etcd.io/etcd/pkg/v3/schedule.(*fifo).run
	etcd/release/etcd/pkg/schedule/schedule.go:157
```

(And in fact fails with the same exception on every subsequent restart until the offending alarm is cleaned out of the data directory!)

The test I've added is at the same level (http request from the outside world) where I discovered the bug, because I'm not super familiar with the etcd codebase. Let me know if it'd be more appropriate to add a narrower unit test.

I tried to keep my fix in line with the existing behavior of `applierV3backend.Alarm()`, which is to say it turns bad requests into silent noops.

Finally: I've found at least one other crashing bug through fuzzing, as well as other, less severe issues. Please let me know if you don't want further PRs based on these findings!