### PR TITLE
Identify corrupted member depending on quorum

### DIFF
--- a/client/pkg/types/id.go
+++ b/client/pkg/types/id.go
@@ -14,7 +14,10 @@
 
 package types
 
-import "strconv"
+import (
+	"bytes"
+	"strconv"
+)
 
 // ID represents a generic identifier which is canonically
 // stored as a uint64 but is typically represented as a
@@ -37,3 +40,17 @@ type IDSlice []ID
 func (p IDSlice) Len() int           { return len(p) }
 func (p IDSlice) Less(i, j int) bool { return uint64(p[i]) < uint64(p[j]) }
 func (p IDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+func (p IDSlice) String() string {
+	var b bytes.Buffer
+	if p.Len() > 0 {
+		b.WriteString(p[0].String())
+	}
+
+	for i := 1; i < p.Len(); i++ {
+		b.WriteString(",")
+		b.WriteString(p[i].String())
+	}
+
+	return b.String()
+}

--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -93,30 +93,13 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	leader := clus.WaitLeader(t)
 
-	// Get sorted member IDs
-	members, err := cc.MemberList(ctx)
-	assert.NoError(t, err, "error on member list %v")
-
-	// NOTE: If the corrupted member has been elected as leader, the
-	// alarm will show the smaller member.
-	var expectedID = uint64(clus.Members[0].ID())
-	if leader == 0 {
-		for _, m := range members.Members {
-			if m.Name != clus.Members[0].Name {
-				expectedID = m.ID
-				break
-			}
-		}
-
-	}
-
 	err = clus.Members[leader].Server.CorruptionChecker().PeriodicCheck()
 	assert.NoError(t, err, "error on periodic check")
 	time.Sleep(50 * time.Millisecond)
 
 	alarmResponse, err := cc.AlarmList(ctx)
 	assert.NoError(t, err, "error on alarm list")
-	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: expectedID}}, alarmResponse.Alarms)
+	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
 }
 
 func TestCompactHashCheck(t *testing.T) {
@@ -186,26 +169,9 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	leader := clus.WaitLeader(t)
 
-	// Get sorted member IDs
-	members, err := cc.MemberList(ctx)
-	assert.NoError(t, err, "error on member list %v")
-
-	// NOTE: If the corrupted member has been elected as leader, the
-	// alarm will show the smaller member.
-	var expectedID = uint64(clus.Members[0].ID())
-	if leader == 0 {
-		for _, m := range members.Members {
-			if m.Name != clus.Members[0].Name {
-				expectedID = m.ID
-				break
-			}
-		}
-
-	}
-
 	clus.Members[leader].Server.CorruptionChecker().CompactHashCheck()
 	time.Sleep(50 * time.Millisecond)
 	alarmResponse, err := cc.AlarmList(ctx)
 	assert.NoError(t, err, "error on alarm list")
-	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: expectedID}}, alarmResponse.Alarms)
+	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
 }


### PR DESCRIPTION
Currently when the compact hash checker detects hash mismatch, it assumes that the corrupted member is always one of the followers. This isn't correct, because it's also possible that it's the leader's data corrupted. It's also possible that there are multiple members corrupted, for example 2 members out of a 5 member cluster.

The solution is to depend on quorum to identify the corrupted member. For example, for a 3 member cluster, if 2 members have the same compactRevision and hash, then the left one member is the corrupted one. For a 5 member cluster, if at least 3 members have the same CompactRevision and hash, then the left members are the corrupted ones.

If there isn't a quorum, then the least minority are regarded as the corrupted member. For example, for a 5 member cluster, m1 and m2 have the same CompactRevision and hash, m3 and 4 have the same CompactRevision and hash, the m5 is the corrupted member.
