### PR TITLE
Update maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,7 +9,6 @@
 # Please keep the list sorted.
 
 # MAINTAINERS
-Brandon Philips <brandon@ifup.org> (@philips) pkg:*
 Gyuho Lee <gyuhox@gmail.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ These emeritus maintainers dedicated a part of their career to etcd and reviewed
 
 * Fanmin Shi
 * Anthony Romano
+* Brandon Philips
 
 ### License
 


### PR DESCRIPTION
Move Brandon Philips to emeritus status. Thank you so much Brandon for the etcd and leadership!!!
cc @philips 
