### PR TITLE
Doc: update logging convention

### DIFF
--- a/Documentation/contributor-guide/logging.md
+++ b/Documentation/contributor-guide/logging.md
@@ -1,29 +1,33 @@
 # Logging Conventions
 
-etcd uses the [capnslog][capnslog] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
+etcd uses the [zap][zap] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
 
-* Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost
+* Debug: Everything is still fine, but even common operations may be logged, and less helpful but more quantity of notices. Usually not used in production.
   * Examples:
-    * A failure to allocate disk space for WAL
+    * Send a normal message to a remote peer
+    * Write a log entry to disk
+
+* Info: Normal, working log information, everything is fine, but helpful notices for auditing or common operations. Should rather not be logged more frequently than once per a few seconds in normal server's operation.
+  * Examples:
+    * Startup configuration
+    * Start to do snapshot
 
 * Warning: (Hopefully) Temporary conditions that may cause errors, but may work fine. A replica disappearing (that may reconnect) is a warning.
   * Examples:
     * Failure to send raft message to a remote peer
     * Failure to receive heartbeat message within the configured election timeout
 
-* Notice: Normal, but important (uncommon) log information.
+* Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost.
   * Examples:
-    * Add a new node into the cluster
-    * Add a new user into auth subsystem
+    * Failure to allocate disk space for WAL
 
-* Info: Normal, working log information, everything is fine, but helpful notices for auditing or common operations.
+* Panic: Unrecoverable or unexpected error situation that requires stopping execution.
   * Examples:
-    * Startup configuration
-    * Start to do snapshot
+    * Failure to create the database
 
-* Debug: Everything is still fine, but even common operations may be logged, and less helpful but more quantity of notices.
+* Fatal: Unrecoverable or unexpected error situation that requires immediate exit. Mostly used in the test.
   * Examples:
-    * Send a normal message to a remote peer
-    * Write a log entry to disk
+    * Failure to find the data directory
+    * Failure to run a test function
 
-[capnslog]: https://github.com/coreos/pkg/tree/master/capnslog
+[zap]: https://github.com/uber-go/zap


### PR DESCRIPTION
Update the logging convention as capnslog is replaced by zap. Also, update the log levels to proper order.

@serathius thank you for catching this required update in https://github.com/etcd-io/etcd/pull/13965 
