### PR TITLE
server: add more debug information for kvdecode failure case

### DIFF
--- a/server/storage/backend/backend_test.go
+++ b/server/storage/backend/backend_test.go
@@ -310,7 +310,7 @@ func TestBackendWritebackForEach(t *testing.T) {
 	tx.Unlock()
 
 	seq := ""
-	getSeq := func(k, v []byte) error {
+	getSeq := func(k, v []byte, fromTxBuf bool) error {
 		seq += string(k)
 		return nil
 	}

--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -201,8 +201,10 @@ func (t *batchTx) UnsafeDelete(bucketType Bucket, key []byte) {
 }
 
 // UnsafeForEach must be called holding the lock on the tx.
-func (t *batchTx) UnsafeForEach(bucket Bucket, visitor func(k, v []byte) error) error {
-	return unsafeForEach(t.tx, bucket, visitor)
+func (t *batchTx) UnsafeForEach(bucket Bucket, visitor func(k, v []byte, fromTxBuf bool) error) error {
+	return unsafeForEach(t.tx, bucket, func(k, v []byte) error {
+		return visitor(k, v, false)
+	})
 }
 
 func unsafeForEach(tx *bolt.Tx, bucket Bucket, visitor func(k, v []byte) error) error {

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -198,7 +198,7 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 
 	h.Write(schema.Key.Name())
-	err = tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
+	err = tx.UnsafeForEach(schema.Key, func(k, v []byte, fromTxBuf bool) error {
 		kr := bytesToRev(k)
 		if !upper.GreaterThan(kr) {
 			return nil

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -891,7 +891,7 @@ func (b *fakeBatchTx) UnsafeRange(bucket backend.Bucket, key, endKey []byte, lim
 func (b *fakeBatchTx) UnsafeDelete(bucket backend.Bucket, key []byte) {
 	b.Recorder.Record(testutil.Action{Name: "delete", Params: []interface{}{bucket, key}})
 }
-func (b *fakeBatchTx) UnsafeForEach(bucket backend.Bucket, visitor func(k, v []byte) error) error {
+func (b *fakeBatchTx) UnsafeForEach(bucket backend.Bucket, visitor func(k, v []byte, fromTxBuf bool) error) error {
 	return nil
 }
 func (b *fakeBatchTx) Commit()        {}

--- a/server/storage/schema/alarm.go
+++ b/server/storage/schema/alarm.go
@@ -80,7 +80,7 @@ func (s *alarmBackend) GetAllAlarms() ([]*etcdserverpb.AlarmMember, error) {
 
 func (s *alarmBackend) unsafeGetAllAlarms(tx backend.ReadTx) ([]*etcdserverpb.AlarmMember, error) {
 	ms := []*etcdserverpb.AlarmMember{}
-	err := tx.UnsafeForEach(Alarm, func(k, v []byte) error {
+	err := tx.UnsafeForEach(Alarm, func(k, v []byte, fromTxBuf bool) error {
 		var m etcdserverpb.AlarmMember
 		if err := m.Unmarshal(k); err != nil {
 			return err


### PR DESCRIPTION
This patch is related to patch #13426. 

In case of failure, we add more information in the log for us to find the root cause.