### PR TITLE
test.sh script improvement (OsX centric)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,16 +96,16 @@ pull-docker-test:
 test:
 	$(info TEST_OPTS: $(TEST_OPTS))
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	$(TEST_OPTS) ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
+	$(TEST_OPTS) OUTPUT_FILE="test-$(TEST_SUFFIX).log" ./scripts/test.sh
 	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 test-smoke:
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	PASSES="fmt build unit" ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
+	PASSES="fmt build unit" OUTPUT_FILE="test-$(TEST_SUFFIX).log" ./scripts/test.sh
 
 test-full:
 	$(info log-file: test-$(TEST_SUFFIX).log)
-	PASSES="fmt build release unit integration functional e2e grpcproxy" ./scripts/test.sh > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
+	PASSES="fmt build release unit integration functional e2e grpcproxy" OUTPUT_FILE="test-$(TEST_SUFFIX).log" ./scripts/test.sh
 
 ensure-docker-test-image-exists:
 	make pull-docker-test || ( echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test )
@@ -122,7 +122,7 @@ docker-test: ensure-docker-test-image-exists
 	  $(TMP_DIR_MOUNT_FLAG) \
 	  --mount type=bind,source=`pwd`,destination=/go/src/go.etcd.io/etcd \
 	  gcr.io/etcd-development/etcd-test:go$(GO_VERSION) \
-	  /bin/bash -c "$(TEST_OPTS) ./scripts/test.sh 2>&1" > test-$(TEST_SUFFIX).log 2>&1 || (cat test-$(TEST_SUFFIX).log && exit 1)
+	  /bin/bash -c "$(TEST_OPTS) OUTPUT_FILE='test-$(TEST_SUFFIX).log' ./scripts/test.sh"
 	! egrep "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
 docker-test-coverage:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -101,7 +101,7 @@ tools_build() {
 
 tests_build() {
   out=${BINDIR:-./bin}
-  out=$(readlink -m "$out")
+  out=$(readlink -f "$out")
   out="${out}/functional/cmd"
   mkdir -p "${out}"
   BINDIR="${out}" run ./tests/functional/build.sh || return 2

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -46,6 +46,11 @@ export ETCD_VERIFY=all
 source ./scripts/test_lib.sh
 source ./scripts/build.sh
 
+if [ -n "${OUTPUT_FILE}" ]; then
+  log_callout "Dumping output to: ${OUTPUT_FILE}"
+  exec > >(tee -a "${OUTPUT_FILE}") 2>&1
+fi
+
 PASSES=${PASSES:-"fmt bom dep build unit"}
 PKG=${PKG:-}
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -462,7 +462,7 @@ function staticcheck_pass {
 }
 
 function revive_pass {
-  run_for_modules generic_checker run_go_tool "github.com/mgechev/revive" -config "${ETCD_ROOT_DIR}/tests/revive.toml" -exclude "vendor/..."
+  run_for_modules generic_checker run_go_tool "github.com/mgechev/revive" -config "${ETCD_ROOT_DIR}/tests/revive.toml" -exclude "vendor/..." -exclude "out/..."
 }
 
 function unconvert_pass {

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -319,7 +319,7 @@ function go_test {
     local cmd=( go test ${goTestFlags} ${additional_flags} "$@" ${pkg} )
 
     # shellcheck disable=SC2086
-    if ! run env ${goTestEnv} "${cmd[@]}" | tee ${junit_filename_prefix:+"${junit_filename_prefix}.stdout"} | grep --binary-files=text "${go_test_grep_pattern}" ; then
+    if ! run env ${goTestEnv} ETCD_VERIFY="${ETCD_VERIFY}" "${cmd[@]}" | tee ${junit_filename_prefix:+"${junit_filename_prefix}.stdout"} | grep --binary-files=text "${go_test_grep_pattern}" ; then
       if [ "${mode}" != "keep_going" ]; then
         produce_junit_xmlreport "${junit_filename_prefix}"
         return 2
@@ -373,7 +373,7 @@ function tool_get_bin {
     pkg_part=$(dirname "${pkg_part}")
   fi
 
-  command -v "$(basename "${pkg_part}")"
+  run_for_module ./tools/mod go list -f '{{.Target}}' "${pkg_part}"
 }
 
 # tool_pkg_dir [pkg] - returns absolute path to a directory that stores given pkg.
@@ -386,6 +386,7 @@ function tool_pkg_dir {
 function run_go_tool {
   local cmdbin
   if ! cmdbin=$(GOARCH="" tool_get_bin "${1}"); then
+    log_warning "Failed to install tool '${1}'"
     return 2
   fi
   shift 1

--- a/server/go.sum
+++ b/server/go.sum
@@ -317,8 +317,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f h1:aZp0e2vLN4MToVqnjNEYEtrEA8RH8U8FN1CU7JgqsPU=
-golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -383,6 +381,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220105145211-5b0dc2dfae98 h1:+6WJMRLHlD7X7frgp7TUZ36RnQzSf9wVVTNakEp+nqY=
 golang.org/x/net v0.0.0-20220105145211-5b0dc2dfae98/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -444,9 +443,9 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gyuho/gocovmerge v0.0.0-20171205171859-50c7e6afd535
 	github.com/hexfusion/schwag v0.0.0-20211117114134-3ceb0191ccbf
 	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f
-	github.com/mgechev/revive v1.2.0
+	github.com/mgechev/revive v1.2.1
 	github.com/mikefarah/yq/v4 v4.24.2
 	go.etcd.io/protodoc v0.0.0-20180829002748-484ab544e116
 	gotest.tools/gotestsum v1.7.0
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/a8m/envsubst v1.3.0 // indirect

--- a/tools/mod/go.sum
+++ b/tools/mod/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -176,6 +178,8 @@ github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8c
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.2.0 h1:NMrnKXYvqnM1v+SwfQcDME/wiYrw0jrwH3n1CH619Qk=
 github.com/mgechev/revive v1.2.0/go.mod h1:ve5USoWcra0JIucczIiejniI4xLJluHg4pkBv5kEtOs=
+github.com/mgechev/revive v1.2.1 h1:GjFml7ZsoR0IrQ2E2YIvWFNS5GPDV7xNwvA5GM1HZC4=
+github.com/mgechev/revive v1.2.1/go.mod h1:+Ro3wqY4vakcYNtkBWdZC7dBg1xSB6sp054wWwmeFm0=
 github.com/mikefarah/yq/v4 v4.24.2 h1:2xRu/L49ee+4n964G9cD2PtHOvj3/OQ7up0uXAHb/BY=
 github.com/mikefarah/yq/v4 v4.24.2/go.mod h1:S+m9R9Qq17v0Mg/DtaESrbvfvrgbrOEMlEsSN57huV0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=


### PR DESCRIPTION
Bunch of fixes makes development difficult on OsX: 

    - The location of installed tools is found using `go list`
    - ETCD_VERIFY env variable is printed in repro command line.
    -  `readlink -f` is supported since OsX 12.3.

Before the change: 
```
PASSES="build" ./scripts/test.sh
./scripts/updatebom.sh
PASSES="revive" ./scripts/test.sh
```
were failing on OsX (12.3).