### PR TITLE
functional-test: move the check on log-outputs out of the 'if clientTLS' branch

### DIFF
--- a/tests/functional/tester/cluster_read_config.go
+++ b/tests/functional/tester/cluster_read_config.go
@@ -356,17 +356,17 @@ func read(lg *zap.Logger, fpath string) (*Cluster, error) {
 				}
 				clus.Members[i].ClientCertData = string(data)
 			}
+		}
 
-			if len(mem.Etcd.LogOutputs) == 0 {
-				return nil, fmt.Errorf("mem.Etcd.LogOutputs cannot be empty")
-			}
-			for _, v := range mem.Etcd.LogOutputs {
-				switch v {
-				case "stderr", "stdout", "/dev/null", "default":
-				default:
-					if !strings.HasPrefix(v, mem.BaseDir) {
-						return nil, fmt.Errorf("LogOutput %q must be prefixed with BaseDir %q", v, mem.BaseDir)
-					}
+		if len(mem.Etcd.LogOutputs) == 0 {
+			return nil, fmt.Errorf("mem.Etcd.LogOutputs cannot be empty")
+		}
+		for _, v := range mem.Etcd.LogOutputs {
+			switch v {
+			case "stderr", "stdout", "/dev/null", "default":
+			default:
+				if !strings.HasPrefix(v, mem.BaseDir) {
+					return nil, fmt.Errorf("LogOutput %q must be prefixed with BaseDir %q", v, mem.BaseDir)
 				}
 			}
 		}


### PR DESCRIPTION
The check on the` log-outputs ` is included in the `if clientTLS` branch. It doesn't make sense, because they are unrelated.  So move it out of the if branch.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @mitake 



