### PR TITLE
format listenning address correctly for IPv6 ip address

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -41,6 +41,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Fix [Lease checkpoints don't prevent to reset ttl on leader change](https://github.com/etcd-io/etcd/pull/13508).
 - Fix [assertion failed due to tx closed when recovering v3 backend from a snapshot db](https://github.com/etcd-io/etcd/pull/13500)
 - Fix [A client can panic etcd by passing invalid utf-8 in the client-api-version header](https://github.com/etcd-io/etcd/pull/13560)
+- Fix [etcd gateway doesn't format the endpoint of IPv6 address correctly](https://github.com/etcd-io/etcd/pull/13551)
 
 ### tools/benchmark
 

--- a/server/proxy/tcpproxy/userspace_test.go
+++ b/server/proxy/tcpproxy/userspace_test.go
@@ -129,3 +129,34 @@ func TestUserspaceProxyPriority(t *testing.T) {
 		t.Errorf("got = %s, want %s", got, want)
 	}
 }
+
+func TestFormatAddr(t *testing.T) {
+	addrs := []struct {
+		host         string
+		port         uint16
+		expectedAddr string
+	}{
+		{
+			"192.168.1.10",
+			2379,
+			"192.168.1.10:2379",
+		},
+		{
+			"::1",
+			2379,
+			"[::1]:2379",
+		},
+		{
+			"2001:db8::ff00:42:8329",
+			80,
+			"[2001:db8::ff00:42:8329]:80",
+		},
+	}
+
+	for _, addr := range addrs {
+		actualAddr := formatAddr(addr.host, addr.port)
+		if actualAddr != addr.expectedAddr {
+			t.Errorf("actualAddr: %s, expectedAddr: %s", actualAddr, addr.expectedAddr)
+		}
+	}
+}


### PR DESCRIPTION
Fix [issues/13548 ](https://github.com/etcd-io/etcd/issues/13548 )

We should add more test for IPv6, but probably it would be better to resolve the test in a separate PR. 

@xiang90 @ptabor @serathius 