### PR TITLE
raft: Remove the redundant `append` execution

### DIFF
--- a/raft/log_unstable.go
+++ b/raft/log_unstable.go
@@ -135,8 +135,7 @@ func (u *unstable) truncateAndAppend(ents []pb.Entry) {
 		// truncate to after and copy to u.entries
 		// then append
 		u.logger.Infof("truncate the unstable entries before index %d", after)
-		u.entries = append([]pb.Entry{}, u.slice(u.offset, after)...)
-		u.entries = append(u.entries, ents...)
+		u.entries = append(u.slice(u.offset, after), ents...)
 	}
 }
 


### PR DESCRIPTION
Avoid extra `slice` creation of the `Entry`

Signed-off-by: SimFG <1142838399@qq.com>
