### PR TITLE
Cleanup remaining TODOs for/past 3.5 release

### DIFF
--- a/server/storage/mvcc/metrics_txn.go
+++ b/server/storage/mvcc/metrics_txn.go
@@ -61,7 +61,6 @@ func (tw *metricsTxnWrite) End() {
 
 	ranges := float64(tw.ranges)
 	rangeCounter.Add(ranges)
-	rangeCounterDebug.Add(ranges) // TODO: remove in 3.5 release
 
 	puts := float64(tw.puts)
 	putCounter.Add(puts)

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -48,8 +48,6 @@ type v3cURLTest struct {
 	expected string
 }
 
-// TODO remove /kv/lease/timetolive, /kv/lease/revoke, /kv/lease/leases tests in 3.5 release
-
 func testV3CurlLeaseGrant(cx ctlCtx) {
 	leaseID := randomLeaseID()
 
@@ -74,11 +72,6 @@ func testV3CurlLeaseGrant(cx ctlCtx) {
 			value:    gwLeaseTTLWithKeys(cx, leaseID),
 			expected: `"grantedTTL"`,
 		},
-		{
-			endpoint: "/kv/lease/timetolive",
-			value:    gwLeaseTTLWithKeys(cx, leaseID),
-			expected: `"grantedTTL"`,
-		},
 	}
 	if err := cURLWithExpected(cx, tests); err != nil {
 		cx.t.Fatalf("testV3CurlLeaseGrant: %v", err)
@@ -99,11 +92,6 @@ func testV3CurlLeaseRevoke(cx ctlCtx) {
 			value:    gwLeaseRevoke(cx, leaseID),
 			expected: `"revision":"`,
 		},
-		{
-			endpoint: "/kv/lease/revoke",
-			value:    gwLeaseRevoke(cx, leaseID),
-			expected: `etcdserver: requested lease not found`,
-		},
 	}
 	if err := cURLWithExpected(cx, tests); err != nil {
 		cx.t.Fatalf("testV3CurlLeaseRevoke: %v", err)
@@ -121,11 +109,6 @@ func testV3CurlLeaseLeases(cx ctlCtx) {
 		},
 		{
 			endpoint: "/lease/leases",
-			value:    "{}",
-			expected: gwLeaseIDExpected(leaseID),
-		},
-		{
-			endpoint: "/kv/lease/leases",
 			value:    "{}",
 			expected: gwLeaseIDExpected(leaseID),
 		},

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -31,8 +31,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
-// TODO: remove /v3beta tests in 3.5 release
-var apiPrefix = []string{"/v3", "/v3beta"}
+var apiPrefix = []string{"/v3"}
 
 func TestV3CurlPutGetNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {


### PR DESCRIPTION
This cleans up open TODOs that I found that were supposed to be removed in 3.5

Pinging @gyuho @hexfusion as they added the TODOs initially.
