### PR TITLE
contrib/mixin: omit Defragment method from etcdGRPCRequestsSlow

### DIFF
--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -124,7 +124,7 @@
           {
             alert: 'etcdGRPCRequestsSlow',
             expr: |||
-              histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{%(etcd_selector)s, grpc_type="unary"}[5m])) without(grpc_type))
+              histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{%(etcd_selector)s, grpc_method!="Defragment", grpc_type="unary"}[5m])) without(grpc_type))
               > 0.15
             ||| % $._config,
             'for': '10m',


### PR DESCRIPTION
A critical alert should notify an admin of an unexpected condition. In the case of defragmentation, it is expected for the server handling to exceed 150ms.

cc @lilic @hasbro17