### PR TITLE
logging RoleGrantPermission key and range end

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -832,6 +832,8 @@ func (as *authStore) RoleGrantPermission(r *pb.AuthRoleGrantPermissionRequest) (
 		"granted/updated a permission to a user",
 		zap.String("user-name", r.Name),
 		zap.String("permission-name", authpb.Permission_Type_name[int32(r.Perm.PermType)]),
+		zap.ByteString("key", r.Perm.Key),
+		zap.ByteString("range-end", r.Perm.RangeEnd),
 	)
 	return &pb.AuthRoleGrantPermissionResponse{}, nil
 }


### PR DESCRIPTION
logging RoleGrantPermission key and range end

related to https://github.com/etcd-io/etcd/pull/14041

Signed-off-by: Chao Chen <chaochn@amazon.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
