### PR TITLE
Update changelog for 3.4.21

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,12 +4,13 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
-## v3.4.21 (TBD)
+## v3.4.21 (2022-09-15)
 
 ### etcd server
 - Fix [Durability API guarantee broken in single node cluster](https://github.com/etcd-io/etcd/pull/14423)
 - Fix [Panic due to nil log object](https://github.com/etcd-io/etcd/pull/14420)
 - Fix [authentication data not loaded on member startup](https://github.com/etcd-io/etcd/pull/14410)
+- Fix [exit with error on shadowed environment variables](https://github.com/etcd-io/etcd/pull/14441)
 
 ### etcdctl v3
 


### PR DESCRIPTION
3.4.21 is just released. 
FYI. https://github.com/etcd-io/etcd/releases/tag/v3.4.21 

Signed-off-by: Benjamin Wang <wachao@vmware.com>


cc @spzala @serathius @mitake 
