### PR TITLE
fix defrag block lease keepalive

### DIFF
--- a/server/etcdserver/api/v3rpc/header.go
+++ b/server/etcdserver/api/v3rpc/header.go
@@ -47,3 +47,13 @@ func (h *header) fill(rh *pb.ResponseHeader) {
 		rh.Revision = h.rev()
 	}
 }
+
+// fillWithoutRevision populates pb.ResponseHeader using etcdserver information
+func (h *header) fillWithoutRevision(rh *pb.ResponseHeader) {
+	if rh == nil {
+		panic("unexpected nil resp.Header")
+	}
+	rh.ClusterId = uint64(h.clusterID)
+	rh.MemberId = uint64(h.memberID)
+	rh.RaftTerm = h.sg.Term()
+}

--- a/server/etcdserver/api/v3rpc/lease.go
+++ b/server/etcdserver/api/v3rpc/lease.go
@@ -123,6 +123,7 @@ func (ls *LeaseServer) leaseKeepAlive(stream pb.Lease_LeaseKeepAliveServer) erro
 			return err
 		}
 
+		// TODO fake this interpret
 		// Create header before we sent out the renew request.
 		// This can make sure that the revision is strictly smaller or equal to
 		// when the keepalive happened at the local server (when the local server is the leader)
@@ -130,7 +131,7 @@ func (ls *LeaseServer) leaseKeepAlive(stream pb.Lease_LeaseKeepAliveServer) erro
 		// Without this, a lease might be revoked at rev 3 but client can see the keepalive succeeded
 		// at rev 4.
 		resp := &pb.LeaseKeepAliveResponse{ID: req.ID, Header: &pb.ResponseHeader{}}
-		ls.hdr.fill(resp.Header)
+		ls.hdr.fillWithoutRevision(resp.Header)
 
 		ttl, err := ls.le.LeaseRenew(stream.Context(), lease.LeaseID(req.ID))
 		if err == lease.ErrLeaseNotFound {


### PR DESCRIPTION
1. production env, we found when defrag etcd node, some user system will found lease all expired.
2. I found the code, see when defrag it will add a readTx.Lock() for concurrentReadTx.
3. When lease keepalive,  header.fill() will get rev(), this method will invoke concurrentReadTx.RLock().
4. So all leases will expired if defrag run slowly. (client use lease expired in 5 seconds)

There is a question, why lease keepalive need care about the etcd current Revision???  Keepalive is just update the heap in memory, not do any read or write to boltDB(disk),  So I think lease keepalive do not need response revision to client.

Easy,  Crude, Direct, Effective