### PR TITLE
server/etcdmain: add build support for Apple M1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ jobs:
           - linux-amd64
           - linux-386
           - darwin-amd64
+          - darwin-arm64
           - windows-amd64
           - linux-arm
           - linux-arm64
@@ -33,6 +34,9 @@ jobs:
               ;;
             darwin-amd64)
               ARCH=amd64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh
+              ;;
+            darwin-arm64)
+              ARCH=arm64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh
               ;;
             windows-amd64)
               ARCH=amd64 GOOS=windows GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -79,6 +79,10 @@ function main {
       TARGET_ARCHS+=("s390x")
     fi
 
+    if [ ${GOOS} == "darwin" ]; then
+      TARGET_ARCHS+=("arm64")
+    fi
+
     for TARGET_ARCH in "${TARGET_ARCHS[@]}"; do
       export GOARCH=${TARGET_ARCH}
 


### PR DESCRIPTION
This has been additionally verified by running the tests locally as a basic smoke test. GitHub Actions doesn't provide MacOS M1 (arm64) yet, so there's no good way to automate testing.

Ran `TMPDIR=/tmp make test` locally. The `TMPDIR` bit is needed so there's no really long path used that breaks Unix socket setup in one of the tests.

The lever of support would be tier 3 in https://etcd.io/docs/v3.5/op-guide/supported-platform/ which is the same as the existing Darwin amd64 support. 