### PR TITLE
scripts: add script to measure percentage of commits with failed status

### DIFF
--- a/.github/workflows/measure-test-flakiness.yaml
+++ b/.github/workflows/measure-test-flakiness.yaml
@@ -1,0 +1,15 @@
+name: Measure Test Flakiness
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  measure-test-flakiness:
+    name: Measure Test Flakiness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run script to measure test flakiness
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "./scripts/measure-test-flakiness.sh"

--- a/scripts/measure-test-flakiness.sh
+++ b/scripts/measure-test-flakiness.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [[ -z ${GITHUB_TOKEN} ]]
+then
+    echo "Please set the \$GITHUB_TOKEN environment variable for the script to work"
+    exit 1
+fi
+
+temp_dir=$(mktemp -d)
+
+trap '{ rm -rf -- "${temp_dir}"; }' EXIT
+
+json_file="${temp_dir}/commit-and-check-data.json"
+
+curl --fail --show-error --silent -H "Authorization: token ${GITHUB_TOKEN}" \
+    -X POST \
+    -d '{
+        "query": "query { repository(owner: \"etcd-io\", name: \"etcd\") { defaultBranchRef { target { ... on Commit { history(first: 100) { edges { node { ... on Commit { commitUrl statusCheckRollup { state } } } } } } } } } }"
+    }' \
+    https://api.github.com/graphql | jq . > "${json_file}"
+
+failure_percentage=$(jq '.data.repository.defaultBranchRef.target.history.edges | reduce .[] as $item (0; if $item.node.statusCheckRollup.state == "FAILURE" then (. + 1) else . end)' "${json_file}")
+
+echo "Commit status failure percentage is - ${failure_percentage} %"


### PR DESCRIPTION
This is to start measuring the test flakiness and see the numbers improving once we improve and deflake flaky tests
This PR is a part of the fix for the issue #13167

## What this PR does -
It tries to get the last 100 etcd commits and their commit status data from the GitHub GraphQL API and count the number of failures and shows the failure percentage

It uses the following tools
- bash
- curl
- jq

## What this PR does not do -

- ~This PR does not introduce any GitHub Actions Workflow to run the script automatically weekly once as mentioned in #13167 . Let me know if we need to do it as part of this PR, I could add a GitHub Action Workflow config Yaml for it with cron schedule - This has been added~
- This PR does **not** analyze PRs of the commits with failure status and identify flaky tests

## Secrets

This PR introduces a script which needs a GitHub Token to access the GitHub API and get etcd repo commit data

## Documentation

This script does not have any documentation as of now. Let me know if I need to add any details in some docs. Like what it does, it's purpose in some README and any other details

## Questions
- Should we consider commits that don't have any status (multiple commits in a PR)? That is they have null status. Should we count them as part of the last 100 commits? The 100 commits currently have three statuses - success, null, failure. We count failures and then do calculation and say that's the percentage, so it assumes that the ones with null are all successes
- Should we add documentation for this script? If yes, where should we add it?
- Should we parameterize the number of commits we want to choose from the history? Currently it's hard coded as 100 last commits
- Does the script name look okay? Let me know if I need to change it
- The script creates a JSON file to dump all the GitHub API data about the repo commits and then does processing on it. Is that okay? Also, I have git ignored that file too
- Does the message `Commit status failure percentage is 31 %` make sense? Or we want to give some other message talking about test flayness directly?
- Is the commit message okay?
- I put `Fixes #13167` in the commit message but this is only part of fixing #13167. I think it might close #13167 with the merge of this PR. If it does, we can reopen the issue, yeah?