### PR TITLE
Test: increase the TestKVDelete's timeout to 15s

### DIFF
--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -123,7 +123,7 @@ func TestKVDelete(t *testing.T) {
 	testRunner.BeforeTest(t)
 	for _, tc := range clusterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, tc.config)
 			defer clus.Close()


### PR DESCRIPTION
The test case `TestKVDelete` is flaky. Sometimes it just needs more time to execute the test case, so increase the timeout from 10s to 15s.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc  @spzala 
