### PR TITLE
Documentation: Update Broken Links

### DIFF
--- a/Documentation/contributor-guide/branch_management.md
+++ b/Documentation/contributor-guide/branch_management.md
@@ -15,13 +15,13 @@ The `main` branch is our development branch. All new features land here first.
 
 To try new and experimental features, pull `main` and play with it. Note that `main` may not be stable because new features may introduce bugs.
 
-Before the release of the next stable version, feature PRs will be frozen. A [release manager](../dev-internal/release/#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
+Before the release of the next stable version, feature PRs will be frozen. A [release manager](./release.md/#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
 
 ### Stable branches
 
 All branches with prefix `release-` are considered _stable_ branches.
 
-After every minor release ([semver.org](https://semver.org/)), we will have a new stable branch for that release, managed by a [patch release manager](../dev-internal/release/#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
+After every minor release ([semver.org](https://semver.org/)), we will have a new stable branch for that release, managed by a [patch release manager](./release.md/#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
 
 [main]: https://github.com/etcd-io/etcd/tree/main
 

--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -71,5 +71,5 @@ git log ...${PREV_VERSION} --pretty=format:"%an" | sort | uniq | tr '\n' ',' | s
 
 ## Post release
 
-- Create new stable branch through `git push origin ${VERSION_MAJOR}.${VERSION_MINOR}` if this is a major stable release. This assumes `origin` corresponds to "https://github.com/etcd-io/etcd\".
+- Create new stable branch through `git push origin ${VERSION_MAJOR}.${VERSION_MINOR}` if this is a major stable release. This assumes `origin` corresponds to "https://github.com/etcd-io/etcd".
 - Bump [hardcoded Version in the repository](https://github.com/etcd-io/etcd/blob/v3.4.15/version/version.go#L30) to the version `${VERSION}+git`.

--- a/Documentation/contributor-guide/trige_prs.md
+++ b/Documentation/contributor-guide/trige_prs.md
@@ -9,7 +9,7 @@ A PR can have various labels, milestone, reviewer etc. The detailed list of labe
 https://github.com/kubernetes/kubernetes/labels
 
 Following are few example searches on PR for convenience:
-* [Open PRS for milestone etcd-v3.4](https://github.com/etcd-io/etcd/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Aetcd-v3.4)
+* [Open PRS for milestone etcd-v3.6](https://github.com/etcd-io/etcd/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Aetcd-v3.6)
 * [PRs under investigation](https://github.com/etcd-io/etcd/labels/Investigating)
 
 ## Scope


### PR DESCRIPTION
Fix broken links in documentation/contributor-guide. Also bumped `Open PRS for milestone etcd-v3.4` in [trige_prs.md](https://github.com/etcd-io/etcd/compare/main...AustinBenoit:etcd:Docs/update_links?expand=1#diff-2d9fec3b14fab28960ccf2768e2b771ffd2e716c9a8b6a549dfa7dbb484fccde) to be more relevant to current development.

Signed-off-by: Austin Benoit <austinryanbenoit@gmail.com>