### PR TITLE
mvcc/backend: restore original bolt db options after defrag

### DIFF
--- a/mvcc/backend/backend_test.go
+++ b/mvcc/backend/backend_test.go
@@ -120,7 +120,16 @@ func TestBackendBatchIntervalCommit(t *testing.T) {
 }
 
 func TestBackendDefrag(t *testing.T) {
-	b, tmpPath := NewDefaultTmpBackend()
+	bcfg := DefaultBackendConfig()
+	// Make sure we change BackendFreelistType
+	// The goal is to verify that we restore config option after defrag.
+	if bcfg.BackendFreelistType == bolt.FreelistMapType {
+		bcfg.BackendFreelistType = bolt.FreelistArrayType
+	} else {
+		bcfg.BackendFreelistType = bolt.FreelistMapType
+	}
+
+	b, tmpPath := NewTmpBackendFromCfg(bcfg)
 	defer cleanup(b, tmpPath)
 
 	tx := b.BatchTx()
@@ -165,6 +174,10 @@ func TestBackendDefrag(t *testing.T) {
 	nsize := b.Size()
 	if nsize >= size {
 		t.Errorf("new size = %v, want < %d", nsize, size)
+	}
+
+	if b.db.FreelistType != bcfg.BackendFreelistType {
+		t.Errorf("db FreelistType = [%v], want [%v]", b.db.FreelistType, bcfg.BackendFreelistType)
 	}
 
 	// try put more keys after shrink.


### PR DESCRIPTION
Problem: Defrag was implemented before custom bolt options were added.
Currently defrag doesn't restore backend options.
For example BackendFreelistType will be unset after defrag.

Solution: save bolt db options and use them in defrag.


fixes https://github.com/etcd-io/etcd/issues/13678 for release-3.4
