### PR TITLE
[release-3.5] testing: fix TestOpenWithMaxIndex cleanup

### DIFF
--- a/server/wal/wal_test.go
+++ b/server/wal/wal_test.go
@@ -691,24 +691,31 @@ func TestOpenWithMaxIndex(t *testing.T) {
 	}
 	defer os.RemoveAll(p)
 	// create WAL
-	w, err := Create(zap.NewExample(), p, nil)
+	w1, err := Create(zap.NewExample(), p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer w.Close()
+	defer func() {
+		if w1 != nil {
+			w1.Close()
+		}
+	}()
 
 	es := []raftpb.Entry{{Index: uint64(math.MaxInt64)}}
-	if err = w.Save(raftpb.HardState{}, es); err != nil {
+	if err = w1.Save(raftpb.HardState{}, es); err != nil {
 		t.Fatal(err)
 	}
-	w.Close()
+	w1.Close()
+	w1 = nil
 
-	w, err = Open(zap.NewExample(), p, walpb.Snapshot{})
+	w2, err := Open(zap.NewExample(), p, walpb.Snapshot{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, err = w.ReadAll()
-	if err == nil || err != ErrSliceOutOfRange {
+	defer w2.Close()
+
+	_, _, _, err = w2.ReadAll()
+	if err != ErrSliceOutOfRange {
 		t.Fatalf("err = %v, want ErrSliceOutOfRange", err)
 	}
 }


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/14421 to v3.5 fixing https://github.com/etcd-io/etcd/issues/14332

A WAL object was closed by defer, however the WAL was rewritten afterwards, so defer closed already closed WAL but not the new one. It caused a data race between writing file and cleaning up a temporary test directory, which led to a non-deterministic bug.

Fixes #14332
