### PR TITLE
tests: Fix cluster version and downgrade request timeout

### DIFF
--- a/server/etcdserver/apply.go
+++ b/server/etcdserver/apply.go
@@ -148,15 +148,15 @@ func (a *applierV3backend) Apply(r *pb.InternalRaftRequest, shouldApplyV3 member
 	case r.ClusterVersionSet != nil: // Implemented in 3.5.x
 		op = "ClusterVersionSet"
 		a.s.applyV3Internal.ClusterVersionSet(r.ClusterVersionSet, shouldApplyV3)
-		return nil
+		return ar
 	case r.ClusterMemberAttrSet != nil:
 		op = "ClusterMemberAttrSet" // Implemented in 3.5.x
 		a.s.applyV3Internal.ClusterMemberAttrSet(r.ClusterMemberAttrSet, shouldApplyV3)
-		return nil
+		return ar
 	case r.DowngradeInfoSet != nil:
 		op = "DowngradeInfoSet" // Implemented in 3.5.x
 		a.s.applyV3Internal.DowngradeInfoSet(r.DowngradeInfoSet, shouldApplyV3)
-		return nil
+		return ar
 	}
 
 	if !shouldApplyV3 {

--- a/server/etcdserver/version/version.go
+++ b/server/etcdserver/version/version.go
@@ -64,7 +64,7 @@ func (m *Manager) DowngradeEnable(ctx context.Context, targetVersion *semver.Ver
 	if err != nil {
 		return err
 	}
-	return m.s.DowngradeEnable(context.Background(), targetVersion)
+	return m.s.DowngradeEnable(ctx, targetVersion)
 }
 
 // DowngradeCancel cancels ongoing downgrade process.


### PR DESCRIPTION
Returning nil means that raft.Trigger was not called, causing member to
wait infinitly for response for response on raft request.

cc @ptabor @ahrtr @spzala 