### PR TITLE
compact: skip compact when keyIndex's first revision is bigger than compactMainRev

### DIFF
--- a/server/storage/mvcc/key_index.go
+++ b/server/storage/mvcc/key_index.go
@@ -213,6 +213,11 @@ func (ki *keyIndex) compact(lg *zap.Logger, atRev int64, available map[revision]
 		)
 	}
 
+	if len(ki.generations[0].revs) > 0 &&
+		ki.generations[0].revs[0].main > atRev+1 {
+		return
+	}
+
 	genIdx, revIndex := ki.doCompact(atRev, available)
 
 	g := &ki.generations[genIdx]


### PR DESCRIPTION
Signed-off-by: qsyqian <qsyqian@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
