### PR TITLE
tests: add a ClusterOption interface for ClusterSize in config.Cluster

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -31,7 +31,11 @@ func TestAlarm(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1, config.WithQuotaBackendBytes(int64(13*os.Getpagesize()))))
+	cfg := config.NewClusterConfig(
+		config.WithClusterSize(1),
+		config.WithQuotaBackendBytes(int64(13*os.Getpagesize())),
+	)
+	clus := testRunner.NewCluster(ctx, t, cfg)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -112,7 +116,7 @@ func TestAlarmlistOnMemberRestart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(
-		1,
+		config.WithClusterSize(1),
 		config.WithQuotaBackendBytes(int64(13*os.Getpagesize())),
 		config.WithSnapshotCount(5),
 	))

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -46,7 +46,7 @@ func TestCompact(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+			clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -29,7 +29,7 @@ func TestDefragOnline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	options := config.DefragOption{Timeout: 10 * time.Second}
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		defer clus.Close()

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -28,7 +28,7 @@ func TestEndpointStatus(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -43,7 +43,7 @@ func TestEndpointHashKV(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -58,7 +58,7 @@ func TestEndpointHealth(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -222,7 +222,7 @@ func TestKVGetNoQuorum(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(3))
+			clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
 			defer clus.Close()
 
 			clus.Members()[0].Stop()

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -26,23 +26,23 @@ var testRunner framework.TestRunner
 var clusterTestCases = []testCase{
 	{
 		name:   "NoTLS",
-		config: config.NewClusterConfig(1),
+		config: config.NewClusterConfig(config.WithClusterSize(1)),
 	},
 	{
 		name:   "PeerTLS",
-		config: config.NewClusterConfig(3, config.WithPeerTLS(config.ManualTLS)),
+		config: config.NewClusterConfig(config.WithPeerTLS(config.ManualTLS)),
 	},
 	{
 		name:   "PeerAutoTLS",
-		config: config.NewClusterConfig(3, config.WithPeerTLS(config.AutoTLS)),
+		config: config.NewClusterConfig(config.WithPeerTLS(config.AutoTLS)),
 	},
 	{
 		name:   "ClientTLS",
-		config: config.NewClusterConfig(1, config.WithClientTLS(config.ManualTLS)),
+		config: config.NewClusterConfig(config.WithClusterSize(1), config.WithClientTLS(config.ManualTLS)),
 	},
 	{
 		name:   "ClientAutoTLS",
-		config: config.NewClusterConfig(1, config.WithClientTLS(config.AutoTLS)),
+		config: config.NewClusterConfig(config.WithClusterSize(1), config.WithClientTLS(config.AutoTLS)),
 	},
 }
 

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -51,7 +51,7 @@ func TestRoleAdd_Error(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -74,7 +74,7 @@ func TestRootRole(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -104,7 +104,7 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -139,7 +139,7 @@ func TestRoleDelete(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(1))
+	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/wait_leader_test.go
+++ b/tests/common/wait_leader_test.go
@@ -45,11 +45,11 @@ func TestWaitLeader_MemberStop(t *testing.T) {
 	tcs := []testCase{
 		{
 			name:   "PeerTLS",
-			config: config.NewClusterConfig(3, config.WithPeerTLS(config.ManualTLS)),
+			config: config.NewClusterConfig(config.WithPeerTLS(config.ManualTLS)),
 		},
 		{
 			name:   "PeerAutoTLS",
-			config: config.NewClusterConfig(3, config.WithPeerTLS(config.AutoTLS)),
+			config: config.NewClusterConfig(config.WithPeerTLS(config.AutoTLS)),
 		},
 	}
 

--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -36,13 +36,15 @@ type ClusterConfig struct {
 	SnapshotCount       int
 }
 
-func defaultClusterConfig() ClusterConfig {
-	return ClusterConfig{StrictReconfigCheck: true}
+func DefaultClusterConfig() ClusterConfig {
+	return ClusterConfig{
+		ClusterSize:         3,
+		StrictReconfigCheck: true,
+	}
 }
 
-func NewClusterConfig(clusterSize int, opts ...ClusterOption) ClusterConfig {
-	c := defaultClusterConfig()
-	c.ClusterSize = clusterSize
+func NewClusterConfig(opts ...ClusterOption) ClusterConfig {
+	c := DefaultClusterConfig()
 	for _, opt := range opts {
 		opt(&c)
 	}
@@ -50,6 +52,10 @@ func NewClusterConfig(clusterSize int, opts ...ClusterOption) ClusterConfig {
 }
 
 type ClusterOption func(*ClusterConfig)
+
+func WithClusterSize(size int) ClusterOption {
+	return func(c *ClusterConfig) { c.ClusterSize = size }
+}
 
 func WithPeerTLS(tls TLSConfig) ClusterOption {
 	return func(c *ClusterConfig) { c.PeerTLS = tls }


### PR DESCRIPTION
As mentioned in [#14629](https://github.com/etcd-io/etcd/pull/14629#discussion_r1005582285), the code could be more concise with these changes.

From my understanding, `3` was used as the default value of `clusterSize`.

@ahrtr please have a look, thanks!