### PR TITLE
[3.4] Do not get previous K/V for create event

### DIFF
--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -400,7 +400,7 @@ func (sws *serverWatchStream) sendLoop() {
 			sws.mu.RUnlock()
 			for i := range evs {
 				events[i] = &evs[i]
-				if needPrevKV {
+				if needPrevKV && !isCreateEvent(evs[i]) {
 					opt := mvcc.RangeOptions{Rev: evs[i].Kv.ModRevision - 1}
 					r, err := sws.watchable.Range(evs[i].Kv.Key, nil, opt)
 					if err == nil && len(r.KVs) != 0 {
@@ -532,6 +532,10 @@ func (sws *serverWatchStream) sendLoop() {
 			return
 		}
 	}
+}
+
+func isCreateEvent(e mvccpb.Event) bool {
+	return e.Type == mvccpb.PUT && e.Kv.CreateRevision == e.Kv.ModRevision
 }
 
 func sendFragments(

--- a/test
+++ b/test
@@ -466,7 +466,7 @@ function govet_shadow_pass {
 	# shellcheck disable=SC2206
 	fmtpkgs=($fmtpkgs)
 	# Golang 1.12 onwards the experimental -shadow option is no longer available with go vet
-	go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+	go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@v0.1.11
 	export PATH=${GOPATH}/bin:${PATH}
 	# shellcheck disable=SC2230
 	shadow_tool=$(which shadow)


### PR DESCRIPTION
This might not be the root cause of https://github.com/etcd-io/etcd/issues/14256, but it should can improve the pipeline.

Please also refer to https://github.com/etcd-io/etcd/commit/d70f35f8d14bb208f6c5be130ecf36cfd9d60ac9 

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
