### PR TITLE
fixing one panic and two goroutine leaks

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -607,7 +607,9 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 
 	select {
 	case <-ctx.Done():
-		resp.Body.Close()
+		if resp != nil {
+			resp.Body.Close()
+		}
 		<-done
 		return nil, nil, ctx.Err()
 	case <-done:

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -35,6 +35,8 @@ func TestWatch(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
+		b.Close()
+		s.Close()
 		s.store.Close()
 		os.Remove(tmpPath)
 	}()
@@ -536,6 +538,8 @@ func TestWatchVictims(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
+		b.Close()
+		s.Close()
 		s.store.Close()
 		os.Remove(tmpPath)
 		chanBufLen, maxWatchersPerSync = oldChanBufLen, oldMaxWatchersPerSync

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -37,7 +37,6 @@ func TestWatch(t *testing.T) {
 	defer func() {
 		b.Close()
 		s.Close()
-		s.store.Close()
 		os.Remove(tmpPath)
 	}()
 
@@ -540,7 +539,6 @@ func TestWatchVictims(t *testing.T) {
 	defer func() {
 		b.Close()
 		s.Close()
-		s.store.Close()
 		os.Remove(tmpPath)
 		chanBufLen, maxWatchersPerSync = oldChanBufLen, oldMaxWatchersPerSync
 	}()


### PR DESCRIPTION
1. as shown by [line 592](https://github.com/etcd-io/etcd/blob/main/client/v2/client.go#L592), resp can be nil. Thus, we need to check whether resp is nil before referring to his Body field. 

2. three are three goroutines leaked in TestWatch(), and unfortunately, they cannot be terminated by the deferred function s.store.Close(). The added b.Close() can shut down the goroutine created at [line 220](https://github.com/etcd-io/etcd/blob/main/server/storage/backend/backend.go#L220), and the added s.Close() can turn down the two goroutines created at [line 95](https://github.com/etcd-io/etcd/blob/main/server/storage/mvcc/watchable_store.go#L95) and [line 96](https://github.com/etcd-io/etcd/blob/main/server/storage/mvcc/watchable_store.go#L96).

3. TestWatchVictims() has the same problems as TestWatch(). 