### PR TITLE
add .DS_Store into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ hack/tls-setup/certs
 *.tmp
 *.bak
 .gobincache/
+.DS_Store
 /Documentation/dev-guide/api_reference_v3.md
 /Documentation/dev-guide/api_concurrency_reference_v3.md
 


### PR DESCRIPTION
When accessing directories/files through `Finder` on MacOS, then `.DS_Store` may be generated automatically. We should ignore such file.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
