### PR TITLE
Move consistent_index forward when executing alarmList operation

### DIFF
--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -32,4 +32,5 @@ type ClusterConfig struct {
 	ClientTLS                  TLSConfig
 	QuotaBackendBytes          int64
 	DisableStrictReconfigCheck bool
+	SnapshotCount              int
 }

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -47,6 +47,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.Clus
 		ClusterSize:                cfg.ClusterSize,
 		QuotaBackendBytes:          cfg.QuotaBackendBytes,
 		DisableStrictReconfigCheck: cfg.DisableStrictReconfigCheck,
+		SnapshotCount:              cfg.SnapshotCount,
 	}
 	switch cfg.ClientTLS {
 	case config.NoTLS:
@@ -175,7 +176,7 @@ func (m e2eMember) Client() Client {
 }
 
 func (m e2eMember) Start(ctx context.Context) error {
-	return m.Restart(ctx)
+	return m.EtcdProcess.Start(ctx)
 }
 
 func (m e2eMember) Stop() {

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -44,11 +44,13 @@ func (e integrationRunner) BeforeTest(t testing.TB) {
 
 func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.ClusterConfig) Cluster {
 	var err error
-	var integrationCfg integration.ClusterConfig
-	integrationCfg.Size = cfg.ClusterSize
+	integrationCfg := integration.ClusterConfig{
+		Size:                       cfg.ClusterSize,
+		QuotaBackendBytes:          cfg.QuotaBackendBytes,
+		DisableStrictReconfigCheck: cfg.DisableStrictReconfigCheck,
+		SnapshotCount:              uint64(cfg.SnapshotCount),
+	}
 	integrationCfg.ClientTLS, err = tlsInfo(t, cfg.ClientTLS)
-	integrationCfg.QuotaBackendBytes = cfg.QuotaBackendBytes
-	integrationCfg.DisableStrictReconfigCheck = cfg.DisableStrictReconfigCheck
 	if err != nil {
 		t.Fatalf("ClientTLS: %s", err)
 	}


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/14382

The alarm list is the only exception that doesn't move consistent_index
forward. The reproduction steps are as simple as,

```
etcd --snapshot-count=5 &
for i in {1..6}; do etcdctl  alarm list; done
kill -9 <etcd_pid>
etcd
```

Signed-off-by: Benjamin Wang <wachao@vmware.com>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
