### PR TITLE
Print clusterID, memberID and leaseID in hexdecimal

### DIFF
--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -79,7 +79,7 @@ func NewPrinter(printerType string, isHex bool) printer {
 	case "simple":
 		return &simplePrinter{isHex: isHex}
 	case "fields":
-		return &fieldsPrinter{newPrinterUnsupported("fields")}
+		return &fieldsPrinter{printer: newPrinterUnsupported("fields"), isHex: isHex}
 	case "json":
 		return newJSONPrinter(isHex)
 	case "protobuf":

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -19,10 +19,14 @@ import (
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	spb "go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/client/pkg/v3/types"
 	v3 "go.etcd.io/etcd/client/v3"
 )
 
-type fieldsPrinter struct{ printer }
+type fieldsPrinter struct {
+	printer
+	isHex bool
+}
 
 func (p *fieldsPrinter) kv(pfx string, kv *spb.KeyValue) {
 	fmt.Printf("\"%sKey\" : %q\n", pfx, string(kv.Key))
@@ -30,12 +34,21 @@ func (p *fieldsPrinter) kv(pfx string, kv *spb.KeyValue) {
 	fmt.Printf("\"%sModRevision\" : %d\n", pfx, kv.ModRevision)
 	fmt.Printf("\"%sVersion\" : %d\n", pfx, kv.Version)
 	fmt.Printf("\"%sValue\" : %q\n", pfx, string(kv.Value))
-	fmt.Printf("\"%sLease\" : %d\n", pfx, kv.Lease)
+	if p.isHex {
+		fmt.Printf("\"%sLease\" : %016x\n", pfx, kv.Lease)
+	} else {
+		fmt.Printf("\"%sLease\" : %d\n", pfx, kv.Lease)
+	}
 }
 
 func (p *fieldsPrinter) hdr(h *pb.ResponseHeader) {
-	fmt.Println(`"ClusterID" :`, h.ClusterId)
-	fmt.Println(`"MemberID" :`, h.MemberId)
+	if p.isHex {
+		fmt.Println(`"ClusterID" :`, types.ID(h.ClusterId))
+		fmt.Println(`"MemberID" :`, types.ID(h.MemberId))
+	} else {
+		fmt.Println(`"ClusterID" :`, h.ClusterId)
+		fmt.Println(`"MemberID" :`, h.MemberId)
+	}
 	// Revision only makes sense for k/v responses. For other kinds of
 	// responses, i.e. MemberList, usually the revision isn't populated
 	// at all; so it would be better to hide this field in these cases.
@@ -99,7 +112,11 @@ func (p *fieldsPrinter) Watch(resp v3.WatchResponse) {
 
 func (p *fieldsPrinter) Grant(r v3.LeaseGrantResponse) {
 	p.hdr(r.ResponseHeader)
-	fmt.Println(`"ID" :`, r.ID)
+	if p.isHex {
+		fmt.Printf("\"ID\" : %016x\n", r.ID)
+	} else {
+		fmt.Println(`"ID" :`, r.ID)
+	}
 	fmt.Println(`"TTL" :`, r.TTL)
 }
 
@@ -109,13 +126,21 @@ func (p *fieldsPrinter) Revoke(id v3.LeaseID, r v3.LeaseRevokeResponse) {
 
 func (p *fieldsPrinter) KeepAlive(r v3.LeaseKeepAliveResponse) {
 	p.hdr(r.ResponseHeader)
-	fmt.Println(`"ID" :`, r.ID)
+	if p.isHex {
+		fmt.Printf("\"ID\" : %016x\n", r.ID)
+	} else {
+		fmt.Println(`"ID" :`, r.ID)
+	}
 	fmt.Println(`"TTL" :`, r.TTL)
 }
 
 func (p *fieldsPrinter) TimeToLive(r v3.LeaseTimeToLiveResponse, keys bool) {
 	p.hdr(r.ResponseHeader)
-	fmt.Println(`"ID" :`, r.ID)
+	if p.isHex {
+		fmt.Printf("\"ID\" : %016x\n", r.ID)
+	} else {
+		fmt.Println(`"ID" :`, r.ID)
+	}
 	fmt.Println(`"TTL" :`, r.TTL)
 	fmt.Println(`"GrantedTTL" :`, r.GrantedTTL)
 	for _, k := range r.Keys {
@@ -126,14 +151,22 @@ func (p *fieldsPrinter) TimeToLive(r v3.LeaseTimeToLiveResponse, keys bool) {
 func (p *fieldsPrinter) Leases(r v3.LeaseLeasesResponse) {
 	p.hdr(r.ResponseHeader)
 	for _, item := range r.Leases {
-		fmt.Println(`"ID" :`, item.ID)
+		if p.isHex {
+			fmt.Printf("\"ID\" : %016x\n", item.ID)
+		} else {
+			fmt.Println(`"ID" :`, item.ID)
+		}
 	}
 }
 
 func (p *fieldsPrinter) MemberList(r v3.MemberListResponse) {
 	p.hdr(r.Header)
 	for _, m := range r.Members {
-		fmt.Println(`"ID" :`, m.ID)
+		if p.isHex {
+			fmt.Println(`"ID" :`, types.ID(m.ID))
+		} else {
+			fmt.Println(`"ID" :`, m.ID)
+		}
 		fmt.Printf("\"Name\" : %q\n", m.Name)
 		for _, u := range m.PeerURLs {
 			fmt.Printf("\"PeerURL\" : %q\n", u)
@@ -186,7 +219,11 @@ func (p *fieldsPrinter) EndpointHashKV(hs []epHashKV) {
 func (p *fieldsPrinter) Alarm(r v3.AlarmResponse) {
 	p.hdr(r.Header)
 	for _, a := range r.Alarms {
-		fmt.Println(`"MemberID" :`, a.MemberID)
+		if p.isHex {
+			fmt.Println(`"MemberID" :`, types.ID(a.MemberID))
+		} else {
+			fmt.Println(`"MemberID" :`, a.MemberID)
+		}
 		fmt.Println(`"AlarmType" :`, a.Alarm)
 		fmt.Println()
 	}


### PR DESCRIPTION
ClusterID, memberID and leaseID are just identities, so it doesn't make sense to print them in decimal. Instead, we should always print them in hexadecimal. 

Please note the existing behavior isn't consistent. Sometimes etcdctl prints them in hexdecimal (such as `etcdctl endpoint status -w table`), but sometimes in decimal (such as `etctctl endpoint status -w fields`). 

## Previous output
```
wachao-a01:bin wachao$ ./etcdctl  member list -w fields
"ClusterID" : 14841639068965178418
"MemberID" : 10276657743932975437
"RaftTerm" : 5
"ID" : 10276657743932975437
"Name" : "default"
"PeerURL" : "http://localhost:2380"
"ClientURL" : "http://localhost:2379"
"IsLearner" : false

wachao-a01:bin wachao$ ./etcdctl endpoint status -w fields
"ClusterID" : 14841639068965178418
"MemberID" : 10276657743932975437
"Revision" : 3
"RaftTerm" : 5
"Version" : "3.6.0-alpha.0"
"StorageVersion" : "3.6.0"
"DBSize" : 24576
"DBSizeInUse" : 24576
"Leader" : 10276657743932975437
"IsLearner" : false
"RaftIndex" : 23
"RaftTerm" : 5
"RaftAppliedIndex" : 23
"Errors" : []
"Endpoint" : "127.0.0.1:2379"

wachao-a01:bin wachao$ ./etcdctl  lease list -w fields
"ClusterID" : 14841639068965178418
"MemberID" : 10276657743932975437
"Revision" : 3
"RaftTerm" : 8
"ID" : 7587863798256828424
"ID" : 7587863798360740612
"ID" : 7587863798360740614
"ID" : 7587863798256828422
```

## New output
```
wachao-a01:bin wachao$ ./etcdctl member list -w fields
"ClusterID" : cdf818194e3a8c32
"MemberID" : 8e9e05c52164694d
"RaftTerm" : 7
"ID" : 8e9e05c52164694d
"Name" : "default"
"PeerURL" : "http://localhost:2380"
"ClientURL" : "http://localhost:2379"
"IsLearner" : false

wachao-a01:bin wachao$ ./etcdctl endpoint status -w fields
"ClusterID" : cdf818194e3a8c32
"MemberID" : 8e9e05c52164694d
"Revision" : 3
"RaftTerm" : 7
"Version" : "3.6.0-alpha.0"
"StorageVersion" : "3.6.0"
"DBSize" : 24576
"DBSizeInUse" : 24576
"Leader" : 10276657743932975437
"IsLearner" : false
"RaftIndex" : 27
"RaftTerm" : 7
"RaftAppliedIndex" : 27
"Errors" : []
"Endpoint" : "127.0.0.1:2379"

wachao-a01:bin wachao$ ./etcdctl  lease list -w fields
"ClusterID" : cdf818194e3a8c32
"MemberID" : 8e9e05c52164694d
"Revision" : 3
"RaftTerm" : 7
"ID" : 694d81ec1b250008
"ID" : 694d81ec1b250006
```



Signed-off-by: Benjamin Wang <wachao@vmware.com>

