### PR TITLE
functional_test: stop etcd and cleanup data when test is successful

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -149,7 +149,9 @@ function generic_checker {
 function killall_functional_test {
   log_callout "Killing all etcd-agent and etcd processes..."
   killall -9 etcd-agent
-  killall -9 etcd
+  # When functional test is successful, the etcd processes have already been
+  # stopped by the agent, so we should ignore the error in this case.
+  killall -9 etcd || true
 }
 
 function functional_pass {

--- a/tests/functional/cmd/etcd-tester/etcd_tester_test.go
+++ b/tests/functional/cmd/etcd-tester/etcd_tester_test.go
@@ -47,5 +47,8 @@ func TestFunctional(t *testing.T) {
 		t.Fatal("WaitHealth failed", zap.Error(err))
 	}
 
-	clus.Run(t)
+	if err := clus.Run(t); err == nil {
+		// Only stop etcd and cleanup data when test is successful.
+		clus.Send_SIGQUIT_ETCD_AND_REMOVE_DATA()
+	}
 }

--- a/tests/functional/tester/cluster.go
+++ b/tests/functional/tester/cluster.go
@@ -395,9 +395,14 @@ func (clus *Cluster) Send_INITIAL_START_ETCD() error {
 	return clus.broadcast(rpcpb.Operation_INITIAL_START_ETCD)
 }
 
-// send_SIGQUIT_ETCD_AND_ARCHIVE_DATA sends "send_SIGQUIT_ETCD_AND_ARCHIVE_DATA" operation.
+// send_SIGQUIT_ETCD_AND_ARCHIVE_DATA sends "Operation_SIGQUIT_ETCD_AND_ARCHIVE_DATA" operation.
 func (clus *Cluster) send_SIGQUIT_ETCD_AND_ARCHIVE_DATA() error {
 	return clus.broadcast(rpcpb.Operation_SIGQUIT_ETCD_AND_ARCHIVE_DATA)
+}
+
+// Send_SIGQUIT_ETCD_AND_REMOVE_DATA sends "Operation_SIGQUIT_ETCD_AND_REMOVE_DATA" operation.
+func (clus *Cluster) Send_SIGQUIT_ETCD_AND_REMOVE_DATA() error {
+	return clus.broadcast(rpcpb.Operation_SIGQUIT_ETCD_AND_REMOVE_DATA)
 }
 
 // send_RESTART_ETCD sends restart operation.


### PR DESCRIPTION
Resolve the review comment https://github.com/etcd-io/etcd/pull/14387#issuecomment-1248574599. Since there is no response for a long time, so I decided to resolve it myself.

We should stop etcd and cleanup the data when the functional test is successful, otherwise keep the data for debug.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius @spzala @ptabor @mitake 
