### PR TITLE
Update changelog 3.6 to clearly requiring applications which depend on etcd 3.6 packages must be built with go version >= 1.18

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -12,7 +12,8 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 
 - `etcd` will no longer start on data dir created by newer versions (for example etcd v3.6 will not run on v3.7+ data dir). To downgrade data dir please check out `etcdutl migrate` command.
 - `etcd` doesn't support serving client requests on the peer listen endpoints (--listen-peer-urls). See [pull/13565](https://github.com/etcd-io/etcd/pull/13565).
-- `etcdctl` will sleep(2s) in case of range delete without `--range` flag.See [pull/13747](https://github.com/etcd-io/etcd/pull/13747)
+- `etcdctl` will sleep(2s) in case of range delete without `--range` flag. See [pull/13747](https://github.com/etcd-io/etcd/pull/13747)
+- Applications which depend on etcd v3.6 packages must be built with go version >= v1.18.
 
 ### Deprecations
 


### PR DESCRIPTION
etcdserver starts to using generic in https://github.com/etcd-io/etcd/pull/14515, so any applications which depend on etcdserver must be built with go version >= 1.18.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius @spzala @ptabor
