### PR TITLE
Checking cluster member count in watch_test

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -50,6 +50,10 @@ func runWatchTest(t *testing.T, f watcherTest) {
 	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
+	if len(clus.Members) != 3 {
+		t.Fatalf("not enough members in cluster, expected 3 but found %d", len(clus.Members))
+	}
+
 	wclientMember := rand.Intn(3)
 	w := clus.Client(wclientMember).Watcher
 	// select a different client for KV operations so puts succeed if


### PR DESCRIPTION
The test should fail early on an insufficient cluster instead of
panicking during the test.

Fixes issue #14259.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>
