### PR TITLE
ectdctl: Add the `SilenceErrors` config For the `cobra.Command`

### DIFF
--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -16,6 +16,7 @@
 package ctlv3
 
 import (
+	"os"
 	"time"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -114,7 +115,11 @@ func Start() error {
 
 func MustStart() {
 	if err := Start(); err != nil {
-		cobrautl.ExitWithError(cobrautl.ExitError, err)
+		if rootCmd.SilenceErrors {
+			cobrautl.ExitWithError(cobrautl.ExitError, err)
+		} else {
+			os.Exit(cobrautl.ExitError)
+		}
 	}
 }
 


### PR DESCRIPTION
Avoid repeated printing of error messages.

Signed-off-by: SimFG <1142838399@qq.com>

before
![image](https://user-images.githubusercontent.com/21985684/176190041-cffb89fb-3ba2-40d9-9267-23d258186806.png)
after
![image](https://user-images.githubusercontent.com/21985684/176190091-1db87462-fcbe-49ba-8396-b9bb2067b150.png)
related source code
```
// SilenceErrors is an option to quiet errors down stream.
SilenceErrors bool
```
link: https://github.com/spf13/cobra/blob/bba9331d4e5e5ebe2d0fdf0d9432b4b1e67d5061/command.go#L972-L975
![image](https://user-images.githubusercontent.com/21985684/176190326-6d49daa0-7cc0-46a6-8a13-1d265ad5a41d.png)

