### PR TITLE
update changelogs of 3.4 and 3.5 for handling auth invalid token and old revision errors in watch

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### etcd server
 - Fix [memberID equals zero in corruption alarm](https://github.com/etcd-io/etcd/pull/14530)
+- Fix [auth invalid token and old revision errors in watch](https://github.com/etcd-io/etcd/pull/14548)
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,6 +4,13 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.6 (TBD)
+
+### etcd server
+- Fix [auth invalid token and old revision errors in watch](https://github.com/etcd-io/etcd/pull/14547)
+
+<hr>
+
 ## v3.5.5 (2022-09-15)
 
 ### Deprecations


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Updating changelogs for https://github.com/etcd-io/etcd/pull/14547 and https://github.com/etcd-io/etcd/pull/14548 . cc @ahrtr @spzala @kafuu-chino 