### PR TITLE
[3.5] Set the backend again after recovering v3 backend from snapshot

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -514,6 +514,9 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 			if be, err = recoverSnapshotBackend(cfg, be, *snapshot, beExist, beHooks); err != nil {
 				cfg.Logger.Panic("failed to recover v3 backend from snapshot", zap.Error(err))
 			}
+			// A snapshot db may have already been recovered, and the old db should have
+			// already been closed in this case, so we should set the backend again.
+			ci.SetBackend(be)
 			s1, s2 := be.Size(), be.SizeInUse()
 			cfg.Logger.Info(
 				"recovered v3 backend from snapshot",


### PR DESCRIPTION
Fix [issues/13494](https://github.com/etcd-io/etcd/issues/13494).

When etcd recovers v3 backend from a snapshot, then it closes the old backend, see [backend.go#L107](https://github.com/etcd-io/etcd/blob/eac7f986999107cd41fa1098b36a6a59015760f5/server/etcdserver/backend.go#L107). So we should set the backend for the consistentIndex again in this case.

This PR is for 3.5. A separate PR [pull/13500](https://github.com/etcd-io/etcd/pull/13500) has already been submitted for the main branch.

cc @ptabor  @serathius  @jingyih 

/kind bug