### PR TITLE
tests: fix status responses size and nil

### DIFF
--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+func TestStatus(t *testing.T) {
+
+	testRunner.BeforeTest(t)
+
+	for _, tc := range clusterTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			clus := testRunner.NewCluster(ctx, t, tc.config)
+			defer clus.Close()
+			cc := clus.Client()
+
+			testutils.ExecuteUntil(ctx, t, func() {
+				rs, err := cc.Status()
+				if err != nil {
+					t.Fatalf("could not get status, err: %s", err)
+				}
+				if len(rs) != tc.config.ClusterSize {
+					t.Fatalf("wrong number of status responses. expected:%d, got:%d ", tc.config.ClusterSize, len(rs))
+				}
+				memberIds := make(map[uint64]struct{})
+				for _, r := range rs {
+					if r == nil {
+						t.Fatalf("status response is nil")
+					}
+					memberIds[r.Header.MemberId] = struct{}{}
+				}
+				if len(rs) != len(memberIds) {
+					t.Fatalf("found duplicated members")
+				}
+			})
+		})
+	}
+}

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -292,13 +292,13 @@ func (ctl *EtcdctlV3) Status() ([]*clientv3.StatusResponse, error) {
 		Endpoint string
 		Status   *clientv3.StatusResponse
 	}
-	err := ctl.spawnJsonCmd(&epStatus, "endpoint", "status", "--endpoints", strings.Join(ctl.endpoints, ","))
+	err := ctl.spawnJsonCmd(&epStatus, "endpoint", "status")
 	if err != nil {
 		return nil, err
 	}
 	resp := make([]*clientv3.StatusResponse, len(epStatus))
-	for _, e := range epStatus {
-		resp = append(resp, e.Status)
+	for i, e := range epStatus {
+		resp[i] = e.Status
 	}
 	return resp, err
 }


### PR DESCRIPTION
As I migrate tests to common framework,  I found 2 problems in the following code
1. `resp` is filled with `nil` before it is appended
2. `--endpoints` argument is redundant, as `ctl.spawnJsonCmd()` has already taken care of it. With this redundant`--endpoints`, status of one endpoint appears 2 times in `epStatus`

https://github.com/etcd-io/etcd/blob/4f0e92d94ceacdd0af26e7268764a5bce7b0a3eb/tests/framework/e2e/etcdctl.go#L290-L304