### PR TITLE
Procfiles: Update Goreman Installation Command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-# Use goreman to run `go get github.com/mattn/goreman`
+# Use goreman to run `go install github.com/mattn/goreman@latest`
 # Change the path of bin/etcd if etcd is located elsewhere
 
 etcd1: bin/etcd --name infra1 --listen-client-urls http://127.0.0.1:2379 --advertise-client-urls http://127.0.0.1:2379 --listen-peer-urls http://127.0.0.1:12380 --initial-advertise-peer-urls http://127.0.0.1:12380 --initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new --enable-pprof --logger=zap --log-outputs=stderr

--- a/Procfile.learner
+++ b/Procfile.learner
@@ -1,4 +1,4 @@
-# Use goreman to run `go get github.com/mattn/goreman`
+# Use goreman to run `go install github.com/mattn/goreman@latest`
 
 # 1. Start the cluster using Procfile
 # 2. Add learner node to the cluster

--- a/Procfile.v2
+++ b/Procfile.v2
@@ -1,4 +1,4 @@
-# Use goreman to run `go get github.com/mattn/goreman`
+# Use goreman to run `go install github.com/mattn/goreman@latest`
 # Change the path of bin/etcd if etcd is located elsewhere
 etcd1: bin/etcd --name infra1 --listen-client-urls http://127.0.0.1:2379 --advertise-client-urls http://127.0.0.1:2379 --listen-peer-urls http://127.0.0.1:12380 --initial-advertise-peer-urls http://127.0.0.1:12380 --initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new --enable-pprof
 etcd2: bin/etcd --name infra2 --listen-client-urls http://127.0.0.1:22379 --advertise-client-urls http://127.0.0.1:22379 --listen-peer-urls http://127.0.0.1:22380 --initial-advertise-peer-urls http://127.0.0.1:22380 --initial-cluster-token etcd-cluster-1 --initial-cluster 'infra1=http://127.0.0.1:12380,infra2=http://127.0.0.1:22380,infra3=http://127.0.0.1:32380' --initial-cluster-state new --enable-pprof


### PR DESCRIPTION
Starting in Go 1.17, Installing executables with go get is deprecated. go install may be used instead.

Refer to https://go.dev/doc/go-get-install-deprecation


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
