### PR TITLE
test: Prevent TestMaintenanceSnapshotWithVersionVersion & TestSaveSnapshotVersion from flaking

### DIFF
--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -253,6 +253,11 @@ func TestMaintenanceSnapshotWithVersionVersion(t *testing.T) {
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1, SnapshotCount: 1})
 	defer clus.Terminate(t)
 
+	// Put some keys to ensure that wal snapshot is triggered
+	for i := 0; i < 10; i++ {
+		clus.RandClient().Put(context.Background(), fmt.Sprintf("%d", i), "1")
+	}
+
 	// reading snapshot with canceled context should error out
 	resp, err := clus.RandClient().SnapshotWithVersion(context.Background())
 	if err != nil {

--- a/tests/integration/clientv3/snapshot/v3_snapshot_test.go
+++ b/tests/integration/clientv3/snapshot/v3_snapshot_test.go
@@ -54,7 +54,11 @@ func TestSaveSnapshotFilePermissions(t *testing.T) {
 
 // TestSaveSnapshotVersion ensures that the snapshot returns proper storage version.
 func TestSaveSnapshotVersion(t *testing.T) {
-	kvs := []kv{{"foo1", "bar1"}, {"foo2", "bar2"}, {"foo3", "bar3"}}
+	// Put some keys to ensure that wal snapshot is triggered
+	kvs := []kv{}
+	for i := 0; i < 10; i++ {
+		kvs = append(kvs, kv{fmt.Sprintf("%d", i), "test"})
+	}
 	cfg := newEmbedConfig(t)
 	// Force raft snapshot to ensure that storage version is set
 	cfg.SnapshotCount = 1


### PR DESCRIPTION
When running 100 times in row those tests flaked around 10-20%. Based on
some experimentation 10 keys was enough to ensure that wal snapshot is
created and prevented any flakes.


cc @ptabor
