### PR TITLE
Implement single node downgrades

### DIFF
--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/coreos/go-semver/semver"
-	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/membershippb"
@@ -88,15 +87,12 @@ func (s *serverVersionAdapter) GetStorageVersion() *semver.Version {
 	return &v
 }
 
-func (s *serverVersionAdapter) UpdateStorageVersion(target semver.Version) {
+func (s *serverVersionAdapter) UpdateStorageVersion(target semver.Version) error {
 	if s.tx == nil {
 		s.Lock()
 		defer s.Unlock()
 	}
-	err := schema.UnsafeMigrate(s.lg, s.tx, target)
-	if err != nil {
-		s.lg.Error("failed migrating storage schema", zap.String("storage-version", target.String()), zap.Error(err))
-	}
+	return schema.UnsafeMigrate(s.lg, s.tx, target)
 }
 
 func (s *serverVersionAdapter) Lock() {

--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -91,7 +91,7 @@ func (s *serverVersionAdapter) UpdateStorageVersion(target semver.Version) error
 		s.Lock()
 		defer s.Unlock()
 	}
-	return schema.UnsafeMigrate(s.lg, s.tx, target)
+	return schema.UnsafeMigrate(s.lg, s.tx, s.r.storage, target)
 }
 
 func (s *serverVersionAdapter) Lock() {

--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -43,8 +43,7 @@ func newServerVersionAdapter(s *EtcdServer) *serverVersionAdapter {
 var _ serverversion.Server = (*serverVersionAdapter)(nil)
 
 func (s *serverVersionAdapter) UpdateClusterVersion(version string) {
-	// TODO switch to updateClusterVersionV3 in 3.6
-	s.GoAttach(func() { s.updateClusterVersionV2(version) })
+	s.GoAttach(func() { s.updateClusterVersionV3(version) })
 }
 
 func (s *serverVersionAdapter) LinearizableReadNotify(ctx context.Context) error {

--- a/server/etcdserver/version/downgrade.go
+++ b/server/etcdserver/version/downgrade.go
@@ -37,30 +37,10 @@ func isValidDowngrade(verFrom *semver.Version, verTo *semver.Version) bool {
 	return verTo.Equal(*allowedDowngradeVersion(verFrom))
 }
 
-// MustDetectDowngrade will detect unexpected downgrade when the local server is recovered.
-func MustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version, d *DowngradeInfo) {
+// MustDetectDowngrade will detect local server joining cluster that doesn't support it's version.
+func MustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) {
 	// only keep major.minor version for comparison against cluster version
 	sv = &semver.Version{Major: sv.Major, Minor: sv.Minor}
-
-	// if the cluster enables downgrade, check local version against downgrade target version.
-	if d != nil && d.Enabled && d.TargetVersion != "" {
-		if sv.Equal(*d.GetTargetVersion()) {
-			if cv != nil {
-				lg.Info(
-					"cluster is downgrading to target version",
-					zap.String("target-cluster-version", d.TargetVersion),
-					zap.String("determined-cluster-version", version.Cluster(cv.String())),
-					zap.String("current-server-version", sv.String()),
-				)
-			}
-			return
-		}
-		lg.Panic(
-			"invalid downgrade; server version is not allowed to join when downgrade is enabled",
-			zap.String("current-server-version", sv.String()),
-			zap.String("target-cluster-version", d.TargetVersion),
-		)
-	}
 
 	// if the cluster disables downgrade, check local version against determined cluster version.
 	// the validation passes when local version is not less than cluster version

--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -40,9 +40,6 @@ type Server interface {
 
 	GetStorageVersion() *semver.Version
 	UpdateStorageVersion(semver.Version) error
-
-	Lock()
-	Unlock()
 }
 
 func NewMonitor(lg *zap.Logger, storage Server) *Monitor {
@@ -100,8 +97,6 @@ func (m *Monitor) UpdateStorageVersionIfNeeded() {
 	if cv == nil {
 		return
 	}
-	m.s.Lock()
-	defer m.s.Unlock()
 	sv := m.s.GetStorageVersion()
 
 	if sv == nil || sv.Major != cv.Major || sv.Minor != cv.Minor {

--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -185,11 +185,12 @@ func (m *Monitor) membersMinimalServerVersion() *semver.Version {
 // It can be used to decide the whether the cluster finishes downgrading to target version.
 func (m *Monitor) versionsMatchTarget(targetVersion *semver.Version) bool {
 	vers := m.s.GetMembersVersions()
+	targetVersion = &semver.Version{Major: targetVersion.Major, Minor: targetVersion.Minor}
 	for mid, ver := range vers {
 		if ver == nil {
 			return false
 		}
-		v, err := semver.NewVersion(ver.Cluster)
+		v, err := semver.NewVersion(ver.Server)
 		if err != nil {
 			m.lg.Warn(
 				"failed to parse server version of remote member",
@@ -199,6 +200,7 @@ func (m *Monitor) versionsMatchTarget(targetVersion *semver.Version) bool {
 			)
 			return false
 		}
+		v = &semver.Version{Major: v.Major, Minor: v.Minor}
 		if !targetVersion.Equal(*v) {
 			m.lg.Warn("remotes server has mismatching etcd version",
 				zap.String("remote-member-id", mid),

--- a/server/etcdserver/version/monitor_test.go
+++ b/server/etcdserver/version/monitor_test.go
@@ -127,7 +127,7 @@ func TestVersionMatchTarget(t *testing.T) {
 			"When cannot parse peer version",
 			&semver.Version{Major: 3, Minor: 4},
 			map[string]*version.Versions{
-				"mem1": {Server: "3.4.1", Cluster: "3.4"},
+				"mem1": {Server: "3.4", Cluster: "3.4.0"},
 				"mem2": {Server: "3.4.2-pre", Cluster: "3.4.0"},
 				"mem3": {Server: "3.4.2", Cluster: "3.4.0"},
 			},
@@ -276,6 +276,24 @@ func TestCancelDowngradeIfNeeded(t *testing.T) {
 				"a": {Cluster: "3.6.0", Server: "3.6.1"},
 				"b": {Cluster: "3.6.0", Server: "3.6.2"},
 			},
+		},
+		{
+			name: "Continue downgrade if just started",
+			memberVersions: map[string]*version.Versions{
+				"a": {Cluster: "3.5.0", Server: "3.6.1"},
+				"b": {Cluster: "3.5.0", Server: "3.6.2"},
+			},
+			downgrade:       &DowngradeInfo{TargetVersion: "3.5.0", Enabled: true},
+			expectDowngrade: &DowngradeInfo{TargetVersion: "3.5.0", Enabled: true},
+		},
+		{
+			name: "Continue downgrade if there is at least one member with not matching",
+			memberVersions: map[string]*version.Versions{
+				"a": {Cluster: "3.5.0", Server: "3.5.1"},
+				"b": {Cluster: "3.5.0", Server: "3.6.2"},
+			},
+			downgrade:       &DowngradeInfo{TargetVersion: "3.5.0", Enabled: true},
+			expectDowngrade: &DowngradeInfo{TargetVersion: "3.5.0", Enabled: true},
 		},
 		{
 			name: "Cancel downgrade if all members have downgraded",

--- a/server/etcdserver/version/monitor_test.go
+++ b/server/etcdserver/version/monitor_test.go
@@ -421,14 +421,3 @@ func (s *storageMock) UpdateStorageVersion(v semver.Version) error {
 	s.storageVersion = &v
 	return nil
 }
-
-func (s *storageMock) Lock() {
-	if s.locked {
-		panic("Deadlock")
-	}
-	s.locked = true
-}
-
-func (s *storageMock) Unlock() {
-	s.locked = false
-}

--- a/server/etcdserver/version/version_test.go
+++ b/server/etcdserver/version/version_test.go
@@ -256,9 +256,3 @@ func (m *memberMock) UpdateStorageVersion(v semver.Version) error {
 
 func (m *memberMock) TriggerSnapshot() {
 }
-
-func (m *memberMock) Lock() {
-}
-
-func (m *memberMock) Unlock() {
-}

--- a/server/mock/mockstorage/storage_recorder.go
+++ b/server/mock/mockstorage/storage_recorder.go
@@ -15,6 +15,7 @@
 package mockstorage
 
 import (
+	"github.com/coreos/go-semver/semver"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
@@ -57,4 +58,5 @@ func (p *storageRecorder) Sync() error {
 	return nil
 }
 
-func (p *storageRecorder) Close() error { return nil }
+func (p *storageRecorder) Close() error                        { return nil }
+func (p *storageRecorder) MinimalEtcdVersion() *semver.Version { return nil }

--- a/server/storage/schema/migration.go
+++ b/server/storage/schema/migration.go
@@ -24,19 +24,7 @@ import (
 
 type migrationPlan []migrationStep
 
-func newPlan(lg *zap.Logger, current semver.Version, target semver.Version) (p migrationPlan, err error) {
-	// TODO(serathius): Implement downgrades
-	if target.LessThan(current) {
-		lg.Error("Target version is lower than the current version, downgrades are not yet supported",
-			zap.String("storage-version", current.String()),
-			zap.String("target-storage-version", target.String()),
-		)
-		return nil, fmt.Errorf("downgrades are not yet supported")
-	}
-	return buildPlan(lg, current, target)
-}
-
-func buildPlan(lg *zap.Logger, current semver.Version, target semver.Version) (plan migrationPlan, err error) {
+func newPlan(lg *zap.Logger, current semver.Version, target semver.Version) (plan migrationPlan, err error) {
 	current = trimToMinor(current)
 	target = trimToMinor(target)
 	if current.Major != target.Major {

--- a/server/storage/schema/migration_test.go
+++ b/server/storage/schema/migration_test.go
@@ -46,11 +46,9 @@ func TestNewPlan(t *testing.T) {
 			target:  V3_6,
 		},
 		{
-			name:           "Downgrade v3.6 to v3.5 should fail as downgrades are not yet supported",
-			current:        V3_6,
-			target:         V3_5,
-			expectError:    true,
-			expectErrorMsg: "downgrades are not yet supported",
+			name:    "Downgrade v3.6 to v3.5 should fail as downgrades are not yet supported",
+			current: V3_6,
+			target:  V3_5,
 		},
 		{
 			name:           "Upgrade v3.6 to v3.7 should fail as v3.7 is unknown",

--- a/server/storage/wal/testing/waltesting.go
+++ b/server/storage/wal/testing/waltesting.go
@@ -1,0 +1,89 @@
+// Copyright 2021 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/pkg/v3/pbutil"
+	"go.etcd.io/etcd/raft/v3/raftpb"
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.uber.org/zap/zaptest"
+)
+
+func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
+	t.Helper()
+	dir, err := ioutil.TempDir(t.TempDir(), "etcd_wal_test")
+	if err != nil {
+		panic(err)
+	}
+	tmpPath := filepath.Join(dir, "wal")
+	lg := zaptest.NewLogger(t)
+	w, err := wal.Create(lg, tmpPath, nil)
+	if err != nil {
+		t.Fatalf("Failed to create WAL: %v", err)
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatalf("Failed to close WAL: %v", err)
+	}
+	if len(reqs) != 0 {
+		w, err = wal.Open(lg, tmpPath, walpb.Snapshot{})
+		if err != nil {
+			t.Fatalf("Failed to open WAL: %v", err)
+		}
+		_, state, _, err := w.ReadAll()
+		if err != nil {
+			t.Fatalf("Failed to read WAL: %v", err)
+		}
+		entries := []raftpb.Entry{}
+		for _, req := range reqs {
+			entries = append(entries, raftpb.Entry{
+				Term:  1,
+				Index: 1,
+				Type:  raftpb.EntryNormal,
+				Data:  pbutil.MustMarshal(&req),
+			})
+		}
+		err = w.Save(state, entries)
+		if err != nil {
+			t.Fatalf("Failed to save WAL: %v", err)
+		}
+		err = w.Close()
+		if err != nil {
+			t.Fatalf("Failed to close WAL: %v", err)
+		}
+	}
+
+	w, err = wal.OpenForRead(lg, tmpPath, walpb.Snapshot{})
+	if err != nil {
+		t.Fatalf("Failed to open WAL: %v", err)
+	}
+	return w, tmpPath
+}
+
+func Reopen(t testing.TB, walPath string) *wal.WAL {
+	t.Helper()
+	lg := zaptest.NewLogger(t)
+	w, err := wal.OpenForRead(lg, walPath, walpb.Snapshot{})
+	if err != nil {
+		t.Fatalf("Failed to open WAL: %v", err)
+	}
+	return w
+}

--- a/server/storage/wal/version_test.go
+++ b/server/storage/wal/version_test.go
@@ -40,6 +40,9 @@ func TestEtcdVersionFromEntry(t *testing.T) {
 	raftReq := etcdserverpb.InternalRaftRequest{Header: &etcdserverpb.RequestHeader{AuthRevision: 1}}
 	normalRequestData := pbutil.MustMarshal(&raftReq)
 
+	clusterVersionV3_6Req := etcdserverpb.InternalRaftRequest{ClusterVersionSet: &membershippb.ClusterVersionSetRequest{Ver: "3.6.0"}}
+	clusterVersionV3_6Data := pbutil.MustMarshal(&clusterVersionV3_6Req)
+
 	confChange := raftpb.ConfChange{Type: raftpb.ConfChangeAddLearnerNode}
 	confChangeData := pbutil.MustMarshal(&confChange)
 
@@ -60,6 +63,16 @@ func TestEtcdVersionFromEntry(t *testing.T) {
 				Data:  normalRequestData,
 			},
 			expect: &V3_1,
+		},
+		{
+			name: "Setting cluster version implies version within",
+			input: raftpb.Entry{
+				Term:  1,
+				Index: 2,
+				Type:  raftpb.EntryNormal,
+				Data:  clusterVersionV3_6Data,
+			},
+			expect: &V3_6,
 		},
 		{
 			name: "Using ConfigChange implies v3.4",

--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -234,6 +234,14 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 	return w, nil
 }
 
+func (w *WAL) Reopen(lg *zap.Logger, snap walpb.Snapshot) (*WAL, error) {
+	err := w.Close()
+	if err != nil {
+		lg.Panic("failed to close WAL during reopen", zap.Error(err))
+	}
+	return Open(lg, w.dir, snap)
+}
+
 func (w *WAL) SetUnsafeNoFsync() {
 	w.unsafeNoSync = true
 }

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -1,0 +1,144 @@
+// Copyright 2021 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestDowngradeUpgrade(t *testing.T) {
+	currentEtcdBinary := ""
+	lastReleaseBinary := e2e.BinDir + "/etcd-last-release"
+	if !fileutil.Exist(lastReleaseBinary) {
+		t.Skipf("%q does not exist", lastReleaseBinary)
+	}
+	currentVersion := semver.New(version.Version)
+	lastVersion := semver.Version{Major: currentVersion.Major, Minor: currentVersion.Minor - 1}
+	currentVersionStr := fmt.Sprintf("%d.%d", currentVersion.Major, currentVersion.Minor)
+	lastVersionStr := fmt.Sprintf("%d.%d", lastVersion.Major, lastVersion.Minor)
+
+	e2e.BeforeTest(t)
+	dataDirPath := t.TempDir()
+
+	epc := startEtcd(t, currentEtcdBinary, dataDirPath)
+	validateVersion(t, epc, version.Versions{Cluster: currentVersionStr, Server: currentVersionStr})
+
+	downgradeEnable(t, epc, lastVersion)
+	validateVersion(t, epc, version.Versions{Cluster: lastVersionStr, Server: currentVersionStr})
+
+	stopEtcd(t, epc)
+	epc = startEtcd(t, lastReleaseBinary, dataDirPath)
+	validateVersion(t, epc, version.Versions{Cluster: lastVersionStr, Server: lastVersionStr})
+	expectLog(t, epc, "the cluster has been downgraded")
+
+	stopEtcd(t, epc)
+	epc = startEtcd(t, currentEtcdBinary, dataDirPath)
+	// TODO: Verify cluster version after upgrade when we fix cluster version set timeout
+	validateVersion(t, epc, version.Versions{Server: currentVersionStr})
+}
+
+func startEtcd(t *testing.T, execPath, dataDirPath string) *e2e.EtcdProcessCluster {
+	epc, err := e2e.NewEtcdProcessCluster(t, &e2e.EtcdProcessClusterConfig{
+		ExecPath:     execPath,
+		DataDirPath:  dataDirPath,
+		ClusterSize:  1,
+		InitialToken: "new",
+		KeepDataDir:  true,
+		// TODO: REMOVE snapshot override when snapshotting is automated after lowering storage versiont l
+		SnapshotCount: 5,
+	})
+	if err != nil {
+		t.Fatalf("could not start etcd process cluster (%v)", err)
+	}
+	t.Cleanup(func() {
+		if errC := epc.Close(); errC != nil {
+			t.Fatalf("error closing etcd processes (%v)", errC)
+		}
+	})
+
+	prefixArgs := []string{e2e.CtlBinPath, "--endpoints", strings.Join(epc.EndpointsV3(), ",")}
+	t.Log("Write keys to ensure wal snapshot is created so cluster version set is snapshotted")
+	e2e.ExecuteWithTimeout(t, 20*time.Second, func() {
+		for i := 0; i < 10; i++ {
+			if err := e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), "OK"); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+	return epc
+}
+
+func downgradeEnable(t *testing.T, epc *e2e.EtcdProcessCluster, ver semver.Version) {
+	t.Log("etcdctl downgrade...")
+	c, err := clientv3.New(clientv3.Config{
+		Endpoints: epc.EndpointsV3(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	// TODO: Fix request always timing out even thou it succeeds
+	c.Downgrade(ctx, 1, ver.String())
+	cancel()
+
+	expectLog(t, epc, "The server is ready to downgrade")
+}
+
+func stopEtcd(t *testing.T, epc *e2e.EtcdProcessCluster) {
+	t.Log("Stopping the server...")
+	if err := epc.Procs[0].Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateVersion(t *testing.T, epc *e2e.EtcdProcessCluster, expect version.Versions) {
+	t.Log("Validate version")
+	// Two separate calls to expect as it doesn't support multiple matches on the same line
+	e2e.ExecuteWithTimeout(t, 20*time.Second, func() {
+		if expect.Server != "" {
+			err := e2e.SpawnWithExpects(e2e.CURLPrefixArgs(epc, "GET", e2e.CURLReq{Endpoint: "/version"}), nil, `"etcdserver":"`+expect.Server)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if expect.Cluster != "" {
+			err := e2e.SpawnWithExpects(e2e.CURLPrefixArgs(epc, "GET", e2e.CURLReq{Endpoint: "/version"}), nil, `"etcdcluster":"`+expect.Cluster)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+func expectLog(t *testing.T, epc *e2e.EtcdProcessCluster, expectLog string) {
+	t.Helper()
+	e2e.ExecuteWithTimeout(t, 30*time.Second, func() {
+		_, err := epc.Procs[0].Logs().Expect(expectLog)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -105,7 +104,7 @@ func TestAuthority(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				executeWithTimeout(t, 5*time.Second, func() {
+				e2e.ExecuteWithTimeout(t, 5*time.Second, func() {
 					assertAuthority(t, fmt.Sprintf(tc.expectAuthorityPattern, 20000), epc)
 				})
 			})
@@ -152,20 +151,6 @@ func firstMatch(t *testing.T, expectLine string, logs ...e2e.LogsExpect) string 
 		}(logs[i])
 	}
 	return <-match
-}
-
-func executeWithTimeout(t *testing.T, timeout time.Duration, f func()) {
-	donec := make(chan struct{})
-	go func() {
-		defer close(donec)
-		f()
-	}()
-
-	select {
-	case <-time.After(timeout):
-		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
-	case <-donec:
-	}
 }
 
 type etcdctlV3 struct {

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -85,7 +85,7 @@ func TestEtctlutlMigrate(t *testing.T) {
 		{
 			name:                 "Downgrade v3.6 to v3.5 should fail until it's implemented",
 			targetVersion:        "3.5",
-			expectLogsSubString:  "Error: cannot create migration plan: downgrades are not yet supported",
+			expectLogsSubString:  "cannot downgrade storage, WAL contains newer entries",
 			expectStorageVersion: &schema.V3_6,
 		},
 		{

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -117,3 +117,17 @@ func ToTLS(s string) string {
 func SkipInShortMode(t testing.TB) {
 	testutil.SkipTestIfShortMode(t, "e2e tests are not running in --short mode")
 }
+
+func ExecuteWithTimeout(t *testing.T, timeout time.Duration, f func()) {
+	donec := make(chan struct{})
+	go func() {
+		defer close(donec)
+		f()
+	}()
+
+	select {
+	case <-time.After(timeout):
+		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
+	case <-donec:
+	}
+}

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -65,5 +65,5 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 	}
 	defer w.Close()
 	ver := w.MinimalEtcdVersion()
-	assert.Equal(t, &semver.Version{Major: 3, Minor: 5}, ver)
+	assert.Equal(t, &semver.Version{Major: 3, Minor: 6}, ver)
 }

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -64,6 +64,9 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 		panic(err)
 	}
 	defer w.Close()
-	ver := w.MinimalEtcdVersion()
-	assert.Equal(t, &semver.Version{Major: 3, Minor: 6}, ver)
+	walVersion, err := wal.ReadWALVersion(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, &semver.Version{Major: 3, Minor: 6}, walVersion.MinimalEtcdVersion())
 }


### PR DESCRIPTION
This PR implement single downgrades as proposed in https://docs.google.com/document/d/1yD0GDkxqWBPAax6jLZ97clwAz2Gp0Gux6xaTrtJ6wHE/edit?usp=sharing with the goal of introducing e2e tests that can confirm that storage versioning properly validates WAL entries during downgrade. 

This doesn't mean that with this PR etcd supports downgrades, there are still a lot of testing, small problems that we need to fix before  we can say that downgrades are safe. This is meant to allow us to expand testing of downgrades with different scenarios to confirm it's reliability.

Problem detected during implementation that will need to be fixed:
* As Etcd v3.5 imminently panics on SetClusterVersion with version set "3.6" entry in WAL I added it to MinEtcdVersion logic. We should consider adding logic to `etcdutl migrate` to drop this entry. 
* Sometimes setting ClusterVersion after upgrade timeouts, we should debug why.
* I didn't implement snapshoting WAL after lowering cluster version (required to remove non-backward compatible entries). To work around I use very low snapshot count in tests.

cc @ptabor @lilic 
