### PR TITLE
Use Distroless as base image

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -50,4 +50,8 @@ See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per 
 
 - Add [`etcd_disk_defrag_inflight`](https://github.com/etcd-io/etcd/pull/13371).
 
+### Other
+
+- Use Distroless as base image to make the image less vulnerable and reduce image size.
+
 <hr>

--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,5 +1,5 @@
 FROM --platform=linux/amd64 busybox:1.34.1 as source
-FROM --platform=linux/amd64  gcr.io/distroless/base-debian11
+FROM --platform=linux/amd64 gcr.io/distroless/base-debian11
 
 COPY --from=source /bin/sh /bin/sh
 COPY --from=source /bin/mkdir /bin/mkdir

--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,5 +1,8 @@
-# base image source: https://git.k8s.io/release/images/build/debian-base
-FROM --platform=linux/amd64 k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+FROM --platform=linux/amd64 busybox:1.34.1 as source
+FROM --platform=linux/amd64  gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,5 +1,5 @@
 FROM --platform=linux/arm64 busybox:1.34.1 as source
-FROM --platform=linux/arm64  gcr.io/distroless/base-debian11
+FROM --platform=linux/arm64 gcr.io/distroless/base-debian11
 
 COPY --from=source /bin/sh /bin/sh
 COPY --from=source /bin/mkdir /bin/mkdir

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,5 +1,8 @@
-# base image source: https://git.k8s.io/release/images/build/debian-base
-FROM --platform=linux/arm64 k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+FROM --platform=linux/arm64 busybox:1.34.1 as source
+FROM --platform=linux/arm64  gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,5 +1,9 @@
-# base image source: https://git.k8s.io/release/images/build/debian-base
-FROM --platform=linux/ppc64le k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+FROM --platform=linux/ppc64le busybox:1.34.1 as source
+FROM --platform=linux/ppc64le  gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
+
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,9 +1,8 @@
 FROM --platform=linux/ppc64le busybox:1.34.1 as source
-FROM --platform=linux/ppc64le  gcr.io/distroless/base-debian11
+FROM --platform=linux/ppc64le gcr.io/distroless/base-debian11
 
 COPY --from=source /bin/sh /bin/sh
 COPY --from=source /bin/mkdir /bin/mkdir
-
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,5 +1,5 @@
 FROM --platform=linux/s390x busybox:1.34.1 as source
-FROM --platform=linux/s390x  gcr.io/distroless/base-debian11
+FROM --platform=linux/s390x gcr.io/distroless/base-debian11
 
 COPY --from=source /bin/sh /bin/sh
 COPY --from=source /bin/mkdir /bin/mkdir

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,5 +1,9 @@
-# base image source: https://git.k8s.io/release/images/build/debian-base
-FROM --platform=linux/s390x k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+FROM --platform=linux/s390x busybox:1.34.1 as source
+FROM --platform=linux/s390x  gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
+
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Use Distroless as base image to reduce attack surface and image size.

Metioned by #13459 , #10804 and #10805 .

Signed-off-by: yankay <kay.yan@daocloud.io>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
