### PR TITLE
Fixed potential goroutine leak due to p.Ready() receive in pkg/proxy and dependents.

### DIFF
--- a/tests/functional/cmd/etcd-proxy/main.go
+++ b/tests/functional/cmd/etcd-proxy/main.go
@@ -87,7 +87,13 @@ $ ./bin/etcdctl --endpoints localhost:23790 put foo bar`)
 			zap.Int("port", httpPort))
 	}
 	p := proxy.NewServer(cfg)
-	<-p.Ready()
+
+	select {
+	case <-p.Ready():
+	case err := <-p.Error():
+		panic(err)
+	}
+
 	defer p.Close()
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
Fixed potential goroutine leak due to receive operations on p.Ready().

If the server creation process via [NewServer](https://github.com/etcd-io/etcd/blob/4555fc39988a723992748fe36704e114fa80e2a7/pkg/proxy/server.go#L193) encounters an error at [line 257](https://github.com/etcd-io/etcd/blob/4555fc39988a723992748fe36704e114fa80e2a7/pkg/proxy/server.go#L257), it will fail to spawn `go s.listenAndServer` at [line 265](https://github.com/etcd-io/etcd/blob/4555fc39988a723992748fe36704e114fa80e2a7/pkg/proxy/server.go#L265), thus not closing `s.readyc` ([line 289](https://github.com/etcd-io/etcd/blob/4555fc39988a723992748fe36704e114fa80e2a7/pkg/proxy/server.go#L289)) . Any receive on `p.Ready()` for the server `p` returned by `NewServer` will block indefinitely.

The introduced `select` statement captures the error sent to `s.errc` on [line 258](https://github.com/etcd-io/etcd/blob/4555fc39988a723992748fe36704e114fa80e2a7/pkg/proxy/server.go#L258), reports  the abnormal behaviour, and unblocks the receiver thread of `p.Ready()`.