### PR TITLE
Change v3 discovery url to endpoints so as to support failover

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -37,10 +37,9 @@ import (
 type ServerConfig struct {
 	Name string
 
-	EnableV2Discovery bool
-	DiscoveryURL      string
-	DiscoveryProxy    string
-	DiscoveryCfg      v3discovery.DiscoveryConfig
+	DiscoveryURL   string
+	DiscoveryProxy string
+	DiscoveryCfg   v3discovery.DiscoveryConfig
 
 	ClientURLs types.URLs
 	PeerURLs   types.URLs
@@ -309,7 +308,9 @@ func (c *ServerConfig) WALDir() string {
 
 func (c *ServerConfig) SnapDir() string { return filepath.Join(c.MemberDir(), "snap") }
 
-func (c *ServerConfig) ShouldDiscover() bool { return c.DiscoveryURL != "" }
+func (c *ServerConfig) ShouldDiscover() bool {
+	return c.DiscoveryURL != "" || len(c.DiscoveryCfg.Endpoints) > 0
+}
 
 // ReqTimeout returns timeout for request to finish.
 func (c *ServerConfig) ReqTimeout() time.Duration {

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -95,8 +95,6 @@ const (
 	// It's enabled by default.
 	DefaultStrictReconfigCheck = true
 
-	DefaultEnableV2Discovery = true
-
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed in ../Documentation/tuning.md#time-parameters.
 	maxElectionMs = 50000
@@ -106,7 +104,7 @@ const (
 
 var (
 	ErrConflictBootstrapFlags = fmt.Errorf("multiple discovery or bootstrap flags are set. " +
-		"Choose one of \"initial-cluster\", \"discovery\" or \"discovery-srv\"")
+		"Choose one of \"initial-cluster\", \"discovery\", \"discovery-endpoints\" or \"discovery-srv\"")
 	ErrUnsetAdvertiseClientURLsFlag = fmt.Errorf("--advertise-client-urls is required when --listen-client-urls is set explicitly")
 	ErrLogRotationInvalidLogOutput  = fmt.Errorf("--log-outputs requires a single file path when --log-rotate-config-json is defined")
 
@@ -227,9 +225,8 @@ type Config struct {
 	DNSClusterServiceName string `json:"discovery-srv-name"`
 	Dproxy                string `json:"discovery-proxy"`
 
-	EnableV2Discovery bool                        `json:"enable-v2-discovery"`
-	Durl              string                      `json:"discovery"`
-	DiscoveryCfg      v3discovery.DiscoveryConfig `json:"discovery-config"`
+	Durl         string                      `json:"discovery"`
+	DiscoveryCfg v3discovery.DiscoveryConfig `json:"discovery-config"`
 
 	InitialCluster                      string        `json:"initial-cluster"`
 	InitialClusterToken                 string        `json:"initial-cluster-token"`
@@ -518,7 +515,6 @@ func NewConfig() *Config {
 
 		V2Deprecation: config.V2_DEPR_DEFAULT,
 
-		EnableV2Discovery: DefaultEnableV2Discovery,
 		DiscoveryCfg: v3discovery.DiscoveryConfig{
 			DialTimeout:      DefaultDiscoveryDialTimeout,
 			RequestTimeOut:   DefaultDiscoveryRequestTimeOut,
@@ -606,8 +602,8 @@ func (cfg *configYAML) configFromFile(path string) error {
 		cfg.HostWhitelist = uv.Values
 	}
 
-	// If a discovery flag is set, clear default initial cluster set by InitialClusterFromName
-	if (cfg.Durl != "" || cfg.DNSCluster != "") && cfg.InitialCluster == defaultInitialCluster {
+	// If a discovery or discovery-endpoints flag is set, clear default initial cluster set by InitialClusterFromName
+	if (cfg.Durl != "" || cfg.DNSCluster != "" || len(cfg.DiscoveryCfg.Endpoints) > 0) && cfg.InitialCluster == defaultInitialCluster {
 		cfg.InitialCluster = ""
 	}
 	if cfg.ClusterState == "" {
@@ -674,7 +670,7 @@ func (cfg *Config) Validate() error {
 	}
 	// Check if conflicting flags are passed.
 	nSet := 0
-	for _, v := range []bool{cfg.Durl != "", cfg.InitialCluster != "", cfg.DNSCluster != ""} {
+	for _, v := range []bool{cfg.Durl != "", cfg.InitialCluster != "", cfg.DNSCluster != "", len(cfg.DiscoveryCfg.Endpoints) > 0} {
 		if v {
 			nSet++
 		}
@@ -690,18 +686,24 @@ func (cfg *Config) Validate() error {
 
 	// Check if both v2 discovery and v3 discovery flags are passed.
 	v2discoveryFlagsExist := cfg.Dproxy != ""
-	v3discoveryFlagsExist := cfg.DiscoveryCfg.CertFile != "" ||
+	v3discoveryFlagsExist := len(cfg.DiscoveryCfg.Endpoints) > 0 ||
+		cfg.DiscoveryCfg.Token != "" ||
+		cfg.DiscoveryCfg.CertFile != "" ||
 		cfg.DiscoveryCfg.KeyFile != "" ||
 		cfg.DiscoveryCfg.TrustedCAFile != "" ||
 		cfg.DiscoveryCfg.User != "" ||
 		cfg.DiscoveryCfg.Password != ""
-	if cfg.EnableV2Discovery && v3discoveryFlagsExist {
-		return errors.New("v2 discovery is enabled, but some v3 discovery " +
-			"settings (discovery-cert, discovery-key, discovery-cacert, " +
-			"discovery-user, discovery-password) are set")
+
+	if v2discoveryFlagsExist && v3discoveryFlagsExist {
+		return errors.New("both v2 discovery settings (discovery, discovery-proxy) " +
+			"and v3 discovery settings (discovery-token, discovery-endpoints, discovery-cert, " +
+			"discovery-key, discovery-cacert, discovery-user, discovery-password) are set")
 	}
-	if !cfg.EnableV2Discovery && v2discoveryFlagsExist {
-		return errors.New("v3 discovery is enabled, but --discovery-proxy is set")
+
+	// If one of `discovery-token` and `discovery-endpoints` is provided,
+	// then the other one must be provided as well.
+	if (cfg.DiscoveryCfg.Token != "") != (len(cfg.DiscoveryCfg.Endpoints) > 0) {
+		return errors.New("both --discovery-token and --discovery-endpoints must be set")
 	}
 
 	if cfg.TickMs == 0 {
@@ -753,10 +755,17 @@ func (cfg *Config) PeerURLsMapAndToken(which string) (urlsmap types.URLsMap, tok
 	switch {
 	case cfg.Durl != "":
 		urlsmap = types.URLsMap{}
-		// If using discovery, generate a temporary cluster based on
+		// If using v2 discovery, generate a temporary cluster based on
 		// self's advertised peer URLs
 		urlsmap[cfg.Name] = cfg.APUrls
 		token = cfg.Durl
+
+	case len(cfg.DiscoveryCfg.Endpoints) > 0:
+		urlsmap = types.URLsMap{}
+		// If using v3 discovery, generate a temporary cluster based on
+		// self's advertised peer URLs
+		urlsmap[cfg.Name] = cfg.APUrls
+		token = cfg.DiscoveryCfg.Token
 
 	case cfg.DNSCluster != "":
 		clusterStrs, cerr := cfg.GetDNSClusterNames()

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -175,7 +176,6 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		MaxWALFiles:                              cfg.MaxWalFiles,
 		InitialPeerURLsMap:                       urlsmap,
 		InitialClusterToken:                      token,
-		EnableV2Discovery:                        cfg.EnableV2Discovery,
 		DiscoveryURL:                             cfg.Durl,
 		DiscoveryProxy:                           cfg.Dproxy,
 		DiscoveryCfg:                             cfg.DiscoveryCfg,
@@ -348,6 +348,8 @@ func print(lg *zap.Logger, ec Config, sc config.ServerConfig, memberInitialized 
 		zap.String("discovery-url", sc.DiscoveryURL),
 		zap.String("discovery-proxy", sc.DiscoveryProxy),
 
+		zap.String("discovery-token", sc.DiscoveryCfg.Token),
+		zap.String("discovery-endpoints", strings.Join(sc.DiscoveryCfg.Endpoints, ",")),
 		zap.String("discovery-dial-timeout", sc.DiscoveryCfg.DialTimeout.String()),
 		zap.String("discovery-request-timeout", sc.DiscoveryCfg.RequestTimeOut.String()),
 		zap.String("discovery-keepalive-time", sc.DiscoveryCfg.KeepAliveTime.String()),

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -104,10 +104,12 @@ Clustering:
   --advertise-client-urls 'http://localhost:2379'
     List of this member's client URLs to advertise to the public.
     The client URLs advertised should be accessible to machines that talk to etcd cluster. etcd client libraries parse these URLs to connect to the cluster.
-  --enable-v2-discovery 'true'
-    Enable to bootstrap the cluster using v2 discovery. Will be deprecated in v3.7, and be decommissioned in v3.8.
   --discovery ''
-    Discovery URL used to bootstrap the cluster.
+    Discovery URL used to bootstrap the cluster for v2 discovery. Will be deprecated in v3.7, and be decommissioned in v3.8.
+  --discovery-token ''
+    V3 discovery: discovery token for the etcd cluster to be bootstrapped.
+  --discovery-endpoints ''
+    V3 discovery: List of gRPC endpoints of the discovery service.
   --discovery-dial-timeout '2s'
     V3 discovery: dial timeout for client connections.
   --discovery-request-timeout '5s'

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -329,10 +329,12 @@ func bootstrapNewClusterNoWAL(cfg config.ServerConfig, prt http.RoundTripper) (*
 	}
 	if cfg.ShouldDiscover() {
 		var str string
-		if cfg.EnableV2Discovery {
+		if cfg.DiscoveryURL != "" {
+			cfg.Logger.Warn("V2 discovery is deprecated!")
 			str, err = v2discovery.JoinCluster(cfg.Logger, cfg.DiscoveryURL, cfg.DiscoveryProxy, m.ID, cfg.InitialPeerURLsMap.String())
 		} else {
-			str, err = v3discovery.JoinCluster(cfg.Logger, cfg.DiscoveryURL, &cfg.DiscoveryCfg, m.ID, cfg.InitialPeerURLsMap.String())
+			cfg.Logger.Info("Bootstrapping cluster using v3 discovery.")
+			str, err = v3discovery.JoinCluster(cfg.Logger, &cfg.DiscoveryCfg, m.ID, cfg.InitialPeerURLsMap.String())
 		}
 		if err != nil {
 			return nil, &DiscoveryError{Op: "join", Err: err}

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -170,7 +170,11 @@ type EtcdProcessClusterConfig struct {
 	V2deprecation       string
 
 	RollingStart bool
-	Discovery    string
+
+	Discovery string // v2 discovery
+
+	DiscoveryEndpoints []string // v3 discovery
+	DiscoveryToken     string
 }
 
 // NewEtcdProcessCluster launches a new cluster from etcd processes, returning
@@ -348,11 +352,18 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfigs(tb testing.TB) []*
 		}
 	}
 
-	if cfg.Discovery == "" {
+	if cfg.Discovery == "" && len(cfg.DiscoveryEndpoints) == 0 {
 		for i := range etcdCfgs {
 			initialClusterArgs := []string{"--initial-cluster", strings.Join(initialCluster, ",")}
 			etcdCfgs[i].InitialCluster = strings.Join(initialCluster, ",")
 			etcdCfgs[i].Args = append(etcdCfgs[i].Args, initialClusterArgs...)
+		}
+	}
+
+	if len(cfg.DiscoveryEndpoints) > 0 {
+		for i := range etcdCfgs {
+			etcdCfgs[i].Args = append(etcdCfgs[i].Args, fmt.Sprintf("--discovery-token=%s", cfg.DiscoveryToken))
+			etcdCfgs[i].Args = append(etcdCfgs[i].Args, fmt.Sprintf("--discovery-endpoints=%s", strings.Join(cfg.DiscoveryEndpoints, ",")))
 		}
 	}
 

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -588,8 +588,6 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 	peerScheme := SchemeFromTLSInfo(mcfg.PeerTLS)
 	clientScheme := SchemeFromTLSInfo(mcfg.ClientTLS)
 
-	m.EnableV2Discovery = embed.DefaultEnableV2Discovery
-
 	pln := newLocalListener(t)
 	m.PeerListeners = []net.Listener{pln}
 	m.PeerURLs, err = types.NewURLs([]string{peerScheme + "://" + pln.Addr().String()})


### PR DESCRIPTION
Part of [13624](https://github.com/etcd-io/etcd/issues/13624), and it's one of follow-ups to the PR [13635](https://github.com/etcd-io/etcd/pull/13635).

Currently the discovery url is just one endpoint. But actually it should be the same as the etcdctl, which means that it should be a list of endpoints. When one endpoint is down, the clientv3 can fail over to the next endpoint automatically.

cc @ptabor @serathius @spzala 


