### PR TITLE
doc: Fix Markdown code block

### DIFF
--- a/Documentation/contributor-guide/trige_issues.md
+++ b/Documentation/contributor-guide/trige_issues.md
@@ -6,7 +6,7 @@ Speed up issue management.
 
 The `etcd` issues are listed at https://github.com/etcd-io/etcd/issues
 and are identified with labels. For example, an issue that is identified
-as a bug will eventually be set to label `area/bug `. New issues will
+as a bug will eventually be set to label `area/bug`. New issues will
 start out without any labels, but typically `etcd` maintainers and active contributors
 add labels based on their findings. The detailed list of labels can be found at
 https://github.com/kubernetes/kubernetes/labels

--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -385,7 +385,7 @@ func withMax(maxRetries uint) retryOption {
 	}}
 }
 
-// WithBackoff sets the `BackoffFunc `used to control time between retries.
+// WithBackoff sets the `BackoffFunc` used to control time between retries.
 func withBackoff(bf backoffFunc) retryOption {
 	return retryOption{applyFunc: func(o *options) {
 		o.backoffFunc = bf


### PR DESCRIPTION
- Remove redundant space inside `` `code ` ``.
- Change `` The `code `block `` to `` The `code` block `` 