### PR TITLE
etcdctl: delete redundant type conversion

### DIFF
--- a/etcdctl/ctlv2/command/exec_watch_command.go
+++ b/etcdctl/ctlv2/command/exec_watch_command.go
@@ -89,7 +89,7 @@ func execWatchCommandFunc(c *cli.Context, ki client.KeysAPI) {
 		os.Exit(0)
 	}()
 
-	w := ki.Watcher(key, &client.WatcherOptions{AfterIndex: uint64(index), Recursive: recursive})
+	w := ki.Watcher(key, &client.WatcherOptions{AfterIndex: index, Recursive: recursive})
 
 	for {
 		resp, err := w.Next(context.TODO())


### PR DESCRIPTION
Modify the index variable allocated to uint64 type so that it is not used by unnecessarily casting it to uint64 type.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
