### PR TITLE
bump go version to 1.19.3 to address security fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.2"
+          go-version: "1.19.3"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -7,5 +7,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: make -C contrib/mixin tools test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: GOARCH=amd64 CPU=4 make fuzz
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.2"
+          go-version: "1.19.3"
       - run: date
       - env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: |
         pushd tools/mod; go install go.etcd.io/gofail; popd
         mkdir -p /tmp/linearizability

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: |
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.2"
+          go-version: "1.19.3"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.2"
+        go-version: "1.19.3"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf check-update || true \
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
-ENV GO_VERSION 1.19.2
+ENV GO_VERSION 1.19.3
 ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang
 RUN rm -rf ${GOROOT} \
   && curl -s ${GO_DOWNLOAD_URL}/go${GO_VERSION}.linux-amd64.tar.gz | tar -v -C /usr/local/ -xz \

--- a/tests/manual/Makefile
+++ b/tests/manual/Makefile
@@ -1,5 +1,5 @@
 TMP_DOCKERFILE:=$(shell mktemp)
-GO_VERSION ?= 1.19.2
+GO_VERSION ?= 1.19.3
 TMP_DIR_MOUNT_FLAG = --tmpfs=/tmp:exec
 ifdef HOST_TMP_DIR
 	TMP_DIR_MOUNT_FLAG = --mount type=bind,source=$(HOST_TMP_DIR),destination=/tmp


### PR DESCRIPTION
```
# govulncheck ./...
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Scanning for dependencies with known vulnerabilities...
Found 1 known vulnerability.

Vulnerability #1: GO-2022-1095
  Due to unsanitized NUL values, attackers may be able to
  maliciously set environment variables on Windows. In
  syscall.StartProcess and os/exec.Cmd, invalid environment
  variable values containing NUL values are not properly checked
  for. A malicious environment variable value can exploit this
  behavior to set a value for a different environment variable.
  For example, the environment variable string "A=B\x00C=D" sets
  the variables "A=B" and "C=D".

  Call stacks in your code:
      tools/etcd-dump-logs/main.go:340:18: go.etcd.io/etcd/v3/tools/etcd-dump-logs.listEntriesType calls os/exec.Cmd.Start
      tools/etcd-dump-metrics/install_linux.go:53:86: go.etcd.io/etcd/v3/tools/etcd-dump-metrics.install calls os/exec.Cmd.Run

  Found in: os/exec@go1.19.2
  Fixed in: os/exec@go1.19.3
  More info: https://pkg.go.dev/vuln/GO-2022-1095

Vulnerability #2: GO-2022-1095
  Due to unsanitized NUL values, attackers may be able to
  maliciously set environment variables on Windows. In
  syscall.StartProcess and os/exec.Cmd, invalid environment
  variable values containing NUL values are not properly checked
  for. A malicious environment variable value can exploit this
  behavior to set a value for a different environment variable.
  For example, the environment variable string "A=B\x00C=D" sets
  the variables "A=B" and "C=D".

  Call stacks in your code:
      tools/etcd-dump-logs/main.go:340:18: go.etcd.io/etcd/v3/tools/etcd-dump-logs.listEntriesType calls os/exec.Cmd.Start, which eventually calls syscall.StartProcess

  Found in: syscall@go1.19.2
  Fixed in: syscall@go1.19.3
  More info: https://pkg.go.dev/vuln/GO-2022-1095
```

FYI. https://groups.google.com/g/golang-announce/c/dRtDK7WS78g



Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @mitake @ptabor @serathius @spzala 
