### PR TITLE
change ARCH to GOARCH in build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,31 +27,31 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-amd64)
-              ARCH=amd64 PASSES='build' ./scripts/test.sh
+              GOARCH=amd64 PASSES='build' ./scripts/test.sh
               ;;
             linux-386)
-              ARCH=386 PASSES='build' ./scripts/test.sh
+              GOARCH=386 PASSES='build' ./scripts/test.sh
               ;;
             darwin-amd64)
-              ARCH=amd64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=amd64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             darwin-arm64)
-              ARCH=arm64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=arm64 GOOS=darwin GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             windows-amd64)
-              ARCH=amd64 GOOS=windows GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=amd64 GOOS=windows GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             linux-arm)
-              ARCH=arm GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=arm GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             linux-arm64)
-              ARCH=arm64 GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=arm64 GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             linux-ppc64le)
-              ARCH=ppc64le GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=ppc64le GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             linux-s390x)
-              ARCH=s390x GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              GOARCH=s390x GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             *)
               echo "Failed to find target"


### PR DESCRIPTION
`ARCH` isn't correct, instead we should use `GOARCH`. The script `scripts/build.sh` doesn't use `ARCH` at all.