### PR TITLE
test: Bump release tests to use 3.5.0

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -611,13 +611,13 @@ function dep_pass {
 function release_pass {
   rm -f ./bin/etcd-last-release
   # to grab latest patch release; bump this up for every minor release
-  UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.4.*" | head -1)
+  UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.5.*" | head -1 | cut -d- -f1)
   if [ -n "$MANUAL_VER" ]; then
     # in case, we need to test against different version
     UPGRADE_VER=$MANUAL_VER
   fi
   if [[ -z ${UPGRADE_VER} ]]; then
-    UPGRADE_VER="v3.3.0"
+    UPGRADE_VER="v3.5.0"
     log_warning "fallback to" ${UPGRADE_VER}
   fi
 


### PR DESCRIPTION
Using cut to split by '-' to remove `-rc.0` suffix.

