### PR TITLE
Minor refactoring on the keepAliveListener and keepAliveConn

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -17,6 +17,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 ### Deprecations
 
 - Deprecated [V2 discovery](https://etcd.io/docs/v3.5/dev-internal/discovery_protocol/).
+- Deprecated [SetKeepAlive and SetKeepAlivePeriod in limitListenerConn](https://github.com/etcd-io/etcd/pull/14356).
 - Removed [etcdctl defrag --data-dir](https://github.com/etcd-io/etcd/pull/13793).
 - Removed [etcdctl snapshot status](https://github.com/etcd-io/etcd/pull/13809).
 - Removed [etcdctl snapshot restore](https://github.com/etcd-io/etcd/pull/13809).

--- a/client/pkg/transport/keepalive_listener.go
+++ b/client/pkg/transport/keepalive_listener.go
@@ -21,26 +21,29 @@ import (
 	"time"
 )
 
-type keepAliveConn interface {
-	SetKeepAlive(bool) error
-	SetKeepAlivePeriod(d time.Duration) error
-}
-
 // NewKeepAliveListener returns a listener that listens on the given address.
 // Be careful when wrap around KeepAliveListener with another Listener if TLSInfo is not nil.
 // Some pkgs (like go/http) might expect Listener to return TLSConn type to start TLS handshake.
 // http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html
+//
+// Note(ahrtr):
+// only `net.TCPConn` supports `SetKeepAlive` and `SetKeepAlivePeriod`
+// by default, so if you want to wrap multiple layers of net.Listener,
+// the `keepaliveListener` should be the one which is closest to the
+// original `net.Listener` implementation, namely `TCPListener`.
 func NewKeepAliveListener(l net.Listener, scheme string, tlscfg *tls.Config) (net.Listener, error) {
+	kal := &keepaliveListener{
+		Listener: l,
+	}
+
 	if scheme == "https" {
 		if tlscfg == nil {
 			return nil, fmt.Errorf("cannot listen on TLS for given listener: KeyFile and CertFile are not presented")
 		}
-		return newTLSKeepaliveListener(l, tlscfg), nil
+		return newTLSKeepaliveListener(kal, tlscfg), nil
 	}
 
-	return &keepaliveListener{
-		Listener: l,
-	}, nil
+	return kal, nil
 }
 
 type keepaliveListener struct{ net.Listener }
@@ -50,13 +53,43 @@ func (kln *keepaliveListener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	kac := c.(keepAliveConn)
+
+	kac, err := createKeepaliveConn(c)
+	if err != nil {
+		return nil, fmt.Errorf("create keepalive connection failed, %w", err)
+	}
 	// detection time: tcp_keepalive_time + tcp_keepalive_probes + tcp_keepalive_intvl
 	// default on linux:  30 + 8 * 30
 	// default on osx:    30 + 8 * 75
-	kac.SetKeepAlive(true)
-	kac.SetKeepAlivePeriod(30 * time.Second)
-	return c, nil
+	if err := kac.SetKeepAlive(true); err != nil {
+		return nil, fmt.Errorf("SetKeepAlive failed, %w", err)
+	}
+	if err := kac.SetKeepAlivePeriod(30 * time.Second); err != nil {
+		return nil, fmt.Errorf("SetKeepAlivePeriod failed, %w", err)
+	}
+	return kac, nil
+}
+
+func createKeepaliveConn(c net.Conn) (*keepAliveConn, error) {
+	tcpc, ok := c.(*net.TCPConn)
+	if !ok {
+		return nil, ErrNotTCP
+	}
+	return &keepAliveConn{tcpc}, nil
+}
+
+type keepAliveConn struct {
+	*net.TCPConn
+}
+
+// SetKeepAlive sets keepalive
+func (l *keepAliveConn) SetKeepAlive(doKeepAlive bool) error {
+	return l.TCPConn.SetKeepAlive(doKeepAlive)
+}
+
+// SetKeepAlivePeriod sets keepalive period
+func (l *keepAliveConn) SetKeepAlivePeriod(d time.Duration) error {
+	return l.TCPConn.SetKeepAlivePeriod(d)
 }
 
 // A tlsKeepaliveListener implements a network listener (net.Listener) for TLS connections.
@@ -72,12 +105,7 @@ func (l *tlsKeepaliveListener) Accept() (c net.Conn, err error) {
 	if err != nil {
 		return
 	}
-	kac := c.(keepAliveConn)
-	// detection time: tcp_keepalive_time + tcp_keepalive_probes + tcp_keepalive_intvl
-	// default on linux:  30 + 8 * 30
-	// default on osx:    30 + 8 * 75
-	kac.SetKeepAlive(true)
-	kac.SetKeepAlivePeriod(30 * time.Second)
+
 	c = tls.Server(c, l.config)
 	return c, nil
 }

--- a/client/pkg/transport/keepalive_listener_test.go
+++ b/client/pkg/transport/keepalive_listener_test.go
@@ -40,6 +40,9 @@ func TestNewKeepAliveListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected Accept error: %v", err)
 	}
+	if _, ok := conn.(*keepAliveConn); !ok {
+		t.Fatalf("Unexpected conn type: %T, wanted *keepAliveConn", conn)
+	}
 	conn.Close()
 	ln.Close()
 

--- a/client/pkg/transport/limit_listen.go
+++ b/client/pkg/transport/limit_listen.go
@@ -63,6 +63,9 @@ func (l *limitListenerConn) Close() error {
 	return err
 }
 
+// SetKeepAlive sets keepalive
+//
+// Deprecated: use (*keepAliveConn) SetKeepAlive instead.
 func (l *limitListenerConn) SetKeepAlive(doKeepAlive bool) error {
 	tcpc, ok := l.Conn.(*net.TCPConn)
 	if !ok {
@@ -71,6 +74,9 @@ func (l *limitListenerConn) SetKeepAlive(doKeepAlive bool) error {
 	return tcpc.SetKeepAlive(doKeepAlive)
 }
 
+// SetKeepAlivePeriod sets keepalive period
+//
+// Deprecated: use (*keepAliveConn) SetKeepAlivePeriod instead.
 func (l *limitListenerConn) SetKeepAlivePeriod(d time.Duration) error {
 	tcpc, ok := l.Conn.(*net.TCPConn)
 	if !ok {

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -205,6 +205,15 @@ func TestNewListenerWithSocketOpts(t *testing.T) {
 			if !test.expectedErr && err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+
+			if test.scheme == "http" {
+				lnOpts := newListenOpts(test.opts...)
+				if !lnOpts.IsSocketOpts() && !lnOpts.IsTimeout() {
+					if _, ok := ln.(*keepaliveListener); !ok {
+						t.Fatalf("ln: unexpected listener type: %T, wanted *keepaliveListener", ln)
+					}
+				}
+			}
 		})
 	}
 }

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -666,12 +666,6 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 			sctx.l = transport.LimitListener(sctx.l, int(fdLimit-reservedInternalFDNum))
 		}
 
-		if network == "tcp" {
-			if sctx.l, err = transport.NewKeepAliveListener(sctx.l, network, nil); err != nil {
-				return nil, err
-			}
-		}
-
 		defer func(u url.URL) {
 			if err == nil {
 				return


### PR DESCRIPTION
## Two issues:
1. When starting etcd using `./etcd --socket-reuse-address --socket-reuse-port`, actually[ etcd setting the SetKeepAlive or SetKeepAlivePeriod](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/client/pkg/transport/keepalive_listener.go#L57-L58) fails, but the current code ignores the errors. This issue can happen on both Linux and Mac.
2. When running the functional test on Mac, the etcd always runs into issue below. This issue only happens on Mac,

```
panic: interface conversion: transport.timeoutConn is not transport.keepAliveConn: missing method SetKeepAlive

goroutine 295 [running]:
go.etcd.io/etcd/client/pkg/v3/transport.(*keepaliveListener).Accept(0x1f)
        /Users/wachao/go/src/go.etcd.io/etcd/client/pkg/transport/keepalive_listener.go:53 +0x51
github.com/soheilhy/cmux.(*cMux).Serve(0xc00057c3c0)
        /Users/wachao/go/gopath/pkg/mod/github.com/soheilhy/cmux@v0.1.5/cmux.go:170 +0xa9
go.etcd.io/etcd/server/v3/embed.(*serveCtx).serve(0xc0001b51f0, 0xc00037c300, 0xc0001a6868, {0x1d789c0, 0xc0003a2400}, 0xc0002f9250, {0xc0002a4280, 0x2, 0x2})
        /Users/wachao/go/src/go.etcd.io/etcd/server/embed/serve.go:220 +0x191d
go.etcd.io/etcd/server/v3/embed.(*Etcd).serveClients.func1(0xc000280ba0)
        /Users/wachao/go/src/go.etcd.io/etcd/server/embed/etcd.go:735 +0xa8
created by go.etcd.io/etcd/server/v3/embed.(*Etcd).serveClients
        /Users/wachao/go/src/go.etcd.io/etcd/server/embed/etcd.go:734 +0x5f6
,"--socket-reuse-address=true","--socket-reuse-port=true"]}
```

## Analysis and solution
Currently etcd defines an [keepAliveConn](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/client/pkg/transport/keepalive_listener.go#L24) interface, and the 
[limitListenerConn](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/client/pkg/transport/limit_listen.go#L66-L80) implements this interface. 

The high level diagram/relationship is something like below (excluding the unix(s) and TLS for  simplicity),
![etcd_listener](https://user-images.githubusercontent.com/30739825/185067471-a4c81e27-cf3e-4625-8ca5-f9927b823de8.png)

There are three issues:
1. Only [net.TCPConn](https://github.com/golang/go/blob/go1.17.9/src/net/tcpsock.go#L86) supports `SetKeepAlive` and `SetKeepAlivePeriod` by default. So the customized conns (previously the `limitListenConn`, now the `keepAliveConn`) use golang's type assertion to convert the `net.Conn` to `net.TCPConn`, and it just leverage the `net.TCPConn` to set the `keepalive` and `keepalivePeriod`. If there are multiple layers of net.Listener encapsulations, then it must be the one which is closest to the original `net.Listener` implementation, namely `TCPListener`. Otherwise, [the type assertion](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/client/pkg/transport/limit_listen.go#L67) fails. It's exactly the reason for the first issue above.
2. Mac (Darwin) doesn't somehow support [FDLimit](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/server/embed/etcd.go#L658) , so the net.Listener chain doesn't include the `limitListener`, which is the only one which implements the [keepAliveConn](https://github.com/etcd-io/etcd/blob/ff6b85da834e8e3acb2627895294a65548632fe1/client/pkg/transport/keepalive_listener.go#L24) interface. It's exactly the reason for the failure on Mac. 
3. It doesn't make sense to let `limitListenConn` to support `SetKeepAlive` and `SetKeepAlivePeriod`, because it should focus on the functionality (rate limit) it's designed to.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
