### PR TITLE
Change default sampling rate from 100% to 0%

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -849,6 +849,7 @@ func (e *Etcd) setupTracing(ctx context.Context) (exporter tracesdk.SpanExporter
 			tracesdk.NewTracerProvider(
 				tracesdk.WithBatcher(exporter),
 				tracesdk.WithResource(res),
+				tracesdk.WithSampler(tracesdk.ParentBased(tracesdk.NeverSample())),
 			),
 		),
 	)


### PR DESCRIPTION
This changes the default parent-based trace sampling rate from
100% to 0%. Due to the high QPS etcd can handle, having 100% trace
sampling leads to very high resource usage. Defaulting to 0% means
that only already-sampled traces will be sampled in etcd.

Fixes #14310
