### PR TITLE
removes empty option in JSON tag

### DIFF
--- a/server/etcdserver/api/v2stats/server.go
+++ b/server/etcdserver/api/v2stats/server.go
@@ -59,7 +59,7 @@ type serverStats struct {
 		StartTime time.Time `json:"startTime"`
 	} `json:"leaderInfo"`
 
-	RecvAppendRequestCnt uint64  `json:"recvAppendRequestCnt,"`
+	RecvAppendRequestCnt uint64  `json:"recvAppendRequestCnt"`
 	RecvingPkgRate       float64 `json:"recvPkgRate,omitempty"`
 	RecvingBandwidthRate float64 `json:"recvBandwidthRate,omitempty"`
 


### PR DESCRIPTION
option can not be empty in JSON tag


Found with [`revive`](https://github.com/mgechev/revive) (rule `struct-tag`)
