### PR TITLE
compact optimization based on keep diff

### DIFF
--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -77,7 +77,10 @@ type store struct {
 	// currentRev is the revision of the last completed transaction.
 	currentRev int64
 	// compactMainRev is the main revision of the last compaction.
-	compactMainRev int64
+	compactMainRev     int64
+	lastCompactMainRev int64
+	lastKeep           []revision
+	keyCompactions     int64
 
 	fifoSched schedule.Scheduler
 
@@ -105,8 +108,10 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 
 		le: le,
 
-		currentRev:     1,
-		compactMainRev: -1,
+		currentRev:         1,
+		compactMainRev:     -1,
+		lastCompactMainRev: -1,
+		lastKeep:           make([]revision, 0),
 
 		fifoSched: schedule.NewFIFOScheduler(),
 

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -16,19 +16,96 @@ package mvcc
 
 import (
 	"encoding/binary"
+	"go.uber.org/zap"
 	"time"
 
 	"go.etcd.io/etcd/server/v3/storage/schema"
-	"go.uber.org/zap"
 )
 
 func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struct{}) bool {
 	totalStart := time.Now()
 	defer func() { dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond)) }()
-	keyCompactions := 0
-	defer func() { dbCompactionKeysCounter.Add(float64(keyCompactions)) }()
+	s.keyCompactions = 0
+	defer func() { dbCompactionKeysCounter.Add(float64(s.keyCompactions)) }()
 	defer func() { dbCompactionLast.Set(float64(time.Now().Unix())) }()
 
+	if s.lastCompactMainRev == -1 {
+		s.lg.Info("begin scheduleCompactionNewest")
+		if !s.scheduleCompactionNewest(0, compactMainRev, keep) {
+			return false
+		}
+	} else {
+		s.lg.Info("begin scheduleCompactionOld")
+		if !s.scheduleCompactionOld(keep) {
+			return false
+		}
+		if !s.scheduleCompactionNewest(s.lastCompactMainRev, compactMainRev, keep) {
+			return false
+		}
+	}
+
+	s.lg.Info(
+		"finished scheduled compaction",
+		zap.Int64("compact-revision", compactMainRev),
+		zap.Int64("compact-keys", s.keyCompactions),
+		zap.Duration("took", time.Since(totalStart)),
+	)
+
+	s.lastKeep = s.lastKeep[:0]
+	for key := range keep {
+		s.lastKeep = append(s.lastKeep, key)
+	}
+	s.lastCompactMainRev = compactMainRev
+
+	return true
+}
+
+func (s *store) scheduleCompactionOld(keep map[revision]struct{}) bool {
+	batchNum := s.cfg.CompactionBatchLimit / 10
+	batchInterval := s.cfg.CompactionSleepInterval
+
+	lastIndex := 0
+	keyByte := make([]byte, 8+1+8)
+	for {
+		start := time.Now()
+
+		tx := s.b.BatchTx()
+		tx.Lock()
+
+		num := 0
+		for lastIndex < len(s.lastKeep) {
+			key := s.lastKeep[lastIndex]
+			revToBytes(key, keyByte)
+			if _, ok := keep[key]; !ok {
+				tx.UnsafeDelete(schema.Key, keyByte)
+				s.keyCompactions++
+			}
+			num++
+			lastIndex++
+			if num >= batchNum {
+				break
+			}
+		}
+
+		tx.Unlock()
+		// Immediately commit the compaction deletes instead of letting them accumulate in the write buffer
+		s.b.ForceCommit()
+
+		dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
+
+		if lastIndex >= len(s.lastKeep) {
+			return true
+		}
+
+		select {
+		case <-time.After(batchInterval):
+		case <-s.stopc:
+			return false
+		}
+	}
+}
+
+func (s *store) scheduleCompactionNewest(lastCompactRev, compactMainRev int64, keep map[revision]struct{}) bool {
 	end := make([]byte, 8)
 	binary.BigEndian.PutUint64(end, uint64(compactMainRev+1))
 
@@ -36,6 +113,8 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 	batchInterval := s.cfg.CompactionSleepInterval
 
 	last := make([]byte, 8+1+8)
+	revToBytes(revision{main: lastCompactRev, sub: 0}, last)
+
 	for {
 		var rev revision
 
@@ -48,24 +127,19 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 			rev = bytesToRev(key)
 			if _, ok := keep[rev]; !ok {
 				tx.UnsafeDelete(schema.Key, key)
-				keyCompactions++
+				s.keyCompactions++
 			}
 		}
 
 		if len(keys) < batchNum {
 			UnsafeSetFinishedCompact(tx, compactMainRev)
 			tx.Unlock()
-			s.lg.Info(
-				"finished scheduled compaction",
-				zap.Int64("compact-revision", compactMainRev),
-				zap.Duration("took", time.Since(totalStart)),
-			)
 			return true
 		}
 
-		tx.Unlock()
 		// update last
 		revToBytes(revision{main: rev.main, sub: rev.sub + 1}, last)
+		tx.Unlock()
 		// Immediately commit the compaction deletes instead of letting them accumulate in the write buffer
 		s.b.ForceCommit()
 		dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -344,7 +344,7 @@ func TestStoreCompact(t *testing.T) {
 	binary.BigEndian.PutUint64(end, uint64(4))
 	wact := []testutil.Action{
 		{Name: "put", Params: []interface{}{schema.Meta, schema.ScheduledCompactKeyName, newTestRevBytes(revision{3, 0})}},
-		{Name: "range", Params: []interface{}{schema.Key, make([]byte, 17), end, int64(10000)}},
+		{Name: "range", Params: []interface{}{schema.Key, newTestRevBytes(revision{0, 0}), end, int64(10000)}},
 		{Name: "delete", Params: []interface{}{schema.Key, key2}},
 		{Name: "put", Params: []interface{}{schema.Meta, schema.FinishedCompactKeyName, newTestRevBytes(revision{3, 0})}},
 	}
@@ -847,15 +847,16 @@ func newFakeStore() *store {
 		indexCompactRespc:     make(chan map[revision]struct{}, 1),
 	}
 	s := &store{
-		cfg:            StoreConfig{CompactionBatchLimit: 10000},
-		b:              b,
-		le:             &lease.FakeLessor{},
-		kvindex:        fi,
-		currentRev:     0,
-		compactMainRev: -1,
-		fifoSched:      schedule.NewFIFOScheduler(),
-		stopc:          make(chan struct{}),
-		lg:             zap.NewExample(),
+		cfg:                StoreConfig{CompactionBatchLimit: 10000},
+		b:                  b,
+		le:                 &lease.FakeLessor{},
+		kvindex:            fi,
+		currentRev:         0,
+		compactMainRev:     -1,
+		lastCompactMainRev: -1,
+		fifoSched:          schedule.NewFIFOScheduler(),
+		stopc:              make(chan struct{}),
+		lg:                 zap.NewExample(),
 	}
 	s.ReadView, s.WriteView = &readView{s}, &writeView{s}
 	return s


### PR DESCRIPTION
This PR can avoid to scan all keys in boltdb by comparing two keep map.
