### PR TITLE
Client: fix check for WithPrefix op

### DIFF
--- a/client/v3/op.go
+++ b/client/v3/op.go
@@ -389,12 +389,12 @@ func getPrefix(key []byte) []byte {
 // can return 'foo1', 'foo2', and so on.
 func WithPrefix() OpOption {
 	return func(op *Op) {
+		op.isOptsWithPrefix = true
 		if len(op.key) == 0 {
 			op.key, op.end = []byte{0}, []byte{0}
 			return
 		}
 		op.end = getPrefix(op.key)
-		op.isOptsWithPrefix = true
 	}
 }
 

--- a/client/v3/op_test.go
+++ b/client/v3/op_test.go
@@ -75,3 +75,27 @@ func TestIsSortOptionValid(t *testing.T) {
 		}
 	}
 }
+
+func TestIsOptsWithPrefix(t *testing.T) {
+	optswithprefix := []OpOption{WithPrefix()}
+	if !IsOptsWithPrefix(optswithprefix) {
+		t.Errorf("IsOptsWithPrefix = false, expected true")
+	}
+
+	optswithfromkey := []OpOption{WithFromKey()}
+	if IsOptsWithPrefix(optswithfromkey) {
+		t.Errorf("IsOptsWithPrefix = true, expected false")
+	}
+}
+
+func TestIsOptsWithFromKey(t *testing.T) {
+	optswithfromkey := []OpOption{WithFromKey()}
+	if !IsOptsWithFromKey(optswithfromkey) {
+		t.Errorf("IsOptsWithFromKey = false, expected true")
+	}
+
+	optswithprefix := []OpOption{WithPrefix()}
+	if IsOptsWithFromKey(optswithprefix) {
+		t.Errorf("IsOptsWithFromKey = true, expected false")
+	}
+}


### PR DESCRIPTION
Make sure that WithPrefix correctly set the flag, and add test.
Also, add test for WithFromKey.

fixes #14056

