### PR TITLE
CI: remove hardcode go version in .golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,4 @@
 run:
-  go: '1.17'
   timeout: 30m
   skip-files:
     - "^zz_generated.*"


### PR DESCRIPTION
The default Go version used by golinter is coming from the go.mod file, fallback on the env var `GOVERSION`. So no need to configure the go version in .golangci.yaml.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @spzala @serathius @mitake 
