### PR TITLE
server/auth: enable tokenProvider if recoved store enables auth

### DIFF
--- a/server/auth/simple_token.go
+++ b/server/auth/simple_token.go
@@ -156,6 +156,11 @@ func (t *tokenSimple) invalidateUser(username string) {
 }
 
 func (t *tokenSimple) enable() {
+	t.simpleTokensMu.Lock()
+	defer t.simpleTokensMu.Unlock()
+	if t.simpleTokenKeeper != nil { // already enabled
+		return
+	}
 	if t.simpleTokenTTL <= 0 {
 		t.simpleTokenTTL = simpleTokenTTLDefault
 	}

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -358,6 +358,9 @@ func (as *authStore) Recover(be backend.Backend) {
 
 	as.enabledMu.Lock()
 	as.enabled = enabled
+	if enabled {
+		as.tokenProvider.enable()
+	}
 	as.enabledMu.Unlock()
 }
 


### PR DESCRIPTION
we found a lease leak issue:
if a new member(by member add) is recovered by snapshot, and then
become leader, the lease will never expire afterwards. leader will
log the revoke failure caused by "invalid auth token", since the
token provider is not functional, and drops all generated token
from upper layer, which in this case, is the lease revoking
routine.

