### PR TITLE
etcdctl: allow move-leader to connect to multiple endpoints

### DIFF
--- a/etcdctl/ctlv3/command/move_leader_command.go
+++ b/etcdctl/ctlv3/command/move_leader_command.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
@@ -43,7 +44,8 @@ func transferLeadershipCommandFunc(cmd *cobra.Command, args []string) {
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
 
-	c := mustClientFromCmd(cmd)
+	cfg := clientConfigFromCmd(cmd)
+	c := mustClient(cfg)
 	eps := c.Endpoints()
 	c.Close()
 
@@ -53,7 +55,6 @@ func transferLeadershipCommandFunc(cmd *cobra.Command, args []string) {
 	var leaderCli *clientv3.Client
 	var leaderID uint64
 	for _, ep := range eps {
-		cfg := clientConfigFromCmd(cmd)
 		cfg.Endpoints = []string{ep}
 		cli := mustClient(cfg)
 		resp, serr := cli.Status(ctx, ep)

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -109,6 +109,10 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig) {
 			[]string{cx.epc.EndpointsV3()[leadIdx]},
 			fmt.Sprintf("Leadership transferred from %s to %s", types.ID(leaderID), types.ID(transferee)),
 		},
+		{ // request to all endpoints
+			cx.epc.EndpointsV3(),
+			fmt.Sprintf("Leadership transferred"),
+		},
 	}
 	for i, tc := range tests {
 		prefix := cx.prefixArgs(tc.eps)


### PR DESCRIPTION
Re-opening closed PR etcd-io#11775 which was originaly authored by benmoss.
Then again opened PR etcd-io#12757 which was authored by zerodayz.

The mustClientForCmd function is responsible for parsing environment
variables and flags into configuration data. A change was made in etcd-io#9382
to call Fatal if a flag is provided multiple times. This means that we
cannot call the mustClientForCmd function more than once,
since it will think that flags parsed the first time are now
being redefined and error out.

Some people have commented about this in etcd-io#8380 but I don't think
there's an open issue for it.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

tracked under our [BZ1918413](https://bugzilla.redhat.com/show_bug.cgi?id=1918413) 
