### PR TITLE
[release-3.5]: [Fix] --log-outputs relative path are not supported when --log-rotate-config-json is defined

### DIFF
--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -87,7 +87,11 @@ func (cfg *Config) setupLogging() error {
 				var path string
 				if cfg.EnableLogRotation {
 					// append rotate scheme to logs managed by lumberjack log rotation
-					path = fmt.Sprintf("rotate:%s", v)
+					if v[0:1] == "/" {
+						path = fmt.Sprintf("rotate:/%%2F%s", v[1:])
+					} else {
+						path = fmt.Sprintf("rotate:/%s", v)
+					}
 				} else {
 					path = v
 				}
@@ -254,7 +258,7 @@ func setupLogRotation(logOutputs []string, logRotateConfigJSON string) error {
 		}
 	}
 	zap.RegisterSink("rotate", func(u *url.URL) (zap.Sink, error) {
-		logRotationConfig.Filename = u.Path
+		logRotationConfig.Filename = u.Path[1:]
 		return &logRotationConfig, nil
 	})
 	return nil

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -305,6 +305,11 @@ func TestLogRotation(t *testing.T) {
 			logRotationConfig: `{"maxsize": 1}`,
 		},
 		{
+			name:              "log output relative path",
+			logOutputs:        []string{"stderr", "tmp/path"},
+			logRotationConfig: `{"maxsize": 1}`,
+		},
+		{
 			name:              "no file targets",
 			logOutputs:        []string{"stderr"},
 			logRotationConfig: `{"maxsize": 1}`,
@@ -360,6 +365,9 @@ func TestLogRotation(t *testing.T) {
 			}
 			if err == nil && tt.wantErr {
 				t.Errorf("test %q, expected error, got nil", tt.name)
+			}
+			if err == nil {
+				cfg.GetLogger().Info("test log")
 			}
 		})
 	}


### PR DESCRIPTION
The PR is a manual cherry-pick of #13049 into release-3.5

cc @lilic @gyuho
