### PR TITLE
Reproduce issue 13766 in linearizability tests

### DIFF
--- a/.github/workflows/linearizability-nightly.yaml
+++ b/.github/workflows/linearizability-nightly.yaml
@@ -10,17 +10,17 @@ jobs:
     uses: ./.github/workflows/linearizability-template.yaml
     with:
       ref: main
-      count: 300
-      testTimeout: 170m
+      count: 100
+      testTimeout: 200m
   test-35:
     uses: ./.github/workflows/linearizability-template.yaml
     with:
       ref: release-3.5
-      count: 300
-      testTimeout: 170m
+      count: 100
+      testTimeout: 200m
   test-34:
     uses: ./.github/workflows/linearizability-template.yaml
     with:
       ref: release-3.4
-      count: 300
-      testTimeout: 170m
+      count: 100
+      testTimeout: 200m

--- a/.github/workflows/linearizability-template.yaml
+++ b/.github/workflows/linearizability-template.yaml
@@ -15,7 +15,7 @@ on:
 permissions: read-all
 jobs:
   test:
-    timeout-minutes: 180
+    timeout-minutes: 210
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -6,5 +6,5 @@ jobs:
     uses: ./.github/workflows/linearizability-template.yaml
     with:
       ref: ${{ github.ref }}
-      count: 60
+      count: 15
       testTimeout: 30m


### PR DESCRIPTION
Decided to use the original approach of reproduction of the issue. I was not able to reliable reproduction via SIGKILL on lower QPS or clients. This approach has downside that validating linerizability for so many clients is too costly.  Memory usage for pourcupine just exploded and would definitely not fit in github action worker. 

Decided to use the initial data inconsistency validation for reproduction.