### PR TITLE
Use test.sh instead of test for linux-386-unit-1-cpu

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
             GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test.sh -p=2
             ;;
           linux-386-unit-1-cpu)
-            GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4
+            GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test.sh -p=4
             ;;
           *)
             echo "Failed to find target"


### PR DESCRIPTION
The test is deprecated, so we need to use test.sh instead. 