### PR TITLE
server: fix nil-pointer in applierV3backend Range

### DIFF
--- a/server/etcdserver/apply.go
+++ b/server/etcdserver/apply.go
@@ -412,6 +412,9 @@ func (a *applierV3backend) Range(ctx context.Context, txn mvcc.TxnRead, r *pb.Ra
 		default:
 			lg.Panic("unexpected sort target", zap.Int32("sort-target", int32(r.SortTarget)))
 		}
+		if sorter == nil {
+			return nil, ErrSortTargetNotSuppoted
+		}
 		switch {
 		case sortOrder == pb.RangeRequest_ASCEND:
 			sort.Sort(sorter)

--- a/server/etcdserver/errors.go
+++ b/server/etcdserver/errors.go
@@ -41,6 +41,7 @@ var (
 	ErrBadLeaderTransferee         = errors.New("etcdserver: bad leader transferee")
 	ErrClusterVersionUnavailable   = errors.New("etcdserver: cluster version not found during downgrade")
 	ErrWrongDowngradeVersionFormat = errors.New("etcdserver: wrong downgrade target version format")
+	ErrSortTargetNotSuppoted       = errors.New("etcdserver: badrequest: SortTarget not supported")
 )
 
 type DiscoveryError struct {


### PR DESCRIPTION
`sort.Sort()` will throw a nil-dereference if its argument is `nil`. The nil-dereference will be triggered here: 
https://github.com/golang/go/blob/master/src/sort/sort.go#L230.

This PR adds a check to avoid a nil-deref.

OSS-fuzz report: https://oss-fuzz.com/testcase-detail/4666686108729344