### PR TITLE
Build: remove the invalid quote character ' for flag -ldflags

### DIFF
--- a/scripts/build_lib.sh
+++ b/scripts/build_lib.sh
@@ -93,7 +93,7 @@ tools_build() {
     # shellcheck disable=SC2086
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
       -installsuffix=cgo \
-      "-ldflags='${GO_LDFLAGS[*]}'" \
+      "-ldflags=${GO_LDFLAGS[*]}" \
       -o="${out}/${tool}" "./${tool}" || return 2
   done
   tests_build "${@}"


### PR DESCRIPTION
It isn't valid to start with quote character ' for flag -ldflags. Go cmd older than 1.19 just ignores the error. Starting from go 1.19, Go cmd will fail with error message something like below,
```
stderr: invalid value "'-X=go.etcd.io/etcd/api/v3/version.GitSHA=01250c9'" for flag -ldflags: parameter may not start with quote character '
```

Actually we don't have such quote character ' when building [etcd](https://github.com/etcd-io/etcd/blob/35bc65d3ec1f26d0cf2bd3d22c6b5ec07ebafa68/scripts/build_lib.sh#L44-L46)/[etcdctl](https://github.com/etcd-io/etcd/blob/35bc65d3ec1f26d0cf2bd3d22c6b5ec07ebafa68/scripts/build_lib.sh#L64-L66)/[etcdutl](https://github.com/etcd-io/etcd/blob/35bc65d3ec1f26d0cf2bd3d22c6b5ec07ebafa68/scripts/build_lib.sh#L54-L56).

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @spzala @serathius @mitake 
