### PR TITLE
e2e: test DowngradeVersion with latest point release

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
         echo "${TARGET}"
         case "${TARGET}" in
           linux-amd64-e2e)
-            PASSES='build release e2e' MANUAL_VER=v3.5.0 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./scripts/test.sh 2>&1 | tee test.log
+            PASSES='build release e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./scripts/test.sh 2>&1 | tee test.log
             ! grep -E "(--- FAIL:|FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test.log
             ;;
           linux-386-e2e)


### PR DESCRIPTION
Signed-off-by: Wei Fu <fuweid89@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Local test result:

```
'build' completed at Sun Nov 13 05:22:08 PM HKT 2022

'release' started at Sun Nov 13 05:22:08 PM HKT 2022
Downloading etcd-v3.5.5-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 18.5M  100 18.5M    0     0  5453k      0  0:00:03  0:00:03 --:--:-- 9325k
etcd-v3.5.5-linux-amd64/etcdutl
etcd-v3.5.5-linux-amd64/Documentation/
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/apispec/
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/apispec/swagger/
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/apispec/swagger/v3election.swagger.json
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/apispec/swagger/v3lock.swagger.json
etcd-v3.5.5-linux-amd64/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
etcd-v3.5.5-linux-amd64/Documentation/README.md
etcd-v3.5.5-linux-amd64/README-etcdutl.md
etcd-v3.5.5-linux-amd64/README-etcdctl.md
etcd-v3.5.5-linux-amd64/etcdctl
etcd-v3.5.5-linux-amd64/etcd
etcd-v3.5.5-linux-amd64/READMEv2-etcdctl.md
etcd-v3.5.5-linux-amd64/README.md
'release' completed at Sun Nov 13 05:22:12 PM HKT 2022

'e2e' started at Sun Nov 13 05:22:12 PM HKT 2022
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' '-timeout=30m' 'go.etcd.io/etcd/tests/v3/e2e')
ok      go.etcd.io/etcd/tests/v3/e2e    427.905s
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' '--tags=e2e' '-timeout=30m' 'go.etcd.io/etcd/tests/v3/common')
ok      go.etcd.io/etcd/tests/v3/common 1051.636s
'e2e' completed at Sun Nov 13 05:46:54 PM HKT 2022
SUCCESS
```

