### PR TITLE
server: add more context to panic message

### DIFF
--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -105,6 +105,13 @@ func (tr *storeTxnRead) rangeKeys(ctx context.Context, key, end []byte, curRev i
 				"range failed to find revision pair",
 				zap.Int64("revision-main", revpair.main),
 				zap.Int64("revision-sub", revpair.sub),
+				zap.Int64("revision-current", curRev),
+				zap.Int64("range-option-rev", ro.Rev),
+				zap.Int64("range-option-limit", ro.Limit),
+				zap.Binary("key", key),
+				zap.Binary("end", end),
+				zap.Int("len-revpairs", len(revpairs)),
+				zap.Int("len-values", len(vs)),
 			)
 		}
 		if err := kvs[i].Unmarshal(vs[0]); err != nil {


### PR DESCRIPTION
Adding more context to the panic log message for https://github.com/etcd-io/etcd/issues/14211 .

Our goal is to capture enough information that will allow us to reproduce the issue when it happens again.