### PR TITLE
clientv3: Fix parsing of ETCD_CLIENT_DEBUG

### DIFF
--- a/client/v3/logger.go
+++ b/client/v3/logger.go
@@ -52,7 +52,7 @@ func etcdClientDebugLevel() zapcore.Level {
 	}
 	var l zapcore.Level
 	if err := l.Set(envLevel); err != nil {
-		log.Printf("Deprecated env ETCD_CLIENT_DEBUG value. Using default level: 'info'")
+		log.Printf("Invalid value for environment variable 'ETCD_CLIENT_DEBUG'. Using default level: 'info'")
 		return zapcore.InfoLevel
 	}
 	return l

--- a/client/v3/logger.go
+++ b/client/v3/logger.go
@@ -51,7 +51,7 @@ func etcdClientDebugLevel() zapcore.Level {
 		return zapcore.InfoLevel
 	}
 	var l zapcore.Level
-	if err := l.Set(envLevel); err == nil {
+	if err := l.Set(envLevel); err != nil {
 		log.Printf("Deprecated env ETCD_CLIENT_DEBUG value. Using default level: 'info'")
 		return zapcore.InfoLevel
 	}


### PR DESCRIPTION
It checked `err == nil` rather than `err != nil`.

@ptabor

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.