### PR TITLE
test: add common function "WithAuth"

### DIFF
--- a/tests/common/e2e_test.go
+++ b/tests/common/e2e_test.go
@@ -17,8 +17,16 @@
 
 package common
 
-import "go.etcd.io/etcd/tests/v3/framework"
+import (
+	"go.etcd.io/etcd/tests/v3/framework"
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
 
 func init() {
 	testRunner = framework.E2eTestRunner
+}
+
+func WithAuth(userName, password string) config.ClientOption {
+	return e2e.WithAuth(userName, password)
 }

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -19,8 +19,14 @@ package common
 
 import (
 	"go.etcd.io/etcd/tests/v3/framework"
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
 func init() {
 	testRunner = framework.IntegrationTestRunner
+}
+
+func WithAuth(userName, password string) config.ClientOption {
+	return integration.WithAuth(userName, password)
 }

--- a/tests/framework/config/client.go
+++ b/tests/framework/config/client.go
@@ -21,9 +21,10 @@ import (
 )
 
 // ClientOption configures the client with additional parameter.
-// For example, if Auth is enabled,
-//  1. e2e test cases use e2e.WithAuth to return a ClientOption;
-//  2. integration test, uses integration.WithAuth to return a ClientOption.
+// For example, if Auth is enabled, the common test cases just need to
+// use `WithAuth` to return a ClientOption. Note that the common `WithAuth`
+// function calls `e2e.WithAuth` or `integration.WithAuth`, depending on the
+// build tag (either "e2e" or "integration").
 type ClientOption func(any)
 
 type GetOptions struct {


### PR DESCRIPTION
This PR is on top of https://github.com/etcd-io/etcd/pull/14615

We defines two common `WithAuth` functions for e2e and integration test respectively. They are calling `integration.WithAuth` and `e2e.WithAuth` respectively.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala @mitake @ptabor @chaochn47 @veshij 
