### PR TITLE
[Release-3.5] Makefile: additional logic fix / Update Ubuntu base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ test-full:
 	PASSES="fmt build release unit integration functional e2e grpcproxy" ./test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
 
 ensure-docker-test-image-exists:
-	make pull-docker-test || echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test
+	make pull-docker-test || ( echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test )
 
 docker-test: ensure-docker-test-image-exists
 	$(info GO_VERSION: $(GO_VERSION))

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:22.04
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections


### PR DESCRIPTION
backport of https://github.com/etcd-io/etcd/pull/13860 and updating the used ubuntu base image to something that is not EOL.