### PR TITLE
Fixed goroutine leak

### DIFF
--- a/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
@@ -37,6 +37,9 @@ func TestQueueOneReaderOneWriter(t *testing.T) {
 	defer clus.Terminate(t)
 
 	done := make(chan struct{})
+	defer func() {
+		<-done
+	}()
 	go func() {
 		defer func() {
 			done <- struct{}{}
@@ -61,7 +64,6 @@ func TestQueueOneReaderOneWriter(t *testing.T) {
 			t.Fatalf("expected dequeue value %v, got %v", s, i)
 		}
 	}
-	<-done
 }
 
 func TestQueueManyReaderOneWriter(t *testing.T) {


### PR DESCRIPTION
package: recipes_test

Fixed potential goroutine leak for [TestQueueOneReaderOneWriter](https://github.com/etcd-io/etcd/blob/a1fb9ff1e4de40337735d07ca0773cfc242ad00f/tests/integration/clientv3/experimental/recipes/v3_queue_test.go#L33). Failing the test at any point will prevent [receiving from channel done](https://github.com/etcd-io/etcd/blob/a1fb9ff1e4de40337735d07ca0773cfc242ad00f/tests/integration/clientv3/experimental/recipes/v3_queue_test.go#L64), blocking [its corresponding send](https://github.com/etcd-io/etcd/blob/a1fb9ff1e4de40337735d07ca0773cfc242ad00f/tests/integration/clientv3/experimental/recipes/v3_queue_test.go#L42). 