### PR TITLE
common tests framework: cluster client creation could fail with invalid auth

### DIFF
--- a/client/v3/config.go
+++ b/client/v3/config.go
@@ -121,6 +121,10 @@ type AuthConfig struct {
 	Password string `json:"password"`
 }
 
+func (cfg AuthConfig) Empty() bool {
+	return cfg.Username == "" && cfg.Password == ""
+}
+
 // NewClientConfig creates a Config based on the provided ConfigSpec.
 func NewClientConfig(confSpec *ConfigSpec, lg *zap.Logger) (*Config, error) {
 	tlsCfg, err := newTLSConfig(confSpec.Secure, lg)

--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -32,17 +33,18 @@ func TestAlarm(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1, QuotaBackendBytes: int64(13 * os.Getpagesize())})
 	defer clus.Close()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		// test small put still works
 		smallbuf := strings.Repeat("a", 64)
-		if err := clus.Client().Put(ctx, "1st_test", smallbuf, config.PutOptions{}); err != nil {
+		if err := cc.Put(ctx, "1st_test", smallbuf, config.PutOptions{}); err != nil {
 			t.Fatalf("alarmTest: put kv error (%v)", err)
 		}
 
 		// write some chunks to fill up the database
 		buf := strings.Repeat("b", os.Getpagesize())
 		for {
-			if err := clus.Client().Put(ctx, "2nd_test", buf, config.PutOptions{}); err != nil {
+			if err := cc.Put(ctx, "2nd_test", buf, config.PutOptions{}); err != nil {
 				if !strings.Contains(err.Error(), "etcdserver: mvcc: database space exceeded") {
 					t.Fatal(err)
 				}
@@ -51,20 +53,20 @@ func TestAlarm(t *testing.T) {
 		}
 
 		// quota alarm should now be on
-		alarmResp, err := clus.Client().AlarmList(ctx)
+		alarmResp, err := cc.AlarmList(ctx)
 		if err != nil {
 			t.Fatalf("alarmTest: Alarm error (%v)", err)
 		}
 
 		// check that Put is rejected when alarm is on
-		if err := clus.Client().Put(ctx, "3rd_test", smallbuf, config.PutOptions{}); err != nil {
+		if err := cc.Put(ctx, "3rd_test", smallbuf, config.PutOptions{}); err != nil {
 			if !strings.Contains(err.Error(), "etcdserver: mvcc: database space exceeded") {
 				t.Fatal(err)
 			}
 		}
 
 		// get latest revision to compact
-		sresp, err := clus.Client().Status(ctx)
+		sresp, err := cc.Status(ctx)
 		if err != nil {
 			t.Fatalf("get endpoint status error: %v", err)
 		}
@@ -77,12 +79,12 @@ func TestAlarm(t *testing.T) {
 		}
 
 		// make some space
-		_, err = clus.Client().Compact(ctx, rvs, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
+		_, err = cc.Compact(ctx, rvs, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
 		if err != nil {
 			t.Fatalf("alarmTest: Compact error (%v)", err)
 		}
 
-		if err = clus.Client().Defragment(ctx, config.DefragOption{Timeout: 10 * time.Second}); err != nil {
+		if err = cc.Defragment(ctx, config.DefragOption{Timeout: 10 * time.Second}); err != nil {
 			t.Fatalf("alarmTest: defrag error (%v)", err)
 		}
 
@@ -92,14 +94,14 @@ func TestAlarm(t *testing.T) {
 				MemberID: alarm.MemberID,
 				Alarm:    alarm.Alarm,
 			}
-			_, err = clus.Client().AlarmDisarm(ctx, alarmMember)
+			_, err = cc.AlarmDisarm(ctx, alarmMember)
 			if err != nil {
 				t.Fatalf("alarmTest: Alarm error (%v)", err)
 			}
 		}
 
 		// put one more key below quota
-		if err := clus.Client().Put(ctx, "4th_test", smallbuf, config.PutOptions{}); err != nil {
+		if err := cc.Put(ctx, "4th_test", smallbuf, config.PutOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -115,10 +117,11 @@ func TestAlarmlistOnMemberRestart(t *testing.T) {
 		SnapshotCount:     5,
 	})
 	defer clus.Close()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 	testutils.ExecuteUntil(ctx, t, func() {
 		for i := 0; i < 6; i++ {
-			if _, err := clus.Client().AlarmList(ctx); err != nil {
+			if _, err := cc.AlarmList(ctx); err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 		}

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -29,20 +31,21 @@ func TestDefragOnline(t *testing.T) {
 	defer cancel()
 	options := config.DefragOption{Timeout: 10 * time.Second}
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		defer clus.Close()
 		var kvs = []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 		for i := range kvs {
-			if err := clus.Client().Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}); err != nil {
+			if err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}); err != nil {
 				t.Fatalf("compactTest #%d: put kv error (%v)", i, err)
 			}
 		}
-		_, err := clus.Client().Compact(ctx, 4, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
+		_, err := cc.Compact(ctx, 4, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
 		if err != nil {
 			t.Fatalf("defrag_test: compact with revision error (%v)", err)
 		}
 
-		if err = clus.Client().Defragment(ctx, options); err != nil {
+		if err = cc.Defragment(ctx, options); err != nil {
 			t.Fatalf("defrag_test: defrag error (%v)", err)
 		}
 	})

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -29,8 +31,9 @@ func TestEndpointStatus(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
 	defer clus.Close()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
-		_, err := clus.Client().Status(ctx)
+		_, err := cc.Status(ctx)
 		if err != nil {
 			t.Fatalf("get endpoint status error: %v", err)
 		}
@@ -43,8 +46,9 @@ func TestEndpointHashKV(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
 	defer clus.Close()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
-		_, err := clus.Client().HashKV(ctx, 0)
+		_, err := cc.HashKV(ctx, 0)
 		if err != nil {
 			t.Fatalf("get endpoint hashkv error: %v", err)
 		}
@@ -57,8 +61,9 @@ func TestEndpointHealth(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
 	defer clus.Close()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
-		if err := clus.Client().Health(ctx); err != nil {
+		if err := cc.Health(ctx); err != nil {
 			t.Fatalf("get endpoint health error: %v", err)
 		}
 	})

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -33,7 +34,7 @@ func TestKVPut(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				key, value := "foo", "bar"
@@ -67,7 +68,7 @@ func TestKVGet(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				var (
@@ -127,7 +128,7 @@ func TestKVDelete(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 			testutils.ExecuteUntil(ctx, t, func() {
 				kvs := []string{"a", "b", "c", "c/abc", "d"}
 				tests := []struct {

--- a/tests/common/lease_test.go
+++ b/tests/common/lease_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -59,7 +60,7 @@ func TestLeaseGrantTimeToLive(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				ttl := int64(10)
@@ -103,7 +104,7 @@ func TestLeaseGrantAndList(t *testing.T) {
 				t.Logf("Creating cluster...")
 				clus := testRunner.NewCluster(ctx, t, tc.config)
 				defer clus.Close()
-				cc := clus.Client()
+				cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 				t.Logf("Created cluster and client")
 				testutils.ExecuteUntil(ctx, t, func() {
 					var createdLeases []clientv3.LeaseID
@@ -150,7 +151,7 @@ func TestLeaseGrantTimeToLiveExpired(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				leaseResp, err := cc.Grant(ctx, 2)
@@ -187,7 +188,7 @@ func TestLeaseGrantKeepAliveOnce(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				leaseResp, err := cc.Grant(ctx, 2)
@@ -216,7 +217,7 @@ func TestLeaseGrantRevoke(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				leaseResp, err := cc.Grant(ctx, 20)

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -35,7 +35,7 @@ func TestMemberList(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				resp, err := cc.MemberList(ctx)
@@ -109,7 +109,7 @@ func TestMemberAdd(t *testing.T) {
 					c.DisableStrictReconfigCheck = !quorumTc.strictReconfigCheck
 					clus := testRunner.NewCluster(ctx, t, c)
 					defer clus.Close()
-					cc := clus.Client()
+					cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 					testutils.ExecuteUntil(ctx, t, func() {
 						var addResp *clientv3.MemberAddResponse

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -34,7 +35,7 @@ func TestRoleAdd_Simple(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				_, err := cc.RoleAdd(ctx, "root")
@@ -52,7 +53,7 @@ func TestRoleAdd_Error(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
 	defer clus.Close()
-	cc := clus.Client()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "test-role")
 		if err != nil {
@@ -75,7 +76,7 @@ func TestRootRole(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
 	defer clus.Close()
-	cc := clus.Client()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "root")
 		if err != nil {
@@ -105,7 +106,7 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
 	defer clus.Close()
-	cc := clus.Client()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
 		if err != nil {
@@ -140,7 +141,7 @@ func TestRoleDelete(t *testing.T) {
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
 	defer clus.Close()
-	cc := clus.Client()
+	cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
 		if err != nil {

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -32,7 +34,7 @@ func TestStatus(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				rs, err := cc.Status(ctx)

--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -60,7 +61,7 @@ func TestTxnSucc(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, cfg.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 			testutils.ExecuteUntil(ctx, t, func() {
 				if err := cc.Put(ctx, "key1", "value1", config.PutOptions{}); err != nil {
 					t.Fatalf("could not create key:%s, value:%s", "key1", "value1")
@@ -104,7 +105,7 @@ func TestTxnFail(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, cfg.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 			testutils.ExecuteUntil(ctx, t, func() {
 				if err := cc.Put(ctx, "key1", "value1", config.PutOptions{}); err != nil {
 					t.Fatalf("could not create key:%s, value:%s", "key1", "value1")

--- a/tests/common/user_test.go
+++ b/tests/common/user_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -68,7 +70,7 @@ func TestUserAdd_Simple(t *testing.T) {
 				defer cancel()
 				clus := testRunner.NewCluster(ctx, t, tc.config)
 				defer clus.Close()
-				cc := clus.Client()
+				cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 				testutils.ExecuteUntil(ctx, t, func() {
 					resp, err := cc.UserAdd(ctx, nc.username, nc.password, config.UserAddOptions{NoPassword: nc.noPassword})
@@ -102,7 +104,7 @@ func TestUserAdd_DuplicateUserNotAllowed(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				user := "barb"
@@ -131,7 +133,7 @@ func TestUserList(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				// No Users Yet
@@ -172,7 +174,7 @@ func TestUserDelete(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				user := "barb"
@@ -224,7 +226,7 @@ func TestUserChangePassword(t *testing.T) {
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				user := "barb"

--- a/tests/common/watch_test.go
+++ b/tests/common/watch_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -20,7 +22,7 @@ func TestWatch(t *testing.T) {
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 
 			defer clus.Close()
-			cc := clus.Client()
+			cc := framework.MustClient(clus.Client(clientv3.AuthConfig{}))
 			testutils.ExecuteUntil(ctx, t, func() {
 				tests := []struct {
 					puts     []testutils.KV

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -30,7 +30,7 @@ type testRunner interface {
 
 type Cluster interface {
 	Members() []Member
-	Client() Client
+	Client(cfg clientv3.AuthConfig) (Client, error)
 	WaitLeader(t testing.TB) int
 	Close() error
 }
@@ -57,18 +57,23 @@ type Client interface {
 	Leases(context context.Context) (*clientv3.LeaseLeasesResponse, error)
 	KeepAliveOnce(context context.Context, id clientv3.LeaseID) (*clientv3.LeaseKeepAliveResponse, error)
 	Revoke(context context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error)
+
+	AuthEnable(context context.Context) (*clientv3.AuthEnableResponse, error)
+	AuthDisable(context context.Context) (*clientv3.AuthDisableResponse, error)
+	AuthStatus(context context.Context) (*clientv3.AuthStatusResponse, error)
 	UserAdd(context context.Context, name, password string, opts config.UserAddOptions) (*clientv3.AuthUserAddResponse, error)
+	UserGet(context context.Context, name string) (*clientv3.AuthUserGetResponse, error)
 	UserList(context context.Context) (*clientv3.AuthUserListResponse, error)
 	UserDelete(context context.Context, name string) (*clientv3.AuthUserDeleteResponse, error)
 	UserChangePass(context context.Context, user, newPass string) error
-
+	UserGrantRole(context context.Context, user string, role string) (*clientv3.AuthUserGrantRoleResponse, error)
+	UserRevokeRole(context context.Context, user string, role string) (*clientv3.AuthUserRevokeRoleResponse, error)
 	RoleAdd(context context.Context, name string) (*clientv3.AuthRoleAddResponse, error)
 	RoleGrantPermission(context context.Context, name string, key, rangeEnd string, permType clientv3.PermissionType) (*clientv3.AuthRoleGrantPermissionResponse, error)
 	RoleGet(context context.Context, role string) (*clientv3.AuthRoleGetResponse, error)
 	RoleList(context context.Context) (*clientv3.AuthRoleListResponse, error)
 	RoleRevokePermission(context context.Context, role string, key, rangeEnd string) (*clientv3.AuthRoleRevokePermissionResponse, error)
 	RoleDelete(context context.Context, role string) (*clientv3.AuthRoleDeleteResponse, error)
-
 	Txn(context context.Context, compares, ifSucess, ifFail []string, o config.TxnOptions) (*clientv3.TxnResponse, error)
 
 	MemberList(context context.Context) (*clientv3.MemberListResponse, error)

--- a/tests/framework/util.go
+++ b/tests/framework/util.go
@@ -12,26 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package framework
 
-import "time"
-
-type TLSConfig string
-
-const (
-	NoTLS     TLSConfig = ""
-	AutoTLS   TLSConfig = "auto-tls"
-	ManualTLS TLSConfig = "manual-tls"
-
-	TickDuration = 10 * time.Millisecond
-)
-
-type ClusterConfig struct {
-	ClusterSize                int
-	PeerTLS                    TLSConfig
-	ClientTLS                  TLSConfig
-	QuotaBackendBytes          int64
-	DisableStrictReconfigCheck bool
-	AuthToken                  string
-	SnapshotCount              int
+func MustClient(c Client, err error) Client {
+	if err != nil {
+		panic(err)
+	}
+	return c
 }

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -77,7 +77,7 @@ func TestCompactionHash(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -34,7 +34,7 @@ func TestPeriodicCheck(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -70,7 +70,7 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -106,7 +106,7 @@ func TestCompactHashCheck(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -143,7 +143,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -34,11 +34,10 @@ func TestCompactionHash(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	cc, err := clus.ClusterClient()
+	cc, err := clus.ClusterClient(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -523,11 +523,11 @@ func testLeaseStress(t *testing.T, stresser func(context.Context, pb.LeaseClient
 	errc := make(chan error)
 
 	if useClusterClient {
+		clusterClient, err := clus.ClusterClient(t)
+		if err != nil {
+			t.Fatal(err)
+		}
 		for i := 0; i < 300; i++ {
-			clusterClient, err := clus.ClusterClient()
-			if err != nil {
-				t.Fatal(err)
-			}
 			go func(i int) { errc <- stresser(ctx, integration.ToGRPC(clusterClient).Lease) }(i)
 		}
 	} else {


### PR DESCRIPTION
common tests framework: cluster client creation with auth could fail

related to #14041

> More than 2K line of code change is too big, could you try to break down this PR into small ones?

This PR has 227 additions and 73 deletions. 

Signed-off-by: Chao Chen <chaochn@amazon.com>

---

In order to fail the test cluster client creation with invalid auth, I have to change the interface function signature. 
