### PR TITLE
Makefile: Drop log tee calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,16 +96,16 @@ pull-docker-test:
 test:
 	$(info TEST_OPTS: $(TEST_OPTS))
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	$(TEST_OPTS) ./scripts/test.sh 2>&1 | tee test-$(TEST_SUFFIX).log
+	$(TEST_OPTS) ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
 	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 test-smoke:
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	PASSES="fmt build unit" ./scripts/test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
+	PASSES="fmt build unit" ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
 
 test-full:
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	PASSES="fmt build release unit integration functional e2e grpcproxy" ./scripts/test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
+	PASSES="fmt build release unit integration functional e2e grpcproxy" ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
 
 ensure-docker-test-image-exists:
 	make pull-docker-test || echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test
@@ -122,7 +122,7 @@ docker-test: ensure-docker-test-image-exists
 	  $(TMP_DIR_MOUNT_FLAG) \
 	  --mount type=bind,source=`pwd`,destination=/go/src/go.etcd.io/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(GO_VERSION) \
-	  /bin/bash -c "$(TEST_OPTS) ./scripts/test.sh 2>&1 | tee test-$(TEST_SUFFIX).log"
+	  /bin/bash -c "$(TEST_OPTS) ./scripts/test.sh 2>&1" > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
 	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 docker-test-coverage:


### PR DESCRIPTION
We've had these since in one form or another since 23a302364c, but in at least some cases the
underlying shell does not pipefail, a test failure gets swallowed, and [the `make` call exits zero despite failing the tests][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_etcd/109/pull-ci-openshift-etcd-openshift-4.11-unit/1509260812278042624/artifacts/test/build-log.txt
TEST_OPTS: PASSES='unit'
log-file: test-MTY0ODY3MTA1MQo.log
PASSES='unit' ./test.sh 2>&1 | tee test-MTY0ODY3MTA1MQo.log
% env GO111MODULE=off go get github.com/myitcv/gobin
Running with --race
Starting at: Wed Mar 30 20:10:52 UTC 2022

'unit' started at Wed Mar 30 20:10:52 UTC 2022
% (cd api && env go test -short -timeout=3m --race ./...)
stderr: authpb/auth.pb.go:12:2: open /go/pkg/mod/github.com/gogo/protobuf@v1.3.2/gogoproto: permission denied
stderr: authpb/auth.pb.go:13:2: open /go/pkg/mod/github.com/golang/protobuf@v1.5.2/proto: permission denied
stderr: etcdserverpb/rpc.pb.go:17:2: open /go/pkg/mod/google.golang.org/genproto@v0.0.0-20210602131652-f16073e35f0c/googleapis/api/annotations: permission denied
stderr: etcdserverpb/rpc.pb.go:18:2: open /go/pkg/mod/google.golang.org/grpc@v1.38.0: permission denied
stderr: etcdserverpb/rpc.pb.go:19:2: open /go/pkg/mod/google.golang.org/grpc@v1.38.0/codes: permission denied
stderr: etcdserverpb/rpc.pb.go:20:2: open /go/pkg/mod/google.golang.org/grpc@v1.38.0/status: permission denied
stderr: etcdserverpb/gw/rpc.pb.gw.go:17:2: open /go/pkg/mod/github.com/golang/protobuf@v1.5.2/descriptor: permission denied
stderr: etcdserverpb/gw/rpc.pb.gw.go:19:2: open /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.16.0/runtime: permission denied
stderr: etcdserverpb/gw/rpc.pb.gw.go:20:2: open /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.16.0/utilities: permission denied
FAIL: (code:1):
  % (cd api && env go test -short -timeout=3m --race ./...)
stderr: etcdserverpb/gw/rpc.pb.gw.go:23:2: open /go/pkg/mod/google.golang.org/grpc@v1.38.0/grpclog: permission denied
stderr: version/version.go:23:2: open /go/pkg/mod/github.com/coreos/go-semver@v0.3.0/semver: permission denied
FAIL: 'unit' failed at Wed Mar 30 20:10:52 UTC 2022
! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-MTY0ODY3MTA1MQo.log
```

We can't drop the log aggregation, because the log files are used for the panic/race grepping.  But I'm dropping the `tee` (so no more synchronous updates, but we no longer have to worry about pipefail handling).  And then if the test script fails, I'm dumping the log file to stdout and exiting 1, so the overall run fails.

openshift/etcd#112 has a similar patch (`Makefile` I'm building on is slightly different), and it confirms that [we now catch failing unit tests][2].

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_etcd/109/pull-ci-openshift-etcd-openshift-4.11-unit/1509260812278042624
[2]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_etcd/112/pull-ci-openshift-etcd-openshift-4.11-unit/1509950630381228032