### PR TITLE
wal: remove the repeated test case

### DIFF
--- a/server/storage/wal/file_pipeline.go
+++ b/server/storage/wal/file_pipeline.go
@@ -58,6 +58,7 @@ func newFilePipeline(lg *zap.Logger, dir string, fileSize int64) *filePipeline {
 
 // Open returns a fresh file for writing. Rename the file before calling
 // Open again or there will be file collisions.
+// it will 'block' if the tmp file lock is already taken.
 func (fp *filePipeline) Open() (f *fileutil.LockedFile, err error) {
 	select {
 	case f = <-fp.filec:

--- a/server/storage/wal/file_pipeline_test.go
+++ b/server/storage/wal/file_pipeline_test.go
@@ -45,15 +45,3 @@ func TestFilePipelineFailPreallocate(t *testing.T) {
 		t.Fatal("expected error on invalid pre-allocate size, but no error")
 	}
 }
-
-func TestFilePipelineFailLockFile(t *testing.T) {
-	tdir := t.TempDir()
-
-	fp := newFilePipeline(zaptest.NewLogger(t), tdir, math.MaxInt64)
-	defer fp.Close()
-
-	f, ferr := fp.Open()
-	if f != nil || ferr == nil { // no such file or directory
-		t.Fatal("expected error on invalid pre-allocate size, but no error")
-	}
-}


### PR DESCRIPTION
The TestFilePipelineFailLockFile case maybe test the line 77 in the alloc function. But the LockFile will not throw an error when the file lock is hold. And TestFilePipelineFailPreallocate and TestFilePipelineFailLockFile are exactly the same except for the comments.
