### PR TITLE
sync-changelog: /health break change was reverted

### DIFF
--- a/CHANGELOG/CHANGELOG-4.0.md
+++ b/CHANGELOG/CHANGELOG-4.0.md
@@ -18,10 +18,6 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v4.0.0) and 
 ### Breaking Changes
 
 - [Secure etcd by default](https://github.com/etcd-io/etcd/issues/9475)?
-- Change `/health` endpoint output.
-  - Previously, `{"health":"true"}`.
-  - Now, `{"health":true}`.
-  - Breaks [Kubernetes `kubectl get componentstatuses` command](https://github.com/kubernetes/kubernetes/issues/58240).
 - Deprecate [`etcd --proxy*`](TODO) flags; **no more v2 proxy**.
 - Deprecate [v2 storage backend](https://github.com/etcd-io/etcd/issues/9232); **no more v2 store**.
   - v2 API is still supported via [v2 emulation](TODO).


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

The changelog update was included in https://github.com/etcd-io/etcd/commit/7563bec19f6a36d70697a22682d75edf6711ee4d.

But https://github.com/etcd-io/etcd/pull/9143 revert the change for backward compatibility.