### PR TITLE
server/etcdserver: check whether raftNode has stopped

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -377,7 +377,14 @@ func (r *raftNode) apply() chan toApply {
 }
 
 func (r *raftNode) stop() {
-	r.stopped <- struct{}{}
+	select {
+	case r.stopped <- struct{}{}:
+		// Not already stopped, so trigger it
+	case <-r.done:
+		// Has already been stopped - no need to do anything
+		return
+	}
+	// Block until the stop has been acknowledged by start()
 	<-r.done
 }
 

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -288,9 +288,8 @@ func TestExpvarWithNoRaftStatus(t *testing.T) {
 
 func TestStopRaftNodeMoreThanOnce(t *testing.T) {
 	n := newNopReadyNode()
-
 	r := newRaftNode(raftNodeConfig{
-		lg:          zap.NewExample(),
+		lg:          zaptest.NewLogger(t),
 		Node:        n,
 		storage:     mockstorage.NewStorageRecorder(""),
 		raftStorage: raft.NewMemoryStorage(),

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -285,3 +285,30 @@ func TestExpvarWithNoRaftStatus(t *testing.T) {
 		_ = kv.Value.String()
 	})
 }
+
+func TestStopRaftNodeMoreThanOnce(t *testing.T) {
+	n := newNopReadyNode()
+
+	r := newRaftNode(raftNodeConfig{
+		lg:          zap.NewExample(),
+		Node:        n,
+		storage:     mockstorage.NewStorageRecorder(""),
+		raftStorage: raft.NewMemoryStorage(),
+		transport:   newNopTransporter(),
+	})
+	r.start(&raftReadyHandler{})
+
+	for i := 0; i < 2; i++ {
+		stopped := make(chan struct{})
+		go func() {
+			r.stop()
+			close(stopped)
+		}()
+
+		select {
+		case <-stopped:
+		case <-time.After(time.Second):
+			t.Errorf("*raftNode.stop() is blocked !")
+		}
+	}
+}


### PR DESCRIPTION
In order to remove the risk of blocking and make the program more robust. 
When calling the stop method of raftNode, check whether it has stopped.

Signed-off-by:  mind1949 <lianjie1949@gmail.com>

cc @hexfusion @ahrtr @ptabor @wking @simonpasquier