### PR TITLE
Move inactive maintainers to emeritus

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,22 +10,12 @@
 
 # MAINTAINERS
 Benjamin Wang <wachao@vmware.com> (ahrtr@) pkg:*
-Gyuho Lee <gyuhox@gmail.com> (@gyuho) pkg:*
 Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
-Jingyi Hu <jingyih@google.com> (@jingyih) pkg:*
 Marek Siarkowicz <siarkowicz@google.com> (@serathius) pkg:*
 Piotr Tabor <ptab@google.com> (@ptabor) pkg:*
 Sahdev Zala <spzala@us.ibm.com> (@spzala) pkg:*
 Sam Batschelet <sbatschelet@gmail.com> (@hexfusion) pkg:*
-Wenjia Zhang <wenjiazhang@google.com> (@wenjiaswe) pkg:*
-Xiang Li <xiangli.cs@gmail.com> (@xiang90) pkg:*
-
-Ben Darnell <ben@cockroachlabs.com> (@bdarnell) pkg:go.etcd.io/etcd/raft
-Tobias Grieger <tobias.schottdorf@gmail.com> (@tbg) pkg:go.etcd.io/etcd/raft
 
 # REVIEWERS
 Lili Cosic <cosiclili@gmail.com> (lilic@) pkg:*
 Wilson Wang <wilson.wang@bytedance.com> (wilsonwang371@) pkg:*
-
-# EMERITUS MAINTAINERS
-Joe Betz <jpbetz@google.com> (@jpbetz) pkg:*

--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ These emeritus maintainers dedicated a part of their career to etcd and reviewed
 * Fanmin Shi
 * Anthony Romano
 * Brandon Philips
+* Joe Betz
+* Gyuho Lee
+* Jingyi Hu
+* Wenjia Zhang
+* Xiang Li
+* Ben Darnell
+* Tobias Grieger
 
 ### License
 


### PR DESCRIPTION
I'm proposing to remove inactive maintainers based on new process established in https://github.com/etcd-io/etcd/pull/14238.

In addition I will be sending an email to maintainers mailing list that will cc removed maintainers, to ensure they are notified.

This PR requires approval of two other maintainers. To allow affected maintainers time to object I will leave 3 weeks of lazy consensus on this PR.

cc @ptabor @ahrtr @spzala @gyuho @mitake @jingyih @jpbetz @hexfusion @wenjiaswe @xiang90 @bdarnell @tbg