### PR TITLE
raft/tracker: use testify packages in tests

### DIFF
--- a/raft/go.mod
+++ b/raft/go.mod
@@ -8,16 +8,19 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/stretchr/testify v1.7.2
 )
 
 require (
 	github.com/cockroachdb/errors v1.2.4 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // Bad imports are sometimes causing attempts to pull that code.

--- a/raft/go.sum
+++ b/raft/go.sum
@@ -7,6 +7,8 @@ github.com/cockroachdb/errors v1.2.4 h1:Lap807SXTH5tri2TivECb/4abUkMZC9zRoLarvcK
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -32,6 +34,9 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -64,3 +69,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/raft/tracker/inflights_test.go
+++ b/raft/tracker/inflights_test.go
@@ -15,8 +15,9 @@
 package tracker
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInflightsAdd(t *testing.T) {
@@ -37,10 +38,7 @@ func TestInflightsAdd(t *testing.T) {
 		//               ↓------------
 		buffer: []uint64{0, 1, 2, 3, 4, 0, 0, 0, 0, 0},
 	}
-
-	if !reflect.DeepEqual(in, wantIn) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn)
-	}
+	require.Equal(t, wantIn, in)
 
 	for i := 5; i < 10; i++ {
 		in.Add(uint64(i))
@@ -53,10 +51,7 @@ func TestInflightsAdd(t *testing.T) {
 		//               ↓---------------------------
 		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn2) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn2)
-	}
+	require.Equal(t, wantIn2, in)
 
 	// rotating case
 	in2 := &Inflights{
@@ -76,10 +71,7 @@ func TestInflightsAdd(t *testing.T) {
 		//                              ↓------------
 		buffer: []uint64{0, 0, 0, 0, 0, 0, 1, 2, 3, 4},
 	}
-
-	if !reflect.DeepEqual(in2, wantIn21) {
-		t.Fatalf("in = %+v, want %+v", in2, wantIn21)
-	}
+	require.Equal(t, wantIn21, in2)
 
 	for i := 5; i < 10; i++ {
 		in2.Add(uint64(i))
@@ -92,10 +84,7 @@ func TestInflightsAdd(t *testing.T) {
 		//               -------------- ↓------------
 		buffer: []uint64{5, 6, 7, 8, 9, 0, 1, 2, 3, 4},
 	}
-
-	if !reflect.DeepEqual(in2, wantIn22) {
-		t.Fatalf("in = %+v, want %+v", in2, wantIn22)
-	}
+	require.Equal(t, wantIn22, in2)
 }
 
 func TestInflightFreeTo(t *testing.T) {
@@ -114,10 +103,7 @@ func TestInflightFreeTo(t *testing.T) {
 		//                  ↓------------------------
 		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn0) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn0)
-	}
+	require.Equal(t, wantIn0, in)
 
 	in.FreeLE(4)
 
@@ -128,10 +114,7 @@ func TestInflightFreeTo(t *testing.T) {
 		//                              ↓------------
 		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn)
-	}
+	require.Equal(t, wantIn, in)
 
 	in.FreeLE(8)
 
@@ -142,10 +125,7 @@ func TestInflightFreeTo(t *testing.T) {
 		//                                          ↓
 		buffer: []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn2) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn2)
-	}
+	require.Equal(t, wantIn2, in)
 
 	// rotating case
 	for i := 10; i < 15; i++ {
@@ -161,10 +141,7 @@ func TestInflightFreeTo(t *testing.T) {
 		//                           ↓-----
 		buffer: []uint64{10, 11, 12, 13, 14, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn3) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn3)
-	}
+	require.Equal(t, wantIn3, in)
 
 	in.FreeLE(14)
 
@@ -175,8 +152,5 @@ func TestInflightFreeTo(t *testing.T) {
 		//               ↓
 		buffer: []uint64{10, 11, 12, 13, 14, 5, 6, 7, 8, 9},
 	}
-
-	if !reflect.DeepEqual(in, wantIn4) {
-		t.Fatalf("in = %+v, want %+v", in, wantIn4)
-	}
+	require.Equal(t, wantIn4, in)
 }

--- a/raft/tracker/progress_test.go
+++ b/raft/tracker/progress_test.go
@@ -16,6 +16,8 @@ package tracker
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProgressString(t *testing.T) {
@@ -32,9 +34,7 @@ func TestProgressString(t *testing.T) {
 		Inflights:        ins,
 	}
 	const exp = `StateSnapshot match=1 next=2 learner paused pendingSnap=123 inactive inflight=1[full]`
-	if act := pr.String(); act != exp {
-		t.Errorf("exp: %s\nact: %s", exp, act)
-	}
+	assert.Equal(t, exp, pr.String())
 }
 
 func TestProgressIsPaused(t *testing.T) {
@@ -57,9 +57,7 @@ func TestProgressIsPaused(t *testing.T) {
 			MsgAppFlowPaused: tt.paused,
 			Inflights:        NewInflights(256),
 		}
-		if g := p.IsPaused(); g != tt.w {
-			t.Errorf("#%d: paused= %t, want %t", i, g, tt.w)
-		}
+		assert.Equal(t, tt.w, p.IsPaused(), i)
 	}
 }
 
