### PR TITLE
chore: remove duplicate word in comments

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -3250,7 +3250,7 @@ func TestAddNodeCheckQuorum(t *testing.T) {
 }
 
 // TestRemoveNode tests that removeNode could update nodes and
-// and removed list correctly.
+// removed list correctly.
 func TestRemoveNode(t *testing.T) {
 	r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
 	r.applyConfChange(pb.ConfChange{NodeID: 2, Type: pb.ConfChangeRemoveNode}.AsV2())
@@ -3269,7 +3269,7 @@ func TestRemoveNode(t *testing.T) {
 }
 
 // TestRemoveLearner tests that removeNode could update nodes and
-// and removed list correctly.
+// removed list correctly.
 func TestRemoveLearner(t *testing.T) {
 	r := newTestLearnerRaft(1, 10, 1, newTestMemoryStorage(withPeers(1), withLearners(2)))
 	r.applyConfChange(pb.ConfChange{NodeID: 2, Type: pb.ConfChangeRemoveNode}.AsV2())


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

same with #14390, but the key word is `and`.