### PR TITLE
etcdctl: add --max-txn-ops flag to make-mirror command

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -29,6 +29,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - When print endpoint status, [show db size in use](https://github.com/etcd-io/etcd/pull/13639)
 - [Always print the raft_term in decimal](https://github.com/etcd-io/etcd/pull/13711) when displaying member list in json.
 - [Add one more field `storageVersion`](https://github.com/etcd-io/etcd/pull/13773) into the response of command `etcdctl endpoint status`.
+- Add [`--max-txn-ops`](https://github.com/etcd-io/etcd/pull/14340) flag to make-mirror command.
 
 ### etcdutl v3
 

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -1466,6 +1466,8 @@ RPC: UserRevokeRole
 
 - dest-insecure-transport -- Disable transport security for client connections
 
+- max-txn-ops -- Maximum number of operations permitted in a transaction during syncing updates
+
 #### Output
 
 The approximate total number of keys transferred to the destination cluster, updated every 30 seconds.


### PR DESCRIPTION
### what is this

--max-txn-ops flag allows users to define the maximum number of operations permitted in
a transaction during syncing updates.if unlimited syncing may fail when number of txn ops
exceeds the maximum number of server side.

### why need this

DefaultMaxTxnOps in server side is 128. it also can be defined by the --max-txn-ops flag in etcd server side.
if the number of operations permitted per transaction exceeds the limitation during make-mirror, 
make-mirror will crash.

> 2022/08/12 14:58:44 INFO: [core] [Channel #3 SubChannel #4] Subchannel Connectivity change to IDLE
2022/08/12 14:58:44 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc00057c550, IDLE
2022/08/12 14:58:44 INFO: [transport] transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2022/08/12 14:58:44 INFO: [roundrobin] roundrobinPicker: Build called with info: {map[]}
2022/08/12 14:58:44 INFO: [core] [Channel #3] Channel Connectivity change to IDLE
2022/08/12 14:58:44 INFO: [core] [Channel #3 SubChannel #4] Subchannel Connectivity change to CONNECTING
2022/08/12 14:58:44 INFO: [core] [Channel #3 SubChannel #4] Subchannel picks a new address "10.20.144.27:2379" to connect
2022/08/12 14:58:44 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc00057c550, CONNECTING
2022/08/12 14:58:44 INFO: [core] [Channel #3] Channel Connectivity change to CONNECTING
2022/08/12 14:58:44 INFO: [core] [Channel #3 SubChannel #4] Subchannel Connectivity change to READY
2022/08/12 14:58:44 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc00057c550, READY
2022/08/12 14:58:44 INFO: [roundrobin] roundrobinPicker: Build called with info: {map[0xc00057c550:{{
  "Addr": "10.20.144.27:2379",
  "ServerName": "10.20.144.27",
  "Attributes": null,
  "BalancerAttributes": null,
  "Type": 0,
  "Metadata": null
}}]}
2022/08/12 14:58:44 INFO: [core] [Channel #3] Channel Connectivity change to READY
17313
{"level":"warn","ts":"2022-08-12T14:59:21.543+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:64","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001c85a0/192.168.48.220:2379","method":"/etcdserverpb.KV/Txn","attempt":0,"error":"rpc error: code = InvalidArgument desc = etcdserver: too many operations in txn request"}
Error: etcdserver: too many operations in txn request

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
