### PR TITLE
[release-3.3] Dockerfile: bump debian bullseye-20210927

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,4 +1,5 @@
-FROM alpine:latest
+# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
+FROM debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,9 +1,16 @@
-FROM aarch64/ubuntu:16.04
+# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
+FROM arm64v8/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 ADD var/etcd /var/etcd
 ADD var/lib/etcd /var/lib/etcd
+
+# Alpine Linux doesn't use pam, which means that there is no /etc/nsswitch.conf,
+# but Golang relies on /etc/nsswitch.conf to check the order of DNS resolving
+# (see https://github.com/golang/go/commit/9dee7771f561cf6aee081c0af6658cc81fac3918)
+# To fix this we just create /etc/nsswitch.conf and add the following line:
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
 EXPOSE 2379 2380
 

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,9 +1,16 @@
-FROM ppc64le/ubuntu:16.04
+# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
+FROM ppc64le/debian:bullseye-20210927
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/
 ADD var/etcd /var/etcd
 ADD var/lib/etcd /var/lib/etcd
+
+# Alpine Linux doesn't use pam, which means that there is no /etc/nsswitch.conf,
+# but Golang relies on /etc/nsswitch.conf to check the order of DNS resolving
+# (see https://github.com/golang/go/commit/9dee7771f561cf6aee081c0af6658cc81fac3918)
+# To fix this we just create /etc/nsswitch.conf and add the following line:
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION
Manual cherry-pick of #13376 onto release-3.3