### PR TITLE
tests: fix anti-pattern name in `NewEtcdProcessCluster`

### DIFF
--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -222,7 +222,7 @@ func testCtlWithOffline(t *testing.T, testFunc func(ctlCtx), testOfflineFunc fun
 	if !ret.quorum {
 		ret.cfg = *e2e.ConfigStandalone(ret.cfg)
 	}
-	ret.cfg.DisableStrictReconfigCheck = ret.disableStrictReconfigCheck
+	ret.cfg.StrictReconfigCheck = !ret.disableStrictReconfigCheck
 	if ret.initialCorruptCheck {
 		ret.cfg.InitialCorruptCheck = ret.initialCorruptCheck
 	}

--- a/tests/framework/e2e/curl.go
+++ b/tests/framework/e2e/curl.go
@@ -64,7 +64,7 @@ func CURLPrefixArgs(cfg *EtcdProcessClusterConfig, member EtcdProcess, method st
 			cmdArgs = append(cmdArgs, "--cacert", CaPath, "--cert", CertPath, "--key", PrivateKeyPath)
 			acurl = ToTLS(member.Config().Acurl)
 		} else if cfg.Client.ConnectionType == ClientTLS {
-			if !cfg.NoCN {
+			if cfg.CN {
 				cmdArgs = append(cmdArgs, "--cacert", CaPath, "--cert", CertPath, "--key", PrivateKeyPath)
 			} else {
 				cmdArgs = append(cmdArgs, "--cacert", CaPath, "--cert", CertPath3, "--key", PrivateKeyPath3)

--- a/tests/framework/e2e/e2e.go
+++ b/tests/framework/e2e/e2e.go
@@ -48,7 +48,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.
 	e2eConfig := NewConfig(
 		WithClusterSize(cfg.ClusterSize),
 		WithQuotaBackendBytes(cfg.QuotaBackendBytes),
-		WithDisableStrictReconfigCheck(!cfg.StrictReconfigCheck),
+		WithStrictReconfigCheck(cfg.StrictReconfigCheck),
 		WithAuthTokenOpts(cfg.AuthToken),
 		WithSnapshotCount(cfg.SnapshotCount),
 	)


### PR DESCRIPTION
Context #14711 

Rename anti-pattern-naming fields(DisableStrictReconfigCheck and NoCN) and move them to DefaultConfig.