### PR TITLE
*: fix typo "iff" to "if" in comments

### DIFF
--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -325,7 +325,7 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 //
 // Previously,
 // 1. Server has non-empty (*tls.Config).Certificates on client hello
-// 2. Server calls (*tls.Config).GetCertificate iff:
+// 2. Server calls (*tls.Config).GetCertificate if:
 //    - Server's (*tls.Config).Certificates is not empty, or
 //    - Client supplies SNI; non-empty (*tls.ClientHelloInfo).ServerName
 //

--- a/client/v3/clientv3util/util.go
+++ b/client/v3/clientv3util/util.go
@@ -19,14 +19,14 @@ import (
 	"go.etcd.io/etcd/client/v3"
 )
 
-// KeyExists returns a comparison operation that evaluates to true iff the given
+// KeyExists returns a comparison operation that evaluates to true if the given
 // key exists. It does this by checking if the key `Version` is greater than 0.
 // It is a useful guard in transaction delete operations.
 func KeyExists(key string) clientv3.Cmp {
 	return clientv3.Compare(clientv3.Version(key), ">", 0)
 }
 
-// KeyMissing returns a comparison operation that evaluates to true iff the
+// KeyMissing returns a comparison operation that evaluates to true if the
 // given key does not exist.
 func KeyMissing(key string) clientv3.Cmp {
 	return clientv3.Compare(clientv3.Version(key), "=", 0)

--- a/client/v3/op.go
+++ b/client/v3/op.go
@@ -106,13 +106,13 @@ func (op Op) RangeBytes() []byte { return op.end }
 // Rev returns the requested revision, if any.
 func (op Op) Rev() int64 { return op.rev }
 
-// IsPut returns true iff the operation is a Put.
+// IsPut returns true if the operation is a Put.
 func (op Op) IsPut() bool { return op.t == tPut }
 
-// IsGet returns true iff the operation is a Get.
+// IsGet returns true if the operation is a Get.
 func (op Op) IsGet() bool { return op.t == tRange }
 
-// IsDelete returns true iff the operation is a Delete.
+// IsDelete returns true if the operation is a Delete.
 func (op Op) IsDelete() bool { return op.t == tDeleteRange }
 
 // IsSerializable returns true if the serializable field is true.

--- a/pkg/adt/interval_tree_test.go
+++ b/pkg/adt/interval_tree_test.go
@@ -497,7 +497,7 @@ func TestIntervalTreeVisitExit(t *testing.T) {
 	}
 }
 
-// TestIntervalTreeContains tests that contains returns true iff the ivt maps the entire interval.
+// TestIntervalTreeContains tests that contains returns true if the ivt maps the entire interval.
 func TestIntervalTreeContains(t *testing.T) {
 	tests := []struct {
 		ivls   []Interval

--- a/raft/quorum/datadriven_test.go
+++ b/raft/quorum/datadriven_test.go
@@ -37,7 +37,7 @@ func TestDataDriven(t *testing.T) {
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			// Two majority configs. The first one is always used (though it may
-			// be empty) and the second one is used iff joint is true.
+			// be empty) and the second one is used if joint is true.
 			var joint bool
 			var ids, idsj []uint64
 			// The committed indexes for the nodes in the config in the order in

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1708,7 +1708,7 @@ func (r *raft) loadState(state pb.HardState) {
 	r.Vote = state.Vote
 }
 
-// pastElectionTimeout returns true iff r.electionElapsed is greater
+// pastElectionTimeout returns true if r.electionElapsed is greater
 // than or equal to the randomized election timeout in
 // [electiontimeout, 2 * electiontimeout - 1].
 func (r *raft) pastElectionTimeout() bool {

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -254,7 +254,7 @@ func (b *backend) ConcurrentReadTx() ReadTx {
 
 	// TODO: might want to copy the read buffer lazily - create copy when A) end of a write transaction B) end of a batch interval.
 
-	// inspect/update cache recency iff there's no ongoing update to the cache
+	// inspect/update cache recency if there's no ongoing update to the cache
 	// this falls through if there's no cache update
 
 	// by this line, "ConcurrentReadTx" code path is already protected against concurrent "writeback" operations

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1016,7 +1016,7 @@ func (m *Member) Launch() error {
 			//
 			// Previously,
 			// 1. Server has non-empty (*tls.Config).Certificates on client hello
-			// 2. Server calls (*tls.Config).GetCertificate iff:
+			// 2. Server calls (*tls.Config).GetCertificate if:
 			//    - Server'Server (*tls.Config).Certificates is not empty, or
 			//    - Client supplies SNI; non-empty (*tls.ClientHelloInfo).ServerName
 			//


### PR DESCRIPTION
Fixed typo "iff" to "if" in comments.

Searched for all occurences in the project by `grep -rw`.