### PR TITLE
raft: update prevHardSt on Ready accept, not advance

### DIFF
--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -141,6 +141,9 @@ func (rn *RawNode) acceptReady(rd Ready) {
 	if rd.SoftState != nil {
 		rn.prevSoftSt = rd.SoftState
 	}
+	if !IsEmptyHardState(rd.HardState) {
+		rn.prevHardSt = rd.HardState
+	}
 	if len(rd.ReadStates) != 0 {
 		rn.raft.readStates = nil
 	}
@@ -172,9 +175,6 @@ func (rn *RawNode) HasReady() bool {
 // Advance notifies the RawNode that the application has applied and saved progress in the
 // last Ready results.
 func (rn *RawNode) Advance(rd Ready) {
-	if !IsEmptyHardState(rd.HardState) {
-		rn.prevHardSt = rd.HardState
-	}
 	rn.raft.advance(rd)
 }
 


### PR DESCRIPTION
This commit updates the `RawNode`'s `prevHardSt` to the new HardState in `acceptReady` instead of on `Advance`. This aligns the handling of `prevHardSt` with that of `prevSoftSt` (and other fields like `msgs`) and simplifies the logic in `Advance`.

cc. @tbg 
