### PR TITLE
build script: Allow for over ride of CGO_ENABLED

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,11 +8,12 @@ if [[ -n "$FAILPOINTS" ]]; then
 fi
 
 VERSION_SYMBOL="${ROOT_MODULE}/api/v3/version.GitSHA"
+CGO_ENABLED="${CGO_ENABLED:-0}"
 
 # Set GO_LDFLAGS="-s" for building without symbols for debugging.
 # shellcheck disable=SC2206
 GO_LDFLAGS=(${GO_LDFLAGS} "-X=${VERSION_SYMBOL}=${GIT_SHA}")
-GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS}" "GOOS=${GOOS}" "GOARCH=${GOARCH}")
+GO_BUILD_ENV=("CGO_ENABLED=${CGO_ENABLED}" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS}" "GOOS=${GOOS}" "GOARCH=${GOARCH}")
 
 # enable/disable failpoints
 toggle_failpoints() {
@@ -91,7 +92,7 @@ tools_build() {
     echo "Building" "'${tool}'"...
     run rm -f "${out}/${tool}"
     # shellcheck disable=SC2086
-    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
+    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=${CGO_ENABLED} go build ${GO_BUILD_FLAGS} \
       -installsuffix=cgo \
       "-ldflags='${GO_LDFLAGS[*]}'" \
       -o="${out}/${tool}" "./${tool}" || return 2


### PR DESCRIPTION
The current build.sh script hard codes the value of CGO_ENABLED to 0
This commit makes it configurable in such a way that it defaults to 0
but can be overriden via an environment variable