### PR TITLE
changelog: update the recommended version to 3.5.4+

### DIFF
--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -6,6 +6,6 @@ The minimum recommended etcd versions to run in **production** are v3.4.8+ and v
 
 Running etcd v3.5.2, v3.5.1 and v3.5.0 under high load can cause a data corruption issue.
 If etcd process is killed, occasionally some committed transactions are not reflected on all the members.
-Recommendation is to upgrade to v3.5.3.
+Recommendation is to upgrade to v3.5.4+.
 
 If you have encountered data corruption, please follow instructions on https://etcd.io/docs/v3.5/op-guide/data_corruption/.


### PR DESCRIPTION
We already mention `The minimum recommended etcd versions to run in production are v3.4.8+ and v3.5.4+.` in [CHANGELOG/README.md](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/README.md), so let's keep it consistent. Actually there is also a minor regression bug in 3.5.3, so 3.5.4 is better. 


Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc  @serathius @spzala 

