### PR TITLE
etcdserver: added more debug log for the purgeFile goroutine

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -328,6 +328,8 @@ func print(lg *zap.Logger, ec Config, sc config.ServerConfig, memberInitialized 
 		zap.String("wait-cluster-ready-timeout", sc.WaitClusterReadyTimeout.String()),
 		zap.Bool("initial-election-tick-advance", sc.InitialElectionTickAdvance),
 		zap.Uint64("snapshot-count", sc.SnapshotCount),
+		zap.Uint("max-wals", sc.MaxWALFiles),
+		zap.Uint("max-snapshots", sc.MaxSnapFiles),
 		zap.Uint64("snapshot-catchup-entries", sc.SnapshotCatchUpEntries),
 		zap.Strings("initial-advertise-peer-urls", ec.getAPURLs()),
 		zap.Strings("listen-peer-urls", ec.getLPURLs()),


### PR DESCRIPTION
I see some cases what etcd somehow failed to purge WAL files, but there is no any error log at all. So added some log to help debug.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @mitake 



