### PR TITLE
clientv3: close streams after use in lessor keepAliveOnce method

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -397,7 +397,7 @@ func (l *lessor) closeRequireLeader() {
 	}
 }
 
-func (l *lessor) keepAliveOnce(ctx context.Context, id LeaseID) (*LeaseKeepAliveResponse, error) {
+func (l *lessor) keepAliveOnce(ctx context.Context, id LeaseID) (karesp *LeaseKeepAliveResponse, ferr error) {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -405,6 +405,15 @@ func (l *lessor) keepAliveOnce(ctx context.Context, id LeaseID) (*LeaseKeepAlive
 	if err != nil {
 		return nil, toErr(ctx, err)
 	}
+
+	defer func() {
+		if err := stream.CloseSend(); err != nil {
+			if ferr == nil {
+				ferr = toErr(ctx, err)
+			}
+			return
+		}
+	}()
 
 	err = stream.Send(&pb.LeaseKeepAliveRequest{ID: int64(id)})
 	if err != nil {
@@ -416,7 +425,7 @@ func (l *lessor) keepAliveOnce(ctx context.Context, id LeaseID) (*LeaseKeepAlive
 		return nil, toErr(ctx, rerr)
 	}
 
-	karesp := &LeaseKeepAliveResponse{
+	karesp = &LeaseKeepAliveResponse{
 		ResponseHeader: resp.GetHeader(),
 		ID:             LeaseID(resp.ID),
 		TTL:            resp.TTL,


### PR DESCRIPTION
We use `client.KeepAliveOnce` heavily in Sensu Go. Since upgrading to Etcd 3.5 we've seen an excessive amount of logs containing `failed to receive lease keepalive request from gRPC stream` when logging at debug level. I believe this is happening as there's no attempt to close the stream after the `keepAliveOnce` method has completed. The stream is instead closed by the deferred call to cancel the context.

The log lines no longer appear after attempting to close the stream using the code in this PR.
