### PR TITLE
mvcc: clean up duplicate metrics name

### DIFF
--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -500,9 +500,6 @@ func (s *store) setupMetricsReporter() {
 	reportDbTotalSizeInBytesMu.Lock()
 	reportDbTotalSizeInBytes = func() float64 { return float64(b.Size()) }
 	reportDbTotalSizeInBytesMu.Unlock()
-	reportDbTotalSizeInBytesDebugMu.Lock()
-	reportDbTotalSizeInBytesDebug = func() float64 { return float64(b.Size()) }
-	reportDbTotalSizeInBytesDebugMu.Unlock()
 	reportDbTotalSizeInUseInBytesMu.Lock()
 	reportDbTotalSizeInUseInBytes = func() float64 { return float64(b.SizeInUse()) }
 	reportDbTotalSizeInUseInBytesMu.Unlock()

--- a/server/storage/mvcc/metrics.go
+++ b/server/storage/mvcc/metrics.go
@@ -169,10 +169,6 @@ var (
 	reportDbTotalSizeInBytesMu sync.RWMutex
 	reportDbTotalSizeInBytes   = func() float64 { return 0 }
 
-	// overridden by mvcc initialization
-	reportDbTotalSizeInBytesDebugMu sync.RWMutex
-	reportDbTotalSizeInBytesDebug   = func() float64 { return 0 }
-
 	dbTotalSizeInUse = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "etcd",
 		Subsystem: "mvcc",


### PR DESCRIPTION
Metrics `reportDbTotalSizeInBytesDebug` has been replaced by `reportDbTotalSizeInBytes`.
Delete duplicate code.