### PR TITLE
[release-3.4] fix the potential data loss for clusters with only one member

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -215,6 +215,18 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 					notifyc:  notifyc,
 				}
 
+				waitWALSync := shouldWaitWALSync(rd)
+				if waitWALSync {
+					// gofail: var raftBeforeSaveWaitWalSync struct{}
+					if err := r.storage.Save(rd.HardState, rd.Entries); err != nil {
+						if r.lg != nil {
+							r.lg.Fatal("failed to save Raft hard state and entries", zap.Error(err))
+						} else {
+							plog.Fatalf("failed to save state and entries error: %v", err)
+						}
+					}
+				}
+
 				updateCommittedIndex(&ap, rh)
 
 				select {
@@ -245,12 +257,14 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 					// gofail: var raftAfterSaveSnap struct{}
 				}
 
-				// gofail: var raftBeforeSave struct{}
-				if err := r.storage.Save(rd.HardState, rd.Entries); err != nil {
-					if r.lg != nil {
-						r.lg.Fatal("failed to save Raft hard state and entries", zap.Error(err))
-					} else {
-						plog.Fatalf("failed to save state and entries error: %v", err)
+				if !waitWALSync {
+					// gofail: var raftBeforeSave struct{}
+					if err := r.storage.Save(rd.HardState, rd.Entries); err != nil {
+						if r.lg != nil {
+							r.lg.Fatal("failed to save Raft hard state and entries", zap.Error(err))
+						} else {
+							plog.Fatalf("failed to save state and entries error: %v", err)
+						}
 					}
 				}
 				if !raft.IsEmptyHardState(rd.HardState) {
@@ -340,6 +354,42 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 			}
 		}
 	}()
