### PR TITLE
raft: change the log from debug to warning when uncommitted size exceeds threshold

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -643,7 +643,7 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 	}
 	// Track the size of this uncommitted proposal.
 	if !r.increaseUncommittedSize(es) {
-		r.logger.Debugf(
+		r.logger.Warningf(
 			"%x appending new entries to log would exceed uncommitted entry size limit; dropping proposal",
 			r.id,
 		)


### PR DESCRIPTION


Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @tbg @nvanbenschoten 
