### PR TITLE
tests: Parallelize grpcproxy tests

### DIFF
--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -7,7 +7,8 @@ jobs:
       fail-fast: true
       matrix:
         target:
-        - linux-amd64-grpcproxy
+        - linux-amd64-grpcproxy-integration
+        - linux-amd64-grpcproxy-e2e
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -19,8 +20,12 @@ jobs:
       run: |
         echo "${TARGET}"
         case "${TARGET}" in
-          linux-amd64-grpcproxy)
-            PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+          linux-amd64-grpcproxy-integration)
+            PASSES='build grpcproxy_integration'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
+            ! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
+            ;;
+          linux-amd64-grpcproxy-e2e)
+            PASSES='build grpcproxy_e2e'  CPU='4' COVER='false' RACE='true' ./test.sh 2>&1 | tee test.log
             ! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           *)

--- a/test.sh
+++ b/test.sh
@@ -189,7 +189,17 @@ function functional_pass {
 }
 
 function grpcproxy_pass {
-  run_for_module "tests" go_test "./integration/... ./e2e" "fail_fast" : \
+  run_pass "grpcproxy_integration" "${@}"
+  run_pass "grpcproxy_e2e" "${@}"
+}
+
+function grpcproxy_integration_pass {
+  run_for_module "tests" go_test "./integration/..." "fail_fast" : \
+      -timeout=30m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
+}
+
+function grpcproxy_e2e_pass {
+  run_for_module "tests" go_test "./e2e" "fail_fast" : \
       -timeout=30m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
 }
 


### PR DESCRIPTION
grpc tests take twice as much time as e2e and integration tests as they run both scenarios sequentially. This PR changes this to run them in parallel. 