### PR TITLE
[e2e] Fix AuthEnable/Disable e2e test implementations

### DIFF
--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -486,11 +486,7 @@ func (ctl *EtcdctlV3) AuthEnable(ctx context.Context) (*clientv3.AuthEnableRespo
 
 func (ctl *EtcdctlV3) AuthDisable(ctx context.Context) (*clientv3.AuthDisableResponse, error) {
 	args := []string{"auth", "disable"}
-	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
-	if err != nil {
-		return nil, err
-	}
-	err = cmd.Send(strings.Join(args, " "))
+	cmd, err := SpawnCmd(ctl.cmdArgs(args...), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -467,11 +467,7 @@ func (ctl *EtcdctlV3) AlarmDisarm(ctx context.Context, _ *clientv3.AlarmMember) 
 
 func (ctl *EtcdctlV3) AuthEnable(ctx context.Context) (*clientv3.AuthEnableResponse, error) {
 	args := []string{"auth", "enable"}
-	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
-	if err != nil {
-		return nil, err
-	}
-	err = cmd.Send(strings.Join(args, " "))
+	cmd, err := SpawnCmd(ctl.cmdArgs(args...), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -466,15 +466,41 @@ func (ctl *EtcdctlV3) AlarmDisarm(ctx context.Context, _ *clientv3.AlarmMember) 
 }
 
 func (ctl *EtcdctlV3) AuthEnable(ctx context.Context) (*clientv3.AuthEnableResponse, error) {
-	var resp clientv3.AuthEnableResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "auth", "enable")
-	return &resp, err
+	args := []string{"auth", "enable"}
+	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Send(strings.Join(args, " "))
+	if err != nil {
+		return nil, err
+	}
+	defer cmd.Close()
+
+	_, err = cmd.ExpectWithContext(ctx, "Authentication Enabled")
+	if err != nil {
+		return nil, err
+	}
+	return &clientv3.AuthEnableResponse{}, nil
 }
 
 func (ctl *EtcdctlV3) AuthDisable(ctx context.Context) (*clientv3.AuthDisableResponse, error) {
-	var resp clientv3.AuthDisableResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "auth", "disable")
-	return &resp, err
+	args := []string{"auth", "disable"}
+	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Send(strings.Join(args, " "))
+	if err != nil {
+		return nil, err
+	}
+	defer cmd.Close()
+
+	_, err = cmd.ExpectWithContext(ctx, "Authentication Disabled")
+	if err != nil {
+		return nil, err
+	}
+	return &clientv3.AuthDisableResponse{}, nil
 }
 
 func (ctl *EtcdctlV3) AuthStatus(ctx context.Context) (*clientv3.AuthStatusResponse, error) {


### PR DESCRIPTION
etcdctl AuthEnable and AuthDisable subcommands does not support json output and produce single-line output even is json mode is requested.
Existing implementations does not work correctly in newly added e2e test.

Splitting https://github.com/etcd-io/etcd/pull/14574 into multiple PRs.

Signed-off-by: Oleg Guba <oleg@dropbox.com>
