### PR TITLE
Cancel timeout for defrag command if user does not specify "--command-timeout" flag

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -21,6 +21,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13133).
 - When print endpoint status, [show db size in use](https://github.com/etcd-io/etcd/pull/13639)
 - [Always print the raft_term in decimal](https://github.com/etcd-io/etcd/pull/13711) when displaying member list in json.
+- Changed defrag command to [cancel client timeout if user does not specify "--command-timeout" flag](https://github.com/etcd-io/etcd/pull/13531).
 
 ### etcdutl v3
 


### PR DESCRIPTION
The `--command-timeout` option in etcdctl is set to 5s by default.
When the defragment takes over 5s(it happens when etcd has massive data to defrag), the error output will be:
```
Failed to defragment etcd member[https://xxx:2379] . took 5s. (context deadline exceeded)
```
Which is confusing.
I think we should cancel the timeout opition unless users specify the `--command-timeout` flag like [snapshot save](https://github.com/etcd-io/etcd/blob/main/etcdctl/ctlv3/command/snapshot_command.go#L109-L113)  command.
```
        // if user does not specify "--command-timeout" flag, there will be no timeout for snapshot save command
	ctx, cancel := context.WithCancel(context.Background())
	if isCommandTimeoutFlagSet(cmd) {
		ctx, cancel = commandCtx(cmd)
	}
```