### PR TITLE
Avoid always update meta term.

### DIFF
--- a/server/storage/schema/cindex.go
+++ b/server/storage/schema/cindex.go
@@ -58,7 +58,7 @@ func ReadConsistentIndex(tx backend.ReadTx) (uint64, uint64) {
 
 func UnsafeUpdateConsistentIndex(tx backend.BatchTx, index uint64, term uint64, onlyGrow bool) {
 	if index == 0 {
-		// Never save 0 as it means that we didn't loaded the real index yet.
+		// Never save 0 as it means that we didn't load the real index yet.
 		return
 	}
 
@@ -67,14 +67,13 @@ func UnsafeUpdateConsistentIndex(tx backend.BatchTx, index uint64, term uint64, 
 		if term < oldTerm {
 			return
 		}
-		if term == oldTerm && index <= oldi {
-			return
+		if index > oldi {
+			bs1 := make([]byte, 8)
+			binary.BigEndian.PutUint64(bs1, index)
+			// put the index into the underlying backend
+			// tx has been locked in TxnBegin, so there is no need to lock it again
+			tx.UnsafePut(Meta, MetaConsistentIndexKeyName, bs1)
 		}
-		bs1 := make([]byte, 8)
-		binary.BigEndian.PutUint64(bs1, index)
-		// put the index into the underlying backend
-		// tx has been locked in TxnBegin, so there is no need to lock it again
-		tx.UnsafePut(Meta, MetaConsistentIndexKeyName, bs1)
 		if term > 0 && term > oldTerm {
 			bs2 := make([]byte, 8)
 			binary.BigEndian.PutUint64(bs2, term)

--- a/server/storage/schema/cindex.go
+++ b/server/storage/schema/cindex.go
@@ -70,6 +70,17 @@ func UnsafeUpdateConsistentIndex(tx backend.BatchTx, index uint64, term uint64, 
 		if term == oldTerm && index <= oldi {
 			return
 		}
+		bs1 := make([]byte, 8)
+		binary.BigEndian.PutUint64(bs1, index)
+		// put the index into the underlying backend
+		// tx has been locked in TxnBegin, so there is no need to lock it again
+		tx.UnsafePut(Meta, MetaConsistentIndexKeyName, bs1)
+		if term > 0 && term > oldTerm {
+			bs2 := make([]byte, 8)
+			binary.BigEndian.PutUint64(bs2, term)
+			tx.UnsafePut(Meta, MetaTermKeyName, bs2)
+		}
+		return
 	}
 
 	bs1 := make([]byte, 8)


### PR DESCRIPTION
term won't change usually. Check term is change to avoid update `term`.