### PR TITLE
clientv3: Fixed clientv3.Config DialTimeout usage

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -299,7 +299,9 @@ func (c *Client) dial(creds grpccredentials.TransportCredentials, dopts ...grpc.
 	if c.cfg.DialTimeout > 0 {
 		var cancel context.CancelFunc
 		dctx, cancel = context.WithTimeout(c.ctx, c.cfg.DialTimeout)
-		defer cancel() // TODO: Is this right for cases where grpc.WithBlock() is not set on the dial options?
+		defer cancel()
+
+		opts = append(opts, grpc.WithBlock())
 	}
 	target := fmt.Sprintf("%s://%p/%s", resolver.Schema, c, authority(c.endpoints[0]))
 	conn, err := grpc.DialContext(dctx, target, opts...)


### PR DESCRIPTION
if DialTimeout > 0, grpc.WithBlock() opt shall be set


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
