### PR TITLE
fixing the goroutine leaks in TestHashKVWhenCompacting

### DIFF
--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -536,6 +536,8 @@ type hashKVResult struct {
 func TestHashKVWhenCompacting(t *testing.T) {
 	b, tmpPath := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
+	defer s.Close()
+	defer b.Close()
 	defer os.Remove(tmpPath)
 
 	rev := 10000

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -536,7 +536,8 @@ func TestWatchVictims(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
-		s.store.Close()
+		s.Close()
+		b.Close()
 		os.Remove(tmpPath)
 		chanBufLen, maxWatchersPerSync = oldChanBufLen, oldMaxWatchersPerSync
 	}()

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -536,8 +536,8 @@ func TestWatchVictims(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
-		s.Close()
 		b.Close()
+		s.Close()
 		os.Remove(tmpPath)
 		chanBufLen, maxWatchersPerSync = oldChanBufLen, oldMaxWatchersPerSync
 	}()

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -615,7 +615,8 @@ func TestStressWatchCancelClose(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
-		s.store.Close()
+		b.Close()
+		s.Close()
 		os.Remove(tmpPath)
 	}()
 


### PR DESCRIPTION
The pull request fixes the goroutine leaks in TestHashKVWhenCompacting. The backend and store created in `TestHashKVWhenCompacting()` are not closed, and their attached goroutines do not terminate when the unit test finishes. The patch can clean up the created backend and store and stop their attached goroutines. 

TestStressWatchCancelClose has the same problem, which is also fixed in this pull request. 