### PR TITLE
Bump etcd version to 3.5.0 and 3.6.0-pre

### DIFF
--- a/api/version/version.go
+++ b/api/version/version.go
@@ -26,7 +26,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.5.0-alpha.0"
+	Version           = "3.6.0-pre"
 	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -5,8 +5,8 @@ go 1.16
 require (
 	github.com/json-iterator/go v1.1.11
 	github.com/modern-go/reflect2 v1.0.1
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 )
 
 replace (

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.11.0
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.38.0
 	sigs.k8s.io/yaml v1.2.0

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/urfave/cli v1.22.4
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/v2 v2.305.0-beta.4
-	go.etcd.io/etcd/client/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/etcdutl/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/pkg/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
+	go.etcd.io/etcd/client/v2 v2.305.0
+	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/etcdutl/v3 v3.5.0
+	go.etcd.io/etcd/pkg/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.38.0

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -25,11 +25,11 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.1.3
 	go.etcd.io/bbolt v1.3.6
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/raft/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/server/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
+	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/pkg/v3 v3.5.0
+	go.etcd.io/etcd/raft/v3 v3.5.0
+	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 )

--- a/go.mod
+++ b/go.mod
@@ -20,16 +20,16 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/spf13/cobra v1.1.3
 	go.etcd.io/bbolt v1.3.6
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/v2 v2.305.0-beta.4
-	go.etcd.io/etcd/client/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/etcdctl/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/etcdutl/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/raft/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/server/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/tests/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
+	go.etcd.io/etcd/client/v2 v2.305.0
+	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/etcdctl/v3 v3.5.0
+	go.etcd.io/etcd/etcdutl/v3 v3.5.0
+	go.etcd.io/etcd/pkg/v3 v3.5.0
+	go.etcd.io/etcd/raft/v3 v3.5.0
+	go.etcd.io/etcd/server/v3 v3.5.0
+	go.etcd.io/etcd/tests/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.38.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.38.0
 )

--- a/raft/go.mod
+++ b/raft/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/pkg/errors v0.9.1 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 )
 
 // Bad imports are sometimes causing attempts to pull that code.

--- a/server/etcdserver/api/capability.go
+++ b/server/etcdserver/api/capability.go
@@ -40,6 +40,7 @@ var (
 		"3.3.0": {AuthCapability: true, V3rpcCapability: true},
 		"3.4.0": {AuthCapability: true, V3rpcCapability: true},
 		"3.5.0": {AuthCapability: true, V3rpcCapability: true},
+		"3.6.0": {AuthCapability: true, V3rpcCapability: true},
 	}
 
 	enableMapMu sync.RWMutex

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -59,6 +59,7 @@ var (
 		"3.3.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"3.4.0": {streamTypeMsgAppV2, streamTypeMessage},
 		"3.5.0": {streamTypeMsgAppV2, streamTypeMessage},
+		"3.6.0": {streamTypeMsgAppV2, streamTypeMessage},
 	}
 )
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -25,12 +25,12 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 	go.etcd.io/bbolt v1.3.6
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/v2 v2.305.0-beta.4
-	go.etcd.io/etcd/client/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/raft/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
+	go.etcd.io/etcd/client/v2 v2.305.0
+	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/pkg/v3 v3.5.0
+	go.etcd.io/etcd/raft/v3 v3.5.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp v0.20.0

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -204,7 +204,7 @@ func testIssue6361(t *testing.T, etcdutl bool) {
 	t.Log("etcdctl saving snapshot...")
 	if err = spawnWithExpects(append(prefixArgs, "snapshot", "save", fpath),
 		fmt.Sprintf("Snapshot saved at %s", fpath),
-		"Server version 3.5.0",
+		"Server version 3.6.0",
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -27,14 +27,14 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.etcd.io/bbolt v1.3.6
-	go.etcd.io/etcd/api/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/client/v2 v2.305.0-beta.4
-	go.etcd.io/etcd/client/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/etcdutl/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/pkg/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/raft/v3 v3.5.0-beta.4
-	go.etcd.io/etcd/server/v3 v3.5.0-beta.4
+	go.etcd.io/etcd/api/v3 v3.5.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.0
+	go.etcd.io/etcd/client/v2 v2.305.0
+	go.etcd.io/etcd/client/v3 v3.5.0
+	go.etcd.io/etcd/etcdutl/v3 v3.5.0
+	go.etcd.io/etcd/pkg/v3 v3.5.0
+	go.etcd.io/etcd/raft/v3 v3.5.0
+	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
Noticed while building etcdctl that we still reference the 3.5-alpha.0 version.

I am not sure if we want to backport this to release-3.5 branch or not. 🤔 