### PR TITLE
Enhance the '/version' endpoint to add storageVersion

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -50,6 +50,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [`etcdctl make-mirror --rev`](https://github.com/etcd-io/etcd/pull/13519) flag to support incremental mirror.
 - Add [`etcd --experimental-wait-cluster-ready-timeout`](https://github.com/etcd-io/etcd/pull/13525) flag to wait for cluster to be ready before serving client requests.
 - Add [v3 discovery](https://github.com/etcd-io/etcd/pull/13635) to bootstrap a new etcd cluster.
+- Add [field `storage`](https://github.com/etcd-io/etcd/pull/13772) into the response body of endpoint `/version`.
 - Fix [non mutating requests pass through quotaKVServer when NOSPACE](https://github.com/etcd-io/etcd/pull/13435)
 - Fix [exclude the same alarm type activated by multiple peers](https://github.com/etcd-io/etcd/pull/13467).
 - Fix [Provide a better liveness probe for when etcd runs as a Kubernetes pod](https://github.com/etcd-io/etcd/pull/13399)

--- a/api/version/version.go
+++ b/api/version/version.go
@@ -43,6 +43,7 @@ func init() {
 type Versions struct {
 	Server  string `json:"etcdserver"`
 	Cluster string `json:"etcdcluster"`
+	Storage string `json:"storage"`
 	// TODO: raft state machine version
 }
 

--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -74,18 +74,7 @@ func (s *serverVersionAdapter) GetMembersVersions() map[string]*version.Versions
 }
 
 func (s *serverVersionAdapter) GetStorageVersion() *semver.Version {
-	// `applySnapshot` sets a new backend instance, so we need to acquire the bemu lock.
-	s.bemu.RLock()
-	defer s.bemu.RUnlock()
-
-	tx := s.be.ReadTx()
-	tx.RLock()
-	defer tx.RUnlock()
-	v, err := schema.UnsafeDetectSchemaVersion(s.lg, tx)
-	if err != nil {
-		return nil
-	}
-	return &v
+	return s.StorageVersion()
 }
 
 func (s *serverVersionAdapter) UpdateStorageVersion(target semver.Version) error {

--- a/server/etcdserver/api/etcdhttp/peer.go
+++ b/server/etcdserver/api/etcdhttp/peer.go
@@ -71,7 +71,7 @@ func newPeerHandler(
 	if hashKVHandler != nil {
 		mux.Handle(etcdserver.PeerHashKVPath, hashKVHandler)
 	}
-	mux.HandleFunc(versionPath, versionHandler(s.Cluster(), serveVersion))
+	mux.HandleFunc(versionPath, versionHandler(s, serveVersion))
 	return mux
 }
 

--- a/server/etcdserver/api/etcdhttp/peer_test.go
+++ b/server/etcdserver/api/etcdhttp/peer_test.go
@@ -74,6 +74,7 @@ func (s *fakeServer) PromoteMember(ctx context.Context, id uint64) ([]*membershi
 	return nil, fmt.Errorf("PromoteMember not implemented in fakeServer")
 }
 func (s *fakeServer) ClusterVersion() *semver.Version      { return nil }
+func (s *fakeServer) StorageVersion() *semver.Version      { return nil }
 func (s *fakeServer) Cluster() api.Cluster                 { return s.cluster }
 func (s *fakeServer) Alarms() []*pb.AlarmMember            { return s.alarms }
 func (s *fakeServer) LeaderChangedNotify() <-chan struct{} { return nil }

--- a/server/etcdserver/api/etcdhttp/version_test.go
+++ b/server/etcdserver/api/etcdhttp/version_test.go
@@ -29,13 +29,14 @@ func TestServeVersion(t *testing.T) {
 		t.Fatalf("error creating request: %v", err)
 	}
 	rw := httptest.NewRecorder()
-	serveVersion(rw, req, "2.1.0")
+	serveVersion(rw, req, "3.6.0", "3.5.2")
 	if rw.Code != http.StatusOK {
 		t.Errorf("code=%d, want %d", rw.Code, http.StatusOK)
 	}
 	vs := version.Versions{
 		Server:  version.Version,
-		Cluster: "2.1.0",
+		Cluster: "3.6.0",
+		Storage: "3.5.2",
 	}
 	w, err := json.Marshal(&vs)
 	if err != nil {
@@ -53,14 +54,16 @@ func TestServeVersionFails(t *testing.T) {
 	for _, m := range []string{
 		"CONNECT", "TRACE", "PUT", "POST", "HEAD",
 	} {
-		req, err := http.NewRequest(m, "", nil)
-		if err != nil {
-			t.Fatalf("error creating request: %v", err)
-		}
-		rw := httptest.NewRecorder()
-		serveVersion(rw, req, "2.1.0")
-		if rw.Code != http.StatusMethodNotAllowed {
-			t.Errorf("method %s: code=%d, want %d", m, rw.Code, http.StatusMethodNotAllowed)
-		}
+		t.Run(m, func(t *testing.T) {
+			req, err := http.NewRequest(m, "", nil)
+			if err != nil {
+				t.Fatalf("error creating request: %v", err)
+			}
+			rw := httptest.NewRecorder()
+			serveVersion(rw, req, "3.6.0", "3.5.2")
+			if rw.Code != http.StatusMethodNotAllowed {
+				t.Errorf("method %s: code=%d, want %d", m, rw.Code, http.StatusMethodNotAllowed)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Part of [issues/13735](https://github.com/etcd-io/etcd/issues/13735).

I added one more field "storageVersion" in the response of `/version` endpoint. I will submit a separate PR to update the command `etcdctl endpoint status `. 

cc @serathius @ptabor @spzala 