### PR TITLE
Trim the suffix dot from the srv.Target for etcd-client DNS lookup

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -16,6 +16,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13133).
 - When print endpoint status, [show db size in use](https://github.com/etcd-io/etcd/pull/13639)
+- [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13712) in SRV records returned by DNS lookup.
 
 ### etcdutl v3
 

--- a/client/pkg/srv/srv.go
+++ b/client/pkg/srv/srv.go
@@ -106,9 +106,10 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 			return err
 		}
 		for _, srv := range addrs {
+			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(shortHost, fmt.Sprintf("%d", srv.Port)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -226,8 +226,8 @@ func TestSRVDiscover(t *testing.T) {
 		},
 		{
 			[]*net.SRV{
-				{Target: "a.example.com", Port: 2480},
-				{Target: "b.example.com", Port: 2480},
+				{Target: "a.example.com.", Port: 2480},
+				{Target: "b.example.com.", Port: 2480},
 				{Target: "c.example.com", Port: 2480},
 			},
 			[]*net.SRV{},


### PR DESCRIPTION
Usually the SRV records returned by DNS lookup have a trailing dot but URL shouldn't, so we should trim the suffix dot.  We have already trimmed the suffix dot when bootstrapping etcd server ( see [srv.go#L72](https://github.com/etcd-io/etcd/blob/e814f6f78a1213a344038447cd1e48949327b36c/client/pkg/srv/srv.go#L72) ), but not for etcd client.  

cc @serathius @spzala @ptabor 

