### PR TITLE
Fix goroutine leaks in TestCommitPagination

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -945,6 +945,7 @@ func TestCommitPagination(t *testing.T) {
 	}
 	s.Append(rd.Entries)
 	n.Advance()
+	n.Stop()
 }
 
 type ignoreSizeHintMemStorage struct {


### PR DESCRIPTION
raft/v3: fix goroutine leaks in `TestCommitPagination`

The goroutine created with `n.run()` will leak if we forget to `call n.Stop()`.

We can reproduce the goroutine leaks by using [goleak](https://github.com/uber-go/goleak):

```
$ cd raft &&  env go test -short -v -timeout=3m --race -run=TestCommitPagination.
... ...
raft2021/12/27 20:47:15 INFO: raft.node: 1 elected leader 1 at term 1
    leaks.go:78: found unexpected goroutines:
        [Goroutine 20 in state select, with go.etcd.io/etcd/raft/v3.(*node).run on top of the stack:
        goroutine 20 [select]:
        go.etcd.io/etcd/raft/v3.(*node).run(0xc00036f260)
                /home/yuanting/work/dev/goprojects/etcd/raft/node.go:344 +0xc1d
        created by go.etcd.io/etcd/raft/v3.TestCommitPagination
                /home/yuanting/work/dev/goprojects/etcd/raft/node_test.go:920 +0x554
        ]
--- FAIL: TestCommitPagination (0.45s)
FAIL
FAIL    go.etcd.io/etcd/raft/v3 0.508s
FAIL
```
