### PR TITLE
Changelog: correct the 3.4 changelog item

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -10,7 +10,6 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [Durability API guarantee broken in single node cluster](https://github.com/etcd-io/etcd/pull/14423)
 - Fix [Panic due to nil log object](https://github.com/etcd-io/etcd/pull/14420)
 - Fix [authentication data not loaded on member startup](https://github.com/etcd-io/etcd/pull/14410)
-- Fix [exit with error on shadowed environment variables](https://github.com/etcd-io/etcd/pull/14441)
 
 ### etcdctl v3
 


### PR DESCRIPTION
There are duplicated items for https://github.com/etcd-io/etcd/pull/14441. Since it's a `etcdctl` side change, so we should keep the item under `etcdctl`, and remove the duplicated item under "`etcd server`"

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius @spzala My mistake, sorry for inconvenience. 