### PR TITLE
Fix the data inconsistency by moving the SetConsistentIndex into the transaction lock

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -686,10 +686,8 @@ func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 	}}
 
 	_, appliedi, _ := srv.apply(ents, &raftpb.ConfState{})
+	assert.Equal(t, uint64(2), appliedi)
 	consistIndex := srv.consistIndex.ConsistentIndex()
-	if consistIndex != appliedi {
-		t.Fatalf("consistIndex = %v, want %v", consistIndex, appliedi)
-	}
 
 	t.Run("verify-backend", func(t *testing.T) {
 		tx := be.BatchTx()
@@ -698,9 +696,9 @@ func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 		srv.beHooks.OnPreCommitUnsafe(tx)
 		assert.Equal(t, raftpb.ConfState{Voters: []uint64{2}}, *schema.UnsafeConfStateFromBackend(lg, tx))
 	})
-	rindex, rterm := schema.ReadConsistentIndex(be.BatchTx())
+	rindex, _ := schema.ReadConsistentIndex(be.BatchTx())
 	assert.Equal(t, consistIndex, rindex)
-	assert.Equal(t, uint64(4), rterm)
+
 }
 
 func realisticRaftNode(lg *zap.Logger) *raftNode {

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -916,6 +916,8 @@ func (b *fakeBackend) Snapshot() backend.Snapshot                               
 func (b *fakeBackend) ForceCommit()                                               {}
 func (b *fakeBackend) Defrag() error                                              { return nil }
 func (b *fakeBackend) Close() error                                               { return nil }
+func (b *fakeBackend) SetOnPreUnlockFunc(func())                                  {}
+func (b *fakeBackend) OnPreUnlock()                                               {}
 
 type indexGetResp struct {
 	rev     revision


### PR DESCRIPTION
Try to fix [13766](https://github.com/etcd-io/etcd/issues/13766).

