### PR TITLE
[3.5] trim build path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ etcd_build() {
     # Static compilation is useful when etcd is run in a container. $GO_BUILD_FLAGS is OK
     # shellcheck disable=SC2086
     run env "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcd" . || return 2
@@ -52,6 +53,7 @@ etcd_build() {
   (
     cd ./etcdutl
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcdutl" . || return 2
@@ -62,6 +64,7 @@ etcd_build() {
   (
     cd ./etcdctl
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" "${GO_BUILD_ENV[@]}" go build $GO_BUILD_FLAGS \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags=${GO_LDFLAGS[*]}" \
       -o="../${out}/etcdctl" . || return 2
@@ -92,6 +95,7 @@ tools_build() {
     run rm -f "${out}/${tool}"
     # shellcheck disable=SC2086
     run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} \
+      -trimpath \
       -installsuffix=cgo \
       "-ldflags='${GO_LDFLAGS[*]}'" \
       -o="${out}/${tool}" "./${tool}" || return 2

--- a/scripts/build-binary
+++ b/scripts/build-binary
@@ -87,7 +87,7 @@ function main {
       export GOARCH=${TARGET_ARCH}
 
       pushd etcd >/dev/null
-      GO_LDFLAGS="-s" ./build.sh
+      GO_LDFLAGS="-s -w" ./build.sh
       popd >/dev/null
 
       TARGET="etcd-${VER}-${GOOS}-${GOARCH}"

--- a/tests/functional/build
+++ b/tests/functional/build
@@ -7,8 +7,8 @@ fi
 
 (
   cd ./tests 
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o ../bin/etcd-agent ./functional/cmd/etcd-agent
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o ../bin/etcd-proxy ./functional/cmd/etcd-proxy
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o ../bin/etcd-runner ./functional/cmd/etcd-runner
-  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s" -o ../bin/etcd-tester ./functional/cmd/etcd-tester
+  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s -w" -o ../bin/etcd-agent ./functional/cmd/etcd-agent
+  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s -w" -o ../bin/etcd-proxy ./functional/cmd/etcd-proxy
+  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s -w" -o ../bin/etcd-runner ./functional/cmd/etcd-runner
+  CGO_ENABLED=0 go build -v -installsuffix cgo -ldflags "-s -w" -o ../bin/etcd-tester ./functional/cmd/etcd-tester
 )


### PR DESCRIPTION
Trimming GOPATH etcd binary for next release.
Backports https://github.com/etcd-io/etcd/pull/13552