### PR TITLE
Refactor NewServer function

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -623,23 +623,14 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 
 	heartbeat := time.Duration(cfg.TickMs) * time.Millisecond
 	srv = &EtcdServer{
-		readych:     make(chan struct{}),
-		Cfg:         cfg,
-		lgMu:        new(sync.RWMutex),
-		lg:          cfg.Logger,
-		errorc:      make(chan error, 1),
-		v2store:     b.st,
-		snapshotter: b.ss,
-		r: *newRaftNode(
-			raftNodeConfig{
-				lg:          cfg.Logger,
-				isIDRemoved: func(id uint64) bool { return b.raft.cl.IsIDRemoved(types.ID(id)) },
-				Node:        b.raft.node,
-				heartbeat:   heartbeat,
-				raftStorage: b.raft.storage,
-				storage:     NewStorage(b.raft.wal, b.ss),
-			},
-		),
+		readych:            make(chan struct{}),
+		Cfg:                cfg,
+		lgMu:               new(sync.RWMutex),
+		lg:                 cfg.Logger,
+		errorc:             make(chan error, 1),
+		v2store:            b.st,
+		snapshotter:        b.ss,
+		r:                  *b.raft.newRaftNode(b.ss),
 		id:                 b.raft.id,
 		attributes:         membership.Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
 		cluster:            b.raft.cl,

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -465,7 +465,7 @@ func bootstrapExistingClusterNoWAL(cfg config.ServerConfig, prt http.RoundTrippe
 	cl.SetID(types.ID(0), existingCluster.ID())
 	cl.SetStore(st)
 	cl.SetBackend(buckets.NewMembershipStore(cfg.Logger, be))
-	br := startNode(cfg, cl, nil)
+	br := boostrapRaftFromCluster(cfg, cl, nil)
 	cl.SetID(br.id, existingCluster.ID())
 	return &boostrapResult{
 		raft:    br,
@@ -505,7 +505,7 @@ func boostrapNewClusterNoWAL(cfg config.ServerConfig, prt http.RoundTripper, st 
 	}
 	cl.SetStore(st)
 	cl.SetBackend(buckets.NewMembershipStore(cfg.Logger, be))
-	br := startNode(cfg, cl, cl.MemberIDs())
+	br := boostrapRaftFromCluster(cfg, cl, cl.MemberIDs())
 	cl.SetID(br.id, cl.ID())
 	return &boostrapResult{
 		remotes: nil,
@@ -588,9 +588,9 @@ func boostrapWithWAL(cfg config.ServerConfig, st v2store.Store, be backend.Backe
 
 	r := &boostrapResult{}
 	if !cfg.ForceNewCluster {
-		r.raft = restartNode(cfg, snapshot)
+		r.raft = boostrapRaftFromWal(cfg, snapshot)
 	} else {
-		r.raft = restartAsStandaloneNode(cfg, snapshot)
+		r.raft = boostrapRaftFromWalStandalone(cfg, snapshot)
 	}
 
 	r.raft.cl.SetStore(st)


### PR DESCRIPTION
Working towards cleaning up NewServer to create obvious place to put storage schema upgrade.
Goals:
* Separate starting raft node from wal loading
* Make bootstrap hierarchical 

Proposed naming scheme `bootstrapX` is done to separate those functions. Prefix can be changed but would prefer to this in last commit or separate PR to avoid resolving a lot of conflicts during rebase. I also plan to move those functions to separate file, but also do it on last step as moving functions makes it harder to see diff.