### PR TITLE
replace ioutil with os package

### DIFF
--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -44,7 +43,7 @@ func BeforeTest(t testing.TB) {
 func BeforeIntegrationExamples(*testing.M) func() {
 	ExitInShortMode("Skipping: the tests require real cluster")
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "etcd-integration")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "etcd-integration")
 	if err != nil {
 		log.Printf("Failed to obtain tempDir: %v", tempDir)
 		os.Exit(1)

--- a/server/storage/wal/testing/waltesting.go
+++ b/server/storage/wal/testing/waltesting.go
@@ -15,7 +15,7 @@
 package testing
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +29,7 @@ import (
 
 func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
 	t.Helper()
-	dir, err := ioutil.TempDir(t.TempDir(), "etcd_wal_test")
+	dir, err := os.MkdirTemp(t.TempDir(), "etcd_wal_test")
 	if err != nil {
 		panic(err)
 	}

--- a/tests/integration/clientv3/examples/main_test.go
+++ b/tests/integration/clientv3/examples/main_test.go
@@ -15,7 +15,6 @@
 package clientv3_test
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -47,7 +46,7 @@ func forUnitTestsRunInMockedContext(_ func(), example func()) {
 func TestMain(m *testing.M) {
 	testutil.ExitInShortMode("Skipping: the tests require real cluster")
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "etcd-integration")
+	tempDir, err := os.MkdirTemp(os.TempDir(), "etcd-integration")
 	if err != nil {
 		log.Printf("Failed to obtain tempDir: %v", tempDir)
 		os.Exit(1)


### PR DESCRIPTION
The ioutil has already been deprecated in Golang 1.16. FYI. [go1.16#ioutil](https://go.dev/doc/go1.16#ioutil)
