### PR TITLE
Grafana datasource template should be labelled 'Data Source'.

### DIFF
--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -1381,7 +1381,7 @@
               value: 'Prometheus',
             },
             hide: 0,
-            label: null,
+            label: 'Data Source',
             name: 'datasource',
             options: [],
             query: 'prometheus',


### PR DESCRIPTION
Hello! We're building a linter for mixins & grafana dashboards and this was one of the things that it turned up. Sorry for the super minor nit!

Signed-off-by: Tom Wilkie <tom@grafana.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
