### PR TITLE
[DRAFT] add powershell build scripts for native Windows development of etcd

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: Build
 on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -58,3 +59,33 @@ jobs:
               exit 1
               ;;
           esac
+
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        go: ["1.17.8"]
+    env:
+      GIT_ORG: ${{ github.repository_owner }}
+      GIT_REPO: ${{ github.events.repository.name }}
+      GO_VERSION: ${{ matrix.go }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    # This step is required as long as the symlinks for client/v3/*_test.go -> tests/integration/clientv3/examples/*_test.go exist
+      - name: core.symlinks
+        run: |
+          git config --global core.symlinks true
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1      
+      - uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Continuous Integration
+        run: make.ps1 -Script ci # -Version ${{ github.ref }}
+      - uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1"
+          install-go: false
+          cache-key: ${{ matrix.go }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hack/tls-setup/certs
 .gobincache/
 /Documentation/dev-guide/api_reference_v3.md
 /Documentation/dev-guide/api_concurrency_reference_v3.md
+.DS_Store

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,233 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS 
+    Native etcd binary builds for Windows
+.DESCRIPTION 
+    Run the script to build etcd binaries on a Windows machine
+.NOTES
+    Environment Variables
+    - DEBUG (Sets specific Go ldflags for debugging purposes | Switch parameter)
+    - GIT_VERSION (Local version of Git to install | default: 2.35.2)
+    - GO_VERSION (Local version of Go to install | default: 1.17.8)
+    - GIT_ORG (default: etcd-io}
+    - GIT_REPO (default: etcd}
+
+    
+.EXAMPLE
+    make.ps1 -GoDebug
+    make.ps1 -Script ci
+    $env:GIT_ORG="YOUR-GITHUB-ORG"; $env:GIT_REPO="YOUR-GITHUB-REPO"; make.ps1 -Script build
+#>
+
+# Make sure these params matches the CmdletBinding below
+param (
+    # [Parameter(Mandatory = $true)]
+    # [ValidateNotNullOrEmpty()]
+    # [String]
+    # $Version,
+    [Switch]
+    $GoDebug,
+    [AllowEmptyString()]
+    [String]
+    $Script = "build"  # Default invocation is full CI    
+)
+
+function Invoke-EtcdBuild() {
+    # [CmdletBinding()]
+    # param (
+    #     [Parameter(Mandatory = $true)]
+    #     [ValidateNotNullOrEmpty()]
+    #     [String]
+    #     $Version
+    # )
+
+    # TODO: Integration Tests
+    if ($env:SCRIPT_PATH.ToLower().Contains("integration")) {
+        Invoke-EtcdIntegrationTests
+    }
+
+    # TODO: Additional Tests
+    if ($env:SCRIPT_PATH.ToLower().Contains("all")) {
+        Invoke-AllEtcd
+    }
+
+    if ($env:SCRIPT_PATH.ToLower().Contains("build")) {
+        Write-LogInfo "Starting Builds for etcd and etcdctl"
+        Invoke-Script -File scripts\windows\build.ps1
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+        exit 0
+    }
+
+    if (Test-Path $env:SCRIPT_PATH) {
+        Write-LogInfo ("Running {0}.ps1" -f $env:SCRIPT_PATH)
+        Invoke-Script -File $env:SCRIPT_PATH
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+        exit 0
+    }
+}
+
+function Get-Args() {
+    # if ($Version) {
+    #     $env:VERSION = $Version
+    #     $env:GIT_TAG = $env:VERSION
+    # }
+
+    if ($GoDebug.IsPresent) {
+        $env:DEBUG = "true"
+    }
+
+    if ($Script) {
+        $env:SCRIPT_PATH = ("{0}\scripts\windows\{1}.ps1" -f $PSScriptRoot, $Script)
+    }
+}
+
+function Set-Environment() {
+    $GIT_VERSION = $env:GIT_VERSION
+    if (-Not $GIT_VERSION) {        
+        $env:GIT_VERSION = "2.35.2"
+    }
+
+    $GOLANG_VERSION = $env:GOLANG_VERSION
+    if (-Not $GOLANG_VERSION) {        
+        $env:GOLANG_VERSION = "1.17.8"
+    }
+
+    $ORG_PATH = $env:ORG_PATH
+    if (-Not $ORG_PATH) {
+        $env:ORG_PATH = "go.etcd.io"
+    }
+
+    $GIT_ORG = $env:GIT_ORG
+    if (-Not $GIT_ORG) {
+        $env:GIT_ORG = "etcd-io"
+    }
+
+    $GIT_REPO = $env:GIT_REPO
+    if (-Not $GIT_REPO) {
+        $env:GIT_REPO = "etcd"
+    }
+
+    # $VERSION = $env:VERSION
+    # if (-Not $VERSION) {
+    #     $env:VERSION = "$(git rev-parse --short HEAD)"
+    # }
+}
+
+function Set-Path() {
+    # ideally, gopath would be C:\go to match Linux a bit closer
+    # but C:\go is the recommended install path for Go itself on Windows, so we use C:\gopath
+    $env:PATH += ";C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;C:\gopath\bin;C:\go\bin"
+    $environment = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+    $environment = $environment.Insert($environment.Length, ";C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;C:\gopath\bin;C:\go\bin")
+    [System.Environment]::SetEnvironmentVariable("Path", $environment, "Machine")
+}
+    
+function Test-Architecture() {
+    if ($env:PROCESSOR_ARCHITECTURE -ne "AMD64" -and $env:PROCESSOR_ARCHITECTURE -ne "ARM64") {
+        Write-LogFatal "Unsupported architecture $( $env:PROCESSOR_ARCHITECTURE )"
+    }
+}
+
+function Install-Git() {
+    # install git
+    if ($null -eq (Get-Command "git" -ErrorAction SilentlyContinue)) {
+        Push-Location C:\
+        Write-LogInfo ('not found in PATH, installing git v{0} ...' -f $env:GIT_VERSION)
+        Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v$env:GIT_VERSION.windows.1/MinGit-$env:GIT_VERSION-64-bit.zip" -OutFile 'go.zip'
+        Expand-Archive -Force -Path c:\git.zip -DestinationPath c:\git\.
+        Remove-Item -Force -Recurse -Path c:\git.zip
+        Pop-Location
+    } else {
+        Write-LogInfo ('{0} found in PATH, skipping install ...' -f $(git version))
+    }
+}
+    
+function Install-Go() {
+    # install go
+    if ($null -eq (Get-Command "go" -ErrorAction SilentlyContinue)) {
+        Write-LogInfo ("go not found in PATH, installing go{0}" -f $env:GOLANG_VERSION)
+        Push-Location C:\
+        Invoke-WebRequest -Uri ('https://go.dev/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION) -OutFile 'go.zip'
+        Expand-Archive go.zip -DestinationPath C:\
+        Remove-Item go.zip -Force
+        Pop-Location
+        Write-LogInfo ('Installed go{0}' -f $env:GOLANG_VERSION)
+    } else {
+        Write-LogInfo ('{0} found in PATH, skipping go install ...' -f $(go version))
+    }
+}
+
+function Install-Ginkgo() {
+    if ($null -eq (Get-Command "ginkgo" -ErrorAction SilentlyContinue)) {
+        Write-LogInfo "ginkgo not found in PATH, installing"
+        Push-Location c:\
+        go install github.com/onsi/ginkgo/ginkgo@latest
+        go get github.com/onsi/gomega/...
+        Pop-Location
+    } else {
+        Write-LogInfo ('{0} found in PATH, skipping install ...' -f $(ginkgo version))
+    }
+}
+
+function Initialize-Environment() {
+    Write-LogInfo 'Preparing local etcd build environment'
+    Install-Git
+    Install-Go
+    # Install-Ginkgo
+}
+
+function Invoke-EtcdIntegrationTests() {
+    Write-LogInfo "Running Integration Tests"
+    Invoke-Script -File scripts\windows\build.ps1
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    Invoke-Script -File scripts\windows\integration.ps1
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    exit 0
+}
+
+function Invoke-AllEtcd() {
+    Write-LogInfo "Running CI and Integration Tests"
+    Invoke-Script -File scripts\windows\build.ps1
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+    Invoke-Script -File scripts\windows\integration.ps1
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    exit 0
+}
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+Set-StrictMode -Version Latest
+
+if (-Not (Test-Path "$PSScriptRoot\scripts\windows\$Script.ps1")) {
+    throw "$Script is not a valid script name in $(Write-Output $PSScriptRoot\scripts\windows)"
+}
+$env:SCRIPT_PATH = $Script
+
+Import-Module -WarningAction Ignore -Name "$PSScriptRoot\scripts\windows\utils.psm1"
+
+if ($GoDebug.IsPresent) {
+    Write-LogInfo "Debug mode is enabled"
+    $env:DEBUG = "true"
+}
+
+Get-Args
+Test-Architecture
+Initialize-Environment
+Set-Environment
+Set-Path
+# This is required as long as the symlinks for client/v3/*_test.go -> tests/integration/clientv3/examples/*_test.go exist
+git config --global core.symlinks true
+
+Invoke-EtcdBuild # -Version $env:VERSION

--- a/scripts/windows/README
+++ b/scripts/windows/README
@@ -1,0 +1,1 @@
+Scripts for Windows native CI and Development of etcd

--- a/scripts/windows/build.ps1
+++ b/scripts/windows/build.ps1
@@ -1,0 +1,69 @@
+#Requires -Version 5.0
+$ErrorActionPreference = 'Stop'
+
+Import-Module -WarningAction Ignore -Name "$PSScriptRoot\utils.psm1"
+
+
+function Build {
+    param (
+        # [Parameter()]
+        # [String]
+        # $Version,
+        [parameter()]
+        [string]
+        $BuildPath,
+        [parameter()]
+        [string]
+        $Commit,
+        [parameter()]
+        [string]
+        $Output        
+    )
+    $env:GO_LDFLAGS = '-s -w -gcflags=all=-dwarf=false -extldflags "-static"'
+
+    if ($env:DEBUG) {
+        $env:GO_LDFLAGS = '-v -gcflags=all=-N -l'
+        Write-LogInfo ('Debug flag passed, changing ldflags to {0}' -f $env:GO_LDFLAGS )
+        # go install github.com/go-delve/delve/cmd/dlv@latest
+    }
+
+    $GO_LDFLAGS = ("'{0} -X {1}/{2}/version.GitSHA={3}'" -f $env:GO_LDFLAGS, $env:ORG_PATH, $env:GIT_REPO, $Commit)
+    if ($env:DEBUG){
+        Write-LogInfo "[DEBUG] Running command: go build -o $Output -ldflags $GO_LDFLAGS"
+    }
+
+    Push-Location $BuildPath
+    go build -o $Output -ldflags $GO_LDFLAGS .
+    Pop-Location
+    if (-Not $?) {
+        Write-LogFatal "go build for $BuildPath failed!"
+    }
+}
+
+trap {
+    Write-Host -NoNewline -ForegroundColor Red "[ERROR]: "
+    Write-Host -ForegroundColor Red "$_"
+
+    Pop-Location
+    exit 1
+}
+
+Invoke-Script -File "$PSScriptRoot\version.ps1"
+
+$SRC_PATH = (Resolve-Path "$PSScriptRoot\..\..").Path
+Push-Location $SRC_PATH
+if ($env:DEBUG) {
+    Write-LogInfo "[DEBUG] Build Path: $SRC_PATH"
+}
+
+Remove-Item -Path "$SRC_PATH/bin/*.exe" -Force -ErrorAction Ignore
+$null = New-Item -Type Directory -Path bin -ErrorAction Ignore
+$env:GOARCH = $env:ARCH
+$env:GOOS = 'windows'
+$env:CGO_ENABLED = 0
+
+Build -BuildPath "$SRC_PATH/server" -Commit $env:COMMIT -Output "..\bin\etcd.exe" # -Version $env:VERSION
+Build -BuildPath "$SRC_PATH/etcdctl" -Commit $env:COMMIT -Output "..\bin\etcdctl.exe" # -Version $env:VERSION
+Write-LogInfo "Builds Complete"
+
+Pop-Location

--- a/scripts/windows/ci.ps1
+++ b/scripts/windows/ci.ps1
@@ -1,0 +1,9 @@
+#Requires -Version 5.0
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module -WarningAction Ignore -Name "$PSScriptRoot\utils.psm1"
+
+# TODO: Invoke-Script -File "$PSScriptRoot\test.ps1"
+Invoke-Script -File "$PSScriptRoot\build.ps1"
+# TODO: Invoke-Script -File "$PSScriptRoot\integration.ps1"

--- a/scripts/windows/utils.psm1
+++ b/scripts/windows/utils.psm1
@@ -1,0 +1,52 @@
+#Requires -Version 5.0
+
+$ErrorActionPreference = 'Stop'
+$WarningPreference = 'SilentlyContinue'
+$VerbosePreference = 'SilentlyContinue'
+$DebugPreference = 'SilentlyContinue'
+$InformationPreference = 'SilentlyContinue'
+
+function Write-LogInfo {
+    Write-Host -NoNewline -ForegroundColor Blue "INFO: "
+    Write-Host -ForegroundColor Gray ("{0,-44}" -f ($Args -join " "))
+}
+
+function Write-LogWarn {
+    Write-Host -NoNewline -ForegroundColor DarkYellow "WARN: "
+    Write-Host -ForegroundColor Gray ("{0,-44}" -f ($args -join " "))
+}
+
+function Write-LogError {
+    Write-Host -NoNewline -ForegroundColor DarkRed "ERRO "
+    Write-Host -ForegroundColor Gray ("{0,-44}" -f ($args -join " "))
+}
+
+
+function Write-LogFatal {
+    Write-Host -NoNewline -ForegroundColor DarkRed "FATA: "
+    Write-Host -ForegroundColor Gray ("{0,-44}" -f ($args -join " "))
+
+    exit 255
+}
+
+function Invoke-Script {
+    param (
+        [parameter(Mandatory = $true)] [string]$File
+    )
+
+    try {
+        Invoke-Expression -Command $File
+        if (-not $?) {
+            Write-LogFatal "Failed to invoke $File"
+        }
+    }
+    catch {
+        Write-LogFatal "Could not invoke $File, $($_.Exception.Message)"
+    }
+}
+
+Export-ModuleMember -Function Write-LogInfo
+Export-ModuleMember -Function Write-LogWarn
+Export-ModuleMember -Function Write-LogError
+Export-ModuleMember -Function Write-LogFatal
+Export-ModuleMember -Function Invoke-Script

--- a/scripts/windows/version.ps1
+++ b/scripts/windows/version.ps1
@@ -1,0 +1,40 @@
+#Requires -Version 5.0
+$ErrorActionPreference = 'Stop'
+
+Import-Module -WarningAction Ignore -Name "$PSScriptRoot\utils.psm1"
+
+$DIRTY = ""
+if ("$(git status --porcelain --untracked-files=no)") {
+    $DIRTY = "-dirty"
+}
+
+$COMMIT = $(git rev-parse --short HEAD)
+$GIT_TAG = $env:GIT_TAG
+if (-not $GIT_TAG) {
+    $GIT_TAG = $(git tag -l --contains HEAD | Select-Object -First 1)
+}
+$env:COMMIT = $COMMIT
+
+$VERSION = "${COMMIT}${DIRTY}"
+if ((-not $DIRTY) -and ($GIT_TAG)) {
+    $VERSION = "${GIT_TAG}"
+}
+$env:VERSION = $VERSION
+
+$ARCH = $env:ARCH
+if (-not $ARCH) {
+    $ARCH = "amd64"
+}
+$env:ARCH = $ARCH
+
+$buildTags = @{ "17763" = "1809"; "19042" = "20H2"; "20348" = "ltsc2022";}
+$buildNumber = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\' -ErrorAction Ignore).CurrentBuildNumber
+$SERVERCORE_VERSION = $buildTags[$buildNumber]
+if (-not $SERVERCORE_VERSION) {
+    $env:SERVERCORE_VERSION = "1809"
+}
+
+Write-LogInfo "ARCH: $ARCH"
+Write-LogInfo "VERSION: $VERSION"
+Write-LogInfo "GIT_SHA: $COMMIT"
+Write-LogInfo "SERVERCORE_VERSION: $SERVERCORE_VERSION"


### PR DESCRIPTION
This PR adds new Windows build scripts as the previous script was [removed](https://github.com/etcd-io/etcd/pull/13710) due to no longer working and not being actively maintained.

I have also added a step to the `build` GH action that leverages the new scripts to build the etcd/etcdctl binaries on a Windows runner.

Status:  
- etcd and etcdctl build with the new scripts.
- I am currently working through issues with the etcd binary `version.GitSha` not being correctly set during build time even with the same linker flag values and process as linux. This appears to be a more complex problem than I anticipated and that's delayed this PR. It appears to be due to the same underlying issue that caused the original script to break. 

I wanted to get this PR up as a draft in the interim until I can figure out how to fix the linker flag.

@serathius I believe this PR will meet the requirements you stated here https://github.com/etcd-io/etcd/issues/13667#issuecomment-1044177247 once I get the linker flag item resolved.
