### PR TITLE
fix watchablestore runlock bug

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -355,8 +355,11 @@ func (s *watchableStore) syncWatchers() int {
 	tx := s.store.b.ReadTx()
 	tx.RLock()
 	revs, vs := tx.UnsafeRange(schema.Key, minBytes, maxBytes, 0)
-	tx.RUnlock()
 	evs := kvsToEvents(s.store.lg, wg, revs, vs)
+	// Must unlock after kvsToEvents, because vs (come from boltdb memory) is not deep copy.
+	// We can only unlock after Unmarshal, which will do deep copy.
+	// Otherwise we will trigger SIGSEGV during boltdb re-mmap.
+	tx.RUnlock()
 
 	victims := make(watcherBatch)
 	wb := newWatcherBatch(wg, evs)


### PR DESCRIPTION
```
tx.RLock()
revs, vs := tx.UnsafeRange(keyBucketName, minBytes, maxBytes, 0)
tx.RUnLock()
```
First we must know, the value(vs) got from function UnsafeRange is using shallow copy. 
The pointer(of vs) comes from memory of bolt db.
So if bolt db is re-mmaping, the memory will be retrieved, then will trigger SIGSEGV:


```
{"log":"unexpected fault address 0x7ff096486221\r\n","stream":"stdout","time":"2021-11-22T05:58:18.896795868Z"}
{"log":"fatal error: fault\r\n","stream":"stdout","time":"2021-11-22T05:58:18.896824465Z"}
{"log":"[signal SIGSEGV: segmentation violation code=0x1 addr=0x7ff096486221 pc=0x472ee5]\r\n","stream":"stdout","time":"2021-11-22T05:58:18.90016673Z"}
{"log":"\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900182456Z"}
{"log":"goroutine 335 [running]:\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900185844Z"}
{"log":"runtime.throw(0x1035d04, 0x5)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900200492Z"}
{"log":"\u0009/usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc0f035fac0 sp=0xc0f035fa90 pc=0x4381b2\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900211528Z"}
{"log":"runtime.sigpanic()\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900214574Z"}
{"log":"\u0009/usr/local/go/src/runtime/signal_unix.go:741 +0x268 fp=0xc0f035faf8 sp=0xc0f035fac0 pc=0x44f9c8\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900217998Z"}
{"log":"runtime.memmove(0xc0c597a000, 0x7ff09647f0b4, 0x71ed)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.90022098Z"}
{"log":"\u0009/usr/local/go/src/runtime/memmove_amd64.s:332 +0x3c5 fp=0xc0f035fb00 sp=0xc0f035faf8 pc=0x472ee5\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900223571Z"}
{"log":"go.etcd.io/etcd/mvcc/mvccpb.(*KeyValue).Unmarshal(0xc0487ef3b0, 0x7ff09647f041, 0x7260, 0x7260, 0x5f, 0x0)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900238058Z"}
{"log":"\u0009/workspace/code-repo/mvcc/mvccpb/kv.pb.go:410 +0x8ae fp=0xc0f035fbb8 sp=0xc0f035fb00 pc=0x8bfeee\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900258776Z"}
{"log":"go.etcd.io/etcd/mvcc.kvsToEvents(0xc00015e0c0, 0xc0003242c0, 0xc17c5a4000, 0x4af7, 0x5000, 0xc17c222000, 0x4af7, 0x5000, 0x11, 0x12, ...)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900290453Z"}
{"log":"\u0009/workspace/code-repo/mvcc/watchable_store.go:412 +0xf0 fp=0xc0f035fd30 sp=0xc0f035fbb8 pc=0xa66930\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900294704Z"}
{"log":"go.etcd.io/etcd/mvcc.(*watchableStore).syncWatchers(0xc000324280, 0x0)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900309685Z"}
{"log":"\u0009/workspace/code-repo/mvcc/watchable_store.go:354 +0x8c9 fp=0xc0f035ff20 sp=0xc0f035fd30 pc=0xa66789\r\n","stream":"stdout","time":"2021-11-22T05:58:18.90032452Z"}
{"log":"go.etcd.io/etcd/mvcc.(*watchableStore).syncWatchersLoop(0xc000324280)\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900328268Z"}
{"log":"\u0009/workspace/code-repo/mvcc/watchable_store.go:215 +0x1e8 fp=0xc0f035ffd8 sp=0xc0f035ff20 pc=0xa65588\r\n","stream":"stdout","time":"2021-11-22T05:58:18.900338151Z"}
```
