### PR TITLE
[release-3.5] server/etcdmain: add build support for Apple M1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,7 @@ jobs:
             GOARCH=amd64 PASSES='build' ./test.sh
             GOARCH=386 PASSES='build' ./test.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=amd64 ./build.sh
+            GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=arm64 ./build.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOOS=windows GOARCH=amd64 ./build.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm ./build.sh
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm64 ./build.sh

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -79,6 +79,10 @@ function main {
       TARGET_ARCHS+=("s390x")
     fi
 
+    if [ ${GOOS} == "darwin" ]; then
+      TARGET_ARCHS+=("arm64")
+    fi
+
     for TARGET_ARCH in "${TARGET_ARCHS[@]}"; do
       export GOARCH=${TARGET_ARCH}
 


### PR DESCRIPTION
Backports https://github.com/etcd-io/etcd/pull/13545 to release-3.5
Fixes https://github.com/etcd-io/etcd/issues/14001