### PR TITLE
Stop using tip golang version in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "^1.16"
+        go-version: "1.16.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}


### PR DESCRIPTION
Cherry picking https://github.com/etcd-io/etcd/pull/13338 to release 3.5. This change fixes CI and has no impact on etcd release itself.

cc @ptabor