### PR TITLE
improve learner's auth operation and endpoint health

### DIFF
--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -126,7 +126,7 @@ func epHealthCommandFunc(cmd *cobra.Command, args []string) {
 			// get a random key. As long as we can get the response without an error, the
 			// endpoint is health.
 			ctx, cancel := commandCtx(cmd)
-			_, err = cli.Get(ctx, "health")
+			_, err = cli.Get(ctx, "health", v3.WithSerializable())
 			eh := epHealth{Ep: ep, Health: false, Took: time.Since(st).String()}
 			// permission denied is OK since proposal goes through consensus to get it
 			if err == nil || err == rpctypes.ErrPermissionDenied {

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -141,6 +141,10 @@ func isRPCSupportedForLearner(req interface{}) bool {
 		return true
 	case *pb.RangeRequest:
 		return r.Serializable
+	case *pb.AuthenticateRequest:
+		return true
+	case *pb.AlarmRequest:
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
my etcd cluster had open auth, and had a learner. when I run endpoint status/endpoint health operation(--endpoints contains learner in command) and something else by auth,  the result contains like 'etcdserver: rpc not supported for learner' and 'failed to getToken ...'

I try to fix this by the pr, The effect is as follows:
- support auth operation to learner (endpoint status、Serializable get from learner ...)
- support endpoint health for learner (etcdctl) (I think the cli.get of health operation (get a random key) ,'WithSerializable' is enough, so it can also fit to learner’s health operation)
```shell
######get key######
# before
[root@i ~]# export ETCDCTL_API=3;etcdctl --endpoints=http://110.190.241.32:2379 --user='root:PvkEt' get /shx --consistency="s"
{"level":"warn","ts":"2021-09-01T19:24:42.460+0800","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-2265ab24-0ca0-4d92-a504-3fa53ed7a115/110.190.241.32:2379","attempt":0,"error":"rpc error: code = Unavailable desc = etcdserver: rpc not supported for learner"}
Error: etcdserver: rpc not supported for learner

# after
[root@i ~]# export ETCDCTL_API=3;./etcdctl --endpoints=http://110.190.241.32:2379 --user='root:PvkEt' get /shx
/shx
aaa

######endpoint status######
# before
[root@etcd-tempshx-fwhw2 ~]# export ETCDCTL_API=3;/etcd/etcdctl --endpoints=http://111.99.132.103:2379,http://111.65.96.150:2379,http://111.93.114.66:2379,http://110.190.241.32:2379 --user='root:PvkEt' endpoint status -w table
{"level":"warn","ts":"2021-09-01T16:52:28.853+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000284000/#initially=[http://111.99.132.103:2379;http://111.65.96.150:2379;http://111.93.114.66:2379;http://110.190.241.32:2379]","attempt":0,"error":"rpc error: code = Unavailable desc = etcdserver: rpc not supported for learner"}
Failed to get the status of endpoint http://111.99.132.103:2379 (failed to getToken from endpoint http://111.99.132.103:2379 with maintenance client: etcdserver: rpc not supported for learner)
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|         ENDPOINT           |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|  http://111.65.96.150:2379 | c580c0b00f8e9660 |   3.5.0 |   20 kB |     false |      false |         2 |       1102 |               1102 |        |
|  http://111.93.114.66:2379 | 4ec0bd06c2b88328 |   3.5.0 |   20 kB |      true |      false |         2 |       1103 |               1103 |        |
| http://110.190.241.32:2379 | 257cc63913e6458b |   3.5.0 |   20 kB |     false |       true |         2 |       1104 |               1104 |        |
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

# after
[root@etcd-tempshx-fwhw2 logs]# export ETCDCTL_API=3;/etcd/etcdctl --endpoints=http://111.99.132.103:2379,http://111.65.96.150:2379,http://111.93.114.66:2379,http://110.190.241.32:2379 --user='root:PvkEt' endpoint status -w table
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|         ENDPOINT           |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| http://111.99.132.103:2379 | 3217d83fab8239be |   3.5.0 |   20 kB |      true |      false |         4 |       1624 |               1624 |        |
|  http://111.65.96.150:2379 | 571dc14ca27e37d1 |   3.5.0 |   20 kB |     false |      false |         4 |       1625 |               1625 |        |
|  http://111.93.114.66:2379 | e7681b01ff5cb00d |   3.5.0 |   20 kB |     false |      false |         4 |       1626 |               1626 |        |
| http://110.190.241.32:2379 | 31cb0362354560f5 |   3.5.0 |   20 kB |     false |       true |         4 |       1627 |               1627 |        |
+----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+

######endpoint health######

# before
[root@etcd-tempshx-fwhw2 logs]# export ETCDCTL_API=3;/etcd/etcdctl --endpoints=http://111.99.132.103:2379,http://111.65.96.150:2379,http://111.93.114.66:2379,http://110.190.241.32:2379 --user='root:PvkEt' endpoint health -w table
{"level":"warn","ts":1630499554.5592766,"logger":"client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00022a000/#initially=[http://110.190.241.32:2379]","attempt":99,"error":"rpc error: code = Unavailable desc = etcdserver: rpc not supported for learner"}
+----------------------------+--------+--------------+--------------------------------+
|         ENDPOINT           | HEALTH |     TOOK     |             ERROR              |
+----------------------------+--------+--------------+--------------------------------+
| http://111.99.132.103:2379 |   true |     627.58µs |                                |
|  http://111.93.114.66:2379 |   true |    623.586µs |                                |
|  http://111.65.96.150:2379 |   true |    669.219µs |                                |
| http://110.190.241.32:2379 |  false | 2.645110502s |  etcdserver: rpc not supported |
|                            |        |              |                    for learner |
+----------------------------+--------+--------------+--------------------------------+
Error: unhealthy cluster

# after
[root@etcd-tempshx-fwhw2 logs]# export ETCDCTL_API=3;/etcd/etcdctl --endpoints=http://111.99.132.103:2379,http://111.65.96.150:2379,http://111.93.114.66:2379,http://110.190.241.32:2379 --user='root:PvkEt' endpoint health -w table
+----------------------------+--------+--------------+--------------------------------+
|         ENDPOINT           | HEALTH |     TOOK     |             ERROR              |
+----------------------------+--------+--------------+--------------------------------+
| http://111.99.132.103:2379 |   true |     627.58µs |                                |
|  http://111.93.114.66:2379 |   true |    623.586µs |                                |
|  http://111.65.96.150:2379 |   true |    669.219µs |                                |
| http://110.190.241.32:2379 |   true |    569.119µs |                                |
+----------------------------+--------+--------------+--------------------------------+
```