### PR TITLE
server: Director can be stopped

### DIFF
--- a/server/proxy/httpproxy/director.go
+++ b/server/proxy/httpproxy/director.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"go.etcd.io/etcd/pkg/v3/osutil"
 	"go.uber.org/zap"
 )
 
@@ -45,7 +44,6 @@ func newDirector(lg *zap.Logger, urlsFunc GetProxyURLs, failureWait time.Duratio
 		stopc:       make(chan struct{}),
 		donec:       make(chan struct{}),
 	}
-	osutil.RegisterInterruptHandler(d.stop)
 	d.refresh()
 	go func() {
 		defer close(d.donec)

--- a/server/proxy/httpproxy/director_test.go
+++ b/server/proxy/httpproxy/director_test.go
@@ -67,12 +67,7 @@ func TestNewDirectorScheme(t *testing.T) {
 			t.Errorf("#%d: want endpoints = %#v, got = %#v", i, tt.want, gep)
 		}
 
-		close(got.stopc)
-		select {
-		case <-got.donec:
-		case <-time.After(time.Second):
-			t.Fatalf("done took too long")
-		}
+		got.stop()
 	}
 }
 

--- a/server/proxy/httpproxy/director_test.go
+++ b/server/proxy/httpproxy/director_test.go
@@ -55,8 +55,7 @@ func TestNewDirectorScheme(t *testing.T) {
 		uf := func() []string {
 			return tt.urls
 		}
-		stop, donec := make(chan struct{}), make(chan struct{})
-		got := newDirector(zaptest.NewLogger(t), uf, time.Minute, time.Minute, stop, donec)
+		got := newDirector(zaptest.NewLogger(t), uf, time.Minute, time.Minute)
 
 		var gep []string
 		for _, ep := range got.ep {
@@ -68,9 +67,9 @@ func TestNewDirectorScheme(t *testing.T) {
 			t.Errorf("#%d: want endpoints = %#v, got = %#v", i, tt.want, gep)
 		}
 
-		close(stop)
+		close(got.stopc)
 		select {
-		case <-donec:
+		case <-got.donec:
 		case <-time.After(time.Second):
 			t.Fatalf("done took too long")
 		}

--- a/server/proxy/httpproxy/proxy.go
+++ b/server/proxy/httpproxy/proxy.go
@@ -58,7 +58,7 @@ func NewHandler(lg *zap.Logger, t *http.Transport, urlsFunc GetProxyURLs, failur
 
 	p := &reverseProxy{
 		lg:        lg,
-		director:  newDirector(lg, urlsFunc, failureWait, refreshInterval),
+		director:  newDirector(lg, urlsFunc, failureWait, refreshInterval, nil, nil),
 		transport: t,
 	}
 

--- a/server/proxy/httpproxy/proxy.go
+++ b/server/proxy/httpproxy/proxy.go
@@ -58,7 +58,7 @@ func NewHandler(lg *zap.Logger, t *http.Transport, urlsFunc GetProxyURLs, failur
 
 	p := &reverseProxy{
 		lg:        lg,
-		director:  newDirector(lg, urlsFunc, failureWait, refreshInterval, nil, nil),
+		director:  newDirector(lg, urlsFunc, failureWait, refreshInterval),
 		transport: t,
 	}
 


### PR DESCRIPTION
Goroutine for new directors would live past director scope. Tests
could occasionally fail if this goroutine had log events after
test execution should have ended.

Fixes #14021 
