### PR TITLE
fileutil: fixed work with wal files lock on the windows

### DIFF
--- a/client/pkg/fileutil/lock_windows.go
+++ b/client/pkg/fileutil/lock_windows.go
@@ -18,15 +18,12 @@
 package fileutil
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
-
-var errLocked = errors.New("the process cannot access the file because another process has locked a portion of the file")
 
 func TryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
 	f, err := open(path, flag, perm)
@@ -89,10 +86,8 @@ func lockFile(fd windows.Handle, flags uint32) error {
 	err := windows.LockFileEx(fd, flags|windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &windows.Overlapped{})
 	if err == nil {
 		return nil
-	} else if err.Error() == errLocked.Error() {
+	} else if err == windows.ERROR_LOCK_VIOLATION {
 		return ErrLocked
-	} else if err != windows.ERROR_LOCK_VIOLATION {
-		return err
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
The current wal file lock check contains a very strange code. 

```go
//Etcd/client/pkg/fileutil/lock_windows.go

        if err == nil {
		return nil
	} else if err.Error() == errLocked.Error() {
		return ErrLocked
	} else if err != windows.ERROR_LOCK_VIOLATION {
		return err
	}
	return nil
```

This code check whether the lock is set or not by the message of the error received from the operating system. At the same time, the message with which it is compared differs from the message that the operating system returns. 

```go
//The message returned by the OS
"The process cannot access the file because another process has locked a portion of the file."
//The message expected in the code
"the process cannot access the file because another process has locked a portion of the file"
```

As a result, the check fails and the purge loop deletes the blocked wal files. I rewrote the check to check the error code, in my opinion this is a more reliable way.

Linked issue [14252](https://github.com/etcd-io/etcd/issues/14252)