### PR TITLE
Add no_proxy environment variable for localhost,127.0.0.1

### DIFF
--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -115,6 +115,9 @@ func SkipInShortMode(t testing.TB) {
 
 func mergeEnvVariables(envVars map[string]string) []string {
 	var env []string
+
+	envVars = addNoProxy(envVars)
+
 	// Environment variables are passed as parameter have higher priority
 	// than os environment variables.
 	for k, v := range envVars {
@@ -131,4 +134,23 @@ func mergeEnvVariables(envVars map[string]string) []string {
 	}
 
 	return env
+}
+
+// addNoProxy adds no_proxy entry for "localhost,127.0.0.1".
+func addNoProxy(envVars map[string]string) map[string]string {
+	newEnvMap := make(map[string]string)
+
+	// clone the old env map, otherwise it may run into "fatal error: concurrent map read and map write".
+	for k, v := range envVars {
+		newEnvMap[k] = v
+	}
+
+	localHosts := "localhost,127.0.0.1"
+	if val, ok := newEnvMap["no_proxy"]; ok && len(val) > 0 {
+		newEnvMap["no_proxy"] = fmt.Sprintf("%s,%s", val, localHosts)
+	} else {
+		newEnvMap["no_proxy"] = localHosts
+	}
+
+	return newEnvMap
 }


### PR DESCRIPTION
The e2e test `TestClusterVersion` always fails, the reason is the OS environment variables, including`http_proxy` and `https_proxy` if present, are automatically added into the command's environment variable list, see [expect.go#L58](https://github.com/etcd-io/etcd/blob/main/pkg/expect/expect.go#L58) .

Accordingly all http requests to localhost fail, the error message is something like below,
```
 (expected "\"etcdcluster\":\"3.6", got ["<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\r\n" "<html><head>\r\n" "<meta type=\"copyright\" content=\"Copyright (C) 1996-2016 The Squid Software Foundation and contributors\">\r\n" "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\r\n"

```

This is one of the reasons for the CI failures. cc @ptabor @serathius @spzala 