### PR TITLE
update changelog-3.4 to protection for rangePermCache with a RW lock

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,6 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
+## v3.4.20 (TBD)
+
+### etcd server
+- Fix [Protect rangePermCache with a RW lock correctly](https://github.com/etcd-io/etcd/pull/14230)
+
 ## v3.4.19 (2022-07-12)
 
 See [code changes](https://github.com/etcd-io/etcd/compare/v3.4.18...v3.4.19) and [v3.4 upgrade guide](https://etcd.io/docs/latest/upgrades/upgrade_3_4/) for any breaking changes.


### PR DESCRIPTION
Signed-off-by: Hitoshi Mitake <h.mitake@gmail.com>

