### PR TITLE
force new cluster, learner to leader

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -559,6 +559,10 @@ func getIDs(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) ([]uint6
 		for _, id := range snap.Metadata.ConfState.Voters {
 			ids[id] = true
 		}
+		for _, id := range snap.Metadata.ConfState.Learners {
+			ids[id] = true
+			isLearnerMap[id] = true
+		}
 	}
 	for _, e := range ents {
 		if e.Type != raftpb.EntryConfChange {

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -617,7 +617,6 @@ func createConfigChangeEnts(lg *zap.Logger, ids []uint64, isLearnerMap map[uint6
 			Type:    raftpb.ConfChangeAddNode,
 			NodeID:  id,
 			Context: ctx,
-			ID:      id,
 		}
 		e := raftpb.Entry{
 			Type:  raftpb.EntryConfChange,

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -574,7 +574,6 @@ func getIDs(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) ([]uint6
 			ids[cc.NodeID] = true
 		case raftpb.ConfChangeRemoveNode:
 			delete(ids, cc.NodeID)
-			delete(isLearnerMap, cc.NodeID)
 		case raftpb.ConfChangeUpdateNode:
 			// do nothing
 		default:

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -66,7 +66,7 @@ func TestGetIDs(t *testing.T) {
 		if tt.confState != nil {
 			snap.Metadata.ConfState = *tt.confState
 		}
-		idSet := getIDs(testLogger, &snap, tt.ents)
+		idSet, _ := getIDs(testLogger, &snap, tt.ents)
 		if !reflect.DeepEqual(idSet, tt.widSet) {
 			t.Errorf("#%d: idset = %#v, want %#v", i, idSet, tt.widSet)
 		}
@@ -146,7 +146,7 @@ func TestCreateConfigChangeEnts(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		gents := createConfigChangeEnts(testLogger, tt.ids, tt.self, tt.term, tt.index)
+		gents := createConfigChangeEnts(testLogger, tt.ids, make(map[uint64]bool), tt.self, tt.term, tt.index)
 		if !reflect.DeepEqual(gents, tt.wents) {
 			t.Errorf("#%d: ents = %v, want %v", i, gents, tt.wents)
 		}

--- a/server/etcdserver/storage.go
+++ b/server/etcdserver/storage.go
@@ -192,9 +192,11 @@ func (wal *bootstrappedWAL) CommitedEntries() []raftpb.Entry {
 }
 
 func (wal *bootstrappedWAL) ConfigChangeEntries() []raftpb.Entry {
+	ids, isLearnerMap := getIDs(wal.lg, wal.snapshot, wal.ents)
 	return createConfigChangeEnts(
 		wal.lg,
-		getIDs(wal.lg, wal.snapshot, wal.ents),
+		ids,
+		isLearnerMap,
 		uint64(wal.id),
 		wal.st.Term,
 		wal.st.Commit,


### PR DESCRIPTION
When the business has cross-computer room disaster recovery requirements for ETCD, we hope to build an ETCD cluster in one computer room, and set up a separate Learner node in another computer room as a cross-computer room disaster recovery node. When the host room fails, we can manually set the learner The node is forcibly upgraded to a leader node to provide services to the business and ensure the high availability of the entire cluster in the event of a computer room-level failure.Of course, the reduction of data consistency is acceptable for the business.
But when we use the ETCD3.5 version to do the solution, we found that when the leader and follower nodes are down, when the learner passes new_force_cluster, it happens.
```
panic: removed all voters

goroutine 149 [running]:
go.etcd.io/etcd/raft/v3.(*raft).applyConfChange(0xc00014e000, 0x0, 0xc000736350, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
github.com/go.etcd.io/etcd/raft/raft.go:1633 +0x21a
go.etcd.io/etcd/raft/v3.(*node).run(0xc0001a3440)
github.com/go.etcd.io/etcd/raft/node.go:360 +0x856
created by go.etcd.io/etcd/raft/v3.RestartNode
github.com/go.etcd.io/etcd/raft/node.go:244 +0x330
```
This panic prevented me from forcibly promoting learner to leader to complete disaster recovery across computer rooms.