### PR TITLE
[release-3.5] Update go to 1.16.15

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.16.3"
+        go-version: "1.16.15"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.16.3"
+        go-version: "1.16.15"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.16.3"
+        go-version: "1.16.15"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.16.3"
+        go-version: "1.16.15"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 services: docker
 
 go:
-  - "1.16.3"
+  - "1.16.15"
   - tip
 
 notifications:
@@ -21,14 +21,14 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - go: "1.16.3"
+    - go: "1.16.15"
       env: TARGET=linux-amd64-coverage
     - go: tip
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
   exclude:
     - go: tip
       env: TARGET=linux-amd64-coverage
-    - go: "1.16.3"
+    - go: "1.16.15"
       env: TARGET=linux-amd64-fmt-unit-go-tip-2-cpu
 
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.16.3
+GO_VERSION ?= 1.16.15
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,10 @@ test-full:
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	PASSES="fmt build release unit integration functional e2e grpcproxy" ./test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
 
-docker-test:
+ensure-docker-test-image-exists:
+	make push-docker-test || echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test
+
+docker-test: ensure-docker-test-image-exists
 	$(info GO_VERSION: $(GO_VERSION))
 	$(info ETCD_VERSION: $(ETCD_VERSION))
 	$(info TEST_OPTS: $(TEST_OPTS))


### PR DESCRIPTION
This change ensures etcd is built with latest available patch version of go 1.16.