### PR TITLE
*: move from io/ioutil to io and os packages

### DIFF
--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -17,7 +17,6 @@ package fileutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ func IsDirWriteable(dir string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(f, []byte(""), PrivateFileMode); err != nil {
+	if err := os.WriteFile(f, []byte(""), PrivateFileMode); err != nil {
 		return err
 	}
 	return os.Remove(f)

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -17,7 +17,6 @@ package fileutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/user"
@@ -31,9 +30,9 @@ import (
 )
 
 func TestIsDirWriteable(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
-		t.Fatalf("unexpected ioutil.TempDir error: %v", err)
+		t.Fatalf("unexpected os.MkdirTemp error: %v", err)
 	}
 	defer os.RemoveAll(tmpdir)
 	if err = IsDirWriteable(tmpdir); err != nil {
@@ -60,7 +59,7 @@ func TestIsDirWriteable(t *testing.T) {
 }
 
 func TestCreateDirAll(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "foo")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestCreateDirAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(tmpdir2, "text.txt"), []byte("test text"), PrivateFileMode); err != nil {
+	if err = os.WriteFile(filepath.Join(tmpdir2, "text.txt"), []byte("test text"), PrivateFileMode); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,7 +90,7 @@ func TestExist(t *testing.T) {
 		t.Fatalf("expected Exist true, got %v", Exist(fdir))
 	}
 
-	f, err := ioutil.TempFile(os.TempDir(), "fileutil")
+	f, err := os.CreateTemp(os.TempDir(), "fileutil")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +107,7 @@ func TestExist(t *testing.T) {
 }
 
 func TestDirEmpty(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "empty_dir")
+	dir, err := os.MkdirTemp(os.TempDir(), "empty_dir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +117,7 @@ func TestDirEmpty(t *testing.T) {
 		t.Fatalf("expected DirEmpty true, got %v", DirEmpty(dir))
 	}
 
-	file, err := ioutil.TempFile(dir, "new_file")
+	file, err := os.CreateTemp(dir, "new_file")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +132,7 @@ func TestDirEmpty(t *testing.T) {
 }
 
 func TestZeroToEnd(t *testing.T) {
-	f, err := ioutil.TempFile(os.TempDir(), "fileutil")
+	f, err := os.CreateTemp(os.TempDir(), "fileutil")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +177,7 @@ func TestZeroToEnd(t *testing.T) {
 }
 
 func TestDirPermission(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "foo")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,12 +197,12 @@ func TestDirPermission(t *testing.T) {
 func TestRemoveMatchFile(t *testing.T) {
 	tmpdir := t.TempDir()
 	defer os.RemoveAll(tmpdir)
-	f, err := ioutil.TempFile(tmpdir, "tmp")
+	f, err := os.CreateTemp(tmpdir, "tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
 	f.Close()
-	f, err = ioutil.TempFile(tmpdir, "foo.tmp")
+	f, err = os.CreateTemp(tmpdir, "foo.tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +222,7 @@ func TestRemoveMatchFile(t *testing.T) {
 		t.Errorf("expected exist 1 files, got %d", len(fnames))
 	}
 
-	f, err = ioutil.TempFile(tmpdir, "tmp")
+	f, err = os.CreateTemp(tmpdir, "tmp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/fileutil/lock_test.go
+++ b/client/pkg/fileutil/lock_test.go
@@ -15,14 +15,13 @@
 package fileutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 )
 
 func TestLockAndUnlock(t *testing.T) {
-	f, err := ioutil.TempFile("", "lock")
+	f, err := os.CreateTemp("", "lock")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/fileutil/preallocate_test.go
+++ b/client/pkg/fileutil/preallocate_test.go
@@ -15,7 +15,6 @@
 package fileutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -63,13 +62,13 @@ func testPreallocateFixed(t *testing.T, f *os.File) {
 }
 
 func runPreallocTest(t *testing.T, test func(*testing.T, *os.File)) {
-	p, err := ioutil.TempDir(os.TempDir(), "preallocateTest")
+	p, err := os.MkdirTemp(os.TempDir(), "preallocateTest")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(p)
 
-	f, err := ioutil.TempFile(p, "")
+	f, err := os.CreateTemp(p, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/fileutil/purge_test.go
+++ b/client/pkg/fileutil/purge_test.go
@@ -16,7 +16,6 @@ package fileutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -27,7 +26,7 @@ import (
 )
 
 func TestPurgeFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "purgefile")
+	dir, err := os.MkdirTemp("", "purgefile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +92,7 @@ func TestPurgeFile(t *testing.T) {
 }
 
 func TestPurgeFileHoldingLockFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "purgefile")
+	dir, err := os.MkdirTemp("", "purgefile")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/fileutil/read_dir_test.go
+++ b/client/pkg/fileutil/read_dir_test.go
@@ -15,7 +15,6 @@
 package fileutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,10 +22,10 @@ import (
 )
 
 func TestReadDir(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	defer os.RemoveAll(tmpdir)
 	if err != nil {
-		t.Fatalf("unexpected ioutil.TempDir error: %v", err)
+		t.Fatalf("unexpected os.MkdirTemp error: %v", err)
 	}
 
 	files := []string{"def", "abc", "xyz", "ghi"}

--- a/client/pkg/testutil/testingtb.go
+++ b/client/pkg/testutil/testingtb.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -112,7 +111,7 @@ func (t *testingTBProthesis) Name() string {
 }
 
 func (t *testingTBProthesis) TempDir() string {
-	dir, err := ioutil.TempDir("", t.name)
+	dir, err := os.MkdirTemp("", t.name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/tlsutil/tlsutil.go
+++ b/client/pkg/tlsutil/tlsutil.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 )
 
 // NewCertPool creates x509 certPool with provided CA files.
@@ -26,7 +26,7 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 
 	for _, CAFile := range CAFiles {
-		pemByte, err := ioutil.ReadFile(CAFile)
+		pemByte, err := os.ReadFile(CAFile)
 		if err != nil {
 			return nil, err
 		}
@@ -51,12 +51,12 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 
 // NewCert generates TLS cert by using the given cert,key and parse function.
 func NewCert(certfile, keyfile string, parseFunc func([]byte, []byte) (tls.Certificate, error)) (*tls.Certificate, error) {
-	cert, err := ioutil.ReadFile(certfile)
+	cert, err := os.ReadFile(certfile)
 	if err != nil {
 		return nil, err
 	}
 
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := os.ReadFile(keyfile)
 	if err != nil {
 		return nil, err
 	}

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -34,7 +33,7 @@ func createSelfCert(hosts ...string) (*TLSInfo, func(), error) {
 }
 
 func createSelfCertEx(host string, additionalUsages ...x509.ExtKeyUsage) (*TLSInfo, func(), error) {
-	d, terr := ioutil.TempDir("", "etcd-test-tls-")
+	d, terr := os.MkdirTemp("", "etcd-test-tls-")
 	if terr != nil {
 		return nil, nil, terr
 	}
@@ -278,7 +277,7 @@ func testNewListenerTLSInfoClientCheck(t *testing.T, skipClientSANVerify, goodCl
 	tlsInfo.TrustedCAFile = clientTLSInfo.CertFile
 
 	rootCAs := x509.NewCertPool()
-	loaded, err := ioutil.ReadFile(tlsInfo.CertFile)
+	loaded, err := os.ReadFile(tlsInfo.CertFile)
 	if err != nil {
 		t.Fatalf("unexpected missing certfile: %v", err)
 	}
@@ -532,7 +531,7 @@ func TestNewListenerUnixSocket(t *testing.T) {
 
 // TestNewListenerTLSInfoSelfCert tests that a new certificate accepts connections.
 func TestNewListenerTLSInfoSelfCert(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "tlsdir")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "tlsdir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/pkg/transport/listener_tls.go
+++ b/client/pkg/transport/listener_tls.go
@@ -19,8 +19,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"sync"
 )
@@ -168,7 +168,7 @@ func (l *tlsListener) acceptLoop() {
 
 func checkCRL(crlPath string, cert []*x509.Certificate) error {
 	// TODO: cache
-	crlBytes, err := ioutil.ReadFile(crlPath)
+	crlBytes, err := os.ReadFile(crlPath)
 	if err != nil {
 		return err
 	}

--- a/client/pkg/transport/timeout_transport_test.go
+++ b/client/pkg/transport/timeout_transport_test.go
@@ -16,7 +16,7 @@ package transport
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +63,7 @@ func TestNewTimeoutTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err %v", err)
 	}
-	addr0, err := ioutil.ReadAll(resp.Body)
+	addr0, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("unexpected err %v", err)
@@ -73,7 +73,7 @@ func TestNewTimeoutTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err %v", err)
 	}
-	addr1, err := ioutil.ReadAll(resp.Body)
+	addr1, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		t.Fatalf("unexpected err %v", err)

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net"
 	"net/http"
@@ -601,7 +601,7 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 	var body []byte
 	done := make(chan struct{})
 	go func() {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		done <- struct{}{}
 	}()
 

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -127,7 +126,7 @@ func TestSimpleHTTPClientDoSuccess(t *testing.T) {
 
 	tr.respchan <- &http.Response{
 		StatusCode: http.StatusTeapot,
-		Body:       ioutil.NopCloser(strings.NewReader("foo")),
+		Body:       io.NopCloser(strings.NewReader("foo")),
 	}
 
 	resp, body, err := c.Do(context.Background(), &fakeAction{})
@@ -210,7 +209,7 @@ func TestSimpleHTTPClientDoCancelContextResponseBodyClosed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	body := &checkableReadCloser{ReadCloser: ioutil.NopCloser(strings.NewReader("foo"))}
+	body := &checkableReadCloser{ReadCloser: io.NopCloser(strings.NewReader("foo"))}
 	go func() {
 		// wait that simpleHTTPClient knows the context is already timed out,
 		// and calls CancelRequest

--- a/client/v2/curl.go
+++ b/client/v2/curl.go
@@ -17,7 +17,7 @@ package client
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
@@ -53,7 +53,7 @@ func printcURL(req *http.Request) error {
 	}
 
 	if req.Body != nil {
-		b, err = ioutil.ReadAll(req.Body)
+		b, err = io.ReadAll(req.Body)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func printcURL(req *http.Request) error {
 
 	// reset body
 	body := bytes.NewBuffer(b)
-	req.Body = ioutil.NopCloser(body)
+	req.Body = io.NopCloser(body)
 
 	return nil
 }

--- a/client/v2/keys_test.go
+++ b/client/v2/keys_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -654,7 +654,7 @@ func assertRequest(got http.Request, wantMethod string, wantURL *url.URL, wantHe
 		if wantBody == nil {
 			return fmt.Errorf("want.Body=%v got.Body=%s", wantBody, got.Body)
 		}
-		gotBytes, err := ioutil.ReadAll(got.Body)
+		gotBytes, err := io.ReadAll(got.Body)
 		if err != nil {
 			return err
 		}

--- a/client/v3/mock/mockserver/mockserver.go
+++ b/client/v3/mock/mockserver/mockserver.go
@@ -17,7 +17,6 @@ package mockserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -84,7 +83,7 @@ func startMockServersUnix(count int) (ms *MockServers, err error) {
 	dir := os.TempDir()
 	addrs := make([]string, 0, count)
 	for i := 0; i < count; i++ {
-		f, err := ioutil.TempFile(dir, "etcd-unix-so-")
+		f, err := os.CreateTemp(dir, "etcd-unix-so-")
 		if err != nil {
 			return nil, fmt.Errorf("failed to allocate temp file for unix socket: %v", err)
 		}

--- a/client/v3/yaml/config.go
+++ b/client/v3/yaml/config.go
@@ -18,7 +18,7 @@ package yaml
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 
@@ -42,7 +42,7 @@ type yamlConfig struct {
 
 // NewConfig creates a new clientv3.Config from a yaml file.
 func NewConfig(fpath string) (*clientv3.Config, error) {
-	b, err := ioutil.ReadFile(fpath)
+	b, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}

--- a/client/v3/yaml/config_test.go
+++ b/client/v3/yaml/config_test.go
@@ -15,7 +15,6 @@
 package yaml
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -73,7 +72,7 @@ func TestConfigFromFile(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		tmpfile, err := ioutil.TempFile("", "clientcfg")
+		tmpfile, err := os.CreateTemp("", "clientcfg")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/contrib/lock/client/client.go
+++ b/contrib/lock/client/client.go
@@ -26,7 +26,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -98,7 +98,7 @@ func write(key string, value string, version int64) error {
 		os.Exit(1)
 	}
 
-	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	respBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		fmt.Printf("failed to read request body: %s\n", err)
 		os.Exit(1)
@@ -136,7 +136,7 @@ func read(key string) (string, int64) {
 		os.Exit(1)
 	}
 
-	respBytes, err := ioutil.ReadAll(httpResp.Body)
+	respBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		fmt.Printf("failed to read request body: %s\n", err)
 		os.Exit(1)

--- a/contrib/lock/storage/storage.go
+++ b/contrib/lock/storage/storage.go
@@ -17,7 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -57,7 +57,7 @@ func writeResponse(resp response, w http.ResponseWriter) {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	rBytes, err := ioutil.ReadAll(r.Body)
+	rBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		fmt.Printf("failed to read http request: %s\n", err)
 		os.Exit(1)

--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -34,7 +34,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	switch r.Method {
 	case http.MethodPut:
-		v, err := ioutil.ReadAll(r.Body)
+		v, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Failed to read on PUT (%v)\n", err)
 			http.Error(w, "Failed on PUT", http.StatusBadRequest)
@@ -53,7 +53,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to GET", http.StatusNotFound)
 		}
 	case http.MethodPost:
-		url, err := ioutil.ReadAll(r.Body)
+		url, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Failed to read on POST (%v)\n", err)
 			http.Error(w, "Failed on POST", http.StatusBadRequest)

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -17,7 +17,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -211,7 +211,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/etcdctl/ctlv2/command/cluster_health.go
+++ b/etcdctl/ctlv2/command/cluster_health.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -89,7 +89,7 @@ func handleClusterHealth(c *cli.Context) error {
 
 				result := struct{ Health string }{}
 				nresult := struct{ Health bool }{}
-				bytes, err := ioutil.ReadAll(resp.Body)
+				bytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					fmt.Printf("failed to check the health of member %s on %s: %v\n", m.ID, url, err)
 					continue

--- a/etcdctl/ctlv2/command/util.go
+++ b/etcdctl/ctlv2/command/util.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -48,7 +47,7 @@ func argOrStdin(args []string, stdin io.Reader, i int) (string, error) {
 	if i < len(args) {
 		return args[i], nil
 	}
-	bytes, err := ioutil.ReadAll(stdin)
+	bytes, err := io.ReadAll(stdin)
 	if string(bytes) == "" || err != nil {
 		return "", ErrNoAvailSrc
 	}

--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -141,7 +140,7 @@ func clientConfigFromCmd(cmd *cobra.Command) *clientConfig {
 		// too many routine connection disconnects to turn on by default.
 		//
 		// See https://github.com/etcd-io/etcd/pull/9623 for background
-		grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	}
 
 	cfg := &clientConfig{}
@@ -254,7 +253,7 @@ func argOrStdin(args []string, stdin io.Reader, i int) (string, error) {
 	if i < len(args) {
 		return args[i], nil
 	}
-	bytes, err := ioutil.ReadAll(stdin)
+	bytes, err := io.ReadAll(stdin)
 	if string(bytes) == "" || err != nil {
 		return "", errors.New("no available argument and stdin")
 	}

--- a/etcdctl/ctlv3/command/util.go
+++ b/etcdctl/ctlv3/command/util.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -117,7 +117,7 @@ func endpointMemoryMetrics(host string, scfg *secureCfg) float64 {
 		fmt.Println(fmt.Sprintf("fetch error: %v", err))
 		return 0.0
 	}
-	byts, readerr := ioutil.ReadAll(resp.Body)
+	byts, readerr := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if readerr != nil {
 		fmt.Println(fmt.Sprintf("fetch error: reading %s: %v", url, readerr))

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -21,7 +21,6 @@ package httputil
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 )
@@ -31,7 +30,7 @@ import (
 // therefore available for reuse.
 // Borrowed from golang/net/context/ctxhttp/cancelreq.go.
 func GracefulClose(resp *http.Response) {
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 }
 

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -476,7 +476,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/hello", func(w http.ResponseWriter, req *http.Request) {
-		d, err := ioutil.ReadAll(req.Body)
+		d, err := io.ReadAll(req.Body)
 		req.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -497,7 +497,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 		Addr:      dstAddr,
 		Handler:   mux,
 		TLSConfig: tlsConfig,
-		ErrorLog:  log.New(ioutil.Discard, "net/http", 0),
+		ErrorLog:  log.New(io.Discard, "net/http", 0),
 	}
 
 	donec := make(chan struct{})
@@ -548,7 +548,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 		defer http.DefaultClient.CloseIdleConnections()
 	}
 	assert.NoError(t, err)
-	d, err := ioutil.ReadAll(resp.Body)
+	d, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,7 +588,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, err = ioutil.ReadAll(resp.Body)
+	d, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -215,7 +214,7 @@ func TestLog(t *testing.T) {
 			}
 			tt.trace.lg = lg
 			tt.trace.Log()
-			data, err := ioutil.ReadFile(logPath)
+			data, err := os.ReadFile(logPath)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -293,7 +292,7 @@ func TestLogIfLong(t *testing.T) {
 
 			tt.trace.lg = lg
 			tt.trace.LogIfLong(tt.threshold)
-			data, err := ioutil.ReadFile(logPath)
+			data, err := os.ReadFile(logPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/raft/diff_test.go
+++ b/raft/diff_test.go
@@ -17,7 +17,6 @@ package raft
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -43,7 +42,7 @@ func diffu(a, b string) string {
 }
 
 func mustTemp(pre, body string) string {
-	f, err := ioutil.TempFile("", pre)
+	f, err := os.CreateTemp("", pre)
 	if err != nil {
 		panic(err)
 	}

--- a/raft/logger.go
+++ b/raft/logger.go
@@ -16,7 +16,7 @@ package raft
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -60,7 +60,7 @@ func getLogger() Logger {
 
 var (
 	defaultLogger = &DefaultLogger{Logger: log.New(os.Stderr, "raft", log.LstdFlags)}
-	discardLogger = &DefaultLogger{Logger: log.New(ioutil.Discard, "", 0)}
+	discardLogger = &DefaultLogger{Logger: log.New(io.Discard, "", 0)}
 	raftLoggerMu  sync.Mutex
 	raftLogger    = Logger(defaultLogger)
 )

--- a/server/auth/options.go
+++ b/server/auth/options.go
@@ -18,7 +18,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
@@ -70,14 +70,14 @@ func (opts *jwtOptions) Parse(optMap map[string]string) error {
 	}
 
 	if file := optMap[optPublicKey]; file != "" {
-		opts.PublicKey, err = ioutil.ReadFile(file)
+		opts.PublicKey, err = os.ReadFile(file)
 		if err != nil {
 			return err
 		}
 	}
 
 	if file := optMap[optPrivateKey]; file != "" {
-		opts.PrivateKey, err = ioutil.ReadFile(file)
+		opts.PrivateKey, err = os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/server/embed/auth_test.go
+++ b/server/embed/auth_test.go
@@ -16,7 +16,6 @@ package embed
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -24,7 +23,7 @@ import (
 )
 
 func TestEnableAuth(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "auth-test")
+	tdir, err := os.MkdirTemp(os.TempDir(), "auth-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -16,7 +16,6 @@ package embed
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -520,7 +519,7 @@ func ConfigFromFile(path string) (*Config, error) {
 }
 
 func (cfg *configYAML) configFromFile(path string) error {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 
@@ -230,7 +230,7 @@ func (cfg *Config) SetupGlobalLoggers() {
 			grpc.EnableTracing = true
 			grpclog.SetLoggerV2(zapgrpc.NewLogger(lg))
 		} else {
-			grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+			grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr))
 		}
 		zap.ReplaceGlobals(lg)
 	}

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -17,7 +17,6 @@ package embed
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -158,7 +157,7 @@ func (s *securityConfig) equals(t *transport.TLSInfo) bool {
 }
 
 func mustCreateCfgFile(t *testing.T, b []byte) *os.File {
-	tmpfile, err := ioutil.TempFile("", "servercfg")
+	tmpfile, err := os.CreateTemp("", "servercfg")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	defaultLog "log"
 	"net"
 	"net/http"
@@ -545,7 +545,7 @@ func (e *Etcd) servePeers() (err error) {
 		srv := &http.Server{
 			Handler:     grpcHandlerFunc(gs, ph),
 			ReadTimeout: 5 * time.Minute,
-			ErrorLog:    defaultLog.New(ioutil.Discard, "", 0), // do not log user error
+			ErrorLog:    defaultLog.New(io.Discard, "", 0), // do not log user error
 		}
 		go srv.Serve(m.Match(cmux.Any()))
 		p.serve = func() error {

--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -17,7 +17,7 @@ package embed
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	defaultLog "log"
 	"math"
 	"net"
@@ -92,7 +92,7 @@ func (sctx *serveCtx) serve(
 	handler http.Handler,
 	errHandler func(error),
 	gopts ...grpc.ServerOption) (err error) {
-	logger := defaultLog.New(ioutil.Discard, "etcdhttp", 0)
+	logger := defaultLog.New(io.Discard, "etcdhttp", 0)
 	<-s.ReadyNotify()
 
 	sctx.lg.Info("ready to serve client requests")

--- a/server/embed/serve_test.go
+++ b/server/embed/serve_test.go
@@ -16,7 +16,6 @@ package embed
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"testing"
@@ -26,7 +25,7 @@ import (
 
 // TestStartEtcdWrongToken ensures that StartEtcd with wrong configs returns with error.
 func TestStartEtcdWrongToken(t *testing.T) {
-	tdir, err := ioutil.TempDir(t.TempDir(), "token-test")
+	tdir, err := os.MkdirTemp(t.TempDir(), "token-test")
 
 	if err != nil {
 		t.Fatal(err)

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -19,7 +19,6 @@ package etcdmain
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -429,7 +428,7 @@ func (cfg *config) configFromFile(path string) error {
 	cfg.ec = *eCfg
 
 	// load extra config information
-	b, rerr := ioutil.ReadFile(path)
+	b, rerr := os.ReadFile(path)
 	if rerr != nil {
 		return rerr
 	}

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -16,7 +16,6 @@ package etcdmain
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -494,7 +493,7 @@ func TestConfigFileElectionTimeout(t *testing.T) {
 }
 
 func mustCreateCfgFile(t *testing.T, b []byte) *os.File {
-	tmpfile, err := ioutil.TempFile("", "servercfg")
+	tmpfile, err := os.CreateTemp("", "servercfg")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -17,7 +17,6 @@ package etcdmain
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -283,7 +282,7 @@ func startProxy(cfg *config) error {
 	var peerURLs []string
 	clusterfile := filepath.Join(cfg.ec.Dir, "cluster")
 
-	b, err := ioutil.ReadFile(clusterfile)
+	b, err := os.ReadFile(clusterfile)
 	switch {
 	case err == nil:
 		if cfg.ec.Durl != "" {

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"net"
@@ -469,7 +469,7 @@ func mustHTTPListener(lg *zap.Logger, m cmux.CMux, tlsinfo *transport.TLSInfo, c
 	}
 	srvhttp := &http.Server{
 		Handler:  httpmux,
-		ErrorLog: log.New(ioutil.Discard, "net/http", 0),
+		ErrorLog: log.New(io.Discard, "net/http", 0),
 	}
 
 	if tlsinfo == nil {
@@ -497,7 +497,7 @@ func newHTTPTransport(ca, cert, key string) (*http.Transport, error) {
 	tr := &http.Transport{}
 
 	if ca != "" && cert != "" && key != "" {
-		caCert, err := ioutil.ReadFile(ca)
+		caCert, err := os.ReadFile(ca)
 		if err != nil {
 			return nil, err
 		}

--- a/server/etcdserver/api/etcdhttp/metrics_test.go
+++ b/server/etcdserver/api/etcdhttp/metrics_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -127,7 +126,7 @@ func TestHealthHandler(t *testing.T) {
 
 func parseHealthOutput(body io.Reader) (Health, error) {
 	obj := Health{}
-	d, derr := ioutil.ReadAll(body)
+	d, derr := io.ReadAll(body)
 	if derr != nil {
 		return obj, derr
 	}

--- a/server/etcdserver/api/etcdhttp/peer_test.go
+++ b/server/etcdserver/api/etcdhttp/peer_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -98,9 +98,9 @@ func TestNewPeerHandlerOnRaftPrefix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected http.Get error: %v", err)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Fatalf("unexpected ioutil.ReadAll error: %v", err)
+			t.Fatalf("unexpected io.ReadAll error: %v", err)
 		}
 		if w := "test data"; string(body) != w {
 			t.Errorf("#%d: body = %s, want %s", i, body, w)
@@ -267,10 +267,10 @@ func TestNewPeerHandlerOnMembersPromotePrefix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get http response: %v", err)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
-			t.Fatalf("unexpected ioutil.ReadAll error: %v", err)
+			t.Fatalf("unexpected io.ReadAll error: %v", err)
 		}
 		if resp.StatusCode != tt.wcode {
 			t.Fatalf("#%d: code = %d, want %d", i, resp.StatusCode, tt.wcode)

--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -111,7 +111,7 @@ func (h *pipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Limit the data size that could be read from the request body, which ensures that read from
 	// connection will not time out accidentally due to possible blocking in underlying implementation.
 	limitedr := pioutil.NewLimitedBufferReader(r.Body, connReadLimitByte)
-	b, err := ioutil.ReadAll(limitedr)
+	b, err := io.ReadAll(limitedr)
 	if err != nil {
 		h.lg.Warn(
 			"failed to read Raft message",

--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"runtime"
 	"sync"
 	"time"
@@ -154,7 +154,7 @@ func (p *pipeline) post(data []byte) (err error) {
 		return err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		p.picker.unreachable(u)
 		return err

--- a/server/etcdserver/api/rafthttp/pipeline_test.go
+++ b/server/etcdserver/api/rafthttp/pipeline_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"testing"
@@ -158,7 +157,7 @@ func TestPipelinePost(t *testing.T) {
 	if g := req.Header.Get("X-Etcd-Cluster-ID"); g != "1" {
 		t.Errorf("cluster id = %s, want %s", g, "1")
 	}
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatalf("unexpected ReadAll error: %v", err)
 	}

--- a/server/etcdserver/api/rafthttp/snapshot_sender.go
+++ b/server/etcdserver/api/rafthttp/snapshot_sender.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -169,7 +168,7 @@ func (s *snapshotSender) post(req *http.Request) (err error) {
 		// prevents from reading the body forever when the other side dies right after
 		// successfully receives the request body.
 		time.AfterFunc(snapResponseReadTimeout, func() { httputil.GracefulClose(resp) })
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		result <- responseAndError{resp, body, err}
 	}()
 

--- a/server/etcdserver/api/rafthttp/snapshot_test.go
+++ b/server/etcdserver/api/rafthttp/snapshot_test.go
@@ -17,7 +17,6 @@ package rafthttp
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -94,8 +93,8 @@ func TestSnapshotSend(t *testing.T) {
 	}
 }
 
-func testSnapshotSend(t *testing.T, sm *snap.Message) (bool, []os.FileInfo) {
-	d, err := ioutil.TempDir(os.TempDir(), "snapdir")
+func testSnapshotSend(t *testing.T, sm *snap.Message) (bool, []os.DirEntry) {
+	d, err := os.MkdirTemp(os.TempDir(), "snapdir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +123,7 @@ func testSnapshotSend(t *testing.T, sm *snap.Message) (bool, []os.FileInfo) {
 	// wait for handler to finish accepting snapshot
 	<-ch
 
-	files, rerr := ioutil.ReadDir(d)
+	files, rerr := os.ReadDir(d)
 	if rerr != nil {
 		t.Fatal(rerr)
 	}

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -629,7 +628,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("peer %s failed to find local node %s", cr.peerID, cr.tr.ID)
 
 	case http.StatusPreconditionFailed:
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			cr.picker.unreachable(u)
 			return nil, err

--- a/server/etcdserver/api/snap/db.go
+++ b/server/etcdserver/api/snap/db.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -36,7 +35,7 @@ var ErrNoDBSnapshot = errors.New("snap: snapshot file doesn't exist")
 func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 	start := time.Now()
 
-	f, err := ioutil.TempFile(s.dir, "tmp")
+	f, err := os.CreateTemp(s.dir, "tmp")
 	if err != nil {
 		return 0, err
 	}

--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -160,7 +159,7 @@ func loadSnap(lg *zap.Logger, dir, name string) (*raftpb.Snapshot, error) {
 
 // Read reads the snapshot named by snapname and returns the snapshot.
 func Read(lg *zap.Logger, snapname string) (*raftpb.Snapshot, error) {
-	b, err := ioutil.ReadFile(snapname)
+	b, err := os.ReadFile(snapname)
 	if err != nil {
 		if lg != nil {
 			lg.Warn("failed to read a snap file", zap.String("path", snapname), zap.Error(err))

--- a/server/etcdserver/api/snap/snapshotter_test.go
+++ b/server/etcdserver/api/snap/snapshotter_test.go
@@ -17,7 +17,6 @@ package snap
 import (
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -94,7 +93,7 @@ func TestFailback(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	large := fmt.Sprintf("%016x-%016x-%016x.snap", 0xFFFF, 0xFFFF, 0xFFFF)
-	err = ioutil.WriteFile(filepath.Join(dir, large), []byte("bad data"), 0666)
+	err = os.WriteFile(filepath.Join(dir, large), []byte("bad data"), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +233,7 @@ func TestEmptySnapshot(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "1.snap"), []byte(""), 0x700)
+	err = os.WriteFile(filepath.Join(dir, "1.snap"), []byte(""), 0x700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +254,7 @@ func TestAllSnapshotBroken(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "1.snap"), []byte("bad"), 0x700)
+	err = os.WriteFile(filepath.Join(dir, "1.snap"), []byte("bad"), 0x700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +277,7 @@ func TestReleaseSnapDBs(t *testing.T) {
 	snapIndices := []uint64{100, 200, 300, 400}
 	for _, index := range snapIndices {
 		filename := filepath.Join(dir, fmt.Sprintf("%016x.snap.db", index))
-		if err := ioutil.WriteFile(filename, []byte("snap file\n"), 0644); err != nil {
+		if err := os.WriteFile(filename, []byte("snap file\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/server/etcdserver/api/v2http/client.go
+++ b/server/etcdserver/api/v2http/client.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -675,7 +675,7 @@ func unmarshalRequest(lg *zap.Logger, r *http.Request, req json.Unmarshaler, w h
 		writeError(lg, w, r, httptypes.NewHTTPError(http.StatusUnsupportedMediaType, fmt.Sprintf("Bad Content-Type %s, accept application/json", ctype)))
 		return false
 	}
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeError(lg, w, r, httptypes.NewHTTPError(http.StatusBadRequest, err.Error()))
 		return false

--- a/server/etcdserver/api/v2http/client_auth_test.go
+++ b/server/etcdserver/api/v2http/client_auth_test.go
@@ -21,10 +21,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -456,7 +456,7 @@ func unauthedRequest() *http.Request {
 }
 
 func tlsAuthedRequest(req *http.Request, certname string) *http.Request {
-	bytes, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.pem", certname))
+	bytes, err := os.ReadFile(fmt.Sprintf("testdata/%s.pem", certname))
 	if err != nil {
 		panic(err)
 	}

--- a/server/etcdserver/api/v2http/client_test.go
+++ b/server/etcdserver/api/v2http/client_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -924,7 +924,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader("bad json")),
+				Body:   io.NopCloser(strings.NewReader("bad json")),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&resServer{},
@@ -936,7 +936,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/bad"}},
 			},
 			&errServer{},
@@ -948,7 +948,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://a"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://a"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{},
@@ -960,7 +960,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{
@@ -974,7 +974,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{
@@ -988,7 +988,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, membersPrefix),
 				Method: "POST",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{
@@ -1058,7 +1058,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader("bad json")),
+				Body:   io.NopCloser(strings.NewReader("bad json")),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&resServer{},
@@ -1070,7 +1070,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/bad"}},
 			},
 			&errServer{},
@@ -1082,7 +1082,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://a"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://a"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{},
@@ -1094,7 +1094,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{
@@ -1108,7 +1108,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{
@@ -1122,7 +1122,7 @@ func TestServeMembersFail(t *testing.T) {
 			&http.Request{
 				URL:    testutil.MustNewURL(t, path.Join(membersPrefix, "0")),
 				Method: "PUT",
-				Body:   ioutil.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
+				Body:   io.NopCloser(strings.NewReader(`{"PeerURLs": ["http://127.0.0.1:1"]}`)),
 				Header: map[string][]string{"Content-Type": {"application/json"}},
 			},
 			&errServer{

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -80,7 +80,7 @@ func getClusterFromRemotePeers(lg *zap.Logger, urls []string, timeout time.Durat
 			}
 			continue
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			if logerr {
@@ -256,7 +256,7 @@ func getVersion(lg *zap.Logger, m *membership.Member, rt http.RoundTripper) (*ve
 			continue
 		}
 		var b []byte
-		b, err = ioutil.ReadAll(resp.Body)
+		b, err = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			lg.Warn(
@@ -297,7 +297,7 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 		return nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func getDowngradeEnabled(lg *zap.Logger, m *membership.Member, rt http.RoundTrip
 			continue
 		}
 		var b []byte
-		b, err = ioutil.ReadAll(resp.Body)
+		b, err = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			lg.Warn(

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -360,7 +360,7 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "error reading body", http.StatusBadRequest)
 		return
@@ -417,7 +417,7 @@ func (s *EtcdServer) getPeerHashKVHTTP(ctx context.Context, url string, rev int6
 		return nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"os"
@@ -1087,7 +1086,7 @@ func TestSnapshotOrdering(t *testing.T) {
 	cl := membership.NewCluster(lg)
 	cl.SetStore(st)
 
-	testdir, err := ioutil.TempDir(t.TempDir(), "testsnapdir")
+	testdir, err := os.MkdirTemp(t.TempDir(), "testsnapdir")
 	if err != nil {
 		t.Fatalf("couldn't open tempdir (%v)", err)
 	}
@@ -1243,7 +1242,7 @@ func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
 	cl := membership.NewCluster(lg)
 	cl.SetStore(st)
 
-	testdir, err := ioutil.TempDir(t.TempDir(), "testsnapdir")
+	testdir, err := os.MkdirTemp(t.TempDir(), "testsnapdir")
 	if err != nil {
 		t.Fatalf("Couldn't open tempdir (%v)", err)
 	}

--- a/server/etcdserver/zap_raft_test.go
+++ b/server/etcdserver/zap_raft_test.go
@@ -17,7 +17,6 @@ package etcdserver
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,7 +50,7 @@ func TestNewRaftLogger(t *testing.T) {
 	}
 
 	gl.Info("etcd-logutil-1")
-	data, err := ioutil.ReadFile(logPath)
+	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +59,7 @@ func TestNewRaftLogger(t *testing.T) {
 	}
 
 	gl.Warning("etcd-logutil-2")
-	data, err = ioutil.ReadFile(logPath)
+	data, err = os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/lease/leasehttp/http.go
+++ b/server/lease/leasehttp/http.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -53,7 +53,7 @@ func (h *leaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "error reading body", http.StatusBadRequest)
 		return
@@ -242,7 +242,7 @@ func TimeToLiveHTTP(ctx context.Context, id lease.LeaseID, keys bool, url string
 }
 
 func readResponse(resp *http.Response) (b []byte, err error) {
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	httputil.GracefulClose(resp)
 	return
 }

--- a/server/lease/lessor_test.go
+++ b/server/lease/lessor_test.go
@@ -17,7 +17,6 @@ package lease
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -600,7 +599,7 @@ func (fd *fakeDeleter) DeleteRange(key, end []byte) (int64, int64) {
 }
 
 func NewTestBackend(t *testing.T) (string, backend.Backend) {
-	tmpPath, err := ioutil.TempDir("", "lease")
+	tmpPath, err := os.MkdirTemp("", "lease")
 	if err != nil {
 		t.Fatalf("failed to create tmpdir (%v)", err)
 	}

--- a/server/proxy/grpcproxy/metrics.go
+++ b/server/proxy/grpcproxy/metrics.go
@@ -16,7 +16,7 @@ package grpcproxy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -94,7 +94,7 @@ func HandleMetrics(mux *http.ServeMux, c *http.Client, eps []string) {
 		}
 		defer resp.Body.Close()
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(w, "%s", body)
 	})
 }

--- a/server/proxy/httpproxy/proxy_test.go
+++ b/server/proxy/httpproxy/proxy_test.go
@@ -15,7 +15,7 @@
 package httpproxy
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -92,7 +92,7 @@ func TestConfigHandlerGET(t *testing.T) {
 
 	wbody := "{\"endpoints\":[\"http://example1.com\",\"http://example2.com\",\"http://example3.com\"]}\n"
 
-	body, err := ioutil.ReadAll(rr.Body)
+	body, err := io.ReadAll(rr.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/proxy/httpproxy/reverse.go
+++ b/server/proxy/httpproxy/reverse.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -72,7 +71,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 	)
 
 	if clientreq.Body != nil {
-		proxybody, err = ioutil.ReadAll(clientreq.Body)
+		proxybody, err = io.ReadAll(clientreq.Body)
 		if err != nil {
 			msg := fmt.Sprintf("failed to read request body: %v", err)
 			p.lg.Info("failed to read request body", zap.Error(err))
@@ -144,7 +143,7 @@ func (p *reverseProxy) ServeHTTP(rw http.ResponseWriter, clientreq *http.Request
 
 	for _, ep := range endpoints {
 		if proxybody != nil {
-			proxyreq.Body = ioutil.NopCloser(bytes.NewBuffer(proxybody))
+			proxyreq.Body = io.NopCloser(bytes.NewBuffer(proxybody))
 		}
 		redirectRequest(proxyreq, ep.URL)
 

--- a/server/proxy/httpproxy/reverse_test.go
+++ b/server/proxy/httpproxy/reverse_test.go
@@ -17,7 +17,7 @@ package httpproxy
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -51,7 +51,7 @@ func TestReverseProxyServe(t *testing.T) {
 			rt: &staticRoundTripper{
 				res: &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       ioutil.NopCloser(&bytes.Reader{}),
+					Body:       io.NopCloser(&bytes.Reader{}),
 				},
 			},
 			want: http.StatusServiceUnavailable,
@@ -70,7 +70,7 @@ func TestReverseProxyServe(t *testing.T) {
 			rt: &staticRoundTripper{
 				res: &http.Response{
 					StatusCode: http.StatusCreated,
-					Body:       ioutil.NopCloser(&bytes.Reader{}),
+					Body:       io.NopCloser(&bytes.Reader{}),
 					Header:     map[string][]string{"Content-Type": {"application/json"}},
 				},
 			},

--- a/server/proxy/tcpproxy/userspace_test.go
+++ b/server/proxy/tcpproxy/userspace_test.go
@@ -16,7 +16,7 @@ package tcpproxy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -57,7 +57,7 @@ func TestUserspaceProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, gerr := ioutil.ReadAll(res.Body)
+	got, gerr := io.ReadAll(res.Body)
 	res.Body.Close()
 	if gerr != nil {
 		t.Fatal(gerr)
@@ -118,7 +118,7 @@ func TestUserspaceProxyPriority(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, gerr := ioutil.ReadAll(res.Body)
+	got, gerr := io.ReadAll(res.Body)
 	res.Body.Close()
 	if gerr != nil {
 		t.Fatal(gerr)

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -456,7 +455,7 @@ func (b *backend) defrag() error {
 	// Create a temporary file to ensure we start with a clean slate.
 	// Snapshotter.cleanupSnapdir cleans up any of these that are found during startup.
 	dir := filepath.Dir(b.db.Path())
-	temp, err := ioutil.TempFile(dir, "db.tmp.*")
+	temp, err := os.CreateTemp(dir, "db.tmp.*")
 	if err != nil {
 		return err
 	}

--- a/server/storage/backend/backend_test.go
+++ b/server/storage/backend/backend_test.go
@@ -16,7 +16,7 @@ package backend_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -59,7 +59,7 @@ func TestBackendSnapshot(t *testing.T) {
 	b.ForceCommit()
 
 	// write snapshot to a new file
-	f, err := ioutil.TempFile(t.TempDir(), "etcd_backend_test")
+	f, err := os.CreateTemp(t.TempDir(), "etcd_backend_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/storage/backend/testing/betesting.go
+++ b/server/storage/backend/testing/betesting.go
@@ -15,7 +15,7 @@
 package betesting
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -26,7 +26,7 @@ import (
 )
 
 func NewTmpBackendFromCfg(t testing.TB, bcfg backend.BackendConfig) (backend.Backend, string) {
-	dir, err := ioutil.TempDir(t.TempDir(), "etcd_backend_test")
+	dir, err := os.MkdirTemp(t.TempDir(), "etcd_backend_test")
 	if err != nil {
 		panic(err)
 	}

--- a/server/storage/wal/file_pipeline_test.go
+++ b/server/storage/wal/file_pipeline_test.go
@@ -15,7 +15,6 @@
 package wal
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -24,7 +23,7 @@ import (
 )
 
 func TestFilePipeline(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "wal-test")
+	tdir, err := os.MkdirTemp(os.TempDir(), "wal-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestFilePipeline(t *testing.T) {
 }
 
 func TestFilePipelineFailPreallocate(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "wal-test")
+	tdir, err := os.MkdirTemp(os.TempDir(), "wal-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +56,7 @@ func TestFilePipelineFailPreallocate(t *testing.T) {
 }
 
 func TestFilePipelineFailLockFile(t *testing.T) {
-	tdir, err := ioutil.TempDir(os.TempDir(), "wal-test")
+	tdir, err := os.MkdirTemp(os.TempDir(), "wal-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/storage/wal/record_test.go
+++ b/server/storage/wal/record_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -53,7 +52,7 @@ func TestReadRecord(t *testing.T) {
 	rec := &walpb.Record{}
 	for i, tt := range tests {
 		buf := bytes.NewBuffer(tt.data)
-		decoder := newDecoder(ioutil.NopCloser(buf))
+		decoder := newDecoder(io.NopCloser(buf))
 		e := decoder.decode(rec)
 		if !reflect.DeepEqual(rec, tt.wr) {
 			t.Errorf("#%d: block = %v, want %v", i, rec, tt.wr)
@@ -73,7 +72,7 @@ func TestWriteRecord(t *testing.T) {
 	e := newEncoder(buf, 0, 0)
 	e.encode(&walpb.Record{Type: typ, Data: d})
 	e.flush()
-	decoder := newDecoder(ioutil.NopCloser(buf))
+	decoder := newDecoder(io.NopCloser(buf))
 	err := decoder.decode(b)
 	if err != nil {
 		t.Errorf("err = %v, want nil", err)

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -17,7 +17,6 @@ package wal
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestRepairTruncate(t *testing.T) {
 }
 
 func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expectedEnts int) {
-	p, err := ioutil.TempDir(os.TempDir(), "waltest")
+	p, err := os.MkdirTemp(os.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +183,7 @@ func TestRepairWriteTearMiddle(t *testing.T) {
 }
 
 func TestRepairFailDeleteDir(t *testing.T) {
-	p, err := ioutil.TempDir(os.TempDir(), "waltest")
+	p, err := os.MkdirTemp(os.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/storage/wal/wal_bench_test.go
+++ b/server/storage/wal/wal_bench_test.go
@@ -15,7 +15,6 @@
 package wal
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func BenchmarkWrite1000EntryBatch500(b *testing.B)     { benchmarkWriteEntry(b, 
 func BenchmarkWrite1000EntryBatch1000(b *testing.B)    { benchmarkWriteEntry(b, 1000, 1000) }
 
 func benchmarkWriteEntry(b *testing.B, size int, batch int) {
-	p, err := ioutil.TempDir(os.TempDir(), "waltest")
+	p, err := os.MkdirTemp(os.TempDir(), "waltest")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -45,7 +44,7 @@ var (
 )
 
 func TestNew(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,12 +98,12 @@ func TestNew(t *testing.T) {
 }
 
 func TestCreateFailFromPollutedDir(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(p)
-	ioutil.WriteFile(filepath.Join(p, "test.wal"), []byte("data"), os.ModeTemporary)
+	os.WriteFile(filepath.Join(p, "test.wal"), []byte("data"), os.ModeTemporary)
 
 	_, err = Create(zap.NewExample(), p, []byte("data"))
 	if err != os.ErrExist {
@@ -113,11 +112,11 @@ func TestCreateFailFromPollutedDir(t *testing.T) {
 }
 
 func TestWalCleanup(t *testing.T) {
-	testRoot, err := ioutil.TempDir(t.TempDir(), "waltestroot")
+	testRoot, err := os.MkdirTemp(t.TempDir(), "waltestroot")
 	if err != nil {
 		t.Fatal(err)
 	}
-	p, err := ioutil.TempDir(testRoot, "waltest")
+	p, err := os.MkdirTemp(testRoot, "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +143,7 @@ func TestWalCleanup(t *testing.T) {
 }
 
 func TestCreateFailFromNoSpaceLeft(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +162,7 @@ func TestCreateFailFromNoSpaceLeft(t *testing.T) {
 }
 
 func TestNewForInitedDir(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +175,7 @@ func TestNewForInitedDir(t *testing.T) {
 }
 
 func TestOpenAtIndex(t *testing.T) {
-	dir, err := ioutil.TempDir(t.TempDir(), "waltest")
+	dir, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +218,7 @@ func TestOpenAtIndex(t *testing.T) {
 	}
 	w.Close()
 
-	emptydir, err := ioutil.TempDir(t.TempDir(), "waltestempty")
+	emptydir, err := os.MkdirTemp(t.TempDir(), "waltestempty")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +233,7 @@ func TestOpenAtIndex(t *testing.T) {
 // it corrupts one of the files by completely truncating it.
 func TestVerify(t *testing.T) {
 	lg := zaptest.NewLogger(t)
-	walDir, err := ioutil.TempDir(t.TempDir(), "waltest")
+	walDir, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +266,7 @@ func TestVerify(t *testing.T) {
 	}
 	assert.Equal(t, hs, *hardstate)
 
-	walFiles, err := ioutil.ReadDir(walDir)
+	walFiles, err := os.ReadDir(walDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +285,7 @@ func TestVerify(t *testing.T) {
 
 // TODO: split it into smaller tests for better readability
 func TestCut(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +347,7 @@ func TestCut(t *testing.T) {
 }
 
 func TestSaveWithCut(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,7 +410,7 @@ func TestSaveWithCut(t *testing.T) {
 }
 
 func TestRecover(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -526,7 +525,7 @@ func TestScanWalName(t *testing.T) {
 }
 
 func TestRecoverAfterCut(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +583,7 @@ func TestRecoverAfterCut(t *testing.T) {
 }
 
 func TestOpenAtUncommittedIndex(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -618,7 +617,7 @@ func TestOpenAtUncommittedIndex(t *testing.T) {
 // it releases the lock of part of data, and excepts that OpenForRead
 // can read out all files even if some are locked for write.
 func TestOpenForRead(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +658,7 @@ func TestOpenForRead(t *testing.T) {
 }
 
 func TestOpenWithMaxIndex(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -702,7 +701,7 @@ func TestSaveEmpty(t *testing.T) {
 }
 
 func TestReleaseLockTo(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -774,7 +773,7 @@ func TestReleaseLockTo(t *testing.T) {
 
 // TestTailWriteNoSlackSpace ensures that tail writes append if there's no preallocated space.
 func TestTailWriteNoSlackSpace(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,7 +839,7 @@ func TestTailWriteNoSlackSpace(t *testing.T) {
 
 // TestRestartCreateWal ensures that an interrupted WAL initialization is clobbered on restart
 func TestRestartCreateWal(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -880,7 +879,7 @@ func TestOpenOnTornWrite(t *testing.T) {
 	clobberIdx := 20
 	overwriteEntries := 5
 
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -965,7 +964,7 @@ func TestOpenOnTornWrite(t *testing.T) {
 }
 
 func TestRenameFail(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -977,7 +976,7 @@ func TestRenameFail(t *testing.T) {
 	}()
 	SegmentSizeBytes = math.MaxInt64
 
-	tp, terr := ioutil.TempDir(t.TempDir(), "waltest")
+	tp, terr := os.MkdirTemp(t.TempDir(), "waltest")
 	if terr != nil {
 		t.Fatal(terr)
 	}
@@ -995,7 +994,7 @@ func TestRenameFail(t *testing.T) {
 
 // TestReadAllFail ensure ReadAll error if used without opening the WAL
 func TestReadAllFail(t *testing.T) {
-	dir, err := ioutil.TempDir(t.TempDir(), "waltest")
+	dir, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1017,7 +1016,7 @@ func TestReadAllFail(t *testing.T) {
 // TestValidSnapshotEntries ensures ValidSnapshotEntries returns all valid wal snapshot entries, accounting
 // for hardstate
 func TestValidSnapshotEntries(t *testing.T) {
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1074,7 +1073,7 @@ func TestValidSnapshotEntriesAfterPurgeWal(t *testing.T) {
 	defer func() {
 		SegmentSizeBytes = oldSegmentSizeBytes
 	}()
-	p, err := ioutil.TempDir(t.TempDir(), "waltest")
+	p, err := os.MkdirTemp(t.TempDir(), "waltest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -229,7 +228,7 @@ func TestUtlCtlV2Backup(t *testing.T) {
 func testUtlCtlV2Backup(t *testing.T, snapCount int, v3 bool, utl bool) {
 	BeforeTestV2(t)
 
-	backupDir, err := ioutil.TempDir(t.TempDir(), "testbackup0.etcd")
+	backupDir, err := os.MkdirTemp(t.TempDir(), "testbackup0.etcd")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func TestEtcdMultiPeer(t *testing.T) {
 	peers, tmpdirs := make([]string, 3), make([]string, 3)
 	for i := range peers {
 		peers[i] = fmt.Sprintf("e%d=http://127.0.0.1:%d", i, e2e.EtcdProcessBasePort+i)
-		d, err := ioutil.TempDir("", fmt.Sprintf("e%d.etcd", i))
+		d, err := os.MkdirTemp("", fmt.Sprintf("e%d.etcd", i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -94,7 +93,7 @@ func TestEtcdMultiPeer(t *testing.T) {
 func TestEtcdUnixPeers(t *testing.T) {
 	e2e.SkipInShortMode(t)
 
-	d, err := ioutil.TempDir("", "e1.etcd")
+	d, err := os.MkdirTemp("", "e1.etcd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func TestEtcdPeerCNAuth(t *testing.T) {
 	peers, tmpdirs := make([]string, 3), make([]string, 3)
 	for i := range peers {
 		peers[i] = fmt.Sprintf("e%d=https://127.0.0.1:%d", i, e2e.EtcdProcessBasePort+i)
-		d, err := ioutil.TempDir("", fmt.Sprintf("e%d.etcd", i))
+		d, err := os.MkdirTemp("", fmt.Sprintf("e%d.etcd", i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,7 +210,7 @@ func TestEtcdPeerNameAuth(t *testing.T) {
 	peers, tmpdirs := make([]string, 3), make([]string, 3)
 	for i := range peers {
 		peers[i] = fmt.Sprintf("e%d=https://127.0.0.1:%d", i, e2e.EtcdProcessBasePort+i)
-		d, err := ioutil.TempDir("", fmt.Sprintf("e%d.etcd", i))
+		d, err := os.MkdirTemp("", fmt.Sprintf("e%d.etcd", i))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/framework/integration/bridge.go
+++ b/tests/framework/integration/bridge.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"sync"
 )
@@ -197,7 +196,7 @@ func (b *bridge) ioCopy(dst io.Writer, src io.Reader) (err error) {
 	for {
 		select {
 		case <-b.blackholec:
-			io.Copy(ioutil.Discard, src)
+			io.Copy(io.Discard, src)
 			return nil
 		default:
 		}

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -664,7 +664,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 
 	m.Name = mcfg.Name
 
-	m.DataDir, err = ioutil.TempDir(t.TempDir(), "etcd")
+	m.DataDir, err = os.MkdirTemp(t.TempDir(), "etcd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -993,7 +993,7 @@ func (m *Member) Launch() error {
 			Config: &http.Server{
 				Handler:   h,
 				TLSConfig: peerTLScfg,
-				ErrorLog:  log.New(ioutil.Discard, "net/http", 0),
+				ErrorLog:  log.New(io.Discard, "net/http", 0),
 			},
 			TLS: peerTLScfg,
 		}
@@ -1021,7 +1021,7 @@ func (m *Member) Launch() error {
 					m.Server,
 					m.ServerConfig.ReqTimeout(),
 				),
-				ErrorLog: log.New(ioutil.Discard, "net/http", 0),
+				ErrorLog: log.New(io.Discard, "net/http", 0),
 			},
 		}
 		if m.ClientTLSInfo == nil {
@@ -1300,7 +1300,7 @@ func (m *Member) Metric(metricName string, expectLabels ...string) (string, erro
 		return "", err
 	}
 	defer resp.Body.Close()
-	b, rerr := ioutil.ReadAll(resp.Body)
+	b, rerr := io.ReadAll(resp.Body)
 	if rerr != nil {
 		return "", rerr
 	}

--- a/tests/functional/agent/handler.go
+++ b/tests/functional/agent/handler.go
@@ -17,7 +17,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -311,7 +310,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.PeerCertData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.PeerCertPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.PeerCertPath, []byte(srv.Member.PeerCertData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.PeerCertPath, []byte(srv.Member.PeerCertData), 0644); err != nil {
 			return err
 		}
 	}
@@ -319,7 +318,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.PeerKeyData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.PeerKeyPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.PeerKeyPath, []byte(srv.Member.PeerKeyData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.PeerKeyPath, []byte(srv.Member.PeerKeyData), 0644); err != nil {
 			return err
 		}
 	}
@@ -327,7 +326,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.PeerTrustedCAData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.PeerTrustedCAPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.PeerTrustedCAPath, []byte(srv.Member.PeerTrustedCAData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.PeerTrustedCAPath, []byte(srv.Member.PeerTrustedCAData), 0644); err != nil {
 			return err
 		}
 	}
@@ -346,7 +345,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.ClientCertData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.ClientCertPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.ClientCertPath, []byte(srv.Member.ClientCertData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.ClientCertPath, []byte(srv.Member.ClientCertData), 0644); err != nil {
 			return err
 		}
 	}
@@ -354,7 +353,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.ClientKeyData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.ClientKeyPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.ClientKeyPath, []byte(srv.Member.ClientKeyData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.ClientKeyPath, []byte(srv.Member.ClientKeyData), 0644); err != nil {
 			return err
 		}
 	}
@@ -362,7 +361,7 @@ func (srv *Server) saveTLSAssets() error {
 		if srv.Member.ClientTrustedCAData == "" {
 			return fmt.Errorf("got empty data for %q", srv.Member.ClientTrustedCAPath)
 		}
-		if err := ioutil.WriteFile(srv.Member.ClientTrustedCAPath, []byte(srv.Member.ClientTrustedCAData), 0644); err != nil {
+		if err := os.WriteFile(srv.Member.ClientTrustedCAPath, []byte(srv.Member.ClientTrustedCAData), 0644); err != nil {
 			return err
 		}
 	}
@@ -396,7 +395,7 @@ func (srv *Server) loadAutoTLSAssets() error {
 		if !fileutil.Exist(certPath) {
 			return fmt.Errorf("cannot find %q", certPath)
 		}
-		certData, err := ioutil.ReadFile(certPath)
+		certData, err := os.ReadFile(certPath)
 		if err != nil {
 			return fmt.Errorf("cannot read %q (%v)", certPath, err)
 		}
@@ -406,7 +405,7 @@ func (srv *Server) loadAutoTLSAssets() error {
 		if !fileutil.Exist(keyPath) {
 			return fmt.Errorf("cannot find %q", keyPath)
 		}
-		keyData, err := ioutil.ReadFile(keyPath)
+		keyData, err := os.ReadFile(keyPath)
 		if err != nil {
 			return fmt.Errorf("cannot read %q (%v)", keyPath, err)
 		}
@@ -437,7 +436,7 @@ func (srv *Server) loadAutoTLSAssets() error {
 		if !fileutil.Exist(certPath) {
 			return fmt.Errorf("cannot find %q", certPath)
 		}
-		certData, err := ioutil.ReadFile(certPath)
+		certData, err := os.ReadFile(certPath)
 		if err != nil {
 			return fmt.Errorf("cannot read %q (%v)", certPath, err)
 		}
@@ -447,7 +446,7 @@ func (srv *Server) loadAutoTLSAssets() error {
 		if !fileutil.Exist(keyPath) {
 			return fmt.Errorf("cannot find %q", keyPath)
 		}
-		keyData, err := ioutil.ReadFile(keyPath)
+		keyData, err := os.ReadFile(keyPath)
 		if err != nil {
 			return fmt.Errorf("cannot read %q (%v)", keyPath, err)
 		}

--- a/tests/functional/cmd/etcd-proxy/main.go
+++ b/tests/functional/cmd/etcd-proxy/main.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -203,7 +203,7 @@ $ ./bin/etcdctl --endpoints localhost:23790 put foo bar`)
 	srv := &http.Server{
 		Addr:     fmt.Sprintf(":%d", httpPort),
 		Handler:  mux,
-		ErrorLog: log.New(ioutil.Discard, "net/http", 0),
+		ErrorLog: log.New(io.Discard, "net/http", 0),
 	}
 	defer srv.Close()
 

--- a/tests/functional/tester/case_failpoints.go
+++ b/tests/functional/tester/case_failpoints.go
@@ -16,7 +16,7 @@ package tester
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -74,7 +74,7 @@ func failpointPaths(endpoint string) ([]string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, rerr := ioutil.ReadAll(resp.Body)
+	body, rerr := io.ReadAll(resp.Body)
 	if rerr != nil {
 		return nil, rerr
 	}

--- a/tests/functional/tester/cluster.go
+++ b/tests/functional/tester/cluster.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -112,7 +112,7 @@ func NewCluster(lg *zap.Logger, fpath string) (*Cluster, error) {
 	clus.testerHTTPServer = &http.Server{
 		Addr:     clus.Tester.Addr,
 		Handler:  mux,
-		ErrorLog: log.New(ioutil.Discard, "net/http", 0),
+		ErrorLog: log.New(io.Discard, "net/http", 0),
 	}
 	go clus.serveTesterServer()
 	lg.Info("tester server started")
@@ -533,7 +533,7 @@ func (clus *Cluster) sendOpWithResp(idx int, op rpcpb.Operation) (*rpcpb.Respons
 			return nil, fmt.Errorf("got empty client cert from %q", m.EtcdClientEndpoint)
 		}
 		clientCertPath := filepath.Join(dirClient, "cert.pem")
-		if err = ioutil.WriteFile(clientCertPath, clientCertData, 0644); err != nil { // overwrite if exists
+		if err = os.WriteFile(clientCertPath, clientCertData, 0644); err != nil { // overwrite if exists
 			return nil, err
 		}
 		resp.Member.ClientCertPath = clientCertPath
@@ -547,7 +547,7 @@ func (clus *Cluster) sendOpWithResp(idx int, op rpcpb.Operation) (*rpcpb.Respons
 			return nil, fmt.Errorf("got empty client key from %q", m.EtcdClientEndpoint)
 		}
 		clientKeyPath := filepath.Join(dirClient, "key.pem")
-		if err = ioutil.WriteFile(clientKeyPath, clientKeyData, 0644); err != nil { // overwrite if exists
+		if err = os.WriteFile(clientKeyPath, clientKeyData, 0644); err != nil { // overwrite if exists
 			return nil, err
 		}
 		resp.Member.ClientKeyPath = clientKeyPath
@@ -560,7 +560,7 @@ func (clus *Cluster) sendOpWithResp(idx int, op rpcpb.Operation) (*rpcpb.Respons
 		if len(clientTrustedCAData) != 0 {
 			// TODO: disable this when auto TLS is deprecated
 			clientTrustedCAPath := filepath.Join(dirClient, "ca.pem")
-			if err = ioutil.WriteFile(clientTrustedCAPath, clientTrustedCAData, 0644); err != nil { // overwrite if exists
+			if err = os.WriteFile(clientTrustedCAPath, clientTrustedCAData, 0644); err != nil { // overwrite if exists
 				return nil, err
 			}
 			resp.Member.ClientTrustedCAPath = clientTrustedCAPath

--- a/tests/functional/tester/cluster_read_config.go
+++ b/tests/functional/tester/cluster_read_config.go
@@ -17,8 +17,8 @@ package tester
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -29,7 +29,7 @@ import (
 )
 
 func read(lg *zap.Logger, fpath string) (*Cluster, error) {
-	bts, err := ioutil.ReadFile(fpath)
+	bts, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].PeerCertPath = mem.Etcd.PeerCertFile
 			if mem.Etcd.PeerCertFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.PeerCertFile)
+				data, err = os.ReadFile(mem.Etcd.PeerCertFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.PeerCertFile, err)
 				}
@@ -289,7 +289,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].PeerKeyPath = mem.Etcd.PeerKeyFile
 			if mem.Etcd.PeerKeyFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.PeerKeyFile)
+				data, err = os.ReadFile(mem.Etcd.PeerKeyFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.PeerKeyFile, err)
 				}
@@ -298,7 +298,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].PeerTrustedCAPath = mem.Etcd.PeerTrustedCAFile
 			if mem.Etcd.PeerTrustedCAFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.PeerTrustedCAFile)
+				data, err = os.ReadFile(mem.Etcd.PeerTrustedCAFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.PeerTrustedCAFile, err)
 				}
@@ -332,7 +332,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].ClientCertPath = mem.Etcd.ClientCertFile
 			if mem.Etcd.ClientCertFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.ClientCertFile)
+				data, err = os.ReadFile(mem.Etcd.ClientCertFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.ClientCertFile, err)
 				}
@@ -341,7 +341,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].ClientKeyPath = mem.Etcd.ClientKeyFile
 			if mem.Etcd.ClientKeyFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.ClientKeyFile)
+				data, err = os.ReadFile(mem.Etcd.ClientKeyFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.ClientKeyFile, err)
 				}
@@ -350,7 +350,7 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 			clus.Members[i].ClientTrustedCAPath = mem.Etcd.ClientTrustedCAFile
 			if mem.Etcd.ClientTrustedCAFile != "" {
 				var data []byte
-				data, err = ioutil.ReadFile(mem.Etcd.ClientTrustedCAFile)
+				data, err = os.ReadFile(mem.Etcd.ClientTrustedCAFile)
 				if err != nil {
 					return nil, fmt.Errorf("failed to read %q (%v)", mem.Etcd.ClientTrustedCAFile, err)
 				}

--- a/tests/functional/tester/stresser_runner.go
+++ b/tests/functional/tester/stresser_runner.go
@@ -16,7 +16,7 @@ package tester
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"syscall"
 
@@ -77,7 +77,7 @@ func (rs *runnerStresser) setupOnce() (err error) {
 
 	go func() {
 		defer close(rs.donec)
-		out, err := ioutil.ReadAll(stderr)
+		out, err := io.ReadAll(stderr)
 		if err != nil {
 			rs.errc <- err
 		} else {

--- a/tests/integration/clientv3/examples/example_metrics_test.go
+++ b/tests/integration/clientv3/examples/example_metrics_test.go
@@ -17,7 +17,7 @@ package clientv3_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -72,7 +72,7 @@ func ExampleClient_metrics() {
 		if err != nil {
 			log.Fatalf("fetch error: %v", err)
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			log.Fatalf("fetch error: reading %s: %v", url, err)

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"path/filepath"
 	"testing"
@@ -116,7 +115,7 @@ func TestMaintenanceSnapshotCancel(t *testing.T) {
 	defer rc1.Close()
 
 	cancel()
-	_, err = io.Copy(ioutil.Discard, rc1)
+	_, err = io.Copy(io.Discard, rc1)
 	if err != context.Canceled {
 		t.Errorf("expected %v, got %v", context.Canceled, err)
 	}
@@ -161,7 +160,7 @@ func testMaintenanceSnapshotTimeout(t *testing.T, snapshot func(context.Context,
 
 	time.Sleep(2 * time.Second)
 
-	_, err = io.Copy(ioutil.Discard, rc2)
+	_, err = io.Copy(io.Discard, rc2)
 	if err != nil && !IsClientTimeout(err) {
 		t.Errorf("expected client timeout, got %v", err)
 	}
@@ -222,7 +221,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 		cancel()
 		close(donec)
 	}()
-	_, err = io.Copy(ioutil.Discard, rc1)
+	_, err = io.Copy(io.Discard, rc1)
 	if err != nil && err != context.Canceled {
 		t.Errorf("expected %v, got %v", context.Canceled, err)
 	}
@@ -239,7 +238,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 
 	// 300ms left and expect timeout while snapshot reading is in progress
 	time.Sleep(700 * time.Millisecond)
-	_, err = io.Copy(ioutil.Discard, rc2)
+	_, err = io.Copy(io.Discard, rc2)
 	if err != nil && !IsClientTimeout(err) {
 		t.Errorf("expected client timeout, got %v", err)
 	}

--- a/tests/integration/member_test.go
+++ b/tests/integration/member_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -72,7 +72,7 @@ func TestLaunchDuplicateMemberShouldFail(t *testing.T) {
 	c := integration.NewCluster(t, size)
 	m := c.Members[0].Clone(t)
 	var err error
-	m.DataDir, err = ioutil.TempDir(t.TempDir(), "etcd")
+	m.DataDir, err = os.MkdirTemp(t.TempDir(), "etcd")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/v2_http_kv_test.go
+++ b/tests/integration/v2_http_kv_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -1096,7 +1095,7 @@ func (t *testHttpClient) ReadBody(resp *http.Response) []byte {
 	if resp == nil {
 		return []byte{}
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	return body
 }

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -1637,20 +1636,20 @@ func TestTLSGRPCAcceptSecureAll(t *testing.T) {
 // when all certs are atomically replaced by directory renaming.
 // And expects server to reject client requests, and vice versa.
 func TestTLSReloadAtomicReplace(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(t.TempDir(), "fixtures-tmp")
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "fixtures-tmp")
 	if err != nil {
 		t.Fatal(err)
 	}
 	os.RemoveAll(tmpDir)
 	defer os.RemoveAll(tmpDir)
 
-	certsDir, err := ioutil.TempDir(t.TempDir(), "fixtures-to-load")
+	certsDir, err := os.MkdirTemp(t.TempDir(), "fixtures-to-load")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(certsDir)
 
-	certsDirExp, err := ioutil.TempDir(t.TempDir(), "fixtures-expired")
+	certsDirExp, err := os.MkdirTemp(t.TempDir(), "fixtures-expired")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1696,7 +1695,7 @@ func TestTLSReloadAtomicReplace(t *testing.T) {
 // when new certs are copied over, one by one. And expects server
 // to reject client requests, and vice versa.
 func TestTLSReloadCopy(t *testing.T) {
-	certsDir, err := ioutil.TempDir(t.TempDir(), "fixtures-to-load")
+	certsDir, err := os.MkdirTemp(t.TempDir(), "fixtures-to-load")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1726,7 +1725,7 @@ func TestTLSReloadCopy(t *testing.T) {
 // when new certs are copied over, one by one. And expects server
 // to reject client requests, and vice versa.
 func TestTLSReloadCopyIPOnly(t *testing.T) {
-	certsDir, err := ioutil.TempDir(t.TempDir(), "fixtures-to-load")
+	certsDir, err := os.MkdirTemp(t.TempDir(), "fixtures-to-load")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -48,7 +47,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 	decoder_correctoutputformat := filepath.Join(binDir, "/testdecoder/decoder_correctoutputformat.sh")
 	decoder_wrongoutputformat := filepath.Join(binDir, "/testdecoder/decoder_wrongoutputformat.sh")
 
-	p, err := ioutil.TempDir(os.TempDir(), "etcddumplogstest")
+	p, err := os.MkdirTemp(os.TempDir(), "etcddumplogstest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			expected, err := ioutil.ReadFile(path.Join(binDir, argtest.fileExpected))
+			expected, err := os.ReadFile(path.Join(binDir, argtest.fileExpected))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tools/etcd-dump-metrics/etcd.go
+++ b/tools/etcd-dump-metrics/etcd.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -44,7 +43,7 @@ func setupEmbedCfg(cfg *embed.Config, curls, purls, ics []url.URL) {
 	// []string{"stderr"} to enable server logging
 
 	var err error
-	cfg.Dir, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("%016X", time.Now().UnixNano()))
+	cfg.Dir, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("%016X", time.Now().UnixNano()))
 	if err != nil {
 		panic(err)
 	}

--- a/tools/etcd-dump-metrics/install_darwin.go
+++ b/tools/etcd-dump-metrics/install_darwin.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,13 +38,13 @@ func install(ver, dir string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	d, err := ioutil.ReadAll(resp.Body)
+	d, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
 
 	zipPath := filepath.Join(dir, "etcd.zip")
-	if err = ioutil.WriteFile(zipPath, d, fileutil.PrivateFileMode); err != nil {
+	if err = os.WriteFile(zipPath, d, fileutil.PrivateFileMode); err != nil {
 		return "", err
 	}
 

--- a/tools/etcd-dump-metrics/install_linux.go
+++ b/tools/etcd-dump-metrics/install_linux.go
@@ -19,8 +19,9 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -38,13 +39,13 @@ func install(ver, dir string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	d, err := ioutil.ReadAll(resp.Body)
+	d, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
 
 	tarPath := filepath.Join(dir, "etcd.tar.gz")
-	if err = ioutil.WriteFile(tarPath, d, fileutil.PrivateFileMode); err != nil {
+	if err = os.WriteFile(tarPath, d, fileutil.PrivateFileMode); err != nil {
 		return "", err
 	}
 

--- a/tools/etcd-dump-metrics/main.go
+++ b/tools/etcd-dump-metrics/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -59,7 +58,7 @@ func main() {
 			ver := *downloadVer
 
 			// download release binary to temporary directory
-			d, err := ioutil.TempDir(os.TempDir(), ver)
+			d, err := os.MkdirTemp(os.TempDir(), ver)
 			if err != nil {
 				panic(err)
 			}

--- a/tools/etcd-dump-metrics/metrics.go
+++ b/tools/etcd-dump-metrics/metrics.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -38,7 +38,7 @@ func fetchMetrics(ep string) (lines []string, err error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	b, rerr := ioutil.ReadAll(resp.Body)
+	b, rerr := io.ReadAll(resp.Body)
 	if rerr != nil {
 		return nil, rerr
 	}

--- a/tools/local-tester/bridge/bridge.go
+++ b/tools/local-tester/bridge/bridge.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -74,7 +73,7 @@ func timeBridge(b *bridgeConn) {
 
 func blackhole(b *bridgeConn) {
 	log.Println("blackholing connection", b.String())
-	io.Copy(ioutil.Discard, b.in)
+	io.Copy(io.Discard, b.in)
 	b.Close()
 }
 


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since etcd has been upgraded to Go 1.17 (#13440), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.