### PR TITLE
raft: rename raftLog.nextEnts to raftLog.nextCommittedEnts

### DIFF
--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -339,7 +339,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	}
 }
 
-func TestHasNextEnts(t *testing.T) {
+func TestHasNextCommittedEnts(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
@@ -365,14 +365,14 @@ func TestHasNextEnts(t *testing.T) {
 		raftLog.maybeCommit(5, 1)
 		raftLog.appliedTo(tt.applied)
 
-		hasNext := raftLog.hasNextEnts()
+		hasNext := raftLog.hasNextCommittedEnts()
 		if hasNext != tt.hasNext {
 			t.Errorf("#%d: hasNext = %v, want %v", i, hasNext, tt.hasNext)
 		}
 	}
 }
 
-func TestNextEnts(t *testing.T) {
+func TestNextCommittedEnts(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
@@ -398,7 +398,7 @@ func TestNextEnts(t *testing.T) {
 		raftLog.maybeCommit(5, 1)
 		raftLog.appliedTo(tt.applied)
 
-		nents := raftLog.nextEnts()
+		nents := raftLog.nextCommittedEnts()
 		if !reflect.DeepEqual(nents, tt.wents) {
 			t.Errorf("#%d: nents = %+v, want %+v", i, nents, tt.wents)
 		}

--- a/raft/node.go
+++ b/raft/node.go
@@ -568,7 +568,7 @@ func (n *node) ReadIndex(ctx context.Context, rctx []byte) error {
 func newReady(r *raft, prevSoftSt *SoftState, prevHardSt pb.HardState) Ready {
 	rd := Ready{
 		Entries:          r.raftLog.unstableEntries(),
-		CommittedEntries: r.raftLog.nextEnts(),
+		CommittedEntries: r.raftLog.nextCommittedEnts(),
 		Messages:         r.msgs,
 	}
 	if softSt := r.softState(); !softSt.equal(prevSoftSt) {

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -952,8 +952,8 @@ func (s *ignoreSizeHintMemStorage) Entries(lo, hi uint64, maxSize uint64) ([]raf
 // internal one. The original bug was the following:
 //
 //   - node learns that index 11 (or 100, doesn't matter) is committed
-//   - nextEnts returns index 1..10 in CommittedEntries due to size limiting. However,
-//     index 10 already exceeds maxBytes, due to a user-provided impl of Entries.
+//   - nextCommittedEnts returns index 1..10 in CommittedEntries due to size limiting.
+//     However, index 10 already exceeds maxBytes, due to a user-provided impl of Entries.
 //   - Commit index gets bumped to 10
 //   - the node persists the HardState, but crashes before applying the entries
 //   - upon restart, the storage returns the same entries, but `slice` takes a different code path

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -450,8 +450,8 @@ func TestLeaderCommitEntry(t *testing.T) {
 		t.Errorf("committed = %d, want %d", g, li+1)
 	}
 	wents := []pb.Entry{{Index: li + 1, Term: 1, Data: []byte("some data")}}
-	if g := r.raftLog.nextEnts(); !reflect.DeepEqual(g, wents) {
-		t.Errorf("nextEnts = %+v, want %+v", g, wents)
+	if g := r.raftLog.nextCommittedEnts(); !reflect.DeepEqual(g, wents) {
+		t.Errorf("nextCommittedEnts = %+v, want %+v", g, wents)
 	}
 	msgs := r.readMessages()
 	sort.Sort(messageSlice(msgs))
@@ -538,7 +538,7 @@ func TestLeaderCommitPrecedingEntries(t *testing.T) {
 
 		li := uint64(len(tt))
 		wents := append(tt, pb.Entry{Term: 3, Index: li + 1}, pb.Entry{Term: 3, Index: li + 2, Data: []byte("some data")})
-		if g := r.raftLog.nextEnts(); !reflect.DeepEqual(g, wents) {
+		if g := r.raftLog.nextCommittedEnts(); !reflect.DeepEqual(g, wents) {
 			t.Errorf("#%d: ents = %+v, want %+v", i, g, wents)
 		}
 	}
@@ -590,8 +590,8 @@ func TestFollowerCommitEntry(t *testing.T) {
 			t.Errorf("#%d: committed = %d, want %d", i, g, tt.commit)
 		}
 		wents := tt.ents[:int(tt.commit)]
-		if g := r.raftLog.nextEnts(); !reflect.DeepEqual(g, wents) {
-			t.Errorf("#%d: nextEnts = %v, want %v", i, g, wents)
+		if g := r.raftLog.nextCommittedEnts(); !reflect.DeepEqual(g, wents) {
+			t.Errorf("#%d: nextCommittedEnts = %v, want %v", i, g, wents)
 		}
 	}
 }

--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -163,7 +163,7 @@ func (rn *RawNode) HasReady() bool {
 	if r.raftLog.hasPendingSnapshot() {
 		return true
 	}
-	if len(r.msgs) > 0 || len(r.raftLog.unstableEntries()) > 0 || r.raftLog.hasNextEnts() {
+	if len(r.msgs) > 0 || len(r.raftLog.unstableEntries()) > 0 || r.raftLog.hasNextCommittedEnts() {
 		return true
 	}
 	if len(r.readStates) != 0 {

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -885,8 +885,8 @@ func TestRawNodeStatus(t *testing.T) {
 // Raft group would forget to apply entries:
 //
 //   - node learns that index 11 is committed
-//   - nextEnts returns index 1..10 in CommittedEntries (but index 10 already
-//     exceeds maxBytes), which isn't noticed internally by Raft
+//   - nextCommittedEnts returns index 1..10 in CommittedEntries (but index 10
+//     already exceeds maxBytes), which isn't noticed internally by Raft
 //   - Commit index gets bumped to 10
 //   - the node persists the HardState, but crashes before applying the entries
 //   - upon restart, the storage returns the same entries, but `slice` takes a


### PR DESCRIPTION
Also rename `hasNextEnts` to `hasNextCommittedEnts`.
Also rename `maxNextEntsSize` to `maxNextCommittedEntsSize`.

Extracted from #14627. cc. @tbg 

Pure refactor.

Signed-off-by: Nathan VanBenschoten <nvanbenschoten@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
