### PR TITLE
[3.4] clientv3/mvcc: fixed DATA RACE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966
 	github.com/urfave/cli v1.20.0
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2


### PR DESCRIPTION
clientv3/mvcc: fixed DATA RACE between mvcc.(*store).setupMetricsReporter and mvcc.(*store).restore
issue: #14270 

By comparing the code on the main branch, it is found that the main branch does not have this problem. But there is a small problem on the main branch, the code is as follows:
https://github.com/etcd-io/etcd/blob/a3b410cac74d6b0082ad3e40ba384b8650a809e4/server/storage/mvcc/kvstore.go#L349-L364
L362: `s.compactMainRev`
I think this needs a read lock. However, I think this simple modification like this pull request is more appropriate.
```
{
		s.revMu.Lock()
		s.currentRev = <-revc

		// keys in the range [compacted revision -N, compaction] might all be deleted due to compaction.
		// the correct revision should be set to compaction revision in the case, not the largest revision
		// we have seen.
		if s.currentRev < s.compactMainRev {
			s.currentRev = s.compactMainRev
		}

		if scheduledCompact <= s.compactMainRev {
			scheduledCompact = 0
		}
		s.revMu.Unlock()
	}
```

Signed-off-by: SimFG <1142838399@qq.com>
