### PR TITLE
Expect exit code enhancement

### DIFF
--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -28,30 +28,30 @@ import (
 )
 
 type txnReq struct {
-	compare  []string
-	ifSucess []string
-	ifFail   []string
-	results  []string
+	compare   []string
+	ifSuccess []string
+	ifFail    []string
+	results   []string
 }
 
 func TestTxnSucc(t *testing.T) {
 	testRunner.BeforeTest(t)
 	reqs := []txnReq{
 		{
-			compare:  []string{`value("key1") != "value2"`, `value("key2") != "value1"`},
-			ifSucess: []string{"get key1", "get key2"},
-			results:  []string{"SUCCESS", "key1", "value1", "key2", "value2"},
+			compare:   []string{`value("key1") != "value2"`, `value("key2") != "value1"`},
+			ifSuccess: []string{"get key1", "get key2"},
+			results:   []string{"SUCCESS", "key1", "value1", "key2", "value2"},
 		},
 		{
-			compare:  []string{`version("key1") = "1"`, `version("key2") = "1"`},
-			ifSucess: []string{"get key1", "get key2", `put "key \"with\" space" "value \x23"`},
-			ifFail:   []string{`put key1 "fail"`, `put key2 "fail"`},
-			results:  []string{"SUCCESS", "key1", "value1", "key2", "value2", "OK"},
+			compare:   []string{`version("key1") = "1"`, `version("key2") = "1"`},
+			ifSuccess: []string{"get key1", "get key2", `put "key \"with\" space" "value \x23"`},
+			ifFail:    []string{`put key1 "fail"`, `put key2 "fail"`},
+			results:   []string{"SUCCESS", "key1", "value1", "key2", "value2", "OK"},
 		},
 		{
-			compare:  []string{`version("key \"with\" space") = "1"`},
-			ifSucess: []string{`get "key \"with\" space"`},
-			results:  []string{"SUCCESS", `key "with" space`, "value \x23"},
+			compare:   []string{`version("key \"with\" space") = "1"`},
+			ifSuccess: []string{`get "key \"with\" space"`},
+			results:   []string{"SUCCESS", `key "with" space`, "value \x23"},
 		},
 	}
 	for _, cfg := range clusterTestCases() {
@@ -69,7 +69,7 @@ func TestTxnSucc(t *testing.T) {
 					t.Fatalf("could not create key:%s, value:%s", "key2", "value2")
 				}
 				for _, req := range reqs {
-					resp, err := cc.Txn(ctx, req.compare, req.ifSucess, req.ifFail, config.TxnOptions{
+					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,
 					})
 					if err != nil {
@@ -86,16 +86,16 @@ func TestTxnFail(t *testing.T) {
 	testRunner.BeforeTest(t)
 	reqs := []txnReq{
 		{
-			compare:  []string{`version("key") < "0"`},
-			ifSucess: []string{`put key "success"`},
-			ifFail:   []string{`put key "fail"`},
-			results:  []string{"FAILURE", "OK"},
+			compare:   []string{`version("key") < "0"`},
+			ifSuccess: []string{`put key "success"`},
+			ifFail:    []string{`put key "fail"`},
+			results:   []string{"FAILURE", "OK"},
 		},
 		{
-			compare:  []string{`value("key1") != "value1"`},
-			ifSucess: []string{`put key1 "success"`},
-			ifFail:   []string{`put key1 "fail"`},
-			results:  []string{"FAILURE", "OK"},
+			compare:   []string{`value("key1") != "value1"`},
+			ifSuccess: []string{`put key1 "success"`},
+			ifFail:    []string{`put key1 "fail"`},
+			results:   []string{"FAILURE", "OK"},
 		},
 	}
 	for _, cfg := range clusterTestCases() {
@@ -110,7 +110,7 @@ func TestTxnFail(t *testing.T) {
 					t.Fatalf("could not create key:%s, value:%s", "key1", "value1")
 				}
 				for _, req := range reqs {
-					resp, err := cc.Txn(ctx, req.compare, req.ifSucess, req.ifFail, config.TxnOptions{
+					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,
 					})
 					if err != nil {

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -90,10 +91,7 @@ func snapshotCorruptTest(cx ctlCtx) {
 			fpath),
 		cx.envMap,
 		"expected sha256")
-
-	if serr != nil {
-		cx.t.Fatal(serr)
-	}
+	require.ErrorContains(cx.t, serr, "Error: expected sha256")
 }
 
 // This test ensures that the snapshot status does not modify the snapshot file

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -248,9 +248,8 @@ func runCtlTest(t *testing.T, testFunc func(ctlCtx), testOfflineFunc func(ctlCtx
 			cx.envMap = make(map[string]string)
 		}
 		if cx.epc != nil {
-			if errC := cx.epc.Close(); errC != nil {
-				t.Fatalf("error closing etcd processes (%v)", errC)
-			}
+			cx.epc.Stop()
+			cx.epc.Close()
 		}
 	}()
 
@@ -270,6 +269,7 @@ func runCtlTest(t *testing.T, testFunc func(ctlCtx), testOfflineFunc func(ctlCtx
 	}
 
 	t.Log("closing test cluster...")
+	assert.NoError(t, cx.epc.Stop())
 	assert.NoError(t, cx.epc.Close())
 	cx.epc = nil
 	t.Log("closed test cluster...")

--- a/tests/e2e/ctl_v3_txn_test.go
+++ b/tests/e2e/ctl_v3_txn_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 type txnRequests struct {
-	compare  []string
-	ifSucess []string
-	ifFail   []string
-	results  []string
+	compare   []string
+	ifSuccess []string
+	ifFail    []string
+	results   []string
 }
 
-func ctlV3Txn(cx ctlCtx, rqs txnRequests) error {
+func ctlV3Txn(cx ctlCtx, rqs txnRequests, expectedExitErr bool) error {
 	// TODO: support non-interactive mode
 	cmdArgs := append(cx.PrefixArgs(), "txn")
 	if cx.interactive {
@@ -52,7 +52,7 @@ func ctlV3Txn(cx ctlCtx, rqs txnRequests) error {
 	if err != nil {
 		return err
 	}
-	for _, req := range rqs.ifSucess {
+	for _, req := range rqs.ifSuccess {
 		if err = proc.Send(req + "\r"); err != nil {
 			return err
 		}
@@ -80,5 +80,11 @@ func ctlV3Txn(cx ctlCtx, rqs txnRequests) error {
 			return err
 		}
 	}
-	return proc.Close()
+
+	err = proc.Close()
+	if expectedExitErr {
+		return nil
+	}
+
+	return err
 }

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -57,6 +58,7 @@ func TestEtcdMultiPeer(t *testing.T) {
 		for i := range procs {
 			if procs[i] != nil {
 				procs[i].Stop()
+				procs[i].Close()
 			}
 		}
 	}()
@@ -128,6 +130,7 @@ func TestEtcdPeerCNAuth(t *testing.T) {
 		for i := range procs {
 			if procs[i] != nil {
 				procs[i].Stop()
+				procs[i].Close()
 			}
 		}
 	}()
@@ -206,6 +209,7 @@ func TestEtcdPeerNameAuth(t *testing.T) {
 		for i := range procs {
 			if procs[i] != nil {
 				procs[i].Stop()
+				procs[i].Close()
 			}
 			os.RemoveAll(tmpdirs[i])
 		}
@@ -287,9 +291,7 @@ func TestGrpcproxyAndCommonName(t *testing.T) {
 	}
 
 	err := e2e.SpawnWithExpect(argsWithNonEmptyCN, "cert has non empty Common Name")
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
+	require.ErrorContains(t, err, "cert has non empty Common Name")
 
 	p, err := e2e.SpawnCmd(argsWithEmptyCN, nil)
 	defer func() {

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -37,7 +37,10 @@ func TestGateway(t *testing.T) {
 	eps := strings.Join(ec.EndpointsV3(), ",")
 
 	p := startGateway(t, eps)
-	defer p.Stop()
+	defer func() {
+		p.Stop()
+		p.Close()
+	}()
 
 	err = e2e.SpawnWithExpect([]string{e2e.BinPath.Etcdctl, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, "OK\r\n")
 	if err != nil {

--- a/tests/e2e/no_quorum_ready_test.go
+++ b/tests/e2e/no_quorum_ready_test.go
@@ -28,6 +28,8 @@ func TestInitDaemonNotifyWithoutQuorum(t *testing.T) {
 		t.Fatalf("Failed to initilize the etcd cluster: %v", err)
 	}
 
+	defer epc.Close()
+
 	// Remove two members, so that only one etcd will get started
 	epc.Procs = epc.Procs[:1]
 
@@ -40,6 +42,4 @@ func TestInitDaemonNotifyWithoutQuorum(t *testing.T) {
 	e2e.AssertProcessLogs(t, epc.Procs[0], "startEtcd: timed out waiting for the ready notification")
 	// Expect log message indicating systemd notify message has been sent
 	e2e.AssertProcessLogs(t, epc.Procs[0], "notifying init daemon")
-
-	epc.Close()
 }

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -155,7 +156,11 @@ func TestEtctlutlMigrate(t *testing.T) {
 			}
 			err = e2e.SpawnWithExpect(args, tc.expectLogsSubString)
 			if err != nil {
-				t.Fatal(err)
+				if tc.expectLogsSubString != "" {
+					require.ErrorContains(t, err, tc.expectLogsSubString)
+				} else {
+					t.Fatal(err)
+				}
 			}
 
 			t.Log("etcdutl migrate...")

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -212,7 +213,7 @@ func submitRangeAfterConcurrentWatch(cx ctlCtx, expectedValue string) {
 
 	cx.t.Log("Submitting range request...")
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Expected: expectedValue, Timeout: 5}); err != nil {
-		cx.t.Fatalf("testV3CurlMaxStream get failed, error: %v", err)
+		require.ErrorContains(cx.t, err, expectedValue)
 	}
 	cx.t.Log("range request done")
 }

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/authpb"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -141,9 +142,8 @@ func testV3CurlWatch(cx ctlCtx) {
 		cx.t.Fatalf("failed testV3CurlWatch put with curl using prefix (%s) (%v)", p, err)
 	}
 	// expects "bar", timeout after 2 seconds since stream waits forever
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: path.Join(p, "/watch"), Value: wstr, Expected: `"YmFy"`, Timeout: 2}); err != nil {
-		cx.t.Fatalf("failed testV3CurlWatch watch with curl using prefix (%s) (%v)", p, err)
-	}
+	err = e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: path.Join(p, "/watch"), Value: wstr, Expected: `"YmFy"`, Timeout: 2})
+	require.ErrorContains(cx.t, err, "unexpected exit code")
 }
 
 func testV3CurlTxn(cx ctlCtx) {

--- a/tests/linearizability/failpoints.go
+++ b/tests/linearizability/failpoints.go
@@ -69,7 +69,7 @@ func (f killFailpoint) Trigger(ctx context.Context, clus *e2e.EtcdProcessCluster
 		return err
 	}
 	err = member.Wait()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
 		return err
 	}
 	err = member.Start(ctx)
@@ -103,7 +103,7 @@ func (f goFailpoint) Trigger(ctx context.Context, clus *e2e.EtcdProcessCluster) 
 		}
 	}
 	err = member.Wait()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
 		return err
 	}
 	err = member.Start(ctx)


### PR DESCRIPTION
ExpectProcess and ExpectFunc now take the exit code of the process into account, not just the matching of the tty output.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

I'm still fixing some of the tests that are now failing due to this.