### PR TITLE
raft: fix out-of-bounds in maybeAppend

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -95,6 +95,9 @@ func (l *raftLog) maybeAppend(index, logTerm, committed uint64, ents ...pb.Entry
 			l.logger.Panicf("entry %d conflict with committed entry [committed(%d)]", ci, l.committed)
 		default:
 			offset := index + 1
+			if ci-offset > uint64(len(ents)) {
+				l.logger.Panicf("index, %d, is out of range [%d]", ci-offset, len(ents))
+			}
 			l.append(ents[ci-offset:]...)
 		}
 		l.commitTo(min(committed, lastnewi))


### PR DESCRIPTION
Fixes an OOB in `maybeAppend`. 

The fix is to throw a `l.logger.Panicf` in similar fashion as [here](https://github.com/etcd-io/etcd/blob/b2f6ffdd81d710c22a7d2aed626e58439eb368d0/raft/log.go#L110-L112) and [here](https://github.com/etcd-io/etcd/blob/b2f6ffdd81d710c22a7d2aed626e58439eb368d0/raft/log.go#L236-L238).

OSS-fuzz issue: https://oss-fuzz.com/testcase-detail/6604212964818944