### PR TITLE
e2e: test experimental-warning-unary-request-duration flag

### DIFF
--- a/tests/e2e/cluster_proxy_test.go
+++ b/tests/e2e/cluster_proxy_test.go
@@ -115,6 +115,8 @@ func (p *proxyEtcdProcess) WithStopSignal(sig os.Signal) os.Signal {
 	return p.etcdProc.WithStopSignal(sig)
 }
 
+func (p *proxyEtcdProcess) ExpectProc() *expect.ExpectProcess { return p.etcdProc.ExpectProc() }
+
 type proxyProc struct {
 	lg       *zap.Logger
 	execPath string

--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -164,14 +164,15 @@ type etcdProcessClusterConfig struct {
 
 	cipherSuites []string
 
-	forceNewCluster     bool
-	initialToken        string
-	quotaBackendBytes   int64
-	noStrictReconfig    bool
-	enableV2            bool
-	initialCorruptCheck bool
-	authTokenOpts       string
-	v2deprecation       string
+	forceNewCluster      bool
+	initialToken         string
+	quotaBackendBytes    int64
+	noStrictReconfig     bool
+	enableV2             bool
+	initialCorruptCheck  bool
+	unaryRequestDuration string
+	authTokenOpts        string
+	v2deprecation        string
 
 	rollingStart bool
 }
@@ -294,6 +295,9 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs(tb testing.TB) []*
 		}
 		if cfg.initialCorruptCheck {
 			args = append(args, "--experimental-initial-corrupt-check")
+		}
+		if cfg.unaryRequestDuration != "" {
+			args = append(args, "--experimental-warning-unary-request-duration", cfg.unaryRequestDuration)
 		}
 		var murl string
 		if cfg.metricsURLScheme != "" {

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestCtlV3AuthEnable(t *testing.T) {

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -139,7 +139,8 @@ type ctlCtx struct {
 	user string
 	pass string
 
-	initialCorruptCheck bool
+	initialCorruptCheck  bool
+	unaryRequestDuration string
 
 	// for compaction
 	compactPhysical bool
@@ -166,6 +167,10 @@ func withCfg(cfg etcdProcessClusterConfig) ctlOption {
 
 func withDialTimeout(timeout time.Duration) ctlOption {
 	return func(cx *ctlCtx) { cx.dialTimeout = timeout }
+}
+
+func withUnaryRequestDuration(duration string) ctlOption {
+	return func(cx *ctlCtx) { cx.unaryRequestDuration = duration }
 }
 
 func withQuorum() ctlOption {
@@ -231,6 +236,9 @@ func testCtlWithOffline(t *testing.T, testFunc func(ctlCtx), testOfflineFunc fun
 	ret.cfg.noStrictReconfig = ret.noStrictReconfig
 	if ret.initialCorruptCheck {
 		ret.cfg.initialCorruptCheck = ret.initialCorruptCheck
+	}
+	if ret.unaryRequestDuration != "" {
+		ret.cfg.unaryRequestDuration = ret.unaryRequestDuration
 	}
 	if testOfflineFunc != nil {
 		ret.cfg.keepDataDir = true

--- a/tests/e2e/etcd_process.go
+++ b/tests/e2e/etcd_process.go
@@ -43,6 +43,7 @@ type etcdProcess interface {
 	Close() error
 	WithStopSignal(sig os.Signal) os.Signal
 	Config() *etcdServerProcessConfig
+	ExpectProc() *expect.ExpectProcess
 }
 
 type etcdServerProcess struct {
@@ -162,4 +163,5 @@ func (ep *etcdServerProcess) waitReady() error {
 	return waitReadyExpectProc(ep.proc, etcdServerReadyLines)
 }
 
-func (ep *etcdServerProcess) Config() *etcdServerProcessConfig { return ep.cfg }
+func (ep *etcdServerProcess) Config() *etcdServerProcessConfig  { return ep.cfg }
+func (ep *etcdServerProcess) ExpectProc() *expect.ExpectProcess { return ep.proc }


### PR DESCRIPTION
Tests the `put` request as an example of unary request with `experimental-warning-unary-request-duration` flag.

Fixes #13264
