### PR TITLE
Calculate hash during compaction

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -250,8 +250,8 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 
 	// newly started member ("memberInitialized==false")
 	// does not need corruption check
-	if memberInitialized {
-		if err = e.Server.CheckInitialHashKV(); err != nil {
+	if memberInitialized && srvcfg.InitialCorruptCheck {
+		if err = etcdserver.NewCorruptionMonitor(e.cfg.logger, e.Server).InitialCheck(); err != nil {
 			// set "EtcdServer" to nil, so that it does not block on "EtcdServer.Close()"
 			// (nothing to close since rafthttp transports have not been started)
 

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -208,7 +208,7 @@ func (ms *maintenanceServer) HashKV(ctx context.Context, r *pb.HashKVRequest) (*
 		return nil, togRPCError(err)
 	}
 
-	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: h, CompactRevision: compactRev}
+	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: h.Hash, CompactRevision: compactRev}
 	ms.hdr.fill(resp.Header)
 	return resp, nil
 }

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -70,20 +70,20 @@ type ClusterStatusGetter interface {
 }
 
 type maintenanceServer struct {
-	lg  *zap.Logger
-	rg  apply.RaftStatusGetter
-	kg  KVGetter
-	bg  BackendGetter
-	a   Alarmer
-	lt  LeaderTransferrer
-	hdr header
-	cs  ClusterStatusGetter
-	d   Downgrader
-	vs  serverversion.Server
+	lg     *zap.Logger
+	rg     apply.RaftStatusGetter
+	hasher mvcc.HashStorage
+	bg     BackendGetter
+	a      Alarmer
+	lt     LeaderTransferrer
+	hdr    header
+	cs     ClusterStatusGetter
+	d      Downgrader
+	vs     serverversion.Server
 }
 
 func NewMaintenanceServer(s *etcdserver.EtcdServer) pb.MaintenanceServer {
-	srv := &maintenanceServer{lg: s.Cfg.Logger, rg: s, kg: s, bg: s, a: s, lt: s, hdr: newHeader(s), cs: s, d: s, vs: etcdserver.NewServerVersionAdapter(s)}
+	srv := &maintenanceServer{lg: s.Cfg.Logger, rg: s, hasher: s.KV().HashStorage(), bg: s, a: s, lt: s, hdr: newHeader(s), cs: s, d: s, vs: etcdserver.NewServerVersionAdapter(s)}
 	if srv.lg == nil {
 		srv.lg = zap.NewNop()
 	}
@@ -193,7 +193,7 @@ func (ms *maintenanceServer) Snapshot(sr *pb.SnapshotRequest, srv pb.Maintenance
 }
 
 func (ms *maintenanceServer) Hash(ctx context.Context, r *pb.HashRequest) (*pb.HashResponse, error) {
-	h, rev, err := ms.kg.KV().Hash()
+	h, rev, err := ms.hasher.Hash()
 	if err != nil {
 		return nil, togRPCError(err)
 	}
@@ -203,7 +203,7 @@ func (ms *maintenanceServer) Hash(ctx context.Context, r *pb.HashRequest) (*pb.H
 }
 
 func (ms *maintenanceServer) HashKV(ctx context.Context, r *pb.HashKVRequest) (*pb.HashKVResponse, error) {
-	h, rev, err := ms.kg.KV().HashByRev(r.Revision)
+	h, rev, err := ms.hasher.HashByRev(r.Revision)
 	if err != nil {
 		return nil, togRPCError(err)
 	}

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -203,12 +203,12 @@ func (ms *maintenanceServer) Hash(ctx context.Context, r *pb.HashRequest) (*pb.H
 }
 
 func (ms *maintenanceServer) HashKV(ctx context.Context, r *pb.HashKVRequest) (*pb.HashKVResponse, error) {
-	h, rev, compactRev, err := ms.kg.KV().HashByRev(r.Revision)
+	h, rev, err := ms.kg.KV().HashByRev(r.Revision)
 	if err != nil {
 		return nil, togRPCError(err)
 	}
 
-	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: h.Hash, CompactRevision: compactRev}
+	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: h.Hash, CompactRevision: h.CompactRevision}
 	ms.hdr.fill(resp.Header)
 	return resp, nil
 }

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -39,7 +39,7 @@ type corruptionMonitor struct {
 }
 
 type Hasher interface {
-	mvcc.Hasher
+	mvcc.HashStorage
 	ReqTimeout() time.Duration
 	MemberId() types.ID
 	PeerHashByRev(int64) []*peerHashKVResp
@@ -50,13 +50,13 @@ type Hasher interface {
 func NewCorruptionMonitor(lg *zap.Logger, s *EtcdServer) *corruptionMonitor {
 	return &corruptionMonitor{
 		lg:     lg,
-		hasher: hasherAdapter{s, s.KV()},
+		hasher: hasherAdapter{s, s.KV().HashStorage()},
 	}
 }
 
 type hasherAdapter struct {
 	*EtcdServer
-	mvcc.KV
+	mvcc.HashStorage
 }
 
 func (h hasherAdapter) ReqTimeout() time.Duration {
@@ -345,7 +345,7 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "error unmarshalling request", http.StatusBadRequest)
 		return
 	}
-	hash, rev, err := h.server.KV().HashByRev(req.Revision)
+	hash, rev, err := h.server.KV().HashStorage().HashByRev(req.Revision)
 	if err != nil {
 		h.lg.Warn(
 			"failed to get hashKV",

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -82,7 +82,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 		zap.Duration("timeout", cm.hasher.ReqTimeout()),
 	)
 
-	h, rev, crev, err := cm.hasher.HashByRev(0)
+	h, rev, err := cm.hasher.HashByRev(0)
 	if err != nil {
 		return fmt.Errorf("%s failed to fetch hash (%v)", cm.hasher.MemberId(), err)
 	}
@@ -94,7 +94,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 			fields := []zap.Field{
 				zap.String("local-member-id", cm.hasher.MemberId().String()),
 				zap.Int64("local-member-revision", rev),
-				zap.Int64("local-member-compact-revision", crev),
+				zap.Int64("local-member-compact-revision", h.CompactRevision),
 				zap.Uint32("local-member-hash", h.Hash),
 				zap.String("remote-peer-id", peerID.String()),
 				zap.Strings("remote-peer-endpoints", p.eps),
@@ -104,7 +104,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 			}
 
 			if h.Hash != p.resp.Hash {
-				if crev == p.resp.CompactRevision {
+				if h.CompactRevision == p.resp.CompactRevision {
 					cm.lg.Warn("found different hash values from remote peer", fields...)
 					mismatch++
 				} else {
@@ -122,7 +122,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 					"cannot fetch hash from slow remote peer",
 					zap.String("local-member-id", cm.hasher.MemberId().String()),
 					zap.Int64("local-member-revision", rev),
-					zap.Int64("local-member-compact-revision", crev),
+					zap.Int64("local-member-compact-revision", h.CompactRevision),
 					zap.Uint32("local-member-hash", h.Hash),
 					zap.String("remote-peer-id", p.id.String()),
 					zap.Strings("remote-peer-endpoints", p.eps),
@@ -133,7 +133,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 					"cannot fetch hash from remote peer; local member is behind",
 					zap.String("local-member-id", cm.hasher.MemberId().String()),
 					zap.Int64("local-member-revision", rev),
-					zap.Int64("local-member-compact-revision", crev),
+					zap.Int64("local-member-compact-revision", h.CompactRevision),
 					zap.Uint32("local-member-hash", h.Hash),
 					zap.String("remote-peer-id", p.id.String()),
 					zap.Strings("remote-peer-endpoints", p.eps),
@@ -154,7 +154,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 }
 
 func (cm *corruptionMonitor) periodicCheck() error {
-	h, rev, crev, err := cm.hasher.HashByRev(0)
+	h, rev, err := cm.hasher.HashByRev(0)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		return err
 	}
 
-	h2, rev2, crev2, err := cm.hasher.HashByRev(0)
+	h2, rev2, err := cm.hasher.HashByRev(0)
 	if err != nil {
 		return err
 	}
@@ -181,14 +181,14 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		cm.hasher.TriggerCorruptAlarm(id)
 	}
 
-	if h2.Hash != h.Hash && rev2 == rev && crev == crev2 {
+	if h2.Hash != h.Hash && rev2 == rev && h.CompactRevision == h2.CompactRevision {
 		cm.lg.Warn(
 			"found hash mismatch",
 			zap.Int64("revision-1", rev),
-			zap.Int64("compact-revision-1", crev),
+			zap.Int64("compact-revision-1", h.CompactRevision),
 			zap.Uint32("hash-1", h.Hash),
 			zap.Int64("revision-2", rev2),
-			zap.Int64("compact-revision-2", crev2),
+			zap.Int64("compact-revision-2", h2.CompactRevision),
 			zap.Uint32("hash-2", h2.Hash),
 		)
 		mismatch(uint64(cm.hasher.MemberId()))
@@ -214,10 +214,10 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		}
 
 		// leader expects follower's latest compact revision less than or equal to leader's
-		if p.resp.CompactRevision > crev2 {
+		if p.resp.CompactRevision > h2.CompactRevision {
 			cm.lg.Warn(
 				"compact revision from follower must be less than or equal to leader's",
-				zap.Int64("leader-compact-revision", crev2),
+				zap.Int64("leader-compact-revision", h2.CompactRevision),
 				zap.Int64("follower-compact-revision", p.resp.CompactRevision),
 				zap.String("follower-peer-id", types.ID(id).String()),
 			)
@@ -225,10 +225,10 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		}
 
 		// follower's compact revision is leader's old one, then hashes must match
-		if p.resp.CompactRevision == crev && p.resp.Hash != h.Hash {
+		if p.resp.CompactRevision == h.CompactRevision && p.resp.Hash != h.Hash {
 			cm.lg.Warn(
 				"same compact revision then hashes must match",
-				zap.Int64("leader-compact-revision", crev2),
+				zap.Int64("leader-compact-revision", h2.CompactRevision),
 				zap.Uint32("leader-hash", h.Hash),
 				zap.Int64("follower-compact-revision", p.resp.CompactRevision),
 				zap.Uint32("follower-hash", p.resp.Hash),
@@ -345,7 +345,7 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "error unmarshalling request", http.StatusBadRequest)
 		return
 	}
-	hash, rev, compactRev, err := h.server.KV().HashByRev(req.Revision)
+	hash, rev, err := h.server.KV().HashByRev(req.Revision)
 	if err != nil {
 		h.lg.Warn(
 			"failed to get hashKV",
@@ -355,7 +355,7 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: hash.Hash, CompactRevision: compactRev}
+	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: hash.Hash, CompactRevision: hash.CompactRevision}
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		h.lg.Warn("failed to marshal hashKV response", zap.Error(err))

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -174,14 +174,7 @@ func (s *EtcdServer) checkHashKV() error {
 			return
 		}
 		alarmed = true
-		a := &pb.AlarmRequest{
-			MemberID: id,
-			Action:   pb.AlarmRequest_ACTIVATE,
-			Alarm:    pb.AlarmType_CORRUPT,
-		}
-		s.GoAttach(func() {
-			s.raftRequest(s.ctx, pb.InternalRaftRequest{Alarm: a})
-		})
+		s.triggerCorruptAlarm(id)
 	}
 
 	if h2 != h && rev2 == rev && crev == crev2 {
@@ -242,6 +235,17 @@ func (s *EtcdServer) checkHashKV() error {
 	}
 	lg.Info("finished peer corruption check", zap.Int("number-of-peers-checked", checkedCount))
 	return nil
+}
+
+func (s *EtcdServer) triggerCorruptAlarm(id uint64) {
+	a := &pb.AlarmRequest{
+		MemberID: id,
+		Action:   pb.AlarmRequest_ACTIVATE,
+		Alarm:    pb.AlarmType_CORRUPT,
+	}
+	s.GoAttach(func() {
+		s.raftRequest(s.ctx, pb.InternalRaftRequest{Alarm: a})
+	})
 }
 
 type peerInfo struct {

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -50,20 +50,13 @@ type Hasher interface {
 func NewCorruptionMonitor(lg *zap.Logger, s *EtcdServer) *corruptionMonitor {
 	return &corruptionMonitor{
 		lg:     lg,
-		hasher: hasherAdapter{s},
+		hasher: hasherAdapter{s, s.KV()},
 	}
 }
 
 type hasherAdapter struct {
 	*EtcdServer
-}
-
-func (h hasherAdapter) Hash() (hash uint32, revision int64, err error) {
-	return h.EtcdServer.KV().Hash()
-}
-
-func (h hasherAdapter) HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error) {
-	return h.EtcdServer.KV().HashByRev(rev)
+	mvcc.KV
 }
 
 func (h hasherAdapter) ReqTimeout() time.Duration {
@@ -102,7 +95,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 				zap.String("local-member-id", cm.hasher.MemberId().String()),
 				zap.Int64("local-member-revision", rev),
 				zap.Int64("local-member-compact-revision", crev),
-				zap.Uint32("local-member-hash", h),
+				zap.Uint32("local-member-hash", h.Hash),
 				zap.String("remote-peer-id", peerID.String()),
 				zap.Strings("remote-peer-endpoints", p.eps),
 				zap.Int64("remote-peer-revision", p.resp.Header.Revision),
@@ -110,7 +103,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 				zap.Uint32("remote-peer-hash", p.resp.Hash),
 			}
 
-			if h != p.resp.Hash {
+			if h.Hash != p.resp.Hash {
 				if crev == p.resp.CompactRevision {
 					cm.lg.Warn("found different hash values from remote peer", fields...)
 					mismatch++
@@ -130,7 +123,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 					zap.String("local-member-id", cm.hasher.MemberId().String()),
 					zap.Int64("local-member-revision", rev),
 					zap.Int64("local-member-compact-revision", crev),
-					zap.Uint32("local-member-hash", h),
+					zap.Uint32("local-member-hash", h.Hash),
 					zap.String("remote-peer-id", p.id.String()),
 					zap.Strings("remote-peer-endpoints", p.eps),
 					zap.Error(err),
@@ -141,7 +134,7 @@ func (cm *corruptionMonitor) InitialCheck() error {
 					zap.String("local-member-id", cm.hasher.MemberId().String()),
 					zap.Int64("local-member-revision", rev),
 					zap.Int64("local-member-compact-revision", crev),
-					zap.Uint32("local-member-hash", h),
+					zap.Uint32("local-member-hash", h.Hash),
 					zap.String("remote-peer-id", p.id.String()),
 					zap.Strings("remote-peer-endpoints", p.eps),
 					zap.Error(err),
@@ -188,15 +181,15 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		cm.hasher.TriggerCorruptAlarm(id)
 	}
 
-	if h2 != h && rev2 == rev && crev == crev2 {
+	if h2.Hash != h.Hash && rev2 == rev && crev == crev2 {
 		cm.lg.Warn(
 			"found hash mismatch",
 			zap.Int64("revision-1", rev),
 			zap.Int64("compact-revision-1", crev),
-			zap.Uint32("hash-1", h),
+			zap.Uint32("hash-1", h.Hash),
 			zap.Int64("revision-2", rev2),
 			zap.Int64("compact-revision-2", crev2),
-			zap.Uint32("hash-2", h2),
+			zap.Uint32("hash-2", h2.Hash),
 		)
 		mismatch(uint64(cm.hasher.MemberId()))
 	}
@@ -232,11 +225,11 @@ func (cm *corruptionMonitor) periodicCheck() error {
 		}
 
 		// follower's compact revision is leader's old one, then hashes must match
-		if p.resp.CompactRevision == crev && p.resp.Hash != h {
+		if p.resp.CompactRevision == crev && p.resp.Hash != h.Hash {
 			cm.lg.Warn(
 				"same compact revision then hashes must match",
 				zap.Int64("leader-compact-revision", crev2),
-				zap.Uint32("leader-hash", h),
+				zap.Uint32("leader-hash", h.Hash),
 				zap.Int64("follower-compact-revision", p.resp.CompactRevision),
 				zap.Uint32("follower-hash", p.resp.Hash),
 				zap.String("follower-peer-id", types.ID(id).String()),
@@ -362,7 +355,7 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: hash, CompactRevision: compactRev}
+	resp := &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: rev}, Hash: hash.Hash, CompactRevision: compactRev}
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		h.lg.Warn("failed to marshal hashKV response", zap.Error(err))

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -277,6 +277,7 @@ func (s *EtcdServer) getPeerHashKVs(rev int64) []*peerHashKVResp {
 
 	lg := s.Logger()
 
+	cc := &http.Client{Transport: s.peerRt}
 	var resps []*peerHashKVResp
 	for _, p := range peers {
 		if len(p.eps) == 0 {
@@ -287,7 +288,7 @@ func (s *EtcdServer) getPeerHashKVs(rev int64) []*peerHashKVResp {
 		var lastErr error
 		for _, ep := range p.eps {
 			ctx, cancel := context.WithTimeout(context.Background(), s.Cfg.ReqTimeout())
-			resp, lastErr := s.getPeerHashKVHTTP(ctx, ep, rev)
+			resp, lastErr := HashByRev(ctx, cc, ep, rev)
 			cancel()
 			if lastErr == nil {
 				resps = append(resps, &peerHashKVResp{peerInfo: p, resp: resp, err: nil})
@@ -368,9 +369,8 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(respBytes)
 }
 
-// getPeerHashKVHTTP fetch hash of kv store at the given rev via http call to the given url
-func (s *EtcdServer) getPeerHashKVHTTP(ctx context.Context, url string, rev int64) (*pb.HashKVResponse, error) {
-	cc := &http.Client{Transport: s.peerRt}
+// HashByRev fetch hash of kv store at the given rev via http call to the given url
+func HashByRev(ctx context.Context, cc *http.Client, url string, rev int64) (*pb.HashKVResponse, error) {
 	hashReq := &pb.HashKVRequest{Revision: rev}
 	hashReqBytes, err := json.Marshal(hashReq)
 	if err != nil {

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -1,0 +1,277 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestInitialCheck(t *testing.T) {
+	tcs := []struct {
+		name          string
+		hasher        fakeHasher
+		expectError   bool
+		expectCorrupt bool
+		expectActions []string
+	}{
+		{
+			name: "No peers",
+			hasher: fakeHasher{
+				hashByRevResponses: []hashByRev{{revision: 10}},
+			},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(10)", "MemberId()"},
+		},
+		{
+			name:          "Error getting hash",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{err: fmt.Errorf("error getting hash")}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "MemberId()"},
+			expectError:   true,
+		},
+		{
+			name:          "Peer with empty response",
+			hasher:        fakeHasher{peerHashes: []*peerHashKVResp{{}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()"},
+		},
+		{
+			name:          "Peer returned ErrFutureRev",
+			hasher:        fakeHasher{peerHashes: []*peerHashKVResp{{err: rpctypes.ErrFutureRev}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
+		},
+		{
+			name:          "Peer returned ErrCompacted",
+			hasher:        fakeHasher{peerHashes: []*peerHashKVResp{{err: rpctypes.ErrCompacted}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
+		},
+		{
+			name:          "Peer returned other error",
+			hasher:        fakeHasher{peerHashes: []*peerHashKVResp{{err: rpctypes.ErrCorrupt}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()"},
+		},
+		{
+			name:          "Peer returned same hash",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 1}}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
+		},
+		{
+			name:          "Peer returned different hash with same compaction rev",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 1}}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
+			expectError:   true,
+		},
+		{
+			name:          "Peer returned different hash and compaction rev",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 2}}}},
+			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := corruptionMonitor{
+				lg:     zaptest.NewLogger(t),
+				hasher: &tc.hasher,
+			}
+			err := monitor.InitialCheck()
+			if gotError := err != nil; gotError != tc.expectError {
+				t.Errorf("Unexpected error, got: %v, expected?: %v", err, tc.expectError)
+			}
+			if tc.hasher.alarmTriggered != tc.expectCorrupt {
+				t.Errorf("Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
+			}
+			assert.Equal(t, tc.expectActions, tc.hasher.actions)
+		})
+	}
+}
+
+func TestPeriodicCheck(t *testing.T) {
+	tcs := []struct {
+		name          string
+		hasher        fakeHasher
+		expectError   bool
+		expectCorrupt bool
+		expectActions []string
+	}{
+		{
+			name:          "Same local hash and no peers",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{revision: 10}, {revision: 10}}},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(10)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+		},
+		{
+			name:          "Error getting hash first time",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{err: fmt.Errorf("error getting hash")}}},
+			expectActions: []string{"HashByRev(0)"},
+			expectError:   true,
+		},
+		{
+			name:          "Error getting hash second time",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{revision: 11}, {err: fmt.Errorf("error getting hash")}}},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(11)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+			expectError:   true,
+		},
+		{
+			name:          "Error linearizableReadNotify",
+			hasher:        fakeHasher{linearizableReadNotify: fmt.Errorf("error getting linearizableReadNotify")},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()"},
+			expectError:   true,
+		},
+		{
+			name:          "Different local hash and revision",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, revision: 1}, {hash: 2, revision: 2}}},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+		},
+		{
+			name:          "Different local hash and compaction revision",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}, {hash: 2, compactRev: 2}}},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+		},
+		{
+			name:          "Different local hash and same revisions",
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 1, compactRev: 1}}},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "MemberId()", "TriggerCorruptAlarm(1)"},
+			expectCorrupt: true,
+		},
+		{
+			name: "Peer with nil response",
+			hasher: fakeHasher{
+				peerHashes: []*peerHashKVResp{{}},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+		},
+		{
+			name: "Peer with newer revision",
+			hasher: fakeHasher{
+				peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 1, MemberId: 42}}}},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "TriggerCorruptAlarm(42)"},
+			expectCorrupt: true,
+		},
+		{
+			name: "Peer with newer compact revision",
+			hasher: fakeHasher{
+				peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 10, MemberId: 88}, CompactRevision: 2}}},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "TriggerCorruptAlarm(88)"},
+			expectCorrupt: true,
+		},
+		{
+			name: "Peer with same hash and compact revision",
+			hasher: fakeHasher{
+				hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 2, compactRev: 2}},
+				peerHashes:         []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 1}, CompactRevision: 1, Hash: 1}}},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
+		},
+		{
+			name: "Peer with different hash and same compact revision as first local",
+			hasher: fakeHasher{
+				hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 2, compactRev: 2}},
+				peerHashes:         []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 1, MemberId: 666}, CompactRevision: 1, Hash: 2}}},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "TriggerCorruptAlarm(666)"},
+			expectCorrupt: true,
+		},
+		{
+			name: "Multiple corrupted peers trigger one alarm",
+			hasher: fakeHasher{
+				peerHashes: []*peerHashKVResp{
+					{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 10, MemberId: 88}, CompactRevision: 2}},
+					{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 10, MemberId: 89}, CompactRevision: 2}},
+				},
+			},
+			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "TriggerCorruptAlarm(88)"},
+			expectCorrupt: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := corruptionMonitor{
+				lg:     zaptest.NewLogger(t),
+				hasher: &tc.hasher,
+			}
+			err := monitor.periodicCheck()
+			if gotError := err != nil; gotError != tc.expectError {
+				t.Errorf("Unexpected error, got: %v, expected?: %v", err, tc.expectError)
+			}
+			if tc.hasher.alarmTriggered != tc.expectCorrupt {
+				t.Errorf("Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
+			}
+			assert.Equal(t, tc.expectActions, tc.hasher.actions)
+		})
+	}
+}
+
+type fakeHasher struct {
+	peerHashes             []*peerHashKVResp
+	hashByRevIndex         int
+	hashByRevResponses     []hashByRev
+	linearizableReadNotify error
+
+	alarmTriggered bool
+	actions        []string
+}
+
+type hashByRev struct {
+	hash       uint32
+	revision   int64
+	compactRev int64
+	err        error
+}
+
+func (f *fakeHasher) Hash() (hash uint32, revision int64, err error) {
+	panic("not implemented")
+}
+
+func (f *fakeHasher) HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error) {
+	f.actions = append(f.actions, fmt.Sprintf("HashByRev(%d)", rev))
+	if len(f.hashByRevResponses) == 0 {
+		return 0, 0, 0, nil
+	}
+	hashByRev := f.hashByRevResponses[f.hashByRevIndex]
+	f.hashByRevIndex++
+	return hashByRev.hash, hashByRev.revision, hashByRev.compactRev, hashByRev.err
+}
+
+func (f *fakeHasher) ReqTimeout() time.Duration {
+	f.actions = append(f.actions, "ReqTimeout()")
+	return time.Second
+}
+
+func (f *fakeHasher) MemberId() types.ID {
+	f.actions = append(f.actions, "MemberId()")
+	return 1
+}
+
+func (f *fakeHasher) PeerHashByRev(rev int64) []*peerHashKVResp {
+	f.actions = append(f.actions, fmt.Sprintf("PeerHashByRev(%d)", rev))
+	return f.peerHashes
+}
+
+func (f *fakeHasher) LinearizableReadNotify(ctx context.Context) error {
+	f.actions = append(f.actions, "LinearizableReadNotify()")
+	return f.linearizableReadNotify
+}
+
+func (f *fakeHasher) TriggerCorruptAlarm(memberId uint64) {
+	f.actions = append(f.actions, fmt.Sprintf("TriggerCorruptAlarm(%d)", memberId))
+	f.alarmTriggered = true
+}

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -251,6 +251,10 @@ func (f *fakeHasher) HashByRev(rev int64) (hash mvcc.KeyValueHash, revision int6
 	return hashByRev.hash, hashByRev.revision, hashByRev.err
 }
 
