### PR TITLE
Cleanup the go.mod for etcdctl

### DIFF
--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -43,12 +43,8 @@ require (
 replace (
 	go.etcd.io/etcd/api/v3 => ../api
 	go.etcd.io/etcd/client/pkg/v3 => ../client/pkg
-	go.etcd.io/etcd/client/v2 => ../client/v2
 	go.etcd.io/etcd/client/v3 => ../client/v3
-	go.etcd.io/etcd/etcdutl/v3 => ../etcdutl
 	go.etcd.io/etcd/pkg/v3 => ../pkg
-	go.etcd.io/etcd/raft/v3 => ../raft
-	go.etcd.io/etcd/server/v3 => ../server
 )
 
 // Bad imports are sometimes causing attempts to pull that code.


### PR DESCRIPTION
etcdctl doesn't depend on the following packages at all,
1. go.etcd.io/etcd/client/v2
2. go.etcd.io/etcd/etcdutl/v3
3. go.etcd.io/etcd/raft/v3
4. go.etcd.io/etcd/server/v3

Signed-off-by: Benjamin Wang <wachao@vmware.com>
