### PR TITLE
Fixed infinite loop in ExpectProcess.ExpectFunc

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -18,6 +18,7 @@ package expect
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -96,7 +97,7 @@ func (ep *ExpectProcess) read() {
 }
 
 // ExpectFunc returns the first line satisfying the function f.
-func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
+func (ep *ExpectProcess) ExpectFunc(ctx context.Context, f func(string) bool) (string, error) {
 	i := 0
 
 	for {
@@ -114,7 +115,13 @@ func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
 			break
 		}
 		ep.mu.Unlock()
-		time.Sleep(time.Millisecond * 10)
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("failed to find match string: %w", ctx.Err())
+		case <-time.After(time.Millisecond * 10):
+			// continue loop
+		}
 	}
 	ep.mu.Lock()
 	lastLinesIndex := len(ep.lines) - DEBUG_LINES_TAIL
@@ -128,9 +135,15 @@ func (ep *ExpectProcess) ExpectFunc(f func(string) bool) (string, error) {
 		ep.err, lastLines)
 }
 
+// ExpectWithContext returns the first line containing the given string.
+func (ep *ExpectProcess) ExpectWithContext(ctx context.Context, s string) (string, error) {
+	return ep.ExpectFunc(ctx, func(txt string) bool { return strings.Contains(txt, s) })
+}
+
 // Expect returns the first line containing the given string.
+// Deprecated: please use ExpectWithContext instead.
 func (ep *ExpectProcess) Expect(s string) (string, error) {
-	return ep.ExpectFunc(func(txt string) bool { return strings.Contains(txt, s) })
+	return ep.ExpectWithContext(context.Background(), s)
 }
 
 // LineCount returns the number of recorded lines since

--- a/tests/e2e/ctl_v3_elect_test.go
+++ b/tests/e2e/ctl_v3_elect_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -106,7 +107,7 @@ func ctlV3Elect(cx ctlCtx, name, proposal string) (*expect.ExpectProcess, <-chan
 		return proc, outc, err
 	}
 	go func() {
-		s, xerr := proc.ExpectFunc(func(string) bool { return true })
+		s, xerr := proc.ExpectFunc(context.TODO(), func(string) bool { return true })
 		if xerr != nil {
 			cx.t.Errorf("expect failed (%v)", xerr)
 		}

--- a/tests/e2e/ctl_v3_lock_test.go
+++ b/tests/e2e/ctl_v3_lock_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -127,7 +128,7 @@ func ctlV3Lock(cx ctlCtx, name string) (*expect.ExpectProcess, <-chan string, er
 		return proc, outc, err
 	}
 	go func() {
-		s, xerr := proc.ExpectFunc(func(string) bool { return true })
+		s, xerr := proc.ExpectFunc(context.TODO(), func(string) bool { return true })
 		if xerr != nil {
 			cx.t.Errorf("expect failed (%v)", xerr)
 		}

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -249,7 +250,7 @@ func testV3CurlAuth(cx ctlCtx) {
 		testutil.AssertNil(cx.t, err)
 		defer proc.Close()
 
-		cURLRes, err := proc.ExpectFunc(lineFunc)
+		cURLRes, err := proc.ExpectFunc(context.Background(), lineFunc)
 		testutil.AssertNil(cx.t, err)
 
 		authRes := make(map[string]interface{})

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -36,7 +37,7 @@ func WaitReadyExpectProc(exproc *expect.ExpectProcess, readyStrs []string) error
 		}
 		return false
 	}
-	_, err := exproc.ExpectFunc(matchSet)
+	_, err := exproc.ExpectFunc(context.Background(), matchSet)
 	return err
 }
 


### PR DESCRIPTION
I wrote unit test (expect_test.go, TestExpectFuncTimeout) that shows how to get stuck in the infinite loop of ExpectFunc.

The problem is that this function releases lock, sleeps and reads new lines. For some talkative processes 10ms is enough to write new line.

First purpose of the diff is to show the problem and possible solution. I'm not sure about interface for Expect function (it seems like you're okay with context, but maybe you prefer time.Duration as a parameter for some reasons) and existing code - should I use timeout there or not?