### PR TITLE
etcdserver: call the OnPreCommitUnsafe in unsafeCommit

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -329,10 +329,6 @@ func (t *batchTxBuffered) CommitAndStop() {
 }
 
 func (t *batchTxBuffered) commit(stop bool) {
-	if t.backend.hooks != nil {
-		t.backend.hooks.OnPreCommitUnsafe(t)
-	}
-
 	// all read txs must be closed to acquire boltdb commit rwlock
 	t.backend.readTx.Lock()
 	t.unsafeCommit(stop)
@@ -340,6 +336,10 @@ func (t *batchTxBuffered) commit(stop bool) {
 }
 
 func (t *batchTxBuffered) unsafeCommit(stop bool) {
+	if t.backend.hooks != nil {
+		t.backend.hooks.OnPreCommitUnsafe(t)
+	}
+
 	if t.backend.readTx.tx != nil {
 		// wait all store read transactions using the current boltdb tx to finish,
 		// then close the boltdb tx


### PR DESCRIPTION
Fix the issue discovered in https://github.com/etcd-io/etcd/pull/14685

`unsafeCommit` is called by both `(*batchTxBuffered) commit` and `(*backend) defrag`. When users perform the defragmentation operation, etcd doesn't update the consistent index, because `unsafeCommit` doesn't call the `OnPreCommitUnsafe`. If etcd crashes(e.g. panicking) in the process for whatever reason, when etcd starts again it replays the WAL entries starting from the latest snapshot, accordingly it may re-apply entries which might have already been applied, eventually the revision isn't consistent with other members.

Refer to discussion in [pull/14685](https://github.com/etcd-io/etcd/pull/14685), especially the comment https://github.com/etcd-io/etcd/pull/14685#issuecomment-1310999115.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @mitake @ptabor @serathius @spzala 


