### PR TITLE
tests: e2e and integration share TickDuration constant

### DIFF
--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -14,12 +14,16 @@
 
 package config
 
+import "time"
+
 type TLSConfig string
 
 const (
 	NoTLS     TLSConfig = ""
 	AutoTLS   TLSConfig = "auto-tls"
 	ManualTLS TLSConfig = "manual-tls"
+
+	TickDuration = 10 * time.Millisecond
 )
 
 type ClusterConfig struct {

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -26,8 +26,6 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-const TickDuration = 10 * time.Millisecond
-
 type e2eRunner struct{}
 
 func (e e2eRunner) TestMain(m *testing.M) {
@@ -116,7 +114,7 @@ func (c *e2eCluster) WaitMembersForLeader(ctx context.Context, t testing.TB, mem
 			t.Fatal("WaitMembersForLeader timeout")
 		default:
 		}
-		_, err := cc.Get("0", config.GetOptions{Timeout: 10*TickDuration + time.Second})
+		_, err := cc.Get("0", config.GetOptions{Timeout: 10*config.TickDuration + time.Second})
 		if err == nil || strings.Contains(err.Error(), "Key not found") {
 			break
 		}
@@ -149,7 +147,7 @@ func (c *e2eCluster) WaitMembersForLeader(ctx context.Context, t testing.TB, mem
 		}
 		leaders = make(map[uint64]struct{})
 		members = make(map[uint64]int)
-		time.Sleep(10 * TickDuration)
+		time.Sleep(10 * config.TickDuration)
 	}
 	for l := range leaders {
 		if index, ok := members[l]; ok {

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -27,6 +27,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
@@ -294,7 +295,7 @@ func TestIssue3699(t *testing.T) {
 		// do not restart the killed member immediately.
 		// the member will advance its election timeout after restart,
 		// so it will have a better chance to become the leader again.
-		time.Sleep(time.Duration(integration.ElectionTicks * int(integration.TickDuration)))
+		time.Sleep(time.Duration(integration.ElectionTicks * int(config.TickDuration)))
 		c.Members[leaderID].Restart(t)
 		leaderID = c.WaitMembersForLeader(t, c.Members)
 	}
@@ -391,7 +392,7 @@ func TestRejectUnhealthyRemove(t *testing.T) {
 	}
 
 	// member stopped after launch; wait for missing heartbeats
-	time.Sleep(time.Duration(integration.ElectionTicks * int(integration.TickDuration)))
+	time.Sleep(time.Duration(integration.ElectionTicks * int(config.TickDuration)))
 
 	// permit remove dead member since (3,2) - (0,1) => (3,1) has quorum
 	if err = c.RemoveMember(t, c.Members[2].Client, uint64(c.Members[0].Server.MemberId())); err != nil {

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 
 	"google.golang.org/grpc"
@@ -1817,7 +1818,7 @@ func TestGRPCRequireLeader(t *testing.T) {
 	defer client.Close()
 
 	// wait for election timeout, then member[0] will not have a leader.
-	time.Sleep(time.Duration(3*integration.ElectionTicks) * integration.TickDuration)
+	time.Sleep(time.Duration(3*integration.ElectionTicks) * config.TickDuration)
 
 	md := metadata.Pairs(rpctypes.MetadataRequireLeaderKey, rpctypes.MetadataHasLeader)
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
@@ -1870,7 +1871,7 @@ func TestGRPCStreamRequireLeader(t *testing.T) {
 	clus.Members[2].Restart(t)
 
 	clus.WaitMembersForLeader(t, clus.Members)
-	time.Sleep(time.Duration(2*integration.ElectionTicks) * integration.TickDuration)
+	time.Sleep(time.Duration(2*integration.ElectionTicks) * config.TickDuration)
 
 	// new stream should also be OK now after we restarted the other members
 	wStream, err = wAPI.Watch(ctx)

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -26,6 +26,7 @@ import (
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	framecfg "go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 
 	"google.golang.org/grpc/codes"
@@ -391,7 +392,7 @@ func TestV3LeaseCheckpoint(t *testing.T) {
 				leaderId := clus.WaitLeader(t)
 				leader := clus.Members[leaderId]
 				leader.Stop(t)
-				time.Sleep(time.Duration(3*integration.ElectionTicks) * integration.TickDuration)
+				time.Sleep(time.Duration(3*integration.ElectionTicks) * framecfg.TickDuration)
 				leader.Restart(t)
 			}
 

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
@@ -28,7 +29,7 @@ import (
 // waiting for not-empty value or 'timeout'.
 func MustFetchNotEmptyMetric(tb testing.TB, member *integration.Member, metric string, timeout <-chan time.Time) string {
 	metricValue := ""
-	tick := time.Tick(integration.TickDuration)
+	tick := time.Tick(config.TickDuration)
 	for metricValue == "" {
 		tb.Logf("Waiting for metric: %v", metric)
 		select {


### PR DESCRIPTION
As mentioned in https://github.com/etcd-io/etcd/pull/14304#discussion_r945192946, it would be a good idea to share the same `TickDuration` constant between `integration/cluster.go` and `e2e.go`, for the benefit of less duplication.