### PR TITLE
Tests: Check Watch response error not nil to avoid runtime panic.

### DIFF
--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -340,6 +340,9 @@ func putAndWatch(t *testing.T, wctx *watchctx, key, val string) {
 		if !ok {
 			t.Fatalf("unexpected watch close")
 		}
+		if err := v.Err(); err != nil {
+			t.Fatalf("unexpected watch response error: %v", err)
+		}
 		if string(v.Events[0].Kv.Value) != val {
 			t.Fatalf("bad value got %v, wanted %v", v.Events[0].Kv.Value, val)
 		}


### PR DESCRIPTION
Check Watch response error not nil to avoid test suite runtime panic.
Fixes issue: #14259

Signed-off-by: Wang Xiaoxiao 1141195807@qq.com


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
