### PR TITLE
fix potential goroutine leaks

### DIFF
--- a/client/v3/txn_test.go
+++ b/client/v3/txn_test.go
@@ -27,7 +27,7 @@ func TestTxnPanics(t *testing.T) {
 
 	kv := &kv{}
 
-	errc := make(chan string, 1)
+	errc := make(chan string, 6)
 	df := func() {
 		if s := recover(); s != nil {
 			errc <- s.(string)

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -96,6 +96,7 @@ func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 	writec <- data1
 	now := time.Now()
 	if d := <-recvc; !bytes.Equal(data1, d) {
+		close(writec)
 		t.Fatalf("expected %q, got %q", string(data1), string(d))
 	}
 	took1 := time.Since(now)
@@ -110,6 +111,7 @@ func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 	writec <- data2
 	now = time.Now()
 	if d := <-recvc; !bytes.Equal(data2, d) {
+		close(writec)
 		t.Fatalf("expected %q, got %q", string(data2), string(d))
 	}
 	took2 := time.Since(now)
@@ -122,6 +124,7 @@ func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
 	if delayTx {
 		p.UndelayTx()
 		if took2 < lat-rv {
+			close(writec)
 			t.Fatalf("expected took2 %v (with latency) > delay: %v", took2, lat-rv)
 		}
 	}

--- a/server/storage/backend/backend_test.go
+++ b/server/storage/backend/backend_test.go
@@ -32,7 +32,7 @@ func TestBackendClose(t *testing.T) {
 	b, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
 
 	// check close could work
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		err := b.Close()
 		if err != nil {


### PR DESCRIPTION
Three test functions contain potential goroutine leaks. 

1. [TestTxnPanics](https://github.com/etcd-io/etcd/blob/main/client/v3/txn_test.go#L25): All six tests in the function can timeout in the worst cases. Thus, the buffer size of channel errc should be 6 to completely eliminate all possible goroutine leaks.  

2. [TestBackendClose](https://github.com/etcd-io/etcd/blob/main/server/storage/backend/backend_test.go#L31):  when timeout happens, the child goroutine blocks at the send operation at line 41 forever. Increasing the buffer size from 0 to 1 can help the child goroutine terminate itself, even when the timeout happens. 

3. [testServer](https://github.com/etcd-io/etcd/blob/main/pkg/proxy/server_test.go#L49): if one of the three calls of t.Fatalf() executes, close(writec) will be skipped. One child goroutine will block at ranging over channel writec endlessly. The patch is to close channel writec when t.Fatalf() executes to guarantee the child goroutine can always stop.  