### PR TITLE
tools: modify rw-heatmaps to generate separated read & write performance graphs

### DIFF
--- a/tools/rw-heatmaps/README.md
+++ b/tools/rw-heatmaps/README.md
@@ -14,13 +14,13 @@ To get a mixed read/write performance evaluation result:
 
 Note: the result csv file will be saved to current working directory. The working directory is where etcd database is saved. The working directory is designed for scenarios where a different mounted disk is preferred.
 
-### Plot Graph
-To generate a image based on the benchmark result csv file:
+### Plot Graphs
+To generate two images (read and write) based on the benchmark result csv file:
 ```sh
-# to generate a image from one data csv file
+# to generate a pair of read & write images from one data csv file
 ./plot_data.py ${FIRST_CSV_FILE} -t ${IMAGE_TITLE} -o ${OUTPUT_IMAGE_NAME}
 
 
-# to generate a image comparing two data csv files
+# to generate a pair of read & write images by comparing two data csv files
 ./plot_data.py ${FIRST_CSV_FILE} ${SECOND_CSV_FILE} -t ${IMAGE_TITLE} -o ${OUTPUT_IMAGE_NAME}
 ```


### PR DESCRIPTION
Generate separate read and write performance graphs for better performance interpreting.

Also, print gain min and max percentage for better reading.


![output_read](https://user-images.githubusercontent.com/3913185/120908951-86587b00-c624-11eb-9f8e-f49a95396801.png)
![output_write](https://user-images.githubusercontent.com/3913185/120908954-89ec0200-c624-11eb-88ff-8f267a350531.png)


