### PR TITLE
server/auth: invalidate range permission cache during recovering from…

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -388,6 +388,8 @@ func (as *authStore) Recover(be AuthBackend) {
 		as.tokenProvider.enable()
 	}
 	as.enabledMu.Unlock()
+
+	as.rangePermCache = make(map[string]*unifiedRangePermissions)
 }
 
 func (as *authStore) selectPassword(password string, hashedPassword string) ([]byte, error) {

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -168,6 +168,10 @@ func TestRecover(t *testing.T) {
 	if !as.IsAuthEnabled() {
 		t.Fatalf("expected auth enabled got disabled")
 	}
+
+	if len(as.rangePermCache) != 0 {
+		t.Fatalf("expected range permission cache is empty")
+	}
 }
 
 func TestCheckPassword(t *testing.T) {


### PR DESCRIPTION
… snapshot

Fix https://github.com/etcd-io/etcd/issues/13883

The above issue reports a problem that `authStore.Recover()` doesn't invalidate `rangePermCache`, so an etcd node which is isolated from its cluster might not invalidate stale permission cache after resolving the network partitioning. This PR fixes the issue by invalidating the cache in a defensive manner.

cc @ptabor 