### PR TITLE
Add revive to the list of linters.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters:
     - staticcheck
     - stylecheck
     - unused
+    - revive
 
 linters-settings: # please keep this alphabetized
   staticcheck:

--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -60,7 +60,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		nodeId, err := strconv.ParseUint(key[1:], 0, 64)
+		nodeID, err := strconv.ParseUint(key[1:], 0, 64)
 		if err != nil {
 			log.Printf("Failed to convert ID for conf change (%v)\n", err)
 			http.Error(w, "Failed on POST", http.StatusBadRequest)
@@ -69,14 +69,14 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		cc := raftpb.ConfChange{
 			Type:    raftpb.ConfChangeAddNode,
-			NodeID:  nodeId,
+			NodeID:  nodeID,
 			Context: url,
 		}
 		h.confChangeC <- cc
 		// As above, optimistic that raft will apply the conf change
 		w.WriteHeader(http.StatusNoContent)
 	case http.MethodDelete:
-		nodeId, err := strconv.ParseUint(key[1:], 0, 64)
+		nodeID, err := strconv.ParseUint(key[1:], 0, 64)
 		if err != nil {
 			log.Printf("Failed to convert ID for conf change (%v)\n", err)
 			http.Error(w, "Failed on DELETE", http.StatusBadRequest)
@@ -85,7 +85,7 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		cc := raftpb.ConfChange{
 			Type:   raftpb.ConfChangeRemoveNode,
-			NodeID: nodeId,
+			NodeID: nodeID,
 		}
 		h.confChangeC <- cc
 
@@ -100,8 +100,8 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// serveHttpKVAPI starts a key-value server with a GET/PUT API and listens.
-func serveHttpKVAPI(kv *kvstore, port int, confChangeC chan<- raftpb.ConfChange, errorC <-chan error) {
+// serveHTTPKVAPI starts a key-value server with a GET/PUT API and listens.
+func serveHTTPKVAPI(kv *kvstore, port int, confChangeC chan<- raftpb.ConfChange, errorC <-chan error) {
 	srv := http.Server{
 		Addr: ":" + strconv.Itoa(port),
 		Handler: &httpKVAPI{

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -41,5 +41,5 @@ func main() {
 	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
-	serveHttpKVAPI(kvs, *kvport, confChangeC, errorC)
+	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/bgentry/speakeasy"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/report"
 	"google.golang.org/grpc/grpclog"
 )
@@ -47,16 +47,16 @@ func mustFindLeaderEndpoints(c *clientv3.Client) {
 		os.Exit(1)
 	}
 
-	leaderId := uint64(0)
+	leaderID := uint64(0)
 	for _, ep := range c.Endpoints() {
 		if sresp, serr := c.Status(context.TODO(), ep); serr == nil {
-			leaderId = sresp.Leader
+			leaderID = sresp.Leader
 			break
 		}
 	}
 
 	for _, m := range resp.Members {
-		if m.ID == leaderId {
+		if m.ID == leaderID {
 			leaderEps = m.ClientURLs
 			return
 		}

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -44,8 +44,8 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 		t.Skipf("%q does not exist", dumpLogsBinary)
 	}
 
-	decoder_correctoutputformat := filepath.Join(binDir, "/testdecoder/decoder_correctoutputformat.sh")
-	decoder_wrongoutputformat := filepath.Join(binDir, "/testdecoder/decoder_wrongoutputformat.sh")
+	decoderCorrectOutputFormat := filepath.Join(binDir, "/testdecoder/decoder_correctoutputformat.sh")
+	decoderWrongOutputFormat := filepath.Join(binDir, "/testdecoder/decoder_wrongoutputformat.sh")
 
 	p := t.TempDir()
 
@@ -100,8 +100,8 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 		{"lease grant entry-type", []string{"-entry-type", "IRRLeaseGrant", p}, "expectedoutput/listIRRLeaseGrant.output"},
 		{"lease revoke entry-type", []string{"-entry-type", "IRRLeaseRevoke", p}, "expectedoutput/listIRRLeaseRevoke.output"},
 		{"confchange and txn entry-type", []string{"-entry-type", "ConfigChange,IRRCompaction", p}, "expectedoutput/listConfigChangeIRRCompaction.output"},
-		{"decoder_correctoutputformat", []string{"-stream-decoder", decoder_correctoutputformat, p}, "expectedoutput/decoder_correctoutputformat.output"},
-		{"decoder_wrongoutputformat", []string{"-stream-decoder", decoder_wrongoutputformat, p}, "expectedoutput/decoder_wrongoutputformat.output"},
+		{"decoder_correctoutputformat", []string{"-stream-decoder", decoderCorrectOutputFormat, p}, "expectedoutput/decoder_correctoutputformat.output"},
+		{"decoder_wrongoutputformat", []string{"-stream-decoder", decoderWrongOutputFormat, p}, "expectedoutput/decoder_wrongoutputformat.output"},
 	}
 
 	for _, argtest := range argtests {

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -90,12 +90,12 @@ and output a hex encoded line of binary for each input line`)
 		case nil:
 			walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
 			nodes := genIDSlice(snapshot.Metadata.ConfState.Voters)
-			confstateJson, err := json.Marshal(snapshot.Metadata.ConfState)
+			confStateJSON, err := json.Marshal(snapshot.Metadata.ConfState)
 			if err != nil {
-				confstateJson = []byte(fmt.Sprintf("confstate err: %v", err))
+				confStateJSON = []byte(fmt.Sprintf("confstate err: %v", err))
 			}
 			fmt.Printf("Snapshot:\nterm=%d index=%d nodes=%s confstate=%s\n",
-				walsnap.Term, walsnap.Index, nodes, confstateJson)
+				walsnap.Term, walsnap.Index, nodes, confStateJSON)
 		case snap.ErrNoSnapshot:
 			fmt.Printf("Snapshot:\nempty\n")
 		default:
@@ -372,9 +372,9 @@ func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry
 				return
 			}
 
-			decoder_status, decoded_data := parseDecoderOutput(decoderoutput)
+			decoderStatus, decodedData := parseDecoderOutput(decoderoutput)
 
-			fmt.Printf("\t%s\t%s", decoder_status, decoded_data)
+			fmt.Printf("\t%s\t%s", decoderStatus, decodedData)
 		}
 	}
 
@@ -393,19 +393,19 @@ func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry
 }
 
 func parseDecoderOutput(decoderoutput string) (string, string) {
-	var decoder_status string
-	var decoded_data string
+	var decoderStatus string
+	var decodedData string
 	output := strings.Split(decoderoutput, "|")
 	switch len(output) {
 	case 1:
-		decoder_status = "decoder output format is not right, print output anyway"
-		decoded_data = decoderoutput
+		decoderStatus = "decoder output format is not right, print output anyway"
+		decodedData = decoderoutput
 	case 2:
-		decoder_status = output[0]
-		decoded_data = output[1]
+		decoderStatus = output[0]
+		decodedData = output[1]
 	default:
-		decoder_status = output[0] + "(*WARNING: data might contain deliminator used by etcd-dump-logs)"
-		decoded_data = strings.Join(output[1:], "")
+		decoderStatus = output[0] + "(*WARNING: data might contain deliminator used by etcd-dump-logs)"
+		decodedData = strings.Join(output[1:], "")
 	}
-	return decoder_status, decoded_data
+	return decoderStatus, decodedData
 }


### PR DESCRIPTION
Part of "Enhance the static-analysis workflow" issue. #14164

The list of issues found and fixed were:
```
[dev:etcd]{main}% make lint
golangci-lint run
tools/etcd-dump-logs/etcd-dump-log_test.go:47:2: var-naming: don't use underscores in Go names; var decoder_correctoutputformat should be decoderCorrectoutputformat (revive)
        decoder_correctoutputformat := filepath.Join(binDir, "/testdecoder/decoder_correctoutputformat.sh")
        ^
tools/etcd-dump-logs/etcd-dump-log_test.go:48:2: var-naming: don't use underscores in Go names; var decoder_wrongoutputformat should be decoderWrongoutputformat (revive)
        decoder_wrongoutputformat := filepath.Join(binDir, "/testdecoder/decoder_wrongoutputformat.sh")
        ^
tools/etcd-dump-logs/main.go:93:4: var-naming: var confstateJson should be confstateJSON (revive)
                        confstateJson, err := json.Marshal(snapshot.Metadata.ConfState)
                        ^
tools/etcd-dump-logs/main.go:375:4: var-naming: don't use underscores in Go names; var decoder_status should be decoderStatus (revive)
                        decoder_status, decoded_data := parseDecoderOutput(decoderoutput)
                        ^
tools/etcd-dump-logs/main.go:396:6: var-naming: don't use underscores in Go names; var decoder_status should be decoderStatus (revive)
        var decoder_status string
            ^
tools/etcd-dump-logs/main.go:397:6: var-naming: don't use underscores in Go names; var decoded_data should be decodedData (revive)
        var decoded_data string
            ^
contrib/raftexample/httpapi.go:63:3: var-naming: var nodeId should be nodeID (revive)
                nodeId, err := strconv.ParseUint(key[1:], 0, 64)
                ^
contrib/raftexample/httpapi.go:79:3: var-naming: var nodeId should be nodeID (revive)
                nodeId, err := strconv.ParseUint(key[1:], 0, 64)
                ^
contrib/raftexample/httpapi.go:104:6: var-naming: func serveHttpKVAPI should be serveHTTPKVAPI (revive)
func serveHttpKVAPI(kv *kvstore, port int, confChangeC chan<- raftpb.ConfChange, errorC <-chan error) {
     ^
tools/benchmark/cmd/util.go:50:2: var-naming: var leaderId should be leaderID (revive)
        leaderId := uint64(0)
        ^
make: *** [lint] Error 1
```