### PR TITLE
Allow downgrade to proceed on same version

### DIFF
--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -75,6 +75,14 @@ func (m *Monitor) decideClusterVersion() *semver.Version {
 	}
 	downgrade := m.s.GetDowngradeInfo()
 	if downgrade != nil && downgrade.Enabled {
+		if clusterVersion.Equal(*downgrade.GetTargetVersion()) {
+			m.lg.Error("Downgrade already finished, despite enabled downgrade present",
+				zap.String("downgrade-version", downgrade.TargetVersion),
+				zap.String("cluster-version", clusterVersion.String()),
+				zap.String("minimal-server-version", minimalServerVersion.String()),
+			)
+			return downgrade.GetTargetVersion()
+		}
 		if IsValidVersionChange(clusterVersion, downgrade.GetTargetVersion()) && IsValidVersionChange(minimalServerVersion, downgrade.GetTargetVersion()) {
 			return downgrade.GetTargetVersion()
 		}

--- a/server/etcdserver/version/monitor_test.go
+++ b/server/etcdserver/version/monitor_test.go
@@ -219,6 +219,16 @@ func TestUpdateClusterVersionIfNeeded(t *testing.T) {
 			expectClusterVersion: &version.V3_5,
 		},
 		{
+			name: "Should allow downgrade target version to be equal to current version",
+			memberVersions: map[string]*version.Versions{
+				"a": {Cluster: "3.5.0", Server: "3.5.0"},
+				"b": {Cluster: "3.5.0", Server: "3.5.0"},
+			},
+			clusterVersion:       &version.V3_5,
+			downgrade:            &DowngradeInfo{TargetVersion: "3.5.0", Enabled: true},
+			expectClusterVersion: &version.V3_5,
+		},
+		{
 			name: "Don't downgrade below supported range",
 			memberVersions: map[string]*version.Versions{
 				"a": {Cluster: "3.5.0", Server: "3.6.0"},


### PR DESCRIPTION
This is to fix the downgrade/upgrade test that sometimes is stuck on the same version already downgraded to.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

"fix" for #14540