### PR TITLE
common test: update auth test interface

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -122,7 +123,8 @@ func startEtcd(t *testing.T, ep e2e.EtcdProcess, execPath string) {
 }
 
 func downgradeEnable(t *testing.T, epc *e2e.EtcdProcessCluster, ver semver.Version) {
-	c := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	c, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
 	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
 		err := c.DowngradeEnable(context.TODO(), ver.String())
 		if err != nil {

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -116,7 +116,8 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 		}
 	})
 
-	cc := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	cc, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		err := cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
@@ -164,7 +165,8 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 		}
 	})
 
-	cc := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	cc, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		err := cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -98,7 +98,8 @@ func TestAuthority(t *testing.T) {
 				defer epc.Close()
 				endpoints := templateEndpoints(t, tc.clientURLPattern, epc)
 
-				client := e2e.NewEtcdctl(cfg, endpoints)
+				client, err := e2e.NewEtcdctl(cfg, endpoints)
+				assert.NoError(t, err)
 				err = client.Put(ctx, "foo", "bar", config.PutOptions{})
 				if err != nil {
 					t.Fatal(err)

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -59,7 +59,8 @@ func TestGrpcProxyAutoSync(t *testing.T) {
 		assert.NoError(t, proxyProc.Stop())
 	}()
 
-	proxyCtl := e2e.NewEtcdctl(&e2e.EtcdProcessClusterConfig{}, []string{proxyClientURL})
+	proxyCtl, err := e2e.NewEtcdctl(&e2e.EtcdProcessClusterConfig{}, []string{proxyClientURL})
+	require.NoError(t, err)
 	err = proxyCtl.Put(ctx, "k1", "v1", config.PutOptions{})
 	require.NoError(t, err)
 

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -109,10 +109,14 @@ func TestV2DeprecationSnapshotMatches(t *testing.T) {
 	}
 	snapshotCount := 10
 	epc := runEtcdAndCreateSnapshot(t, lastReleaseBinary, lastReleaseData, snapshotCount)
-	members1 := addAndRemoveKeysAndMembers(ctx, t, e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3()), snapshotCount)
+	cc1, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
+	members1 := addAndRemoveKeysAndMembers(ctx, t, cc1, snapshotCount)
 	assert.NoError(t, epc.Close())
 	epc = runEtcdAndCreateSnapshot(t, currentReleaseBinary, currentReleaseData, snapshotCount)
-	members2 := addAndRemoveKeysAndMembers(ctx, t, e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3()), snapshotCount)
+	cc2, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
+	members2 := addAndRemoveKeysAndMembers(ctx, t, cc2, snapshotCount)
 	assert.NoError(t, epc.Close())
 
 	assertSnapshotsMatch(t, lastReleaseData, currentReleaseData, func(data []byte) []byte {
@@ -144,7 +148,8 @@ func TestV2DeprecationSnapshotRecover(t *testing.T) {
 	}
 	epc := runEtcdAndCreateSnapshot(t, lastReleaseBinary, dataDir, 10)
 
-	cc := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	cc, err := e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
 
 	lastReleaseGetResponse, err := cc.Get(ctx, "", config.GetOptions{Prefix: true})
 	assert.NoError(t, err)
@@ -157,7 +162,8 @@ func TestV2DeprecationSnapshotRecover(t *testing.T) {
 	epc, err = e2e.NewEtcdProcessCluster(context.TODO(), t, cfg)
 	assert.NoError(t, err)
 
-	cc = e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	cc, err = e2e.NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	assert.NoError(t, err)
 	currentReleaseGetResponse, err := cc.Get(ctx, "", config.GetOptions{Prefix: true})
 	assert.NoError(t, err)
 

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -88,8 +88,8 @@ type e2eCluster struct {
 }
 
 func (c *e2eCluster) Client(opts ...config.ClientOption) (Client, error) {
-	etcdctl := e2e.NewEtcdctl(c.Cfg, c.EndpointsV3(), opts...)
-	return e2eClient{etcdctl}, nil
+	etcdctl, err := e2e.NewEtcdctl(c.Cfg, c.EndpointsV3(), opts...)
+	return e2eClient{etcdctl}, err
 }
 
 func (c *e2eCluster) Endpoints() []string {
@@ -179,7 +179,11 @@ type e2eMember struct {
 }
 
 func (m e2eMember) Client() Client {
-	return e2eClient{e2e.NewEtcdctl(m.Cfg, m.EndpointsV3())}
+	etcdctl, err := e2e.NewEtcdctl(m.Cfg, m.EndpointsV3())
+	if err != nil {
+		panic(err)
+	}
+	return e2eClient{etcdctl}
 }
 
 func (m e2eMember) Start(ctx context.Context) error {

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -613,7 +613,11 @@ func (epc *EtcdProcessCluster) Stop() (err error) {
 }
 
 func (epc *EtcdProcessCluster) Client() *EtcdctlV3 {
-	return NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	etcdctl, err := NewEtcdctl(epc.Cfg, epc.EndpointsV3())
+	if err != nil {
+		panic(err)
+	}
+	return etcdctl
 }
 
 func (epc *EtcdProcessCluster) Close() error {

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -274,12 +274,14 @@ func (c integrationClient) Revoke(ctx context.Context, id clientv3.LeaseID) (*cl
 	return c.Client.Revoke(ctx, id)
 }
 
-func (c integrationClient) AuthEnable(ctx context.Context) (*clientv3.AuthEnableResponse, error) {
-	return c.Client.AuthEnable(ctx)
+func (c integrationClient) AuthEnable(ctx context.Context) error {
+	_, err := c.Client.AuthEnable(ctx)
+	return err
 }
 
-func (c integrationClient) AuthDisable(ctx context.Context) (*clientv3.AuthDisableResponse, error) {
-	return c.Client.AuthDisable(ctx)
+func (c integrationClient) AuthDisable(ctx context.Context) error {
+	_, err := c.Client.AuthDisable(ctx)
+	return err
 }
 
 func (c integrationClient) AuthStatus(ctx context.Context) (*clientv3.AuthStatusResponse, error) {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1457,9 +1457,9 @@ func (c *Cluster) ClusterClient(t testing.TB, opts ...framecfg.ClientOption) (cl
 
 func WithAuth(userName, password string) framecfg.ClientOption {
 	return func(c any) {
-		client := c.(*clientv3.Client)
-		client.Username = userName
-		client.Password = password
+		cfg := c.(*clientv3.Config)
+		cfg.Username = userName
+		cfg.Password = password
 	}
 }
 

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -59,8 +59,8 @@ type Client interface {
 	KeepAliveOnce(context context.Context, id clientv3.LeaseID) (*clientv3.LeaseKeepAliveResponse, error)
 	Revoke(context context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error)
 
-	AuthEnable(context context.Context) (*clientv3.AuthEnableResponse, error)
-	AuthDisable(context context.Context) (*clientv3.AuthDisableResponse, error)
+	AuthEnable(context context.Context) error
+	AuthDisable(context context.Context) error
 	AuthStatus(context context.Context) (*clientv3.AuthStatusResponse, error)
 	UserAdd(context context.Context, name, password string, opts config.UserAddOptions) (*clientv3.AuthUserAddResponse, error)
 	UserGet(context context.Context, name string) (*clientv3.AuthUserGetResponse, error)
@@ -75,6 +75,7 @@ type Client interface {
 	RoleList(context context.Context) (*clientv3.AuthRoleListResponse, error)
 	RoleRevokePermission(context context.Context, role string, key, rangeEnd string) (*clientv3.AuthRoleRevokePermissionResponse, error)
 	RoleDelete(context context.Context, role string) (*clientv3.AuthRoleDeleteResponse, error)
+
 	Txn(context context.Context, compares, ifSucess, ifFail []string, o config.TxnOptions) (*clientv3.TxnResponse, error)
 
 	MemberList(context context.Context) (*clientv3.MemberListResponse, error)


### PR DESCRIPTION
1. set up a default `withAuth` option in common test entry point
2. `NewEtcdctl` accepts a client option that could have invalid user name and password, it should fail client creation. I am happy to add more comments to reduce the confusion.
3. `AuthEnable` and `AuthDisable` does not need response in the function signature.

@ahrtr @serathius 
