### PR TITLE
Hide the revision field when it isn't populated

### DIFF
--- a/api/etcdserverpb/rpc.pb.go
+++ b/api/etcdserverpb/rpc.pb.go
@@ -275,7 +275,8 @@ type ResponseHeader struct {
 	ClusterId uint64 `protobuf:"varint,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	// member_id is the ID of the member which sent the response.
 	MemberId uint64 `protobuf:"varint,2,opt,name=member_id,json=memberId,proto3" json:"member_id,omitempty"`
-	// revision is the key-value store revision when the request was applied.
+	// revision is the key-value store revision when the request was applied, and it's
+	// unset (so 0) in case of calls not interacting with key-value store.
 	// For watch progress responses, the header.revision indicates progress. All future events
 	// received in this stream are guaranteed to have a higher revision number than the
 	// header.revision number.

--- a/api/etcdserverpb/rpc.proto
+++ b/api/etcdserverpb/rpc.proto
@@ -395,7 +395,8 @@ message ResponseHeader {
   uint64 cluster_id = 1;
   // member_id is the ID of the member which sent the response.
   uint64 member_id = 2;
-  // revision is the key-value store revision when the request was applied.
+  // revision is the key-value store revision when the request was applied, and it's
+  // unset (so 0) in case of calls not interacting with key-value store.
   // For watch progress responses, the header.revision indicates progress. All future events
   // received in this stream are guaranteed to have a higher revision number than the
   // header.revision number.

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -36,7 +36,12 @@ func (p *fieldsPrinter) kv(pfx string, kv *spb.KeyValue) {
 func (p *fieldsPrinter) hdr(h *pb.ResponseHeader) {
 	fmt.Println(`"ClusterID" :`, h.ClusterId)
 	fmt.Println(`"MemberID" :`, h.MemberId)
-	fmt.Println(`"Revision" :`, h.Revision)
+	// Revision only makes sense for k/v responses. For other kinds of
+	// responses, i.e. MemberList, usually the revision isn't populated
+	// at all; so it would be better to hide this field in these cases.
+	if h.Revision > 0 {
+		fmt.Println(`"Revision" :`, h.Revision)
+	}
 	fmt.Println(`"RaftTerm" :`, h.RaftTerm)
 }
 


### PR DESCRIPTION
Refer to [discussion_r869007119](https://github.com/etcd-io/etcd/pull/14026#discussion_r869007119) and [discussion_r869044404](https://github.com/etcd-io/etcd/pull/14026#discussion_r869044404)

Before the change: 
```
$ etcdctl  member list -w fields
"ClusterID" : 14841639068965178418
"MemberID" : 10276657743932975437
"Revision" : 0
"RaftTerm" : 2
"ID" : 10276657743932975437
"Name" : "default"
"PeerURL" : "http://localhost:2380"
"ClientURL" : "http://localhost:2379"
"IsLearner" : false
```

After the change:
```
$ ./etcdctl  member list  -w fields
"ClusterID" : 14841639068965178418
"MemberID" : 10276657743932975437
"RaftTerm" : 2
"ID" : 10276657743932975437
"Name" : "default"
"PeerURL" : "http://localhost:2380"
"ClientURL" : "http://localhost:2379"
"IsLearner" : false
```