### PR TITLE
Fix TestauthTokenBundleOnOverwrite on OsX:

### DIFF
--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2022 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package testutil
 
 import (
+	"os"
 	"testing"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
+// These are constants from "go.etcd.io/etcd/server/v3/verify",
+// but we don't want to take dependency.
+const ENV_VERIFY = "ETCD_VERIFY"
+const ENV_VERIFY_ALL_VALUE = "all"
+
 func BeforeTest(t testing.TB) {
-	SkipInShortMode(t)
-	testutil.BeforeTest(t)
+	RegisterLeakDetection(t)
+	os.Setenv(ENV_VERIFY, ENV_VERIFY_ALL_VALUE)
+
+	path, err := os.Getwd()
+	assert.NoError(t, err)
+	tempDir := t.TempDir()
+	assert.NoError(t, os.Chdir(tempDir))
+	t.Logf("Changing working directory to: %s", tempDir)
+
+	t.Cleanup(func() { assert.NoError(t, os.Chdir(path)) })
 }

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -204,8 +203,13 @@ func TestZapWithLogger(t *testing.T) {
 }
 
 func TestAuthTokenBundleNoOverwrite(t *testing.T) {
+	// This call in particular changes working directory to the tmp dir of
+	// the test. The `etcd-auth-test:0` can be created in local directory,
+	// not exceeding the longest allowed path on OsX.
+	testutil.BeforeTest(t)
+
 	// Create a mock AuthServer to handle Authenticate RPCs.
-	lis, err := net.Listen("unix", filepath.Join(t.TempDir(), "etcd-auth-test:0"))
+	lis, err := net.Listen("unix", "etcd-auth-test:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/clientv3/examples/main_test.go
+++ b/tests/integration/clientv3/examples/main_test.go
@@ -15,6 +15,7 @@
 package clientv3_test
 
 import (
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -44,6 +45,16 @@ func forUnitTestsRunInMockedContext(mocking func(), example func()) {
 // TestMain sets up an etcd cluster if running the examples.
 func TestMain(m *testing.M) {
 	testutil.ExitInShortMode("Skipping: the tests require real cluster")
+
+	tempDir := os.TempDir()
+	defer os.RemoveAll(tempDir)
+
+	err := os.Chdir(tempDir)
+	if err != nil {
+		log.Printf("Failed to change working dir to: %s: %v", tempDir, err)
+		os.Exit(1)
+	}
+
 	v := m.Run()
 	lazyCluster.Terminate()
 


### PR DESCRIPTION
The test used to be failing with: 

```
% (cd client/v3 && env go test -short -timeout=3m --race ./...)
--- FAIL: TestAuthTokenBundleNoOverwrite (0.00s)
    client_test.go:210: listen unix /var/folders/t1/3m8z9xz93t9c3vpt7zyzjm6w00374n/T/TestAuthTokenBundleNoOverwrite3197524989/001/etcd-auth-test:0: bind: invalid argument
FAIL
FAIL	go.etcd.io/etcd/client/v3	4.270s
```

The reason was that the path exceeded 108 chars (that is too much for socket).
In the mitigation we first change chroot (working directory) to the tempDir... such the path is 'local'.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
