### PR TITLE
[backport 3.5]: server/auth: enable tokenProvider if recoved store enables auth

### DIFF
--- a/server/auth/simple_token.go
+++ b/server/auth/simple_token.go
@@ -156,6 +156,11 @@ func (t *tokenSimple) invalidateUser(username string) {
 }
 
 func (t *tokenSimple) enable() {
+	t.simpleTokensMu.Lock()
+	defer t.simpleTokensMu.Unlock()
+	if t.simpleTokenKeeper != nil { // already enabled
+		return
+	}
 	if t.simpleTokenTTL <= 0 {
 		t.simpleTokenTTL = simpleTokenTTLDefault
 	}

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -368,6 +368,9 @@ func (as *authStore) Recover(be backend.Backend) {
 
 	as.enabledMu.Lock()
 	as.enabled = enabled
+	if enabled {
+		as.tokenProvider.enable()
+	}
 	as.enabledMu.Unlock()
 }
 


### PR DESCRIPTION
backport  #13172
we would like to have this fix in release 3.5
cc @mitake @spzala