### PR TITLE
Update 3.5 and 3.6 changelog to cover the data inconsistency issue

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -10,6 +10,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 - Fix [Provide a better liveness probe for when etcd runs as a Kubernetes pod](https://github.com/etcd-io/etcd/pull/13706)
 - Fix [inconsistent log format](https://github.com/etcd-io/etcd/pull/13864)
+- Fix [Inconsistent revision and data occurs](https://github.com/etcd-io/etcd/pull/13908)
 
 ### package `client/pkg/v3`
 

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -64,6 +64,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Fix [Grant lease with negative ID can possibly cause db out of sync](https://github.com/etcd-io/etcd/pull/13676)
 - Fix [segmentation violation(SIGSEGV) error due to premature unlocking of watchableStore](https://github.com/etcd-io/etcd/pull/13505)
 - Fix [inconsistent log format](https://github.com/etcd-io/etcd/pull/13864)
+- Fix [Inconsistent revision and data occurs](https://github.com/etcd-io/etcd/pull/13854)
 
 ### tools/benchmark
 


### PR DESCRIPTION
Both PR [13854](https://github.com/etcd-io/etcd/pull/13854) for 3.6 and PR [13908](https://github.com/etcd-io/etcd/pull/13908) are merged. 

Issue: [13766](https://github.com/etcd-io/etcd/issues/13766)
