### PR TITLE
Update changelog-3.6 to reflect the bumping of go 1.19

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -75,7 +75,8 @@ See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per 
 - Add [`etcd_debugging_server_alarms`](https://github.com/etcd-io/etcd/pull/14276).
 
 ### Go
-- Compile with [Go 1.17+](https://golang.org/doc/devel/release.html#go1.17)
+- Require [Go 1.19+](https://github.com/etcd-io/etcd/pull/14463).
+- Compile with [Go 1.19+](https://golang.org/doc/devel/release.html#go1.19). Please refer to [gc-guide](https://go.dev/doc/gc-guide) to configure `GOGC` and `GOMEMLIMIT` properly. 
 
 ### Other
 


### PR DESCRIPTION
Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius @spzala @mitake @ptabor 
