### PR TITLE
server: Snapshot after cluster version downgrade

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -291,6 +291,9 @@ type EtcdServer struct {
 	clusterVersionChanged *notify.Notifier
 
 	*AccessController
+	// forceSnapshot can force snapshot be triggered after apply, independent of the snapshotCount.
+	// Should only be set within apply code path. Used to force snapshot after cluster version downgrade.
+	forceSnapshot bool
 }
 
 // NewServer creates a new EtcdServer from the supplied configuration. The
@@ -1079,10 +1082,9 @@ func (s *EtcdServer) applyEntries(ep *etcdProgress, apply *apply) {
 }
 
 func (s *EtcdServer) triggerSnapshot(ep *etcdProgress) {
-	if ep.appliedi-ep.snapi <= s.Cfg.SnapshotCount {
+	if !s.shouldSnapshot(ep) {
 		return
 	}
-
 	lg := s.Logger()
 	lg.Info(
 		"triggering snapshot",
@@ -1090,10 +1092,16 @@ func (s *EtcdServer) triggerSnapshot(ep *etcdProgress) {
 		zap.Uint64("local-member-applied-index", ep.appliedi),
 		zap.Uint64("local-member-snapshot-index", ep.snapi),
 		zap.Uint64("local-member-snapshot-count", s.Cfg.SnapshotCount),
+		zap.Bool("snapshot-forced", s.forceSnapshot),
 	)
+	s.forceSnapshot = false
 
 	s.snapshot(ep.appliedi, ep.confState)
 	ep.snapi = ep.appliedi
+}
+
+func (s *EtcdServer) shouldSnapshot(ep *etcdProgress) bool {
+	return (s.forceSnapshot && ep.appliedi != ep.snapi) || (ep.appliedi-ep.snapi > s.Cfg.SnapshotCount)
 }
 
 func (s *EtcdServer) hasMultipleVotingMembers() bool {

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -66,8 +65,6 @@ func startEtcd(t *testing.T, execPath, dataDirPath string) *e2e.EtcdProcessClust
 		ClusterSize:  1,
 		InitialToken: "new",
 		KeepDataDir:  true,
-		// TODO: REMOVE snapshot override when snapshotting is automated after lowering storage versiont l
-		SnapshotCount: 5,
 	})
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
@@ -75,16 +72,6 @@ func startEtcd(t *testing.T, execPath, dataDirPath string) *e2e.EtcdProcessClust
 	t.Cleanup(func() {
 		if errC := epc.Close(); errC != nil {
 			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
-	})
-
-	prefixArgs := []string{e2e.CtlBinPath, "--endpoints", strings.Join(epc.EndpointsV3(), ",")}
-	t.Log("Write keys to ensure wal snapshot is created so cluster version set is snapshotted")
-	e2e.ExecuteWithTimeout(t, 20*time.Second, func() {
-		for i := 0; i < 10; i++ {
-			if err := e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), "OK"); err != nil {
-				t.Fatal(err)
-			}
 		}
 	})
 	return epc


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/13168

Etcd downgrades rely on both cluster version and storage version being lowered lowered. After cluster version is lowered peer-to-peer communication should become backward compatible with older etcd. This is prerequisite to downgrade storage version as there will not be new incompatible entries added to WAL. However WAL can still include older incompatible entries that make downgrading storage version impossible. To remove those entries we need to wait for snapshot. Waiting for automatic snapshot would take us too long (every 10000 proposals), so I propose to snapshot imminently after cluster version is lowered.

There is no internal Raft request for asking every cluster member to snapshot, so we do it in raft apply step. 
Not the cleanest implementation, however I didn't find a reasonable way to send a signal from applier to apply function.

cc @ptabor @ahrtr @spzala 