### PR TITLE
benchmark: Fix the panic when running `benchmark watch`

### DIFF
--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/report"
 
 	"github.com/cheggaaa/pb/v3"
@@ -209,7 +209,12 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 		}
 	}()
 
-	limit := rate.NewLimiter(rate.Limit(watchPutRate), 1)
+	watchPutLimit := rate.Inf
+	if watchPutRate > 0 {
+		watchPutLimit = rate.Limit(watchPutRate)
+	}
+
+	limit := rate.NewLimiter(watchPutLimit, 1)
 	for _, cc := range clients {
 		go func(c *clientv3.Client) {
 			for op := range putreqc {


### PR DESCRIPTION
When executing the `go run main.go watch` in the `tools/benchmark` dir, error:
![image](https://user-images.githubusercontent.com/21985684/178401462-44cc823a-3031-4c65-96fb-f4424d37cc41.png)
The default value of `watchPutRate` is `0`, we get a `Limiter` and the `limit` property of the `Limiter` object is 0 and the `burst` property is 1.
`limit := rate.NewLimiter(rate.Limit(watchPutRate), 1)` 
Each time running the code `limit.Wait(context.TODO())`, the value of the burst property will be decremented by one. Therefore, when the second `wait` is executed, the value of burst will become 0, which is less than the limit, and an error will be reported at this time.
```
limit := rate.NewLimiter(rate.Limit(watchPutRate), watchPutTotal)
	for _, cc := range clients {
		go func(c *clientv3.Client) {
			for op := range putreqc {
				if err := limit.Wait(context.TODO()); err != nil {
					panic(err)
				}
				if _, err := c.Do(context.TODO(), op); err != nil {
					panic(err)
				}
			}
		}(cc)
	}
```
```
func (lim *Limiter) Wait(ctx context.Context) (err error) {
	return lim.WaitN(ctx, 1)
}

func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
	// The test code calls lim.wait with a fake timer generator.
	// This is the real timer generator.
	newTimer := func(d time.Duration) (<-chan time.Time, func() bool, func()) {
		timer := time.NewTimer(d)
		return timer.C, timer.Stop, func() {}
	}

	return lim.wait(ctx, n, time.Now(), newTimer)
}

func (lim *Limiter) wait(ctx context.Context, n int, now time.Time, newTimer func(d time.Duration) (<-chan time.Time, func() bool, func())) error {
	// ...

	if n > burst && limit != Inf {
		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, burst)
	}
	// ...
	// Reserve
	r := lim.reserveN(now, n, waitLimit)
	// ...
}

func (lim *Limiter) reserveN(now time.Time, n int, maxFutureReserve time.Duration) Reservation {
	lim.mu.Lock()
	defer lim.mu.Unlock()

	if lim.limit == Inf {
		// ...
	} else if lim.limit == 0 {
		var ok bool
		if lim.burst >= n {
			ok = true
			lim.burst -= n
		}
		return Reservation{
			ok:        ok,
			lim:       lim,
			tokens:    lim.burst,
			timeToAct: now,
		}
	}
        // ...

	return r
}
```


Signed-off-by: SimFG <1142838399@qq.com>
