### PR TITLE
[3.4] Skip WatchRequestProgress test in grpc-proxy mode.

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -607,6 +607,9 @@ func TestConfigurableWatchProgressNotifyInterval(t *testing.T) {
 }
 
 func TestWatchRequestProgress(t *testing.T) {
+	if integration.ThroughProxy {
+		t.Skip("grpc-proxy does not support WatchProgress yet")
+	}
 	testCases := []struct {
 		name     string
 		watchers []string

--- a/integration/cluster_direct.go
+++ b/integration/cluster_direct.go
@@ -23,7 +23,7 @@ import (
 	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 )
 
-const throughProxy = false
+const ThroughProxy = false
 
 func toGRPC(c *clientv3.Client) grpcAPI {
 	return grpcAPI{

--- a/integration/cluster_proxy.go
+++ b/integration/cluster_proxy.go
@@ -26,7 +26,7 @@ import (
 	"go.etcd.io/etcd/proxy/grpcproxy/adapter"
 )
 
-const throughProxy = true
+const ThroughProxy = true
 
 var (
 	pmu     sync.Mutex

--- a/integration/v3_watch_test.go
+++ b/integration/v3_watch_test.go
@@ -1242,7 +1242,7 @@ func TestV3WatchCancellation(t *testing.T) {
 	}
 
 	var expected string
-	if throughProxy {
+	if ThroughProxy {
 		// grpc proxy has additional 2 watches open
 		expected = "3"
 	} else {

--- a/proxy/grpcproxy/watch.go
+++ b/proxy/grpcproxy/watch.go
@@ -262,7 +262,8 @@ func (wps *watchProxyStream) recvLoop() error {
 		case *pb.WatchRequest_CancelRequest:
 			wps.delete(uv.CancelRequest.WatchId)
 		default:
-			panic("not implemented")
+			// Panic or Fatalf would allow network clients to crash the serve remotely.
+			//panic("not implemented")
 		}
 	}
 }


### PR DESCRIPTION
Cherry pick commit [5f9a1394db444bc8cebbcbc19b3bc3221894c87c](https://github.com/etcd-io/etcd/commit/5f9a1394db444bc8cebbcbc19b3bc3221894c87c) to 3.4. 

Part of effort in [14105](https://github.com/etcd-io/etcd/issues/14105) 

We shouldn't fail the grpc-server (completely) by a not implemented RPC to fail whole server by remote request is anti-pattern and security risk.

Refer to https://github.com/etcd-io/etcd/runs/7034342964?check_suite_focus=true#step:5:2284

```
=== RUN   TestWatchRequestProgress/1-watcher
panic: not implemented
goroutine 83024 [running]:
go.etcd.io/etcd/proxy/grpcproxy.(*watchProxyStream).recvLoop(0xc009232f00, 0x4a73e1, 0xc00e2406e0)
	/home/runner/work/etcd/etcd/proxy/grpcproxy/watch.go:265 +0xbf2
go.etcd.io/etcd/proxy/grpcproxy.(*watchProxy).Watch.func1(0xc0038a3bc0, 0xc009232f00)
	/home/runner/work/etcd/etcd/proxy/grpcproxy/watch.go:125 +0x70
created by go.etcd.io/etcd/proxy/grpcproxy.(*watchProxy).Watch
	/home/runner/work/etcd/etcd/proxy/grpcproxy/watch.go:123 +0x73b
FAIL	go.etcd.io/etcd/clientv3/integration	222.813s
FAIL
```

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
