### PR TITLE
netutil:  in urlsEqual function, URL compare using individual URL fields 

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"reflect"
 	"sort"
 	"time"
 
@@ -157,7 +156,10 @@ func urlsEqual(ctx context.Context, lg *zap.Logger, a []url.URL, b []url.URL) (b
 	sort.Sort(types.URLs(a))
 	sort.Sort(types.URLs(b))
 	for i := range a {
-		if !reflect.DeepEqual(a[i], b[i]) {
+		ipa:= net.ParseIP(a[i].Hostname())
+		ipb:= net.ParseIP(b[i].Hostname())
+
+		if ! ( ipa.Equal(ipb) && (a[i].Port() == b[i].Port()) && (a[i].Scheme == b[i].Scheme) ) {
 			return false, fmt.Errorf("%q(resolved from %q) != %q(resolved from %q)",
 				a[i].String(), preva[i].String(),
 				b[i].String(), prevb[i].String(),


### PR DESCRIPTION
netutil:  as part of urlsEqual function, to avoid string compare failure
of URL/IP address due to additional leading zero or different IP format,
code has been updated to compare URL fields individually.

Merge pull request #13266
Fix https://github.com/etcd-io/etcd/issues/13266