@@ -71,14 +69,10 @@ func TestProgressResume(t *testing.T) {
 		MsgAppFlowPaused: true,
 	}
 	p.MaybeDecrTo(1, 1)
-	if p.MsgAppFlowPaused {
-		t.Errorf("paused= %v, want false", p.MsgAppFlowPaused)
-	}
+	assert.False(t, p.MsgAppFlowPaused)
 	p.MsgAppFlowPaused = true
 	p.MaybeUpdate(2)
-	if p.MsgAppFlowPaused {
-		t.Errorf("paused= %v, want false", p.MsgAppFlowPaused)
-	}
+	assert.False(t, p.MsgAppFlowPaused)
 }
 
 func TestProgressBecomeProbe(t *testing.T) {
@@ -104,46 +98,26 @@ func TestProgressBecomeProbe(t *testing.T) {
 	}
 	for i, tt := range tests {
 		tt.p.BecomeProbe()
-		if tt.p.State != StateProbe {
-			t.Errorf("#%d: state = %s, want %s", i, tt.p.State, StateProbe)
-		}
-		if tt.p.Match != match {
-			t.Errorf("#%d: match = %d, want %d", i, tt.p.Match, match)
-		}
-		if tt.p.Next != tt.wnext {
-			t.Errorf("#%d: next = %d, want %d", i, tt.p.Next, tt.wnext)
-		}
+		assert.Equal(t, StateProbe, tt.p.State, i)
+		assert.Equal(t, match, tt.p.Match, i)
+		assert.Equal(t, tt.wnext, tt.p.Next, i)
 	}
 }
 
 func TestProgressBecomeReplicate(t *testing.T) {
 	p := &Progress{State: StateProbe, Match: 1, Next: 5, Inflights: NewInflights(256)}
 	p.BecomeReplicate()
-
-	if p.State != StateReplicate {
-		t.Errorf("state = %s, want %s", p.State, StateReplicate)
-	}
-	if p.Match != 1 {
-		t.Errorf("match = %d, want 1", p.Match)
-	}
-	if w := p.Match + 1; p.Next != w {
-		t.Errorf("next = %d, want %d", p.Next, w)
-	}
+	assert.Equal(t, StateReplicate, p.State)
+	assert.Equal(t, uint64(1), p.Match)
+	assert.Equal(t, p.Match+1, p.Next)
 }
 
 func TestProgressBecomeSnapshot(t *testing.T) {
 	p := &Progress{State: StateProbe, Match: 1, Next: 5, Inflights: NewInflights(256)}
 	p.BecomeSnapshot(10)
-
-	if p.State != StateSnapshot {
-		t.Errorf("state = %s, want %s", p.State, StateSnapshot)
-	}
-	if p.Match != 1 {
-		t.Errorf("match = %d, want 1", p.Match)
-	}
-	if p.PendingSnapshot != 10 {
-		t.Errorf("pendingSnapshot = %d, want 10", p.PendingSnapshot)
-	}
+	assert.Equal(t, StateSnapshot, p.State)
+	assert.Equal(t, uint64(1), p.Match)
+	assert.Equal(t, uint64(10), p.PendingSnapshot)
 }
 
 func TestProgressUpdate(t *testing.T) {
@@ -165,16 +139,9 @@ func TestProgressUpdate(t *testing.T) {
 			Match: prevM,
 			Next:  prevN,
 		}
-		ok := p.MaybeUpdate(tt.update)
-		if ok != tt.wok {
-			t.Errorf("#%d: ok= %v, want %v", i, ok, tt.wok)
-		}
-		if p.Match != tt.wm {
-			t.Errorf("#%d: match= %d, want %d", i, p.Match, tt.wm)
-		}
-		if p.Next != tt.wn {
-			t.Errorf("#%d: next= %d, want %d", i, p.Next, tt.wn)
-		}
+		assert.Equal(t, tt.wok, p.MaybeUpdate(tt.update), i)
+		assert.Equal(t, tt.wm, p.Match, i)
+		assert.Equal(t, tt.wn, p.Next, i)
 	}
 }
 
@@ -237,14 +204,8 @@ func TestProgressMaybeDecr(t *testing.T) {
 			Match: tt.m,
 			Next:  tt.n,
 		}
-		if g := p.MaybeDecrTo(tt.rejected, tt.last); g != tt.w {
-			t.Errorf("#%d: maybeDecrTo= %t, want %t", i, g, tt.w)
-		}
-		if gm := p.Match; gm != tt.m {
-			t.Errorf("#%d: match= %d, want %d", i, gm, tt.m)
-		}
-		if gn := p.Next; gn != tt.wn {
-			t.Errorf("#%d: next= %d, want %d", i, gn, tt.wn)
-		}
+		assert.Equal(t, tt.w, p.MaybeDecrTo(tt.rejected, tt.last), i)
+		assert.Equal(t, tt.m, p.Match, i)
+		assert.Equal(t, tt.wn, p.Next, i)
 	}
 }


### PR DESCRIPTION
This commit removes the verbose comparisons in tests, in favor of using assert/require helpers from the testify packages.

Part of #14709

Signed-off-by: Pavel Kalinnikov <pavel@cockroachlabs.com>