### PR TITLE
[e2e] don't pass --endpoints flag in test HashKV implementation

### DIFF
--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"go.etcd.io/etcd/api/v3/authpb"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/config"
-	"google.golang.org/grpc"
 )
 
 type EtcdctlV3 struct {
@@ -355,7 +356,7 @@ func (ctl *EtcdctlV3) HashKV(ctx context.Context, rev int64) ([]*clientv3.HashKV
 		Endpoint string
 		HashKV   *clientv3.HashKVResponse
 	}
-	err := ctl.spawnJsonCmd(ctx, &epHashKVs, "endpoint", "hashkv", "--endpoints", strings.Join(ctl.endpoints, ","), "--rev", fmt.Sprint(rev))
+	err := ctl.spawnJsonCmd(ctx, &epHashKVs, "endpoint", "hashkv", "--rev", fmt.Sprint(rev))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Flag is already set in https://github.com/etcd-io/etcd/blob/9bc4a63a419cd316f6920e37ec551b87d1c7c3a7/tests/framework/e2e/etcdctl.go#L317.
Duplicate flag leads to duplicate entries in hashkv output.