### PR TITLE
Update goreman installation command in local_cluster.md

### DIFF
--- a/Documentation/contributor-guide/local_cluster.md
+++ b/Documentation/contributor-guide/local_cluster.md
@@ -48,8 +48,9 @@ A `Procfile` at the base of the etcd git repository is provided to easily config
 1. Install `goreman` to control Procfile-based applications:
 
     ```
-    $ go get github.com/mattn/goreman
+    $ go install github.com/mattn/goreman@latest
     ```
+   The installation will place executables in the $GOPATH/bin. If $GOPATH environment variable is not set, the tool will be installed into the $HOME/go/bin. Make sure that $PATH is set accordingly in your environment.
 
 2. Start a cluster with `goreman` using etcd's stock Procfile:
 


### PR DESCRIPTION
`go install` is the recommended way to build and install packages in
module mode. `go get` should be used with the -d flag to adjust the
current module's dependencies without building packages, and use of
`go get` to build and install packages is deprecated. In a future
release, the -d flag will always be enabled.

Refer to https://go.dev/doc/go1.16.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
