### PR TITLE
Update go to 1.17.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.6"
+          go-version: "1.17.8"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -7,5 +7,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - run: make -C contrib/mixin tools test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.6"
+          go-version: "1.17.8"
       - run: date
       - env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.17.6"
+        go-version: "1.17.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -74,6 +74,9 @@ See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per 
 
 - Add [`etcd_disk_defrag_inflight`](https://github.com/etcd-io/etcd/pull/13371).
 
+### Go
+- Compile with [Go 1.17+](https://golang.org/doc/devel/release.html#go1.17)
+
 ### Other
 
 - Use Distroless as base image to make the image less vulnerable and reduce image size.

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	rm -rf ./tests/e2e/default.proxy
 	find ./ -name "127.0.0.1:*" -o -name "localhost:*" -o -name "*.log" -o -name "agent-*" -o -name "*.coverprofile" -o -name "testname-proxy-*" | $(XARGS)
 
-GO_VERSION ?= 1.17.6
+GO_VERSION ?= 1.17.8
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf check-update || true \
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
-ENV GO_VERSION 1.17.6
+ENV GO_VERSION 1.17.8
 ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang
 RUN rm -rf ${GOROOT} \
   && curl -s ${GO_DOWNLOAD_URL}/go${GO_VERSION}.linux-amd64.tar.gz | tar -v -C /usr/local/ -xz \

--- a/tests/manual/Makefile
+++ b/tests/manual/Makefile
@@ -1,5 +1,5 @@
 TMP_DOCKERFILE:=$(shell mktemp)
-GO_VERSION ?= 1.17.2
+GO_VERSION ?= 1.17.8
 TMP_DIR_MOUNT_FLAG = --tmpfs=/tmp:exec
 ifdef HOST_TMP_DIR
 	TMP_DIR_MOUNT_FLAG = --mount type=bind,source=$(HOST_TMP_DIR),destination=/tmp


### PR DESCRIPTION
This change switches to latest go 1.17 to build etcd.