### PR TITLE
tests/framework/integration: Fail BeforeTest nesting early

### DIFF
--- a/tests/framework/integration/testing.go
+++ b/tests/framework/integration/testing.go
@@ -72,6 +72,10 @@ func BeforeTest(t testutil.TB, opts ...TestOption) {
 	t.Helper()
 	options := newTestOptions(opts...)
 
+	if insideTestContext {
+		t.Fatal("already in test context. BeforeTest was likely already called")
+	}
+
 	if options.skipInShort {
 		testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
 	}
@@ -92,10 +96,6 @@ func BeforeTest(t testutil.TB, opts ...TestOption) {
 		insideTestContext = previousInsideTestContext
 		os.Chdir(previousWD)
 	})
-
-	if insideTestContext {
-		t.Fatal("already in test context. BeforeTest was likely already called")
-	}
 
 	grpc_logger.Set(zapgrpc.NewLogger(zaptest.NewLogger(t).Named("grpc")))
 	insideTestContext = true


### PR DESCRIPTION
Currently there are a handful of tests within etcd that silently fail because LeakDetection will skip the test before it manages to hit this check.

Here we move the check to the beginning of the process to highlight these cases earlier, and to avoid them accidentally presenting as leaks.
