### PR TITLE
ctlv3: add forgotten member promote method to printerRPC

### DIFF
--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -110,6 +110,9 @@ func (p *printerRPC) MemberRemove(id uint64, r v3.MemberRemoveResponse) {
 func (p *printerRPC) MemberUpdate(id uint64, r v3.MemberUpdateResponse) {
 	p.p((*pb.MemberUpdateResponse)(&r))
 }
+func (p *printerRPC) MemberPromote(id uint64, r v3.MemberPromoteResponse) {
+	p.p((*pb.MemberPromoteResponse)(&r))
+}
 func (p *printerRPC) MemberList(r v3.MemberListResponse) { p.p((*pb.MemberListResponse)(&r)) }
 func (p *printerRPC) Alarm(r v3.AlarmResponse)           { p.p((*pb.AlarmResponse)(&r)) }
 func (p *printerRPC) MoveLeader(leader, target uint64, r v3.MoveLeaderResponse) {


### PR DESCRIPTION
The printerRPC struct was missing a MemberPromote method, leading to
panic in ectdctl when trying to print it as JSON. This PR fixes that panic.