### PR TITLE
test: removing the redundant set -o pipefail

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -32,7 +32,6 @@
 # $ COVERDIR=coverage PASSES="build build_cov cov" ./test.sh
 # $ go tool cover -html ./coverage/cover.out
 set -e
-set -o pipefail
 
 
 # Consider command as failed when any component of the pipe fails:


### PR DESCRIPTION
ci: update the test.sh script.

I'm new to ETCD, while learning from the CI part, I found that the test.sh script happened to have 2 lines of `set -o pipefail`, where 1 should suffice. This tiny pull request just removes the first one.

I think no issue need for it. If you think needed, I'll create one later.