### PR TITLE
[release-3.4] Dockerfile: bump debian bullseye-20210927

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/debian-base:v1.0.0
+# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
+FROM debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/debian-base-arm64:v1.0.0
+# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
+FROM arm64v8/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,5 @@
-FROM k8s.gcr.io/debian-base-ppc64le:v1.0.0
+# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
+FROM ppc64le/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Manual cherry-pick of #13376 onto release-3.4
