### PR TITLE
Stop using golang tip version in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.16"
+          go-version: "1.16.3"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.16"
+          go-version: "1.16.3"
       - run: date
       - env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}


### PR DESCRIPTION
This PR is meant to disable using tip golang version ("^1.16" means at least 1.16), and set one version in both CI and build. This is meant to avoid issues like https://github.com/etcd-io/etcd/pull/13334 where CI can break when new Go version is released. Having reproducible test is very important for fast resolution of bugs and reduction of flakes. This PR sets 1.16 version instead of upgrading to 1.16 as it should be also cherry-picked to v3.5 which is affected with the same problem.

Historically we also tested on Golang tip, but as a test that can fail. Having additional signal from "tip" in CI is a separate problem, that we can take a look after.

@ptabor 
