### PR TITLE
Fix panic in etcd validate secure endpoints #13810

### DIFF
--- a/client/pkg/transport/tls.go
+++ b/client/pkg/transport/tls.go
@@ -28,6 +28,8 @@ func ValidateSecureEndpoints(tlsInfo TLSInfo, eps []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer t.CloseIdleConnections()
+
 	var errs []string
 	var endpoints []string
 	for _, ep := range eps {

--- a/client/pkg/transport/tls.go
+++ b/client/pkg/transport/tls.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -34,7 +35,7 @@ func ValidateSecureEndpoints(tlsInfo TLSInfo, eps []string) ([]string, error) {
 			errs = append(errs, fmt.Sprintf("%q is insecure", ep))
 			continue
 		}
-		conn, cerr := t.Dial("tcp", ep[len("https://"):])
+		conn, cerr := t.DialContext(context.Background(), "tcp", ep[len("https://"):])
 		if cerr != nil {
 			errs = append(errs, fmt.Sprintf("%q failed to dial (%v)", ep, cerr))
 			continue

--- a/client/pkg/transport/tls_test.go
+++ b/client/pkg/transport/tls_test.go
@@ -78,16 +78,11 @@ func TestValidateSecureEndpoints(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			secureEps, err := ValidateSecureEndpoints(*tlsInfo, test.endPoints)
 			if test.expectedErr != (err != nil) {
-				t.Errorf("Unexpected error, got: %v, want: %v", err, test.expectedError)
+				t.Errorf("Unexpected error, got: %v, want: %v", err, test.expectedErr)
 			}
 
-			if err == nil && !test.expectedErr {
-				if len(secureEps) != len(test.expectedEndpoints) {
-					t.Errorf("expected %v endpoints, got %v", len(test.expectedEndpoints), len(secureEps))
-				}
-				if !reflect.DeepEqual(test.expectedEndpoints, secureEps) {
-					t.Errorf("expected endpoints %v, got %v", test.expectedEndpoints, secureEps)
-				}
+			if !reflect.DeepEqual(test.expectedEndpoints, secureEps) {
+				t.Errorf("expected endpoints %v, got %v", test.expectedEndpoints, secureEps)
 			}
 		})
 	}

--- a/client/pkg/transport/tls_test.go
+++ b/client/pkg/transport/tls_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package transport
 
 import (

--- a/client/pkg/transport/tls_test.go
+++ b/client/pkg/transport/tls_test.go
@@ -77,12 +77,10 @@ func TestValidateSecureEndpoints(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			secureEps, err := ValidateSecureEndpoints(*tlsInfo, test.endPoints)
-			if test.expectedErr && err == nil {
-				t.Errorf("expected error")
+			if test.expectedErr != (err != nil) {
+				t.Errorf("Unexpected error, got: %v, want: %v", err, test.expectedError)
 			}
-			if !test.expectedErr && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+
 			if err == nil && !test.expectedErr {
 				if len(secureEps) != len(test.expectedEndpoints) {
 					t.Errorf("expected %v endpoints, got %v", len(test.expectedEndpoints), len(secureEps))

--- a/client/pkg/transport/tls_test.go
+++ b/client/pkg/transport/tls_test.go
@@ -1,0 +1,36 @@
+package transport
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateSecureEndpoints(t *testing.T) {
+	tlsInfo, err := createSelfCert(t)
+	if err != nil {
+		t.Fatalf("unable to create cert: %v", err)
+	}
+
+	remoteAddr := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.RemoteAddr))
+	}
+	srv := httptest.NewServer(http.HandlerFunc(remoteAddr))
+	defer srv.Close()
+
+	insecureEps := []string{
+		"http://" + srv.Listener.Addr().String(),
+		"invalid remote address",
+	}
+	if _, err := ValidateSecureEndpoints(*tlsInfo, insecureEps); err == nil || !strings.Contains(err.Error(), "is insecure") {
+		t.Error("validate secure endpoints should fail")
+	}
+
+	secureEps := []string{
+		"https://" + srv.Listener.Addr().String(),
+	}
+	if _, err := ValidateSecureEndpoints(*tlsInfo, secureEps); err != nil {
+		t.Error("validate secure endpoints should succeed")
+	}
+}


### PR DESCRIPTION
This pr fix #13810 

https://github.com/etcd-io/etcd/blob/1b208aa9d9e6cab42fd300e524c4c2ea97437c39/client/pkg/transport/transport.go#L33-L43

In `etcd/client/pkg/transport/tls.go`:
`ValidateSecureEndpoints()` should call `t.DialContext()` instead of `t.Dial()`, because `t.Dial` is `nil`

