### PR TITLE
Update 3.5 changelog to cover the PR of always printing raft_term in decimal

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -13,7 +13,12 @@ The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.
 - Fix [Provide a better liveness probe for when etcd runs as a Kubernetes pod](https://github.com/etcd-io/etcd/pull/13706)
 
 ### package `client/pkg/v3`
+
 - [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13714) in SRV records returned by DNS lookup
+
+### etcdctl v3
+
+- [Always print the raft_term in decimal](https://github.com/etcd-io/etcd/pull/13727) when displaying member list in json.
 
 <hr>
 


### PR DESCRIPTION
Update 3.5 changelog to cover the PR [pull/13727](https://github.com/etcd-io/etcd/pull/13727)

cc @serathius @spzala 