### PR TITLE
raft: delete unused Ready.containsUpdates method

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -103,12 +103,6 @@ func IsEmptySnap(sp pb.Snapshot) bool {
 	return sp.Metadata.Index == 0
 }
 
-func (rd Ready) containsUpdates() bool {
-	return rd.SoftState != nil || !IsEmptyHardState(rd.HardState) ||
-		!IsEmptySnap(rd.Snapshot) || len(rd.Entries) > 0 ||
-		len(rd.CommittedEntries) > 0 || len(rd.Messages) > 0 || len(rd.ReadStates) != 0
-}
-
 // appliedCursor extracts from the Ready the highest index the client has
 // applied (once the Ready is confirmed via Advance). If no information is
 // contained in the Ready, returns zero.

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -526,27 +526,6 @@ func TestNodeStop(t *testing.T) {
 	n.Stop()
 }
 
-func TestReadyContainUpdates(t *testing.T) {
-	tests := []struct {
-		rd       Ready
-		wcontain bool
-	}{
-		{Ready{}, false},
-		{Ready{SoftState: &SoftState{Lead: 1}}, true},
-		{Ready{HardState: raftpb.HardState{Vote: 1}}, true},
-		{Ready{Entries: make([]raftpb.Entry, 1)}, true},
-		{Ready{CommittedEntries: make([]raftpb.Entry, 1)}, true},
-		{Ready{Messages: make([]raftpb.Message, 1)}, true},
-		{Ready{Snapshot: raftpb.Snapshot{Metadata: raftpb.SnapshotMetadata{Index: 1}}}, true},
-	}
-
-	for i, tt := range tests {
-		if g := tt.rd.containsUpdates(); g != tt.wcontain {
-			t.Errorf("#%d: containUpdates = %v, want %v", i, g, tt.wcontain)
-		}
-	}
-}
-
 // TestNodeStart ensures that a node can be started correctly. The node should
 // start with correct configuration change entries, and can accept and commit
 // proposals.

--- a/raft/rawnode.go
+++ b/raft/rawnode.go
@@ -151,7 +151,6 @@ func (rn *RawNode) acceptReady(rd Ready) {
 }
 
 // HasReady called when RawNode user need to check if any Ready pending.
-// Checking logic in this method should be consistent with Ready.containsUpdates().
 func (rn *RawNode) HasReady() bool {
 	r := rn.raft
 	if !r.softState().equal(rn.prevSoftSt) {


### PR DESCRIPTION
The function was unused beyond its own unit test. Delete it.

Signed-off-by: Nathan VanBenschoten <nvanbenschoten@gmail.com>

Extracted from https://github.com/etcd-io/etcd/pull/14627. cc. @tbg

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
