### PR TITLE
fix: add a warning message on startup if the server name is default

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -765,6 +765,15 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("--experimental-compact-hash-check-time must be >0 (set to %v)", cfg.ExperimentalCompactHashCheckTime)
 	}
 
+	// If `--name` isn't configured, then multiple members may have the same "default" name.
+	// When adding a new member with the "default" name as well, etcd may regards its peerURL
+	// as one additional peerURL of the existing member which has the same "default" name,
+	// because each member can have multiple client or peer URLs.
+	// Please refer to https://github.com/etcd-io/etcd/issues/13757
+	if cfg.Name == DefaultName {
+		cfg.logger.Warn("the server is using default name, which might cause error that failed the startup.")
+	}
+
 	return nil
 }
 

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -90,6 +90,10 @@ func startEtcdOrProxyV2(args []string) {
 		lg.Info("failed to detect default host", zap.Error(dhErr))
 	}
 
+	if cfg.ec.Name == embed.DefaultName {
+		lg.Warn("the server is using default name, which might cause error that failed the startup.")
+	}
+
 	if cfg.ec.Dir == "" {
 		cfg.ec.Dir = fmt.Sprintf("%v.etcd", cfg.ec.Name)
 		lg.Warn(

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -90,10 +90,6 @@ func startEtcdOrProxyV2(args []string) {
 		lg.Info("failed to detect default host", zap.Error(dhErr))
 	}
 
-	if cfg.ec.Name == embed.DefaultName {
-		lg.Warn("the server is using default name, which might cause error that failed the startup.")
-	}
-
 	if cfg.ec.Dir == "" {
 		cfg.ec.Dir = fmt.Sprintf("%v.etcd", cfg.ec.Name)
 		lg.Warn(


### PR DESCRIPTION
fix #13757
