### PR TITLE
e2e: Call WithStopSignal on proxyV2 object

### DIFF
--- a/tests/framework/e2e/cluster_proxy.go
+++ b/tests/framework/e2e/cluster_proxy.go
@@ -110,7 +110,7 @@ func (p *proxyEtcdProcess) Close() error {
 }
 
 func (p *proxyEtcdProcess) WithStopSignal(sig os.Signal) os.Signal {
-	p.proxyV3.WithStopSignal(sig)
+	p.proxyV2.WithStopSignal(sig)
 	p.proxyV3.WithStopSignal(sig)
 	return p.etcdProc.WithStopSignal(sig)
 }


### PR DESCRIPTION
`WithStopSignal` method is called twice on proxyv3 object but not once on proxyv2 object.
This PR fixes this.
