### PR TITLE
test: define a default WithAuth to resolve Unresolved reference error

### DIFF
--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -21,7 +21,8 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
-var testRunner = framework.UnitTestRunner
+var testRunner framework.TestRunner
+
 var clusterTestCases = []testCase{
 	{
 		name:   "NoTLS",

--- a/tests/common/unit_test.go
+++ b/tests/common/unit_test.go
@@ -12,35 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package framework
+//go:build !(e2e || integration)
+
+package common
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"os"
-	"testing"
-
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
-type unitRunner struct{}
-
-var _ TestRunner = (*unitRunner)(nil)
-
-func (e unitRunner) TestMain(m *testing.M) {
-	flag.Parse()
-	if !testing.Short() {
-		fmt.Println(`No test mode selected, please selected either e2e mode with "--tags e2e" or integration mode with "--tags integration"`)
-		os.Exit(1)
-	}
+func init() {
+	testRunner = framework.UnitTestRunner
 }
 
-func (e unitRunner) BeforeTest(t testing.TB) {
-}
-
-func (e unitRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.ClusterConfig) Cluster {
-	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
-	return nil
+// When a build tag (e.g. e2e or integration) isn't configured in IDE,
+// then IDE may complain "Unresolved reference 'WithAuth'". So we need
+// to define a default WithAuth to resolve such case.
+func WithAuth(userName, password string) config.ClientOption {
+	return func(any) {}
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -16,7 +16,7 @@ package framework
 
 var (
 	// UnitTestRunner only runs in `--short` mode, will fail otherwise. Attempts in cluster creation will result in tests being skipped.
-	UnitTestRunner testRunner = unitRunner{}
+	UnitTestRunner TestRunner = unitRunner{}
 	// E2eTestRunner runs etcd and etcdctl binaries in a separate process.
 	E2eTestRunner = e2eRunner{}
 	// IntegrationTestRunner runs etcdserver.EtcdServer in separate goroutine and uses client libraries to communicate.

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -22,7 +22,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
-type testRunner interface {
+type TestRunner interface {
 	TestMain(m *testing.M)
 	BeforeTest(testing.TB)
 	NewCluster(context.Context, testing.TB, config.ClusterConfig) Cluster


### PR DESCRIPTION

```
// When a build tag (e.g. e2e or integration) isn't configured in IDE,
// then IDE may complain "Unresolved reference 'WithAuth'". So we need
// to define a default WithAuth to resolve such case.
```

Signed-off-by: Benjamin Wang <wachao@vmware.com>


cc @chaochn47 @serathius @spzala @ptabor 