### PR TITLE
Add Marek as a project maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -13,6 +13,7 @@ Gyuho Lee <gyuhox@gmail.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
 Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*
+Marek Siarkowicz <siarkowicz@google.com> (@serathius) pkg:*
 Piotr Tabor <ptab@google.com> (@ptabor) pkg:*
 Sahdev Zala <spzala@us.ibm.com> (@spzala) pkg:*
 Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
@@ -24,6 +25,5 @@ Tobias Grieger <tobias.schottdorf@gmail.com> (@tbg) pkg:go.etcd.io/etcd/raft
 
 # REVIEWERS
 Lili Cosic <cosiclili@gmail.com> (lilic@) pkg:*
-Marek Siarkowicz <siarkowicz@google.com> (serathius@) pkg:*
 Wilson Wang <wilson.wang@bytedance.com> (wilsonwang371@) pkg:*
 


### PR DESCRIPTION
Marek is one of the current reviewers. He has consistently performed all the tasks to earn a top-level maintainer role as described in the
https://github.com/etcd-io/etcd/blob/main/GOVERNANCE.md#maintainers
Per discussion with existing maintainers, I nominate him for the maintainer role.

@serathius thank you for your outstanding contributions to the project.

/cc @ptabor @gyuho @hexfusion @jpbetz @xiang90 @mitake @jingyih @wenjiaswe 

