### PR TITLE
etcdserver: Expose metrics with all known peers

### DIFF
--- a/server/etcdserver/api/membership/metrics.go
+++ b/server/etcdserver/api/membership/metrics.go
@@ -24,8 +24,17 @@ var (
 		Help:      "Which version is running. 1 for 'cluster_version' label with current cluster version",
 	},
 		[]string{"cluster_version"})
+	knownPeers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "network",
+		Name:      "known_peers",
+		Help:      "The current number of known peers.",
+	},
+		[]string{"Local", "Remote"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(ClusterVersionMetrics)
+	prometheus.MustRegister(knownPeers)
 }


### PR DESCRIPTION
To make it possible to alert on misconfigured etcd clusters that have
missing/superfluous peers, expose the list of peers as a metric.
This metric can, for example, be compared to the control-plane nodes of
a kubernetes cluster.