### PR TITLE
[release-3.5] scripts: Avoid additional repo clone

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -179,7 +179,7 @@ main() {
 
   # Verify the clean working tree
   # shellcheck disable=SC2155
-  local diff="$(git diff --stat)"
+  local diff="$(git diff HEAD --stat)"
   if [[ "${diff}" != '' ]]; then
     log_error "Error: Expected clean working tree, but 'git diff --stat' reported: ${diff}"
     exit 1

--- a/scripts/release
+++ b/scripts/release
@@ -161,13 +161,6 @@ main() {
       REMOTE_REPO="origin" push_mod_tags_cmd
     fi
 
-    # Verify the latest commit has the version tag
-    local tag="$(git describe --exact-match HEAD)"
-    if [ "${tag}" != "${RELEASE_VERSION}" ]; then
-      log_error "Error: Expected HEAD to be tagged with ${RELEASE_VERSION}, but 'git describe --exact-match HEAD' reported: ${tag}"
-      exit 1
-    fi
-
     # Verify the version tag is on the right branch
     local branch=$(git for-each-ref --contains "${RELEASE_VERSION}" --format="%(refname)" 'refs/heads' | cut -d '/' -f 3)
     if [ "${branch}" != "${BRANCH}" ]; then
@@ -176,18 +169,29 @@ main() {
     fi
   fi
 
+  # Verify the latest commit has the version tag
+  # shellcheck disable=SC2155
+  local tag="$(git describe --exact-match HEAD)"
+  if [ "${tag}" != "${RELEASE_VERSION}" ]; then
+    log_error "Error: Expected HEAD to be tagged with ${RELEASE_VERSION}, but 'git describe --exact-match HEAD' reported: ${tag}"
+    exit 1
+  fi
+
+  # Verify the clean working tree
+  # shellcheck disable=SC2155
+  local diff="$(git diff --stat)"
+  if [[ "${diff}" != '' ]]; then
+    log_error "Error: Expected clean working tree, but 'git diff --stat' reported: ${diff}"
+    exit 1
+  fi
+
   # Build release.
   # TODO: check the release directory for all required build artifacts.
   if [ -d release ]; then
     log_warning "Skipping release build step. /release directory already exists."
   else
     log_callout "Building release..."
-    if [ "$DRY_RUN" == "true" ]; then
-      log_warning "In DRY_RUN mode we clone the current release directory (as there was no push)"
-      REPOSITORY=$(pwd) ./scripts/build-release.sh "${RELEASE_VERSION}"
-    else
-      REPOSITORY=${REPOSITORY} ./scripts/build-release.sh "${RELEASE_VERSION}"
-    fi
+    REPOSITORY=$(pwd) ./scripts/build-release.sh "${RELEASE_VERSION}"
   fi
 
   # Sanity checks.


### PR DESCRIPTION
This PR removes additional clone when building artifacts.

When releasing v3.5.4 this clone was main cause of issues and
confusion about what release script is doing.

release.sh script already clones repo in /tmp/ directory, so clonning
before build is not needed. As precautions for bug in script leaving
/tmp/ clone in bad state  I moved "Verify the latest commit has the
version tag" and added "Verify the clean working tree" to be always run
before build.

cc @ahrtr @ptabor 