### PR TITLE
etcdctl: enhance the make-mirror command to return error asap when invalid flags are provided

### DIFF
--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -130,6 +130,11 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 func makeMirror(ctx context.Context, c *clientv3.Client, dc *clientv3.Client) error {
 	total := int64(0)
 
+	// if destination prefix is specified and remove destination prefix is true return error
+	if mmnodestprefix && len(mmdestprefix) > 0 {
+		cobrautl.ExitWithError(cobrautl.ExitBadArgs, errors.New("`--dest-prefix` and `--no-dest-prefix` cannot be set at the same time, choose one"))
+	}
+
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
@@ -140,11 +145,6 @@ func makeMirror(ctx context.Context, c *clientv3.Client, dc *clientv3.Client) er
 	s := mirror.NewSyncer(c, mmprefix, 0)
 
 	rc, errc := s.SyncBase(ctx)
-
-	// if destination prefix is specified and remove destination prefix is true return error
-	if mmnodestprefix && len(mmdestprefix) > 0 {
-		cobrautl.ExitWithError(cobrautl.ExitBadArgs, fmt.Errorf("`--dest-prefix` and `--no-dest-prefix` cannot be set at the same time, choose one"))
-	}
 
 	// if remove destination prefix is false and destination prefix is empty set the value of destination prefix same as prefix
 	if !mmnodestprefix && len(mmdestprefix) == 0 {


### PR DESCRIPTION
When both "--no-dest-prefix" and "--dest-prefix" are provided for the "`etcdctl make-mirror`" command, then an error will be returned. The behavior is OK, but the current implementation returns the error after starting the s.SyncBase. Instead we should return the error as early as possible, and it's exactly the PR tries to resolve.

Another minor change is to replace the fmt.Errorf with errors.New, because there is no additional parameter at all.

cc @xiang90 @ptabor @sinsharat 