### PR TITLE
lease: Rename `Poll` to `Peek` in the `LeaseExpiredNotifier`

### DIFF
--- a/server/lease/lease_queue.go
+++ b/server/lease/lease_queue.go
@@ -96,7 +96,7 @@ func (mq *LeaseExpiredNotifier) Unregister() *LeaseWithTime {
 	return item
 }
 
-func (mq *LeaseExpiredNotifier) Poll() *LeaseWithTime {
+func (mq *LeaseExpiredNotifier) Peek() *LeaseWithTime {
 	if mq.Len() == 0 {
 		return nil
 	}

--- a/server/lease/lease_queue_test.go
+++ b/server/lease/lease_queue_test.go
@@ -40,8 +40,8 @@ func TestLeaseQueue(t *testing.T) {
 	}
 
 	// first element is expired.
-	if le.leaseExpiredNotifier.Poll().id != LeaseID(1) {
-		t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseExpiredNotifier.Poll().id)
+	if le.leaseExpiredNotifier.Peek().id != LeaseID(1) {
+		t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseExpiredNotifier.Peek().id)
 	}
 
 	existExpiredEvent := func() {
@@ -60,8 +60,8 @@ func TestLeaseQueue(t *testing.T) {
 			t.Fatalf("expected the expired lease to be pushed back to the heap, heap size got %d", le.leaseExpiredNotifier.Len())
 		}
 
-		if le.leaseExpiredNotifier.Poll().id != LeaseID(1) {
-			t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseExpiredNotifier.Poll().id)
+		if le.leaseExpiredNotifier.Peek().id != LeaseID(1) {
+			t.Fatalf("first item expected lease ID %d, got %d", LeaseID(1), le.leaseExpiredNotifier.Peek().id)
 		}
 	}
 

--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -683,7 +683,7 @@ func (le *lessor) expireExists() (l *Lease, ok bool, next bool) {
 		return nil, false, false
 	}
 
-	item := le.leaseExpiredNotifier.Poll()
+	item := le.leaseExpiredNotifier.Peek()
 	l = le.leaseMap[item.id]
 	if l == nil {
 		// lease has expired or been revoked


### PR DESCRIPTION
`Poll` means that the elements in the heap will be removed.
And it is more appropriate to use `Peek` to get the top of the heap.

Signed-off-by: SimFG <1142838399@qq.com>