+func (f *fakeHasher) Store(valueHash mvcc.KeyValueHash) {
+	panic("not implemented")
+}
+
 func (f *fakeHasher) ReqTimeout() time.Duration {
 	f.actions = append(f.actions, "ReqTimeout()")
 	return time.Second

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -24,6 +24,7 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/server/v3/storage/mvcc"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -70,18 +71,18 @@ func TestInitialCheck(t *testing.T) {
 		},
 		{
 			name:          "Peer returned same hash",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 1}}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 1}}}},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
 		},
 		{
 			name:          "Peer returned different hash with same compaction rev",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 1}}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 1}}}},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
 			expectError:   true,
 		},
 		{
 			name:          "Peer returned different hash and compaction rev",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 2}}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, compactRev: 1}}, peerHashes: []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{}, Hash: 2, CompactRevision: 2}}}},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
 		},
 	}
@@ -136,17 +137,17 @@ func TestPeriodicCheck(t *testing.T) {
 		},
 		{
 			name:          "Different local hash and revision",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, revision: 1}, {hash: 2, revision: 2}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, revision: 1}, {hash: mvcc.KeyValueHash{Hash: 2}, revision: 2}}},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
 		},
 		{
 			name:          "Different local hash and compaction revision",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, compactRev: 1}, {hash: 2, compactRev: 2}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, compactRev: 1}, {hash: mvcc.KeyValueHash{Hash: 2}, compactRev: 2}}},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
 		},
 		{
 			name:          "Different local hash and same revisions",
-			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 1, compactRev: 1}}},
+			hasher:        fakeHasher{hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, revision: 1, compactRev: 1}, {hash: mvcc.KeyValueHash{Hash: 2}, revision: 1, compactRev: 1}}},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "MemberId()", "TriggerCorruptAlarm(1)"},
 			expectCorrupt: true,
 		},
