### PR TITLE
wal: add wal-segment-size-bytes flags to limit size of each wal segment file

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -172,6 +172,8 @@ type ServerConfig struct {
 
 	EnableGRPCGateway bool
 
+	WalSegmentSizeBytes int64
+
 	// ExperimentalEnableDistributedTracing enables distributed tracing using OpenTelemetry protocol.
 	ExperimentalEnableDistributedTracing bool
 	// ExperimentalTracerOptions are options for OpenTelemetry gRPC interceptor.

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -98,6 +98,9 @@ const (
 	// It's enabled by default.
 	DefaultStrictReconfigCheck = true
 
+	// DefaultWalSegmentSizeBytes is the default value for "--wal-segment-size-bytes" flag
+	DefaultWalSegmentSizeBytes = 64 * 1000 * 1000 // 64MB
+
 	// maxElectionMs specifies the maximum value of election timeout.
 	// More details are listed on etcd.io/docs > version > tuning/#time-parameters
 	maxElectionMs = 50000
@@ -424,6 +427,9 @@ type Config struct {
 
 	// V2Deprecation describes phase of API & Storage V2 support
 	V2Deprecation config.V2DeprecationEnum `json:"v2-deprecation"`
+
+	// WalSegmentSizeBytes Setting the preallocated size of each wal segment file.
+	WalSegmentSizeBytes int64 `json:"wal-segment-size-bytes"`
 }
 
 // configYAML holds the config suitable for yaml parsing
@@ -526,6 +532,8 @@ func NewConfig() *Config {
 
 		ExperimentalCompactHashCheckEnabled: false,
 		ExperimentalCompactHashCheckTime:    time.Minute,
+
+		WalSegmentSizeBytes: DefaultWalSegmentSizeBytes,
 
 		V2Deprecation: config.V2_DEPR_DEFAULT,
 

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -223,6 +223,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		ExperimentalBootstrapDefragThresholdMegabytes: cfg.ExperimentalBootstrapDefragThresholdMegabytes,
 		ExperimentalMaxLearners:                       cfg.ExperimentalMaxLearners,
 		V2Deprecation:                                 cfg.V2DeprecationEffective(),
+		WalSegmentSizeBytes:                           cfg.WalSegmentSizeBytes,
 	}
 
 	if srvcfg.ExperimentalEnableDistributedTracing {

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -279,6 +279,7 @@ func newConfig() *config {
 	fs.UintVar(&cfg.ec.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
 	fs.IntVar(&cfg.ec.ExperimentalMaxLearners, "experimental-max-learners", membership.DefaultMaxLearners, "Sets the maximum number of learners that can be available in the cluster membership.")
 	fs.DurationVar(&cfg.ec.ExperimentalWaitClusterReadyTimeout, "experimental-wait-cluster-ready-timeout", cfg.ec.ExperimentalWaitClusterReadyTimeout, "Maximum duration to wait for the cluster to be ready.")
+	fs.Int64Var(&cfg.ec.WalSegmentSizeBytes, "wal-segment-size-bytes", cfg.ec.WalSegmentSizeBytes, "The preallocated size of each wal segment file.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -75,6 +75,7 @@ func bootstrap(cfg config.ServerConfig) (b *bootstrappedServer, err error) {
 		return nil, err
 	}
 
+	wal.SegmentSizeBytes = cfg.WalSegmentSizeBytes
 	haveWAL := wal.Exist(cfg.WALDir())
 	st := v2store.New(StoreClusterPrefix, StoreKeysPrefix)
 	backend, err := bootstrapBackend(cfg, haveWAL, st, ss)


### PR DESCRIPTION
fix [14832](https://github.com/etcd-io/etcd/issues/14832)