### PR TITLE
[3.4] etcdserver: fix broken APIv2 with long URI

### DIFF
--- a/embed/serve.go
+++ b/embed/serve.go
@@ -132,7 +132,7 @@ func (sctx *serveCtx) serve(
 			Handler:  createAccessController(sctx.lg, s, httpmux),
 			ErrorLog: logger, // do not log user error
 		}
-		httpl := m.Match(cmux.HTTP1())
+		httpl := m.Match(cmux.HTTP1Fast())
 		go func() { errHandler(srvhttp.Serve(httpl)) }()
 
 		sctx.serversC <- &servers{grpc: gs, http: srvhttp}


### PR DESCRIPTION
APIv2 doesn't support operations with URI length > 4k.
This could be relatively easy achieved by CAS operations with value size
about 2k.

This is not documented issue caused by using cmux to serve HTTP1
and HTTP2 protocols on the same port (2379 by default).
cmux has hardcoded max request size for HTTP1 matcher
and returns `false` if size is greater.
HTTP1Fast matcher from cmux validates requests only against known
HTTP methods (GET, POST, PUT, DELETE, OPTIONS,..)
and doesn't have such limit.

Fixes #14023 
