### PR TITLE
No need to manually remove tmp directory created by t.TempDir()

### DIFF
--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -180,7 +180,6 @@ func TestDirPermission(t *testing.T) {
 
 func TestRemoveMatchFile(t *testing.T) {
 	tmpdir := t.TempDir()
-	defer os.RemoveAll(tmpdir)
 	f, err := os.CreateTemp(tmpdir, "tmp")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The temporary directory created by t.TempDir() can be automatically removed by
the golang testing utilities. So no need to remove it manually.

FYI.
* https://github.com/golang/go/blob/go1.16.15/src/testing/testing.go#L911-L915
* https://github.com/golang/go/blob/go1.16.15/src/testing/testing.go#L957

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
