### PR TITLE
update changelogs of 3.4 and 3.5 for fixing avoid closing a watch with ID 0 incorrectly

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -9,6 +9,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### etcd server
 - Fix [memberID equals zero in corruption alarm](https://github.com/etcd-io/etcd/pull/14530)
 - Fix [auth invalid token and old revision errors in watch](https://github.com/etcd-io/etcd/pull/14548)
+- Fix [avoid closing a watch with ID 0 incorrectly](https://github.com/etcd-io/etcd/pull/14562)
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### etcd server
 - Fix [auth invalid token and old revision errors in watch](https://github.com/etcd-io/etcd/pull/14547)
+- Fix [avoid closing a watch with ID 0 incorrectly](https://github.com/etcd-io/etcd/pull/14563)
 
 <hr>
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Updating changelogs for https://github.com/etcd-io/etcd/pull/14562 and https://github.com/etcd-io/etcd/pull/14563 .cc @ahrtr  @mitake @spzala 