### PR TITLE
tests: refactor `EtcdProcessClusterConfig` using Functional Options Pattern

### DIFF
--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -51,10 +51,11 @@ func TestClusterVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e2e.BeforeTest(t)
-			cfg := e2e.NewConfigNoTLS()
-			cfg.SnapshotCount = 3
-			cfg.BaseScheme = "unix" // to avoid port conflict
-			cfg.RollingStart = tt.rollingStart
+			cfg := e2e.NewConfig(
+				e2e.WithSnapshotCount(3),
+				e2e.WithBaseScheme("unix"), // to avoid port conflict)
+				e2e.WithRollingStart(tt.rollingStart),
+			)
 
 			epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, cfg)
 			if err != nil {

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -42,12 +42,12 @@ func testClusterUsingDiscovery(t *testing.T, size int, peerTLS bool) {
 		t.Skipf("%q does not exist", e2e.BinPath.EtcdLastRelease)
 	}
 
-	dc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-		BasePort:    2000,
-		Version:     e2e.LastVersion,
-		ClusterSize: 1,
-		EnableV2:    true,
-	})
+	dc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+		e2e.WithBasePort(2000),
+		e2e.WithVersion(e2e.LastVersion),
+		e2e.WithClusterSize(1),
+		e2e.WithEnableV2(true),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -61,12 +61,12 @@ func testClusterUsingDiscovery(t *testing.T, size int, peerTLS bool) {
 	}
 	cancel()
 
-	c, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-		BasePort:    3000,
-		ClusterSize: size,
-		IsPeerTLS:   peerTLS,
-		Discovery:   dc.EndpointsV2()[0] + "/v2/keys",
-	})
+	c, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+		e2e.WithBasePort(3000),
+		e2e.WithClusterSize(size),
+		e2e.WithIsPeerTLS(peerTLS),
+		e2e.WithDiscovery(dc.EndpointsV2()[0]+"/v2/keys"),
+	)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -48,13 +48,12 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 	e2e.BeforeTest(t)
 
 	// step 1: start the discovery service
-	ds, err := e2e.NewEtcdProcessCluster(context.TODO(), t, &e2e.EtcdProcessClusterConfig{
-		InitialToken:    "new",
-		BasePort:        2000,
-		ClusterSize:     discoveryClusterSize,
-		ClientTLS:       clientTlsType,
-		IsClientAutoTLS: isClientAutoTls,
-	})
+	ds, err := e2e.NewEtcdProcessCluster(context.TODO(), t, nil,
+		e2e.WithBasePort(2000),
+		e2e.WithClusterSize(discoveryClusterSize),
+		e2e.WithClientTLS(clientTlsType),
+		e2e.WithIsClientAutoTLS(isClientAutoTls),
+	)
 	if err != nil {
 		t.Fatalf("could not start discovery etcd cluster (%v)", err)
 	}
@@ -87,14 +86,14 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 
 func bootstrapEtcdClusterUsingV3Discovery(t *testing.T, discoveryEndpoints []string, discoveryToken string, clusterSize int, clientTlsType e2e.ClientConnType, isClientAutoTls bool) (*e2e.EtcdProcessCluster, error) {
 	// cluster configuration
-	cfg := &e2e.EtcdProcessClusterConfig{
-		BasePort:           3000,
-		ClusterSize:        clusterSize,
-		IsPeerTLS:          true,
-		IsPeerAutoTLS:      true,
-		DiscoveryToken:     discoveryToken,
-		DiscoveryEndpoints: discoveryEndpoints,
-	}
+	cfg := e2e.NewConfig(
+		e2e.WithBasePort(3000),
+		e2e.WithClusterSize(clusterSize),
+		e2e.WithIsPeerTLS(true),
+		e2e.WithIsPeerAutoTLS(true),
+		e2e.WithDiscoveryToken(discoveryToken),
+		e2e.WithDiscoveryEndpoints(discoveryEndpoints),
+	)
 
 	// initialize the cluster
 	epc, err := e2e.InitEtcdProcessCluster(t, cfg)

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -35,9 +35,7 @@ func TestGrpcProxyAutoSync(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	epc, err := e2e.NewEtcdProcessCluster(ctx, t, &e2e.EtcdProcessClusterConfig{
-		ClusterSize: 1,
-	})
+	epc, err := e2e.NewEtcdProcessCluster(ctx, t, nil, e2e.WithClusterSize(1))
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, epc.Close())
@@ -59,7 +57,7 @@ func TestGrpcProxyAutoSync(t *testing.T) {
 		assert.NoError(t, proxyProc.Stop())
 	}()
 
-	proxyCtl, err := e2e.NewEtcdctl(&e2e.EtcdProcessClusterConfig{}, []string{proxyClientURL})
+	proxyCtl, err := e2e.NewEtcdctl(e2e.DefaultConfig(), []string{proxyClientURL})
 	require.NoError(t, err)
 	err = proxyCtl.Put(ctx, "k1", "v1", config.PutOptions{})
 	require.NoError(t, err)

--- a/tests/framework/e2e/e2e.go
+++ b/tests/framework/e2e/e2e.go
@@ -48,14 +48,13 @@ func (e e2eRunner) BeforeTest(t testing.TB) {
 
 func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) intf.Cluster {
 	cfg := config.NewClusterConfig(opts...)
-	e2eConfig := EtcdProcessClusterConfig{
-		InitialToken:               "new",
-		ClusterSize:                cfg.ClusterSize,
-		QuotaBackendBytes:          cfg.QuotaBackendBytes,
-		DisableStrictReconfigCheck: !cfg.StrictReconfigCheck,
-		AuthTokenOpts:              cfg.AuthToken,
-		SnapshotCount:              cfg.SnapshotCount,
-	}
+	e2eConfig := NewConfig(
+		WithClusterSize(cfg.ClusterSize),
+		WithQuotaBackendBytes(cfg.QuotaBackendBytes),
+		WithDisableStrictReconfigCheck(!cfg.StrictReconfigCheck),
+		WithAuthTokenOpts(cfg.AuthToken),
+		WithSnapshotCount(cfg.SnapshotCount),
+	)
 
 	if cfg.ClusterContext != nil {
 		e2eClusterCtx := cfg.ClusterContext.(*ClusterContext)
@@ -87,7 +86,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.
 	default:
 		t.Fatalf("PeerTLS config %q not supported", cfg.PeerTLS)
 	}
-	epc, err := NewEtcdProcessCluster(ctx, t, &e2eConfig)
+	epc, err := NewEtcdProcessCluster(ctx, t, e2eConfig)
 	if err != nil {
 		t.Fatalf("could not start etcd integrationCluster: %s", err)
 	}


### PR DESCRIPTION
Context https://github.com/etcd-io/etcd/pull/14711

This PR continues to work on 2nd step: replaces some initialisations of `EtcdProcessClusterConfig` with DefaultConfig, NewConfig and EPClusterOption.

Eventually, `EtcdProcessClusterConfig` should look like:
```go
func NewEtcdProcessCluster(ctx context.Context, t testing.TB, opts ...EPClusterOption) (*EtcdProcessCluster, error) {
 	cfg := NewConfig(opts...)
 	epc, err := InitEtcdProcessCluster(t, cfg)
 	if err != nil {
 		return nil, err
 	}
 	return StartEtcdProcessCluster(ctx, epc, cfg)
 }
```
see https://github.com/etcd-io/etcd/pull/14725#discussion_r1020724228