### PR TITLE
Is it necessary to avoid setting ETCD_UNSUPPORTED_ARCH=riscv64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ jobs:
           - linux-arm64
           - linux-ppc64le
           - linux-s390x
+          - linux-riscv64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -48,6 +49,9 @@ jobs:
               ;;
             linux-s390x)
               ARCH=s390x GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh
+              ;;
+            linux-riscv64)
+              ARCH=riscv64 GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh
               ;;
             *)
               echo "Failed to find target"

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -465,6 +465,7 @@ func checkSupportArch() {
 	// to add a new platform, check https://github.com/etcd-io/website/blob/main/content/en/docs/next/op-guide/supported-platform.md
 	if runtime.GOARCH == "amd64" ||
 		runtime.GOARCH == "arm64" ||
+		runtime.GOARCH == "riscv64" ||
 		runtime.GOARCH == "ppc64le" ||
 		runtime.GOARCH == "s390x" {
 		return


### PR DESCRIPTION
I add ` runtime.GOARCH == "riscv64" ` to avoid setting ETCD_UNSUPPORTED_ARCH=riscv64.