### PR TITLE
Update supported versions and ref to the policy

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -3,7 +3,7 @@
 Previous change logs can be found at [CHANGELOG-3.2](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.2.md).
 
 
-The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, 3.4.2+, and 3.5.1+.
+The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.2+, and 3.5.1+. Refer to the [versioning policy](https://etcd.io/docs/v3.3/op-guide/versioning/) for more details.
 
 <hr>
 

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -3,7 +3,7 @@
 Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.3.md).
 
 
-The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, 3.4.2+, and 3.5.1+.
+The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.2+, and 3.5.1+. Refer to the [versioning policy](https://etcd.io/docs/v3.4/op-guide/versioning/) for more details.
 
 <hr>
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -3,8 +3,7 @@
 Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/etcd/blob/main/CHANGELOG-3.4.md).
 
 
-The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, 3.4.2+, and 3.5.1+.
-
+The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.2+, and 3.5.1+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
 
 <hr>
 


### PR DESCRIPTION
We support current release and two previous minor versions, and so
making changes accordingly. Also, adding link to the details of
the versioning.

cc @ptabor 
I was asked the question of supported versions by few folks recently, so adding more details on versioning policy in the etcd.io PR -https://github.com/etcd-io/website/pull/551