### PR TITLE
server: add range request cache to treeindex

### DIFF
--- a/server/storage/mvcc/index_bench_test.go
+++ b/server/storage/mvcc/index_bench_test.go
@@ -27,8 +27,12 @@ func BenchmarkIndexCompact100000(b *testing.B)  { benchmarkIndexCompact(b, 10000
 func BenchmarkIndexCompact1000000(b *testing.B) { benchmarkIndexCompact(b, 1000000) }
 
 func benchmarkIndexCompact(b *testing.B, size int) {
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
 	log := zap.NewNop()
-	kvindex := newTreeIndex(log)
+	kvindex := newTreeIndex(log, stopc)
 
 	bytesN := 64
 	keys := createBytesSlice(bytesN, size)

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -23,7 +23,11 @@ import (
 )
 
 func TestIndexGet(t *testing.T) {
-	ti := newTreeIndex(zap.NewExample())
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
+	ti := newTreeIndex(zap.NewExample(), stopc)
 	ti.Put([]byte("foo"), revision{main: 2})
 	ti.Put([]byte("foo"), revision{main: 4})
 	ti.Tombstone([]byte("foo"), revision{main: 6})
@@ -62,10 +66,14 @@ func TestIndexGet(t *testing.T) {
 }
 
 func TestIndexRange(t *testing.T) {
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2")}
 	allRevs := []revision{{main: 1}, {main: 2}, {main: 3}}
 
-	ti := newTreeIndex(zap.NewExample())
+	ti := newTreeIndex(zap.NewExample(), stopc)
 	for i := range allKeys {
 		ti.Put(allKeys[i], allRevs[i])
 	}
@@ -121,7 +129,11 @@ func TestIndexRange(t *testing.T) {
 }
 
 func TestIndexTombstone(t *testing.T) {
-	ti := newTreeIndex(zap.NewExample())
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
+	ti := newTreeIndex(zap.NewExample(), stopc)
 	ti.Put([]byte("foo"), revision{main: 1})
 
 	err := ti.Tombstone([]byte("foo"), revision{main: 2})
@@ -140,10 +152,14 @@ func TestIndexTombstone(t *testing.T) {
 }
 
 func TestIndexRangeSince(t *testing.T) {
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2"), []byte("foo2"), []byte("foo1"), []byte("foo")}
 	allRevs := []revision{{main: 1}, {main: 2}, {main: 3}, {main: 4}, {main: 5}, {main: 6}}
 
-	ti := newTreeIndex(zap.NewExample())
+	ti := newTreeIndex(zap.NewExample(), stopc)
 	for i := range allKeys {
 		ti.Put(allKeys[i], allRevs[i])
 	}
@@ -195,6 +211,10 @@ func TestIndexRangeSince(t *testing.T) {
 }
 
 func TestIndexCompactAndKeep(t *testing.T) {
+	stopc := make(chan struct{}, 1)
+	defer func() {
+		close(stopc)
+	}()
 	maxRev := int64(20)
 	tests := []struct {
 		key     []byte
@@ -217,7 +237,7 @@ func TestIndexCompactAndKeep(t *testing.T) {
 	}
 
 	// Continuous Compact and Keep
-	ti := newTreeIndex(zap.NewExample())
+	ti := newTreeIndex(zap.NewExample(), stopc)
 	for _, tt := range tests {
 		if tt.remove {
 			ti.Tombstone(tt.key, tt.rev)
@@ -248,7 +268,7 @@ func TestIndexCompactAndKeep(t *testing.T) {
 
 	// Once Compact and Keep
 	for i := int64(1); i < maxRev; i++ {
-		ti := newTreeIndex(zap.NewExample())
+		ti := newTreeIndex(zap.NewExample(), stopc)
 		for _, tt := range tests {
 			if tt.remove {
 				ti.Tombstone(tt.key, tt.rev)

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -99,9 +99,8 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 		cfg.CompactionSleepInterval = minimumBatchInterval
 	}
 	s := &store{
-		cfg:     cfg,
-		b:       b,
-		kvindex: newTreeIndex(lg),
+		cfg: cfg,
+		b:   b,
 
 		le: le,
 
@@ -114,6 +113,7 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 
 		lg: lg,
 	}
+	s.kvindex = newTreeIndex(lg, s.stopc)
 	s.ReadView = &readView{s}
 	s.WriteView = &writeView{s}
 	if s.le != nil {
@@ -304,7 +304,7 @@ func (s *store) Restore(b backend.Backend) error {
 	s.fifoSched.Stop()
 
 	s.b = b
-	s.kvindex = newTreeIndex(s.lg)
+	s.kvindex = newTreeIndex(s.lg, s.stopc)
 
 	{
 		// During restore the metrics might report 'special' values


### PR DESCRIPTION

This is some initial work to speed up range request with a limit.

Even with a limit specified, we still need to go through the whole treeindex range to get a count of the total number.

If we can cache the result and use it in the later range request, we can increase the performance.

This is WIP now and need further discussion with the community. We also need more performance evaluations.

------------

Update:

The code passed all the tests and we can discuss the design and how to conduct meaningful functionality/performance testing now.