+}
+
+// For a cluster with only one member, the raft may send both the
+// unstable entries and committed entries to etcdserver, and there
+// may have overlapped log entries between them.
+//
+// etcd responds to the client once it finishes (actually partially)
+// the applying workflow. But when the client receives the response,
+// it doesn't mean etcd has already successfully saved the data,
+// including BoltDB and WAL, because:
+//    1. etcd commits the boltDB transaction periodically instead of on each request;
+//    2. etcd saves WAL entries in parallel with applying the committed entries.
+// Accordingly, it might run into a situation of data loss when the etcd crashes
+// immediately after responding to the client and before the boltDB and WAL
+// successfully save the data to disk.
+// Note that this issue can only happen for clusters with only one member.
+//
+// For clusters with multiple members, it isn't an issue, because etcd will
+// not commit & apply the data before it being replicated to majority members.
+// When the client receives the response, it means the data must have been applied.
+// It further means the data must have been committed.
+// Note: for clusters with multiple members, the raft will never send identical
+// unstable entries and committed entries to etcdserver.
+//
+// Refer to https://github.com/etcd-io/etcd/issues/14370.
+func shouldWaitWALSync(rd raft.Ready) bool {
+	if len(rd.CommittedEntries) == 0 || len(rd.Entries) == 0 {
+		return false
+	}
+
+	// Check if there is overlap between unstable and committed entries
+	// assuming that their index and term are only incrementing.
+	lastCommittedEntry := rd.CommittedEntries[len(rd.CommittedEntries)-1]
+	firstUnstableEntry := rd.Entries[0]
+	return lastCommittedEntry.Term > firstUnstableEntry.Term ||
+		(lastCommittedEntry.Term == firstUnstableEntry.Term && lastCommittedEntry.Index >= firstUnstableEntry.Index)
 }
 
 func updateCommittedIndex(ap *apply, rh *raftReadyHandler) {

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/etcdserver/api/membership"
 	"go.etcd.io/etcd/pkg/mock/mockstorage"
 	"go.etcd.io/etcd/pkg/pbutil"
@@ -265,5 +266,81 @@ func TestProcessDuplicatedAppRespMessage(t *testing.T) {
 	got, want := <-sendc, 1
 	if got != want {
 		t.Errorf("count = %d, want %d", got, want)
+	}
+}
+
+func TestShouldWaitWALSync(t *testing.T) {
+	testcases := []struct {
+		name            string
+		unstableEntries []raftpb.Entry
+		commitedEntries []raftpb.Entry
+		expectedResult  bool
+	}{
+		{
+			name:            "both entries are nil",
+			unstableEntries: nil,
+			commitedEntries: nil,
+			expectedResult:  false,
+		},
+		{
+			name:            "both entries are empty slices",
+			unstableEntries: []raftpb.Entry{},
+			commitedEntries: []raftpb.Entry{},
+			expectedResult:  false,
+		},
+		{
+			name:            "one nil and the other empty",
+			unstableEntries: nil,
+			commitedEntries: []raftpb.Entry{},
+			expectedResult:  false,
+		},
+		{
+			name:            "one nil and the other has data",
+			unstableEntries: nil,
+			commitedEntries: []raftpb.Entry{{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			expectedResult:  false,
+		},
+		{
+			name:            "one empty and the other has data",
+			unstableEntries: []raftpb.Entry{},
+			commitedEntries: []raftpb.Entry{{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			expectedResult:  false,
+		},
+		{
+			name:            "has different term and index",
+			unstableEntries: []raftpb.Entry{{Term: 5, Index: 11, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			commitedEntries: []raftpb.Entry{{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			expectedResult:  false,
+		},
+		{
+			name:            "has identical data",
+			unstableEntries: []raftpb.Entry{{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			commitedEntries: []raftpb.Entry{{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}}},
+			expectedResult:  true,
+		},
+		{
+			name: "has overlapped entry",
+			unstableEntries: []raftpb.Entry{
+				{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}},
+				{Term: 4, Index: 11, Type: raftpb.EntryNormal, Data: []byte{0x44, 0x55, 0x66}},
+				{Term: 4, Index: 12, Type: raftpb.EntryNormal, Data: []byte{0x77, 0x88, 0x99}},
+			},
+			commitedEntries: []raftpb.Entry{
+				{Term: 4, Index: 8, Type: raftpb.EntryNormal, Data: []byte{0x07, 0x08, 0x09}},
+				{Term: 4, Index: 9, Type: raftpb.EntryNormal, Data: []byte{0x10, 0x11, 0x12}},
+				{Term: 4, Index: 10, Type: raftpb.EntryNormal, Data: []byte{0x11, 0x22, 0x33}},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			shouldWALSync := shouldWaitWALSync(raft.Ready{
+				Entries:          tc.unstableEntries,
+				CommittedEntries: tc.commitedEntries,
+			})
+			assert.Equal(t, tc.expectedResult, shouldWALSync)
+		})
 	}
 }


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/14400 to v3.4 fixing https://github.com/etcd-io/etcd/issues/14370

Benchmarking showed 4.5% performance degradation.

Command
```
./bin/etcd --quota-backend-bytes=4300000000
bin/tools/benchmark txn-put --endpoints="http://127.0.0.1:2379" --clients=200 --conns=200 --key-space-size=4000000000 --key-size=128 --val-size=10240  --total=200000 --rate=40000
```

Before 
```
Summary:
  Total:	23.7596 secs.
  Slowest:	0.0911 secs.
  Fastest:	0.0020 secs.
  Average:	0.0236 secs.
  Stddev:	0.0181 secs.
  Requests/sec:	8417.6492

Response time histogram:
  0.0020 [1]	|
  0.0109 [9664]	|∎∎
  0.0198 [130352]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0287 [20841]	|∎∎∎∎∎∎
  0.0376 [5570]	|∎
  0.0465 [1158]	|
  0.0554 [6105]	|∎
  0.0643 [14826]	|∎∎∎∎
  0.0732 [8162]	|∎∎
  0.0821 [2434]	|
  0.0911 [887]	|

Latency distribution:
  10% in 0.0115 secs.
  25% in 0.0129 secs.
  50% in 0.0155 secs.
  75% in 0.0222 secs.
  90% in 0.0593 secs.
  95% in 0.0654 secs.
  99% in 0.0771 secs.
  99.9% in 0.0883 secs.
```

After
```
Summary:
  Total:	24.8914 secs.
  Slowest:	0.1210 secs.
  Fastest:	0.0073 secs.
  Average:	0.0248 secs.
  Stddev:	0.0178 secs.
  Requests/sec:	8034.9071

Response time histogram:
  0.0073 [1]	|
  0.0186 [123685]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0300 [35753]	|∎∎∎∎∎∎∎∎∎∎∎
  0.0414 [5384]	|∎
  0.0528 [5270]	|∎
  0.0642 [19048]	|∎∎∎∎∎∎
  0.0755 [8874]	|∎∎
  0.0869 [1528]	|
  0.0983 [253]	|
  0.1097 [4]	|
  0.1210 [200]	|

Latency distribution:
  10% in 0.0131 secs.
  25% in 0.0141 secs.
  50% in 0.0167 secs.
  75% in 0.0235 secs.
  90% in 0.0592 secs.
  95% in 0.0649 secs.
  99% in 0.0754 secs.
  99.9% in 0.1118 secs.
```