### PR TITLE
tests: Pass only etcd related environment variables during e2e tests

### DIFF
--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -127,6 +127,10 @@ func mergeEnvVariables(envVars map[string]string) []string {
 	currVars := os.Environ()
 	for _, v := range currVars {
 		p := strings.Split(v, "=")
+		// TODO: Remove PATH when we stop using system binaries (`awk`, `echo`)
+		if !strings.HasPrefix(p[0], "ETCD_") && !strings.HasPrefix(p[0], "ETCDCTL_") && !strings.HasPrefix(p[0], "EXPECT_") && p[0] != "PATH" {
+			continue
+		}
 		if _, ok := envVars[p[0]]; !ok {
 			env = append(env, fmt.Sprintf("%s=%s", p[0], p[1]))
 		}


### PR DESCRIPTION
Should really clean up e2e test logs and make tests much more repeatable.
cc @ahrtr @spzala 