### PR TITLE
etcdctl|etcdutl: Invaild args 

### DIFF
--- a/etcdctl/main_test.go
+++ b/etcdctl/main_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func SplitTestArgs(args []string) (testArgs, appArgs []string) {
-	for i, arg := range os.Args {
+	for i, arg := range args {
 		switch {
 		case strings.HasPrefix(arg, "-test."):
 			testArgs = append(testArgs, arg)

--- a/etcdutl/main_test.go
+++ b/etcdutl/main_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func SplitTestArgs(args []string) (testArgs, appArgs []string) {
-	for i, arg := range os.Args {
+	for i, arg := range args {
 		switch {
 		case strings.HasPrefix(arg, "-test."):
 			testArgs = append(testArgs, arg)

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func SplitTestArgs(args []string) (testArgs, appArgs []string) {
-	for i, arg := range os.Args {
+	for i, arg := range args {
 		switch {
 		case strings.HasPrefix(arg, "-test."):
 			testArgs = append(testArgs, arg)


### PR DESCRIPTION
etcdctl|etcdutl: args defined in `SplitTestArgs(args []string)` is useless, and hardcode `os.args` may be invaild.