### PR TITLE
Fix goroutine leaks in TestNodeProposeAddDuplicateNode

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -860,6 +860,7 @@ func TestNodeProposeAddLearnerNode(t *testing.T) {
 	<-applyConfChan
 	close(stop)
 	<-done
+	n.Stop()
 }
 
 func TestAppendPagination(t *testing.T) {


### PR DESCRIPTION
raft: fix goroutine leaks in TestNodeProposeAddDuplicateNode

The goroutine created with `n.run()` will leak if we forget to call `n.Stop()`.

We can replay the goroutine leaks by using [goleak](https://github.com/uber-go/goleak):
```
$ cd raft &&  env go test -short -v -timeout=3m --race -run=TestNodeProposeAddLearnerNode .
... ...
--- FAIL: TestNodeProposeAddLearnerNode (1.15s)
    node_test.go:850: raft: [{1 1 EntryNormal []}]
    node_test.go:850: raft: [{1 2 EntryConfChange [8 0 16 3 24 2]}]
    node_test.go:867: apply raft conf {ConfChangeAddLearnerNode 2 [] 0} changed to: voters:1 learners:2
    leaks.go:82: found unexpected goroutines:
        [Goroutine 22 in state select, with go.etcd.io/etcd/raft/v3.(*node).run on top of the stack:
        goroutine 22 [select]:
        go.etcd.io/etcd/raft/v3.(*node).run(0xc00041b620)
                /home/yuanting/dev/goprojects/etcd/raft/node.go:345 +0xc1d
        created by go.etcd.io/etcd/raft/v3.TestNodeProposeAddLearnerNode
                /home/yuanting/dev/goprojects/etcd/raft/node_test.go:835 +0x4f4
        ]
FAIL
FAIL    go.etcd.io/etcd/raft/v3 1.228s
```
