### PR TITLE
Cleanup some e2e test configurations

### DIFF
--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -121,12 +121,11 @@ func dialWithSchemeTest(cx ctlCtx) {
 }
 
 type ctlCtx struct {
-	t                 *testing.T
-	apiPrefix         string
-	cfg               e2e.EtcdProcessClusterConfig
-	quotaBackendBytes int64
-	corruptFunc       func(string) error
-	noStrictReconfig  bool
+	t                *testing.T
+	apiPrefix        string
+	cfg              e2e.EtcdProcessClusterConfig
+	corruptFunc      func(string) error
+	noStrictReconfig bool
 
 	epc *e2e.EtcdProcessCluster
 
@@ -143,9 +142,6 @@ type ctlCtx struct {
 
 	initialCorruptCheck bool
 
-	// for compaction
-	compactPhysical bool
-
 	// dir that was used during the test
 	dataDir string
 }
@@ -156,6 +152,7 @@ func (cx *ctlCtx) applyOpts(opts []ctlOption) {
 	for _, opt := range opts {
 		opt(cx)
 	}
+
 	cx.initialCorruptCheck = true
 }
 
@@ -177,10 +174,6 @@ func withQuorum() ctlOption {
 
 func withInteractive() ctlOption {
 	return func(cx *ctlCtx) { cx.interactive = true }
-}
-
-func withQuota(b int64) ctlOption {
-	return func(cx *ctlCtx) { cx.quotaBackendBytes = b }
 }
 
 func withInitialCorruptCheck() ctlOption {
@@ -231,9 +224,6 @@ func testCtlWithOffline(t *testing.T, testFunc func(ctlCtx), testOfflineFunc fun
 
 	if !ret.quorum {
 		ret.cfg = *e2e.ConfigStandalone(ret.cfg)
-	}
-	if ret.quotaBackendBytes > 0 {
-		ret.cfg.QuotaBackendBytes = ret.quotaBackendBytes
 	}
 	ret.cfg.NoStrictReconfig = ret.noStrictReconfig
 	if ret.initialCorruptCheck {


### PR DESCRIPTION
See https://github.com/etcd-io/etcd/pull/14360#issuecomment-1227863196

Notes:
1. `compactPhysical` in `ctlCtx` and `withQuota` aren't used at all, they are dead code.
2. `quotaBackendBytes` in `ctlCtx` isn't used either. Instead, users (test cases) set the [QuotaBackendBytes](https://github.com/etcd-io/etcd/blob/e40828540cef4e7dbb92ed3ec65a666d87dc8519/tests/framework/e2e/cluster.go#L170) directly.
3. If we want to enable a feature (e.g. `initialCorruptCheck`) by default, then a best practice is to define the field as "`DisableXX`", such as `DisableInitialCorruptCheck bool`. Its value will be `false` by default if not set.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


