### PR TITLE
[backport 3.4]: server/auth: enable tokenProvider if recoved store enables auth

### DIFF
--- a/auth/simple_token.go
+++ b/auth/simple_token.go
@@ -159,6 +159,11 @@ func (t *tokenSimple) invalidateUser(username string) {
 }
 
 func (t *tokenSimple) enable() {
+	t.simpleTokensMu.Lock()
+	defer t.simpleTokensMu.Unlock()
+	if t.simpleTokenKeeper != nil { // already enabled
+		return
+	}
 	if t.simpleTokenTTL <= 0 {
 		t.simpleTokenTTL = simpleTokenTTLDefault
 	}

--- a/auth/store.go
+++ b/auth/store.go
@@ -400,6 +400,9 @@ func (as *authStore) Recover(be backend.Backend) {
 
 	as.enabledMu.Lock()
 	as.enabled = enabled
+	if enabled {
+		as.tokenProvider.enable()
+	}
 	as.enabledMu.Unlock()
 }
 


### PR DESCRIPTION
this is a manual backport of #13172
we would also like to have this fix in release 3.4
cc @mitake @spzala