### PR TITLE
Golang Client docs: defer `cancel()`, avoid erroring

### DIFF
--- a/client/v3/doc.go
+++ b/client/v3/doc.go
@@ -47,8 +47,8 @@
 // To specify a client request timeout, wrap the context with context.WithTimeout:
 //
 //	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+//	defer cancel()
 //	resp, err := kvc.Put(ctx, "sample_key", "sample_value")
-//	cancel()
 //	if err != nil {
 //	    // handle error!
 //	}


### PR DESCRIPTION
In the sample code demonstrating how to specify a client request timeout, the `cancel()` is called immediately after the Put, but it should be deferred instead, giving the Put enough time to complete.

In the canonical Golang context [docs](https://pkg.go.dev/context#WithTimeout), the sample code sets a `defer cancel()` immediately after context creation, and with this commit we adhere to that convention.

fixes:
```json
{
  "level": "warn",
  "ts": "2021-12-29T09:56:42.439-0800",
  "logger": "etcd-client",
  "caller": "v3@v3.5.1/retry_interceptor.go:62",
  "msg": "retrying of unary invoker failed",
  "target": "etcd-endpoints://0xc000213340/localhost:2379",
  "attempt": 0,
  "error": "rpc error: code = Canceled desc = context canceled"
}
```

Personal note:

The lack of `defer` caused me to lose a few hours troubleshooting why my code wasn't succeeding. And although a seasoned developer might know to insert a `defer`, a humble novice like myself, used to cutting-and-pasting sample code, is nonplussed.

_Thanks for `etcd`!_

✅ Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
