### PR TITLE
Add subtrace common fields defined in the last step (with isSubTraceEnd=true) at the end of each sub steps

### DIFF
--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -192,7 +192,7 @@ func (t *Trace) logInfo(threshold time.Duration) (string, []zap.Field) {
 		// add subtrace common fields which defined at the end to each sub-steps
 		if step.isSubTraceEnd {
 			for j := i - 1; j >= 0 && !t.steps[j].isSubTraceStart; j-- {
-				t.steps[j].fields = append(step.fields, t.steps[j].fields...)
+				t.steps[j].fields = append(t.steps[j].fields, step.fields...)
 			}
 			continue
 		}
@@ -215,7 +215,8 @@ func (t *Trace) logInfo(threshold time.Duration) (string, []zap.Field) {
 		zap.Time("start", t.startTime),
 		zap.Time("end", endTime),
 		zap.Strings("steps", steps),
-		zap.Int("step_count", len(steps))}
+		zap.Int("step_count", len(steps)),
+		zap.Int("total_step_count", len(t.steps))}
 	return msg, fs
 }
 

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -194,6 +194,7 @@ func TestLog(t *testing.T) {
 				"traceKey1:traceValue1", "count:1",
 				"stepKey1:stepValue1", "stepKey2:stepValue2", "subStepKey:subStepValue",
 				"beginSubTrace:true", "endSubTrace:true",
+				"beginSubTrace:true; subStepKey:subStepValue; endSubTrace:true;",
 				"\"step_count\":3",
 			},
 		},


### PR DESCRIPTION
etcd supports sub trace, in which the first one has `isSubTraceStart: true`, and the last one has `isSubTraceEnd: true`. When printing the trace in log, we should add the fields in the first or last step at the beginning or end of each sub steps respectively. 
