### PR TITLE
Integration tests flake fixes

### DIFF
--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -15,6 +15,8 @@
 package testutil
 
 import (
+	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 
@@ -37,4 +39,22 @@ func BeforeTest(t testing.TB) {
 	t.Logf("Changing working directory to: %s", tempDir)
 
 	t.Cleanup(func() { assert.NoError(t, os.Chdir(path)) })
+}
+
+func BeforeIntegrationExamples(*testing.M) func() {
+	ExitInShortMode("Skipping: the tests require real cluster")
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "etcd-integration")
+	if err != nil {
+		log.Printf("Failed to obtain tempDir: %v", tempDir)
+		os.Exit(1)
+	}
+
+	err = os.Chdir(tempDir)
+	if err != nil {
+		log.Printf("Failed to change working dir to: %s: %v", tempDir, err)
+		os.Exit(1)
+	}
+	log.Printf("Running tests (examples) in dir(%v): ...", tempDir)
+	return func() { os.RemoveAll(tempDir) }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -108,7 +108,7 @@ function integration_extra {
 
 function integration_pass {
   run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" -p=2 "$@" || return $?
-  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" -p=2 "$@" || return $?
+  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" -p=2 "${RUN_ARG[@]}" "$@" || return $?
   integration_extra "$@"
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -107,8 +107,8 @@ function integration_extra {
 }
 
 function integration_pass {
-  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
-  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@" || return $?
+  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" -p=2 "$@" || return $?
+  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" -p=2 "$@" || return $?
   integration_extra "$@"
 }
 

--- a/tests/common/lease_test.go
+++ b/tests/common/lease_test.go
@@ -120,19 +120,22 @@ func TestLeaseGrantAndList(t *testing.T) {
 
 		for _, nc := range nestedCases {
 			t.Run(tc.name+"/"+nc.name, func(t *testing.T) {
+				t.Logf("Creating cluster...")
 				clus := testRunner.NewCluster(t, tc.config)
 				defer clus.Close()
 				cc := clus.Client()
-
+				t.Logf("Created cluster and client")
 				testutils.ExecuteWithTimeout(t, 10*time.Second, func() {
 					createdLeases := []clientv3.LeaseID{}
 					for i := 0; i < nc.leaseCount; i++ {
 						leaseResp, err := cc.Grant(10)
+						t.Logf("Grant returned: resp:%s err:%v", leaseResp.String(), err)
 						require.NoError(t, err)
 						createdLeases = append(createdLeases, leaseResp.ID)
 					}
 
 					resp, err := cc.LeaseList()
+					t.Logf("Lease list returned: resp:%s err:%v", resp.String(), err)
 					require.NoError(t, err)
 					require.Len(t, resp.Leases, nc.leaseCount)
 

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -259,7 +259,7 @@ func (c *Cluster) mustNewMember(t testutil.TB) *Member {
 	c.LastMemberNum++
 	m := MustNewMember(t,
 		MemberConfig{
-			Name:                        fmt.Sprintf("m%v", memberNumber-1),
+			Name:                        fmt.Sprintf("m%v", memberNumber),
 			MemberNumber:                memberNumber,
 			AuthToken:                   c.Cfg.AuthToken,
 			PeerTLS:                     c.Cfg.PeerTLS,

--- a/tests/integration/clientv3/concurrency/main_test.go
+++ b/tests/integration/clientv3/concurrency/main_test.go
@@ -33,12 +33,13 @@ func forUnitTestsRunInMockedContext(mocking func(), example func()) {
 
 // TestMain sets up an etcd cluster if running the examples.
 func TestMain(m *testing.M) {
-	testutil.ExitInShortMode("Skipping: the tests require real cluster")
+	cleanup := testutil.BeforeIntegrationExamples(m)
 
 	v := m.Run()
 	lazyCluster.Terminate()
 	if v == 0 {
 		testutil.MustCheckLeakedGoroutine()
 	}
+	cleanup()
 	os.Exit(v)
 }

--- a/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
@@ -96,7 +96,7 @@ func TestMutexTryLockSingleNode(t *testing.T) {
 	integration2.BeforeTest(t)
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
-
+	t.Logf("3 nodes cluster created...")
 	var clients []*clientv3.Client
 	testMutexTryLock(t, 5, integration2.MakeSingleNodeClients(t, clus, &clients))
 	integration2.CloseClients(t, clients)
@@ -113,35 +113,39 @@ func TestMutexTryLockMultiNode(t *testing.T) {
 }
 
 func testMutexTryLock(t *testing.T, lockers int, chooseClient func() *clientv3.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	lockedC := make(chan *concurrency.Mutex)
 	notlockedC := make(chan *concurrency.Mutex)
-	stopC := make(chan struct{})
-	defer close(stopC)
+
 	for i := 0; i < lockers; i++ {
-		go func() {
+		go func(i int) {
 			session, err := concurrency.NewSession(chooseClient())
 			if err != nil {
 				t.Error(err)
 			}
 			m := concurrency.NewMutex(session, "test-mutex-try-lock")
-			err = m.TryLock(context.TODO())
+			err = m.TryLock(ctx)
 			if err == nil {
 				select {
 				case lockedC <- m:
-				case <-stopC:
+				case <-ctx.Done():
+					t.Errorf("Thread: %v, Context failed: %v", i, err)
 				}
 			} else if err == concurrency.ErrLocked {
 				select {
 				case notlockedC <- m:
-				case <-stopC:
+				case <-ctx.Done():
+					t.Errorf("Thread: %v, Context failed: %v", i, err)
 				}
 			} else {
-				t.Errorf("Unexpected Error %v", err)
+				t.Errorf("Thread: %v; Unexpected Error %v", i, err)
 			}
-		}()
+		}(i)
 	}
 
-	timerC := time.After(time.Second)
+	timerC := time.After(30 * time.Second)
 	select {
 	case <-lockedC:
 		for i := 0; i < lockers-1; i++ {
@@ -154,7 +158,7 @@ func testMutexTryLock(t *testing.T, lockers int, chooseClient func() *clientv3.C
 			}
 		}
 	case <-timerC:
-		t.Errorf("timed out waiting for lock")
+		t.Errorf("timed out waiting for lock (30s)")
 	}
 }
 

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -274,18 +274,22 @@ func TestMaintenanceStatus(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
+	t.Logf("Waiting for leader...")
 	clus.WaitLeader(t)
+	t.Logf("Leader established.")
 
 	eps := make([]string, 3)
 	for i := 0; i < 3; i++ {
 		eps[i] = clus.Members[i].GRPCURL()
 	}
 
+	t.Logf("Creating client...")
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: eps, DialOptions: []grpc.DialOption{grpc.WithBlock()}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cli.Close()
+	t.Logf("Creating client [DONE]")
 
 	prevID, leaderFound := uint64(0), false
 	for i := 0; i < 3; i++ {
@@ -293,6 +297,7 @@ func TestMaintenanceStatus(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Logf("Response from %v: %v", i, resp)
 		if prevID == 0 {
 			prevID, leaderFound = resp.Header.MemberId, resp.Header.MemberId == resp.Leader
 			continue

--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -415,15 +415,7 @@ func TestWatchResumeCompacted(t *testing.T) {
 	}
 	clus.Members[0].Stop(t)
 
-	ticker := time.After(time.Second * 10)
-	for clus.WaitLeader(t) <= 0 {
-		select {
-		case <-ticker:
-			t.Fatalf("failed to wait for new leader")
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
+	clus.WaitLeader(t)
 
 	// put some data and compact away
 	numPuts := 5

--- a/tests/integration/lazy_cluster.go
+++ b/tests/integration/lazy_cluster.go
@@ -77,12 +77,14 @@ func NewLazyClusterWithConfig(cfg integration.ClusterConfig) LazyCluster {
 
 func (lc *lazyCluster) mustLazyInit() {
 	lc.once.Do(func() {
+		lc.tb.Logf("LazyIniting ...")
 		var err error
 		lc.transport, err = transport.NewTransport(transport.TLSInfo{}, time.Second)
 		if err != nil {
 			log.Fatal(err)
 		}
 		lc.cluster = integration.NewCluster(lc.tb, &lc.cfg)
+		lc.tb.Logf("LazyIniting [Done]")
 	})
 }
 

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -411,8 +411,8 @@ func TestV3LeaseCheckpoint(t *testing.T) {
 				}
 			}
 
-			if tc.expectTTLIsGT != 0 && time.Duration(ttlresp.TTL)*time.Second <= tc.expectTTLIsGT {
-				t.Errorf("Expected lease ttl (%v) to be greather than (%v)", time.Duration(ttlresp.TTL)*time.Second, tc.expectTTLIsGT)
+			if tc.expectTTLIsGT != 0 && time.Duration(ttlresp.TTL)*time.Second < tc.expectTTLIsGT {
+				t.Errorf("Expected lease ttl (%v) to be >= than (%v)", time.Duration(ttlresp.TTL)*time.Second, tc.expectTTLIsGT)
 			}
 
 			if tc.expectTTLIsLT != 0 && time.Duration(ttlresp.TTL)*time.Second > tc.expectTTLIsLT {


### PR DESCRIPTION
There are 3 fixes related (in 3 git commits) to integration tests:
 1. Logging:  The nodes used to be named starting from -1 (so: m-1, m0, m1) now: m0, m1,m2
 2. `integration/clientv3/examples` `ExampleAuth` not flaking with: `socket already in use`. The dir where the socket is created is now test specific. 
 3. WaitLeader is more aggressive (30s) to wait for leader to be actually established. Tests were not expecting -1 as viable output. 
 4. Reduce packet-level concurrency of running integration tests to (2)