### PR TITLE
etcdctl: fix move-leader for multiple endpoints

### DIFF
--- a/etcdctl/ctlv3/command/move_leader_command.go
+++ b/etcdctl/ctlv3/command/move_leader_command.go
@@ -43,9 +43,10 @@ func transferLeadershipCommandFunc(cmd *cobra.Command, args []string) {
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
 
-	c := mustClientFromCmd(cmd)
-	eps := c.Endpoints()
-	c.Close()
+	cfg := clientConfigFromCmd(cmd)
+	cli := mustClient(cfg)
+	eps := cli.Endpoints()
+	cli.Close()
 
 	ctx, cancel := commandCtx(cmd)
 
@@ -53,7 +54,6 @@ func transferLeadershipCommandFunc(cmd *cobra.Command, args []string) {
 	var leaderCli *clientv3.Client
 	var leaderID uint64
 	for _, ep := range eps {
-		cfg := clientConfigFromCmd(cmd)
 		cfg.Endpoints = []string{ep}
 		cli := mustClient(cfg)
 		resp, serr := cli.Status(ctx, ep)


### PR DESCRIPTION
Due to a duplicate call of clientConfigFromCmd, the move-leader command would fail with "conflicting environment variable is shadowed by corresponding command-line flag". Also in scenarios where no command-line flag was supplied.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

---

main pick of #14434 and #14441 
thanks @ahrtr for triple checking me :)