### PR TITLE
Update changelog for both 3.5 and 3.6 for the PRs of trimming the suffix dot from target in SRV record

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,12 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.2+, and 3.5.2+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
 
 <hr>
+## v3.5.3 (TBD)
+
+### package `client/pkg/v3`
+- [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13714) in SRV records returned by DNS lookup
+
+<hr>
 
 ## [v3.5.2](https://github.com/etcd-io/etcd/releases/tag/v3.5.2) (2022-02-01)
 

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -16,12 +16,14 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13133).
 - When print endpoint status, [show db size in use](https://github.com/etcd-io/etcd/pull/13639)
-- [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13712) in SRV records returned by DNS lookup.
 
 ### etcdutl v3
 
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13142).
 - Add `migrate` command for downgrading/upgrading etcd data dir files.
+
+### package `client/pkg/v3`
+- [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13712) in SRV records returned by DNS lookup
 
 ### Package `server`
 


### PR DESCRIPTION
Update 3.5 changelog for PR [pull/13714](https://github.com/etcd-io/etcd/pull/13714).

Previous [changelog for 3.6 ](https://github.com/etcd-io/etcd/pull/13712)isn't accurate, so updated it as well in this PR. 

A couple of generic/minor questions and comments:
1. All CHANGELOG files are only in the main branch. Does it mean that we need to remove the files from a newly cut release ranch? For example, when we cut release-3.6, then we need to remove all the CHANGELOG files from the branch release-3.6?  
2. Each time when contributors backpot a fix to a previous version, then they need to submit a separate PR to update the CHANGELOG, because which exists only in the main branch. Obviously it's a little inconvenience. 
3. I see some CHANGELOG items have a dot at the end, but some haven't. I think we need to follow the same rule. Just as I mentioned previously in another PR. If it's a complete sentence, then a dot is needed at the end, for example 

```
etcd will no longer start on data dir created by newer versions (for example etcd v3.6 will not run on v3.7+ data dir). To downgrade data dir please check out `etcdutl migrate` command.
```

Otherwise, no need, for example,
``` 
Fix non mutating requests pass through quotaKVServer when NOSPACE  
```

cc @serathius @spzala @ptabor 
