### PR TITLE
Client: fix panics if no logger is provided to fileutil and transport.

### DIFF
--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -49,7 +49,7 @@ func TouchDirAll(lg *zap.Logger, dir string) error {
 	// first check if dir exist with an expected permission mode.
 	if Exist(dir) {
 		err := CheckDirPermission(dir, PrivateDirMode)
-		if err != nil {
+		if err != nil && lg != nil {
 			lg.Warn("check file permission", zap.Error(err))
 		}
 	} else {

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -54,6 +54,26 @@ func TestIsDirWriteable(t *testing.T) {
 	}
 }
 
+func TestTouchDirAll(t *testing.T) {
+	tmpdir := t.TempDir()
+	t.Run("test creation of already existing directory with drwxr-xr-x rights without logger", func(t *testing.T) {
+		if err := TouchDirAll(nil, tmpdir); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("test creation of already existing directory with drwxr-xr-x rights with logger", func(t *testing.T) {
+		if err := TouchDirAll(zaptest.NewLogger(t), tmpdir); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("test creation of non-existent directory", func(t *testing.T) {
+		tmpdir2 := filepath.Join(tmpdir, "testdir")
+		if err := TouchDirAll(zaptest.NewLogger(t), tmpdir2); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestCreateDirAll(t *testing.T) {
 	tmpdir := t.TempDir()
 

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -186,11 +186,13 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 	info.Logger = lg
 	if selfSignedCertValidity == 0 {
 		err = fmt.Errorf("selfSignedCertValidity is invalid,it should be greater than 0")
-		info.Logger.Warn(
-			"cannot generate cert",
-			zap.Error(err),
-		)
-		return
+		if info.Logger != nil {
+			info.Logger.Warn(
+				"cannot generate cert",
+				zap.Error(err),
+			)
+			return
+		}
 	}
 	err = fileutil.TouchDirAll(lg, dirpath)
 	if err != nil {
@@ -285,11 +287,13 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 
 	certOut, err := os.Create(certPath)
 	if err != nil {
-		info.Logger.Warn(
-			"cannot cert file",
-			zap.String("path", certPath),
-			zap.Error(err),
-		)
+		if info.Logger != nil {
+			info.Logger.Warn(
+				"cannot cert file",
+				zap.String("path", certPath),
+				zap.Error(err),
+			)
+		}
 		return
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -520,14 +520,27 @@ func TestNewListenerUnixSocket(t *testing.T) {
 // TestNewListenerTLSInfoSelfCert tests that a new certificate accepts connections.
 func TestNewListenerTLSInfoSelfCert(t *testing.T) {
 	tmpdir := t.TempDir()
-	tlsinfo, err := SelfCert(zap.NewExample(), tmpdir, []string{"127.0.0.1"}, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tlsinfo.Empty() {
-		t.Fatalf("tlsinfo should have certs (%+v)", tlsinfo)
-	}
-	testNewListenerTLSInfoAccept(t, tlsinfo)
+	t.Run("test New Listener SelfCert with logger", func(t *testing.T) {
+		tlsinfo, err := SelfCert(zap.NewExample(), tmpdir, []string{"127.0.0.1"}, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tlsinfo.Empty() {
+			t.Fatalf("tlsinfo should have certs (%+v)", tlsinfo)
+		}
+		testNewListenerTLSInfoAccept(t, tlsinfo)
+	})
+	t.Run("test New Listener SelfCert without logger", func(t *testing.T) {
+		tlsinfo, err := SelfCert(nil, tmpdir, []string{"127.0.0.1"}, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tlsinfo.Empty() {
+			t.Fatalf("tlsinfo should have certs (%+v)", tlsinfo)
+		}
+		testNewListenerTLSInfoAccept(t, tlsinfo)
+	})
+
 }
 
 func TestIsClosedConnError(t *testing.T) {


### PR DESCRIPTION
Fixes panics in client pkg in transport that can happen if nil logger is provided. Also fixes panic with nil logger in fileutil, which is used by transport.


