### PR TITLE
server: add a unit test case for authStore.Reocver() with empty rangePermCache

### DIFF
--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -177,6 +177,30 @@ func TestRecover(t *testing.T) {
 	}
 }
 
+func TestRecoverWithEmptyRangePermCache(t *testing.T) {
+	as, tearDown := setupAuthStore(t)
+	defer as.Close()
+	defer tearDown(t)
+
+	as.enabled = false
+	as.rangePermCache = map[string]*unifiedRangePermissions{}
+	as.Recover(as.be)
+
+	if !as.IsAuthEnabled() {
+		t.Fatalf("expected auth enabled got disabled")
+	}
+
+	if len(as.rangePermCache) != 2 {
+		t.Fatalf("rangePermCache should have permission information for 2 users (\"root\" and \"foo\"), but has %d information", len(as.rangePermCache))
+	}
+	if _, ok := as.rangePermCache["root"]; !ok {
+		t.Fatal("user \"root\" should be created by setupAuthStore() but doesn't exist in rangePermCache")
+	}
+	if _, ok := as.rangePermCache["foo"]; !ok {
+		t.Fatal("user \"foo\" should be created by setupAuthStore() but doesn't exist in rangePermCache")
+	}
+}
+
 func TestCheckPassword(t *testing.T) {
 	as, tearDown := setupAuthStore(t)
 	defer tearDown(t)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

This is a corrective action for https://github.com/etcd-io/etcd/issues/14571 Since introducing the change of https://github.com/etcd-io/etcd/pull/13954 `authStore.rangePermCache` needs to be updated immediately after changing auth configuration or recovery from Raft logs or snapshot (prior to the change, `rangePermCache` just needs to be updated during data access). However, the unit test cases don't cover the behavior for `authStore.Recover()`. Although below test cases cover similar scenario, it wasn't enough for testing the new behavior:
- [TestReocver()](https://github.com/etcd-io/etcd/blob/main/server/auth/store_test.go#L167): it tests `authStore.Recover()` but just focusing on `authStore.enabled` flag. This is because prior to https://github.com/etcd-io/etcd/issues/14571 `authStore.rangePermCache` just needs to be empty and updated during data access. In addition, invoking methods like `UserAdd()` in `setupAuthStore()` lets `authStore.rangePermCache` be refreshed.
- [TestRecoverFromSnapshot()](https://github.com/etcd-io/etcd/blob/main/server/auth/store_test.go#L812): it also tests recovery from snapshot. But the test target is `authStore.NewAuthStore()` and not `authStore.Recover()`. 

This PR adds the new test case `TestRecoverWithEmptyRangePermCache()` for preventing regression in future. `authStore.rangePermCache` can be empty (or stale) in the cases like joining to a cluster as a new member. The test case mocks such a scenario.

cc @ahrtr @serathius @yishuT @vishuT @euroelessar 