### PR TITLE
Skip empty query value(alarm) from the query parameter

### DIFF
--- a/server/etcdserver/api/etcdhttp/metrics.go
+++ b/server/etcdserver/api/etcdhttp/metrics.go
@@ -119,7 +119,7 @@ func getExcludedAlarms(r *http.Request) (alarms AlarmSet) {
 	alms, found := r.URL.Query()["exclude"]
 	if found {
 		for _, alm := range alms {
-			if len(alms) == 0 {
+			if len(alm) == 0 {
 				continue
 			}
 			alarms[alm] = struct{}{}


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/13187 
