### PR TITLE
Dockerfile(arm64): Remove ETCD_UNSUPPORTED_ARCH

### DIFF
--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -9,7 +9,6 @@ ADD etcdctl /usr/local/bin/
 ADD etcdutl /usr/local/bin/
 ADD var/etcd /var/etcd
 ADD var/lib/etcd /var/lib/etcd
-ENV ETCD_UNSUPPORTED_ARCH=arm64
 
 EXPOSE 2379 2380
 


### PR DESCRIPTION
Remove ETCD_UNSUPPORTED_ARCH, since the platform is supported. See https://etcd.io/docs/v3.5/op-guide/supported-platform/
