### PR TITLE
etcd-mixin: Use deriv function instead of increase

### DIFF
--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -223,7 +223,7 @@
           {
             alert: 'etcdExcessiveDatabaseGrowth',
             expr: |||
-              increase(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
+              deriv(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
             ||| % $._config,
             'for': '10m',
             labels: {


### PR DESCRIPTION
This commit fixes the etcdExcessiveDatabaseGrowth Prometheus alert
to use deriv function instead of increase as it uses a least squares
regression to know how fast a gauge is changing over time.

Fixes https://github.com/etcd-io/etcd/issues/12550. Thanks.
