### PR TITLE
tests/linearizability: added sleep fail point injection

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -157,7 +157,7 @@ func (r *raftNode) tick() {
 // to modify the fields after it has been started.
 func (r *raftNode) start(rh *raftReadyHandler) {
 	internalTimeout := time.Second
-
+	// gofail: var raftBeforeStart struct{}
 	go func() {
 		defer r.onStop()
 		islead := false


### PR DESCRIPTION
tests/linearizability: added sleep failpoint injection functionality

Injected sleep fail point inside  *raftNode.start() to test functionality

Signed-off-by: Ramil Mirhasanov <ramil600@yahoo.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
