### PR TITLE
etcdutl: add command to generate shell completion

### DIFF
--- a/etcdutl/ctl.go
+++ b/etcdutl/ctl.go
@@ -35,12 +35,16 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&etcdutl.OutputFormat, "write-out", "w", "simple", "set the output format (fields, json, protobuf, simple, table)")
+	rootCmd.RegisterFlagCompletionFunc("write-out", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"fields", "json", "protobuf", "simple", "table"}, cobra.ShellCompDirectiveDefault
+	})
 
 	rootCmd.AddCommand(
 		etcdutl.NewBackupCommand(),
 		etcdutl.NewDefragCommand(),
 		etcdutl.NewSnapshotCommand(),
 		etcdutl.NewVersionCommand(),
+		etcdutl.NewCompletionCommand(),
 	)
 }
 

--- a/etcdutl/etcdutl/backup_command.go
+++ b/etcdutl/etcdutl/backup_command.go
@@ -64,6 +64,10 @@ func NewBackupCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&withV3, "with-v3", true, "Backup v3 backend data")
 	cmd.MarkFlagRequired("data-dir")
 	cmd.MarkFlagRequired("backup-dir")
+	cmd.MarkFlagDirname("data-dir")
+	cmd.MarkFlagDirname("wal-dir")
+	cmd.MarkFlagDirname("backup-dir")
+	cmd.MarkFlagDirname("backup-wal-dir")
 	return cmd
 }
 

--- a/etcdutl/etcdutl/completion_commmand.go
+++ b/etcdutl/etcdutl/completion_commmand.go
@@ -1,0 +1,84 @@
+// Copyright 2021 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutl
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCompletionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+  $ source <(etcdutl completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ etcdutl completion bash > /etc/bash_completion.d/etcdutl
+  # macOS:
+  $ etcdutl completion bash > /usr/local/etc/bash_completion.d/etcdutl
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ etcdutl completion zsh > "${fpath[1]}/_etcdutl"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ etcdutl completion fish | source
+
+  # To load completions for each session, execute once:
+  $ etcdutl completion fish > ~/.config/fish/completions/etcdutl.fish
+
+PowerShell:
+
+  PS> etcdutl completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> etcdutl completion powershell > etcdutl.ps1
+  # and source this file from your PowerShell profile.
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	}
+
+	return cmd
+}

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -38,6 +38,7 @@ func NewDefragCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&defragDataDir, "data-dir", "", "Required. Defragments a data directory not in use by etcd.")
 	cmd.MarkFlagRequired("data-dir")
+	cmd.MarkFlagDirname("data-dir")
 	return cmd
 }
 
@@ -65,7 +66,7 @@ func DefragData(dataDir string) error {
 	case <-bch:
 	case <-time.After(time.Second):
 		fmt.Fprintf(os.Stderr, "waiting for etcd to close and release its lock on %q. "+
-			"To defrag a running etcd instance, omit --data-dir.\n", dbDir)
+			"To defrag a running etcd instance, use `etcdctl defrag` instead.\n", dbDir)
 		<-bch
 	}
 	return be.Defrag()

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -92,7 +92,8 @@ func NewSnapshotRestoreCommand() *cobra.Command {
 	cmd.Flags().StringVar(&restoreName, "name", defaultName, "Human-readable name for this member")
 	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
 
-	cmd.MarkFlagRequired("data-dir")
+	cmd.MarkFlagDirname("data-dir")
+	cmd.MarkFlagDirname("wal-dir")
 
 	return cmd
 }

--- a/tests/e2e/ctl_v3_completion_test.go
+++ b/tests/e2e/ctl_v3_completion_test.go
@@ -24,13 +24,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCtlV3CompletionBash(t *testing.T) { testShellCompletion(t, "bash") }
+func TestCtlV3CompletionBash(t *testing.T) { testShellCompletion(t, ctlBinPath, "bash") }
 
-func testShellCompletion(t *testing.T, shellName string) {
+func TestUtlV3CompletionBash(t *testing.T) { testShellCompletion(t, utlBinPath, "bash") }
+
+func testShellCompletion(t *testing.T, binPath, shellName string) {
 	BeforeTest(t)
 
 	stdout := new(bytes.Buffer)
-	completionCmd := exec.Command(ctlBinPath, "completion", shellName)
+	completionCmd := exec.Command(binPath, "completion", shellName)
 	completionCmd.Stdout = stdout
 	completionCmd.Stderr = os.Stderr
 	require.NoError(t, completionCmd.Run())


### PR DESCRIPTION
Follow up of #13133.

I've removed the required annotation on the `--data-dir` flag for snapshot restore, because the completion behaves a lttle unexpected (see [here](https://github.com/spf13/cobra/issues/1061)) and because it is defaulted anyways.

Also changed the `etcdutl defrag` timeout message to link to `etcdctl defrag`.
