### PR TITLE
tests: refactor `EtcdProcessClusterConfig` using Functional Options Pattern

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -130,11 +130,10 @@ func testDowngradeUpgrade(t *testing.T, clusterSize int) {
 }
 
 func newCluster(t *testing.T, clusterSize int) *e2e.EtcdProcessCluster {
-	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-		ClusterSize:  clusterSize,
-		InitialToken: "new",
-		KeepDataDir:  true,
-	})
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+		e2e.WithClusterSize(clusterSize),
+		e2e.WithKeepDataDir(true),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -102,11 +102,10 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	e2e.BeforeTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	epc, err := e2e.NewEtcdProcessCluster(ctx, t, &e2e.EtcdProcessClusterConfig{
-		ClusterSize:      3,
-		KeepDataDir:      true,
-		CorruptCheckTime: time.Second,
-	})
+	epc, err := e2e.NewEtcdProcessCluster(ctx, t, nil,
+		e2e.WithKeepDataDir(true),
+		e2e.WithCorruptCheckTime(time.Second),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -150,12 +149,11 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	e2e.BeforeTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	epc, err := e2e.NewEtcdProcessCluster(ctx, t, &e2e.EtcdProcessClusterConfig{
-		ClusterSize:             3,
-		KeepDataDir:             true,
-		CompactHashCheckEnabled: true,
-		CompactHashCheckTime:    checkTime,
-	})
+	epc, err := e2e.NewEtcdProcessCluster(ctx, t, nil,
+		e2e.WithKeepDataDir(true),
+		e2e.WithCompactHashCheckEnabled(true),
+		e2e.WithCompactHashCheckTime(checkTime),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}

--- a/tests/e2e/ctl_v3_auth_cluster_test.go
+++ b/tests/e2e/ctl_v3_auth_cluster_test.go
@@ -29,15 +29,13 @@ import (
 
 func TestAuthCluster(t *testing.T) {
 	e2e.BeforeTest(t)
-	cfg := &e2e.EtcdProcessClusterConfig{
-		ClusterSize:   1,
-		InitialToken:  "new",
-		SnapshotCount: 2,
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	epc, err := e2e.NewEtcdProcessCluster(ctx, t, cfg)
+	epc, err := e2e.NewEtcdProcessCluster(ctx, t, nil,
+		e2e.WithClusterSize(1),
+		e2e.WithSnapshotCount(2),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -39,14 +39,13 @@ func TestCtlV3GetCountOnly(t *testing.T) { testCtl(t, getCountOnlyTest) }
 func TestCtlV3DelTimeout(t *testing.T) { testCtl(t, delTest, withDialTimeout(0)) }
 
 func TestCtlV3GetRevokedCRL(t *testing.T) {
-	cfg := e2e.EtcdProcessClusterConfig{
-		ClusterSize:           1,
-		InitialToken:          "new",
-		ClientTLS:             e2e.ClientTLS,
-		IsClientCRL:           true,
-		ClientCertAuthEnabled: true,
-	}
-	testCtl(t, testGetRevokedCRL, withCfg(cfg))
+	cfg := e2e.NewConfig(
+		e2e.WithClusterSize(1),
+		e2e.WithClientTLS(e2e.ClientTLS),
+		e2e.WithIsClientCRL(true),
+		e2e.WithClientCertAuthEnabled(true),
+	)
+	testCtl(t, testGetRevokedCRL, withCfg(*cfg))
 }
 
 func testGetRevokedCRL(cx ctlCtx) {

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -172,11 +172,10 @@ func testIssue6361(t *testing.T) {
 
 	e2e.BeforeTest(t)
 
-	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-		ClusterSize:  1,
-		InitialToken: "new",
-		KeepDataDir:  true,
-	})
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+		e2e.WithClusterSize(1),
+		e2e.WithKeepDataDir(true),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -284,7 +283,7 @@ func testIssue6361(t *testing.T) {
 // For storageVersion to be stored, all fields expected 3.6 fields need to be set. This happens after first WAL snapshot.
 // In this test we lower SnapshotCount to 1 to ensure WAL snapshot is triggered.
 func TestCtlV3SnapshotVersion(t *testing.T) {
-	testCtl(t, snapshotVersionTest, withCfg(e2e.EtcdProcessClusterConfig{SnapshotCount: 1}))
+	testCtl(t, snapshotVersionTest, withCfg(*e2e.NewConfig(e2e.WithSnapshotCount(1))))
 }
 
 func snapshotVersionTest(cx ctlCtx) {

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -115,15 +115,14 @@ func TestEtctlutlMigrate(t *testing.T) {
 			}
 			dataDirPath := t.TempDir()
 
-			epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-				Version:      tc.clusterVersion,
-				DataDirPath:  dataDirPath,
-				ClusterSize:  1,
-				InitialToken: "new",
-				KeepDataDir:  true,
+			epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+				e2e.WithVersion(tc.clusterVersion),
+				e2e.WithDataDirPath(dataDirPath),
+				e2e.WithClusterSize(1),
+				e2e.WithKeepDataDir(true),
 				// Set low SnapshotCount to ensure wal snapshot is done
-				SnapshotCount: 1,
-			})
+				e2e.WithSnapshotCount(1),
+			)
 			if err != nil {
 				t.Fatalf("could not start etcd process cluster (%v)", err)
 			}

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -197,6 +197,10 @@ func WithConfig(cfg *EtcdProcessClusterConfig) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { *c = *cfg }
 }
 
+func WithVersion(version ClusterVersion) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.Version = version }
+}
+
 func WithDataDirPath(path string) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.DataDirPath = path }
 }
@@ -303,7 +307,14 @@ func WithGoFailEnabled(enabled bool) EPClusterOption {
 
 // NewEtcdProcessCluster launches a new cluster from etcd processes, returning
 // a new EtcdProcessCluster once all nodes are ready to accept client requests.
-func NewEtcdProcessCluster(ctx context.Context, t testing.TB, cfg *EtcdProcessClusterConfig) (*EtcdProcessCluster, error) {
+func NewEtcdProcessCluster(ctx context.Context, t testing.TB, cfg *EtcdProcessClusterConfig, opts ...EPClusterOption) (*EtcdProcessCluster, error) {
+	if cfg == nil {
+		cfg = NewConfig(opts...)
+	} else {
+		for _, opt := range opts {
+			opt(cfg)
+		}
+	}
 	epc, err := InitEtcdProcessCluster(t, cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Context #14711

This PR focuses on 2nd step: replaces 1/3(the rest is on the way) initialisations with `DefaultConfig`, `NewConfig` and `EPClusterOption`.