### PR TITLE
raftexample: fixes command line flags

### DIFF
--- a/contrib/raftexample/Procfile
+++ b/contrib/raftexample/Procfile
@@ -1,4 +1,4 @@
 # Use goreman to run `go get github.com/mattn/goreman`
-raftexample1: ./raftexample --id 1 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 12380
-raftexample2: ./raftexample --id 2 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 22380
-raftexample3: ./raftexample --id 3 --cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 --port 32380
+raftexample1: ./raftexample -id 1 -cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 -port 12380
+raftexample2: ./raftexample -id 2 -cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 -port 22380
+raftexample3: ./raftexample -id 3 -cluster http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 -port 32380


### PR DESCRIPTION
Go flags is different from GNU POSIX flags, we should use '-port' instead of '--port'.

Fixes #13324
