### PR TITLE
Use lineariziable range request in TestKVGet

### DIFF
--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -63,7 +63,7 @@ func TestKVPut(t *testing.T) {
 				if err := cc.Put(key, value, config.PutOptions{}); err != nil {
 					t.Fatalf("count not put key %q, err: %s", key, err)
 				}
-				resp, err := cc.Get(key, config.GetOptions{Serializable: true})
+				resp, err := cc.Get(key, config.GetOptions{})
 				if err != nil {
 					t.Fatalf("count not get key %q, err: %s", key, err)
 				}


### PR DESCRIPTION
Fix the following test failure.

```

$ cd tests/common/
$ go test --tags integration -run TestKVPut -v
    logger.go:130: 2022-04-18T08:58:29.561+0800	INFO	m1	trace[1615401671] put	{"member": "m1", "detail": "{key:foo; req_size:10; response_revision:2; }", "duration": "136.483949ms", "start": "2022-04-18T08:58:29.425+0800", "end": "2022-04-18T08:58:29.561+0800", "steps": ["trace[1615401671] 'process raft request'  (duration: 75.406328ms)", "trace[1615401671] 'marshal mvccpb.KeyValue'  (duration: 60.998853ms)"], "step_count": 2}
    kv_test.go:71: Unexpected lenth of response, got 0
    cluster.go:1368: ========= Cluster termination started =====================
panic: runtime error: index out of range [0] with length 0

goroutine 708 [running]:
go.etcd.io/etcd/tests/v3/common.TestKVPut.func1.1()
	/Users/wachao/go/src/github.com/ahrtr/etcd/tests/common/kv_test.go:73 +0x45f
go.etcd.io/etcd/tests/v3/framework/testutils.ExecuteWithTimeout.func1()
	/Users/wachao/go/src/github.com/ahrtr/etcd/tests/framework/testutils/execute.go:29 +0x5b
created by go.etcd.io/etcd/tests/v3/framework/testutils.ExecuteWithTimeout
	/Users/wachao/go/src/github.com/ahrtr/etcd/tests/framework/testutils/execute.go:27 +0xaf
exit status 2
FAIL	go.etcd.io/etcd/tests/v3/common	2.506s

```

Note: use command below can reproduce this issue more easily (without the `-v`),
```
$ go test --tags integration -run TestKVPut
```