### PR TITLE
images: Use Kubernetes debian-base:bullseye-v1.1.0 as base image

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,5 +1,5 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
-FROM debian:bullseye-20210927
+# base image source: https://git.k8s.io/release/images/build/debian-base
+FROM --platform=linux/amd64 k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,5 +1,5 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
-FROM arm64v8/debian:bullseye-20210927
+# base image source: https://git.k8s.io/release/images/build/debian-base
+FROM --platform=linux/arm64 k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,5 +1,5 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
-FROM ppc64le/debian:bullseye-20210927
+# base image source: https://git.k8s.io/release/images/build/debian-base
+FROM --platform=linux/ppc64le k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,5 +1,5 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-s390x:bullseye-1.y.z when patched
-FROM s390x/debian:bullseye-20210927
+# base image source: https://git.k8s.io/release/images/build/debian-base
+FROM --platform=linux/s390x k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Follow-up to https://github.com/etcd-io/etcd/pull/13376, now that an updated debian-base image was promoted in https://github.com/kubernetes/release/pull/2371.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @hexfusion @mrueg

---

Previous scan against `k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0`:

```console
❯ docker run -it aquasec/trivy:0.21.2 image --ignore-unfixed k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
2021-12-17T21:15:53.638Z	INFO	Need to update DB
2021-12-17T21:15:53.639Z	INFO	Downloading DB...
25.23 MiB / 25.23 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 12.94 MiB p/s 2s
2021-12-17T21:15:58.838Z	INFO	Detected OS: debian
2021-12-17T21:15:58.838Z	INFO	Detecting Debian vulnerabilities...
2021-12-17T21:15:58.851Z	INFO	Number of language-specific files: 0

k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0 (debian 11.0)
================================================================
Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 1, CRITICAL: 1)

+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                 TITLE                 |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
| libgssapi-krb5-2 | CVE-2021-37750   | MEDIUM   | 1.18.3-6          | 1.18.3-6+deb11u1 | krb5: NULL pointer dereference        |
|                  |                  |          |                   |                  | in process_tgs_req() in               |
|                  |                  |          |                   |                  | kdc/do_tgs_req.c via a FAST inner...  |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-37750 |
+------------------+                  +          +                   +                  +                                       +
| libk5crypto3     |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+                  +          +                   +                  +                                       +
| libkrb5-3        |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+                  +          +                   +                  +                                       +
| libkrb5support0  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
| libssl1.1        | CVE-2021-3711    | CRITICAL | 1.1.1k-1          | 1.1.1k-1+deb11u1 | openssl: SM2 Decryption               |
|                  |                  |          |                   |                  | Buffer Overflow                       |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3711  |
+                  +------------------+----------+                   +                  +---------------------------------------+
|                  | CVE-2021-3712    | HIGH     |                   |                  | openssl: Read buffer overruns         |
|                  |                  |          |                   |                  | processing ASN.1 strings              |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3712  |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
```

New scan against `k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0`:

```console
❯ docker run -it aquasec/trivy:0.21.2 image --ignore-unfixed k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
2021-12-17T21:17:21.382Z	INFO	Need to update DB
2021-12-17T21:17:21.382Z	INFO	Downloading DB...
25.23 MiB / 25.23 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 12.24 MiB p/s 2s
2021-12-17T21:17:26.077Z	INFO	Detected OS: debian
2021-12-17T21:17:26.077Z	INFO	Detecting Debian vulnerabilities...
2021-12-17T21:17:26.092Z	INFO	Number of language-specific files: 0

k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0 (debian 11.1)
================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```