### PR TITLE
v3compactor: refine some code and fix a typo

### DIFF
--- a/server/etcdserver/api/v3compactor/periodic.go
+++ b/server/etcdserver/api/v3compactor/periodic.go
@@ -56,6 +56,8 @@ func newPeriodic(lg *zap.Logger, clock clockwork.Clock, h time.Duration, rg RevG
 		c:      c,
 		revs:   make([]int64, 0),
 	}
+	// revs won't be longer than the retentions.
+	pc.revs = make([]int64, 0, pc.getRetentions())
 	pc.ctx, pc.cancel = context.WithCancel(context.Background())
 	return pc
 }
@@ -66,7 +68,7 @@ Compaction period 1-hour:
   2. record revisions for every 1/10 of 1-hour (6-minute)
   3. keep recording revisions with no compaction for first 1-hour
   4. do compact with revs[0]
-	- success? contiue on for-loop and move sliding window; revs = revs[1:]
+	- success? continue on for-loop and move sliding window; revs = revs[1:]
 	- failure? update revs, and retry after 1/10 of 1-hour (6-minute)
 
 Compaction period 24-hour:
@@ -74,7 +76,7 @@ Compaction period 24-hour:
   2. record revisions for every 1/10 of 1-hour (6-minute)
   3. keep recording revisions with no compaction for first 24-hour
   4. do compact with revs[0]
-	- success? contiue on for-loop and move sliding window; revs = revs[1:]
+	- success? continue on for-loop and move sliding window; revs = revs[1:]
 	- failure? update revs, and retry after 1/10 of 1-hour (6-minute)
 
 Compaction period 59-min:
@@ -82,7 +84,7 @@ Compaction period 59-min:
   2. record revisions for every 1/10 of 59-min (5.9-min)
   3. keep recording revisions with no compaction for first 59-min
   4. do compact with revs[0]
-	- success? contiue on for-loop and move sliding window; revs = revs[1:]
+	- success? continue on for-loop and move sliding window; revs = revs[1:]
 	- failure? update revs, and retry after 1/10 of 59-min (5.9-min)
 
 Compaction period 5-sec:
@@ -90,7 +92,7 @@ Compaction period 5-sec:
   2. record revisions for every 1/10 of 5-sec (0.5-sec)
   3. keep recording revisions with no compaction for first 5-sec
   4. do compact with revs[0]
-	- success? contiue on for-loop and move sliding window; revs = revs[1:]
+	- success? continue on for-loop and move sliding window; revs = revs[1:]
 	- failure? update revs, and retry after 1/10 of 5-sec (0.5-sec)
 */
 
@@ -113,9 +115,9 @@ func (pc *Periodic) Run() {
 			case <-pc.ctx.Done():
 				return
 			case <-pc.clock.After(retryInterval):
-				pc.mu.Lock()
+				pc.mu.RLock()
 				p := pc.paused
-				pc.mu.Unlock()
+				pc.mu.RUnlock()
 				if p {
 					continue
 				}

--- a/server/etcdserver/api/v3compactor/periodic.go
+++ b/server/etcdserver/api/v3compactor/periodic.go
@@ -54,7 +54,6 @@ func newPeriodic(lg *zap.Logger, clock clockwork.Clock, h time.Duration, rg RevG
 		period: h,
 		rg:     rg,
 		c:      c,
-		revs:   make([]int64, 0),
 	}
 	// revs won't be longer than the retentions.
 	pc.revs = make([]int64, 0, pc.getRetentions())


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

* Pre-allocate `pc.revs` with the `retentions` capacity.
* Use the `RLock/RUnlock` for `pc.paused`.
* A typo fix.