### PR TITLE
MAINTAINERS: update Sam's contact email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,7 +16,7 @@ Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*
 Marek Siarkowicz <siarkowicz@google.com> (@serathius) pkg:*
 Piotr Tabor <ptab@google.com> (@ptabor) pkg:*
 Sahdev Zala <spzala@us.ibm.com> (@spzala) pkg:*
-Sam Batschelet <sbatsche@redhat.com> (@hexfusion) pkg:*
+Sam Batschelet <sbatschelet@gmail.com> (@hexfusion) pkg:*
 Wenjia Zhang <wenjiazhang@google.com> (@wenjiaswe) pkg:*
 Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*
 


### PR DESCRIPTION
Became independent contributor.

Signed-off-by: Sam Batschelet <sbatschelet@gmail.com>