### PR TITLE
testing: fix TestOpenWithMaxIndex cleanup

### DIFF
--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -635,24 +635,31 @@ func TestOpenForRead(t *testing.T) {
 func TestOpenWithMaxIndex(t *testing.T) {
 	p := t.TempDir()
 	// create WAL
-	w, err := Create(zaptest.NewLogger(t), p, nil)
+	w1, err := Create(zaptest.NewLogger(t), p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer w.Close()
+	defer func() {
+		if w1 != nil {
+			w1.Close()
+		}
+	}()
 
 	es := []raftpb.Entry{{Index: uint64(math.MaxInt64)}}
-	if err = w.Save(raftpb.HardState{}, es); err != nil {
+	if err = w1.Save(raftpb.HardState{}, es); err != nil {
 		t.Fatal(err)
 	}
-	w.Close()
+	w1.Close()
+	w1 = nil
 
-	w, err = Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
+	w2, err := Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, err = w.ReadAll()
-	if err == nil || err != ErrSliceOutOfRange {
+	defer w2.Close()
+
+	_, _, _, err = w2.ReadAll()
+	if err != ErrSliceOutOfRange {
 		t.Fatalf("err = %v, want ErrSliceOutOfRange", err)
 	}
 }


### PR DESCRIPTION
A WAL object was closed by defer, however the WAL was rewritten afterwards,
so defer closed already closed WAL but not the new one. It caused a data
race between writing file and cleaning up a temporary test directory,
which led to a non-deterministic bug.

Fixes #14332
