### PR TITLE
upate:use google/btree in the genric way

### DIFF
--- a/server/storage/mvcc/index_bench_test.go
+++ b/server/storage/mvcc/index_bench_test.go
@@ -40,3 +40,30 @@ func benchmarkIndexCompact(b *testing.B, size int) {
 		kvindex.Compact(int64(i))
 	}
 }
+
+func BenchmarkIndexPut(b *testing.B) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	b.ResetTimer()
+	for i := 1; i < b.N; i++ {
+		kvindex.Put(keys[i], revision{main: int64(i), sub: int64(i)})
+	}
+}
+
+func BenchmarkIndexGet(b *testing.B) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	bytesN := 64
+	keys := createBytesSlice(bytesN, b.N)
+	for i := 1; i < b.N; i++ {
+		kvindex.Put(keys[i], revision{main: int64(i), sub: int64(i)})
+	}
+	b.ResetTimer()
+	for i := 1; i < b.N; i++ {
+		kvindex.Get(keys[i], int64(i))
+	}
+}

--- a/server/storage/mvcc/key_index.go
+++ b/server/storage/mvcc/key_index.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/btree"
 	"go.uber.org/zap"
 )
 
@@ -305,8 +304,8 @@ func (ki *keyIndex) findGeneration(rev int64) *generation {
 	return nil
 }
 
-func (ki *keyIndex) Less(b btree.Item) bool {
-	return bytes.Compare(ki.key, b.(*keyIndex).key) == -1
+func (ki *keyIndex) Less(bki *keyIndex) bool {
+	return bytes.Compare(ki.key, bki.key) == -1
 }
 
 func (ki *keyIndex) equal(b *keyIndex) bool {


### PR DESCRIPTION
mvcc: use google/btree in the genric way

As etcd bumped go1.19, using generic instead of cast interface{} to some type has better operation efficiency.

Signed-off-by: wathenjiang <wathenjiang@tencent.com>