### PR TITLE
Add a new flag "--rev" to make-mirror command to support incremental mirror

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -34,6 +34,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [`etcd --log-format`](https://github.com/etcd-io/etcd/pull/13339) flag to support log format.
 - Add [`etcd --experimental-max-learners`](https://github.com/etcd-io/etcd/pull/13377) flag to allow configuration of learner max membership.
 - Add [`etcd --experimental-enable-lease-checkpoint-persist`](https://github.com/etcd-io/etcd/pull/13508) flag to handle upgrade from v3.5.2 clusters with this feature enabled.
+- Add [`etcdctl make-mirror --rev`](https://github.com/etcd-io/etcd/pull/13519) flag to support incremental mirror.
 - Fix [non mutating requests pass through quotaKVServer when NOSPACE](https://github.com/etcd-io/etcd/pull/13435)
 - Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13467).
 - Fix [Provide a better liveness probe for when etcd runs as a Kubernetes pod](https://github.com/etcd-io/etcd/pull/13399)

--- a/tests/e2e/ctl_v3_make_mirror_test.go
+++ b/tests/e2e/ctl_v3_make_mirror_test.go
@@ -25,6 +25,7 @@ import (
 func TestCtlV3MakeMirror(t *testing.T)                 { testCtl(t, makeMirrorTest) }
 func TestCtlV3MakeMirrorModifyDestPrefix(t *testing.T) { testCtl(t, makeMirrorModifyDestPrefixTest) }
 func TestCtlV3MakeMirrorNoDestPrefix(t *testing.T)     { testCtl(t, makeMirrorNoDestPrefixTest) }
+func TestCtlV3MakeMirrorWithWatchRev(t *testing.T)     { testCtl(t, makeMirrorWithWatchRev) }
 
 func makeMirrorTest(cx ctlCtx) {
 	var (
@@ -52,6 +53,18 @@ func makeMirrorNoDestPrefixTest(cx ctlCtx) {
 		flags      = []string{"--prefix", "o_", "--no-dest-prefix"}
 		kvs        = []kv{{"o_key1", "val1"}, {"o_key2", "val2"}, {"o_key3", "val3"}}
 		kvs2       = []kvExec{{key: "key1", val: "val1"}, {key: "key2", val: "val2"}, {key: "key3", val: "val3"}}
+		srcprefix  = "o_"
+		destprefix = "key"
+	)
+
+	testMirrorCommand(cx, flags, kvs, kvs2, srcprefix, destprefix)
+}
+
+func makeMirrorWithWatchRev(cx ctlCtx) {
+	var (
+		flags      = []string{"--prefix", "o_", "--no-dest-prefix", "--rev", "4"}
+		kvs        = []kv{{"o_key1", "val1"}, {"o_key2", "val2"}, {"o_key3", "val3"}, {"o_key4", "val4"}}
+		kvs2       = []kvExec{{key: "key3", val: "val3"}, {key: "key4", val: "val4"}}
 		srcprefix  = "o_"
 		destprefix = "key"
 	)


### PR DESCRIPTION
The current behavior of `etcdctl make-mirror ...` command is to try to copy the whole key space each time on startup. If the process/command is restarted for whatever reason, then it will take a long long time to re-sync all the data if the key space is huge. 

This PR is to add a "--rev" flag to the make-mirror command to support incrementally mirroring the data. Once the flag is provided, then the command just starts watching the key spaces starting from the specified rev. 

The PR can be a solution to the issue something like [issues/13511](https://github.com/etcd-io/etcd/issues/13511). 

@ptabor @xiang90 @sinsharat 
