### PR TITLE
wal: Fix the `walWriteBytes` metric

### DIFF
--- a/pkg/ioutil/pagewriter.go
+++ b/pkg/ioutil/pagewriter.go
@@ -104,11 +104,6 @@ func (pw *PageWriter) Flush() error {
 	return err
 }
 
-// FlushN flushes buffered data and returns the number of written bytes.
-func (pw *PageWriter) FlushN() (int, error) {
-	return pw.flush()
-}
-
 func (pw *PageWriter) flush() (int, error) {
 	if pw.bufferedBytes == 0 {
 		return 0, nil

--- a/server/storage/wal/encoder.go
+++ b/server/storage/wal/encoder.go
@@ -109,10 +109,8 @@ func encodeFrameSize(dataBytes int) (lenField uint64, padBytes int) {
 
 func (e *encoder) flush() error {
 	e.mu.Lock()
-	n, err := e.bw.FlushN()
-	e.mu.Unlock()
-	walWriteBytes.Add(float64(n))
-	return err
+	defer e.mu.Unlock()
+	return e.bw.Flush()
 }
 
 func writeUint64(w io.Writer, n uint64, buf []byte) error {


### PR DESCRIPTION
In the `encode`, the `flush` should not add the `walWriteBytes` metric, because the write byte has counted when executing the `write`.

Signed-off-by: SimFG <1142838399@qq.com>

