### PR TITLE
etcd-dump-logs will panic if there is no WAL entry after the snapshot

### DIFF
--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -123,8 +123,10 @@ and output a hex encoded line of binary for each input line`)
 	fmt.Printf("WAL metadata:\nnodeID=%s clusterID=%s term=%d commitIndex=%d vote=%s\n",
 		id, cid, state.Term, state.Commit, vid)
 
-	fmt.Printf("WAL entries:\n")
-	fmt.Printf("lastIndex=%d\n", ents[len(ents)-1].Index)
+	fmt.Printf("WAL entries: %d\n", len(ents))
+	if len(ents) > 0 {
+		fmt.Printf("lastIndex=%d\n", ents[len(ents)-1].Index)
+	}
 
 	fmt.Printf("%4s\t%10s\ttype\tdata", "term", "index")
 	if *streamdecoder != "" {


### PR DESCRIPTION
Fix a minor bug of the tool etcd-dump-logs. If there is no any WAL entry after the snapshot, the tool will panic,
```

$ ./etcd-dump-logs ~/tmp/etcd/infra3.etcd/
Snapshot:
term=4 index=11 nodes=[8211f1d0f64f3269 91bc3c398fb3c146 fd422379fda50e48] confstate={"voters":[9372538179322589801,10501334649042878790,18249187646912138824],"auto_leave":false}
Start dumping log entries from snapshot.
WAL metadata:
nodeID=fd422379fda50e48 clusterID=ef37ad9dc622a7c4 term=4 commitIndex=11 vote=fd422379fda50e48
WAL entries: 0
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
main.main()
	/Users/wachao/go/src/github.com/ahrtr/etcd/tools/etcd-dump-logs/main.go:127 +0xfbc
```

The issue was discovered when investigating the CI failures of PR [13854](https://github.com/etcd-io/etcd/pull/13854).