### PR TITLE
[test] add the missing parameter 'name' into SpawnCmdWithLogger for cov test

### DIFF
--- a/tests/framework/e2e/etcd_spawn_cov.go
+++ b/tests/framework/e2e/etcd_spawn_cov.go
@@ -36,7 +36,7 @@ var (
 	coverDir = integration.MustAbsPath(os.Getenv("COVERDIR"))
 )
 
-func SpawnCmdWithLogger(lg *zap.Logger, args []string, envVars map[string]string) (*expect.ExpectProcess, error) {
+func SpawnCmdWithLogger(lg *zap.Logger, args []string, envVars map[string]string, name string) (*expect.ExpectProcess, error) {
 	cmd := args[0]
 	env := mergeEnvVariables(envVars)
 	switch {
@@ -63,9 +63,13 @@ func SpawnCmdWithLogger(lg *zap.Logger, args []string, envVars map[string]string
 	// when withFlagByEnv() is used in testCtl(), env variables for ctl is set to os.env.
 	// they must be included in ctl_cov_env.
 
-	all_args := append(args[1:], covArgs...)
-	lg.Info("spawning process", zap.Strings("args", all_args), zap.String("working-dir", wd))
-	ep, err := expect.NewExpectWithEnv(cmd, all_args, env)
+	allArgs := append(args[1:], covArgs...)
+	lg.Info("spawning process in cov test",
+		zap.Strings("args", args),
+		zap.String("working-dir", wd),
+		zap.String("name", name),
+		zap.Strings("environment-variables", env))
+	ep, err := expect.NewExpectWithEnv(cmd, allArgs, env, name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/14393 , which should be caused by https://github.com/etcd-io/etcd/commit/51933a7c8bc3fdb4ad60693b99cabe2df34b6127 

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @tjungblu 
