### PR TITLE
contrib/mixin: Generate rules, fix tests

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -1,0 +1,11 @@
+name: Test contrib/mixin
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.17.6"
+    - run: make -C contrib/mixin tools test

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.test
 hack/tls-setup/certs
 .idea
+/contrib/mixin/manifests
 /contrib/raftexample/raftexample
 /contrib/raftexample/raftexample-*
 /vendor

--- a/contrib/mixin/Makefile
+++ b/contrib/mixin/Makefile
@@ -1,0 +1,23 @@
+.PHONY: tools manifests test clean
+
+OS := linux
+ARCH ?= amd64
+PROMETHEUS_VERSION := 2.33.1
+
+tools:
+	go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+	go install github.com/brancz/gojsontoyaml@latest
+	wget -qO- "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.${OS}-${ARCH}.tar.gz" |\
+	tar xvz --strip-components=1 -C "$$(go env GOPATH)/bin" prometheus-${PROMETHEUS_VERSION}.${OS}-${ARCH}/promtool
+
+manifests: manifests/etcd-prometheusRules.yaml
+
+manifests/etcd-prometheusRules.yaml:
+	mkdir -p manifests
+	jsonnet -e '(import "mixin.libsonnet").prometheusAlerts' | gojsontoyaml > manifests/etcd-prometheusRules.yaml
+
+test: manifests/etcd-prometheusRules.yaml
+	promtool test rules test.yaml
+
+clean:
+	rm -rf manifests/*.yaml

--- a/contrib/mixin/README.md
+++ b/contrib/mixin/README.md
@@ -12,11 +12,15 @@ Instructions for use are the same as the [kubernetes-mixin](https://github.com/k
 
 ## Testing alerts
 
-Make sure to have [jsonnet](https://jsonnet.org/) and [gojsontoyaml](https://github.com/brancz/gojsontoyaml) installed.
+Make sure to have [jsonnet](https://jsonnet.org/) and [gojsontoyaml](https://github.com/brancz/gojsontoyaml) installed. You can fetch it via
+
+```
+make tools
+```
 
 First compile the mixin to a YAML file, which the promtool will read:
 ```
-jsonnet -e '(import "mixin.libsonnet").prometheusAlerts' | gojsontoyaml > mixin.yaml
+make manifests
 ```
 
 Then run the unit test:

--- a/contrib/mixin/test.yaml
+++ b/contrib/mixin/test.yaml
@@ -1,5 +1,5 @@
 rule_files:
-  - mixin.yaml
+  - manifests/etcd-prometheusRules.yaml
 
 evaluation_interval: 1m
 
@@ -86,14 +86,15 @@ tests:
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (1).'
               summary: 'etcd cluster members are down.'
+
   - interval: 1m
     input_series:
       - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}'
         values: '0 0 2 0 0 1 0 0 0 0 0 0 0 0 0 0'
       - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}'
-        values: '0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0'
+        values: '0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0'
       - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}'
-        values: '0 0 0 0 0 0 0 0'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
     alert_rule_test:
       - eval_time: 10m
         alertname: etcdHighNumberOfLeaderChanges
@@ -111,25 +112,34 @@ tests:
       - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}'
         values: '0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0'
       - series: 'etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}'
-        values: '0 0 0 0 0 0 0 0'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
     alert_rule_test:
       - eval_time: 10m
         alertname: etcdHighNumberOfLeaderChanges
         exp_alerts:
+
   - interval: 1m
     input_series:
-      - series: '((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100){job="etcd",instance="10.10.10.0"}'
-        values: '0 10 20 0 0 10 0 0 30 0 0 0 0 0 0 0'
-      - series: '((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100){job="etcd",instance="10.10.10.1"}'
-        values: '0 0 10 0 20 0 0 0 0 0 0 0 0 0 0 0'
-      - series: '((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100){job="etcd",instance="10.10.10.2"}'
-        values: '0 0 0 0 0 0 0 0'
+      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}'
+        values: '0 1 2 0 0 1 0 3 0 0 0 0 0 0 0 0'
+      - series: 'etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.0"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.1"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.2"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'etcd_server_quota_backend_bytes{job="etcd",instance="10.10.10.2"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 11m
         alertname: etcdExcessiveDatabaseGrowth
         exp_alerts:
           - exp_labels:
+              instance: '10.10.10.0'
               job: etcd
               severity: warning
             exp_annotations:
-              message: 'etcd cluster "etcd": Observed surge in etcd writes leading to 50% increase in database size over the past four hours, please check as it might be disruptive.'
+              description: 'etcd cluster "etcd": Observed surge in etcd writes leading to 50% increase in database size over the past four hours on etcd instance 10.10.10.0, please check as it might be disruptive.'
+              summary: 'etcd cluster database growing very fast.'


### PR DESCRIPTION
Primary intent of this PR is to have a rendered rules file that we can include in kube-prometheus-stack.
Additionally I added the following pieces:
* Add Makefile
* Make tests runnable
* Add generated rule manifest file

After changing the time series (series only seems to support plain time series) in the test.yaml so the tests run, those two still fail:
```
promtool test rules test.yaml
Unit Testing:  test.yaml
  FAILED:
    alertname:etcdHighNumberOfLeaderChanges, time:10m, 
        exp:"[Labels:{alertname=\"etcdHighNumberOfLeaderChanges\", job=\"etcd\", severity=\"warning\"} Annotations:{description=\"etcd cluster \\\"etcd\\\": 4 leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.\", summary=\"etcd cluster has high number of leader changes.\"}]", 
        got:"[]"
    alertname:etcdExcessiveDatabaseGrowth, time:10m, 
        exp:"[Labels:{alertname=\"etcdExcessiveDatabaseGrowth\", job=\"etcd\", severity=\"warning\"} Annotations:{message=\"etcd cluster \\\"etcd\\\": Observed surge in etcd writes leading to 50% increase in database size over the past four hours, please check as it might be disruptive.\"}]", 
        got:"[]"

make: *** [Makefile:15: test] Error 1
```

Let me know if anyone has time to provide a fix (I tried to fix them, but for some reason my ideas didn't work).

@ptabor 
