### PR TITLE
tests/integration: deflake Corruption cases

### DIFF
--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -92,12 +92,31 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(50 * time.Millisecond)
 	leader := clus.WaitLeader(t)
+
+	// Get sorted member IDs
+	members, err := cc.MemberList(ctx)
+	assert.NoError(t, err, "error on member list %v")
+
+	// NOTE: If the corrupted member has been elected as leader, the
+	// alarm will show the smaller member.
+	var expectedID = uint64(clus.Members[0].ID())
+	if leader == 0 {
+		for _, m := range members.Members {
+			if m.Name != clus.Members[0].Name {
+				expectedID = m.ID
+				break
+			}
+		}
+
+	}
+
 	err = clus.Members[leader].Server.CorruptionChecker().PeriodicCheck()
 	assert.NoError(t, err, "error on periodic check")
 	time.Sleep(50 * time.Millisecond)
+
 	alarmResponse, err := cc.AlarmList(ctx)
 	assert.NoError(t, err, "error on alarm list")
-	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
+	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: expectedID}}, alarmResponse.Alarms)
 }
 
 func TestCompactHashCheck(t *testing.T) {
@@ -166,9 +185,27 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	assert.NoError(t, err)
 	time.Sleep(50 * time.Millisecond)
 	leader := clus.WaitLeader(t)
+
+	// Get sorted member IDs
+	members, err := cc.MemberList(ctx)
+	assert.NoError(t, err, "error on member list %v")
+
+	// NOTE: If the corrupted member has been elected as leader, the
+	// alarm will show the smaller member.
+	var expectedID = uint64(clus.Members[0].ID())
+	if leader == 0 {
+		for _, m := range members.Members {
+			if m.Name != clus.Members[0].Name {
+				expectedID = m.ID
+				break
+			}
+		}
+
+	}
+
 	clus.Members[leader].Server.CorruptionChecker().CompactHashCheck()
 	time.Sleep(50 * time.Millisecond)
 	alarmResponse, err := cc.AlarmList(ctx)
 	assert.NoError(t, err, "error on alarm list")
-	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
+	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: expectedID}}, alarmResponse.Alarms)
 }


### PR DESCRIPTION
If the corrupted member has been elected as leader, the memberID in alert response won't be the corrupted one. It will be a smaller follower ID since the raftCluster.Members always sorts by ID. We should check the leader ID and decide to use which memberID.

Fixes: #14823

Signed-off-by: Wei Fu <fuweid89@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
