### PR TITLE
etcdserver: don't attempt to grant nil permission to a role

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -58,6 +58,7 @@ var (
 	ErrGRPCRoleNotFound         = status.New(codes.FailedPrecondition, "etcdserver: role name not found").Err()
 	ErrGRPCRoleEmpty            = status.New(codes.InvalidArgument, "etcdserver: role name is empty").Err()
 	ErrGRPCAuthFailed           = status.New(codes.InvalidArgument, "etcdserver: authentication failed, invalid user ID or password").Err()
+	ErrGRPCPermissionNotGiven   = status.New(codes.InvalidArgument, "etcdserver: permission not given").Err()
 	ErrGRPCPermissionDenied     = status.New(codes.PermissionDenied, "etcdserver: permission denied").Err()
 	ErrGRPCRoleNotGranted       = status.New(codes.FailedPrecondition, "etcdserver: role is not granted to the user").Err()
 	ErrGRPCPermissionNotGranted = status.New(codes.FailedPrecondition, "etcdserver: permission is not granted to the role").Err()

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -56,6 +56,7 @@ var (
 	ErrRoleAlreadyExist     = errors.New("auth: role already exists")
 	ErrRoleNotFound         = errors.New("auth: role not found")
 	ErrRoleEmpty            = errors.New("auth: role name is empty")
+	ErrPermissionNotGiven   = errors.New("auth: permission not given")
 	ErrAuthFailed           = errors.New("auth: authentication failed, invalid user ID or password")
 	ErrNoPasswordUser       = errors.New("auth: authentication failed, password was given for no password user")
 	ErrPermissionDenied     = errors.New("auth: permission denied")
@@ -786,6 +787,10 @@ func (perms permSlice) Swap(i, j int) {
 }
 
 func (as *authStore) RoleGrantPermission(r *pb.AuthRoleGrantPermissionRequest) (*pb.AuthRoleGrantPermissionResponse, error) {
+	if r.Perm == nil {
+		return nil, ErrPermissionNotGiven
+	}
+
 	tx := as.be.BatchTx()
 	tx.Lock()
 	defer tx.Unlock()

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -445,6 +445,22 @@ func TestRoleGrantPermission(t *testing.T) {
 	}
 
 	assert.Equal(t, perm, r.Perm[0])
+
+	// trying to grant nil permissions returns an error (and doesn't change the actual permissions!)
+	_, err = as.RoleGrantPermission(&pb.AuthRoleGrantPermissionRequest{
+		Name: "role-test-1",
+	})
+
+	if err != ErrPermissionNotGiven {
+		t.Error(err)
+	}
+
+	r, err = as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, perm, r.Perm[0])
 }
 
 func TestRootRoleGrantPermission(t *testing.T) {

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -77,6 +77,7 @@ var toGRPCErrorMap = map[error]error{
 	auth.ErrRoleNotFound:         rpctypes.ErrGRPCRoleNotFound,
 	auth.ErrRoleEmpty:            rpctypes.ErrGRPCRoleEmpty,
 	auth.ErrAuthFailed:           rpctypes.ErrGRPCAuthFailed,
+	auth.ErrPermissionNotGiven:   rpctypes.ErrGRPCPermissionNotGiven,
 	auth.ErrPermissionDenied:     rpctypes.ErrGRPCPermissionDenied,
 	auth.ErrRoleNotGranted:       rpctypes.ErrGRPCRoleNotGranted,
 	auth.ErrPermissionNotGranted: rpctypes.ErrGRPCPermissionNotGranted,


### PR DESCRIPTION
Similar to #13084, this is a crashing bug found while fuzzing etcd under [Mayhem for API](https://mayhem4api.forallsecure.com/), aka mapi. I'll repeat my disclosure from that ticket: working on mapi is my day job!

On a fresh-out-of-the-box `bin/etcd`:

```
$ curl -d '{"name": "foo"}' http://localhost:2379/v3/auth/role/add
{"header":{"cluster_id":"14841639068965178418", ...
$ curl -d '{"name": "foo"}' http://localhost:2379/v3/auth/role/grant
curl: (52) Empty reply from server
```

The server has crashed hard, with:

```
go.etcd.io/etcd/server/v3/auth.(*authStore).RoleGrantPermission.func1(0x0, 0x17288ea)
	etcd/server/auth/store.go:799 +0x4f
sort.Search(0x1, 0xc00031cba0, 0xc000234840)
	/usr/local/Cellar/go/1.16.4/libexec/src/sort/search.go:66 +0x58
go.etcd.io/etcd/server/v3/auth.(*authStore).RoleGrantPermission(0xc0007be360, 0xc00056ffc0, 0x0, 0x0, 0x0)
	etcd/server/auth/store.go:798 +0x166
go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).RoleGrantPermission(0xc0007980c0, 0xc00056ffc0, 0x106f21b, 0x2f6f001fec762, 0xc0395f9f40)
	etcd/server/etcdserver/apply.go:880 +0x4e
go.etcd.io/etcd/server/v3/etcdserver.(*applierV3backend).Apply(0xc0007980c0, 0xc000cf4360, 0x1, 0x0)
	etcd/server/etcdserver/apply.go:227 +0x7dd
go.etcd.io/etcd/server/v3/etcdserver.(*authApplierV3).Apply(0xc0007c00f0, 0xc000cf4360, 0x1, 0x0)
	etcd/server/etcdserver/apply_auth.go:61 +0xdf
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntryNormal(0xc0003b4300, 0xc00031d538)
	etcd/server/etcdserver/server.go:2212 +0x7d0
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply(0xc0003b4300, 0xc000e92930, 0x1, 0x1, 0xc000120100, 0xc0002a97a0, 0xc00067a6b8, 0x186170e)
	etcd/server/etcdserver/server.go:2122 +0x8ed
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries(0xc0003b4300, 0xc000120100, 0xc0002db3f0)
	etcd/server/etcdserver/server.go:1363 +0xe5
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll(0xc0003b4300, 0xc000120100, 0xc0002db3f0)
	etcd/server/etcdserver/server.go:1185 +0x88
go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func8(0x1f99fd0, 0xc0001444c0)
	etcd/server/etcdserver/server.go:1117 +0x3c
go.etcd.io/etcd/pkg/v3/schedule.(*fifo).run(0xc0007be3c0)
	etcd/pkg/schedule/schedule.go:157 +0xf3
created by go.etcd.io/etcd/pkg/v3/schedule.NewFIFOScheduler
	etcd/pkg/schedule/schedule.go:70 +0x13b
```

The fix seems straightforward enough, in this case.

I found what seemed like the right place to add unit test coverage, as well. I decided to extend the existing `TestRoleGrantPermission` rather than add a new test; just let me know if you'd prefer the latter.