### PR TITLE
add OpenBackendTimeout for cluster admins to be able control db load …

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -34,6 +34,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [`etcd --log-format`](https://github.com/etcd-io/etcd/pull/13339) flag to support log format.
 - Add [`etcd --experimental-max-learners`](https://github.com/etcd-io/etcd/pull/13377) flag to allow configuration of learner max membership.
 - Add [`etcd --experimental-enable-lease-checkpoint-persist`](https://github.com/etcd-io/etcd/pull/13508) flag to handle upgrade from v3.5.2 clusters with this feature enabled.
+- Add [`etcd --open-backend-timeout`](https://github.com/etcd-io/etcd/pull/13586) flag to allow cluster administrator to control the timeout for the backend db file opening operation.
 - Fix [non mutating requests pass through quotaKVServer when NOSPACE](https://github.com/etcd-io/etcd/pull/13435)
 - Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13467).
 - Fix [Provide a better liveness probe for when etcd runs as a Kubernetes pod](https://github.com/etcd-io/etcd/pull/13399)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -110,6 +110,7 @@ type ServerConfig struct {
 	InitialElectionTickAdvance bool
 
 	BootstrapTimeout time.Duration
+	OpenBackendTimeout time.Duration
 
 	AutoCompactionRetention time.Duration
 	AutoCompactionMode      string

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -229,6 +229,10 @@ type Config struct {
 	// Deprecated in 3.5.
 	EnableV2 bool `json:"enable-v2"`
 
+	// OpenBackendTimeout is duration string with time unit
+	// (e.g. '5m' for 5-minute)
+	OpenBackendTimeout string `json:"open-backend-timeout"`
+
 	// AutoCompactionMode is either 'periodic' or 'revision'.
 	AutoCompactionMode string `json:"auto-compaction-mode"`
 	// AutoCompactionRetention is either duration string with time unit

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -194,7 +194,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TickMs:                                   cfg.TickMs,
 		ElectionTicks:                            cfg.ElectionTicks(),
 		InitialElectionTickAdvance:               cfg.InitialElectionTickAdvance,
-		OpenBackendTimeout:						  openBackendTimeout,
+		OpenBackendTimeout:                       openBackendTimeout,
 		AutoCompactionRetention:                  autoCompactionRetention,
 		AutoCompactionMode:                       cfg.AutoCompactionMode,
 		QuotaBackendBytes:                        cfg.QuotaBackendBytes,

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -155,7 +155,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		}
 	}
 
-	// OpenBackendTimeout defaults to "0" if not set.
+	// OpenBackendTimeout defaults to "10s" if not set.
 	if len(cfg.OpenBackendTimeout) == 0 {
 		cfg.OpenBackendTimeout = "10s"
 	}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -157,7 +157,11 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 
 	// OpenBackendTimeout defaults to "0" if not set.
 	if len(cfg.OpenBackendTimeout) == 0 {
-		cfg.OpenBackendTimeout = 10 * time.Second
+		cfg.OpenBackendTimeout = "10s"
+	}
+	openBackendTimeout, err := parseOpenBackendTimeout(cfg.OpenBackendTimeout)
+	if err != nil {
+		return e, err
 	}
 
 	// AutoCompactionRetention defaults to "0" if not set.
@@ -190,7 +194,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TickMs:                                   cfg.TickMs,
 		ElectionTicks:                            cfg.ElectionTicks(),
 		InitialElectionTickAdvance:               cfg.InitialElectionTickAdvance,
-		OpenBackendTimeout:						  cfg.OpenBackendTimeout,
+		OpenBackendTimeout:						  openBackendTimeout,
 		AutoCompactionRetention:                  autoCompactionRetention,
 		AutoCompactionMode:                       cfg.AutoCompactionMode,
 		QuotaBackendBytes:                        cfg.QuotaBackendBytes,
@@ -815,6 +819,14 @@ func parseCompactionRetention(mode, retention string) (ret time.Duration, err er
 		if err != nil {
 			return 0, fmt.Errorf("error parsing CompactionRetention: %v", err)
 		}
+	}
+	return ret, nil
+}
+
+func parseOpenBackendTimeout(retention string) (ret time.Duration, err error) {
+	ret, err = time.ParseDuration(retention)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing CompactionRetention: %v", err)
 	}
 	return ret, nil
 }

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -155,6 +155,11 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		}
 	}
 
