### PR TITLE
Revert #13712

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -34,9 +34,6 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13142).
 - Add `migrate` command for downgrading/upgrading etcd data dir files.
 
-### package `client/pkg/v3`
-- [Trim the suffix dot from the target](https://github.com/etcd-io/etcd/pull/13712) in SRV records returned by DNS lookup
-
 ### Package `server`
 
 - Package `mvcc` was moved to `storage/mvcc`

--- a/client/pkg/srv/srv.go
+++ b/client/pkg/srv/srv.go
@@ -106,10 +106,9 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 			return err
 		}
 		for _, srv := range addrs {
-			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(shortHost, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -228,10 +228,10 @@ func TestSRVDiscover(t *testing.T) {
 			[]*net.SRV{
 				{Target: "a.example.com", Port: 2480},
 				{Target: "b.example.com", Port: 2480},
-				{Target: "c.example.com", Port: 2480},
+				{Target: "c.example.com.", Port: 2480},
 			},
 			[]*net.SRV{},
-			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com:2480"},
+			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com.:2480"},
 			false,
 		},
 	}

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -226,8 +226,8 @@ func TestSRVDiscover(t *testing.T) {
 		},
 		{
 			[]*net.SRV{
-				{Target: "a.example.com.", Port: 2480},
-				{Target: "b.example.com.", Port: 2480},
+				{Target: "a.example.com", Port: 2480},
+				{Target: "b.example.com", Port: 2480},
 				{Target: "c.example.com", Port: 2480},
 			},
 			[]*net.SRV{},


### PR DESCRIPTION
Reverts the PR #13712 and adds a unit test for correct handling of canonical SRV records.

xref https://github.com/etcd-io/etcd/issues/13948

/cc @serathius @spzala @ahrtr