### PR TITLE
[release-3.5] clientv3: filter learners members during autosync

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -185,7 +185,9 @@ func (c *Client) Sync(ctx context.Context) error {
 	}
 	var eps []string
 	for _, m := range mresp.Members {
-		eps = append(eps, m.ClientURLs...)
+		if len(m.Name) != 0 && !m.IsLearner {
+			eps = append(eps, m.ClientURLs...)
+		}
 	}
 	c.SetEndpoints(eps...)
 	return nil


### PR DESCRIPTION
This change is to ensure that all members returned during the client's
AutoSync are started and are not learners, which are not valid
etcd members to make requests to.

Cherry-pick of my previous PR: https://github.com/etcd-io/etcd/pull/13837

Related to: https://github.com/etcd-io/etcd/issues/13894

cc @serathius @spzala @ahrtr 