### PR TITLE
Dockerfile: bump debian image to bullseye-20210927

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.4.0
+# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
+FROM debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/build-image/debian-base-arm64:buster-v1.4.0
+# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
+FROM arm64v8/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/build-image/debian-base-ppc64le:buster-v1.4.0
+# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
+FROM ppc64le/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/build-image/debian-base-s390x:buster-v1.4.0
+# TODO: move to k8s.gcr.io/build-image/debian-base-s390x:bullseye-1.y.z when patched
+FROM s390x/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Debian buster has been replaced with bullseye v11.0 and is getting CVE fixes quicker. This PR moves us from buster to bullseye and also applies a hotfix for openssl to resolve `CVE-2021-3711`. 

We recently moved to `k8s.gcr.io/build-image/debian-base` for our Debian base images to align with upstream k8s which just recently moved to bullseye[1]. The plan is to move back to this registry once these fixes are addressed. But as we are going to cut a new 3.5 release it seems prudent to improve our security profile now.

fixes: CVE-2021-3711, CVE-2021-35942, CVE-2019-9893

CVE testing was done using trivy[2]

[1] https://github.com/kubernetes/kubernetes/commit/531eb712c2cb73a0d2137f1d8f273f21785b0087
[2] https://github.com/aquasecurity/trivy

cc @gyuho @ptabor @hasbro17 @lilic @serathius

