### PR TITLE
Enhance the WAL file related error

### DIFF
--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -377,9 +377,12 @@ func selectWALFiles(lg *zap.Logger, dirpath string, snap walpb.Snapshot) ([]stri
 	}
 
 	nameIndex, ok := searchIndex(lg, names, snap.Index)
-	if !ok || !isValidSeq(lg, names[nameIndex:]) {
-		err = ErrFileNotFound
-		return nil, -1, err
+	if !ok {
+		return nil, -1, fmt.Errorf("wal: file not found which matches the snapshot index '%d'", snap.Index)
+	}
+
+	if !isValidSeq(lg, names[nameIndex:]) {
+		return nil, -1, fmt.Errorf("wal: file sequence numbers (starting from %d) do not increase continuously", nameIndex)
 	}
 
 	return names, nameIndex, nil

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -539,8 +540,8 @@ func TestRecoverAfterCut(t *testing.T) {
 		w, err := Open(zaptest.NewLogger(t), p, walpb.Snapshot{Index: uint64(i), Term: 1})
 		if err != nil {
 			if i <= 4 {
-				if err != ErrFileNotFound {
-					t.Errorf("#%d: err = %v, want %v", i, err, ErrFileNotFound)
+				if !strings.Contains(err.Error(), "do not increase continuously") {
+					t.Errorf("#%d: err = %v isn't expected, want: '* do not increase continuously'", i, err)
 				}
 			} else {
 				t.Errorf("#%d: err = %v, want nil", i, err)


### PR DESCRIPTION
This PR should be helpful to debug https://github.com/etcd-io/etcd/issues/14252

The `ErrFileNotFound` was used for for three cases:
1. There is no any WAL files (probably due to no read permission);
2. There is no WAL files matching the snapshot index;
3. The WAL file seqs do not increase continuously.

It's not good for debug when users see the `ErrFileNotFound` error,
so in this PR, a different error is returned for each case above.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
