### PR TITLE
[3.5] Trim the suffix dot from the srv.Target for etcd-client DNS lookup

### DIFF
--- a/client/pkg/srv/srv.go
+++ b/client/pkg/srv/srv.go
@@ -106,9 +106,10 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 			return err
 		}
 		for _, srv := range addrs {
+			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(shortHost, fmt.Sprintf("%d", srv.Port)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -226,8 +226,8 @@ func TestSRVDiscover(t *testing.T) {
 		},
 		{
 			[]*net.SRV{
-				{Target: "a.example.com", Port: 2480},
-				{Target: "b.example.com", Port: 2480},
+				{Target: "a.example.com.", Port: 2480},
+				{Target: "b.example.com.", Port: 2480},
 				{Target: "c.example.com", Port: 2480},
 			},
 			[]*net.SRV{},


### PR DESCRIPTION
Back port the PR [13712](https://github.com/etcd-io/etcd/pull/13712) to 3.5

Usually the SRV records returned by DNS lookup have a trailing dot but URL shouldn't, so we should trim the suffix dot. We have already trimmed the suffix dot when bootstrapping etcd server ( see [srv.go#L72](https://github.com/etcd-io/etcd/blob/e814f6f78a1213a344038447cd1e48949327b36c/client/pkg/srv/srv.go#L72) ), but not for etcd client.

cc @serathius @spzala @ptabor