### PR TITLE
server/etcdserver/api/etcdhttp: exclude the same alarm type activated by multiple peers

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,11 +5,20 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, 3.4.2+, and 3.5.1+.
 
-See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.17...v3.4.18) and [v3.4 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_4/) for any breaking changes.
+<hr>
+
+## v3.4.19 (TODO)
+
+See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.18...v3.4.19) and [v3.4 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_4/) for any breaking changes.
+
+### etcd server
+- Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13475).
 
 <hr>
 
 ## v3.4.18 (2021-10-15)
+
+See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.17...v3.4.18) and [v3.4 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_4/) for any breaking changes.
 
 ### Metrics, Monitoring
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -8,6 +8,15 @@ The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.
 
 <hr>
 
+## [v3.5.2](https://github.com/etcd-io/etcd/releases/tag/v3.5.2) (TODO)
+
+See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.1...v3.5.2) and [v3.5 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_5/) for any breaking changes.
+
+### etcd server
+- Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13476).
+
+<hr>
+
 ## [v3.5.1](https://github.com/etcd-io/etcd/releases/tag/v3.5.1) (2021-10-15)
 
 See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.5.1) and [v3.5 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_5/) for any breaking changes.

--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -33,6 +33,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 
 - Add [`etcd --log-format`](https://github.com/etcd-io/etcd/pull/13339) flag to support log format.
 - Fix [non mutating requests pass through quotaKVServer when NOSPACE](https://github.com/etcd-io/etcd/pull/13435)
+- Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13467).
 
 ### tools/benchmark
 

--- a/server/etcdserver/api/etcdhttp/metrics.go
+++ b/server/etcdserver/api/etcdhttp/metrics.go
@@ -138,8 +138,7 @@ func checkHealth(lg *zap.Logger, srv etcdserver.ServerV2, excludedAlarms AlarmSe
 		for _, v := range as {
 			alarmName := v.Alarm.String()
 			if _, found := excludedAlarms[alarmName]; found {
-				lg.Debug("/health excluded alarm", zap.String("alarm", alarmName))
-				delete(excludedAlarms, alarmName)
+				lg.Debug("/health excluded alarm", zap.String("alarm", v.String()))
 				continue
 			}
 
@@ -155,10 +154,6 @@ func checkHealth(lg *zap.Logger, srv etcdserver.ServerV2, excludedAlarms AlarmSe
 			lg.Warn("serving /health false due to an alarm", zap.String("alarm", v.String()))
 			return h
 		}
-	}
-
-	if len(excludedAlarms) > 0 {
-		lg.Warn("fail exclude alarms from health check", zap.String("exclude alarms", fmt.Sprintf("%+v", excludedAlarms)))
 	}
 
 	if uint64(srv.Leader()) == raft.None {

--- a/server/etcdserver/api/etcdhttp/metrics_test.go
+++ b/server/etcdserver/api/etcdhttp/metrics_test.go
@@ -78,6 +78,12 @@ func TestHealthHandler(t *testing.T) {
 			"true",
 		},
 		{
+			[]*pb.AlarmMember{{MemberID: uint64(1), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(2), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(3), Alarm: pb.AlarmType_NOSPACE}},
+			"/health?exclude=NOSPACE",
+			http.StatusOK,
+			"true",
+		},
+		{
 			[]*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
 			"/health?exclude=NOSPACE",
 			http.StatusServiceUnavailable,


### PR DESCRIPTION
#12880 failed to exclude all alarms activated by multiple members for a given alarm type. 

### Reproduce
etcd version `3.4.17`
```
$ rm -rf infra1.etcd infra2.etcd infra3.etcd ~/log/etcd/infra*
$ ./bin/etcd --name infra1 \
--listen-client-urls http://127.0.0.1:2379 \
--advertise-client-urls http://127.0.0.1:2379 \
--listen-peer-urls http://127.0.0.1:12380 \
--initial-advertise-peer-urls http://127.0.0.1:12380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--quota-backend-bytes 200000 > ~/log/etcd/infra1.log 2>&1 &

$ ./bin/etcd --name infra2 \
--listen-client-urls http://127.0.0.1:22379 \
--advertise-client-urls http://127.0.0.1:22379 \
--listen-peer-urls http://127.0.0.1:22380 \
--initial-advertise-peer-urls http://127.0.0.1:22380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--quota-backend-bytes 200000 > ~/log/etcd/infra2.log 2>&1 &

$ ./bin/etcd --name infra3 \
--listen-client-urls http://127.0.0.1:32379 \
--advertise-client-urls http://127.0.0.1:32379 \
--listen-peer-urls http://127.0.0.1:32380 \
--initial-advertise-peer-urls http://127.0.0.1:32380 \
--initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new \
--quota-backend-bytes 200000 > ~/log/etcd/infra3.log 2>&1 &

$ for n in {1..3868}; do sleep 0.1; dd if=/dev/urandom bs=1024 count=17 | ETCDCTL_API=3 etcdctl --endpoints http://localhost:2379,http://127.0.0.1:22379,http://127.0.0.1:32379  put /registry/pods/${n} ; done
$ ctrl+c

$ etcdctl alarm list
memberID:9372538179322589801 alarm:NOSPACE
memberID:10501334649042878790 alarm:NOSPACE
memberID:18249187646912138824 alarm:NOSPACE

$ curl "http://localhost:2379/health?exclude=NOSPACE"
{"health":"false"}

# etcd log
2021-11-09 06:01:51.367165 W | etcdserver/api/etcdhttp: /health error due to memberID:10501334649042878790 alarm:NOSPACE
```

### After this PR
```
curl "http://localhost:2379/health?exclude=NOSPACE"
{"health":"true","reason":""}
```

PTAL @hexfusion @gyuho 
