### PR TITLE
raft: panic on self-addressed messages

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -240,12 +240,12 @@ func TestFollowerVote(t *testing.T) {
 		nvote   uint64
 		wreject bool
 	}{
-		{None, 1, false},
 		{None, 2, false},
-		{1, 1, false},
+		{None, 3, false},
 		{2, 2, false},
-		{1, 2, true},
-		{2, 1, true},
+		{3, 3, false},
+		{2, 3, true},
+		{3, 2, true},
 	}
 	for i, tt := range tests {
 		r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -952,7 +952,7 @@ func TestRawNodeCommitPaginationAfterRestart(t *testing.T) {
 		rawNode.Step(pb.Message{
 			Type:   pb.MsgHeartbeat,
 			To:     1,
-			From:   1, // illegal, but we get away with it
+			From:   2, // illegal, but we get away with it
 			Term:   1,
 			Commit: 11,
 		})


### PR DESCRIPTION
These are nonsensical and a network implementation is not required to handle them correctly, so panic instead of sending them out.

Signed-off-by: Nathan VanBenschoten <nvanbenschoten@gmail.com>

cc. @tbg 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
