### PR TITLE
add autoSync flag in benchmark tool

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -25,6 +25,10 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.5.1) and 
 
 - Endpoints self identify now as `etcd-endpoints://{id}/{authority}` where authority is based on first endpoint passed, for example `etcd-endpoints://0xc0009d8540/localhost:2079`
 
+### tools/benchmark
+
+- [Add etcd client autoSync flag](https://github.com/etcd-io/etcd/pull/13416)
+
 ### Other
 
 - Updated [base image](https://github.com/etcd-io/etcd/pull/13386) from `debian:buster-v1.4.0` to `debian:bullseye-20210927` to fix the following critical CVEs:

--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -53,7 +53,8 @@ var (
 
 	dialTimeout time.Duration
 
-	targetLeader bool
+	targetLeader     bool
+	autoSyncInterval time.Duration
 )
 
 func init() {
@@ -71,4 +72,5 @@ func init() {
 	RootCmd.PersistentFlags().DurationVar(&dialTimeout, "dial-timeout", 0, "dial timeout for client connections")
 
 	RootCmd.PersistentFlags().BoolVar(&targetLeader, "target-leader", false, "connect only to the leader node")
+	RootCmd.PersistentFlags().DurationVar(&autoSyncInterval, "auto-sync-interval", time.Duration(0), "AutoSyncInterval is the interval to update endpoints with its latest members")
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -93,8 +93,9 @@ func mustCreateConn() *clientv3.Client {
 		dialTotal++
 	}
 	cfg := clientv3.Config{
-		Endpoints:   connEndpoints,
-		DialTimeout: dialTimeout,
+		AutoSyncInterval: autoSyncInterval,
+		Endpoints:        connEndpoints,
+		DialTimeout:      dialTimeout,
 	}
 	if !tls.Empty() || tls.TrustedCAFile != "" {
 		cfgtls, err := tls.ClientConfig()


### PR DESCRIPTION
Use case: 
etcd client allows autoSync to reconcile etcd members when benchmarking a etcd cluster. 

Other minor fixes to mvcc keyIndex function annotations and genproto.sh script. Please correct me if I am wrong. Thanks!
