### PR TITLE
update changelog for both 3.5 and 3.6 to cover the authBundle overwrite issue

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.5 (TBD)
 
+### Package `clientv3`
+- Fix [do not overwrite authTokenBundle on dial](https://github.com/etcd-io/etcd/pull/14132).
+
 ### etcd server
 - Fix [lease leak issue due to tokenProvider isn't enabled when restoring auth store from a snapshot](https://github.com/etcd-io/etcd/pull/13205).
 - Fix [the race condition between goroutine and channel on the same leases to be revoked](https://github.com/etcd-io/etcd/pull/14087).

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -35,6 +35,9 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add command to generate [shell completion](https://github.com/etcd-io/etcd/pull/13142).
 - Add `migrate` command for downgrading/upgrading etcd data dir files.
 
+### Package `clientv3`
+- Fix [do not overwrite authTokenBundle on dial](https://github.com/etcd-io/etcd/pull/12992).
+
 ### Package `server`
 
 - Package `mvcc` was moved to `storage/mvcc`


### PR DESCRIPTION
The related PRs: [14132](https://github.com/etcd-io/etcd/pull/14132) for 3.5, and [12992](https://github.com/etcd-io/etcd/pull/12992) for 3.6.

Signed-off-by: Benjamin Wang <wachao@vmware.com>
