### PR TITLE
Fix error on Scorecard run by upgrading the action version

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Closes #14636 

I've upgraded the version of Scorecard Github Action from 2.0.3 to 2.0.6.

Here is a test I've made. The [older action](https://github.com/joycebrum/etcd/actions/runs/3305719746) was with the same error. The [latest action](https://github.com/joycebrum/etcd/actions/runs/3348212136) ran with Scorecard Github Action 2.0.6 and with success.
 
![image](https://user-images.githubusercontent.com/22223372/198723318-0a79a32f-4019-4eba-bc73-83f9756ff753.png)
