### PR TITLE
Remove the redundant line from test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -32,8 +32,6 @@
 # $ COVERDIR=coverage PASSES="build build_cov cov" ./test.sh
 # $ go tool cover -html ./coverage/cover.out
 set -e
-set -o pipefail
-
 
 # Consider command as failed when any component of the pipe fails:
 # https://stackoverflow.com/questions/1221833/pipe-output-and-capture-exit-status-in-bash


### PR DESCRIPTION
There are two duplicated lines of "`set -o pipefail`", see 
[test.sh#L35-L40](https://github.com/etcd-io/etcd/blob/29292aa7bdafaf65cb5e054591fe0ff07b36f5ee/test.sh#L35-L40)

@ptabor  @serathius 