### PR TITLE
Update Readme for install etcd client v3 more visibility #13108

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ go get go.etcd.io/etcd/client/v3
 ```
 
 `etcd/clientv3` is the official Go etcd client for v3. Read more:[etcd client v3 install](https://github.com/etcd-io/etcd/tree/main/client/v3#install)
+
 Notes to resolve dependency and compatibility issues for go modules: [#13108](https://github.com/etcd-io/etcd/issues/13108)
 
 ### Next steps

--- a/README.md
+++ b/README.md
@@ -159,10 +159,6 @@ goreman -f ./Procfile.learner start
 go get go.etcd.io/etcd/client/v3
 ```
 
-`etcd/clientv3` is the official Go etcd client for v3. Read more:[etcd client v3 install](https://github.com/etcd-io/etcd/tree/main/client/v3#install)
-
-Notes to resolve dependency and compatibility issues for go modules: [#13108](https://github.com/etcd-io/etcd/issues/13108)
-
 ### Next steps
 
 Now it's time to dig into the full etcd API and other guides.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Follow the steps in [Procfile.learner](./Procfile.learner) to add a learner node
 goreman -f ./Procfile.learner start
 ```
 
+### Install etcd client v3
+
+```bash
+go get go.etcd.io/etcd/client/v3
+```
+
+`etcd/clientv3` is the official Go etcd client for v3. Read more:[etcd client v3 install](https://github.com/etcd-io/etcd/tree/main/client/v3#install)
+Notes to resolve dependency and compatibility issues for go modules: [#13108](https://github.com/etcd-io/etcd/issues/13108)
+
 ### Next steps
 
 Now it's time to dig into the full etcd API and other guides.


### PR DESCRIPTION
There are many developers on the web, confused by how to install etcd v3 for the development of go project.

A number of similar errors were encountered, as follows:
https://github.com/etcd-io/etcd/issues/13108

```
➜  ~ go version
go version go1.16.5 darwin/amd64

➜  ~  go get go.etcd.io/etcd/clientv3

go: downloading golang.org/x/net v0.0.0-20201021035429-f5854403a974
# github.com/coreos/etcd/clientv3/balancer/picker
go/pkg/mod/github.com/coreos/etcd@v3.3.25+incompatible/clientv3/balancer/picker/err.go:37:44: undefined: balancer.PickOptions
go/pkg/mod/github.com/coreos/etcd@v3.3.25+incompatible/clientv3/balancer/picker/roundrobin_balanced.go:55:54: undefined: balancer.PickOptions
# github.com/coreos/etcd/clientv3/balancer/resolver/endpoint
go/pkg/mod/github.com/coreos/etcd@v3.3.25+incompatible/clientv3/balancer/resolver/endpoint/endpoint.go:114:78: undefined: resolver.BuildOption
go/pkg/mod/github.com/coreos/etcd@v3.3.25+incompatible/clientv3/balancer/resolver/endpoint/endpoint.go:182:31: undefined: resolver.ResolveNowOption
```

There are many examples of confusion here:

- https://github.com/etcd-io/etcd/issues/12577
- https://github.com/etcd-io/etcd/issues/12181
- https://github.com/etcd-io/etcd/issues/12068
- https://github.com/etcd-io/etcd/issues/11931
......

So, As suggested by  @lilic , I submitted Readme update.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
