### PR TITLE
tests/integration: re-enable TestV3AuthOldRevConcurrent

### DIFF
--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -358,7 +358,6 @@ func TestV3AuthNonAuthorizedRPCs(t *testing.T) {
 }
 
 func TestV3AuthOldRevConcurrent(t *testing.T) {
-	t.Skip() // TODO(jingyih): re-enable the test when #10408 is fixed.
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)


### PR DESCRIPTION
https://github.com/etcd-io/etcd/pull/10468 and https://github.com/etcd-io/etcd/pull/13308 fixed the issue of TestV3AuthOldRevConcurrent. We can re-enable the test.
cc @endocrimes @jingyih 

Fix https://github.com/etcd-io/etcd/issues/13805