### PR TITLE
readme: remove broken roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Now it's time to dig into the full etcd API and other guides.
 
 - Mailing list: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)
 - IRC: #[etcd](irc://irc.freenode.org:6667/#etcd) on freenode.org
-- Planning/Roadmap: [milestones](https://github.com/etcd-io/etcd/milestones), [roadmap](./ROADMAP.md)
+- Planning: [milestones](https://github.com/etcd-io/etcd/milestones)
 - Bugs: [issues](https://github.com/etcd-io/etcd/issues)
 
 ## Contributing


### PR DESCRIPTION
The ROADMAP.md file was deleted as a part of commit
a722827c96162d7d06e72cadfaed223793dc4d78 and the readme
file was not updated. I could not find a suitable alternative
resource so I am removing the link.

Signed-off-by: Austin Benoit <22805659+AustinBenoit@users.noreply.github.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
