### PR TITLE
Enhance lease keep-alive command for the case when the etcd server isn't reachable

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -46,6 +46,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Fix [etcd gateway doesn't format the endpoint of IPv6 address correctly](https://github.com/etcd-io/etcd/pull/13551)
 - Fix [A client can cause a nil dereference in etcd by passing an invalid SortTarget](https://github.com/etcd-io/etcd/pull/13555)
 - Fix [Grant lease with negative ID can possibly cause db out of sync](https://github.com/etcd-io/etcd/pull/13676)
+- Fix [Enhance `etcdctl lease keep-alive` command for the case when the etcd server isn't reachable](https://github.com/etcd-io/etcd/pull/13576)
 
 ### tools/benchmark
 

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -293,6 +293,10 @@ func runCtlTest(t *testing.T, testFunc func(ctlCtx), testOfflineFunc func(ctlCtx
 	}
 }
 
+func getCtlBinPath() string {
+	return e2e.CtlBinPath + "3"
+}
+
 func (cx *ctlCtx) prefixArgs(eps []string) []string {
 	fmap := make(map[string]string)
 	fmap["endpoints"] = strings.Join(eps, ",")
@@ -317,7 +321,7 @@ func (cx *ctlCtx) prefixArgs(eps []string) []string {
 
 	useEnv := cx.envMap != nil
 
-	cmdArgs := []string{e2e.CtlBinPath + "3"}
+	cmdArgs := []string{getCtlBinPath()}
 	for k, v := range fmap {
 		if useEnv {
 			ek := flags.FlagToEnv("ETCDCTL", k)


### PR DESCRIPTION
Fix [issues/13573](https://github.com/etcd-io/etcd/issues/13573).

Actually there are two issues here. 

The first issue is that the command something like `etcdctl lease keep-alive 32697e065bb41204 --once ` will be blocked forever when the etcd server isn't reachable. The reason is that the client side keeps waiting for the gRPC to be ready, Please see [options.go#L29](https://github.com/etcd-io/etcd/blob/69279532f46cb7491bb60a588be534100fdc058d/client/v3/options.go#L29). 

The second issue is just like the issue [issues/13573](https://github.com/etcd-io/etcd/issues/13573) raises. When the etcd server isn't reachable, the error message is something like "`lease 32697e065bb41204 expired or revoked`", which is really confusing. 

This PR is try to fix both above issues. 

@lilic  @yudai @heyitsanthony @serathius   

