### PR TITLE
rafthttp: test multiple transport removes

### DIFF
--- a/server/etcdserver/api/rafthttp/transport_test.go
+++ b/server/etcdserver/api/rafthttp/transport_test.go
@@ -142,6 +142,25 @@ func TestTransportRemove(t *testing.T) {
 	}
 }
 
+func TestTransportRemoveIsIdempotent(t *testing.T) {
+	tr := &Transport{
+		LeaderStats:    stats.NewLeaderStats(zaptest.NewLogger(t), ""),
+		streamRt:       &roundTripperRecorder{},
+		peers:          make(map[types.ID]Peer),
+		pipelineProber: probing.NewProber(nil),
+		streamProber:   probing.NewProber(nil),
+	}
+
+	tr.AddPeer(1, []string{"http://localhost:2380"})
+	tr.RemovePeer(types.ID(1))
+	tr.RemovePeer(types.ID(1))
+	defer tr.Stop()
+
+	if _, ok := tr.peers[types.ID(1)]; ok {
+		t.Fatalf("senders[1] exists, want removed")
+	}
+}
+
 func TestTransportUpdate(t *testing.T) {
 	peer := newFakePeer()
 	tr := &Transport{


### PR DESCRIPTION
Unit test to verify multiple transport removes does not create an issue.

Created a unit test as a part of [13715](https://github.com/etcd-io/etcd/issues/13715)

Signed-off-by: Austin Benoit <22805659+AustinBenoit@users.noreply.github.com>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.