### PR TITLE
etcdserver: remove code duplication from the peer.send func

### DIFF
--- a/server/etcdserver/api/rafthttp/peer.go
+++ b/server/etcdserver/api/rafthttp/peer.go
@@ -250,30 +250,16 @@ func (p *peer) send(m raftpb.Message) {
 		if isMsgSnap(m) {
 			p.r.ReportSnapshot(m.To, raft.SnapshotFailure)
 		}
-		if p.status.isActive() {
-			if p.lg != nil {
-				p.lg.Warn(
-					"dropped internal Raft message since sending buffer is full (overloaded network)",
-					zap.String("message-type", m.Type.String()),
-					zap.String("local-member-id", p.localID.String()),
-					zap.String("from", types.ID(m.From).String()),
-					zap.String("remote-peer-id", p.id.String()),
-					zap.String("remote-peer-name", name),
-					zap.Bool("remote-peer-active", p.status.isActive()),
-				)
-			}
-		} else {
-			if p.lg != nil {
-				p.lg.Warn(
-					"dropped internal Raft message since sending buffer is full (overloaded network)",
-					zap.String("message-type", m.Type.String()),
-					zap.String("local-member-id", p.localID.String()),
-					zap.String("from", types.ID(m.From).String()),
-					zap.String("remote-peer-id", p.id.String()),
-					zap.String("remote-peer-name", name),
-					zap.Bool("remote-peer-active", p.status.isActive()),
-				)
-			}
+		if p.lg != nil {
+			p.lg.Warn(
+				"dropped internal Raft message since sending buffer is full",
+				zap.String("message-type", m.Type.String()),
+				zap.String("local-member-id", p.localID.String()),
+				zap.String("from", types.ID(m.From).String()),
+				zap.String("remote-peer-id", p.id.String()),
+				zap.String("remote-peer-name", name),
+				zap.Bool("remote-peer-active", p.status.isActive()),
+			)
 		}
 		sentFailures.WithLabelValues(types.ID(m.To).String()).Inc()
 	}


### PR DESCRIPTION
During the refactoring process, duplicate logging of the send buffer overflow event was added.
Each of these log lines logs exactly the same information, the logging context is sufficient to distinguish the cause.
Additionally, the unnecessary context (in parentheses) in the log message was removed, 
which was necessary without the zap context (with the old logger), but now only confuses.

The commit where duplication was added: c68f625353236caf947e910386c76124d8bdc051
