### PR TITLE
Move storage bootstrap to its package

### DIFF
--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -660,7 +660,7 @@ func (wal *bootstrappedWAL) CommitedEntries() []raftpb.Entry {
 func (wal *bootstrappedWAL) NewConfigChangeEntries() []raftpb.Entry {
 	return serverstorage.CreateConfigChangeEnts(
 		wal.lg,
-		serverstorage.GetIDs(wal.lg, wal.snapshot, wal.ents),
+		serverstorage.GetEffectiveNodeIDsFromWalEntries(wal.lg, wal.snapshot, wal.ents),
 		uint64(wal.meta.nodeID),
 		wal.st.Term,
 		wal.st.Commit,

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -105,6 +105,16 @@ type bootstrapedCluster struct {
 	clusterID, nodeID types.ID
 }
 
+type bootstrappedRaft struct {
+	lg        *zap.Logger
+	heartbeat time.Duration
+
+	peers   []raft.Peer
+	config  *raft.Config
+	cl      *membership.RaftCluster
+	storage *raft.MemoryStorage
+}
+
 func bootstrapStorage(cfg config.ServerConfig, ss *snap.Snapshotter, prt http.RoundTripper) (b *bootstrappedStorage, err error) {
 	st := v2store.New(StoreClusterPrefix, StoreKeysPrefix)
 	haveWAL := wal.Exist(cfg.WALDir())
@@ -459,16 +469,6 @@ func raftConfig(cfg config.ServerConfig, id uint64, s *raft.MemoryStorage) *raft
 		PreVote:         cfg.PreVote,
 		Logger:          NewRaftLoggerZap(cfg.Logger.Named("raft")),
 	}
-}
-
-type bootstrappedRaft struct {
-	lg        *zap.Logger
-	heartbeat time.Duration
-
-	peers   []raft.Peer
-	config  *raft.Config
-	cl      *membership.RaftCluster
-	storage *raft.MemoryStorage
 }
 
 func (b *bootstrappedRaft) newRaftNode(ss *snap.Snapshotter, wal *wal.WAL) *raftNode {

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -532,7 +532,7 @@ func bootstrapWALFromSnapshot(cfg config.ServerConfig, snapshot *raftpb.Snapshot
 	if cfg.ForceNewCluster {
 		// discard the previously uncommitted entries
 		bwal.ents = bwal.CommitedEntries()
-		entries := bwal.ConfigChangeEntries()
+		entries := bwal.NewConfigChangeEntries()
 		// force commit config change entries
 		bwal.AppendAndCommitEntries(entries)
 		cfg.Logger.Info(
@@ -657,7 +657,7 @@ func (wal *bootstrappedWAL) CommitedEntries() []raftpb.Entry {
 	return wal.ents
 }
 
-func (wal *bootstrappedWAL) ConfigChangeEntries() []raftpb.Entry {
+func (wal *bootstrappedWAL) NewConfigChangeEntries() []raftpb.Entry {
 	return serverstorage.CreateConfigChangeEnts(
 		wal.lg,
 		serverstorage.GetIDs(wal.lg, wal.snapshot, wal.ents),

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -67,7 +67,7 @@ func TestGetIDs(t *testing.T) {
 		if tt.confState != nil {
 			snap.Metadata.ConfState = *tt.confState
 		}
-		idSet := serverstorage.GetIDs(testLogger, &snap, tt.ents)
+		idSet := serverstorage.GetEffectiveNodeIDsFromWalEntries(testLogger, &snap, tt.ents)
 		if !reflect.DeepEqual(idSet, tt.widSet) {
 			t.Errorf("#%d: idset = %#v, want %#v", i, idSet, tt.widSet)
 		}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -304,7 +304,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 
 	defer func() {
 		if err != nil {
-			b.storage.backend.be.Close()
+			b.Close()
 		}
 	}()
 

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -308,8 +308,8 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		}
 	}()
 
-	sstats := stats.NewServerStats(cfg.Name, b.storage.cluster.wal.id.String())
-	lstats := stats.NewLeaderStats(cfg.Logger, b.storage.cluster.wal.id.String())
+	sstats := stats.NewServerStats(cfg.Name, b.storage.cluster.nodeID.String())
+	lstats := stats.NewLeaderStats(cfg.Logger, b.storage.cluster.nodeID.String())
 
 	heartbeat := time.Duration(cfg.TickMs) * time.Millisecond
 	srv = &EtcdServer{
@@ -321,20 +321,20 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		v2store:               b.storage.st,
 		snapshotter:           b.ss,
 		r:                     *b.storage.cluster.raft.newRaftNode(b.ss, b.storage.cluster.wal.w),
-		id:                    b.storage.cluster.wal.id,
+		id:                    b.storage.cluster.nodeID,
 		attributes:            membership.Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
 		cluster:               b.storage.cluster.raft.cl,
 		stats:                 sstats,
 		lstats:                lstats,
 		SyncTicker:            time.NewTicker(500 * time.Millisecond),
 		peerRt:                b.prt,
-		reqIDGen:              idutil.NewGenerator(uint16(b.storage.cluster.wal.id), time.Now()),
+		reqIDGen:              idutil.NewGenerator(uint16(b.storage.cluster.nodeID), time.Now()),
 		AccessController:      &AccessController{CORS: cfg.CORS, HostWhitelist: cfg.HostWhitelist},
 		consistIndex:          b.storage.ci,
 		firstCommitInTerm:     notify.NewNotifier(),
 		clusterVersionChanged: notify.NewNotifier(),
 	}
-	serverID.With(prometheus.Labels{"server_id": b.storage.cluster.wal.id.String()}).Set(1)
+	serverID.With(prometheus.Labels{"server_id": b.storage.cluster.nodeID.String()}).Set(1)
 	srv.cluster.SetVersionChangedNotifier(srv.clusterVersionChanged)
 	srv.applyV2 = NewApplierV2(cfg.Logger, srv.v2store, srv.cluster)
 
@@ -403,7 +403,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		Logger:      cfg.Logger,
 		TLSInfo:     cfg.PeerTLSInfo,
 		DialTimeout: cfg.PeerDialTimeout(),
-		ID:          b.storage.cluster.wal.id,
+		ID:          b.storage.cluster.nodeID,
 		URLs:        cfg.PeerURLs,
 		ClusterID:   b.storage.cluster.raft.cl.ID(),
 		Raft:        srv,
@@ -417,12 +417,12 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 	}
 	// add all remotes into transport
 	for _, m := range b.storage.cluster.remotes {
-		if m.ID != b.storage.cluster.wal.id {
+		if m.ID != b.storage.cluster.nodeID {
 			tr.AddRemote(m.ID, m.PeerURLs)
 		}
 	}
 	for _, m := range b.storage.cluster.raft.cl.Members() {
-		if m.ID != b.storage.cluster.wal.id {
+		if m.ID != b.storage.cluster.nodeID {
 			tr.AddPeer(m.ID, m.PeerURLs)
 		}
 	}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -320,7 +320,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		errorc:                make(chan error, 1),
 		v2store:               b.storage.st,
 		snapshotter:           b.ss,
-		r:                     *b.cluster.raft.newRaftNode(b.ss, b.cluster.wal.w, b.cluster.cl),
+		r:                     *b.raft.newRaftNode(b.ss, b.cluster.wal.w, b.cluster.cl),
 		id:                    b.cluster.nodeID,
 		attributes:            membership.Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
 		cluster:               b.cluster.cl,

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -320,7 +320,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		errorc:                make(chan error, 1),
 		v2store:               b.storage.st,
 		snapshotter:           b.ss,
-		r:                     *b.raft.newRaftNode(b.ss, b.cluster.wal.w, b.cluster.cl),
+		r:                     *b.raft.newRaftNode(b.ss, b.storage.wal.w, b.cluster.cl),
 		id:                    b.cluster.nodeID,
 		attributes:            membership.Attributes{Name: cfg.Name, ClientURLs: cfg.ClientURLs.StringSlice()},
 		cluster:               b.cluster.cl,

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -304,7 +304,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 
 	defer func() {
 		if err != nil {
-			b.storage.be.Close()
+			b.storage.backend.be.Close()
 		}
 	}()
 
@@ -330,7 +330,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		peerRt:                b.prt,
 		reqIDGen:              idutil.NewGenerator(uint16(b.cluster.nodeID), time.Now()),
 		AccessController:      &AccessController{CORS: cfg.CORS, HostWhitelist: cfg.HostWhitelist},
-		consistIndex:          b.storage.ci,
+		consistIndex:          b.storage.backend.ci,
 		firstCommitInTerm:     notify.NewNotifier(),
 		clusterVersionChanged: notify.NewNotifier(),
 	}
@@ -338,8 +338,8 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 	srv.cluster.SetVersionChangedNotifier(srv.clusterVersionChanged)
 	srv.applyV2 = NewApplierV2(cfg.Logger, srv.v2store, srv.cluster)
 
-	srv.be = b.storage.be
-	srv.beHooks = b.storage.beHooks
+	srv.be = b.storage.backend.be
+	srv.beHooks = b.storage.backend.beHooks
 	minTTL := time.Duration((3*cfg.ElectionTicks)/2) * heartbeat
 
 	// always recover lessor before kv. When we recover the mvcc.KV it will reattach keys to its leases.

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -109,13 +109,13 @@ func CreateConfigChangeEnts(lg *zap.Logger, ids []uint64, self uint64, term, ind
 	return ents
 }
 
-// GetIDs returns an ordered set of IDs included in the given snapshot and
+// GetEffectiveNodeIDsFromWalEntries returns an ordered set of IDs included in the given snapshot and
 // the entries. The given snapshot/entries can contain three kinds of
 // ID-related entry:
 // - ConfChangeAddNode, in which case the contained ID will Be added into the set.
 // - ConfChangeRemoveNode, in which case the contained ID will Be removed from the set.
 // - ConfChangeAddLearnerNode, in which the contained ID will Be added into the set.
-func GetIDs(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
+func GetEffectiveNodeIDsFromWalEntries(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
 	ids := make(map[uint64]bool)
 	if snap != nil {
 		for _, id := range snap.Metadata.ConfState.Voters {


### PR DESCRIPTION
This PR moves all the code related to storage in storage package. 
cc @lilic @ptabor 
Recommend reviewing commit by commit, each of them should be fairly simple.

* Refactors bootstrap package to extract storage bootstraping
* Move storage bootstraping to server/storage package
