### PR TITLE
embed: add `GRPCAdditionalServerOptions` config

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -284,6 +284,10 @@ type Config struct {
 	// before closing a non-responsive connection. 0 to disable.
 	GRPCKeepAliveTimeout time.Duration `json:"grpc-keepalive-timeout"`
 
+	// GRPCAdditionalServerOptions is the additional server option hook
+	// for changing the default internal gRPC configuration.
+	GRPCAdditionalServerOptions []grpc.ServerOption `json:"grpc-additional-server-options"`
+
 	// SocketOpts are socket options passed to listener config.
 	SocketOpts transport.SocketOpts `json:"socket-options"`
 

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -285,7 +285,10 @@ type Config struct {
 	GRPCKeepAliveTimeout time.Duration `json:"grpc-keepalive-timeout"`
 
 	// GRPCAdditionalServerOptions is the additional server option hook
-	// for changing the default internal gRPC configuration.
+	// for changing the default internal gRPC configuration. Note these
+	// additional configurations take precedence over the existing individual
+	// configurations if present. Please refer to
+	// https://github.com/etcd-io/etcd/pull/14066#issuecomment-1248682996
 	GRPCAdditionalServerOptions []grpc.ServerOption `json:"grpc-additional-server-options"`
 
 	// SocketOpts are socket options passed to listener config.

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -761,6 +761,7 @@ func (e *Etcd) serveClients() {
 			Timeout: e.cfg.GRPCKeepAliveTimeout,
 		}))
 	}
+	gopts = append(gopts, e.cfg.GRPCAdditionalServerOptions...)
 
 	splitHTTP := false
 	for _, sctx := range e.sctxs {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -144,14 +144,16 @@ type ClusterConfig struct {
 	QuotaBackendBytes    int64
 	BackendBatchInterval time.Duration
 
-	MaxTxnOps              uint
-	MaxRequestBytes        uint
+	MaxTxnOps       uint
+	MaxRequestBytes uint
+
 	SnapshotCount          uint64
 	SnapshotCatchUpEntries uint64
 
-	GRPCKeepAliveMinTime  time.Duration
-	GRPCKeepAliveInterval time.Duration
-	GRPCKeepAliveTimeout  time.Duration
+	GRPCKeepAliveMinTime        time.Duration
+	GRPCKeepAliveInterval       time.Duration
+	GRPCKeepAliveTimeout        time.Duration
+	GRPCAdditionalServerOptions []grpc.ServerOption
 
 	ClientMaxCallSendMsgSize int
 	ClientMaxCallRecvMsgSize int
@@ -278,6 +280,7 @@ func (c *Cluster) mustNewMember(t testutil.TB) *Member {
 			GRPCKeepAliveMinTime:                c.Cfg.GRPCKeepAliveMinTime,
 			GRPCKeepAliveInterval:               c.Cfg.GRPCKeepAliveInterval,
 			GRPCKeepAliveTimeout:                c.Cfg.GRPCKeepAliveTimeout,
+			GRPCAdditionalServerOptions:         c.Cfg.GRPCAdditionalServerOptions,
 			ClientMaxCallSendMsgSize:            c.Cfg.ClientMaxCallSendMsgSize,
 			ClientMaxCallRecvMsgSize:            c.Cfg.ClientMaxCallRecvMsgSize,
 			UseIP:                               c.Cfg.UseIP,
@@ -603,6 +606,7 @@ type MemberConfig struct {
 	GRPCKeepAliveMinTime        time.Duration
 	GRPCKeepAliveInterval       time.Duration
 	GRPCKeepAliveTimeout        time.Duration
+	GRPCAdditionalServerOptions []grpc.ServerOption
 	ClientMaxCallSendMsgSize    int
 	ClientMaxCallRecvMsgSize    int
 	UseIP                       bool
@@ -709,6 +713,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 			Timeout: mcfg.GRPCKeepAliveTimeout,
 		}))
 	}
+	m.GRPCServerOpts = append(m.GRPCServerOpts, mcfg.GRPCAdditionalServerOptions...)
 	m.ClientMaxCallSendMsgSize = mcfg.ClientMaxCallSendMsgSize
 	m.ClientMaxCallRecvMsgSize = mcfg.ClientMaxCallRecvMsgSize
 	m.UseIP = mcfg.UseIP

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -702,14 +702,12 @@ func TestKVLargeRequests(t *testing.T) {
 		// without proper client-side receive size limit
 		// "code = ResourceExhausted desc = grpc: received message larger than max (5242929 vs. 4194304)"
 		{
-
 			maxRequestBytesServer:  7*1024*1024 + 512*1024,
 			maxCallSendBytesClient: 7 * 1024 * 1024,
 			maxCallRecvBytesClient: 0,
 			valueSize:              5 * 1024 * 1024,
 			expectError:            nil,
 		},
-
 		{
 			maxRequestBytesServer:  10 * 1024 * 1024,
 			maxCallSendBytesClient: 100 * 1024 * 1024,


### PR DESCRIPTION
This PR introduces GRPCAdditionalServerOptions which allow changing the internal gRPC settings. Sometimes, we may register our own gRPC service into `etcd` and change the `max-request-bytes` might affect the internal etcd logic.