### PR TITLE
embed: Fix logger spelling in NewZapLoggerBuilder godoc

### DIFF
--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -201,7 +201,7 @@ func (cfg *Config) setupLogging() error {
 	return nil
 }
 
-// NewZapLoggerBuilder generates a zap logger builder that sets given loger
+// NewZapLoggerBuilder generates a zap logger builder that sets given logger
 // for embedded etcd.
 func NewZapLoggerBuilder(lg *zap.Logger) func(*Config) error {
 	return func(cfg *Config) error {


### PR DESCRIPTION
Just a small docs fix that I happened to notice when setting up a new zap logger for etcd


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
