### PR TITLE
server: Attempt to fix data corruption

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -303,12 +303,11 @@ func (t *batchTxBuffered) CommitAndStop() {
 }
 
 func (t *batchTxBuffered) commit(stop bool) {
+	// all read txs must be closed to acquire boltdb commit rwlock
+	t.backend.readTx.Lock()
 	if t.backend.hooks != nil {
 		t.backend.hooks.OnPreCommitUnsafe(t)
 	}
-
-	// all read txs must be closed to acquire boltdb commit rwlock
-	t.backend.readTx.Lock()
 	t.unsafeCommit(stop)
 	t.backend.readTx.Unlock()
 }


### PR DESCRIPTION
Based on git bisect I identified https://github.com/etcd-io/etcd/commit/50051675f9740a4561e13bc5f00a89982b5202ad as root cause (still not 100% confirmed). In this commit the only change I think could introduce the corruption content of `OnPreCommitUnsafe`. Call to this method was introduced in https://github.com/etcd- io/etcd/pull/12855/commits/9f11b16b2dcab5922bed18b818b84fc1113f7e06 where it is called by `commit` method.

Overall I found it weird in https://github.com/etcd-io/etcd/pull/12855 that introduces both changes, fact that this refactor adds calls `indexer.UnsafeWrite` outside read lock, which doesn't match previous behavior. This is still guessing, and I haven't verified the fix, so I leave it up to author/reviewers of the original PR. cc @ptab