### PR TITLE
raft: send empty appends when replication is paused

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -1304,7 +1304,7 @@ func stepLeader(r *raft, m pb.Message) error {
 		}
 	case pb.MsgHeartbeatResp:
 		pr.RecentActive = true
-		pr.ProbeSent = false
+		pr.MsgAppFlowPaused = false
 
 		// NB: if the follower is paused (full Inflights), this will still send an
 		// empty append, allowing it to recover from situations in which all the
@@ -1349,7 +1349,7 @@ func stepLeader(r *raft, m pb.Message) error {
 		// If snapshot finish, wait for the MsgAppResp from the remote node before sending
 		// out the next MsgApp.
 		// If snapshot failure, wait for a heartbeat interval before next try
-		pr.ProbeSent = true
+		pr.MsgAppFlowPaused = true
 	case pb.MsgUnreachable:
 		// During optimistic replication, if the remote becomes unreachable,
 		// there is huge probability that a MsgApp is lost.

--- a/raft/raft_flow_control_test.go
+++ b/raft/raft_flow_control_test.go
@@ -36,14 +36,14 @@ func TestMsgAppFlowControlFull(t *testing.T) {
 	for i := 0; i < r.prs.MaxInflight; i++ {
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		ms := r.readMessages()
-		if len(ms) != 1 {
-			t.Fatalf("#%d: len(ms) = %d, want 1", i, len(ms))
+		if len(ms) != 1 || ms[0].Type != pb.MsgApp {
+			t.Fatalf("#%d: len(ms) = %d, want 1 MsgApp", i, len(ms))
 		}
 	}
 
 	// ensure 1
-	if !pr2.Inflights.Full() {
-		t.Fatalf("inflights.full = %t, want %t", pr2.Inflights.Full(), true)
+	if !pr2.IsPaused() {
+		t.Fatal("paused = false, want true")
 	}
 
 	// ensure 2
@@ -84,20 +84,20 @@ func TestMsgAppFlowControlMoveForward(t *testing.T) {
 		// fill in the inflights window again
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		ms := r.readMessages()
-		if len(ms) != 1 {
-			t.Fatalf("#%d: len(ms) = %d, want 1", tt, len(ms))
+		if len(ms) != 1 || ms[0].Type != pb.MsgApp {
+			t.Fatalf("#%d: len(ms) = %d, want 1 MsgApp", tt, len(ms))
 		}
 
 		// ensure 1
-		if !pr2.Inflights.Full() {
-			t.Fatalf("inflights.full = %t, want %t", pr2.Inflights.Full(), true)
+		if !pr2.IsPaused() {
+			t.Fatalf("#%d: paused = false, want true", tt)
 		}
 
 		// ensure 2
 		for i := 0; i < tt; i++ {
 			r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: uint64(i)})
-			if !pr2.Inflights.Full() {
-				t.Fatalf("#%d: inflights.full = %t, want %t", tt, pr2.Inflights.Full(), true)
+			if !pr2.IsPaused() {
+				t.Fatalf("#%d.%d: paused = false, want true", tt, i)
 			}
 		}
 	}
@@ -120,32 +120,35 @@ func TestMsgAppFlowControlRecvHeartbeat(t *testing.T) {
 	}
 
 	for tt := 1; tt < 5; tt++ {
-		if !pr2.Inflights.Full() {
-			t.Fatalf("#%d: inflights.full = %t, want %t", tt, pr2.Inflights.Full(), true)
+		if !pr2.IsPaused() {
+			t.Fatalf("#%d: paused = false, want true", tt)
 		}
 
 		// recv tt msgHeartbeatResp and expect one free slot
 		for i := 0; i < tt; i++ {
 			r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgHeartbeatResp})
-			r.readMessages()
-			if pr2.Inflights.Full() {
-				t.Fatalf("#%d.%d: inflights.full = %t, want %t", tt, i, pr2.Inflights.Full(), false)
+			ms := r.readMessages()
+			if len(ms) != 1 || ms[0].Type != pb.MsgApp || len(ms[0].Entries) != 0 {
+				t.Fatalf("#%d.%d: len(ms) == %d, want 1 empty MsgApp", tt, i, len(ms))
+			}
+			if pr2.IsPaused() {
+				t.Fatalf("#%d.%d: paused = true, want false", tt, i)
 			}
 		}
 
 		// one slot
 		r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 		ms := r.readMessages()
-		if len(ms) != 1 {
-			t.Fatalf("#%d: free slot = 0, want 1", tt)
+		if len(ms) != 1 || ms[0].Type != pb.MsgApp || len(ms[0].Entries) != 1 {
+			t.Fatalf("#%d: len(ms) == %d, want 1 MsgApp with 1 entry", tt, len(ms))
 		}
 
 		// and just one slot
 		for i := 0; i < 10; i++ {
 			r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
-			ms1 := r.readMessages()
-			if len(ms1) != 0 {
-				t.Fatalf("#%d.%d: len(ms) = %d, want 0", tt, i, len(ms1))
+			ms := r.readMessages()
+			if len(ms) != 0 {
+				t.Fatalf("#%d.%d: len(ms) = %d, want 0", tt, i, len(ms))
 			}
 		}
 

--- a/raft/raft_snap_test.go
+++ b/raft/raft_snap_test.go
@@ -83,8 +83,8 @@ func TestSnapshotFailure(t *testing.T) {
 	if sm.prs.Progress[2].Next != 1 {
 		t.Fatalf("Next = %d, want 1", sm.prs.Progress[2].Next)
 	}
-	if !sm.prs.Progress[2].ProbeSent {
-		t.Errorf("ProbeSent = %v, want true", sm.prs.Progress[2].ProbeSent)
+	if !sm.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("MsgAppFlowPaused = %v, want true", sm.prs.Progress[2].MsgAppFlowPaused)
 	}
 }
 
@@ -106,8 +106,8 @@ func TestSnapshotSucceed(t *testing.T) {
 	if sm.prs.Progress[2].Next != 12 {
 		t.Fatalf("Next = %d, want 12", sm.prs.Progress[2].Next)
 	}
-	if !sm.prs.Progress[2].ProbeSent {
-		t.Errorf("ProbeSent = %v, want true", sm.prs.Progress[2].ProbeSent)
+	if !sm.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("MsgAppFlowPaused = %v, want true", sm.prs.Progress[2].MsgAppFlowPaused)
 	}
 }
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -94,21 +94,21 @@ func TestProgressResumeByHeartbeatResp(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 
-	r.prs.Progress[2].ProbeSent = true
+	r.prs.Progress[2].MsgAppFlowPaused = true
 
 	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgBeat})
-	if !r.prs.Progress[2].ProbeSent {
-		t.Errorf("paused = %v, want true", r.prs.Progress[2].ProbeSent)
+	if !r.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("paused = %v, want true", r.prs.Progress[2].MsgAppFlowPaused)
 	}
 
 	r.prs.Progress[2].BecomeReplicate()
-	if r.prs.Progress[2].ProbeSent {
-		t.Errorf("paused = %v, want false", r.prs.Progress[2].ProbeSent)
+	if r.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("paused = %v, want false", r.prs.Progress[2].MsgAppFlowPaused)
 	}
-	r.prs.Progress[2].ProbeSent = true
+	r.prs.Progress[2].MsgAppFlowPaused = true
 	r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgHeartbeatResp})
-	if r.prs.Progress[2].ProbeSent {
-		t.Errorf("paused = %v, want false", r.prs.Progress[2].ProbeSent)
+	if r.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("paused = %v, want false", r.prs.Progress[2].MsgAppFlowPaused)
 	}
 }
 
@@ -2658,8 +2658,8 @@ func TestSendAppendForProgressProbe(t *testing.T) {
 			}
 		}
 
-		if !r.prs.Progress[2].ProbeSent {
-			t.Errorf("paused = %v, want true", r.prs.Progress[2].ProbeSent)
+		if !r.prs.Progress[2].MsgAppFlowPaused {
+			t.Errorf("paused = %v, want true", r.prs.Progress[2].MsgAppFlowPaused)
 		}
 		for j := 0; j < 10; j++ {
 			mustAppendEntry(r, pb.Entry{Data: []byte("somedata")})
@@ -2673,8 +2673,8 @@ func TestSendAppendForProgressProbe(t *testing.T) {
 		for j := 0; j < r.heartbeatTimeout; j++ {
 			r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgBeat})
 		}
-		if !r.prs.Progress[2].ProbeSent {
-			t.Errorf("paused = %v, want true", r.prs.Progress[2].ProbeSent)
+		if !r.prs.Progress[2].MsgAppFlowPaused {
+			t.Errorf("paused = %v, want true", r.prs.Progress[2].MsgAppFlowPaused)
 		}
 
 		// consume the heartbeat
@@ -2696,8 +2696,8 @@ func TestSendAppendForProgressProbe(t *testing.T) {
 	if msg[0].Index != 0 {
 		t.Errorf("index = %d, want %d", msg[0].Index, 0)
 	}
-	if !r.prs.Progress[2].ProbeSent {
-		t.Errorf("paused = %v, want true", r.prs.Progress[2].ProbeSent)
+	if !r.prs.Progress[2].MsgAppFlowPaused {
+		t.Errorf("paused = %v, want true", r.prs.Progress[2].MsgAppFlowPaused)
 	}
 }
 

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -102,6 +102,10 @@ func TestProgressResumeByHeartbeatResp(t *testing.T) {
 	}
 
 	r.prs.Progress[2].BecomeReplicate()
+	if r.prs.Progress[2].ProbeSent {
+		t.Errorf("paused = %v, want false", r.prs.Progress[2].ProbeSent)
+	}
+	r.prs.Progress[2].ProbeSent = true
 	r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgHeartbeatResp})
 	if r.prs.Progress[2].ProbeSent {
 		t.Errorf("paused = %v, want false", r.prs.Progress[2].ProbeSent)

--- a/raft/rafttest/interaction_env.go
+++ b/raft/rafttest/interaction_env.go
@@ -84,15 +84,13 @@ type Storage interface {
 	Append([]pb.Entry) error
 }
 
-// defaultRaftConfig sets up a *raft.Config with reasonable testing defaults.
-// In particular, no limits are set.
-func defaultRaftConfig(id uint64, applied uint64, s raft.Storage) *raft.Config {
-	return &raft.Config{
-		ID:              id,
-		Applied:         applied,
+// raftConfigStub sets up a raft.Config stub with reasonable testing defaults.
+// In particular, no limits are set. It is not a complete config: ID and Storage
+// must be set for each node using the stub as a template.
+func raftConfigStub() raft.Config {
+	return raft.Config{
 		ElectionTick:    3,
 		HeartbeatTick:   1,
-		Storage:         s,
 		MaxSizePerMsg:   math.MaxUint64,
 		MaxInflightMsgs: math.MaxInt32,
 	}

--- a/raft/testdata/replicate_pause.txt
+++ b/raft/testdata/replicate_pause.txt
@@ -146,9 +146,9 @@ stabilize 2 3
   Messages:
   3->1 MsgHeartbeatResp Term:1 Log:0/0
 
-# After handling heartbeat responses, node 1 sends a new replication MsgApp to a
-# throttled node 3 which hasn't yet replied to a single MsgApp.
-# TODO(pavelkalinnikov): this should not happen, send empty MsgApp instead.
+# After handling heartbeat responses, node 1 sends an empty MsgApp to a
+# throttled node 3 because it hasn't yet replied to a single MsgApp, and the
+# in-flight tracker is still saturated.
 stabilize 1
 ----
 > 1 receiving messages
@@ -157,13 +157,13 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/14 Commit:17 Entries:[1/15 EntryNormal "prop_1_15", 1/16 EntryNormal "prop_1_16", 1/17 EntryNormal "prop_1_17"]
+  1->3 MsgApp Term:1 Log:1/14 Commit:17
 
 # Node 3 finally receives a MsgApp, but there was a gap, so it rejects it.
 stabilize 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/14 Commit:17 Entries:[1/15 EntryNormal "prop_1_15", 1/16 EntryNormal "prop_1_16", 1/17 EntryNormal "prop_1_17"]
+  1->3 MsgApp Term:1 Log:1/14 Commit:17
   DEBUG 3 [logterm: 0, index: 14] rejected MsgApp [logterm: 1, index: 14] from 1
 > 3 handling Ready
   Ready MustSync=false:

--- a/raft/testdata/replicate_pause.txt
+++ b/raft/testdata/replicate_pause.txt
@@ -1,0 +1,190 @@
+# This test ensures that MsgApp stream to a follower is paused when the
+# in-flight state exceeds the configured limits. This is a regression test for
+# the issue fixed by https://github.com/etcd-io/etcd/pull/14633.
+
+# Turn off output during the setup of the test.
+log-level none
+----
+ok
+
+# Start with 3 nodes, with a limited in-flight capacity.
+add-nodes 3 voters=(1,2,3) index=10 inflight=3
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+# Propose 3 entries.
+propose 1 prop_1_12
+----
+ok
+
+propose 1 prop_1_13
+----
+ok
+
+propose 1 prop_1_14
+----
+ok
+
+# Store entries and send proposals.
+process-ready 1
+----
+ok (quiet)
+
+# Re-enable log messages.
+log-level debug
+----
+ok
+
+# Expect that in-flight tracking to nodes 2 and 3 is saturated.
+status 1
+----
+1: StateReplicate match=14 next=15
+2: StateReplicate match=11 next=15 paused inflight=3[full]
+3: StateReplicate match=11 next=15 paused inflight=3[full]
+
+log-level none
+----
+ok
+
+# Commit entries between nodes 1 and 2.
+stabilize 1 2
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# Expect that the entries are committed and stored on nodes 1 and 2.
+status 1
+----
+1: StateReplicate match=14 next=15
+2: StateReplicate match=14 next=15
+3: StateReplicate match=11 next=15 paused inflight=3[full]
+
+# Drop append messages to node 3.
+deliver-msgs drop=3
+----
+dropped: 1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
+dropped: 1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
+
+
+# Repeat committing 3 entries.
+propose 1 prop_1_15
+----
+ok
+
+propose 1 prop_1_16
+----
+ok
+
+propose 1 prop_1_17
+----
+ok
+
+# In-flight tracking to nodes 2 and 3 is saturated, but node 3 is behind.
+status 1
+----
+1: StateReplicate match=14 next=15
+2: StateReplicate match=14 next=18 paused inflight=3[full]
+3: StateReplicate match=11 next=15 paused inflight=3[full]
+
+log-level none
+----
+ok
+
+# Commit entries between nodes 1 and 2 again.
+stabilize 1 2
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# Expect that the entries are committed and stored only on nodes 1 and 2.
+status 1
+----
+1: StateReplicate match=17 next=18
+2: StateReplicate match=17 next=18
+3: StateReplicate match=11 next=15 paused inflight=3[full]
+
+# Make a heartbeat roundtrip.
+tick-heartbeat 1
+----
+ok
+
+stabilize 1
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+
+stabilize 2 3
+----
+> 2 receiving messages
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
+> 3 receiving messages
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
+
+# After handling heartbeat responses, node 1 sends a new replication MsgApp to a
+# throttled node 3 which hasn't yet replied to a single MsgApp.
+# TODO(pavelkalinnikov): this should not happen, send empty MsgApp instead.
+stabilize 1
+----
+> 1 receiving messages
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:1 Log:1/14 Commit:17 Entries:[1/15 EntryNormal "prop_1_15", 1/16 EntryNormal "prop_1_16", 1/17 EntryNormal "prop_1_17"]
+
+# Node 3 finally receives a MsgApp, but there was a gap, so it rejects it.
+stabilize 3
+----
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/14 Commit:17 Entries:[1/15 EntryNormal "prop_1_15", 1/16 EntryNormal "prop_1_16", 1/17 EntryNormal "prop_1_17"]
+  DEBUG 3 [logterm: 0, index: 14] rejected MsgApp [logterm: 1, index: 14] from 1
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11)
+
+log-level none
+----
+ok
+
+stabilize
+----
+ok (quiet)
+
+log-level debug
+----
+ok
+
+# Eventually all nodes catch up on the committed state.
+status 1
+----
+1: StateReplicate match=17 next=18
+2: StateReplicate match=17 next=18
+3: StateReplicate match=17 next=18

--- a/raft/tracker/inflights.go
+++ b/raft/tracker/inflights.go
@@ -113,10 +113,6 @@ func (in *Inflights) FreeLE(to uint64) {
 	}
 }
 
-// FreeFirstOne releases the first inflight. This is a no-op if nothing is
-// inflight.
-func (in *Inflights) FreeFirstOne() { in.FreeLE(in.buffer[in.start]) }
-
 // Full returns true if no more messages can be sent at the moment.
 func (in *Inflights) Full() bool {
 	return in.count == in.size

--- a/raft/tracker/inflights_test.go
+++ b/raft/tracker/inflights_test.go
@@ -105,6 +105,20 @@ func TestInflightFreeTo(t *testing.T) {
 		in.Add(uint64(i))
 	}
 
+	in.FreeLE(0)
+
+	wantIn0 := &Inflights{
+		start: 1,
+		count: 9,
+		size:  10,
+		//                  ↓------------------------
+		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+
+	if !reflect.DeepEqual(in, wantIn0) {
+		t.Fatalf("in = %+v, want %+v", in, wantIn0)
+	}
+
 	in.FreeLE(4)
 
 	wantIn := &Inflights{
@@ -164,26 +178,5 @@ func TestInflightFreeTo(t *testing.T) {
 
 	if !reflect.DeepEqual(in, wantIn4) {
 		t.Fatalf("in = %+v, want %+v", in, wantIn4)
-	}
-}
-
-func TestInflightFreeFirstOne(t *testing.T) {
-	in := NewInflights(10)
-	for i := 0; i < 10; i++ {
-		in.Add(uint64(i))
-	}
-
-	in.FreeFirstOne()
-
-	wantIn := &Inflights{
-		start: 1,
-		count: 9,
-		size:  10,
-		//                  ↓------------------------
-		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-	}
-
-	if !reflect.DeepEqual(in, wantIn) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn)
 	}
 }

--- a/raft/tracker/progress_test.go
+++ b/raft/tracker/progress_test.go
@@ -22,14 +22,14 @@ func TestProgressString(t *testing.T) {
 	ins := NewInflights(1)
 	ins.Add(123)
 	pr := &Progress{
-		Match:           1,
-		Next:            2,
-		State:           StateSnapshot,
-		PendingSnapshot: 123,
-		RecentActive:    false,
-		ProbeSent:       true,
-		IsLearner:       true,
-		Inflights:       ins,
+		Match:            1,
+		Next:             2,
+		State:            StateSnapshot,
+		PendingSnapshot:  123,
+		RecentActive:     false,
+		MsgAppFlowPaused: true,
+		IsLearner:        true,
+		Inflights:        ins,
 	}
 	const exp = `StateSnapshot match=1 next=2 learner paused pendingSnap=123 inactive inflight=1[full]`
 	if act := pr.String(); act != exp {
@@ -53,9 +53,9 @@ func TestProgressIsPaused(t *testing.T) {
 	}
 	for i, tt := range tests {
 		p := &Progress{
-			State:     tt.state,
-			ProbeSent: tt.paused,
-			Inflights: NewInflights(256),
+			State:            tt.state,
+			MsgAppFlowPaused: tt.paused,
+			Inflights:        NewInflights(256),
 		}
 		if g := p.IsPaused(); g != tt.w {
 			t.Errorf("#%d: paused= %t, want %t", i, g, tt.w)
@@ -64,20 +64,20 @@ func TestProgressIsPaused(t *testing.T) {
 }
 
 // TestProgressResume ensures that MaybeUpdate and MaybeDecrTo will reset
-// ProbeSent.
+// MsgAppFlowPaused.
 func TestProgressResume(t *testing.T) {
 	p := &Progress{
-		Next:      2,
-		ProbeSent: true,
+		Next:             2,
+		MsgAppFlowPaused: true,
 	}
 	p.MaybeDecrTo(1, 1)
-	if p.ProbeSent {
-		t.Errorf("paused= %v, want false", p.ProbeSent)
+	if p.MsgAppFlowPaused {
+		t.Errorf("paused= %v, want false", p.MsgAppFlowPaused)
 	}
-	p.ProbeSent = true
+	p.MsgAppFlowPaused = true
 	p.MaybeUpdate(2)
-	if p.ProbeSent {
-		t.Errorf("paused= %v, want false", p.ProbeSent)
+	if p.MsgAppFlowPaused {
+		t.Errorf("paused= %v, want false", p.MsgAppFlowPaused)
 	}
 }
 

--- a/raft/tracker/progress_test.go
+++ b/raft/tracker/progress_test.go
@@ -47,7 +47,7 @@ func TestProgressIsPaused(t *testing.T) {
 		{StateProbe, false, false},
 		{StateProbe, true, true},
 		{StateReplicate, false, false},
-		{StateReplicate, true, false},
+		{StateReplicate, true, true},
 		{StateSnapshot, false, true},
 		{StateSnapshot, true, true},
 	}


### PR DESCRIPTION
When Inflights to a particular node is full, i.e. MaxInflightMsgs for the append messages flow is saturated, it is still necessary to continue sending MsgApp to ensure progress. Currently this is achieved by "forgetting" the first in-flight message in the window, which frees up quota for one new MsgApp.

This new message is constructed in such a way that it potentially has multiple entries, or a large entry. The effect of this is that the in-flight limitations can be exceeded arbitrarily, for as long as the flow to this node continues being saturated. In particular, if a follower is stuck, the leader will keep sending entries to it.

This commit makes the MsgApp empty when Inflights is saturated, and prevents the described leakage of Entries to slow followers.

Signed-off-by: Pavel Kalinnikov <pavel@cockroachlabs.com>
