### PR TITLE
Remove duplicate certificate configuration for proxy test

### DIFF
--- a/tests/framework/e2e/cluster_proxy.go
+++ b/tests/framework/e2e/cluster_proxy.go
@@ -238,7 +238,8 @@ func newProxyV3Proc(cfg *EtcdServerProcessConfig) *proxyV3Proc {
 		default:
 			tlsArgs = append(tlsArgs, cfg.TlsArgs[i])
 		}
-
+	}
+	if len(cfg.TlsArgs) > 0 {
 		// Configure certificates for connection proxy ---> server.
 		// This certificate must NOT have CN set.
 		tlsArgs = append(tlsArgs,
@@ -247,6 +248,7 @@ func newProxyV3Proc(cfg *EtcdServerProcessConfig) *proxyV3Proc {
 			"--cacert", path.Join(FixturesDir, "ca.crt"),
 			"--client-crl-file", path.Join(FixturesDir, "revoke.crl"))
 	}
+
 	return &proxyV3Proc{
 		proxyProc{
 			lg:       cfg.lg,


### PR DESCRIPTION
The issue was introduced in the following commit,
[093282f5eab8b5ba5613b48594aed8794a757c8a](https://github.com/etcd-io/etcd/commit/093282f5eab8b5ba5613b48594aed8794a757c8a)

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Previously the following code was inside the loop, so the same arguments will be appended multiple times. It isn't correct, so I moved it out of the loop. 

```
		// Configure certificates for connection proxy ---> server.
		// This certificate must NOT have CN set.
		tlsArgs = append(tlsArgs,
			"--cert", path.Join(fixturesDir, "client-nocn.crt"),
			"--key", path.Join(fixturesDir, "client-nocn.key.insecure"),
			"--cacert", path.Join(fixturesDir, "ca.crt"),
			"--client-crl-file", path.Join(fixturesDir, "revoke.crl"))
```


cc @ptabor @spzala @serathius 