### PR TITLE
tests: Move revision tests out of concurrency

### DIFF
--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package concurrency_test
+package integration_test
 
 import (
 	"context"


### PR DESCRIPTION
Tests in tests/integration/clientv3/concurrency are expect to use a global lazyCluster. Running revision tests lead to logs about leaking goroutines.


cc @ptabor 