### PR TITLE
Create common framework for e2e and integration tests and migrate TestKVPut test

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -107,14 +107,15 @@ function integration_extra {
 }
 
 function integration_pass {
-  local pkgs=${USERPKG:-"./integration/..."}
-  run_for_module "tests" go_test "${pkgs}" "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
+  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
+  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
   integration_extra "$@"
 }
 
 function e2e_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
   run_for_module "tests" go_test "./e2e/..." "keep_going" : -timeout="${TIMEOUT:-30m}" "${RUN_ARG[@]}" "$@"
+  run_for_module "tests" go_test "./common/..." "keep_going" : --tags=e2e -timeout="${TIMEOUT:-30m}" "${RUN_ARG[@]}" "$@"
 }
 
 function integration_e2e_pass {

--- a/tests/common/e2e_test.go
+++ b/tests/common/e2e_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package common
+
+import "go.etcd.io/etcd/tests/v3/framework"
+
+func init() {
+	testFramework = framework.RunE2eTests
+}

--- a/tests/common/e2e_test.go
+++ b/tests/common/e2e_test.go
@@ -20,5 +20,5 @@ package common
 import "go.etcd.io/etcd/tests/v3/framework"
 
 func init() {
-	testFramework = framework.RunE2eTests
+	testRunner = framework.E2eTestRunner
 }

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -22,5 +22,5 @@ import (
 )
 
 func init() {
-	testFramework = framework.RunIntegrationTests
+	testRunner = framework.IntegrationTestRunner
 }

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+// +build integration
+
+package common
+
+import (
+	"go.etcd.io/etcd/tests/v3/framework"
+)
+
+func init() {
+	testFramework = framework.RunIntegrationTests
+}

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func TestKVPut(t *testing.T) {
-	testFramework.BeforeTest(t)
-	clus := testFramework.NewCluster(t)
+	testRunner.BeforeTest(t)
+	clus := testRunner.NewCluster(t)
 	defer clus.Close()
 	cc := clus.Client()
 

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+func TestKVPut(t *testing.T) {
+	testFramework.BeforeTest(t)
+	clus := testFramework.NewCluster(t)
+	defer clus.Close()
+	cc := clus.Client()
+
+	testutils.ExecuteWithTimeout(t, 10*time.Second, func() {
+		key, value := "foo", "bar"
+
+		if err := cc.Put(key, value); err != nil {
+			t.Fatalf("count not put key %q, err: %s", key, err)
+		}
+		resp, err := cc.Get(key, testutils.WithSerializable())
+		if err != nil {
+			t.Fatalf("count not get key %q, err: %s", key, err)
+		}
+		if len(resp.Kvs) != 1 {
+			t.Errorf("Unexpected lenth of response, got %d", len(resp.Kvs))
+		}
+		if string(resp.Kvs[0].Key) != key {
+			t.Errorf("Unexpected key, want %q, got %q", key, resp.Kvs[0].Key)
+		}
+		if string(resp.Kvs[0].Value) != value {
+			t.Errorf("Unexpected value, want %q, got %q", value, resp.Kvs[0].Value)
+		}
+	})
+}

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -20,8 +20,8 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework"
 )
 
-var testFramework = framework.TestFramework
+var testRunner = framework.UnitTestRunner
 
 func TestMain(m *testing.M) {
-	testFramework.TestMain(m)
+	testRunner.TestMain(m)
 }

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"go.etcd.io/etcd/tests/v3/framework"
+)
+
+var testFramework = framework.TestFramework
+
+func TestMain(m *testing.M) {
+	testFramework.TestMain(m)
+}

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -23,6 +23,7 @@ import (
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
 func TestDowngradeUpgrade(t *testing.T) {
@@ -78,7 +79,7 @@ func startEtcd(t *testing.T, execPath, dataDirPath string) *e2e.EtcdProcessClust
 func downgradeEnable(t *testing.T, epc *e2e.EtcdProcessCluster, ver semver.Version) {
 	t.Log("etcdctl downgrade...")
 	c := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
-	e2e.ExecuteWithTimeout(t, 20*time.Second, func() {
+	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
 		err := c.DowngradeEnable(ver.String())
 		if err != nil {
 			t.Fatal(err)
@@ -96,7 +97,7 @@ func stopEtcd(t *testing.T, epc *e2e.EtcdProcessCluster) {
 func validateVersion(t *testing.T, epc *e2e.EtcdProcessCluster, expect version.Versions) {
 	t.Log("Validate version")
 	// Two separate calls to expect as it doesn't support multiple matches on the same line
-	e2e.ExecuteWithTimeout(t, 20*time.Second, func() {
+	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
 		if expect.Server != "" {
 			err := e2e.SpawnWithExpects(e2e.CURLPrefixArgs(epc, "GET", e2e.CURLReq{Endpoint: "/version"}), nil, `"etcdserver":"`+expect.Server)
 			if err != nil {
@@ -114,7 +115,7 @@ func validateVersion(t *testing.T, epc *e2e.EtcdProcessCluster, expect version.V
 
 func expectLog(t *testing.T, epc *e2e.EtcdProcessCluster, expectLog string) {
 	t.Helper()
-	e2e.ExecuteWithTimeout(t, 30*time.Second, func() {
+	testutils.ExecuteWithTimeout(t, 30*time.Second, func() {
 		_, err := epc.Procs[0].Logs().Expect(expectLog)
 		if err != nil {
 			t.Fatal(err)

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
 func TestAuthority(t *testing.T) {
@@ -104,7 +105,7 @@ func TestAuthority(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				e2e.ExecuteWithTimeout(t, 5*time.Second, func() {
+				testutils.ExecuteWithTimeout(t, 5*time.Second, func() {
 					assertAuthority(t, fmt.Sprintf(tc.expectAuthorityPattern, 20000), epc)
 				})
 			})

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -18,12 +18,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestCtlV3Put(t *testing.T)          { testCtl(t, putTest, withDialTimeout(7*time.Second)) }
 func TestCtlV3PutNoTLS(t *testing.T)     { testCtl(t, putTest, withCfg(*e2e.NewConfigNoTLS())) }
 func TestCtlV3PutClientTLS(t *testing.T) { testCtl(t, putTest, withCfg(*e2e.NewConfigClientTLS())) }
 func TestCtlV3PutClientAutoTLS(t *testing.T) {

--- a/tests/framework/default.go
+++ b/tests/framework/default.go
@@ -1,0 +1,44 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
+)
+
+type noFrameworkSelected struct{}
+
+var _ testFramework = (*noFrameworkSelected)(nil)
+
+func (e noFrameworkSelected) TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Short() {
+		fmt.Println(`No test mode selected, please selected either e2e mode with "--tags e2e" or integration mode with "--tags integration"`)
+		os.Exit(1)
+	}
+}
+
+func (e noFrameworkSelected) BeforeTest(t testing.TB) {
+	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
+}
+
+func (e noFrameworkSelected) NewCluster(t testing.TB) Cluster {
+	return nil
+}

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -24,9 +24,9 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-type e2eFramework struct{}
+type e2eRunner struct{}
 
-func (e e2eFramework) TestMain(m *testing.M) {
+func (e e2eRunner) TestMain(m *testing.M) {
 	e2e.InitFlags()
 	v := m.Run()
 	if v == 0 && testutil.CheckLeakedGoroutine() {
@@ -35,11 +35,11 @@ func (e e2eFramework) TestMain(m *testing.M) {
 	os.Exit(v)
 }
 
-func (e e2eFramework) BeforeTest(t testing.TB) {
+func (e e2eRunner) BeforeTest(t testing.TB) {
 	e2e.BeforeTest(t)
 }
 
-func (e e2eFramework) NewCluster(t testing.TB) Cluster {
+func (e e2eRunner) NewCluster(t testing.TB) Cluster {
 	epc, err := e2e.NewEtcdProcessCluster(t, e2e.ConfigStandalone(*e2e.NewConfigAutoTLS()))
 	if err != nil {
 		t.Fatalf("could not start etcd integrationCluster: %s", err)

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"os"
+	"testing"
+
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+type e2eFramework struct{}
+
+func (e e2eFramework) TestMain(m *testing.M) {
+	e2e.InitFlags()
+	v := m.Run()
+	if v == 0 && testutil.CheckLeakedGoroutine() {
+		os.Exit(1)
+	}
+	os.Exit(v)
+}
+
+func (e e2eFramework) BeforeTest(t testing.TB) {
+	e2e.BeforeTest(t)
+}
+
+func (e e2eFramework) NewCluster(t testing.TB) Cluster {
+	epc, err := e2e.NewEtcdProcessCluster(t, e2e.ConfigStandalone(*e2e.NewConfigAutoTLS()))
+	if err != nil {
+		t.Fatalf("could not start etcd integrationCluster: %s", err)
+	}
+	return &e2eCluster{*epc}
+}
+
+type e2eCluster struct {
+	e2e.EtcdProcessCluster
+}
+
+func (c *e2eCluster) Client() Client {
+	return e2eClient{e2e.NewEtcdctl(c.Cfg, c.EndpointsV3())}
+}
+
+type e2eClient struct {
+	*e2e.EtcdctlV3
+}
+
+func (c e2eClient) Get(key string, opts ...testutils.GetOption) (*clientv3.GetResponse, error) {
+	o := testutils.GetOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return c.EtcdctlV3.Get(key, o.Serializable)
+}

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -64,5 +64,5 @@ func (c e2eClient) Get(key string, opts ...testutils.GetOption) (*clientv3.GetRe
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return c.EtcdctlV3.Get(key, o.Serializable)
+	return c.EtcdctlV3.Get(key, o)
 }

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -15,31 +15,52 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-type etcdctlV3 struct {
+type EtcdctlV3 struct {
 	cfg       *EtcdProcessClusterConfig
 	endpoints []string
 }
 
-func NewEtcdctl(cfg *EtcdProcessClusterConfig, endpoints []string) *etcdctlV3 {
-	return &etcdctlV3{
+func NewEtcdctl(cfg *EtcdProcessClusterConfig, endpoints []string) *EtcdctlV3 {
+	return &EtcdctlV3{
 		cfg:       cfg,
 		endpoints: endpoints,
 	}
 }
 
-func (ctl *etcdctlV3) Put(key, value string) error {
-	return SpawnWithExpect(ctl.cmdArgs("put", key, value), "OK")
-}
-
-func (ctl *etcdctlV3) DowngradeEnable(version string) error {
+func (ctl *EtcdctlV3) DowngradeEnable(version string) error {
 	return SpawnWithExpect(ctl.cmdArgs("downgrade", "enable", version), "Downgrade enable success")
 }
 
-func (ctl *etcdctlV3) cmdArgs(args ...string) []string {
+func (ctl *EtcdctlV3) Get(key string, serializable bool) (*clientv3.GetResponse, error) {
+	args := ctl.cmdArgs()
+	if serializable {
+		args = append(args, "--consistency", "s")
+	}
+	cmd, err := SpawnCmd(append(args, "get", key, "-w", "json"), nil)
+	if err != nil {
+		return nil, err
+	}
+	line, err := cmd.Expect("kvs")
+	if err != nil {
+		return nil, err
+	}
+	var resp clientv3.GetResponse
+	err = json.Unmarshal([]byte(line), &resp)
+	return &resp, err
+}
+
+func (ctl *EtcdctlV3) Put(key, value string) error {
+	return SpawnWithExpect(ctl.cmdArgs("put", key, value), "OK")
+}
+
+func (ctl *EtcdctlV3) cmdArgs(args ...string) []string {
 	cmdArgs := []string{CtlBinPath + "3"}
 	for k, v := range ctl.flags() {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--%s=%s", k, v))
@@ -47,7 +68,7 @@ func (ctl *etcdctlV3) cmdArgs(args ...string) []string {
 	return append(cmdArgs, args...)
 }
 
-func (ctl *etcdctlV3) flags() map[string]string {
+func (ctl *EtcdctlV3) flags() map[string]string {
 	fmap := make(map[string]string)
 	if ctl.cfg.ClientTLS == ClientTLS {
 		if ctl.cfg.IsClientAutoTLS {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
 type EtcdctlV3 struct {
@@ -38,9 +39,9 @@ func (ctl *EtcdctlV3) DowngradeEnable(version string) error {
 	return SpawnWithExpect(ctl.cmdArgs("downgrade", "enable", version), "Downgrade enable success")
 }
 
-func (ctl *EtcdctlV3) Get(key string, serializable bool) (*clientv3.GetResponse, error) {
+func (ctl *EtcdctlV3) Get(key string, o testutils.GetOptions) (*clientv3.GetResponse, error) {
 	args := ctl.cmdArgs()
-	if serializable {
+	if o.Serializable {
 		args = append(args, "--consistency", "s")
 	}
 	cmd, err := SpawnCmd(append(args, "get", key, "-w", "json"), nil)

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -119,20 +119,6 @@ func SkipInShortMode(t testing.TB) {
 	testutil.SkipTestIfShortMode(t, "e2e tests are not running in --short mode")
 }
 
-func ExecuteWithTimeout(t *testing.T, timeout time.Duration, f func()) {
-	donec := make(chan struct{})
-	go func() {
-		defer close(donec)
-		f()
-	}()
-
-	select {
-	case <-time.After(timeout):
-		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
-	case <-donec:
-	}
-}
-
 func mergeEnvVariables(envVars map[string]string) []string {
 	var env []string
 	// Environment variables are passed as parameter have higher priority

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -15,7 +15,10 @@
 package framework
 
 var (
-	TestFramework       testFramework = noFrameworkSelected{}
-	RunE2eTests         testFramework = e2eFramework{}
-	RunIntegrationTests testFramework = integrationFramework{}
+	// UnitTestRunner only runs in `--short` mode, will fail otherwise. Attempts in cluster creation will result in tests being skipped.
+	UnitTestRunner testRunner = unitRunner{}
+	// E2eTestRunner runs etcd and etcdctl binaries in a separate process.
+	E2eTestRunner = e2eRunner{}
+	// IntegrationTestRunner runs etcdserver.EtcdServer in separate goroutine and uses client libraries to communicate.
+	IntegrationTestRunner = integrationRunner{}
 )

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+var (
+	TestFramework       testFramework = noFrameworkSelected{}
+	RunE2eTests         testFramework = e2eFramework{}
+	RunIntegrationTests testFramework = integrationFramework{}
+)

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/integration"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+type integrationFramework struct{}
+
+func (e integrationFramework) TestMain(m *testing.M) {
+	testutil.MustTestMainWithLeakDetection(m)
+}
+
+func (e integrationFramework) BeforeTest(t testing.TB) {
+	integration.BeforeTest(t)
+}
+
+func (e integrationFramework) NewCluster(t testing.TB) Cluster {
+	return &integrationCluster{
+		Cluster: integration.NewCluster(t, &integration.ClusterConfig{Size: 1}),
+		t:       t,
+	}
+}
+
+type integrationCluster struct {
+	*integration.Cluster
+	t testing.TB
+}
+
+func (c *integrationCluster) Close() error {
+	c.Terminate(c.t)
+	return nil
+}
+
+func (c *integrationCluster) Client() Client {
+	cc, err := c.ClusterClient()
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	return &integrationClient{cc}
+}
+
+type integrationClient struct {
+	*clientv3.Client
+}
+
+func (c integrationClient) Get(key string, opts ...testutils.GetOption) (*clientv3.GetResponse, error) {
+	o := testutils.GetOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	clientOpts := []clientv3.OpOption{}
+	if o.Serializable {
+		clientOpts = append(clientOpts, clientv3.WithSerializable())
+	}
+	return c.Client.Get(context.Background(), key, clientOpts...)
+}
+
+func (c integrationClient) Put(key, value string) error {
+	_, err := c.Client.Put(context.Background(), key, value)
+	return err
+}

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -24,17 +24,17 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-type integrationFramework struct{}
+type integrationRunner struct{}
 
-func (e integrationFramework) TestMain(m *testing.M) {
+func (e integrationRunner) TestMain(m *testing.M) {
 	testutil.MustTestMainWithLeakDetection(m)
 }
 
-func (e integrationFramework) BeforeTest(t testing.TB) {
+func (e integrationRunner) BeforeTest(t testing.TB) {
 	integration.BeforeTest(t)
 }
 
-func (e integrationFramework) NewCluster(t testing.TB) Cluster {
+func (e integrationRunner) NewCluster(t testing.TB) Cluster {
 	return &integrationCluster{
 		Cluster: integration.NewCluster(t, &integration.ClusterConfig{Size: 1}),
 		t:       t,

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"testing"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+type testFramework interface {
+	TestMain(m *testing.M)
+	BeforeTest(testing.TB)
+	NewCluster(testing.TB) Cluster
+}
+
+type Cluster interface {
+	Close() error
+	Client() Client
+}
+
+type Client interface {
+	Put(key, value string) error
+	Get(key string, opts ...testutils.GetOption) (*clientv3.GetResponse, error)
+}

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -21,7 +21,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-type testFramework interface {
+type testRunner interface {
 	TestMain(m *testing.M)
 	BeforeTest(testing.TB)
 	NewCluster(testing.TB) Cluster

--- a/tests/framework/testutils/options.go
+++ b/tests/framework/testutils/options.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+type GetOptions struct {
+	Serializable bool
+}
+
+type GetOption func(*GetOptions)
+
+func WithSerializable() GetOption {
+	return func(options *GetOptions) {
+		options.Serializable = true
+	}
+}

--- a/tests/framework/testutils/util.go
+++ b/tests/framework/testutils/util.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
+)
+
+func ExecuteWithTimeout(t *testing.T, timeout time.Duration, f func()) {
+	donec := make(chan struct{})
+	go func() {
+		defer close(donec)
+		f()
+	}()
+
+	select {
+	case <-time.After(timeout):
+		testutil.FatalStack(t, fmt.Sprintf("test timed out after %v", timeout))
+	case <-donec:
+	}
+}

--- a/tests/framework/unit.go
+++ b/tests/framework/unit.go
@@ -23,11 +23,11 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
-type noFrameworkSelected struct{}
+type unitRunner struct{}
 
-var _ testFramework = (*noFrameworkSelected)(nil)
+var _ testRunner = (*unitRunner)(nil)
 
-func (e noFrameworkSelected) TestMain(m *testing.M) {
+func (e unitRunner) TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Short() {
 		fmt.Println(`No test mode selected, please selected either e2e mode with "--tags e2e" or integration mode with "--tags integration"`)
@@ -35,10 +35,10 @@ func (e noFrameworkSelected) TestMain(m *testing.M) {
 	}
 }
 
-func (e noFrameworkSelected) BeforeTest(t testing.TB) {
-	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
+func (e unitRunner) BeforeTest(t testing.TB) {
 }
 
-func (e noFrameworkSelected) NewCluster(t testing.TB) Cluster {
+func (e unitRunner) NewCluster(t testing.TB) Cluster {
+	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
 	return nil
 }


### PR DESCRIPTION
Context https://github.com/etcd-io/etcd/issues/13637

After trying different approaches, I decided to go with picking single test and migrating them one by one. 

cc @ahrtr @spzala @ptabor 