### PR TITLE
MAINTAINERS: update Gyuho's contact email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,7 +10,7 @@
 
 # MAINTAINERS
 Brandon Philips <brandon@ifup.org> (@philips) pkg:*
-Gyuho Lee <gyuhox@gmail.com> <leegyuho@amazon.com> (@gyuho) pkg:*
+Gyuho Lee <gyuhox@gmail.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*


### PR DESCRIPTION
Became independent contributor.

/cc @chaochn47 @hexfusion 