### PR TITLE
Remove IRC ref

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ etcd is Apache 2.0 licensed and accepts contributions via GitHub pull requests. 
 # Email and chat
 
 - Email: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)
-- IRC: #[etcd](irc://irc.freenode.org:6667/#etcd) IRC channel on freenode.org
 - Slack: [#etcd](https://kubernetes.slack.com/messages/C3HD8ARJ5/details/)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Now it's time to dig into the full etcd API and other guides.
 ## Contact
 
 - Mailing list: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)
-- IRC: #[etcd](irc://irc.freenode.org:6667/#etcd) on freenode.org
+- Slack: [#etcd](https://kubernetes.slack.com/messages/C3HD8ARJ5/details/)
 - Planning: [milestones](https://github.com/etcd-io/etcd/milestones)
 - Bugs: [issues](https://github.com/etcd-io/etcd/issues)
 


### PR DESCRIPTION
While sharing the doc with a potential new contributor, I noticed the 
IRC reference. Removing it per earlier discussion.

cc @serathius @ahrtr 

Signed-off-by: Sahdev Zala <spzala@us.ibm.com>