@@ -176,7 +177,7 @@ func TestPeriodicCheck(t *testing.T) {
 		{
 			name: "Peer with same hash and compact revision",
 			hasher: fakeHasher{
-				hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 2, compactRev: 2}},
+				hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, revision: 1, compactRev: 1}, {hash: mvcc.KeyValueHash{Hash: 2}, revision: 2, compactRev: 2}},
 				peerHashes:         []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 1}, CompactRevision: 1, Hash: 1}}},
 			},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
@@ -184,7 +185,7 @@ func TestPeriodicCheck(t *testing.T) {
 		{
 			name: "Peer with different hash and same compact revision as first local",
 			hasher: fakeHasher{
-				hashByRevResponses: []hashByRev{{hash: 1, revision: 1, compactRev: 1}, {hash: 2, revision: 2, compactRev: 2}},
+				hashByRevResponses: []hashByRev{{hash: mvcc.KeyValueHash{Hash: 1}, revision: 1, compactRev: 1}, {hash: mvcc.KeyValueHash{Hash: 2}, revision: 2, compactRev: 2}},
 				peerHashes:         []*peerHashKVResp{{resp: &pb.HashKVResponse{Header: &pb.ResponseHeader{Revision: 1, MemberId: 666}, CompactRevision: 1, Hash: 2}}},
 			},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(1)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)", "TriggerCorruptAlarm(666)"},
@@ -231,7 +232,7 @@ type fakeHasher struct {
 }
 
 type hashByRev struct {
-	hash       uint32
+	hash       mvcc.KeyValueHash
 	revision   int64
 	compactRev int64
 	err        error
@@ -241,10 +242,10 @@ func (f *fakeHasher) Hash() (hash uint32, revision int64, err error) {
 	panic("not implemented")
 }
 
-func (f *fakeHasher) HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error) {
+func (f *fakeHasher) HashByRev(rev int64) (hash mvcc.KeyValueHash, revision int64, compactRev int64, err error) {
 	f.actions = append(f.actions, fmt.Sprintf("HashByRev(%d)", rev))
 	if len(f.hashByRevResponses) == 0 {
-		return 0, 0, 0, nil
+		return mvcc.KeyValueHash{}, 0, 0, nil
 	}
 	hashByRev := f.hashByRevResponses[f.hashByRevIndex]
 	f.hashByRevIndex++

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2187,6 +2187,34 @@ func (s *EtcdServer) monitorStorageVersion() {
 	}
 }
 
+func (s *EtcdServer) monitorKVHash() {
+	t := s.Cfg.CorruptCheckTime
+	if t == 0 {
+		return
+	}
+
+	lg := s.Logger()
+	lg.Info(
+		"enabled corruption checking",
+		zap.String("local-member-id", s.MemberId().String()),
+		zap.Duration("interval", t),
+	)
+	monitor := NewCorruptionMonitor(lg, s)
+	for {
+		select {
+		case <-s.stopping:
+			return
+		case <-time.After(t):
+		}
+		if !s.isLeader() {
+			continue
+		}
+		if err := monitor.periodicCheck(); err != nil {
+			lg.Warn("failed to check hash KV", zap.Error(err))
+		}
+	}
+}
+
 func (s *EtcdServer) updateClusterVersionV2(ver string) {
 	lg := s.Logger()
 

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -76,3 +76,29 @@ type KeyValueHash struct {
 	CompactRevision int64
 	Revision        int64
 }
+
+type HashStorage interface {
+	// Hash computes the hash of the KV's backend.
+	Hash() (hash uint32, revision int64, err error)
+
+	// HashByRev computes the hash of all MVCC revisions up to a given revision.
+	HashByRev(rev int64) (hash KeyValueHash, currentRev int64, err error)
+}
+
+type hashStorage struct {
+	store *store
+}
+
+func newHashStorage(s *store) HashStorage {
+	return &hashStorage{
+		store: s,
+	}
+}
+
+func (s *hashStorage) Hash() (hash uint32, revision int64, err error) {
+	return s.store.hash()
+}
+
+func (s *hashStorage) HashByRev(rev int64) (KeyValueHash, int64, error) {
+	return s.store.hashByRev(rev)
+}

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -42,8 +42,8 @@ func newKVHasher(lower, upper int64, keep map[revision]struct{}) kvHasher {
 	h.Write(schema.Key.Name())
 	return kvHasher{
 		hash:  h,
-		lower: revision{main: lower},
-		upper: revision{main: upper},
+		lower: revision{main: lower + 1},
+		upper: revision{main: upper + 1},
 		keep:  keep,
 	}
 }

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -33,7 +33,7 @@ func unsafeHashByRev(tx backend.ReadTx, lower, upper int64, keep map[revision]st
 
 type kvHasher struct {
 	hash         hash.Hash32
-	lower, upper revision
+	lower, upper int64
 	keep         map[revision]struct{}
 }
 
@@ -42,20 +42,22 @@ func newKVHasher(lower, upper int64, keep map[revision]struct{}) kvHasher {
 	h.Write(schema.Key.Name())
 	return kvHasher{
 		hash:  h,
-		lower: revision{main: lower + 1},
-		upper: revision{main: upper + 1},
+		lower: lower,
+		upper: upper,
 		keep:  keep,
 	}
 }
 
 func (h *kvHasher) WriteKeyValue(k, v []byte) {
 	kr := bytesToRev(k)
-	if !h.upper.GreaterThan(kr) {
+	upper := revision{main: h.upper + 1}
+	if !upper.GreaterThan(kr) {
 		return
 	}
+	lower := revision{main: h.lower + 1}
 	// skip revisions that are scheduled for deletion
 	// due to compacting; don't skip if there isn't one.
-	if h.lower.GreaterThan(kr) && len(h.keep) > 0 {
+	if lower.GreaterThan(kr) && len(h.keep) > 0 {
 		if _, ok := h.keep[kr]; !ok {
 			return
 		}

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -17,9 +17,16 @@ package mvcc
 import (
 	"hash"
 	"hash/crc32"
+	"sort"
+	"sync"
 
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/schema"
+	"go.uber.org/zap"
+)
+
+const (
+	hashStorageMaxSize = 10
 )
 
 func unsafeHashByRev(tx backend.ReadTx, compactRevision, revision int64, keep map[revision]struct{}) (KeyValueHash, error) {
@@ -83,15 +90,22 @@ type HashStorage interface {
 
 	// HashByRev computes the hash of all MVCC revisions up to a given revision.
 	HashByRev(rev int64) (hash KeyValueHash, currentRev int64, err error)
+
+	// Store adds hash value in local cache, allowing it can be returned by HashByRev.
+	Store(valueHash KeyValueHash)
 }
 
 type hashStorage struct {
-	store *store
+	store  *store
+	hashMu sync.RWMutex
+	hashes []KeyValueHash
+	lg     *zap.Logger
 }
 
-func newHashStorage(s *store) HashStorage {
+func newHashStorage(lg *zap.Logger, s *store) *hashStorage {
 	return &hashStorage{
 		store: s,
+		lg:    lg,
 	}
 }
 
@@ -100,5 +114,35 @@ func (s *hashStorage) Hash() (hash uint32, revision int64, err error) {
 }
 
 func (s *hashStorage) HashByRev(rev int64) (KeyValueHash, int64, error) {
+	s.hashMu.RLock()
+	for _, h := range s.hashes {
+		if rev == h.Revision {
+			s.hashMu.RUnlock()
+
+			s.store.revMu.RLock()
+			currentRev := s.store.currentRev
+			s.store.revMu.RUnlock()
+			return h, currentRev, nil
+		}
+	}
+	s.hashMu.RUnlock()
+
 	return s.store.hashByRev(rev)
+}
+
+func (s *hashStorage) Store(hash KeyValueHash) {
+	s.lg.Info("storing new hash",
+		zap.Uint32("hash", hash.Hash),
+		zap.Int64("revision", hash.Revision),
+		zap.Int64("compact-revision", hash.CompactRevision),
+	)
+	s.hashMu.Lock()
+	defer s.hashMu.Unlock()
+	s.hashes = append(s.hashes, hash)
+	sort.Slice(s.hashes, func(i, j int) bool {
+		return s.hashes[i].Revision < s.hashes[j].Revision
+	})
+	if len(s.hashes) > hashStorageMaxSize {
+		s.hashes = s.hashes[len(s.hashes)-hashStorageMaxSize:]
+	}
 }

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvcc
+
+import (
+	"hash/crc32"
+
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/schema"
+)
+
+func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision]struct{}) (uint32, error) {
+	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+
+	h.Write(schema.Key.Name())
+	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
+		kr := bytesToRev(k)
+		if !upper.GreaterThan(kr) {
+			return nil
+		}
+		// skip revisions that are scheduled for deletion
+		// due to compacting; don't skip if there isn't one.
+		if lower.GreaterThan(kr) && len(keep) > 0 {
+			if _, ok := keep[kr]; !ok {
+				return nil
+			}
+		}
+		h.Write(k)
+		h.Write(v)
+		return nil
+	})
+	return h.Sum32(), err
+}

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -22,8 +22,8 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/schema"
 )
 
-func unsafeHashByRev(tx backend.ReadTx, lower, upper int64, keep map[revision]struct{}) (uint32, error) {
-	h := newKVHasher(lower, upper, keep)
+func unsafeHashByRev(tx backend.ReadTx, compactRevision, revision int64, keep map[revision]struct{}) (KeyValueHash, error) {
+	h := newKVHasher(compactRevision, revision, keep)
 	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
 		h.WriteKeyValue(k, v)
 		return nil
@@ -32,29 +32,30 @@ func unsafeHashByRev(tx backend.ReadTx, lower, upper int64, keep map[revision]st
 }
 
 type kvHasher struct {
-	hash         hash.Hash32
-	lower, upper int64
-	keep         map[revision]struct{}
+	hash            hash.Hash32
+	compactRevision int64
+	revision        int64
+	keep            map[revision]struct{}
 }
 
-func newKVHasher(lower, upper int64, keep map[revision]struct{}) kvHasher {
+func newKVHasher(compactRev, rev int64, keep map[revision]struct{}) kvHasher {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	h.Write(schema.Key.Name())
 	return kvHasher{
-		hash:  h,
-		lower: lower,
-		upper: upper,
-		keep:  keep,
+		hash:            h,
+		compactRevision: compactRev,
+		revision:        rev,
+		keep:            keep,
 	}
 }
 
 func (h *kvHasher) WriteKeyValue(k, v []byte) {
 	kr := bytesToRev(k)
-	upper := revision{main: h.upper + 1}
+	upper := revision{main: h.revision + 1}
 	if !upper.GreaterThan(kr) {
 		return
 	}
-	lower := revision{main: h.lower + 1}
+	lower := revision{main: h.compactRevision + 1}
 	// skip revisions that are scheduled for deletion
 	// due to compacting; don't skip if there isn't one.
 	if lower.GreaterThan(kr) && len(h.keep) > 0 {
@@ -66,6 +67,12 @@ func (h *kvHasher) WriteKeyValue(k, v []byte) {
 	h.hash.Write(v)
 }
 
-func (h *kvHasher) Hash() uint32 {
-	return h.hash.Sum32()
+func (h *kvHasher) Hash() KeyValueHash {
+	return KeyValueHash{Hash: h.hash.Sum32(), CompactRevision: h.compactRevision, Revision: h.revision}
+}
+
+type KeyValueHash struct {
+	Hash            uint32
+	CompactRevision int64
+	Revision        int64
 }

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -23,40 +23,47 @@ import (
 )
 
 func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision]struct{}) (uint32, error) {
-	h := newKVHasher()
+	h := newKVHasher(lower, upper, keep)
 	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
-		kr := bytesToRev(k)
-		if !upper.GreaterThan(kr) {
-			return nil
-		}
-		// skip revisions that are scheduled for deletion
-		// due to compacting; don't skip if there isn't one.
-		if lower.GreaterThan(kr) && len(keep) > 0 {
-			if _, ok := keep[kr]; !ok {
-				return nil
-			}
-		}
 		h.WriteKeyValue(k, v)
 		return nil
 	})
 	return h.Hash(), err
 }
 
-type hasher struct {
-	h hash.Hash32
+type kvHasher struct {
+	hash         hash.Hash32
+	lower, upper revision
+	keep         map[revision]struct{}
 }
 
-func newKVHasher() hasher {
+func newKVHasher(lower, upper revision, keep map[revision]struct{}) kvHasher {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	h.Write(schema.Key.Name())
-	return hasher{h}
+	return kvHasher{
+		hash:  h,
+		lower: lower,
+		upper: upper,
+		keep:  keep,
+	}
 }
 
-func (h *hasher) WriteKeyValue(k, v []byte) {
-	h.h.Write(k)
-	h.h.Write(v)
+func (h *kvHasher) WriteKeyValue(k, v []byte) {
+	kr := bytesToRev(k)
+	if !h.upper.GreaterThan(kr) {
+		return
+	}
+	// skip revisions that are scheduled for deletion
+	// due to compacting; don't skip if there isn't one.
+	if h.lower.GreaterThan(kr) && len(h.keep) > 0 {
+		if _, ok := h.keep[kr]; !ok {
+			return
+		}
+	}
+	h.hash.Write(k)
+	h.hash.Write(v)
 }
 
-func (h *hasher) Hash() uint32 {
-	return h.h.Sum32()
+func (h *kvHasher) Hash() uint32 {
+	return h.hash.Sum32()
 }

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -22,7 +22,7 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/schema"
 )
 
-func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision]struct{}) (uint32, error) {
+func unsafeHashByRev(tx backend.ReadTx, lower, upper int64, keep map[revision]struct{}) (uint32, error) {
 	h := newKVHasher(lower, upper, keep)
 	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
 		h.WriteKeyValue(k, v)
@@ -37,13 +37,13 @@ type kvHasher struct {
 	keep         map[revision]struct{}
 }
 
-func newKVHasher(lower, upper revision, keep map[revision]struct{}) kvHasher {
+func newKVHasher(lower, upper int64, keep map[revision]struct{}) kvHasher {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	h.Write(schema.Key.Name())
 	return kvHasher{
 		hash:  h,
-		lower: lower,
-		upper: upper,
+		lower: revision{main: lower},
+		upper: revision{main: upper},
 		keep:  keep,
 	}
 }

--- a/server/storage/mvcc/hash.go
+++ b/server/storage/mvcc/hash.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"hash"
 	"hash/crc32"
 
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -22,9 +23,7 @@ import (
 )
 
 func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision]struct{}) (uint32, error) {
-	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-
-	h.Write(schema.Key.Name())
+	h := newKVHasher()
 	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
 		kr := bytesToRev(k)
 		if !upper.GreaterThan(kr) {
@@ -37,9 +36,27 @@ func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision
 				return nil
 			}
 		}
-		h.Write(k)
-		h.Write(v)
+		h.WriteKeyValue(k, v)
 		return nil
 	})
-	return h.Sum32(), err
+	return h.Hash(), err
+}
+
+type hasher struct {
+	h hash.Hash32
+}
+
+func newKVHasher() hasher {
+	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	h.Write(schema.Key.Name())
+	return hasher{h}
+}
+
+func (h *hasher) WriteKeyValue(k, v []byte) {
+	h.h.Write(k)
+	h.h.Write(v)
+}
+
+func (h *hasher) Hash() uint32 {
+	return h.h.Sum32()
 }

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -120,7 +120,7 @@ func putKVs(s *store, rev, count int64) {
 }
 
 func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
-	hash, currentRev, _, err := s.HashByRev(rev)
+	hash, currentRev, err := s.HashByRev(rev)
 	assert.NoError(t, err, "error on rev %v", rev)
 
 	if rev == 0 {
@@ -150,7 +150,7 @@ func testCompactionHash(t *testing.T, s *store, start, stop int64) {
 	for i := start; i <= stop; i++ {
 		s.Put([]byte(pickKey(i)), []byte(fmt.Sprint(i)), 0)
 	}
-	hash1, _, _, err := s.HashByRev(stop)
+	hash1, _, err := s.HashByRev(stop)
 	assert.NoError(t, err, "error on rev %v", stop)
 
 	_, prevCompactRev, err := s.updateCompactRev(stop)

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -41,7 +41,7 @@ func TestHashByRevValue(t *testing.T) {
 	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
 	assert.Less(t, int64(compactionCycle*10), totalRevisions)
 	var rev int64
-	var got []kvHash
+	var got []KeyValueHash
 	for ; rev < totalRevisions; rev += compactionCycle {
 		putKVs(s, rev, compactionCycle)
 		hash := testHashByRev(t, s, rev+compactionCycle/2)
@@ -50,7 +50,7 @@ func TestHashByRevValue(t *testing.T) {
 	putKVs(s, rev, totalRevisions)
 	hash := testHashByRev(t, s, rev+totalRevisions/2)
 	got = append(got, hash)
-	assert.Equal(t, []kvHash{
+	assert.Equal(t, []KeyValueHash{
 		{4082599214, -1, 35},
 		{2279933401, 35, 106},
 		{3284231217, 106, 177},
@@ -81,7 +81,7 @@ func TestHashByRevValueZero(t *testing.T) {
 	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
 	assert.Less(t, int64(compactionCycle*10), totalRevisions)
 	var rev int64
-	var got []kvHash
+	var got []KeyValueHash
 	for ; rev < totalRevisions; rev += compactionCycle {
 		putKVs(s, rev, compactionCycle)
 		hash := testHashByRev(t, s, 0)
@@ -90,7 +90,7 @@ func TestHashByRevValueZero(t *testing.T) {
 	putKVs(s, rev, totalRevisions)
 	hash := testHashByRev(t, s, 0)
 	got = append(got, hash)
-	assert.Equal(t, []kvHash{
+	assert.Equal(t, []KeyValueHash{
 		{1913897190, -1, 73},
 		{224860069, 73, 145},
 		{1565167519, 145, 217},
@@ -119,8 +119,8 @@ func putKVs(s *store, rev, count int64) {
 	}
 }
 
-func testHashByRev(t *testing.T, s *store, rev int64) kvHash {
-	hash, currentRev, compactRev, err := s.HashByRev(rev)
+func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
+	hash, currentRev, _, err := s.HashByRev(rev)
 	assert.NoError(t, err, "error on rev %v", rev)
 
 	if rev == 0 {
@@ -128,13 +128,7 @@ func testHashByRev(t *testing.T, s *store, rev int64) kvHash {
 	}
 	_, err = s.Compact(traceutil.TODO(), rev)
 	assert.NoError(t, err, "error on compact %v", rev)
-	return kvHash{hash: hash, compactRevision: compactRev, revision: rev}
-}
-
-type kvHash struct {
-	hash            uint32
-	compactRevision int64
-	revision        int64
+	return hash
 }
 
 // TODO: Change this to fuzz test

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -73,7 +73,7 @@ func TestHashByRevValue(t *testing.T) {
 	}, got)
 }
 
-func TestHashByRevValueZero(t *testing.T) {
+func TestHashByRevValueLastRevision(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
 
@@ -120,12 +120,11 @@ func putKVs(s *store, rev, count int64) {
 }
 
 func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
-	hash, currentRev, err := s.HashByRev(rev)
-	assert.NoError(t, err, "error on rev %v", rev)
-
 	if rev == 0 {
-		rev = currentRev
+		rev = s.Rev()
 	}
+	hash, _, err := s.hashByRev(rev)
+	assert.NoError(t, err, "error on rev %v", rev)
 	_, err = s.Compact(traceutil.TODO(), rev)
 	assert.NoError(t, err, "error on compact %v", rev)
 	return hash
@@ -150,7 +149,7 @@ func testCompactionHash(t *testing.T, s *store, start, stop int64) {
 	for i := start; i <= stop; i++ {
 		s.Put([]byte(pickKey(i)), []byte(fmt.Sprint(i)), 0)
 	}
-	hash1, _, err := s.HashByRev(stop)
+	hash1, _, err := s.hashByRev(stop)
 	assert.NoError(t, err, "error on rev %v", stop)
 
 	_, prevCompactRev, err := s.updateCompactRev(stop)

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -1,0 +1,166 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvcc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/pkg/v3/traceutil"
+	"go.etcd.io/etcd/server/v3/lease"
+	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	// Use high prime
+	compactionCycle = 71
+)
+
+// Test HashByRevValue values to ensure we don't change the output which would
+// have catastrophic consequences. Expected output is just hardcoded, so please
+// regenerate it every time you change input parameters.
+func TestHashByRevValue(t *testing.T) {
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
+
+	var totalRevisions int64 = 1210
+	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
+	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	var rev int64
+	var got []kvHash
+	for ; rev < totalRevisions; rev += compactionCycle {
+		putKVs(s, rev, compactionCycle)
+		hash := testHashByRev(t, s, rev+compactionCycle/2)
+		got = append(got, hash)
+	}
+	putKVs(s, rev, totalRevisions)
+	hash := testHashByRev(t, s, rev+totalRevisions/2)
+	got = append(got, hash)
+	assert.Equal(t, []kvHash{
+		{4082599214, -1, 35},
+		{2279933401, 35, 106},
+		{3284231217, 106, 177},
+		{126286495, 177, 248},
+		{900108730, 248, 319},
+		{2475485232, 319, 390},
+		{1226296507, 390, 461},
+		{2503661030, 461, 532},
+		{4155130747, 532, 603},
+		{106915399, 603, 674},
+		{406914006, 674, 745},
+		{1882211381, 745, 816},
+		{806177088, 816, 887},
+		{664311366, 887, 958},
+		{1496914449, 958, 1029},
+		{2434525091, 1029, 1100},
+		{3988652253, 1100, 1171},
+		{1122462288, 1171, 1242},
+		{724436716, 1242, 1883},
+	}, got)
+}
+
+func TestHashByRevValueZero(t *testing.T) {
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
+
+	var totalRevisions int64 = 1210
+	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
+	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	var rev int64
+	var got []kvHash
+	for ; rev < totalRevisions; rev += compactionCycle {
+		putKVs(s, rev, compactionCycle)
+		hash := testHashByRev(t, s, 0)
+		got = append(got, hash)
+	}
+	putKVs(s, rev, totalRevisions)
+	hash := testHashByRev(t, s, 0)
+	got = append(got, hash)
+	assert.Equal(t, []kvHash{
+		{1913897190, -1, 73},
+		{224860069, 73, 145},
+		{1565167519, 145, 217},
+		{1566261620, 217, 289},
+		{2037173024, 289, 361},
+		{691659396, 361, 433},
+		{2713730748, 433, 505},
+		{3919322507, 505, 577},
+		{769967540, 577, 649},
+		{2909194793, 649, 721},
+		{1576921157, 721, 793},
+		{4067701532, 793, 865},
+		{2226384237, 865, 937},
+		{2923408134, 937, 1009},
+		{2680329256, 1009, 1081},
+		{1546717673, 1081, 1153},
+		{2713657846, 1153, 1225},
+		{1046575299, 1225, 1297},
+		{2017735779, 1297, 2508},
+	}, got)
+}
+
+func putKVs(s *store, rev, count int64) {
+	for i := rev; i <= rev+count; i++ {
+		s.Put([]byte(pickKey(i)), []byte(fmt.Sprint(i)), 0)
+	}
+}
+
+func testHashByRev(t *testing.T, s *store, rev int64) kvHash {
+	hash, currentRev, compactRev, err := s.HashByRev(rev)
+	assert.NoError(t, err, "error on rev %v", rev)
+
+	if rev == 0 {
+		rev = currentRev
+	}
+	_, err = s.Compact(traceutil.TODO(), rev)
+	assert.NoError(t, err, "error on compact %v", rev)
+	return kvHash{hash: hash, compactRevision: compactRev, revision: rev}
+}
+
+type kvHash struct {
+	hash            uint32
+	compactRevision int64
+	revision        int64
+}
+
+func pickKey(i int64) string {
+	if i%(compactionCycle*2) == 30 {
+		return "zenek"
+	}
+	if i%compactionCycle == 30 {
+		return "xavery"
+	}
+	// Use low prime number to ensure repeats without alignment
+	switch i % 7 {
+	case 0:
+		return "alice"
+	case 1:
+		return "bob"
+	case 2:
+		return "celine"
+	case 3:
+		return "dominik"
+	case 4:
+		return "eve"
+	case 5:
+		return "frederica"
+	case 6:
+		return "gorge"
+	default:
+		panic("Can't count")
+	}
+}

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -187,3 +187,53 @@ func pickKey(i int64) string {
 		panic("Can't count")
 	}
 }
+
+func TestHasherStore(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	s := newHashStorage(lg, newFakeStore(lg))
+	var hashes []KeyValueHash
+	for i := 0; i < hashStorageMaxSize; i++ {
+		hash := KeyValueHash{Hash: uint32(i), Revision: int64(i) + 10, CompactRevision: int64(i) + 100}
+		hashes = append(hashes, hash)
+		s.Store(hash)
+	}
+
+	for _, want := range hashes {
+		got, _, err := s.HashByRev(want.Revision)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want.Hash != got.Hash {
+			t.Errorf("Expected stored hash to match, got: %d, expected: %d", want.Hash, got.Hash)
+		}
+		if want.Revision != got.Revision {
+			t.Errorf("Expected stored revision to match, got: %d, expected: %d", want.Revision, got.Revision)
+		}
+		if want.CompactRevision != got.CompactRevision {
+			t.Errorf("Expected stored compact revision to match, got: %d, expected: %d", want.CompactRevision, got.CompactRevision)
+		}
+	}
+}
+
+func TestHasherStoreFull(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	s := newHashStorage(lg, newFakeStore(lg))
+	var minRevision int64 = 100
+	var maxRevision = minRevision + hashStorageMaxSize
+	for i := 0; i < hashStorageMaxSize; i++ {
+		s.Store(KeyValueHash{Revision: int64(i) + minRevision})
+	}
+
+	// Hash for old revision should be discarded as storage is already full
+	s.Store(KeyValueHash{Revision: minRevision - 1})
+	hash, _, err := s.HashByRev(minRevision - 1)
+	if err == nil {
+		t.Errorf("Expected an error as old revision should be discarded, got: %v", hash)
+	}
+	// Hash for new revision should be stored even when storage is full
+	s.Store(KeyValueHash{Revision: maxRevision + 1})
+	_, _, err = s.HashByRev(maxRevision + 1)
+	if err != nil {
+		t.Errorf("Didn't expect error for new revision, err: %v", err)
+	}
+}

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -22,12 +23,8 @@ import (
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
 	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
+	"go.etcd.io/etcd/server/v3/storage/mvcc/testutil"
 	"go.uber.org/zap/zaptest"
-)
-
-const (
-	// Use high prime
-	compactionCycle = 71
 )
 
 // Test HashByRevValue values to ensure we don't change the output which would
@@ -39,12 +36,12 @@ func TestHashByRevValue(t *testing.T) {
 
 	var totalRevisions int64 = 1210
 	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
-	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	assert.Less(t, int64(testutil.CompactionCycle*10), totalRevisions)
 	var rev int64
 	var got []KeyValueHash
-	for ; rev < totalRevisions; rev += compactionCycle {
-		putKVs(s, rev, compactionCycle)
-		hash := testHashByRev(t, s, rev+compactionCycle/2)
+	for ; rev < totalRevisions; rev += testutil.CompactionCycle {
+		putKVs(s, rev, testutil.CompactionCycle)
+		hash := testHashByRev(t, s, rev+testutil.CompactionCycle/2)
 		got = append(got, hash)
 	}
 	putKVs(s, rev, totalRevisions)
@@ -79,11 +76,11 @@ func TestHashByRevValueLastRevision(t *testing.T) {
 
 	var totalRevisions int64 = 1210
 	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
-	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	assert.Less(t, int64(testutil.CompactionCycle*10), totalRevisions)
 	var rev int64
 	var got []KeyValueHash
-	for ; rev < totalRevisions; rev += compactionCycle {
-		putKVs(s, rev, compactionCycle)
+	for ; rev < totalRevisions; rev += testutil.CompactionCycle {
+		putKVs(s, rev, testutil.CompactionCycle)
 		hash := testHashByRev(t, s, 0)
 		got = append(got, hash)
 	}
@@ -115,7 +112,7 @@ func TestHashByRevValueLastRevision(t *testing.T) {
 
 func putKVs(s *store, rev, count int64) {
 	for i := rev; i <= rev+count; i++ {
-		s.Put([]byte(pickKey(i)), []byte(fmt.Sprint(i)), 0)
+		s.Put([]byte(testutil.PickKey(i)), []byte(fmt.Sprint(i)), 0)
 	}
 }
 
@@ -135,57 +132,43 @@ func TestCompactionHash(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
 
-	var totalRevisions int64 = 1210
-	assert.Less(t, int64(s.cfg.CompactionBatchLimit), totalRevisions)
-	assert.Less(t, int64(compactionCycle*10), totalRevisions)
-	var rev int64
-	for ; rev < totalRevisions; rev += compactionCycle {
-		testCompactionHash(t, s, rev, rev+compactionCycle)
-	}
-	testCompactionHash(t, s, rev, rev+totalRevisions)
+	testutil.TestCompactionHash(context.Background(), t, hashTestCase{s}, s.cfg.CompactionBatchLimit)
 }
 
-func testCompactionHash(t *testing.T, s *store, start, stop int64) {
-	for i := start; i <= stop; i++ {
-		s.Put([]byte(pickKey(i)), []byte(fmt.Sprint(i)), 0)
-	}
-	hash1, _, err := s.hashByRev(stop)
-	assert.NoError(t, err, "error on rev %v", stop)
-
-	_, prevCompactRev, err := s.updateCompactRev(stop)
-	assert.NoError(t, err, "error on rev %v", stop)
-
-	hash2, err := s.scheduleCompaction(stop, prevCompactRev)
-	assert.NoError(t, err, "error on rev %v", stop)
-	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
+type hashTestCase struct {
+	*store
 }
 
-func pickKey(i int64) string {
-	if i%(compactionCycle*2) == 30 {
-		return "zenek"
+func (tc hashTestCase) Put(ctx context.Context, key, value string) error {
+	tc.store.Put([]byte(key), []byte(value), 0)
+	return nil
+}
+
+func (tc hashTestCase) Delete(ctx context.Context, key string) error {
+	tc.store.DeleteRange([]byte(key), nil)
+	return nil
+}
+
+func (tc hashTestCase) HashByRev(ctx context.Context, rev int64) (testutil.KeyValueHash, error) {
+	hash, _, err := tc.store.HashStorage().HashByRev(rev)
+	return testutil.KeyValueHash{Hash: hash.Hash, CompactRevision: hash.CompactRevision, Revision: hash.Revision}, err
+}
+
+func (tc hashTestCase) Defrag(ctx context.Context) error {
+	return tc.store.b.Defrag()
+}
+
+func (tc hashTestCase) Compact(ctx context.Context, rev int64) error {
+	done, err := tc.store.Compact(traceutil.TODO(), rev)
+	if err != nil {
+		return err
 	}
-	if i%compactionCycle == 30 {
-		return "xavery"
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	// Use low prime number to ensure repeats without alignment
-	switch i % 7 {
-	case 0:
-		return "alice"
-	case 1:
-		return "bob"
-	case 2:
-		return "celine"
-	case 3:
-		return "dominik"
-	case 4:
-		return "eve"
-	case 5:
-		return "frederica"
-	case 6:
-		return "gorge"
-	default:
-		panic("Can't count")
-	}
+	return nil
 }
 
 func TestHasherStore(t *testing.T) {

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -136,7 +136,7 @@ type Hasher interface {
 	Hash() (hash uint32, revision int64, err error)
 
 	// HashByRev computes the hash of all MVCC revisions up to a given revision.
-	HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error)
+	HashByRev(rev int64) (hash KeyValueHash, revision int64, compactRev int64, err error)
 }
 
 // WatchableKV is a KV that can be watched.

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -112,18 +112,13 @@ const (
 type KV interface {
 	ReadView
 	WriteView
+	Hasher
 
 	// Read creates a read transaction.
 	Read(mode ReadTxMode, trace *traceutil.Trace) TxnRead
 
 	// Write creates a write transaction.
 	Write(trace *traceutil.Trace) TxnWrite
-
-	// Hash computes the hash of the KV's backend.
-	Hash() (hash uint32, revision int64, err error)
-
-	// HashByRev computes the hash of all MVCC revisions up to a given revision.
-	HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error)
 
 	// Compact frees all superseded keys with revisions less than rev.
 	Compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error)
@@ -134,6 +129,14 @@ type KV interface {
 	// Restore restores the KV store from a backend.
 	Restore(b backend.Backend) error
 	Close() error
+}
+
+type Hasher interface {
+	// Hash computes the hash of the KV's backend.
+	Hash() (hash uint32, revision int64, err error)
+
+	// HashByRev computes the hash of all MVCC revisions up to a given revision.
+	HashByRev(rev int64) (hash uint32, revision int64, compactRev int64, err error)
 }
 
 // WatchableKV is a KV that can be watched.

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -112,13 +112,15 @@ const (
 type KV interface {
 	ReadView
 	WriteView
-	Hasher
 
 	// Read creates a read transaction.
 	Read(mode ReadTxMode, trace *traceutil.Trace) TxnRead
 
 	// Write creates a write transaction.
 	Write(trace *traceutil.Trace) TxnWrite
+
+	// HashStorage returns HashStorage interface for KV storage.
+	HashStorage() HashStorage
 
 	// Compact frees all superseded keys with revisions less than rev.
 	Compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error)
@@ -129,14 +131,6 @@ type KV interface {
 	// Restore restores the KV store from a backend.
 	Restore(b backend.Backend) error
 	Close() error
-}
-
-type Hasher interface {
-	// Hash computes the hash of the KV's backend.
-	Hash() (hash uint32, revision int64, err error)
-
-	// HashByRev computes the hash of all MVCC revisions up to a given revision.
-	HashByRev(rev int64) (hash KeyValueHash, revision int64, err error)
 }
 
 // WatchableKV is a KV that can be watched.

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -136,7 +136,7 @@ type Hasher interface {
 	Hash() (hash uint32, revision int64, err error)
 
 	// HashByRev computes the hash of all MVCC revisions up to a given revision.
-	HashByRev(rev int64) (hash KeyValueHash, revision int64, compactRev int64, err error)
+	HashByRev(rev int64) (hash KeyValueHash, revision int64, err error)
 }
 
 // WatchableKV is a KV that can be watched.

--- a/server/storage/mvcc/kv_test.go
+++ b/server/storage/mvcc/kv_test.go
@@ -639,7 +639,7 @@ func TestKVHash(t *testing.T) {
 		kv := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
 		kv.Put([]byte("foo0"), []byte("bar0"), lease.NoLease)
 		kv.Put([]byte("foo1"), []byte("bar0"), lease.NoLease)
-		hashes[i], _, err = kv.Hash()
+		hashes[i], _, err = kv.hash()
 		if err != nil {
 			t.Fatalf("failed to get hash: %v", err)
 		}

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"math"
 	"sync"
 	"time"
@@ -196,29 +195,6 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	hash, err = unsafeHashByRev(tx, revision{main: compactRev + 1}, revision{main: rev + 1}, keep)
 	hashRevSec.Observe(time.Since(start).Seconds())
 	return hash, currentRev, compactRev, err
-}
-
-func unsafeHashByRev(tx backend.ReadTx, lower, upper revision, keep map[revision]struct{}) (uint32, error) {
-	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-
-	h.Write(schema.Key.Name())
-	err := tx.UnsafeForEach(schema.Key, func(k, v []byte) error {
-		kr := bytesToRev(k)
-		if !upper.GreaterThan(kr) {
-			return nil
-		}
-		// skip revisions that are scheduled for deletion
-		// due to compacting; don't skip if there isn't one.
-		if lower.GreaterThan(kr) && len(keep) > 0 {
-			if _, ok := keep[kr]; !ok {
-				return nil
-			}
-		}
-		h.Write(k)
-		h.Write(v)
-		return nil
-	})
-	return h.Sum32(), err
 }
 
 func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -114,7 +114,7 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 
 		lg: lg,
 	}
-	s.hashes = newHashStorage(s)
+	s.hashes = newHashStorage(lg, s)
 	s.ReadView = &readView{s}
 	s.WriteView = &writeView{s}
 	if s.le != nil {
@@ -230,11 +230,13 @@ func (s *store) compact(trace *traceutil.Trace, rev, prevCompactRev int64) (<-ch
 			s.compactBarrier(ctx, ch)
 			return
 		}
-		if _, err := s.scheduleCompaction(rev, prevCompactRev); err != nil {
+		hash, err := s.scheduleCompaction(rev, prevCompactRev)
+		if err != nil {
 			s.lg.Warn("Failed compaction", zap.Error(err))
 			s.compactBarrier(context.TODO(), ch)
 			return
 		}
+		s.hashes.Store(hash)
 		close(ch)
 	}
 

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -82,7 +82,8 @@ type store struct {
 
 	stopc chan struct{}
 
-	lg *zap.Logger
+	lg     *zap.Logger
+	hashes HashStorage
 }
 
 // NewStore returns a new store. It is useful to create a store inside
@@ -113,6 +114,7 @@ func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfi
 
 		lg: lg,
 	}
+	s.hashes = newHashStorage(s)
 	s.ReadView = &readView{s}
 	s.WriteView = &writeView{s}
 	if s.le != nil {
@@ -155,7 +157,7 @@ func (s *store) compactBarrier(ctx context.Context, ch chan struct{}) {
 	close(ch)
 }
 
-func (s *store) Hash() (hash uint32, revision int64, err error) {
+func (s *store) hash() (hash uint32, revision int64, err error) {
 	// TODO: hash and revision could be inconsistent, one possible fix is to add s.revMu.RLock() at the beginning of function, which is costly
 	start := time.Now()
 
@@ -166,7 +168,7 @@ func (s *store) Hash() (hash uint32, revision int64, err error) {
 	return h, s.currentRev, err
 }
 
-func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, err error) {
+func (s *store) hashByRev(rev int64) (hash KeyValueHash, currentRev int64, err error) {
 	var compactRev int64
 	start := time.Now()
 
@@ -182,7 +184,6 @@ func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, err e
 		s.mu.RUnlock()
 		return KeyValueHash{}, currentRev, ErrFutureRev
 	}
-
 	if rev == 0 {
 		rev = currentRev
 	}
@@ -512,4 +513,8 @@ func appendMarkTombstone(lg *zap.Logger, b []byte) []byte {
 // isTombstone checks whether the revision bytes is a tombstone.
 func isTombstone(b []byte) bool {
 	return len(b) == markedRevBytesLen && b[markBytePosition] == markTombstone
+}
+
+func (s *store) HashStorage() HashStorage {
+	return s.hashes
 }

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -191,26 +191,25 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	tx.RLock()
 	defer tx.RUnlock()
 	s.mu.RUnlock()
-
 	hash, err = unsafeHashByRev(tx, revision{main: compactRev + 1}, revision{main: rev + 1}, keep)
 	hashRevSec.Observe(time.Since(start).Seconds())
 	return hash, currentRev, compactRev, err
 }
 
-func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
+func (s *store) updateCompactRev(rev int64) (<-chan struct{}, int64, error) {
 	s.revMu.Lock()
 	if rev <= s.compactMainRev {
 		ch := make(chan struct{})
 		f := func(ctx context.Context) { s.compactBarrier(ctx, ch) }
 		s.fifoSched.Schedule(f)
 		s.revMu.Unlock()
-		return ch, ErrCompacted
+		return ch, 0, ErrCompacted
 	}
 	if rev > s.currentRev {
 		s.revMu.Unlock()
-		return nil, ErrFutureRev
+		return nil, 0, ErrFutureRev
 	}
-
+	compactMainRev := s.compactMainRev
 	s.compactMainRev = rev
 
 	SetScheduledCompact(s.b.BatchTx(), rev)
@@ -219,17 +218,17 @@ func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
 
 	s.revMu.Unlock()
 
-	return nil, nil
+	return nil, compactMainRev, nil
 }
 
-func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error) {
+func (s *store) compact(trace *traceutil.Trace, rev, prevCompactRev int64) (<-chan struct{}, error) {
 	ch := make(chan struct{})
 	var j = func(ctx context.Context) {
 		if ctx.Err() != nil {
 			s.compactBarrier(ctx, ch)
 			return
 		}
-		if err := s.scheduleCompaction(rev); err != nil {
+		if _, err := s.scheduleCompaction(rev, prevCompactRev); err != nil {
 			s.lg.Warn("Failed compaction", zap.Error(err))
 			s.compactBarrier(context.TODO(), ch)
 			return
@@ -243,18 +242,18 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 }
 
 func (s *store) compactLockfree(rev int64) (<-chan struct{}, error) {
-	ch, err := s.updateCompactRev(rev)
+	ch, prevCompactRev, err := s.updateCompactRev(rev)
 	if err != nil {
 		return ch, err
 	}
 
-	return s.compact(traceutil.TODO(), rev)
+	return s.compact(traceutil.TODO(), rev, prevCompactRev)
 }
 
 func (s *store) Compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, error) {
 	s.mu.Lock()
 
-	ch, err := s.updateCompactRev(rev)
+	ch, prevCompactRev, err := s.updateCompactRev(rev)
 	trace.Step("check and update compact revision")
 	if err != nil {
 		s.mu.Unlock()
@@ -262,7 +261,7 @@ func (s *store) Compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 	}
 	s.mu.Unlock()
 
-	return s.compact(trace, rev)
+	return s.compact(trace, rev, prevCompactRev)
 }
 
 func (s *store) Commit() {

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -166,7 +166,7 @@ func (s *store) Hash() (hash uint32, revision int64, err error) {
 	return h, s.currentRev, err
 }
 
-func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev int64, err error) {
+func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, compactRev int64, err error) {
 	start := time.Now()
 
 	s.mu.RLock()
@@ -176,10 +176,10 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 
 	if rev > 0 && rev <= compactRev {
 		s.mu.RUnlock()
-		return 0, 0, compactRev, ErrCompacted
+		return KeyValueHash{}, 0, compactRev, ErrCompacted
 	} else if rev > 0 && rev > currentRev {
 		s.mu.RUnlock()
-		return 0, currentRev, 0, ErrFutureRev
+		return KeyValueHash{}, currentRev, 0, ErrFutureRev
 	}
 
 	if rev == 0 {

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -232,7 +232,8 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 		start := time.Now()
 		keep := s.kvindex.Compact(rev)
 		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
-		if !s.scheduleCompaction(rev, keep) {
+		if err := s.scheduleCompaction(rev, keep); err != nil {
+			s.lg.Warn("Failed compaction", zap.Error(err))
 			s.compactBarrier(context.TODO(), ch)
 			return
 		}

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -191,7 +191,7 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	tx.RLock()
 	defer tx.RUnlock()
 	s.mu.RUnlock()
-	hash, err = unsafeHashByRev(tx, compactRev+1, rev+1, keep)
+	hash, err = unsafeHashByRev(tx, compactRev, rev, keep)
 	hashRevSec.Observe(time.Since(start).Seconds())
 	return hash, currentRev, compactRev, err
 }

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -166,7 +166,8 @@ func (s *store) Hash() (hash uint32, revision int64, err error) {
 	return h, s.currentRev, err
 }
 
-func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, compactRev int64, err error) {
+func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, err error) {
+	var compactRev int64
 	start := time.Now()
 
 	s.mu.RLock()
@@ -176,10 +177,10 @@ func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, compa
 
 	if rev > 0 && rev <= compactRev {
 		s.mu.RUnlock()
-		return KeyValueHash{}, 0, compactRev, ErrCompacted
+		return KeyValueHash{}, 0, ErrCompacted
 	} else if rev > 0 && rev > currentRev {
 		s.mu.RUnlock()
-		return KeyValueHash{}, currentRev, 0, ErrFutureRev
+		return KeyValueHash{}, currentRev, ErrFutureRev
 	}
 
 	if rev == 0 {
@@ -193,7 +194,7 @@ func (s *store) HashByRev(rev int64) (hash KeyValueHash, currentRev int64, compa
 	s.mu.RUnlock()
 	hash, err = unsafeHashByRev(tx, compactRev, rev, keep)
 	hashRevSec.Observe(time.Since(start).Seconds())
-	return hash, currentRev, compactRev, err
+	return hash, currentRev, err
 }
 
 func (s *store) updateCompactRev(rev int64) (<-chan struct{}, int64, error) {

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -191,7 +191,7 @@ func (s *store) HashByRev(rev int64) (hash uint32, currentRev int64, compactRev 
 	tx.RLock()
 	defer tx.RUnlock()
 	s.mu.RUnlock()
-	hash, err = unsafeHashByRev(tx, revision{main: compactRev + 1}, revision{main: rev + 1}, keep)
+	hash, err = unsafeHashByRev(tx, compactRev+1, rev+1, keep)
 	hashRevSec.Observe(time.Since(start).Seconds())
 	return hash, currentRev, compactRev, err
 }

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -229,10 +229,7 @@ func (s *store) compact(trace *traceutil.Trace, rev int64) (<-chan struct{}, err
 			s.compactBarrier(ctx, ch)
 			return
 		}
-		start := time.Now()
-		keep := s.kvindex.Compact(rev)
-		indexCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
-		if err := s.scheduleCompaction(rev, keep); err != nil {
+		if err := s.scheduleCompaction(rev); err != nil {
 			s.lg.Warn("Failed compaction", zap.Error(err))
 			s.compactBarrier(context.TODO(), ch)
 			return

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -23,8 +23,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struct{}) error {
+func (s *store) scheduleCompaction(compactMainRev int64) error {
 	totalStart := time.Now()
+	keep := s.kvindex.Compact(compactMainRev)
+	indexCompactionPauseMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
+
+	totalStart = time.Now()
 	defer func() { dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond)) }()
 	keyCompactions := 0
 	defer func() { dbCompactionKeysCounter.Add(float64(keyCompactions)) }()

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -39,7 +39,7 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (uint32
 
 	batchNum := s.cfg.CompactionBatchLimit
 	batchInterval := s.cfg.CompactionSleepInterval
-	h := newKVHasher(revision{main: prevCompactRev + 1}, revision{main: compactMainRev + 1}, keep)
+	h := newKVHasher(prevCompactRev+1, compactMainRev+1, keep)
 	last := make([]byte, 8+1+8)
 	for {
 		var rev revision

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (uint32, error) {
+func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyValueHash, error) {
 	totalStart := time.Now()
 	keep := s.kvindex.Compact(compactMainRev)
 	indexCompactionPauseMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
@@ -66,7 +66,7 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (uint32
 				"finished scheduled compaction",
 				zap.Int64("compact-revision", compactMainRev),
 				zap.Duration("took", time.Since(totalStart)),
-				zap.Uint32("hash", hash),
+				zap.Uint32("hash", hash.Hash),
 			)
 			return hash, nil
 		}
@@ -81,7 +81,7 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (uint32
 		select {
 		case <-time.After(batchInterval):
 		case <-s.stopc:
-			return 0, fmt.Errorf("interrupted due to stop signal")
+			return KeyValueHash{}, fmt.Errorf("interrupted due to stop signal")
 		}
 	}
 }

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -39,7 +39,7 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (uint32
 
 	batchNum := s.cfg.CompactionBatchLimit
 	batchInterval := s.cfg.CompactionSleepInterval
-	h := newKVHasher(prevCompactRev+1, compactMainRev+1, keep)
+	h := newKVHasher(prevCompactRev, compactMainRev, keep)
 	last := make([]byte, 8+1+8)
 	for {
 		var rev revision

--- a/server/storage/mvcc/kvstore_compaction_test.go
+++ b/server/storage/mvcc/kvstore_compaction_test.go
@@ -79,7 +79,10 @@ func TestScheduleCompaction(t *testing.T) {
 		}
 		tx.Unlock()
 
-		s.scheduleCompaction(tt.rev, tt.keep)
+		err := s.scheduleCompaction(tt.rev, tt.keep)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		tx.Lock()
 		for _, rev := range tt.wrevs {

--- a/server/storage/mvcc/kvstore_compaction_test.go
+++ b/server/storage/mvcc/kvstore_compaction_test.go
@@ -83,9 +83,9 @@ func TestScheduleCompaction(t *testing.T) {
 		}
 		tx.Unlock()
 
-		err := s.scheduleCompaction(tt.rev)
+		_, err := s.scheduleCompaction(tt.rev, 0)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 
 		tx.Lock()

--- a/server/storage/mvcc/kvstore_compaction_test.go
+++ b/server/storage/mvcc/kvstore_compaction_test.go
@@ -69,6 +69,10 @@ func TestScheduleCompaction(t *testing.T) {
 	for i, tt := range tests {
 		b, tmpPath := betesting.NewDefaultTmpBackend(t)
 		s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
+		fi := newFakeIndex()
+		fi.indexCompactRespc <- tt.keep
+		s.kvindex = fi
+
 		tx := s.b.BatchTx()
 
 		tx.Lock()
@@ -79,7 +83,7 @@ func TestScheduleCompaction(t *testing.T) {
 		}
 		tx.Unlock()
 
-		err := s.scheduleCompaction(tt.rev, tt.keep)
+		err := s.scheduleCompaction(tt.rev)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -337,7 +337,7 @@ func TestStoreCompact(t *testing.T) {
 	fi.indexCompactRespc <- map[revision]struct{}{{1, 0}: {}}
 	key1 := newTestKeyBytes(lg, revision{1, 0}, false)
 	key2 := newTestKeyBytes(lg, revision{2, 0}, false)
-	b.tx.rangeRespc <- rangeResp{[][]byte{key1, key2}, nil}
+	b.tx.rangeRespc <- rangeResp{[][]byte{key1, key2}, [][]byte{[]byte("alice"), []byte("bob")}}
 
 	s.Compact(traceutil.TODO(), 3)
 	s.fifoSched.WaitFinish(1)

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -849,18 +849,11 @@ func newFakeStore(lg *zap.Logger) *store {
 	b := &fakeBackend{&fakeBatchTx{
 		Recorder:   &testutil.RecorderBuffered{},
 		rangeRespc: make(chan rangeResp, 5)}}
-	fi := &fakeIndex{
-		Recorder:              &testutil.RecorderBuffered{},
-		indexGetRespc:         make(chan indexGetResp, 1),
-		indexRangeRespc:       make(chan indexRangeResp, 1),
-		indexRangeEventsRespc: make(chan indexRangeEventsResp, 1),
-		indexCompactRespc:     make(chan map[revision]struct{}, 1),
-	}
 	s := &store{
 		cfg:            StoreConfig{CompactionBatchLimit: 10000},
 		b:              b,
 		le:             &lease.FakeLessor{},
-		kvindex:        fi,
+		kvindex:        newFakeIndex(),
 		currentRev:     0,
 		compactMainRev: -1,
 		fifoSched:      schedule.NewFIFOScheduler(),
@@ -869,6 +862,16 @@ func newFakeStore(lg *zap.Logger) *store {
 	}
 	s.ReadView, s.WriteView = &readView{s}, &writeView{s}
 	return s
+}
+
+func newFakeIndex() *fakeIndex {
+	return &fakeIndex{
+		Recorder:              &testutil.RecorderBuffered{},
+		indexGetRespc:         make(chan indexGetResp, 1),
+		indexRangeRespc:       make(chan indexRangeResp, 1),
+		indexRangeEventsRespc: make(chan indexRangeEventsResp, 1),
+		indexCompactRespc:     make(chan map[revision]struct{}, 1),
+	}
 }
 
 type rangeResp struct {

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -560,7 +560,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for {
-				hash, _, err := s.HashByRev(int64(rev))
+				hash, _, err := s.HashStorage().HashByRev(int64(rev))
 				if err != nil {
 					t.Error(err)
 				}
@@ -622,12 +622,12 @@ func TestHashKVZeroRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hash1, _, err := s.HashByRev(int64(rev))
+	hash1, _, err := s.HashStorage().HashByRev(int64(rev))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var hash2 KeyValueHash
-	hash2, _, err = s.HashByRev(0)
+	hash2, _, err = s.HashStorage().HashByRev(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -560,14 +560,14 @@ func TestHashKVWhenCompacting(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for {
-				hash, _, compactRev, err := s.HashByRev(int64(rev))
+				hash, _, err := s.HashByRev(int64(rev))
 				if err != nil {
 					t.Error(err)
 				}
 				select {
 				case <-donec:
 					return
-				case hashCompactc <- hashKVResult{hash.Hash, compactRev}:
+				case hashCompactc <- hashKVResult{hash.Hash, hash.CompactRevision}:
 				}
 			}
 		}()
@@ -622,12 +622,12 @@ func TestHashKVZeroRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hash1, _, _, err := s.HashByRev(int64(rev))
+	hash1, _, err := s.HashByRev(int64(rev))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var hash2 KeyValueHash
-	hash2, _, _, err = s.HashByRev(0)
+	hash2, _, err = s.HashByRev(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -567,7 +567,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 				select {
 				case <-donec:
 					return
-				case hashCompactc <- hashKVResult{hash, compactRev}:
+				case hashCompactc <- hashKVResult{hash.Hash, compactRev}:
 				}
 			}
 		}()
@@ -626,7 +626,7 @@ func TestHashKVZeroRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var hash2 uint32
+	var hash2 KeyValueHash
 	hash2, _, _, err = s.HashByRev(0)
 	if err != nil {
 		t.Fatal(err)

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -861,6 +861,7 @@ func newFakeStore(lg *zap.Logger) *store {
 		lg:             lg,
 	}
 	s.ReadView, s.WriteView = &readView{s}, &writeView{s}
+	s.hashes = newHashStorage(lg, s)
 	return s
 }
 

--- a/server/storage/mvcc/testutil/hash.go
+++ b/server/storage/mvcc/testutil/hash.go
@@ -1,0 +1,105 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// CompactionCycle is high prime used to test hash calculation between compactions.
+	CompactionCycle = 71
+)
+
+func TestCompactionHash(ctx context.Context, t *testing.T, h CompactionHashTestCase, compactionBatchLimit int) {
+	var totalRevisions int64 = 1210
+	assert.Less(t, int64(compactionBatchLimit), totalRevisions)
+	assert.Less(t, int64(CompactionCycle*10), totalRevisions)
+	var rev int64
+	for ; rev < totalRevisions; rev += CompactionCycle {
+		testCompactionHash(ctx, t, h, rev, rev+CompactionCycle)
+	}
+	testCompactionHash(ctx, t, h, rev, rev+totalRevisions)
+}
+
+type CompactionHashTestCase interface {
+	Put(ctx context.Context, key, value string) error
+	Delete(ctx context.Context, key string) error
+	HashByRev(ctx context.Context, rev int64) (KeyValueHash, error)
+	Defrag(ctx context.Context) error
+	Compact(ctx context.Context, rev int64) error
+}
+
+type KeyValueHash struct {
+	Hash            uint32
+	CompactRevision int64
+	Revision        int64
+}
+
+func testCompactionHash(ctx context.Context, t *testing.T, h CompactionHashTestCase, start, stop int64) {
+	for i := start; i <= stop; i++ {
+		if i%67 == 0 {
+			err := h.Delete(ctx, PickKey(i+83))
+			assert.NoError(t, err, "error on delete")
+		} else {
+			err := h.Put(ctx, PickKey(i), fmt.Sprint(i))
+			assert.NoError(t, err, "error on put")
+		}
+	}
+	hash1, err := h.HashByRev(ctx, stop)
+	assert.NoError(t, err, "error on hash (rev %v)", stop)
+
+	err = h.Compact(ctx, stop)
+	assert.NoError(t, err, "error on compact (rev %v)", stop)
+
+	err = h.Defrag(ctx)
+	assert.NoError(t, err, "error on defrag")
+
+	hash2, err := h.HashByRev(ctx, stop)
+	assert.NoError(t, err, "error on hash (rev %v)", stop)
+	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
+}
+
+func PickKey(i int64) string {
+	if i%(CompactionCycle*2) == 30 {
+		return "zenek"
+	}
+	if i%CompactionCycle == 30 {
+		return "xavery"
+	}
+	// Use low prime number to ensure repeats without alignment
+	switch i % 7 {
+	case 0:
+		return "alice"
+	case 1:
+		return "bob"
+	case 2:
+		return "celine"
+	case 3:
+		return "dominik"
+	case 4:
+		return "eve"
+	case 5:
+		return "frederica"
+	case 6:
+		return "gorge"
+	default:
+		panic("Can't count")
+	}
+}

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/server/v3/storage/mvcc/testutil"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
@@ -35,11 +35,6 @@ import (
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
-)
-
-const (
-	// Use high prime
-	compactionCycle = 71
 )
 
 func TestMaintenanceHashKV(t *testing.T) {
@@ -75,72 +70,51 @@ func TestMaintenanceHashKV(t *testing.T) {
 	}
 }
 
+// TODO: Change this to fuzz test
 func TestCompactionHash(t *testing.T) {
 	integration2.BeforeTest(t)
 
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx := context.Background()
 	cc, err := clus.ClusterClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var totalRevisions int64 = 1210
-	assert.Less(t, int64(1000), totalRevisions)
-	assert.Less(t, int64(compactionCycle*10), totalRevisions)
-	var rev int64
-	for ; rev < totalRevisions; rev += compactionCycle {
-		testCompactionHash(ctx, t, cc, clus.Members[0].GRPCURL(), rev, rev+compactionCycle)
-	}
-	testCompactionHash(ctx, t, cc, clus.Members[0].GRPCURL(), rev, rev+totalRevisions)
+	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL()}, 1000)
 }
 
-func testCompactionHash(ctx context.Context, t *testing.T, cc *clientv3.Client, url string, start, stop int64) {
-	for i := start; i <= stop; i++ {
-		cc.Put(ctx, pickKey(i), fmt.Sprint(i))
-	}
-	hash1, err := cc.HashKV(ctx, url, stop)
-	assert.NoError(t, err, "error on rev %v", stop)
+type hashTestCase struct {
+	*clientv3.Client
+	url string
+}
 
-	_, err = cc.Compact(ctx, stop)
-	assert.NoError(t, err, "error on compact rev %v", stop)
+func (tc hashTestCase) Put(ctx context.Context, key, value string) error {
+	_, err := tc.Client.Put(ctx, key, value)
+	return err
+}
 
+func (tc hashTestCase) Delete(ctx context.Context, key string) error {
+	_, err := tc.Client.Delete(ctx, key)
+	return err
+}
+
+func (tc hashTestCase) HashByRev(ctx context.Context, rev int64) (testutil.KeyValueHash, error) {
+	resp, err := tc.Client.HashKV(ctx, tc.url, rev)
+	return testutil.KeyValueHash{Hash: resp.Hash, CompactRevision: resp.CompactRevision, Revision: resp.Header.Revision}, err
+}
+
+func (tc hashTestCase) Defrag(ctx context.Context) error {
+	_, err := tc.Client.Defragment(ctx, tc.url)
+	return err
+}
+
+func (tc hashTestCase) Compact(ctx context.Context, rev int64) error {
+	_, err := tc.Client.Compact(ctx, rev)
 	// Wait for compaction to be compacted
 	time.Sleep(50 * time.Millisecond)
-
-	hash2, err := cc.HashKV(ctx, url, stop)
-	assert.NoError(t, err, "error on rev %v", stop)
-	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
-}
-
-func pickKey(i int64) string {
-	if i%(compactionCycle*2) == 30 {
-		return "zenek"
-	}
-	if i%compactionCycle == 30 {
-		return "xavery"
-	}
-	// Use low prime number to ensure repeats without alignment
-	switch i % 7 {
-	case 0:
-		return "alice"
-	case 1:
-		return "bob"
-	case 2:
-		return "celine"
-	case 3:
-		return "dominik"
-	case 4:
-		return "eve"
-	case 5:
-		return "frederica"
-	case 6:
-		return "gorge"
-	default:
-		panic("Can't count")
-	}
+	return err
 }
 
 func TestMaintenanceMoveLeader(t *testing.T) {

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
@@ -34,6 +35,11 @@ import (
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
+)
+
+const (
+	// Use high prime
+	compactionCycle = 71
 )
 
 func TestMaintenanceHashKV(t *testing.T) {
@@ -66,6 +72,74 @@ func TestMaintenanceHashKV(t *testing.T) {
 		if hv != hresp.Hash {
 			t.Fatalf("#%d: hash expected %d, got %d", i, hv, hresp.Hash)
 		}
+	}
+}
+
+func TestCompactionHash(t *testing.T) {
+	integration2.BeforeTest(t)
+
+	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	ctx := context.Background()
+	cc, err := clus.ClusterClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var totalRevisions int64 = 1210
+	assert.Less(t, int64(1000), totalRevisions)
+	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	var rev int64
+	for ; rev < totalRevisions; rev += compactionCycle {
+		testCompactionHash(ctx, t, cc, clus.Members[0].GRPCURL(), rev, rev+compactionCycle)
+	}
+	testCompactionHash(ctx, t, cc, clus.Members[0].GRPCURL(), rev, rev+totalRevisions)
+}
+
+func testCompactionHash(ctx context.Context, t *testing.T, cc *clientv3.Client, url string, start, stop int64) {
+	for i := start; i <= stop; i++ {
+		cc.Put(ctx, pickKey(i), fmt.Sprint(i))
+	}
+	hash1, err := cc.HashKV(ctx, url, stop)
+	assert.NoError(t, err, "error on rev %v", stop)
+
+	_, err = cc.Compact(ctx, stop)
+	assert.NoError(t, err, "error on compact rev %v", stop)
+
+	// Wait for compaction to be compacted
+	time.Sleep(50 * time.Millisecond)
+
+	hash2, err := cc.HashKV(ctx, url, stop)
+	assert.NoError(t, err, "error on rev %v", stop)
+	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
+}
+
+func pickKey(i int64) string {
+	if i%(compactionCycle*2) == 30 {
+		return "zenek"
+	}
+	if i%compactionCycle == 30 {
+		return "xavery"
+	}
+	// Use low prime number to ensure repeats without alignment
+	switch i % 7 {
+	case 0:
+		return "alice"
+	case 1:
+		return "bob"
+	case 2:
+		return "celine"
+	case 3:
+		return "dominik"
+	case 4:
+		return "eve"
+	case 5:
+		return "frederica"
+	case 6:
+		return "gorge"
+	default:
+		panic("Can't count")
 	}
 }
 

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -16,39 +16,29 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver"
+	"go.etcd.io/etcd/server/v3/storage/mvcc/testutil"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
-const (
-	// Use high prime
-	compactionCycle = 71
-)
-
-func TestCompactionHashHTTP(t *testing.T) {
+// TODO: Change this to fuzz test
+func TestCompactionHash(t *testing.T) {
 	integration2.BeforeTest(t)
 
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx := context.Background()
 	cc, err := clus.ClusterClient()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var totalRevisions int64 = 1210
-	assert.Less(t, int64(1000), totalRevisions)
-	assert.Less(t, int64(compactionCycle*10), totalRevisions)
-	var rev int64
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
@@ -56,54 +46,39 @@ func TestCompactionHashHTTP(t *testing.T) {
 			},
 		},
 	}
-	for ; rev < totalRevisions; rev += compactionCycle {
-		testCompactionHash(ctx, t, cc, client, rev, rev+compactionCycle)
-	}
-	testCompactionHash(ctx, t, cc, client, rev, rev+totalRevisions)
+
+	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL(), client}, 1000)
 }
 
-func testCompactionHash(ctx context.Context, t *testing.T, cc *clientv3.Client, client *http.Client, start, stop int64) {
-	for i := start; i <= stop; i++ {
-		cc.Put(ctx, pickKey(i), fmt.Sprint(i))
-	}
-	hash1, err := etcdserver.HashByRev(ctx, client, "http://unix", stop)
-	assert.NoError(t, err, "error on rev %v", stop)
+type hashTestCase struct {
+	*clientv3.Client
+	url  string
+	http *http.Client
+}
 
-	_, err = cc.Compact(ctx, stop)
-	assert.NoError(t, err, "error on compact rev %v", stop)
+func (tc hashTestCase) Put(ctx context.Context, key, value string) error {
+	_, err := tc.Client.Put(ctx, key, value)
+	return err
+}
 
+func (tc hashTestCase) Delete(ctx context.Context, key string) error {
+	_, err := tc.Client.Delete(ctx, key)
+	return err
+}
+
+func (tc hashTestCase) HashByRev(ctx context.Context, rev int64) (testutil.KeyValueHash, error) {
+	resp, err := etcdserver.HashByRev(ctx, tc.http, "http://unix", rev)
+	return testutil.KeyValueHash{Hash: resp.Hash, CompactRevision: resp.CompactRevision, Revision: resp.Header.Revision}, err
+}
+
+func (tc hashTestCase) Defrag(ctx context.Context) error {
+	_, err := tc.Client.Defragment(ctx, tc.url)
+	return err
+}
+
+func (tc hashTestCase) Compact(ctx context.Context, rev int64) error {
+	_, err := tc.Client.Compact(ctx, rev)
 	// Wait for compaction to be compacted
 	time.Sleep(50 * time.Millisecond)
-
-	hash2, err := etcdserver.HashByRev(ctx, client, "http://unix", stop)
-	assert.NoError(t, err, "error on rev %v", stop)
-	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
-}
-
-func pickKey(i int64) string {
-	if i%(compactionCycle*2) == 30 {
-		return "zenek"
-	}
-	if i%compactionCycle == 30 {
-		return "xavery"
-	}
-	// Use low prime number to ensure repeats without alignment
-	switch i % 7 {
-	case 0:
-		return "alice"
-	case 1:
-		return "bob"
-	case 2:
-		return "celine"
-	case 3:
-		return "dominik"
-	case 4:
-		return "eve"
-	case 5:
-		return "frederica"
-	case 6:
-		return "gorge"
-	default:
-		panic("Can't count")
-	}
+	return err
 }

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -1,0 +1,109 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/etcdserver"
+	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
+)
+
+const (
+	// Use high prime
+	compactionCycle = 71
+)
+
+func TestCompactionHashHTTP(t *testing.T) {
+	integration2.BeforeTest(t)
+
+	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	ctx := context.Background()
+	cc, err := clus.ClusterClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var totalRevisions int64 = 1210
+	assert.Less(t, int64(1000), totalRevisions)
+	assert.Less(t, int64(compactionCycle*10), totalRevisions)
+	var rev int64
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", clus.Members[0].PeerURLs[0].Host)
+			},
+		},
+	}
+	for ; rev < totalRevisions; rev += compactionCycle {
+		testCompactionHash(ctx, t, cc, client, rev, rev+compactionCycle)
+	}
+	testCompactionHash(ctx, t, cc, client, rev, rev+totalRevisions)
+}
+
+func testCompactionHash(ctx context.Context, t *testing.T, cc *clientv3.Client, client *http.Client, start, stop int64) {
+	for i := start; i <= stop; i++ {
+		cc.Put(ctx, pickKey(i), fmt.Sprint(i))
+	}
+	hash1, err := etcdserver.HashByRev(ctx, client, "http://unix", stop)
+	assert.NoError(t, err, "error on rev %v", stop)
+
+	_, err = cc.Compact(ctx, stop)
+	assert.NoError(t, err, "error on compact rev %v", stop)
+
+	// Wait for compaction to be compacted
+	time.Sleep(50 * time.Millisecond)
+
+	hash2, err := etcdserver.HashByRev(ctx, client, "http://unix", stop)
+	assert.NoError(t, err, "error on rev %v", stop)
+	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
+}
+
+func pickKey(i int64) string {
+	if i%(compactionCycle*2) == 30 {
+		return "zenek"
+	}
+	if i%compactionCycle == 30 {
+		return "xavery"
+	}
+	// Use low prime number to ensure repeats without alignment
+	switch i % 7 {
+	case 0:
+		return "alice"
+	case 1:
+		return "bob"
+	case 2:
+		return "celine"
+	case 3:
+		return "dominik"
+	case 4:
+		return "eve"
+	case 5:
+		return "frederica"
+	case 6:
+		return "gorge"
+	default:
+		panic("Can't count")
+	}
+}


### PR DESCRIPTION
Implements low cost hash calculation during compaction as proposed in https://github.com/etcd-io/etcd/issues/14039

This PR was deliberately split into smaller commits to avoid any mistakes in code. Recommend to review it one by one.

To make sure that hash calculated by hashKV and scheduleCompaction is the same, I needed to change API so that it's always accompanied by revision range it was calculated on, which is change from previous API that always returned latest revision (WAT?).

I also introduced a intense tests for hash function on a first commit to make sure I will not change result of hashing function. 

This PR is big even though it's meant to be backported to v3.5, this is by design as I don't think we could make a quick hacky change and not make mistake. I included some refactors that should make code clear to understood.

cc @ahrtr @ptabor 