### PR TITLE
pkg/expect: send SIGTERM to target expect process instead of SIGKILL for `Stop()`

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -42,7 +42,7 @@ type ExpectProcess struct {
 	count int // increment whenever new line gets added
 	err   error
 
-	// StopSignal is the signal Stop sends to the process; defaults to SIGKILL.
+	// StopSignal is the signal Stop sends to the process; defaults to SIGTERM.
 	StopSignal os.Signal
 }
 
@@ -58,7 +58,7 @@ func NewExpectWithEnv(name string, args []string, env []string) (ep *ExpectProce
 	cmd.Env = env
 	ep = &ExpectProcess{
 		cmd:        cmd,
-		StopSignal: syscall.SIGKILL,
+		StopSignal: syscall.SIGTERM,
 	}
 	ep.cmd.Stderr = ep.cmd.Stdout
 	ep.cmd.Stdin = nil


### PR DESCRIPTION
The `SIGKILL` signal is extremely rude to a process, it can not be caught by target process.
Kill a process by `SIGTERM` is more elegent, because we can give the target process a chance to do clean ups, if the target process has a signal handler for `SIGTERM`.


https://linuxhandbook.com/sigterm-vs-sigkill/
https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html