### PR TITLE
Fix member response header missing revision

### DIFF
--- a/server/etcdserver/api/v3rpc/member.go
+++ b/server/etcdserver/api/v3rpc/member.go
@@ -106,7 +106,7 @@ func (cs *ClusterServer) MemberPromote(ctx context.Context, r *pb.MemberPromoteR
 }
 
 func (cs *ClusterServer) header() *pb.ResponseHeader {
-	return &pb.ResponseHeader{ClusterId: uint64(cs.cluster.ID()), MemberId: uint64(cs.server.ID()), RaftTerm: cs.server.Term()}
+	return &pb.ResponseHeader{ClusterId: uint64(cs.cluster.ID()), MemberId: uint64(cs.server.ID()), RaftTerm: cs.server.Term(), Revision: cs.server.KV().Rev()}
 }
 
 func membersToProtoMembers(membs []*membership.Member) []*pb.Member {


### PR DESCRIPTION
Fix issue raised in https://github.com/etcd-io/etcd/pull/14020#discussion_r868453327

Before
```
$ etcdctl member list -w json | jq .
{
  "header": {
    "cluster_id": 14841639068965180000,
    "member_id": 10276657743932975000,
    "raft_term": 13
  },
  "members": [
    {
      "ID": 10276657743932975000,
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```

After
```
$ etcdctl member list -w json | jq .
{
  "header": {
    "cluster_id": 14841639068965180000,
    "member_id": 10276657743932975000,
    "revision": 1,
    "raft_term": 14
  },
  "members": [
    {
      "ID": 10276657743932975000,
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```
