### PR TITLE
Add golangci-lint config file and `make` target.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,5 @@
 run:
+  go: '1.17'
   timeout: 30m
   skip-files:
     - "^zz_generated.*"
@@ -27,15 +28,10 @@ linters:
 
 linters-settings: # please keep this alphabetized
   staticcheck:
-    go: "1.17"
-    checks: [
-      "all",
-      "-SA1019", # TODO(fix) Using a deprecated function, variable, constant or field
-      "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
-    ]
+    checks:
+      - "all"
+      - "-SA1019" # TODO(fix) Using a deprecated function, variable, constant or field
+      - "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
   stylecheck:
-    checks: [
-      "ST1019",  # Importing the same package multiple times.
-    ]
-  unused:
-    go: "1.17"
+    checks:
+      - "ST1019"  # Importing the same package multiple times.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,41 @@
+run:
+  timeout: 30m
+  skip-files:
+    - "^zz_generated.*"
+
+issues:
+  max-same-issues: 0
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # exclude ineffassing linter for generated files for conversion
+    - path: conversion\.go
+      linters:
+        - ineffassign
+
+linters:
+  disable-all: true
+  enable: # please keep this alphabetized
+  # Don't use soon to deprecated[1] linters that lead to false
+  # https://github.com/golangci/golangci-lint/issues/1841
+  # - deadcode
+  # - structcheck
+  # - varcheck
+    - ineffassign
+    - staticcheck
+    - stylecheck
+    - unused
+
+linters-settings: # please keep this alphabetized
+  staticcheck:
+    go: "1.17"
+    checks: [
+      "all",
+      "-SA1019", # TODO(fix) Using a deprecated function, variable, constant or field
+      "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
+    ]
+  stylecheck:
+    checks: [
+      "ST1019",  # Importing the same package multiple times.
+    ]
+  unused:
+    go: "1.17"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,9 @@ commit using message with a more generic `*:` prefix.
 *: <what changed>
 [..]
 ```
+
+### Static analysis.
+
+We recommend that you install [golangci-lint](https://golangci-lint.run/usage/install/) and run `make lint`.
+
+Very soon we will have a GitHub action to run our linters.

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,10 @@ push-docker-release-main:
 	$(info ETCD_VERSION: $(ETCD_VERSION))
 	docker push gcr.io/etcd-development/etcd:$(ETCD_VERSION)
 
+# Recursively analyzes the tree:
 lint:
-	# Recursively analyzes the tree:
-	golangci-lint -v run
+	golangci-lint run
+
+# Fixes found issues, if supported by the linter:
+lint-fix:
+	golangci-lint run --fix

--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,7 @@ build-docker-release-main:
 push-docker-release-main:
 	$(info ETCD_VERSION: $(ETCD_VERSION))
 	docker push gcr.io/etcd-development/etcd:$(ETCD_VERSION)
+
+lint:
+	# Recursively analyzes the tree:
+	golangci-lint -v run

--- a/contrib/lock/client/client.go
+++ b/contrib/lock/client/client.go
@@ -30,7 +30,7 @@ import (
 	"strconv"
 	"time"
 
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 


### PR DESCRIPTION
Here we add file `.golangci.yaml`, to have a common configuration for
static analysis. If you use the following IDEs/editors, they will read
the file:

- `vim` with vim-go.
- VSCode.

The initial configuration file is based on Kubernetes' HEAD. We removed
a custom kubernetes-linter for custom kubernetes-logging. We also
changed to Golang version 1.17 (etcd's current target Golang version)
from 1.18.

Also, we added a new target to `Makefile`: `lint`. NOTE that auto-fixing
should be part of a later commit, once we are all happy with how the
configuration file is working for us.

As expected, this change fixes two issues found by this `.golangci.yaml`
in file `contrib/lock/client/client.go`:

- Dead code, removed.
- Innefective assignment, removed.

Finally, we are updating `CONTRIBUTING.md` to mention `golangci-lint`.

We will add a GitHub-action to run `golangci-lint` in a future change.

Local testing done:

- `make build`.
- `make test`.

Both are happy.

This is the initial step to fix
https://github.com/etcd-io/etcd/issues/14164.

Signed-off-by: Ramsés Morales <ramses@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
