### PR TITLE
smoke test:fix license header check

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -108,7 +108,7 @@ function relativePath {
 # go_srcs_in_module [package]
 # returns list of all not-generated go sources in the current (dir) module.
 function go_srcs_in_module {
-  go fmt -n "$1"  | grep -Eo "([^ ]*)$" | grep -vE "(\\_test.go|\\.pb\\.go|\\.pb\\.gw.go)"
+  go list -f "{{with \$c:=.}}{{range \$f:=\$c.GoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{end}}" ./... | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
 }
 
 # pkgs_in_module [optional:package_pattern]


### PR DESCRIPTION
partially fixes: https://github.com/etcd-io/etcd/issues/13896

This PR fixes `make test-smoke` pass for `license_header`

Fixed `function go_srcs_in_module` to return go files in the package.
