### PR TITLE
etcdserver,clientv3: server-side ignore sort-ascend-key for range reqs

### DIFF
--- a/client/v3/mirror/syncer.go
+++ b/client/v3/mirror/syncer.go
@@ -68,7 +68,8 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 
 		var key string
 
-		opts := []clientv3.OpOption{clientv3.WithLimit(batchLimit), clientv3.WithRev(s.rev)}
+		opts := []clientv3.OpOption{clientv3.WithLimit(batchLimit), clientv3.WithRev(s.rev),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)}
 
 		if len(s.prefix) == 0 {
 			// If len(s.prefix) == 0, we will sync the entire key-value space.

--- a/server/etcdserver/apply.go
+++ b/server/etcdserver/apply.go
@@ -386,6 +386,11 @@ func (a *applierV3backend) Range(ctx context.Context, txn mvcc.TxnRead, r *pb.Ra
 		// sorted by keys in lexiographically ascending order,
 		// sort ASCEND by default only when target is not 'KEY'
 		sortOrder = pb.RangeRequest_ASCEND
+	} else if r.SortTarget == pb.RangeRequest_KEY && sortOrder == pb.RangeRequest_ASCEND {
+		// Since current mvcc.Range implementation returns results
+		// sorted by keys in lexiographically ascending order,
+		// don't re-sort when target is 'KEY' and order is ASCEND
+		sortOrder = pb.RangeRequest_NONE
 	}
 	if sortOrder != pb.RangeRequest_NONE {
 		var sorter sort.Interface


### PR DESCRIPTION
A client-side optimization was made in #6100 to filter ascending key sorts to avoid an unnecessary re-sort since this is the order already returned by the back-end logic.

It seems to me that this really belongs on the server side since it's tied to the server implementation and should apply for any caller of the kv api (for example non-go clients).

Related, the client/v3 syncer depends on this default sorting which isn't explicit in the kv api contract. So I'm proposing the required sort parameters be included explicitly; it will take the fast path either way.
