### PR TITLE
fixing goroutine leaks

### DIFF
--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func dummyIndexWaiter(index uint64) <-chan struct{} {
-	ch := make(chan struct{})
+	ch := make(chan struct{}, 1)
 	go func() {
 		ch <- struct{}{}
 	}()

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -722,6 +722,8 @@ func TestConcurrentReadTxAndWrite(t *testing.T) {
 	)
 	b, tmpPath := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
+	defer b.Close()
+	defer s.Close()
 	defer os.Remove(tmpPath)
 
 	var wg sync.WaitGroup

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -265,7 +265,8 @@ func TestWatchFutureRev(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
-		s.store.Close()
+		b.Close()
+		s.Close()
 		os.Remove(tmpPath)
 	}()
 

--- a/server/storage/mvcc/watcher_test.go
+++ b/server/storage/mvcc/watcher_test.go
@@ -216,7 +216,8 @@ func TestWatchDeleteRange(t *testing.T) {
 	s := newWatchableStore(zap.NewExample(), b, &lease.FakeLessor{}, StoreConfig{})
 
 	defer func() {
-		s.store.Close()
+		b.Close()
+		s.Close()
 		os.Remove(tmpPath)
 	}()
 


### PR DESCRIPTION
Multiple goroutine leaks are fixed in this pull request. 

1. the message sent to channel ch in `func dummyIndexWaiter()` is waited for by a select in `func (t *tokenSimple) isValidSimpleToken(ctx context.Context, token string) bool` ([line 234](https://github.com/etcd-io/etcd/blob/main/server/auth/simple_token.go#L234)). Although the chance is low, it is possible that the message from ctx.Done() comes earlier. At that time, the child goroutine in `func dummyIndexWaiter()` is leaked. Increasing the buffer size to 1 can guarantee the send operation in the child goroutine proceeds and the child goroutine terminates. 

2. the store and the backend objects in ``TestConcurrentReadTxAndWrite()` are not closed. Thus, the attached goroutines are leaked. The patch can clean up the store and the backend objects.

3. (and 4) `s.store.Close()` does not close the store object. Moreover, the backend object is not closed. The patch can correctly clean up those objects. 