### PR TITLE
chore: log when an invalid watch request is received

### DIFF
--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -348,7 +348,7 @@ func (sws *serverWatchStream) recvLoop() error {
 			// we probably should not shutdown the entire stream when
 			// receive an invalid command.
 			// so just do nothing instead.
-			sws.lg.Warn("invalid watch request received in gRPC stream")
+			sws.lg.Sugar().Infof("invalid watch request type %T received in gRPC stream", uv)
 			continue
 		}
 	}

--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -346,8 +346,9 @@ func (sws *serverWatchStream) recvLoop() error {
 			}
 		default:
 			// we probably should not shutdown the entire stream when
-			// receive an valid command.
+			// receive an invalid command.
 			// so just do nothing instead.
+			sws.lg.Warn("invalid watch request received in gRPC stream")
 			continue
 		}
 	}


### PR DESCRIPTION
As protobuf doesn't have required field, user may send an empty
WatchRequest by mistake. Currently, etcd will ignore the invalid request
and keep the stream opening. If we don't reject the invalid request by
closing the stream, it would be better to leave a log there.

This commit also fixes a typo in the comment.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
