### PR TITLE
tests: TestRunner.NewCluster accepts options

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -31,11 +31,10 @@ func TestAlarm(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	cfg := config.NewClusterConfig(
+	clus := testRunner.NewCluster(ctx, t,
 		config.WithClusterSize(1),
 		config.WithQuotaBackendBytes(int64(13*os.Getpagesize())),
 	)
-	clus := testRunner.NewCluster(ctx, t, cfg)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -115,11 +114,11 @@ func TestAlarmlistOnMemberRestart(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(
+	clus := testRunner.NewCluster(ctx, t,
 		config.WithClusterSize(1),
 		config.WithQuotaBackendBytes(int64(13*os.Getpagesize())),
 		config.WithSnapshotCount(5),
-	))
+	)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -46,7 +46,7 @@ func TestCompact(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+			clus := testRunner.NewCluster(ctx, t)
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -29,7 +29,7 @@ func TestDefragOnline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	options := config.DefragOption{Timeout: 10 * time.Second}
-	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+	clus := testRunner.NewCluster(ctx, t)
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		defer clus.Close()

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/tests/v3/framework"
-	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -28,7 +27,7 @@ func TestEndpointStatus(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+	clus := testRunner.NewCluster(ctx, t)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -43,7 +42,7 @@ func TestEndpointHashKV(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+	clus := testRunner.NewCluster(ctx, t)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -58,7 +57,7 @@ func TestEndpointHealth(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+	clus := testRunner.NewCluster(ctx, t)
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -32,7 +32,7 @@ func TestKVPut(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -66,7 +66,7 @@ func TestKVGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -126,7 +126,7 @@ func TestKVDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
@@ -222,7 +222,7 @@ func TestKVGetNoQuorum(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, config.DefaultClusterConfig())
+			clus := testRunner.NewCluster(ctx, t)
 			defer clus.Close()
 
 			clus.Members()[0].Stop()

--- a/tests/common/lease_test.go
+++ b/tests/common/lease_test.go
@@ -33,7 +33,7 @@ func TestLeaseGrantTimeToLive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -77,7 +77,7 @@ func TestLeaseGrantAndList(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				t.Logf("Creating cluster...")
-				clus := testRunner.NewCluster(ctx, t, tc.config)
+				clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 				defer clus.Close()
 				cc := framework.MustClient(clus.Client())
 				t.Logf("Created cluster and client")
@@ -124,7 +124,7 @@ func TestLeaseGrantTimeToLiveExpired(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -161,7 +161,7 @@ func TestLeaseGrantKeepAliveOnce(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -190,7 +190,7 @@ func TestLeaseGrantRevoke(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -23,6 +23,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -33,7 +34,7 @@ func TestMemberList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -107,7 +108,7 @@ func TestMemberAdd(t *testing.T) {
 					defer cancel()
 					c := clusterTc.config
 					c.StrictReconfigCheck = quorumTc.strictReconfigCheck
-					clus := testRunner.NewCluster(ctx, t, c)
+					clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(c))
 					defer clus.Close()
 					cc := framework.MustClient(clus.Client())
 
@@ -188,7 +189,7 @@ func TestMemberRemove(t *testing.T) {
 				defer cancel()
 				c := clusterTc.config
 				c.StrictReconfigCheck = quorumTc.strictReconfigCheck
-				clus := testRunner.NewCluster(ctx, t, c)
+				clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(c))
 				defer clus.Close()
 				// client connects to a specific member which won't be removed from cluster
 				cc := clus.Members()[0].Client()

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -33,7 +33,7 @@ func TestRoleAdd_Simple(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -51,7 +51,7 @@ func TestRoleAdd_Error(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
+	clus := testRunner.NewCluster(ctx, t, config.WithClusterSize(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -74,7 +74,7 @@ func TestRootRole(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
+	clus := testRunner.NewCluster(ctx, t, config.WithClusterSize(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -104,7 +104,7 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
+	clus := testRunner.NewCluster(ctx, t, config.WithClusterSize(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
@@ -139,7 +139,7 @@ func TestRoleDelete(t *testing.T) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	clus := testRunner.NewCluster(ctx, t, config.NewClusterConfig(config.WithClusterSize(1)))
+	clus := testRunner.NewCluster(ctx, t, config.WithClusterSize(1))
 	defer clus.Close()
 	cc := framework.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/tests/v3/framework"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -31,7 +32,7 @@ func TestStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 

--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -59,7 +59,7 @@ func TestTxnSucc(t *testing.T) {
 		t.Run(cfg.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, cfg.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(cfg.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
@@ -103,7 +103,7 @@ func TestTxnFail(t *testing.T) {
 		t.Run(cfg.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, cfg.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(cfg.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {

--- a/tests/common/user_test.go
+++ b/tests/common/user_test.go
@@ -67,7 +67,7 @@ func TestUserAdd_Simple(t *testing.T) {
 			t.Run(tc.name+"/"+nc.name, func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				clus := testRunner.NewCluster(ctx, t, tc.config)
+				clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 				defer clus.Close()
 				cc := framework.MustClient(clus.Client())
 
@@ -101,7 +101,7 @@ func TestUserAdd_DuplicateUserNotAllowed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -130,7 +130,7 @@ func TestUserList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -171,7 +171,7 @@ func TestUserDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 
@@ -223,7 +223,7 @@ func TestUserChangePassword(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())
 

--- a/tests/common/wait_leader_test.go
+++ b/tests/common/wait_leader_test.go
@@ -29,7 +29,7 @@ func TestWaitLeader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 
 			leader := clus.WaitLeader(t)
@@ -57,7 +57,7 @@ func TestWaitLeader_MemberStop(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 
 			lead1 := clus.WaitLeader(t)

--- a/tests/common/watch_test.go
+++ b/tests/common/watch_test.go
@@ -18,7 +18,7 @@ func TestWatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
-			clus := testRunner.NewCluster(ctx, t, tc.config)
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 
 			defer clus.Close()
 			cc := framework.MustClient(clus.Client())

--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -53,6 +53,10 @@ func NewClusterConfig(opts ...ClusterOption) ClusterConfig {
 
 type ClusterOption func(*ClusterConfig)
 
+func WithClusterConfig(cfg ClusterConfig) ClusterOption {
+	return func(c *ClusterConfig) { *c = cfg }
+}
+
 func WithClusterSize(size int) ClusterOption {
 	return func(c *ClusterConfig) { c.ClusterSize = size }
 }
@@ -73,6 +77,6 @@ func WithSnapshotCount(count int) ClusterOption {
 	return func(c *ClusterConfig) { c.SnapshotCount = count }
 }
 
-func WithDisableStrictReconfigCheck() ClusterOption {
-	return func(c *ClusterConfig) { c.StrictReconfigCheck = false }
+func WithStrictReconfigCheck(strict bool) ClusterOption {
+	return func(c *ClusterConfig) { c.StrictReconfigCheck = strict }
 }

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -41,7 +41,8 @@ func (e e2eRunner) BeforeTest(t testing.TB) {
 	e2e.BeforeTest(t)
 }
 
-func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.ClusterConfig) Cluster {
+func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) Cluster {
+	cfg := config.NewClusterConfig(opts...)
 	e2eConfig := e2e.EtcdProcessClusterConfig{
 		InitialToken:               "new",
 		ClusterSize:                cfg.ClusterSize,

--- a/tests/framework/integration.go
+++ b/tests/framework/integration.go
@@ -42,8 +42,9 @@ func (e integrationRunner) BeforeTest(t testing.TB) {
 	integration.BeforeTest(t)
 }
 
-func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.ClusterConfig) Cluster {
+func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) Cluster {
 	var err error
+	cfg := config.NewClusterConfig(opts...)
 	integrationCfg := integration.ClusterConfig{
 		Size:                       cfg.ClusterSize,
 		QuotaBackendBytes:          cfg.QuotaBackendBytes,

--- a/tests/framework/interface.go
+++ b/tests/framework/interface.go
@@ -25,7 +25,7 @@ import (
 type TestRunner interface {
 	TestMain(m *testing.M)
 	BeforeTest(testing.TB)
-	NewCluster(context.Context, testing.TB, config.ClusterConfig) Cluster
+	NewCluster(context.Context, testing.TB, ...config.ClusterOption) Cluster
 }
 
 type Cluster interface {

--- a/tests/framework/unit.go
+++ b/tests/framework/unit.go
@@ -40,7 +40,7 @@ func (e unitRunner) TestMain(m *testing.M) {
 func (e unitRunner) BeforeTest(t testing.TB) {
 }
 
-func (e unitRunner) NewCluster(ctx context.Context, t testing.TB, cfg config.ClusterConfig) Cluster {
+func (e unitRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) Cluster {
 	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
 	return nil
 }


### PR DESCRIPTION
As mentioned in https://github.com/etcd-io/etcd/pull/14632#pullrequestreview-1158400017 @serathius, `TestRunner.NewCluster` method now accepts options.

This implementation avoids adding a new method to `TestRunner` interface. The downside is that
```
clus := testRunner.NewCluster(ctx, t, tc.config)
```
becomes more verbose as shown below:
```
clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
```