### PR TITLE
release: build with consistent paths

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -87,7 +87,7 @@ function main {
       export GOARCH=${TARGET_ARCH}
 
       pushd etcd >/dev/null
-      GO_LDFLAGS="-s" ./scripts/build.sh
+      GO_LDFLAGS="-s -w" ./scripts/build.sh
       popd >/dev/null
 
       TARGET="etcd-${VER}-${GOOS}-${GOARCH}"

--- a/scripts/build_lib.sh
+++ b/scripts/build_lib.sh
@@ -60,6 +60,7 @@ etcd_build() {
     # Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
     # shellcheck disable=SC2086
     run env "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcd" . || return 2
@@ -70,6 +71,7 @@ etcd_build() {
   (
     cd ./etcdutl
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcdutl" . || return 2
@@ -80,6 +82,7 @@ etcd_build() {
   (
     cd ./etcdctl
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcdctl" . || return 2
@@ -110,6 +113,7 @@ tools_build() {
     run rm -f "${out}/${tool}"
     # shellcheck disable=SC2086
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="${out}/${tool}" "./${tool}" || return 2

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -9,8 +9,8 @@ outdir="${BINDIR:-../bin}"
 
 (
   cd ./tests 
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o "${outdir}/etcd-agent" ./functional/cmd/etcd-agent
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o "${outdir}/etcd-proxy" ./functional/cmd/etcd-proxy
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o "${outdir}/etcd-runner" ./functional/cmd/etcd-runner
-  CGO_ENABLED=0 go test -v -installsuffix cgo -ldflags "-s" -c -o "${outdir}/etcd-tester" ./functional/cmd/etcd-tester
+  CGO_ENABLED=0 go build -trimpath -v -installsuffix cgo -ldflags "-s -w" -o "${outdir}/etcd-agent" ./functional/cmd/etcd-agent
+  CGO_ENABLED=0 go build -trimpath -v -installsuffix cgo -ldflags "-s -w" -o "${outdir}/etcd-proxy" ./functional/cmd/etcd-proxy
+  CGO_ENABLED=0 go build -trimpath -v -installsuffix cgo -ldflags "-s -w" -o "${outdir}/etcd-runner" ./functional/cmd/etcd-runner
+  CGO_ENABLED=0 go test -v -installsuffix cgo -ldflags "-s -w" -c -o "${outdir}/etcd-tester" ./functional/cmd/etcd-tester
 )


### PR DESCRIPTION
This changes the builds to always add -trimpath which removes specific build time paths from the binary (like current directories etc).

Improves build reproducability to make the final binary independent from the specific build path.

Lastly, when stripping debug symbols, also add -w to strip DWARF symbols as well which aren't needed in that case either.

Found this when doing #13545 and thought that maybe these additional changes would also be welcome. 