### PR TITLE
client: update comment for clarity

### DIFF
--- a/client/v3/concurrency/key.go
+++ b/client/v3/concurrency/key.go
@@ -46,7 +46,7 @@ func waitDelete(ctx context.Context, client *v3.Client, key string, rev int64) e
 }
 
 // waitDeletes efficiently waits until all keys matching the prefix and no greater
-// than the create revision.
+// than the create revision are deleted.
 func waitDeletes(ctx context.Context, client *v3.Client, pfx string, maxCreateRev int64) (*pb.ResponseHeader, error) {
 	getOpts := append(v3.WithLastCreate(), v3.WithMaxCreateRev(maxCreateRev))
 	for {


### PR DESCRIPTION
I am not totally sure if I am correct but I think [here](https://github.com/etcd-io/etcd/blob/main/client/v3/concurrency/key.go#L48-L49), we should mention:

> waitDeletes efficiently waits until all keys matching the prefix and no greater than the create revision **_are deleted_**

Instead of just:

> waitDeletes efficiently waits until all keys matching the prefix and no greater than the create revision.

I tried to verify this with [the PR](https://github.com/etcd-io/etcd/pull/7444/files) related to the above change (found using git blame)