### PR TITLE
Update changelog-3.4 to cover the issue: memberID equals zero in corruption alarm

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,6 +4,13 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
+## v3.4.22 (TBD)
+
+### etcd server
+- Fix [memberID equals zero in corruption alarm](https://github.com/etcd-io/etcd/pull/14530)
+
+<hr>
+
 ## v3.4.21 (2022-09-15)
 
 ### etcd server


### PR DESCRIPTION


Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

@serathius @spzala 
