### PR TITLE
etcdserver: boltdb committing async by double read tx buffer

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -185,6 +185,8 @@ type ServerConfig struct {
 	// consider running defrag during bootstrap. Needs to be set to non-zero value to take effect.
 	ExperimentalBootstrapDefragThresholdMegabytes uint `json:"experimental-bootstrap-defrag-threshold-megabytes"`
 
+	ExperimentalCommitAsync bool `json:"experimental-commit-async"`
+
 	// V2Deprecation defines a phase of v2store deprecation process.
 	V2Deprecation V2DeprecationEnum `json:"v2-deprecation"`
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -401,6 +401,8 @@ type Config struct {
 	// ExperimentalTxnModeWriteWithSharedBuffer enables write transaction to use a shared buffer in its readonly check operations.
 	ExperimentalTxnModeWriteWithSharedBuffer bool `json:"experimental-txn-mode-write-with-shared-buffer"`
 
+	ExperimentalCommitAsync bool `json:"experimental-commit-async"`
+
 	// V2Deprecation describes phase of API & Storage V2 support
 	V2Deprecation config.V2DeprecationEnum `json:"v2-deprecation"`
 }
@@ -502,6 +504,7 @@ func NewConfig() *Config {
 		ExperimentalDowngradeCheckTime:           DefaultDowngradeCheckTime,
 		ExperimentalMemoryMlock:                  false,
 		ExperimentalTxnModeWriteWithSharedBuffer: true,
+		ExperimentalCommitAsync:                  true,
 
 		V2Deprecation: config.V2_DEPR_DEFAULT,
 	}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -218,6 +218,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		WarningUnaryRequestDuration:              cfg.ExperimentalWarningUnaryRequestDuration,
 		ExperimentalMemoryMlock:                  cfg.ExperimentalMemoryMlock,
 		ExperimentalTxnModeWriteWithSharedBuffer: cfg.ExperimentalTxnModeWriteWithSharedBuffer,
+		ExperimentalCommitAsync:                  cfg.ExperimentalCommitAsync,
 		ExperimentalBootstrapDefragThresholdMegabytes: cfg.ExperimentalBootstrapDefragThresholdMegabytes,
 		V2Deprecation: cfg.V2DeprecationEffective(),
 	}

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -290,6 +290,7 @@ func newConfig() *config {
 	fs.DurationVar(&cfg.ec.ExperimentalWarningUnaryRequestDuration, "experimental-warning-unary-request-duration", cfg.ec.ExperimentalWarningUnaryRequestDuration, "Time duration after which a warning is generated if a unary request takes more time.")
 	fs.BoolVar(&cfg.ec.ExperimentalMemoryMlock, "experimental-memory-mlock", cfg.ec.ExperimentalMemoryMlock, "Enable to enforce etcd pages (in particular bbolt) to stay in RAM.")
 	fs.BoolVar(&cfg.ec.ExperimentalTxnModeWriteWithSharedBuffer, "experimental-txn-mode-write-with-shared-buffer", true, "Enable the write transaction to use a shared buffer in its readonly check operations.")
+	fs.BoolVar(&cfg.ec.ExperimentalCommitAsync, "experimental-commit-async", true, "Enable the bolt db commit async, avoiding the Interaction between range/put and commit.")
 	fs.UintVar(&cfg.ec.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
 
 	// unsafe

--- a/server/storage/backend.go
+++ b/server/storage/backend.go
@@ -51,6 +51,7 @@ func newBackend(cfg config.ServerConfig, hooks backend.Hooks) backend.Backend {
 		bcfg.MmapSize = uint64(cfg.QuotaBackendBytes + cfg.QuotaBackendBytes/10)
 	}
 	bcfg.Mlock = cfg.ExperimentalMemoryMlock
+	bcfg.CommitAsync = cfg.ExperimentalCommitAsync
 	bcfg.Hooks = hooks
 	return backend.New(bcfg)
 }

--- a/server/storage/backend/hooks.go
+++ b/server/storage/backend/hooks.go
@@ -21,6 +21,10 @@ type Hooks interface {
 	// OnPreCommitUnsafe is executed before Commit of transactions.
 	// The given transaction is already locked.
 	OnPreCommitUnsafe(tx BatchTx)
+
+	OnPreCommitIndexAndTermUnsafe() (uint64, uint64)
+
+	OnPreCommitWithIndexAndTermUnsafe(tx BatchTx, index uint64, term uint64)
 }
 
 type hooks struct {
@@ -28,6 +32,12 @@ type hooks struct {
 }
 
 func (h hooks) OnPreCommitUnsafe(tx BatchTx) {
+	h.onPreCommitUnsafe(tx)
+}
+
+func (h hooks) OnPreCommitIndexAndTermUnsafe() (uint64, uint64) { return 0, 0 }
+
+func (h hooks) OnPreCommitWithIndexAndTermUnsafe(tx BatchTx, index uint64, term uint64) {
 	h.onPreCommitUnsafe(tx)
 }
 

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -87,6 +87,8 @@ type TxnWrite interface {
 	WriteView
 	// Changes gets the changes made since opening the write txn.
 	Changes() []mvccpb.KeyValue
+
+	EndAsync()
 }
 
 // txnReadWrite coerces a read txn to a write, panicking on any write operation.
@@ -97,6 +99,8 @@ func (trw *txnReadWrite) Put(key, value []byte, lease lease.LeaseID) (rev int64)
 	panic("unexpected Put")
 }
 func (trw *txnReadWrite) Changes() []mvccpb.KeyValue { return nil }
+
+func (trw *txnReadWrite) EndAsync() { panic("unexpected txnReadWrite EndAsync") }
 
 func NewReadOnlyTxnWrite(txn TxnRead) TxnWrite { return &txnReadWrite{txn} }
 
@@ -118,6 +122,8 @@ type KV interface {
 
 	// Write creates a write transaction.
 	Write(trace *traceutil.Trace) TxnWrite
+
+	WriteAsync(trace *traceutil.Trace) TxnWrite
 
 	// Hash computes the hash of the KV's backend.
 	Hash() (hash uint32, revision int64, err error)

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -871,8 +871,14 @@ type fakeBatchTx struct {
 	rangeRespc chan rangeResp
 }
 
+func (b *fakeBatchTx) Flash2ReadTx(readTx backend.ReadTx) {
+	panic("implement me")
+}
+
 func (b *fakeBatchTx) Lock()                                    {}
 func (b *fakeBatchTx) Unlock()                                  {}
+func (b *fakeBatchTx) LockAsync()                               {}
+func (b *fakeBatchTx) UnlockAsync()                             {}
 func (b *fakeBatchTx) RLock()                                   {}
 func (b *fakeBatchTx) RUnlock()                                 {}
 func (b *fakeBatchTx) UnsafeCreateBucket(bucket backend.Bucket) {}
@@ -881,6 +887,12 @@ func (b *fakeBatchTx) UnsafePut(bucket backend.Bucket, key []byte, value []byte)
 	b.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{bucket, key, value}})
 }
 func (b *fakeBatchTx) UnsafeSeqPut(bucket backend.Bucket, key []byte, value []byte) {
+	b.Recorder.Record(testutil.Action{Name: "seqput", Params: []interface{}{bucket, key, value}})
+}
+func (b *fakeBatchTx) UnsafePutAsync(bucket backend.Bucket, key []byte, value []byte) {
+	b.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{bucket, key, value}})
+}
+func (b *fakeBatchTx) UnsafeSeqPutAsync(bucket backend.Bucket, key []byte, value []byte) {
 	b.Recorder.Record(testutil.Action{Name: "seqput", Params: []interface{}{bucket, key, value}})
 }
 func (b *fakeBatchTx) UnsafeRange(bucket backend.Bucket, key, endKey []byte, limit int64) (keys [][]byte, vals [][]byte) {
@@ -894,14 +906,16 @@ func (b *fakeBatchTx) UnsafeDelete(bucket backend.Bucket, key []byte) {
 func (b *fakeBatchTx) UnsafeForEach(bucket backend.Bucket, visitor func(k, v []byte) error) error {
 	return nil
 }
-func (b *fakeBatchTx) Commit()        {}
-func (b *fakeBatchTx) CommitAndStop() {}
+func (b *fakeBatchTx) GetBuffer() interface{} { return nil }
+func (b *fakeBatchTx) Commit()                {}
+func (b *fakeBatchTx) CommitAndStop()         {}
 
 type fakeBackend struct {
 	tx *fakeBatchTx
 }
 
 func (b *fakeBackend) BatchTx() backend.BatchTx                                   { return b.tx }
+func (b *fakeBackend) BatchTxAsync() backend.BatchTxAsync                         { return b.tx }
 func (b *fakeBackend) ReadTx() backend.ReadTx                                     { return b.tx }
 func (b *fakeBackend) ConcurrentReadTx() backend.ReadTx                           { return b.tx }
 func (b *fakeBackend) Hash(func(bucketName, keyName []byte) bool) (uint32, error) { return 0, nil }

--- a/server/storage/mvcc/metrics_txn.go
+++ b/server/storage/mvcc/metrics_txn.go
@@ -55,6 +55,15 @@ func (tw *metricsTxnWrite) Put(key, value []byte, lease lease.LeaseID) (rev int6
 
 func (tw *metricsTxnWrite) End() {
 	defer tw.TxnWrite.End()
+	tw.EndCommon()
+}
+
+func (tw *metricsTxnWrite) EndAsync() {
+	defer tw.TxnWrite.EndAsync()
+	tw.EndCommon()
+}
+
+func (tw *metricsTxnWrite) EndCommon() {
 	if sum := tw.ranges + tw.puts + tw.deletes; sum > 1 {
 		txnCounter.Inc()
 	}

--- a/server/storage/schema/bucket.go
+++ b/server/storage/schema/bucket.go
@@ -95,3 +95,7 @@ func DefaultIgnores(bucket, key []byte) bool {
 func BackendMemberKey(id types.ID) []byte {
 	return []byte(id.String())
 }
+
+func init() {
+	backend.SetKeyBucket(Key)
+}


### PR DESCRIPTION
The kernel code is commit function. 

By using double buffer(readTx.buf、readTx.committingBuf), we can commit data to disk without locking readTx!

Lock conflict time between Commit and Range/Put will be less.

```
func (t *batchTxBufferedAsync) commitAndPut(stop bool) {
	t.backend.readTx.Lock()
        ...
	t.backend.readTx.committingBuf.reset()
	bufVersion := t.backend.readTx.buf.bufVersion
	t.backend.readTx.committingBuf, t.backend.readTx.buf = t.backend.readTx.buf, t.backend.readTx.committingBuf
	t.backend.readTx.buf.bufVersion = bufVersion

	t.backend.readTx.Unlock()

	...

	commitDone := make(chan interface{}, 1)

	go t.unsafeCommitAndPut(stop, commitDone)

	timeOut := time.NewTimer(500 * time.Millisecond)
	defer timeOut.Stop()
	select {
	case <-commitDone:
		var rtx *bolt.Tx
		if !stop {
			rtx = t.backend.begin(false)
		}

		t.backend.readTx.Lock()
		t.unsafeRollbackTx()
		if !stop {
			t.backend.readTx.tx = rtx
		}
		t.backend.readTx.Unlock()
	case <-timeOut.C:
		t.backend.lg.Warn("commit too long, lock range and put")
		t.backend.readTx.Lock()
		t.unsafeRollbackTx()
		<-commitDone

		if !stop {
			t.backend.readTx.tx = t.backend.begin(false)
		}
		t.backend.readTx.Unlock()
	}
}

```
