### PR TITLE
Cleanup all etcd-agent and etcd processes when the test finishes

### DIFF
--- a/tests/functional/agent/server.go
+++ b/tests/functional/agent/server.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strings"
 
 	"go.etcd.io/etcd/pkg/v3/proxy"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -102,17 +101,16 @@ func (srv *Server) StartServe() error {
 		zap.String("listener-address", srv.ln.Addr().String()),
 	)
 	err = srv.grpcServer.Serve(srv.ln)
-	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
-		srv.lg.Info(
-			"gRPC server is shut down",
+	if err != nil {
+		srv.lg.Warn(
+			"gRPC server is stopped with error",
 			zap.String("address", srv.address),
 			zap.Error(err),
 		)
 	} else {
-		srv.lg.Warn(
-			"gRPC server returned with error",
+		srv.lg.Info(
+			"gRPC server is stopped",
 			zap.String("address", srv.address),
-			zap.Error(err),
 		)
 	}
 	return err


### PR DESCRIPTION
There are two cases, when interrupted by users, then forcibly kill all processes. Otherwise, gracefully terminate all processes.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @spzala 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
