### PR TITLE
Update 3.5 and 3.6 changelog for recent merged PRs

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,6 +4,16 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.5 (TBD)
+
+### etcd server
+- Fix [lease leak issue due to tokenProvider isn't enabled when restoring auth store from a snapshot](https://github.com/etcd-io/etcd/pull/13205).
+
+### Other
+- [Bump golang.org/x/crypto to latest version](https://github.com/etcd-io/etcd/pull/13996) to address [CVE-2022-27191](https://github.com/advisories/GHSA-8c26-wmh5-6g9v).
+
+<hr>
+
 ## v3.5.4 (2022-04-24)
 
 ### etcd server
@@ -25,6 +35,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [Etcdserver is still in progress of processing LeaseGrantRequest when it receives a LeaseKeepAliveRequest on the same leaseID](https://github.com/etcd-io/etcd/pull/13932)
 - Fix [consistent_index coming from snapshot is overwritten by the old local value](https://github.com/etcd-io/etcd/pull/13933)
 - [Update container base image snapshot](https://github.com/etcd-io/etcd/pull/13862)
+- Fix [Defrag unsets backend options](https://github.com/etcd-io/etcd/pull/13701).
 
 ### package `client/pkg/v3`
 

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -66,6 +66,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Fix [Etcdserver is still in progress of processing LeaseGrantRequest when it receives a LeaseKeepAliveRequest on the same leaseID](https://github.com/etcd-io/etcd/pull/13690)
 - Fix [consistent_index coming from snapshot is overwritten by the old local value](https://github.com/etcd-io/etcd/pull/13930)
 - Fix [etcd panic on startup (auth enabled)](https://github.com/etcd-io/etcd/pull/13942)
+- Fix [Defrag unsets backend options](https://github.com/etcd-io/etcd/pull/13679).
 
 ### tools/benchmark
 
@@ -83,5 +84,6 @@ See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per 
 ### Other
 
 - Use Distroless as base image to make the image less vulnerable and reduce image size.
+- [Bump golang.org/x/crypto to latest version](https://github.com/etcd-io/etcd/pull/13969) to address [CVE-2022-27191](https://github.com/advisories/GHSA-8c26-wmh5-6g9v).
 
 <hr>


### PR DESCRIPTION
Some PRs are merged into 3.5 and main, but the changelogs are not updated.

cc @cfz @lavacat @cmurphy
