### PR TITLE
test: fix anti-pattern naming problem in config.ClusterConfig

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -31,7 +31,7 @@ func TestAlarm(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1, QuotaBackendBytes: int64(13 * os.Getpagesize())})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1, config.WithQuotaBackendBytes(int64(13*os.Getpagesize()))))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -111,11 +111,11 @@ func TestAlarmlistOnMemberRestart(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{
-		ClusterSize:       1,
-		QuotaBackendBytes: int64(13 * os.Getpagesize()),
-		SnapshotCount:     5,
-	})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(
+		1,
+		config.WithQuotaBackendBytes(int64(13*os.Getpagesize())),
+		config.WithSnapshotCount(5),
+	))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -46,7 +46,7 @@ func TestCompact(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+			clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -29,7 +29,7 @@ func TestDefragOnline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	options := config.DefragOption{Timeout: 10 * time.Second}
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		defer clus.Close()

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -28,7 +28,7 @@ func TestEndpointStatus(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -43,7 +43,7 @@ func TestEndpointHashKV(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -58,7 +58,7 @@ func TestEndpointHealth(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -222,7 +222,7 @@ func TestKVGetNoQuorum(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 3})
+			clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
 			defer clus.Close()
 
 			clus.Members()[0].Stop()

--- a/tests/common/lease_test.go
+++ b/tests/common/lease_test.go
@@ -29,32 +29,7 @@ import (
 func TestLeaseGrantTimeToLive(t *testing.T) {
 	testRunner.BeforeTest(t)
 
-	tcs := []struct {
-		name   string
-		config config.ClusterConfig
-	}{
-		{
-			name:   "NoTLS",
-			config: config.ClusterConfig{ClusterSize: 1},
-		},
-		{
-			name:   "PeerTLS",
-			config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.ManualTLS},
-		},
-		{
-			name:   "PeerAutoTLS",
-			config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.AutoTLS},
-		},
-		{
-			name:   "ClientTLS",
-			config: config.ClusterConfig{ClusterSize: 1, ClientTLS: config.ManualTLS},
-		},
-		{
-			name:   "ClientAutoTLS",
-			config: config.ClusterConfig{ClusterSize: 1, ClientTLS: config.AutoTLS},
-		},
-	}
-	for _, tc := range tcs {
+	for _, tc := range clusterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -25,23 +25,23 @@ var testRunner = framework.UnitTestRunner
 var clusterTestCases = []testCase{
 	{
 		name:   "NoTLS",
-		config: config.ClusterConfig{ClusterSize: 1},
+		config: config.NewClusterConfig(1),
 	},
 	{
 		name:   "PeerTLS",
-		config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.ManualTLS},
+		config: config.NewClusterConfig(3, config.WithPeerTLS(config.ManualTLS)),
 	},
 	{
 		name:   "PeerAutoTLS",
-		config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.AutoTLS},
+		config: config.NewClusterConfig(3, config.WithPeerTLS(config.AutoTLS)),
 	},
 	{
 		name:   "ClientTLS",
-		config: config.ClusterConfig{ClusterSize: 1, ClientTLS: config.ManualTLS},
+		config: config.NewClusterConfig(1, config.WithClientTLS(config.ManualTLS)),
 	},
 	{
 		name:   "ClientAutoTLS",
-		config: config.ClusterConfig{ClusterSize: 1, ClientTLS: config.AutoTLS},
+		config: config.NewClusterConfig(1, config.WithClientTLS(config.AutoTLS)),
 	},
 }
 

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -106,7 +106,7 @@ func TestMemberAdd(t *testing.T) {
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
 					c := clusterTc.config
-					c.DisableStrictReconfigCheck = !quorumTc.strictReconfigCheck
+					c.StrictReconfigCheck = quorumTc.strictReconfigCheck
 					clus := testRunner.NewCluster(ctx, t, c)
 					defer clus.Close()
 					cc := framework.MustClient(clus.Client())
@@ -187,7 +187,7 @@ func TestMemberRemove(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				c := clusterTc.config
-				c.DisableStrictReconfigCheck = !quorumTc.strictReconfigCheck
+				c.StrictReconfigCheck = quorumTc.strictReconfigCheck
 				clus := testRunner.NewCluster(ctx, t, c)
 				defer clus.Close()
 				// client connects to a specific member which won't be removed from cluster

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -51,7 +51,7 @@ func TestRoleAdd_Error(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -74,7 +74,7 @@ func TestRootRole(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -104,7 +104,7 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -139,7 +139,7 @@ func TestRoleDelete(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.ClusterConfig{ClusterSize: 1})
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/wait_leader_test.go
+++ b/tests/common/wait_leader_test.go
@@ -45,11 +45,11 @@ func TestWaitLeader_MemberStop(t *testing.T) {
 	tcs := []testCase{
 		{
 			name:   "PeerTLS",
-			config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.ManualTLS},
+			config: config.NewClusterConfig(3, config.WithPeerTLS(config.ManualTLS)),
 		},
 		{
 			name:   "PeerAutoTLS",
-			config: config.ClusterConfig{ClusterSize: 3, PeerTLS: config.AutoTLS},
+			config: config.NewClusterConfig(3, config.WithPeerTLS(config.AutoTLS)),
 		},
 	}
 

--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -27,11 +27,46 @@ const (
 )
 
 type ClusterConfig struct {
-	ClusterSize                int
-	PeerTLS                    TLSConfig
-	ClientTLS                  TLSConfig
-	QuotaBackendBytes          int64
-	DisableStrictReconfigCheck bool
-	AuthToken                  string
-	SnapshotCount              int
+	ClusterSize         int
+	PeerTLS             TLSConfig
+	ClientTLS           TLSConfig
+	QuotaBackendBytes   int64
+	StrictReconfigCheck bool
+	AuthToken           string
+	SnapshotCount       int
+}
+
+func defaultClusterConfig() ClusterConfig {
+	return ClusterConfig{StrictReconfigCheck: true}
+}
+
+func NewClusterConfig(clusterSize int, opts ...ClusterOption) ClusterConfig {
+	c := defaultClusterConfig()
+	c.ClusterSize = clusterSize
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+}
+
+type ClusterOption func(*ClusterConfig)
+
+func WithPeerTLS(tls TLSConfig) ClusterOption {
+	return func(c *ClusterConfig) { c.PeerTLS = tls }
+}
+
+func WithClientTLS(tls TLSConfig) ClusterOption {
+	return func(c *ClusterConfig) { c.ClientTLS = tls }
+}
+
+func WithQuotaBackendBytes(bytes int64) ClusterOption {
+	return func(c *ClusterConfig) { c.QuotaBackendBytes = bytes }
+}
+
+func WithSnapshotCount(count int) ClusterOption {
+	return func(c *ClusterConfig) { c.SnapshotCount = count }
+}
+
+func WithDisableStrictReconfigCheck() ClusterOption {
+	return func(c *ClusterConfig) { c.StrictReconfigCheck = false }
 }

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -46,7 +46,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.Clus
 		InitialToken:               "new",
 		ClusterSize:                cfg.ClusterSize,
 		QuotaBackendBytes:          cfg.QuotaBackendBytes,
-		DisableStrictReconfigCheck: cfg.DisableStrictReconfigCheck,
+		DisableStrictReconfigCheck: !cfg.StrictReconfigCheck,
 		AuthTokenOpts:              cfg.AuthToken,
 		SnapshotCount:              cfg.SnapshotCount,
 	}

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -47,7 +47,7 @@ func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, cfg con
 	integrationCfg := integration.ClusterConfig{
 		Size:                       cfg.ClusterSize,
 		QuotaBackendBytes:          cfg.QuotaBackendBytes,
-		DisableStrictReconfigCheck: cfg.DisableStrictReconfigCheck,
+		DisableStrictReconfigCheck: !cfg.StrictReconfigCheck,
 		AuthToken:                  cfg.AuthToken,
 		SnapshotCount:              uint64(cfg.SnapshotCount),
 	}


### PR DESCRIPTION
This PR tries to fix the anti-pattern naming problem(see [#14389](https://github.com/etcd-io/etcd/pull/14389#discussion_r955668262)), such as `DisableStrictReconfigCheck`(written by me🤣).

As far as I see, at least 4 structs have this problem:
1. [ctlCtx](https://github.com/etcd-io/etcd/blob/8ce81a1624e47f173d195bc335145b9923ee35e6/tests/e2e/ctl_v3_test.go#L124)
2. [config.ClusterConfig](https://github.com/etcd-io/etcd/blob/main/tests/framework/config/cluster.go)
3. [e2e.EtcdProcessClusterConfig](https://github.com/etcd-io/etcd/blob/8ce81a1624e47f173d195bc335145b9923ee35e6/tests/framework/e2e/cluster.go#L138)
4. [integration.ClusterConfig](https://github.com/etcd-io/etcd/blob/8ce81a1624e47f173d195bc335145b9923ee35e6/tests/framework/integration/cluster.go#L135)

This PR only tries to fix `(2)config.ClusterConfig`. 
`(3)e2e.EtcdProcessClusterConfig` and `(4)integration.ClusterConfig` will be fixed after this PR.

This PR changed `(2)config.ClusterConfig` with the **_Functional Options Pattern_**. I’m not sure if this is a proper solution. Please take a look and give some suggestions. 