### PR TITLE
client: fix client fileutil log, backport to v3.5

### DIFF
--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -44,16 +44,12 @@ func IsDirWriteable(dir string) error {
 
 // TouchDirAll is similar to os.MkdirAll. It creates directories with 0700 permission if any directory
 // does not exists. TouchDirAll also ensures the given directory is writable.
-func TouchDirAll(dir string) error {
+func TouchDirAll(lg *zap.Logger, dir string) error {
 	// If path is already a directory, MkdirAll does nothing and returns nil, so,
 	// first check if dir exist with an expected permission mode.
 	if Exist(dir) {
 		err := CheckDirPermission(dir, PrivateDirMode)
 		if err != nil {
-			lg, _ := zap.NewProduction()
-			if lg == nil {
-				lg = zap.NewExample()
-			}
 			lg.Warn("check file permission", zap.Error(err))
 		}
 	} else {
@@ -70,8 +66,8 @@ func TouchDirAll(dir string) error {
 
 // CreateDirAll is similar to TouchDirAll but returns error
 // if the deepest directory was not empty.
-func CreateDirAll(dir string) error {
-	err := TouchDirAll(dir)
+func CreateDirAll(lg *zap.Logger, dir string) error {
+	err := TouchDirAll(lg, dir)
 	if err == nil {
 		var ns []string
 		ns, err = ReadDir(dir)

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -67,7 +67,7 @@ func TestCreateDirAll(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	tmpdir2 := filepath.Join(tmpdir, "testdir")
-	if err = CreateDirAll(tmpdir2); err != nil {
+	if err = CreateDirAll(zaptest.NewLogger(t), tmpdir2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +75,7 @@ func TestCreateDirAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = CreateDirAll(tmpdir2); err == nil || !strings.Contains(err.Error(), "to be empty, got") {
+	if err = CreateDirAll(zaptest.NewLogger(t), tmpdir2); err == nil || !strings.Contains(err.Error(), "to be empty, got") {
 		t.Fatalf("unexpected error %v", err)
 	}
 }
@@ -186,7 +186,7 @@ func TestDirPermission(t *testing.T) {
 
 	tmpdir2 := filepath.Join(tmpdir, "testpermission")
 	// create a new dir with 0700
-	if err = CreateDirAll(tmpdir2); err != nil {
+	if err = CreateDirAll(zaptest.NewLogger(t), tmpdir2); err != nil {
 		t.Fatal(err)
 	}
 	// check dir permission with mode different than created dir

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -205,7 +205,7 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 		)
 		return
 	}
-	err = fileutil.TouchDirAll(dirpath)
+	err = fileutil.TouchDirAll(lg, dirpath)
 	if err != nil {
 		if info.Logger != nil {
 			info.Logger.Warn(

--- a/etcdutl/etcdutl/backup_command.go
+++ b/etcdutl/etcdutl/backup_command.go
@@ -114,7 +114,7 @@ func HandleBackup(withV3 bool, srcDir string, destDir string, srcWAL string, des
 		destWAL = datadir.ToWalDir(destDir)
 	}
 
-	if err := fileutil.CreateDirAll(destSnap); err != nil {
+	if err := fileutil.CreateDirAll(lg, destSnap); err != nil {
 		lg.Fatal("failed creating backup snapshot dir", zap.String("dest-snap", destSnap), zap.Error(err))
 	}
 

--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -322,7 +322,7 @@ func (s *v3Manager) copyAndVerifyDB() error {
 		return err
 	}
 
-	if err := fileutil.CreateDirAll(s.snapDir); err != nil {
+	if err := fileutil.CreateDirAll(s.lg, s.snapDir); err != nil {
 		return err
 	}
 
@@ -383,7 +383,7 @@ func (s *v3Manager) copyAndVerifyDB() error {
 //
 // TODO: This code ignores learners !!!
 func (s *v3Manager) saveWALAndSnap() (*raftpb.HardState, error) {
-	if err := fileutil.CreateDirAll(s.walDir); err != nil {
+	if err := fileutil.CreateDirAll(s.lg, s.walDir); err != nil {
 		return nil, err
 	}
 

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -276,7 +276,7 @@ func startProxy(cfg *config) error {
 	}
 
 	cfg.ec.Dir = filepath.Join(cfg.ec.Dir, "proxy")
-	err = fileutil.TouchDirAll(cfg.ec.Dir)
+	err = fileutil.TouchDirAll(lg, cfg.ec.Dir)
 	if err != nil {
 		return err
 	}

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -115,7 +115,7 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 	}
 	defer os.RemoveAll(tmpdirpath)
 
-	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
+	if err := fileutil.CreateDirAll(lg, tmpdirpath); err != nil {
 		lg.Warn(
 			"failed to create a temporary WAL directory",
 			zap.String("tmp-dir-path", tmpdirpath),

--- a/tests/functional/agent/handler.go
+++ b/tests/functional/agent/handler.go
@@ -473,7 +473,7 @@ func (srv *Server) handle_INITIAL_START_ETCD(req *rpcpb.Request) (*rpcpb.Respons
 		}, nil
 	}
 
-	err := fileutil.TouchDirAll(srv.Member.BaseDir)
+	err := fileutil.TouchDirAll(srv.lg, srv.Member.BaseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +508,7 @@ func (srv *Server) handle_INITIAL_START_ETCD(req *rpcpb.Request) (*rpcpb.Respons
 func (srv *Server) handle_RESTART_ETCD(req *rpcpb.Request) (*rpcpb.Response, error) {
 	var err error
 	if !fileutil.Exist(srv.Member.BaseDir) {
-		err = fileutil.TouchDirAll(srv.Member.BaseDir)
+		err = fileutil.TouchDirAll(srv.lg, srv.Member.BaseDir)
 		if err != nil {
 			return nil, err
 		}
@@ -579,7 +579,7 @@ func (srv *Server) handle_SIGQUIT_ETCD_AND_REMOVE_DATA() (*rpcpb.Response, error
 
 	// create a new log file for next new member restart
 	if !fileutil.Exist(srv.Member.BaseDir) {
-		err = fileutil.TouchDirAll(srv.Member.BaseDir)
+		err = fileutil.TouchDirAll(srv.lg, srv.Member.BaseDir)
 		if err != nil {
 			return nil, err
 		}
@@ -651,6 +651,7 @@ func (srv *Server) handle_SIGQUIT_ETCD_AND_ARCHIVE_DATA() (*rpcpb.Response, erro
 
 	// TODO: support separate WAL directory
 	if err = archive(
+		srv.lg,
 		srv.Member.BaseDir,
 		srv.Member.Etcd.LogOutputs[0],
 		srv.Member.Etcd.DataDir,

--- a/tests/functional/agent/utils.go
+++ b/tests/functional/agent/utils.go
@@ -25,15 +25,17 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+
+	"go.uber.org/zap"
 )
 
 // TODO: support separate WAL directory
-func archive(baseDir, etcdLogPath, dataDir string) error {
+func archive(lg *zap.Logger, baseDir, etcdLogPath, dataDir string) error {
 	dir := filepath.Join(baseDir, "etcd-failure-archive", time.Now().Format(time.RFC3339))
 	if existDir(dir) {
 		dir = filepath.Join(baseDir, "etcd-failure-archive", time.Now().Add(time.Second).Format(time.RFC3339))
 	}
-	if err := fileutil.TouchDirAll(dir); err != nil {
+	if err := fileutil.TouchDirAll(lg, dir); err != nil {
 		return err
 	}
 

--- a/tests/functional/tester/cluster.go
+++ b/tests/functional/tester/cluster.go
@@ -520,7 +520,7 @@ func (clus *Cluster) sendOpWithResp(idx int, op rpcpb.Operation) (*rpcpb.Respons
 			"fixtures",
 			"client",
 		)
-		if err = fileutil.TouchDirAll(dirClient); err != nil {
+		if err = fileutil.TouchDirAll(clus.lg, dirClient); err != nil {
 			return nil, err
 		}
 

--- a/tests/functional/tester/cluster_run.go
+++ b/tests/functional/tester/cluster_run.go
@@ -37,7 +37,7 @@ func (clus *Cluster) Run() {
 	// needs to obtain all the failpoints from the etcd member.
 	clus.updateCases()
 
-	if err := fileutil.TouchDirAll(clus.Tester.DataDir); err != nil {
+	if err := fileutil.TouchDirAll(clus.lg, clus.Tester.DataDir); err != nil {
 		clus.lg.Panic(
 			"failed to create test data directory",
 			zap.String("dir", clus.Tester.DataDir),


### PR DESCRIPTION
backport #13401 to v3.5: client/pkg/fileutil: add missing logger to {Create,Touch}DirAll
    
Also populate it to every invocation.

fix #14736
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
