### PR TITLE
Register codec using encoding.RegisterCodec

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -111,6 +111,9 @@ func (sctx *serveCtx) serve(
 	servElection := v3election.NewElectionServer(v3c)
 	servLock := v3lock.NewLockServer(v3c)
 
+	// register the codec
+	v3rpc.RegisterCodec(s.Cfg.Name)
+
 	var gs *grpc.Server
 	defer func() {
 		if err != nil && gs != nil {

--- a/server/etcdserver/api/v3rpc/codec.go
+++ b/server/etcdserver/api/v3rpc/codec.go
@@ -14,9 +14,25 @@
 
 package v3rpc
 
-import "github.com/golang/protobuf/proto"
+import (
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/encoding"
+)
 
-type codec struct{}
+// RegisterCodec encapsulates the `encoding.RegisterCodec`.
+//
+// `grpc.CustomCodec` has already been deprecated in gRPC 1.47. Users are
+//  supposed to use `encoding.RegisterCodec` to register customized codec.
+func RegisterCodec(name string) {
+	encoding.RegisterCodec(&codec{name})
+}
+
+// codec needs to implement interface `Codec` when registering codec using
+// `encoding.RegisterCodec`, please refer to
+// https://github.com/grpc/grpc-go/blob/v1.47.0/encoding/encoding.go#L86.
+type codec struct {
+	name string
+}
 
 func (c *codec) Marshal(v interface{}) ([]byte, error) {
 	b, err := proto.Marshal(v.(proto.Message))
@@ -29,6 +45,10 @@ func (c *codec) Unmarshal(data []byte, v interface{}) error {
 	return proto.Unmarshal(data, v.(proto.Message))
 }
 
+func (c *codec) Name() string {
+	return c.name
+}
+
 func (c *codec) String() string {
-	return "proto"
+	return c.name
 }

--- a/server/etcdserver/api/v3rpc/grpc.go
+++ b/server/etcdserver/api/v3rpc/grpc.go
@@ -38,7 +38,6 @@ const (
 
 func Server(s *etcdserver.EtcdServer, tls *tls.Config, interceptor grpc.UnaryServerInterceptor, gopts ...grpc.ServerOption) *grpc.Server {
 	var opts []grpc.ServerOption
-	opts = append(opts, grpc.CustomCodec(&codec{}))
 	if tls != nil {
 		bundle := credentials.NewBundle(credentials.Config{TLSConfig: tls})
 		opts = append(opts, grpc.Creds(bundle.TransportCredentials()))

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -616,6 +616,8 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 		UniqNumber:   int(atomic.AddInt32(&LocalListenCount, 1)),
 	}
 
+	v3rpc.RegisterCodec(mcfg.Name)
+
 	peerScheme := SchemeFromTLSInfo(mcfg.PeerTLS)
 	clientScheme := SchemeFromTLSInfo(mcfg.ClientTLS)
 
@@ -720,6 +722,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 	m.GrpcServerRecorder = &grpc_testing.GrpcRecorder{}
 	m.Logger = memberLogger(t, mcfg.Name)
 	m.StrictReconfigCheck = mcfg.StrictReconfigCheck
+
 	if err := m.listenGRPC(); err != nil {
 		t.Fatalf("listenGRPC FAILED: %v", err)
 	}


### PR DESCRIPTION
The function `grpc.CustomCodec` has already been deprecated in grpc 1.47. Instead, users are supposed to use encoding.RegisterCodec to register customized codec. Please refer to [server.go#L271-L276](https://github.com/grpc/grpc-go/blob/v1.47.0/server.go#L271-L276)


Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
