### PR TITLE
tests/e2e: disable testShellCompletion if enable cov flag

### DIFF
--- a/tests/e2e/ctl_v3_completion_test.go
+++ b/tests/e2e/ctl_v3_completion_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !cov
+// +build !cov
+
 package e2e
 
 import (
@@ -33,6 +36,14 @@ func TestUtlV3CompletionBash(t *testing.T) {
 	testShellCompletion(t, e2e.BinPath.Etcdutl, "bash")
 }
 
+// testShellCompletion can only run in non-coverage mode. The etcdctl and etcdutl
+// built with `-tags cov` mode will show go-test result after each execution, like
+//
+//	PASS
+//	coverage: 0.0% of statements in ./...
+//
+// Since the PASS is not real command, the `source completion" fails with
+// command-not-found error.
 func testShellCompletion(t *testing.T, binPath, shellName string) {
 	e2e.BeforeTest(t)
 


### PR DESCRIPTION
The etcdctl and etcdutl built with `-tags cov` mode will show go-test result
after each execution, like

 ```
 ...

PASS
coverage: 0.0% of statements in ./...
```

Since the PASS is not real command, the `source completion` command will
fail with command-not-found error. And there is no easy way to disable
the (*testing.M).Run's output. Therefore, this patch uses build tag !cov
to disable cases when enable coverage.

Fixes: #14694

Signed-off-by: Wei Fu <fuweid89@gmail.com>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
