### PR TITLE
changelog updates for backport  - Add etcd_disk_defrag_inflight to indicate if defrag is active

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -43,6 +43,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.15...v3.4.16) an
 ### Metrics
 
 - Fix [incorrect metrics generated when clients cancel watches](https://github.com/etcd-io/etcd/pull/12803) back-ported from (https://github.com/etcd-io/etcd/pull/12196).
+- Add [`etcd_disk_defrag_inflight`](https://github.com/etcd-io/etcd/pull/13393).
 
 ### Go
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -129,6 +129,7 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 - Add [`etcd_wal_write_bytes_total`](https://github.com/etcd-io/etcd/pull/11738).
 - Add [`etcd_debugging_auth_revision`](https://github.com/etcd-io/etcd/commit/f14d2a087f7b0fd6f7980b95b5e0b945109c95f3).
 - Add [`os_fd_used` and `os_fd_limit` to monitor current OS file descriptors](https://github.com/etcd-io/etcd/pull/12214).
+- Add [`etcd_disk_defrag_inflight`](https://github.com/etcd-io/etcd/pull/13392).
 
 ### etcd server
 


### PR DESCRIPTION
CHANGELOG update for backport - Add etcd_disk_defrag_inflight to indicate if defrag is active


