### PR TITLE
CHANGELOG: update version recommendation

### DIFF
--- a/CHANGELOG/CHANGELOG-4.0.md
+++ b/CHANGELOG/CHANGELOG-4.0.md
@@ -2,12 +2,7 @@
 
 Previous change logs can be found at [CHANGELOG-3.x](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.x.md).
 
-
-The minimum recommended etcd versions to run in **production** are 3.2.28+, 3.3.18+, and 3.4.2+.
-
-
 <hr>
-
 
 ## v4.0.0 (TBD)
 

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -1,6 +1,6 @@
 # Production recommendation
 
-The minimum recommended etcd versions to run in **production** are 3.3.18+, 3.4.2+, v3.5.3+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
+The minimum recommended etcd versions to run in **production** are v3.4.8+ and v3.5.4+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
 
 ### v3.5 data corruption issue 
 


### PR DESCRIPTION
Update version recommendation per the current policy.

For more details, see discussions under
https://github.com/etcd-io/website/pull/601

Signed-off-by: Sahdev Zala <spzala@us.ibm.com>
