### PR TITLE
Fixed goroutine leak in tests/integration/v3_watch_restore_test.go

### DIFF
--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -130,7 +130,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	// should be able to notify on old-revision watchers in unsynced
 	// make sure restore watch operation correctly moves watchers
 	// between synced and unsynced watchers
-	errc := make(chan error)
+	errc := make(chan error, 1)
 	go func() {
 		cresp, cerr := wStream.Recv()
 		if cerr != nil {


### PR DESCRIPTION
Signed-off-by: VladSaioc <vladsaioc10@gmail.com>

package: integration

Fixed goroutine leak due to [select with timeout and unbuffered channel communication cases](https://github.com/etcd-io/etcd/blob/651de5a057c00e204aa74407f93e8f2b5e9ebc00/tests/integration/v3_watch_restore_test.go#L148). Leaks may happen either at lines [137](https://github.com/etcd-io/etcd/blob/651de5a057c00e204aa74407f93e8f2b5e9ebc00/tests/integration/v3_watch_restore_test.go#L137), [142](https://github.com/etcd-io/etcd/blob/651de5a057c00e204aa74407f93e8f2b5e9ebc00/tests/integration/v3_watch_restore_test.go#L142) or [145](https://github.com/etcd-io/etcd/blob/651de5a057c00e204aa74407f93e8f2b5e9ebc00/tests/integration/v3_watch_restore_test.go#L145).
