### PR TITLE
integration/client/watch.TestWatchCancelRunning: remove duplicate setup

### DIFF
--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -299,8 +299,6 @@ func TestWatchCancelRunning(t *testing.T) {
 }
 
 func testWatchCancelRunning(t *testing.T, wctx *watchctx) {
-	integration2.BeforeTest(t)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	if wctx.ch = wctx.w.Watch(ctx, "a"); wctx.ch == nil {
 		t.Fatalf("expected non-nil watcher channel")


### PR DESCRIPTION
TestWatchCancelRunning was being skipped as it has a duplicate call to integration2.BeginTest. This duplicate call registered a second handler for leak detection which failed and skipped the test as the wrapper (runWatchTest) has already started a cluster.

part of #13698 

Validation that all watch tests now (at least don't continuously) get skipped:

(gotestsum would print `DONE 1 tests, 1 skipped in 1.417s` if a test was skipped)

```bash
go test ./integration/... --list '.' | grep TestWatch | xargs -I '{}' sh -c 'echo {} && gotestsum -- ./integration/... --run ^{}$ --count=2 | grep DONE' | tee test.out
TestWatchWithProgressNotify                                                                                                                                                                                                                                                       
DONE 4 tests in 9.551s                                                                                                                                                                                                                                                            
TestWatchFragmentDisable                                                                                                                                                                                                                                                          
DONE 2 tests in 1.228s                                                                                                                                                                                                                                                            
TestWatchFragmentDisableWithGRPCLimit                                                                                                                                                                                                                                             
DONE 2 tests in 1.250s                                                                                                                                                                                                                                                            
TestWatchFragmentEnable                                                                                                                                                                                                                                                           
DONE 2 tests in 1.163s                                                                                                                                                                                                                                                            
TestWatchFragmentEnableWithGRPCLimit                                                                                                                                                                                                                                              
DONE 2 tests in 1.258s                                                                                                                                                                                                                                                            
TestWatchMultiWatcher                                                                                                                                                                                                                                                             
DONE 2 tests in 3.089s                                                                                                                                                                                                                                                            
TestWatchRange                                                                                                                                                                                                                                                                    
DONE 2 tests in 1.071s                                                                                                                                                                                                                                                            
TestWatchReconnRequest                                                                                                                                                                                                                                                            
DONE 2 tests in 6.522s                                                                                                                                                                                                                                                            
TestWatchReconnInit                                                                                                                                                                                                                                                               
DONE 2 tests in 1.185s                                                                                                                                                                                                                                                            
TestWatchReconnRunning                                                                                                                                                                                                                                                            
DONE 2 tests in 1.162s                                                                                                                                                                                                                                                            
TestWatchCancelImmediate                                                                                                                                                                                                                                                          
DONE 2 tests in 1.088s                                                                                                                                                                                                                                                            
TestWatchCancelInit                                                                                                                                                                                                                                                               
DONE 2 tests in 1.071s                                                                                                                                                                                                                                                            
TestWatchCancelRunning                                                                                                                                                                                                                                                            
DONE 2 tests in 1.094s                                                                                                                                                                                                                                                              
TestWatchResumeInitRev                                                                                                                                                                                                                                                            
DONE 2 tests in 1.283s                                                                                                                                                                                                                                                            
TestWatchResumeCompacted                                                                                                                                                                                                                                                          
DONE 2 tests in 3.123s                                                                                                                                                                                                                                                            
TestWatchCompactRevision                                                                                                                                                                                                                                                          
DONE 2 tests in 1.176s                                                                                                                                                                                                                                                            
TestWatchWithProgressNotify                                                                                                                                                                                                                                                       
DONE 4 tests in 9.598s                                                                                                                                                                                                                                                            
TestWatchWithProgressNotifyNoEvent                                                                                                                                                                                                                                                
DONE 2 tests in 13.618s                                                                                                                                                                                                                                                           
TestWatchRequestProgress                                                                                                                                                                                                                                                          
DONE 8 tests in 1.420s                                                                                                                                                                                                                                                            
TestWatchEventType                                                                                                                                                                                                                                                                
DONE 2 tests in 3.870s                                                                                                                                                                                                                                                            
TestWatchErrConnClosed                                                                                                                                                                                                                                                            
DONE 2 tests in 1.023s                                                                                                                                                                                                                                                            
TestWatchAfterClose                                                                                                                                                                                                                                                               
DONE 2 tests in 0.966s                                                                                                                                                                                                                                                            
TestWatchWithRequireLeader                                                                                                                                                                                                                                                        
DONE 2 tests in 2.107s                                                                                                                                                                                                                                                            
TestWatchWithFilter                                                                                                                                                                                                                                                               
DONE 2 tests in 1.207s                                                                                                                                                                                                                                                            
TestWatchWithCreatedNotification                                                                                                                                                                                                                                                  
DONE 2 tests in 0.954s                                                                                                                                                                                                                                                            
TestWatchWithCreatedNotificationDropConn                                                                                                                                                                                                                                          
DONE 2 tests in 3.044s                                                                                                                                                                                                                                                            
TestWatchCancelOnServer                                                                                                                                                                                                                                                           
DONE 2 tests in 3.044s                                                                                                                                                                                                                                                            
TestWatchOverlapContextCancel                                                                                                                                                                                                                                                     
DONE 2 tests in 3.686s                                                                                                                                                                                                                                                            
TestWatchOverlapDropConnContextCancel                                                                                                                                                                                                                                             
DONE 2 tests in 3.423s                                                                                                                                                                                                                                                            
TestWatchCancelAndCloseClient                                                                                                                                                                                                                                                     
DONE 2 tests in 1.071s                                                                                                                                                                                                                                                            
TestWatchStressResumeClose                                                                                                                                                                                                                                                        
DONE 2 tests in 1.196s                                                                                                                                                                                                                                                            
TestWatchCancelDisconnected                                         
DONE 2 tests in 5.015s                                              
TestWatchClose                                                      
DONE 2 tests in 1.055s          
```