### PR TITLE
[test] Fix test code compiling error due to not enough arguments 

### DIFF
--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -1401,7 +1401,7 @@ func authTestCacheReload(cx ctlCtx) {
 
 	// restart the node
 	node0.WithStopSignal(syscall.SIGINT)
-	if err := node0.Restart(); err != nil {
+	if err := node0.Restart(context.TODO()); err != nil {
 		cx.t.Fatal(err)
 	}
 

--- a/tests/e2e/no_quorum_ready_test.go
+++ b/tests/e2e/no_quorum_ready_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -31,7 +32,7 @@ func TestInitDaemonNotifyWithoutQuorum(t *testing.T) {
 	epc.Procs = epc.Procs[:1]
 
 	// Start the etcd cluster with only one member
-	if err := epc.Start(); err != nil {
+	if err := epc.Start(context.TODO()); err != nil {
 		t.Fatalf("Failed to start the etcd cluster: %v", err)
 	}
 


### PR DESCRIPTION
Pipeline error caused by https://github.com/etcd-io/etcd/commit/70de5c8937b3ffc045afa1e12b89d2beb107d98e

```
stderr: go: downloading golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
stderr: # go.etcd.io/etcd/tests/v3/e2e
Error: stderr: vet: e2e/ctl_v3_auth_test.go:1404:26: not enough arguments in call to node0.Restart
FAIL: (code:2):
  % (cd tests && 'go' 'vet' './...')

FAIL: 'run go vet ./...' checking failed (!=0 return code)
FAIL: 'govet' failed at Tue Aug 30 03:07:13 UTC 2022
```

Refer to https://github.com/etcd-io/etcd/runs/8083906786?check_suite_focus=true

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @ptabor 

I will update the CI to add build for the test code in a separate PR. 
