### PR TITLE
changelog: add item to cover the fix on adding protection on maintenance requests when auth is enabled

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -58,6 +58,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [`etcd --max-concurrent-streams`](https://github.com/etcd-io/etcd/pull/14169) flag to configure the max concurrent streams each client can open at a time, and defaults to math.MaxUint32.
 - Add [`etcd grpc-proxy --experimental-enable-grpc-logging`](https://github.com/etcd-io/etcd/pull/14266) flag to logging all grpc requests and responses.
 - Add [`etcd --experimental-compact-hash-check-enabled --experimental-compact-hash-check-time`](https://github.com/etcd-io/etcd/issues/14039) flags to support enabling reliable corruption detection on compacted revisions.
+- Add [Protection on maintenance request when auth is enabled](https://github.com/etcd-io/etcd/pull/14663).
 
 ### etcd grpc-proxy
 


### PR DESCRIPTION
Related PR: https://github.com/etcd-io/etcd/pull/14663

Signed-off-by: Benjamin Wang <wachao@vmware.com>


cc @mitake 
