### PR TITLE
Make Junit report success callout message conditional

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -238,11 +238,16 @@ function produce_junit_xmlreport {
     popd >/dev/null || return
   fi
   gotestsum --junitfile "${junit_xml_filename}" --raw-command cat "${junit_filename_prefix}"*.stdout
+  local cmd_code=$?
   if [ "${VERBOSE}" != "1" ]; then
     rm "${junit_filename_prefix}"*.stdout
   fi
 
-  log_callout "Saved JUnit XML test report to ${junit_xml_filename}"
+  if [ ${cmd_code} -ne 0 ]; then
+    log_error "gotestsum failed and did not generate JUnit XML test report"
+  else
+    log_callout "Saved JUnit XML test report to ${junit_xml_filename}"
+  fi
 }
 
 


### PR DESCRIPTION
gotestsum error messages like `./scripts/test_lib.sh: line 240: gotestsum: command not found` go unnoticed.
In spite of this error message, the current logic at https://github.com/etcd-io/etcd/blob/main/scripts/test_lib.sh#L245 misguides that the Junit report is saved.

Hence this PR is to add the neccessary addition of `$GOPATH/bin` to `$PATH` and making the log_callout message conditional.
