### PR TITLE
[3.5] clientv3: Fix parsing of ETCD_CLIENT_DEBUG

### DIFF
--- a/client/v3/logger.go
+++ b/client/v3/logger.go
@@ -51,8 +51,8 @@ func etcdClientDebugLevel() zapcore.Level {
 		return zapcore.InfoLevel
 	}
 	var l zapcore.Level
-	if err := l.Set(envLevel); err == nil {
-		log.Printf("Deprecated env ETCD_CLIENT_DEBUG value. Using default level: 'info'")
+	if err := l.Set(envLevel); err != nil {
+		log.Printf("Invalid value for environment variable 'ETCD_CLIENT_DEBUG'. Using default level: 'info'")
 		return zapcore.InfoLevel
 	}
 	return l


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/14203 to 3.5.