+	// OpenBackendTimeout defaults to "0" if not set.
+	if len(cfg.OpenBackendTimeout) == 0 {
+		cfg.OpenBackendTimeout = 10 * time.Second
+	}
+
 	// AutoCompactionRetention defaults to "0" if not set.
 	if len(cfg.AutoCompactionRetention) == 0 {
 		cfg.AutoCompactionRetention = "0"
@@ -185,6 +190,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TickMs:                                   cfg.TickMs,
 		ElectionTicks:                            cfg.ElectionTicks(),
 		InitialElectionTickAdvance:               cfg.InitialElectionTickAdvance,
+		OpenBackendTimeout						  cfg.OpenBackendTimeout,
 		AutoCompactionRetention:                  autoCompactionRetention,
 		AutoCompactionMode:                       cfg.AutoCompactionMode,
 		QuotaBackendBytes:                        cfg.QuotaBackendBytes,
@@ -342,6 +348,7 @@ func print(lg *zap.Logger, ec Config, sc config.ServerConfig, memberInitialized 
 		zap.Bool("initial-corrupt-check", sc.InitialCorruptCheck),
 		zap.String("corrupt-check-time-interval", sc.CorruptCheckTime.String()),
 		zap.String("auto-compaction-mode", sc.AutoCompactionMode),
+		zap.Duration("open-backend-timeout", sc.OpenBackendTimeout),
 		zap.Duration("auto-compaction-retention", sc.AutoCompactionRetention),
 		zap.String("auto-compaction-interval", sc.AutoCompactionRetention.String()),
 		zap.String("discovery-url", sc.DiscoveryURL),

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -190,7 +190,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TickMs:                                   cfg.TickMs,
 		ElectionTicks:                            cfg.ElectionTicks(),
 		InitialElectionTickAdvance:               cfg.InitialElectionTickAdvance,
-		OpenBackendTimeout						  cfg.OpenBackendTimeout,
+		OpenBackendTimeout:						  cfg.OpenBackendTimeout,
 		AutoCompactionRetention:                  autoCompactionRetention,
 		AutoCompactionMode:                       cfg.AutoCompactionMode,
 		QuotaBackendBytes:                        cfg.QuotaBackendBytes,

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -255,7 +255,7 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.printVersion, "version", false, "Print the version and exit.")
 
 	// open backend db timeout
-	fs.StringVar(&cfg.ec.OpenBackendTimeout, "open-backend-timeout", "10s", "Time allowed to spend loading the backend db file.")
+	fs.StringVar(&cfg.ec.OpenBackendTimeout, "open-backend-timeout", "10s", "Time allowed to spend loading the backend db file at start.")
 
 	fs.StringVar(&cfg.ec.AutoCompactionRetention, "auto-compaction-retention", "0", "Auto compaction retention for mvcc key value store. 0 means disable auto compaction.")
 	fs.StringVar(&cfg.ec.AutoCompactionMode, "auto-compaction-mode", "periodic", "interpret 'auto-compaction-retention' one of: periodic|revision. 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. '5m'). 'revision' for revision number based retention.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -254,6 +254,9 @@ func newConfig() *config {
 	// version
 	fs.BoolVar(&cfg.printVersion, "version", false, "Print the version and exit.")
 
+	// open backend db timeout
+	fs.StringVar(&cfg.ec.OpenBackendTimeout, "open-backend-timeout", "10s", "Time allowed to spend loading the backend db file.")
+
 	fs.StringVar(&cfg.ec.AutoCompactionRetention, "auto-compaction-retention", "0", "Auto compaction retention for mvcc key value store. 0 means disable auto compaction.")
 	fs.StringVar(&cfg.ec.AutoCompactionMode, "auto-compaction-mode", "periodic", "interpret 'auto-compaction-retention' one of: periodic|revision. 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. '5m'). 'revision' for revision number based retention.")
 

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -119,6 +119,8 @@ Clustering:
     Reject reconfiguration requests that would cause quorum loss.
   --pre-vote 'true'
     Enable to run an additional Raft election phase.
+  --open-backend-timeout '10s'
+    Time allowed to spend loading the backend db file at start.
   --auto-compaction-retention '0'
     Auto compaction retention length. 0 means disable auto compaction.
   --auto-compaction-mode 'periodic'

--- a/server/storage/backend.go
+++ b/server/storage/backend.go
@@ -81,7 +81,7 @@ func OpenBackend(cfg config.ServerConfig, hooks backend.Hooks) backend.Backend {
 		cfg.Logger.Info("opened backend db", zap.String("path", fn), zap.Duration("took", time.Since(now)))
 		return be
 
-	case <-time.After(10 * time.Second):
+	case <-time.After(cfg.OpenBackendTimeout):
 		cfg.Logger.Info(
 			"db file is flocked by another process, or taking too long",
 			zap.String("path", fn),

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -683,6 +683,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 	m.InitialClusterToken = ClusterName
 	m.NewCluster = true
 	m.BootstrapTimeout = 10 * time.Millisecond
+	m.OpenBackendTimeout = 10 * time.Second
 	if m.PeerTLSInfo != nil {
 		m.ServerConfig.PeerTLSInfo = *m.PeerTLSInfo
 	}


### PR DESCRIPTION
Given that [optimisations exist](https://www.cncf.io/blog/2019/05/09/performance-optimization-of-etcd-in-web-scale-data-scenario/) to allow larger DB files to be as fast as the currently recommended ones, I have added a possibility for the cluster administrator to control the timeout for the backend db file opening operation.

Fixes https://github.com/etcd-io/etcd/issues/13557

PS. I am aware of the RAM consumption.