### PR TITLE
Update 3.4, 3.5, and 3.6 changelogs for adding configurable cipher list to gRPC proxy

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -19,6 +19,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
+## v3.4.22 (TBD)
+
+### etcd grpc-proxy
+- Add [`etcd grpc-proxy start --listen-cipher-suites`](https://github.com/etcd-io/etcd/pull/14601) flag to support adding configurable cipher list.
+
 ## v3.4.21 (2022-09-15)
 
 ### etcd server

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -18,6 +18,11 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.6 (TBD)
+
+### etcd grpc-proxy
+- Add [`etcd grpc-proxy start --listen-cipher-suites`](https://github.com/etcd-io/etcd/pull/14500) flag to support adding configurable cipher list.
+
 ## v3.5.5 (2022-09-15)
 
 ### Deprecations


### PR DESCRIPTION
Since I'm backporting #14308 from 3.6 to 3.5, I need to move the changelog line to 3.5
