### PR TITLE
client: retry_interceptor.go: Log the method that failed

### DIFF
--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -54,6 +54,7 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 			c.GetLogger().Debug(
 				"retrying of unary invoker",
 				zap.String("target", cc.Target()),
+				zap.String("method", method),
 				zap.Uint("attempt", attempt),
 			)
 			lastErr = invoker(ctx, method, req, reply, cc, grpcOpts...)
@@ -63,6 +64,7 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 			c.GetLogger().Warn(
 				"retrying of unary invoker failed",
 				zap.String("target", cc.Target()),
+				zap.String("method", method),
 				zap.Uint("attempt", attempt),
 				zap.Error(lastErr),
 			)


### PR DESCRIPTION
When getting warnings from the retry_interceptors that RPCs failed, they provide very little context as to what exactly failed.

I used this patch to try debugging https://groups.google.com/g/etcd-dev/c/3hxxr9ktdpM.