### PR TITLE
[3.4] raft: postpone MsgReadIndex until first commit in the term

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -181,6 +181,8 @@ type Node interface {
 	// Read state has a read index. Once the application advances further than the read
 	// index, any linearizable read requests issued before the read request can be
 	// processed safely. The read state will have the same rctx attached.
+	// Note that request can be lost without notice, therefore it is user's job
+	// to ensure read index retries.
 	ReadIndex(ctx context.Context, rctx []byte) error
 
 	// Status returns the current status of the raft state machine.

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -2384,12 +2384,24 @@ func TestReadOnlyForNewLeader(t *testing.T) {
 		t.Fatalf("last log term = %d, want %d", lastLogTerm, sm.Term)
 	}
 
-	// Ensure peer a accepts read only request after it commits a entry at its term.
-	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgReadIndex, Entries: []pb.Entry{{Data: wctx}}})
+	// Ensure peer a processed postponed read only request after it committed an entry at its term.
 	if len(sm.readStates) != 1 {
 		t.Fatalf("len(readStates) = %d, want 1", len(sm.readStates))
 	}
 	rs := sm.readStates[0]
+	if rs.Index != windex {
+		t.Fatalf("readIndex = %d, want %d", rs.Index, windex)
+	}
+	if !bytes.Equal(rs.RequestCtx, wctx) {
+		t.Fatalf("requestCtx = %v, want %v", rs.RequestCtx, wctx)
+	}
+
+	// Ensure peer a accepts read only request after it committed an entry at its term.
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgReadIndex, Entries: []pb.Entry{{Data: wctx}}})
+	if len(sm.readStates) != 2 {
+		t.Fatalf("len(readStates) = %d, want 2", len(sm.readStates))
+	}
+	rs = sm.readStates[1]
 	if rs.Index != windex {
 		t.Fatalf("readIndex = %d, want %d", rs.Index, windex)
 	}


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/12762 to 3.4

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius 