### PR TITLE
tools: Add -wal-dir flag on etcd-dump-logs to make it compatible with -wal-dir configuration

### DIFF
--- a/tools/etcd-dump-logs/README.md
+++ b/tools/etcd-dump-logs/README.md
@@ -13,7 +13,9 @@ Usage:
                 - data_dir/member/wal/0000000000000000-0000000000000000.wal
 
 Flags:
-
+  -wal-dir string
+      If set, dumps WAL from the informed path, rather than following the
+      standard 'data_dir/member/wal/' location
   -entry-type string
     	If set, filters output by entry type. Must be one or more than one of:
 	    ConfigChange, Normal, Request, InternalRaftRequest,

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -45,6 +45,7 @@ const (
 
 func main() {
 	snapfile := flag.String("start-snap", "", "The base name of snapshot file to start dumping")
+	waldir := flag.String("wal-dir", "", "If set, dumps WAL from the informed path, rather than following the standard 'data_dir/member/wal/' location")
 	index := flag.Uint64("start-index", 0, "The index to start dumping")
 	// Default entry types are Normal and ConfigChange
 	entrytype := flag.String("entry-type", defaultEntryTypes, `If set, filters output by entry type. Must be one or more than one of:
@@ -103,7 +104,12 @@ and output a hex encoded line of binary for each input line`)
 		fmt.Println("Start dumping log entries from snapshot.")
 	}
 
-	w, err := wal.OpenForRead(zap.NewExample(), walDir(dataDir), walsnap)
+	wd := *waldir
+	if wd == "" {
+		wd = walDir(dataDir)
+	}
+
+	w, err := wal.OpenForRead(zap.NewExample(), wd, walsnap)
 	if err != nil {
 		log.Fatalf("Failed opening WAL: %v", err)
 	}


### PR DESCRIPTION
## What?
[etcd-dump-logs](https://github.com/Lz-Gustavo/etcd/tree/master/tools/etcd-dump-logs) expects the etcd data-dir filepath as an obligatory command argument. Considering ```foo``` as the informed path, the tool searches for WAL files on ```foo/member/wal```, and for snapshots on ```foo/member/snap```.

This PR simply adds a new flag on the tool, allowing the script to search for WALs on a different path rather than always fetching ```foo/member/wal```. The intention is to make the script compatible with [etcd's -wal-dir configuration](https://etcd.io/docs/v3.4/op-guide/configuration/#--wal-dir), which sets log entries to be written on a provided path. This path can be set outside of data-dir, allowing a dedicated disk to be used for WAL I/Os.

## Why?
I've faced this very same issue myself when trying to run dump-logs on a cluster previously configured with ```ETCD_WAL_DIR``` env. I've had my snapshots stored on ```ETCD_DATA_DIR/member/snap``` and WALs on ```/media/disk2/etcd/wal```, and thought that would be a better idea to have this kind of configuration on the tool than to move WAL files to ```ETCD_DATA_DIR/member/wal``` each time I had to execute it 😅 .

## Testing
1. start a fresh etcd cluster with -wal-dir configuration (e.g. ```export ETCD_WAL_DIR=/tmp/wal```)
2. commit a few entries
3. run etcd-dump-logs with the implemented flag:
  ```sh
  etcd-dump-logs --wal-dir /tmp/wal PATH_TO_DATA_DIR
  ```
4. WAL entries should now be parsed from ```/tmp/wal/0000000000000000-0000000000000000.wal```, instead of accusing a ```failed opening WAL: open {ETCD_DATA_DIR}/member/wal: no such file or directory``` error