### PR TITLE
Clean up the local variable cps so that it will not continue to schedule checkpoint

### DIFF
--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -646,10 +646,10 @@ func (le *lessor) revokeExpiredLeases() {
 // checkpointScheduledLeases finds all scheduled lease checkpoints that are due and
 // submits them to the checkpointer to persist them to the consensus log.
 func (le *lessor) checkpointScheduledLeases() {
-	var cps []*pb.LeaseCheckpoint
-
 	// rate limit
 	for i := 0; i < leaseCheckpointRate/2; i++ {
+		var cps []*pb.LeaseCheckpoint
+
 		le.mu.Lock()
 		if le.isPrimary() {
 			cps = le.findDueScheduledCheckpoints(maxLeaseCheckpointBatchSize)


### PR DESCRIPTION
Fix a minor issue, which was discovered during code review. 

```
// Clean up the cps, otherwise it will continue to schedule
// checkpoints even after it steps down the leader position.
```