### PR TITLE
etcdserver: modifying the certificate reading mode

### DIFF
--- a/pkg/tlsutil/tlsutil.go
+++ b/pkg/tlsutil/tlsutil.go
@@ -49,14 +49,27 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
+var fileCache = map[string][]byte{}
+func readFile(filename string) ([]byte, error) {
+	if content, ok := fileCache[filename]; ok {
+		return content, nil
+	}
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	fileCache[filename] = content
+	return content, nil
+}
+
 // NewCert generates TLS cert by using the given cert,key and parse function.
 func NewCert(certfile, keyfile string, parseFunc func([]byte, []byte) (tls.Certificate, error)) (*tls.Certificate, error) {
-	cert, err := ioutil.ReadFile(certfile)
+	cert, err := readFile(certfile)
 	if err != nil {
 		return nil, err
 	}
 
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := readFile(keyfile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

etcdserver:  modifying the Certificate Reading Mode

The NewCert function included in the pkg/tlsutil/tlsutil.go file on etcd presents certificate content in plaintext.
I have prepared a straightforward method to handle this issue. Use the code below to enable the certificate content to be read into RAM and then deleted from the storage directory, so the certificate content is not exposed.

Fixes #13269