### PR TITLE
Correct the calculating of the mmapsize based on the value for --quota-backend-bytes

### DIFF
--- a/server/storage/backend.go
+++ b/server/storage/backend.go
@@ -46,7 +46,7 @@ func newBackend(cfg config.ServerConfig, hooks backend.Hooks) backend.Backend {
 	}
 	bcfg.BackendFreelistType = cfg.BackendFreelistType
 	bcfg.Logger = cfg.Logger
-	if cfg.QuotaBackendBytes > 0 && cfg.QuotaBackendBytes != DefaultQuotaBytes {
+	if cfg.QuotaBackendBytes > DefaultQuotaBytes {
 		// permit 10% excess over quota for disarm
 		bcfg.MmapSize = uint64(cfg.QuotaBackendBytes + cfg.QuotaBackendBytes/10)
 	}


### PR DESCRIPTION
Currently we permit the mmapsize to be 10% excess over quota for disarm, see [backend.go#L51](https://github.com/etcd-io/etcd/blob/96a9fd0a1e2a2887ebcf3b8eba90d8f0a881e77b/server/storage/backend.go#L51). The logic is OK. 

The default quota for the backend db size is 2GB, see [quota.go#L31](https://github.com/etcd-io/etcd/blob/96a9fd0a1e2a2887ebcf3b8eba90d8f0a881e77b/server/storage/quota.go#L31), but the default mmapsize is 10GB, see [backend.go#L41](https://github.com/etcd-io/etcd/blob/96a9fd0a1e2a2887ebcf3b8eba90d8f0a881e77b/server/storage/backend/backend.go#L41). I think it makes more sense to set it as (DefaultQuotaBytes + DefaultQuotaBytes/10). I was planning to make change something like below,

```
diff --git a/server/storage/backend/backend.go b/server/storage/backend/backend.go
index c75f443a4..5a6e3b0d8 100644
--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -16,6 +16,7 @@ package backend
 
 import (
        "fmt"
+       "go.etcd.io/etcd/server/v3/storage"
        "hash/crc32"
        "io"
        "os"
@@ -38,7 +39,7 @@ var (
        // initialMmapSize is the initial size of the mmapped region. Setting this larger than
        // the potential max db size can prevent writer from blocking reader.
        // This only works for linux.
-       initialMmapSize = uint64(10 * 1024 * 1024 * 1024)
+       initialMmapSize = uint64(storage.DefaultQuotaBytes + storage.DefaultQuotaBytes/10)

```

But above change introduces Circular reference. So I roll-backed the change, instead I removed the condition "cfg.QuotaBackendBytes != DefaultQuotaBytes" (please see the detailed change in this PR).  

cc @serathius  @heyitsanthony 