### PR TITLE
Nomination for Benjamin (ahrtr@) as a project maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,6 +9,7 @@
 # Please keep the list sorted.
 
 # MAINTAINERS
+Benjamin Wang <wachao@vmware.com> (ahrtr@) pkg:*
 Gyuho Lee <gyuhox@gmail.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
@@ -26,4 +27,3 @@ Tobias Grieger <tobias.schottdorf@gmail.com> (@tbg) pkg:go.etcd.io/etcd/raft
 # REVIEWERS
 Lili Cosic <cosiclili@gmail.com> (lilic@) pkg:*
 Wilson Wang <wilson.wang@bytedance.com> (wilsonwang371@) pkg:*
-Benjamin Wang <wachao@vmware.com> (ahrtr@) pkg:*


### PR DESCRIPTION
Benjamin (@ahrtr) is one of the current reviewers. Benjamin has proven high level of etcd expertise
and impact on the project, including delivering fixes to data-corruption bugs in etcd,
care about test quality and overall project health.

Per discussion with existing maintainers, I nominate him for the maintainer role.
Benjamin, thank you for your outstanding contributions to the project.

@gyuho
@mitake 
@jingyih 
@jpbetz 
@serathius 
@spzala 
@hexfusion 
@wenjiaswe 
@xiang90 