### PR TITLE
backport 3.4 from #13467 exclude the same alarm type activated by multiple peers

### DIFF
--- a/etcdserver/api/etcdhttp/metrics.go
+++ b/etcdserver/api/etcdhttp/metrics.go
@@ -117,18 +117,13 @@ func checkHealth(srv etcdserver.ServerV2, excludedAlarms AlarmSet) Health {
 		for _, v := range as {
 			alarmName := v.Alarm.String()
 			if _, found := excludedAlarms[alarmName]; found {
-				plog.Debugf("/health excluded alarm %s", alarmName)
-				delete(excludedAlarms, alarmName)
+				plog.Debugf("/health excluded alarm %s", v.String())
 				continue
 			}
 			h.Health = "false"
 			plog.Warningf("/health error due to %s", v.String())
 			return h
 		}
-	}
-
-	if len(excludedAlarms) > 0 {
-		plog.Warningf("fail exclude alarms from health check, exclude alarms %+v", excludedAlarms)
 	}
 
 	if h.Health == "true" {

--- a/etcdserver/api/etcdhttp/metrics_test.go
+++ b/etcdserver/api/etcdhttp/metrics_test.go
@@ -92,6 +92,12 @@ func TestHealthHandler(t *testing.T) {
 			"true",
 		},
 		{
+			[]*pb.AlarmMember{{MemberID: uint64(1), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(2), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(3), Alarm: pb.AlarmType_NOSPACE}},
+			"/health?exclude=NOSPACE",
+			http.StatusOK,
+			"true",
+		},
+		{
 			[]*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
 			"/health?exclude=NOSPACE",
 			http.StatusServiceUnavailable,


### PR DESCRIPTION
backport 3.4 from #13467
