### PR TITLE
config: Add the default case when failing to parse the log rotate config json

### DIFF
--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -272,6 +272,8 @@ func setupLogRotation(logOutputs []string, logRotateConfigJSON string) error {
 			return fmt.Errorf("improperly formatted log rotation config: %v", err)
 		case errors.As(err, &unmarshalTypeError):
 			return fmt.Errorf("invalid log rotation config: %v", err)
+		default:
+			return fmt.Errorf("fail to unmarshal log rotation config: %v", err)
 		}
 	}
 	zap.RegisterSink("rotate", func(u *url.URL) (zap.Sink, error) {


### PR DESCRIPTION
Make sure that the `setupLogRotation` function must return the error when failing parse json.

Signed-off-by: SimFG <1142838399@qq.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
