### PR TITLE
Revert #13714

### DIFF
--- a/client/pkg/srv/srv.go
+++ b/client/pkg/srv/srv.go
@@ -106,10 +106,9 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 			return err
 		}
 		for _, srv := range addrs {
-			shortHost := strings.TrimSuffix(srv.Target, ".")
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(shortHost, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -228,10 +228,10 @@ func TestSRVDiscover(t *testing.T) {
 			[]*net.SRV{
 				{Target: "a.example.com", Port: 2480},
 				{Target: "b.example.com", Port: 2480},
-				{Target: "c.example.com", Port: 2480},
+				{Target: "c.example.com.", Port: 2480},
 			},
 			[]*net.SRV{},
-			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com:2480"},
+			[]string{"https://a.example.com:2480", "https://b.example.com:2480", "https://c.example.com.:2480"},
 			false,
 		},
 	}

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -226,8 +226,8 @@ func TestSRVDiscover(t *testing.T) {
 		},
 		{
 			[]*net.SRV{
-				{Target: "a.example.com.", Port: 2480},
-				{Target: "b.example.com.", Port: 2480},
+				{Target: "a.example.com", Port: 2480},
+				{Target: "b.example.com", Port: 2480},
 				{Target: "c.example.com", Port: 2480},
 			},
 			[]*net.SRV{},


### PR DESCRIPTION
Reverts the PR #13714 and adds a unit test for correct handling of canonical SRV records.

xref https://github.com/etcd-io/etcd/issues/13948 and master revert PR #13949

/cc @serathius @spzala @ahrtr