### PR TITLE
README: remove Tobias Grieger from the Emeritus Maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ These emeritus maintainers dedicated a part of their career to etcd and reviewed
 * Wenjia Zhang
 * Xiang Li
 * Ben Darnell
-* Tobias Grieger
 
 ### License
 


### PR DESCRIPTION
Tobias Grieger is actively working on etcd/raft (thanks @tbg ), and has already been added back as a raft maintainer, so no reason to keep him in the Emeritus Maintainers list.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


cc @tbg 
