### PR TITLE
Fixed goroutine leak in tests/integration/clientv3/watch_test.go

### DIFF
--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -27,7 +27,7 @@ import (
 	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/api/v3/version"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 	"google.golang.org/grpc/metadata"
@@ -74,6 +74,12 @@ func testWatchMultiWatcher(t *testing.T, wctx *watchctx) {
 	keys := []string{"foo", "bar", "baz"}
 
 	donec := make(chan struct{})
+	// wait for watcher shutdown
+	defer func() {
+		for i := 0; i < len(keys)+1; i++ {
+			<-donec
+		}
+	}()
 	readyc := make(chan struct{})
 	for _, k := range keys {
 		// key watcher
@@ -155,10 +161,6 @@ func testWatchMultiWatcher(t *testing.T, wctx *watchctx) {
 				t.Fatal(err)
 			}
 		}
-	}
-	// wait for watcher shutdown
-	for i := 0; i < len(keys)+1; i++ {
-		<-donec
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: VladSaioc <vladsaioc10@gmail.com>

package: clientv3test

Goroutines sending to [done](https://github.com/etcd-io/etcd/blob/1597219ca7341436ded080006e6601a60a4b3647/tests/integration/clientv3/watch_test.go#L76) might leak at sends [here](https://github.com/etcd-io/etcd/blob/1597219ca7341436ded080006e6601a60a4b3647/tests/integration/clientv3/watch_test.go#L97) and [here](https://github.com/etcd-io/etcd/blob/1597219ca7341436ded080006e6601a60a4b3647/tests/integration/clientv3/watch_test.go#L142)  if [t.Fatal](https://github.com/etcd-io/etcd/blob/1597219ca7341436ded080006e6601a60a4b3647/tests/integration/clientv3/watch_test.go#L155) is called. Deferring the shutdown loop ensures that all goroutines gracefully terminate.