### PR TITLE
grpcproxy lrucache timeout

### DIFF
--- a/client/v3/config.go
+++ b/client/v3/config.go
@@ -89,4 +89,6 @@ type Config struct {
 	PermitWithoutStream bool `json:"permit-without-stream"`
 
 	// TODO: support custom balancer picker
+
+	LRUCacheTimeout time.Duration
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -94,6 +94,8 @@ const (
 	maxElectionMs = 50000
 	// backend freelist map type
 	freelistArrayType = "array"
+
+	DefaultLRUCacheTimeout = 10 * time.Minute
 )
 
 var (


### PR DESCRIPTION
Grpc proxy LRU have no timeout function.
In our scene,  user use just one request for getALL(), the response will save to the cache.
But user just have the only one op -- getALL(), this will cause the request Key will never remove in LRU cache(1024).

Other ops will put/delete key/value direct to ETCD cluster.
User can accept the response data(getALL()) in grpc-proxy cache not in time, but deny the data never update in the cache.
So I give a timeout in lru cache.   