### PR TITLE
*: drop use of humanize.Time() in favour of zap.Duration and time.Duration

### DIFF
--- a/client/v3/snapshot/v3_snapshot.go
+++ b/client/v3/snapshot/v3_snapshot.go
@@ -65,7 +65,7 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 	}
 	lg.Info("created temporary db file", zap.String("path", partpath))
 
-	now := time.Now()
+	start := time.Now()
 	resp, err := cli.SnapshotWithVersion(ctx)
 	if err != nil {
 		return resp.Version, err
@@ -89,7 +89,7 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 	lg.Info("fetched snapshot",
 		zap.String("endpoint", cfg.Endpoints[0]),
 		zap.String("size", humanize.Bytes(uint64(size))),
-		zap.String("took", humanize.Time(now)),
+		zap.String("took", time.Since(start).String()),
 		zap.String("etcd-version", version),
 	)
 

--- a/client/v3/snapshot/v3_snapshot.go
+++ b/client/v3/snapshot/v3_snapshot.go
@@ -89,7 +89,7 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 	lg.Info("fetched snapshot",
 		zap.String("endpoint", cfg.Endpoints[0]),
 		zap.String("size", humanize.Bytes(uint64(size))),
-		zap.String("took", time.Since(start).String()),
+		zap.Duration("took", time.Since(start)),
 		zap.String("etcd-version", version),
 	)
 

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -184,7 +184,7 @@ func (ms *maintenanceServer) Snapshot(sr *pb.SnapshotRequest, srv pb.Maintenance
 	ms.lg.Info("successfully sent database snapshot to client",
 		zap.Int64("total-bytes", total),
 		zap.String("size", size),
-		zap.String("took", humanize.Time(start)),
+		zap.String("took", time.Since(start).String()),
 		zap.String("storage-version", storageVersion),
 	)
 	return nil

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -184,7 +184,7 @@ func (ms *maintenanceServer) Snapshot(sr *pb.SnapshotRequest, srv pb.Maintenance
 	ms.lg.Info("successfully sent database snapshot to client",
 		zap.Int64("total-bytes", total),
 		zap.String("size", size),
-		zap.String("took", time.Since(start).String()),
+		zap.Duration("took", time.Since(start)),
 		zap.String("storage-version", storageVersion),
 	)
 	return nil


### PR DESCRIPTION
humanize.Time() drops precision resulting in some events reporting they took
"now" time to complete. Using time.Duration.String() results in accurate
duration being reported.

Fixes #13905