### PR TITLE
Add experimental-kvproxy-cache-age to the grpc-proxy

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -32,7 +32,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/flags"
 	"go.etcd.io/etcd/pkg/v3/netutil"
 	"go.etcd.io/etcd/server/v3/config"
@@ -66,6 +66,9 @@ const (
 	DefaultGRPCKeepAliveTimeout        = 20 * time.Second
 	DefaultDowngradeCheckTime          = 5 * time.Second
 	DefaultWaitClusterReadyTimeout     = 5 * time.Second
+
+	// grpc-proxy kvProxy cache valid age
+	DefaultGrpcProxyKvCacheAge = 10 * time.Second
 
 	DefaultDiscoveryDialTimeout      = 2 * time.Second
 	DefaultDiscoveryRequestTimeOut   = 5 * time.Second

--- a/server/proxy/grpcproxy/metrics.go
+++ b/server/proxy/grpcproxy/metrics.go
@@ -58,6 +58,12 @@ var (
 		Name:      "cache_misses_total",
 		Help:      "Total number of cache misses",
 	})
+	cachedExpired = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "etcd",
+		Subsystem: "grpc_proxy",
+		Name:      "cache_expired_total",
+		Help:      "Total number of cache expired",
+	})
 )
 
 func init() {
@@ -66,6 +72,7 @@ func init() {
 	prometheus.MustRegister(cacheKeys)
 	prometheus.MustRegister(cacheHits)
 	prometheus.MustRegister(cachedMisses)
+	prometheus.MustRegister(cachedExpired)
 }
 
 // HandleMetrics performs a GET request against etcd endpoint and returns '/metrics'.

--- a/tests/framework/integration/cluster_proxy.go
+++ b/tests/framework/integration/cluster_proxy.go
@@ -23,6 +23,7 @@ import (
 
 	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/namespace"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter"
 )
@@ -65,7 +66,7 @@ func ToGRPC(c *clientv3.Client) GrpcAPI {
 	c.Watcher = namespace.NewWatcher(c.Watcher, proxyNamespace)
 	c.Lease = namespace.NewLease(c.Lease, proxyNamespace)
 	// test coalescing/caching proxy
-	kvp, kvpch := grpcproxy.NewKvProxy(c)
+	kvp, kvpch := grpcproxy.NewKvProxy(c, embed.DefaultGrpcProxyKvCacheAge)
 	wp, wpch := grpcproxy.NewWatchProxy(ctx, lg, c)
 	lp, lpch := grpcproxy.NewLeaseProxy(ctx, c)
 	mp := grpcproxy.NewMaintenanceProxy(c)

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -21,7 +21,8 @@ import (
 	"time"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 	"google.golang.org/grpc"
@@ -75,7 +76,7 @@ func newKVProxyServer(endpoints []string, t *testing.T) *kvproxyTestServer {
 		t.Fatal(err)
 	}
 
-	kvp, _ := grpcproxy.NewKvProxy(client)
+	kvp, _ := grpcproxy.NewKvProxy(client, embed.DefaultGrpcProxyKvCacheAge)
 
 	kvts := &kvproxyTestServer{
 		kp: kvp,


### PR DESCRIPTION
add experimental-kvproxy-cache-age to support grpc-proxy kv.Range response cache ttl feature

Signed-off-by: stefan bo <stefan_bo@163.com>

## Background

- etcd as our all app config center, the connection is huge, we prefer the grpc-proxy mode with watchers_coalescing feature to reduce etcd server pressure
- With our prod environment, we use domain name and  L4 proxy to connect grpc-proxy and etcd server
    - When watcher increase too huge, just need to add grpc-proxy instances to share watcher connections
    - For watcher scenario, we use L4 Proxy with Session Persistence feature
    - In this topography, ops can do upgrade or other work flexibly without bad effects
- Almost like(localhost with my dev environment to simulate prod env)

```mermaid
graph LR
A(etcd-naming.local.com) -- A record --> B(L4 proxy localhost:9999)
B -- 5s timeout --> D(grpc-proxy localhost:2379)
B -- 5s timeout --> E(grpc-proxy localhost:2479)
B -- 5s timeout --> F(grpc-proxy localhost:2579)
D --> H(192.168.56.31:2379)
D --> I
D --> J
E --> I(192.168.56.32:2379)
E --> H
E --> J
F --> J(192.168.56.33:2379)
F --> H
F --> I
```
- After a period of running, dev find out some strange connect problem: `grpc:appnameA` prefix has some wrong IP. etcdctl get output is right and without wrong IP, but grpc-proxy instances has the wrong IP.
- read etcd proxy code, we find the cache add and delete logic and cache with LRU algorithm. If grpc-proxy is just one instances, the problem will not appear. But in our env, we have three grpc-proxy instances, the procedure will be next:
    - `app A` upgrade in k8s env, new ip online, old ip offline, at the same time, `new app A`  to connect etcd register new ip and `old app A` connect etcd to del old ip
    - with L4 proxy,  the del call just finish in `grpc-proxy 2379`, the `grpc-proxy 2479` and `grpc-proxy 2579` still have old value with `grpc:appnameA` key in cache. And its cache can not be updated, except `DefaultMaxEntries` reached and cache just be removed, or just restart grpc-proxy
    - our app connect etcd with `Serializable` on.
    - after above procedure, other app call app A with read etcd prefix `grpc:appnameA`, still connect wrong IP, and connect failed

## PR fix

- with cache ttl feature, our problem can be fixed. The grpc-proxy can be extend to more instances.
- other work:
    - our app's etcd sdk just need to add connect failed logic for adaptation