### PR TITLE
Reduce ExpectFunc polling interval

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -114,7 +114,7 @@ func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
 			break
 		}
 		ep.mu.Unlock()
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 10)
 	}
 	ep.mu.Lock()
 	lastLinesIndex := len(ep.lines) - DEBUG_LINES_TAIL


### PR DESCRIPTION
Fixes issue #14275, flakes close to timeout like TestKVDelete.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>
