### PR TITLE
Shell func go_srcs_in_module to list go src+test files (#14827)

### DIFF
--- a/api/etcdserverpb/raft_internal_stringer_test.go
+++ b/api/etcdserverpb/raft_internal_stringer_test.go
@@ -20,7 +20,7 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
-// TestInvalidGoYypeIntPanic tests conditions that caused
+// TestInvalidGoTypeIntPanic tests conditions that caused
 // panic: invalid Go type int for field k8s_io.kubernetes.vendor.go_etcd_io.etcd.etcdserver.etcdserverpb.loggablePutRequest.value_size
 // See https://github.com/kubernetes/kubernetes/issues/91937 for more details
 func TestInvalidGoTypeIntPanic(t *testing.T) {

--- a/etcdctl/main_test.go
+++ b/etcdctl/main_test.go
@@ -36,7 +36,7 @@ func SplitTestArgs(args []string) (testArgs, appArgs []string) {
 	return
 }
 
-// Empty test to avoid no-tests warning.
+// TestEmpty is an empty test to avoid no-tests warning.
 func TestEmpty(t *testing.T) {}
 
 /**

--- a/etcdutl/main_test.go
+++ b/etcdutl/main_test.go
@@ -36,7 +36,7 @@ func SplitTestArgs(args []string) (testArgs, appArgs []string) {
 	return
 }
 
-// Empty test to avoid no-tests warning.
+// TestEmpty is empty test to avoid no-tests warning.
 func TestEmpty(t *testing.T) {}
 
 /**

--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -46,7 +46,7 @@ func TestPageWriterRandom(t *testing.T) {
 	t.Logf("total write bytes: %d (of %d)", cw.writeBytes, n)
 }
 
-// TestPageWriterPariallack tests the case where a write overflows the buffer
+// TestPageWriterPartialSlack tests the case where a write overflows the buffer
 // but there is not enough data to complete the slack write.
 func TestPageWriterPartialSlack(t *testing.T) {
 	defaultBufferBytes = 1024

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -81,7 +81,7 @@ func TestNodeStep(t *testing.T) {
 	}
 }
 
-// Cancel and Stop should unblock Step()
+// TestNodeStepUnblock should Cancel and Stop should unblock Step()
 func TestNodeStepUnblock(t *testing.T) {
 	// a node without buffer to block step
 	n := &node{

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1236,8 +1236,8 @@ func TestPastElectionTimeout(t *testing.T) {
 	}
 }
 
-// ensure that the Step function ignores the message from old term and does not pass it to the
-// actual stepX function.
+// TestStepIgnoreOldTermMsg to ensure that the Step function ignores the message
+// from old term and does not pass it to the actual stepX function.
 func TestStepIgnoreOldTermMsg(t *testing.T) {
 	called := false
 	fakeStep := func(r *raft, m pb.Message) error {
@@ -2509,7 +2509,7 @@ func TestLeaderAppResp(t *testing.T) {
 	}
 }
 
-// When the leader receives a heartbeat tick, it should
+// TestBcastBeat is when the leader receives a heartbeat tick, it should
 // send a MsgHeartbeat with m.Index = 0, m.LogTerm=0 and empty entries.
 func TestBcastBeat(t *testing.T) {
 	offset := uint64(1000)
@@ -2569,7 +2569,7 @@ func TestBcastBeat(t *testing.T) {
 	}
 }
 
-// tests the output of the state machine when receiving MsgBeat
+// TestRecvMsgBeat tests the output of the state machine when receiving MsgBeat
 func TestRecvMsgBeat(t *testing.T) {
 	tests := []struct {
 		state StateType
@@ -2848,7 +2848,7 @@ func TestRestoreWithLearner(t *testing.T) {
 	}
 }
 
-// / Tests if outgoing voter can receive and apply snapshot correctly.
+// TestRestoreWithVotersOutgoing tests if outgoing voter can receive and apply snapshot correctly.
 func TestRestoreWithVotersOutgoing(t *testing.T) {
 	s := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{
@@ -4340,12 +4340,12 @@ func testConfChangeCheckBeforeCampaign(t *testing.T, v2 bool) {
 	}
 }
 
-// Tests if unapplied ConfChange is checked before campaign.
+// TestConfChangeCheckBeforeCampaign tests if unapplied ConfChange is checked before campaign.
 func TestConfChangeCheckBeforeCampaign(t *testing.T) {
 	testConfChangeCheckBeforeCampaign(t, false)
 }
 
-// Tests if unapplied ConfChangeV2 is checked before campaign.
+// TestConfChangeV2CheckBeforeCampaign tests if unapplied ConfChangeV2 is checked before campaign.
 func TestConfChangeV2CheckBeforeCampaign(t *testing.T) {
 	testConfChangeCheckBeforeCampaign(t, true)
 }

--- a/raft/rawnode_test.go
+++ b/raft/rawnode_test.go
@@ -36,22 +36,22 @@ type rawNodeAdapter struct {
 
 var _ Node = (*rawNodeAdapter)(nil)
 
-// Node specifies lead, which is pointless, can just be filled in.
+// TransferLeadership is to test when node specifies lead, which is pointless, can just be filled in.
 func (a *rawNodeAdapter) TransferLeadership(ctx context.Context, lead, transferee uint64) {
 	a.RawNode.TransferLeader(transferee)
 }
 
-// Node has a goroutine, RawNode doesn't need this.
+// Stop when node has a goroutine, RawNode doesn't need this.
 func (a *rawNodeAdapter) Stop() {}
 
-// RawNode returns a *Status.
+// Status retirns RawNode's status as *Status.
 func (a *rawNodeAdapter) Status() Status { return a.RawNode.Status() }
 
-// RawNode takes a Ready. It doesn't really have to do that I think? It can hold on
+// Advance is when RawNode takes a Ready. It doesn't really have to do that I think? It can hold on
 // to it internally. But maybe that approach is frail.
 func (a *rawNodeAdapter) Advance() { a.RawNode.Advance(Ready{}) }
 
-// RawNode returns a Ready, not a chan of one.
+// Ready when RawNode returns a Ready, not a chan of one.
 func (a *rawNodeAdapter) Ready() <-chan Ready { return nil }
 
 // Node takes more contexts. Easy enough to fix.

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -108,7 +108,7 @@ function relativePath {
 # go_srcs_in_module [package]
 # returns list of all not-generated go sources in the current (dir) module.
 function go_srcs_in_module {
-  go list -f "{{with \$c:=.}}{{range \$f:=\$c.GoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{end}}" ./... | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
+  go list -f "{{with \$c:=.}}{{range \$f:=\$c.GoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{range \$f:=\$c.TestGoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{end}}" ./... | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
 }
 
 # pkgs_in_module [optional:package_pattern]

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -108,7 +108,7 @@ function relativePath {
 # go_srcs_in_module [package]
 # returns list of all not-generated go sources in the current (dir) module.
 function go_srcs_in_module {
-  go list -f "{{with \$c:=.}}{{range \$f:=\$c.GoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{range \$f:=\$c.TestGoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{end}}" ./... | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
+  go list -f "{{with \$c:=.}}{{range \$f:=\$c.GoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{range \$f:=\$c.TestGoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{range \$f:=\$c.XTestGoFiles  }}{{\$c.Dir}}/{{\$f}}{{\"\n\"}}{{end}}{{end}}" ./... | grep -vE "(\\.pb\\.go|\\.pb\\.gw.go)"
 }
 
 # pkgs_in_module [optional:package_pattern]

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -68,7 +68,7 @@ func TestNewAuthStoreRevision(t *testing.T) {
 	}
 }
 
-// TestNewAuthStoreBryptCost ensures that NewAuthStore uses default when given bcrypt-cost is invalid
+// TestNewAuthStoreBcryptCost ensures that NewAuthStore uses default when given bcrypt-cost is invalid
 func TestNewAuthStoreBcryptCost(t *testing.T) {
 	tp, err := NewTokenProvider(zaptest.NewLogger(t), tokenTypeSimple, dummyIndexWaiter, simpleTokenTTLDefault)
 	if err != nil {
@@ -779,7 +779,7 @@ func TestIsAuthEnabled(t *testing.T) {
 	}
 }
 
-// TestAuthRevisionRace ensures that access to authStore.revision is thread-safe.
+// TestAuthInfoFromCtxRace ensures that access to authStore.revision is thread-safe.
 func TestAuthInfoFromCtxRace(t *testing.T) {
 	tp, err := NewTokenProvider(zaptest.NewLogger(t), tokenTypeSimple, dummyIndexWaiter, simpleTokenTTLDefault)
 	if err != nil {

--- a/server/etcdserver/api/v2store/stats_test.go
+++ b/server/etcdserver/api/v2store/stats_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Ensure that a successful Get is recorded in the stats.
+// TestStoreStatsGetSuccess ensures that a successful Get is recorded in the stats.
 func TestStoreStatsGetSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -29,7 +29,7 @@ func TestStoreStatsGetSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.GetSuccess, "")
 }
 
-// Ensure that a failed Get is recorded in the stats.
+// TestStoreStatsGetFail ensures that a failed Get is recorded in the stats.
 func TestStoreStatsGetFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -37,14 +37,14 @@ func TestStoreStatsGetFail(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.GetFail, "")
 }
 
-// Ensure that a successful Create is recorded in the stats.
+// TestStoreStatsCreateSuccess ensures that a successful Create is recorded in the stats.
 func TestStoreStatsCreateSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	assert.Equal(t, uint64(1), s.Stats.CreateSuccess, "")
 }
 
-// Ensure that a failed Create is recorded in the stats.
+// TestStoreStatsCreateFail ensures that a failed Create is recorded in the stats.
 func TestStoreStatsCreateFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
@@ -52,7 +52,7 @@ func TestStoreStatsCreateFail(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.CreateFail, "")
 }
 
-// Ensure that a successful Update is recorded in the stats.
+// TestStoreStatsUpdateSuccess ensures that a successful Update is recorded in the stats.
 func TestStoreStatsUpdateSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -60,14 +60,14 @@ func TestStoreStatsUpdateSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.UpdateSuccess, "")
 }
 
-// Ensure that a failed Update is recorded in the stats.
+// TestStoreStatsUpdateFail ensures that a failed Update is recorded in the stats.
 func TestStoreStatsUpdateFail(t *testing.T) {
 	s := newStore()
 	s.Update("/foo", "bar", TTLOptionSet{ExpireTime: Permanent})
 	assert.Equal(t, uint64(1), s.Stats.UpdateFail, "")
 }
 
-// Ensure that a successful CAS is recorded in the stats.
+// TestStoreStatsCompareAndSwapSuccess ensures that a successful CAS is recorded in the stats.
 func TestStoreStatsCompareAndSwapSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -75,7 +75,7 @@ func TestStoreStatsCompareAndSwapSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapSuccess, "")
 }
 
-// Ensure that a failed CAS is recorded in the stats.
+// TestStoreStatsCompareAndSwapFail ensures that a failed CAS is recorded in the stats.
 func TestStoreStatsCompareAndSwapFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -83,7 +83,7 @@ func TestStoreStatsCompareAndSwapFail(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapFail, "")
 }
 
-// Ensure that a successful Delete is recorded in the stats.
+// TestStoreStatsDeleteSuccess ensures that a successful Delete is recorded in the stats.
 func TestStoreStatsDeleteSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
@@ -91,14 +91,14 @@ func TestStoreStatsDeleteSuccess(t *testing.T) {
 	assert.Equal(t, uint64(1), s.Stats.DeleteSuccess, "")
 }
 
-// Ensure that a failed Delete is recorded in the stats.
+// TestStoreStatsDeleteFail ensures that a failed Delete is recorded in the stats.
 func TestStoreStatsDeleteFail(t *testing.T) {
 	s := newStore()
 	s.Delete("/foo", false, false)
 	assert.Equal(t, uint64(1), s.Stats.DeleteFail, "")
 }
 
-// Ensure that the number of expirations is recorded in the stats.
+// TestStoreStatsExpireCount ensures that the number of expirations is recorded in the stats.
 func TestStoreStatsExpireCount(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()

--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
-// Ensure that any TTL <= minExpireTime becomes Permanent
+// TestMinExpireTime ensures that any TTL <= minExpireTime becomes Permanent
 func TestMinExpireTime(t *testing.T) {
 	s := newStore()
 	fc := clockwork.NewFakeClock()
@@ -45,7 +45,7 @@ func TestMinExpireTime(t *testing.T) {
 	assert.Equal(t, e.Node.TTL, int64(0))
 }
 
-// Ensure that the store can recursively retrieve a directory listing.
+// TestStoreGetDirectory ensures that the store can recursively retrieve a directory listing.
 // Note that hidden files should not be returned.
 func TestStoreGetDirectory(t *testing.T) {
 	s := newStore()
@@ -94,7 +94,7 @@ func TestStoreGetDirectory(t *testing.T) {
 	}
 }
 
-// Ensure that the store can update the TTL on a value.
+// TestStoreUpdateValueTTL ensures that the store can update the TTL on a value.
 func TestStoreUpdateValueTTL(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -114,7 +114,7 @@ func TestStoreUpdateValueTTL(t *testing.T) {
 	assert.Equal(t, err.(*v2error.Error).ErrorCode, v2error.EcodeKeyNotFound)
 }
 
-// Ensure that the store can update the TTL on a directory.
+// TestStoreUpdateDirTTL ensures that the store can update the TTL on a directory.
 func TestStoreUpdateDirTTL(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -140,7 +140,7 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 	assert.Equal(t, err.(*v2error.Error).ErrorCode, v2error.EcodeKeyNotFound)
 }
 
-// Ensure that the store can watch for key expiration.
+// TestStoreWatchExpire ensures that the store can watch for key expiration.
 func TestStoreWatchExpire(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -178,7 +178,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	assert.Equal(t, e.Node.Dir, true)
 }
 
-// Ensure that the store can watch for key expiration when refreshing.
+// TestStoreWatchExpireRefresh ensures that the store can watch for key expiration when refreshing.
 func TestStoreWatchExpireRefresh(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -214,7 +214,7 @@ func TestStoreWatchExpireRefresh(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foofoo")
 }
 
-// Ensure that the store can watch for key expiration when refreshing with an empty value.
+// TestStoreWatchExpireEmptyRefresh ensures that the store can watch for key expiration when refreshing with an empty value.
 func TestStoreWatchExpireEmptyRefresh(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -239,7 +239,7 @@ func TestStoreWatchExpireEmptyRefresh(t *testing.T) {
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 }
 
-// Update TTL of a key (set TTLOptionSet.Refresh to false) and send notification
+// TestStoreWatchNoRefresh updates TTL of a key (set TTLOptionSet.Refresh to false) and send notification
 func TestStoreWatchNoRefresh(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -265,7 +265,7 @@ func TestStoreWatchNoRefresh(t *testing.T) {
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 }
 
-// Ensure that the store can update the TTL on a value with refresh.
+// TestStoreRefresh ensures that the store can update the TTL on a value with refresh.
 func TestStoreRefresh(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()
@@ -287,7 +287,7 @@ func TestStoreRefresh(t *testing.T) {
 	testutil.AssertNil(t, err)
 }
 
-// Ensure that the store can recover from a previously saved state that includes an expiring key.
+// TestStoreRecoverWithExpiration ensures that the store can recover from a previously saved state that includes an expiring key.
 func TestStoreRecoverWithExpiration(t *testing.T) {
 	s := newStore()
 	s.clock = newFakeClock()
@@ -321,7 +321,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store doesn't see expirations of hidden keys.
+// TestStoreWatchExpireWithHiddenKey ensures that the store doesn't see expirations of hidden keys.
 func TestStoreWatchExpireWithHiddenKey(t *testing.T) {
 	s := newStore()
 	fc := newFakeClock()

--- a/server/etcdserver/api/v3discovery/discovery_test.go
+++ b/server/etcdserver/api/v3discovery/discovery_test.go
@@ -35,7 +35,7 @@ type fakeKVForClusterSize struct {
 	clusterSizeStr string
 }
 
-// We only need to overwrite the method `Get`.
+// Get when we only need to overwrite the method `Get`.
 func (fkv *fakeKVForClusterSize) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	if fkv.clusterSizeStr == "" {
 		// cluster size isn't configured in this case.
@@ -108,7 +108,7 @@ type fakeKVForClusterMembers struct {
 	members []memberInfo
 }
 
-// We only need to overwrite method `Get`.
+// Get when we only need to overwrite method `Get`.
 func (fkv *fakeKVForClusterMembers) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	kvs := memberInfoToKeyValues(fkv.members)
 
@@ -230,7 +230,7 @@ type fakeKVForCheckCluster struct {
 	getMembersRetries int
 }
 
-// We only need to overwrite method `Get`.
+// Get when we only need to overwrite method `Get`.
 func (fkv *fakeKVForCheckCluster) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	clusterSizeKey := fmt.Sprintf("/_etcd/registry/%s/_config/size", fkv.token)
 	clusterMembersKey := fmt.Sprintf("/_etcd/registry/%s/members", fkv.token)
@@ -420,7 +420,7 @@ type fakeKVForRegisterSelf struct {
 	retries          int
 }
 
-// We only need to overwrite method `Put`.
+// Put when we only need to overwrite method `Put`.
 func (fkv *fakeKVForRegisterSelf) Put(ctx context.Context, key string, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
 	if key != fkv.expectedRegKey {
 		fkv.t.Errorf("unexpected register key, expected: %s, got: %s", fkv.expectedRegKey, key)
@@ -515,7 +515,7 @@ type fakeWatcherForWaitPeers struct {
 	members []memberInfo
 }
 
-// We only need to overwrite method `Watch`.
+// Watch we only need to overwrite method `Watch`.
 func (fw *fakeWatcherForWaitPeers) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
 	expectedWatchKey := fmt.Sprintf("/_etcd/registry/%s/members", fw.token)
 	if key != expectedWatchKey {

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -278,9 +278,8 @@ func TestProcessDuplicatedAppRespMessage(t *testing.T) {
 	}
 }
 
-// Test that none of the expvars that get added during init panic.
-// This matters if another package imports etcdserver,
-// doesn't use it, but does use expvars.
+// TestExpvarWithNoRaftStatus to test that none of the expvars that get added during init panic.
+// This matters if another package imports etcdserver, doesn't use it, but does use expvars.
 func TestExpvarWithNoRaftStatus(t *testing.T) {
 	defer func() {
 		if err := recover(); err != nil {

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1014,7 +1014,7 @@ func TestSyncTrigger(t *testing.T) {
 	<-n.Chan()
 }
 
-// snapshot should snapshot the store and cut the persistent
+// TestSnapshot should snapshot the store and cut the persistent
 func TestSnapshot(t *testing.T) {
 	be, _ := betesting.NewDefaultTmpBackend(t)
 
@@ -1170,7 +1170,7 @@ func TestSnapshotOrdering(t *testing.T) {
 	}
 }
 
-// Applied > SnapshotCount should trigger a SaveSnap event
+// TestTriggerSnap for Applied > SnapshotCount should trigger a SaveSnap event
 func TestTriggerSnap(t *testing.T) {
 	be, tmpPath := betesting.NewDefaultTmpBackend(t)
 	defer func() {
@@ -1519,7 +1519,7 @@ func TestPublishV3(t *testing.T) {
 		Name: "node1", ClientUrls: []string{"http://a", "http://b"}}}, r.ClusterMemberAttrSet)
 }
 
-// TestPublishStopped tests that publish will be stopped if server is stopped.
+// TestPublishV3Stopped tests that publish will be stopped if server is stopped.
 func TestPublishV3Stopped(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := newRaftNode(raftNodeConfig{
@@ -1547,7 +1547,7 @@ func TestPublishV3Stopped(t *testing.T) {
 	srv.publishV3(time.Hour)
 }
 
-// TestPublishRetry tests that publish will keep retry until success.
+// TestPublishV3Retry tests that publish will keep retry until success.
 func TestPublishV3Retry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	n := newNodeRecorderStream()

--- a/server/lease/lessor_bench_test.go
+++ b/server/lease/lessor_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkLessorRevoke100000(b *testing.B) { benchmarkLessorRevoke(100000, b
 func BenchmarkLessorRenew1000(b *testing.B)   { benchmarkLessorRenew(1000, b) }
 func BenchmarkLessorRenew100000(b *testing.B) { benchmarkLessorRenew(100000, b) }
 
-// Use findExpired10000 replace findExpired1000, which takes too long.
+// BenchmarkLessorFindExpired10000 uses findExpired10000 replace findExpired1000, which takes too long.
 func BenchmarkLessorFindExpired10000(b *testing.B)  { benchmarkLessorFindExpired(10000, b) }
 func BenchmarkLessorFindExpired100000(b *testing.B) { benchmarkLessorFindExpired(100000, b) }
 

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -27,9 +27,9 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-// Test HashByRevValue values to ensure we don't change the output which would
-// have catastrophic consequences. Expected output is just hardcoded, so please
-// regenerate it every time you change input parameters.
+// TestHashByRevValue test HashByRevValue values to ensure we don't change the
+// output which would have catastrophic consequences. Expected output is just
+// hardcoded, so please regenerate it every time you change input parameters.
 func TestHashByRevValue(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
@@ -127,6 +127,7 @@ func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
 	return hash
 }
 
+// TestCompactionHash tests compaction hash
 // TODO: Change this to fuzz test
 func TestCompactionHash(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)

--- a/server/storage/mvcc/key_index_test.go
+++ b/server/storage/mvcc/key_index_test.go
@@ -530,7 +530,8 @@ func cloneGeneration(g *generation) *generation {
 	return &generation{g.ver, g.created, tmp}
 }
 
-// test that compact on version that higher than last modified version works well
+// TestKeyIndexCompactOnFurtherRev tests that compact on version that
+// higher than last modified version works well
 func TestKeyIndexCompactOnFurtherRev(t *testing.T) {
 	ki := &keyIndex{key: []byte("foo")}
 	ki.put(zaptest.NewLogger(t), 1, 0)

--- a/server/storage/mvcc/kv_test.go
+++ b/server/storage/mvcc/kv_test.go
@@ -394,7 +394,8 @@ func testKVPutWithSameLease(t *testing.T, f putFunc) {
 	}
 }
 
-// test that range, put, delete on single key in sequence repeatedly works correctly.
+// TestKVOperationInSequence tests that range, put, delete on single key in
+// sequence repeatedly works correctly.
 func TestKVOperationInSequence(t *testing.T) {
 	b, tmpPath := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
@@ -496,7 +497,8 @@ func TestKVTxnNonBlockRange(t *testing.T) {
 	}
 }
 
-// test that txn range, put, delete on single key in sequence repeatedly works correctly.
+// TestKVTxnOperationInSequence tests that txn range, put, delete on single key
+// in sequence repeatedly works correctly.
 func TestKVTxnOperationInSequence(t *testing.T) {
 	b, tmpPath := betesting.NewDefaultTmpBackend(t)
 	s := NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})

--- a/server/storage/mvcc/kvstore_bench_test.go
+++ b/server/storage/mvcc/kvstore_bench_test.go
@@ -94,7 +94,7 @@ func BenchmarkConsistentIndex(b *testing.B) {
 	}
 }
 
-// BenchmarkStoreTxnPutUpdate is same as above, but instead updates single key
+// BenchmarkStorePutUpdate is same as above, but instead updates single key
 func BenchmarkStorePutUpdate(b *testing.B) {
 	be, tmpPath := betesting.NewDefaultTmpBackend(b)
 	s := NewStore(zaptest.NewLogger(b), be, &lease.FakeLessor{}, StoreConfig{})

--- a/server/storage/mvcc/watchable_store_bench_test.go
+++ b/server/storage/mvcc/watchable_store_bench_test.go
@@ -112,11 +112,12 @@ func benchmarkWatchableStoreWatchPut(b *testing.B, synced bool) {
 	}
 }
 
-// Benchmarks on cancel function performance for unsynced watchers
-// in a WatchableStore. It creates k*N watchers to populate unsynced
-// with a reasonably large number of watchers. And measures the time it
-// takes to cancel N watchers out of k*N watchers. The performance is
-// expected to differ depending on the unsynced member implementation.
+// BenchmarkWatchableStoreUnsyncedCancel benchmarks on cancel function
+// performance for unsynced watchers in a WatchableStore. It creates
+// k*N watchers to populate unsynced with a reasonably large number of
+// watchers. And measures the time it takes to cancel N watchers out
+// of k*N watchers. The performance is expected to differ depending on
+// the unsynced member implementation.
 // TODO: k is an arbitrary constant. We need to figure out what factor
 // we should put to simulate the real-world use cases.
 func BenchmarkWatchableStoreUnsyncedCancel(b *testing.B) {

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -252,6 +252,7 @@ func TestVerify(t *testing.T) {
 	}
 }
 
+// TestCut tests cut
 // TODO: split it into smaller tests for better readability
 func TestCut(t *testing.T) {
 	p := t.TempDir()

--- a/tests/common/unit_test.go
+++ b/tests/common/unit_test.go
@@ -30,9 +30,9 @@ func unitClusterTestCases() []testCase {
 	return nil
 }
 
-// When a build tag (e.g. e2e or integration) isn't configured in IDE,
-// then IDE may complain "Unresolved reference 'WithAuth'". So we need
-// to define a default WithAuth to resolve such case.
+// WithAuth is when a build tag (e.g. e2e or integration) isn't configured
+// in IDE, then IDE may complain "Unresolved reference 'WithAuth'".
+// So we need to define a default WithAuth to resolve such case.
 func WithAuth(userName, password string) config.ClientOption {
 	return func(any) {}
 }

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -94,7 +94,8 @@ func snapshotCorruptTest(cx ctlCtx) {
 	require.ErrorContains(cx.t, serr, "Error: expected sha256")
 }
 
-// This test ensures that the snapshot status does not modify the snapshot file
+// TestCtlV3SnapshotStatusBeforeRestore ensures that the snapshot
+// status does not modify the snapshot file
 func TestCtlV3SnapshotStatusBeforeRestore(t *testing.T) {
 	testCtl(t, snapshotStatusBeforeRestoreTest)
 }
@@ -278,7 +279,8 @@ func testIssue6361(t *testing.T) {
 	t.Log("Test logic done")
 }
 
-// For storageVersion to be stored, all fields expected 3.6 fields need to be set. This happens after first WAL snapshot.
+// TestCtlV3SnapshotVersion is for storageVersion to be stored, all fields
+// expected 3.6 fields need to be set. This happens after first WAL snapshot.
 // In this test we lower SnapshotCount to 1 to ensure WAL snapshot is triggered.
 func TestCtlV3SnapshotVersion(t *testing.T) {
 	testCtl(t, snapshotVersionTest, withCfg(*e2e.NewConfig(e2e.WithSnapshotCount(1))))

--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -27,6 +27,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
+// TestMixVersionsSendSnapshot tests the mix version send snapshots
 // TODO(ahrtr): add network partition scenario to trigger snapshots.
 func TestMixVersionsSendSnapshot(t *testing.T) {
 	cases := []struct {

--- a/tests/e2e/promote_experimental_flag_test.go
+++ b/tests/e2e/promote_experimental_flag_test.go
@@ -51,6 +51,7 @@ func TestWarningApplyDuration(t *testing.T) {
 	e2e.AssertProcessLogs(t, epc.Procs[0], "request stats")
 }
 
+// TestExperimentalWarningApplyDuration tests the experimental warning apply duration
 // TODO: this test is a duplicate of TestWarningApplyDuration except it uses --experimental-warning-unary-request-duration
 // Remove this test after --experimental-warning-unary-request-duration flag is removed.
 func TestExperimentalWarningApplyDuration(t *testing.T) {

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -32,7 +32,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-// NO TLS
+// TestV3Curl_MaxStreams_BelowLimit_NoTLS_Small tests no TLS
 func TestV3Curl_MaxStreams_BelowLimit_NoTLS_Small(t *testing.T) {
 	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(3))
 }
@@ -58,7 +58,7 @@ func TestV3Curl_MaxStreams_ReachLimit_NoTLS_Medium(t *testing.T) {
 	testV3CurlMaxStream(t, true, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
 }
 
-// TLS
+// TestV3Curl_MaxStreams_BelowLimit_TLS_Small tests with TLS
 func TestV3Curl_MaxStreams_BelowLimit_TLS_Small(t *testing.T) {
 	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(3))
 }

--- a/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
@@ -135,7 +135,7 @@ func TestPrQueueManyReaderManyWriter(t *testing.T) {
 	testReadersWriters(t, rqs, wqs)
 }
 
-// BenchmarkQueue benchmarks Queues using n/n readers/writers
+// BenchmarkPrQueueOneReaderOneWriter benchmarks Queues using n/n readers/writers
 func BenchmarkPrQueueOneReaderOneWriter(b *testing.B) {
 	integration2.BeforeTest(b)
 

--- a/tests/integration/clientv3/lease/lease_test.go
+++ b/tests/integration/clientv3/lease/lease_test.go
@@ -183,6 +183,7 @@ func TestLeaseKeepAliveOneSecond(t *testing.T) {
 	}
 }
 
+// TestLeaseKeepAliveHandleFailure tests lease keep alive handling faillure
 // TODO: add a client that can connect to all the members of cluster via unix sock.
 // TODO: test handle more complicated failures.
 func TestLeaseKeepAliveHandleFailure(t *testing.T) {
@@ -490,7 +491,7 @@ func TestLeaseKeepAliveInitTimeout(t *testing.T) {
 	clus.Members[0].Restart(t)
 }
 
-// TestLeaseKeepAliveInitTimeout ensures the keep alive channel closes if
+// TestLeaseKeepAliveTTLTimeout ensures the keep alive channel closes if
 // a keep alive request after the first never gets a response.
 func TestLeaseKeepAliveTTLTimeout(t *testing.T) {
 	integration2.BeforeTest(t)

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -70,6 +70,7 @@ func TestMaintenanceHashKV(t *testing.T) {
 	}
 }
 
+// TestCompactionHash tests compaction hash
 // TODO: Change this to fuzz test
 func TestCompactionHash(t *testing.T) {
 	integration2.BeforeTest(t)
@@ -246,7 +247,7 @@ func TestMaintenanceSnapshotWithVersionErrorInflight(t *testing.T) {
 	})
 }
 
-// TestMaintenanceSnapshotError ensures that ReaderCloser returned by Snapshot function
+// TestMaintenanceSnapshotErrorInflight ensures that ReaderCloser returned by Snapshot function
 // will fail to read with corresponding context errors on inflight context cancel timeout.
 func TestMaintenanceSnapshotErrorInflight(t *testing.T) {
 	testMaintenanceSnapshotErrorInflight(t, func(ctx context.Context, client *clientv3.Client) (io.ReadCloser, error) {

--- a/tests/integration/clientv3/user_test.go
+++ b/tests/integration/clientv3/user_test.go
@@ -110,7 +110,8 @@ func authSetupRoot(t *testing.T, auth clientv3.Auth) {
 	}
 }
 
-// Client can connect to etcd even if they supply credentials and the server is in AuthDisable mode.
+// TestGetTokenWithoutAuth is when Client can connect to etcd even if they
+// supply credentials and the server is in AuthDisable mode.
 func TestGetTokenWithoutAuth(t *testing.T) {
 	integration2.BeforeTest(t)
 

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -58,8 +58,9 @@ func TestTLSClusterOf3(t *testing.T) {
 	clusterMustProgress(t, c.Members)
 }
 
-// Test that a cluster can progress when using separate client and server certs when peering. This supports certificate
-// authorities that don't issue dual-usage certificates.
+// TestTLSClusterOf3WithSpecificUsage tests that a cluster can progress when
+// using separate client and server certs when peering. This supports
+// certificate authorities that don't issue dual-usage certificates.
 func TestTLSClusterOf3WithSpecificUsage(t *testing.T) {
 	integration.BeforeTest(t)
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, PeerTLS: &integration.TestTLSInfoWithSpecificUsage})
@@ -200,7 +201,7 @@ func TestAddMemberAfterClusterFullRotation(t *testing.T) {
 	clusterMustProgress(t, c.Members)
 }
 
-// Ensure we can remove a member then add a new one back immediately.
+// TestIssue2681 ensures we can remove a member then add a new one back immediately.
 func TestIssue2681(t *testing.T) {
 	integration.BeforeTest(t)
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 5, DisableStrictReconfigCheck: true})
@@ -216,10 +217,10 @@ func TestIssue2681(t *testing.T) {
 	clusterMustProgress(t, c.Members)
 }
 
-// Ensure we can remove a member after a snapshot then add a new one back.
+// TestIssue2746 ensures we can remove a member after a snapshot then add a new one back.
 func TestIssue2746(t *testing.T) { testIssue2746(t, 5) }
 
-// With 3 nodes TestIssue2476 sometimes had a shutdown with an inflight snapshot.
+// TestIssue2746WithThree tests with 3 nodes TestIssue2476 sometimes had a shutdown with an inflight snapshot.
 func TestIssue2746WithThree(t *testing.T) { testIssue2746(t, 3) }
 
 func testIssue2746(t *testing.T, members int) {
@@ -242,7 +243,7 @@ func testIssue2746(t *testing.T, members int) {
 	clusterMustProgress(t, c.Members)
 }
 
-// Ensure etcd will not panic when removing a just started member.
+// TestIssue2904 ensures etcd will not panic when removing a just started member.
 func TestIssue2904(t *testing.T) {
 	integration.BeforeTest(t)
 	// start 1-member Cluster to ensure member 0 is the leader of the Cluster.

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -27,6 +27,7 @@ import (
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
+// TestCompactionHash tests the compaction hash
 // TODO: Change this to fuzz test
 func TestCompactionHash(t *testing.T) {
 	integration2.BeforeTest(t)

--- a/tests/integration/v2store/store_tag_test.go
+++ b/tests/integration/v2store/store_tag_test.go
@@ -23,7 +23,7 @@ import (
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
-// Ensure that the store can recover from a previously saved state.
+// TestStoreRecover ensures that the store can recover from a previously saved state.
 func TestStoreRecover(t *testing.T) {
 	integration2.BeforeTest(t)
 	s := v2store.New()

--- a/tests/integration/v2store/store_test.go
+++ b/tests/integration/v2store/store_test.go
@@ -39,7 +39,7 @@ func TestNewStoreWithNamespaces(t *testing.T) {
 	testutil.AssertNil(t, err)
 }
 
-// Ensure that the store can retrieve an existing value.
+// TestStoreGetValue ensures that the store can retrieve an existing value.
 func TestStoreGetValue(t *testing.T) {
 	s := v2store.New()
 
@@ -53,7 +53,7 @@ func TestStoreGetValue(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "bar")
 }
 
-// Ensure that the store can retrieve a directory in sorted order.
+// TestStoreGetSorted ensures that the store can retrieve a directory in sorted order.
 func TestStoreGetSorted(t *testing.T) {
 	s := v2store.New()
 
@@ -171,7 +171,7 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(5))
 }
 
-// Ensure that the store can create a new key if it doesn't already exist.
+// TestStoreCreateValue ensures that the store can create a new key if it doesn't already exist.
 func TestStoreCreateValue(t *testing.T) {
 	s := v2store.New()
 
@@ -205,7 +205,7 @@ func TestStoreCreateValue(t *testing.T) {
 
 }
 
-// Ensure that the store can create a new directory if it doesn't already exist.
+// TestStoreCreateDirectory ensures that the store can create a new directory if it doesn't already exist.
 func TestStoreCreateDirectory(t *testing.T) {
 	s := v2store.New()
 
@@ -218,7 +218,7 @@ func TestStoreCreateDirectory(t *testing.T) {
 	testutil.AssertTrue(t, e.Node.Dir)
 }
 
-// Ensure that the store fails to create a key if it already exists.
+// TestStoreCreateFailsIfExists ensure that the store fails to create a key if it already exists.
 func TestStoreCreateFailsIfExists(t *testing.T) {
 	s := v2store.New()
 
@@ -235,7 +235,7 @@ func TestStoreCreateFailsIfExists(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store can update a key if it already exists.
+// TestStoreUpdateValue ensures that the store can update a key if it already exists.
 func TestStoreUpdateValue(t *testing.T) {
 	s := v2store.New()
 
@@ -284,7 +284,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "")
 }
 
-// Ensure that the store cannot update a directory.
+// TestStoreUpdateFailsIfDirectory ensures that the store cannot update a directory.
 func TestStoreUpdateFailsIfDirectory(t *testing.T) {
 	s := v2store.New()
 
@@ -297,7 +297,7 @@ func TestStoreUpdateFailsIfDirectory(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store can delete a value.
+// TestStoreDeleteValue ensures that the store can delete a value.
 func TestStoreDeleteValue(t *testing.T) {
 	s := v2store.New()
 
@@ -313,7 +313,7 @@ func TestStoreDeleteValue(t *testing.T) {
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 }
 
-// Ensure that the store can delete a directory if recursive is specified.
+// TestStoreDeleteDirectory ensures that the store can delete a directory if recursive is specified.
 func TestStoreDeleteDirectory(t *testing.T) {
 	s := v2store.New()
 
@@ -349,8 +349,8 @@ func TestStoreDeleteDirectory(t *testing.T) {
 
 }
 
-// Ensure that the store cannot delete a directory if both of recursive
-// and dir are not specified.
+// TestStoreDeleteDirectoryFailsIfNonRecursiveAndDir ensures that the
+// store cannot delete a directory if both of recursive and dir are not specified.
 func TestStoreDeleteDirectoryFailsIfNonRecursiveAndDir(t *testing.T) {
 	s := v2store.New()
 
@@ -450,7 +450,7 @@ func TestStoreCompareAndDeletePrevIndexFailsIfNotMatch(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "bar")
 }
 
-// Ensure that the store cannot delete a directory.
+// TestStoreCompareAndDeleteDirectoryFail ensures that the store cannot delete a directory.
 func TestStoreCompareAndDeleteDirectoryFail(t *testing.T) {
 	s := v2store.New()
 
@@ -461,7 +461,8 @@ func TestStoreCompareAndDeleteDirectoryFail(t *testing.T) {
 	assert.Equal(t, err.ErrorCode, v2error.EcodeNotFile)
 }
 
-// Ensure that the store can conditionally update a key if it has a previous value.
+// TestStoreCompareAndSwapPrevValue ensures that the store can conditionally
+// update a key if it has a previous value.
 func TestStoreCompareAndSwapPrevValue(t *testing.T) {
 	s := v2store.New()
 
@@ -483,7 +484,8 @@ func TestStoreCompareAndSwapPrevValue(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "baz")
 }
 
-// Ensure that the store cannot conditionally update a key if it has the wrong previous value.
+// TestStoreCompareAndSwapPrevValueFailsIfNotMatch ensure that the store cannot
+// conditionally update a key if it has the wrong previous value.
 func TestStoreCompareAndSwapPrevValueFailsIfNotMatch(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -498,7 +500,8 @@ func TestStoreCompareAndSwapPrevValueFailsIfNotMatch(t *testing.T) {
 	assert.Equal(t, e.EtcdIndex, eidx)
 }
 
-// Ensure that the store can conditionally update a key if it has a previous index.
+// TestStoreCompareAndSwapPrevIndex ensures that the store can conditionally
+// update a key if it has a previous index.
 func TestStoreCompareAndSwapPrevIndex(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 2
@@ -520,7 +523,8 @@ func TestStoreCompareAndSwapPrevIndex(t *testing.T) {
 	assert.Equal(t, e.EtcdIndex, eidx)
 }
 
-// Ensure that the store cannot conditionally update a key if it has the wrong previous index.
+// TestStoreCompareAndSwapPrevIndexFailsIfNotMatch ensures that the store cannot
+// conditionally update a key if it has the wrong previous index.
 func TestStoreCompareAndSwapPrevIndexFailsIfNotMatch(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -535,7 +539,7 @@ func TestStoreCompareAndSwapPrevIndexFailsIfNotMatch(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "bar")
 }
 
-// Ensure that the store can watch for key creation.
+// TestStoreWatchCreate ensures that the store can watch for key creation.
 func TestStoreWatchCreate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 0
@@ -555,7 +559,8 @@ func TestStoreWatchCreate(t *testing.T) {
 	}
 }
 
-// Ensure that the store can watch for recursive key creation.
+// TestStoreWatchRecursiveCreate ensures that the store
+// can watch for recursive key creation.
 func TestStoreWatchRecursiveCreate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 0
@@ -570,7 +575,7 @@ func TestStoreWatchRecursiveCreate(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo/bar")
 }
 
-// Ensure that the store can watch for key updates.
+// TestStoreWatchUpdate ensures that the store can watch for key updates.
 func TestStoreWatchUpdate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -585,7 +590,7 @@ func TestStoreWatchUpdate(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo")
 }
 
-// Ensure that the store can watch for recursive key updates.
+// TestStoreWatchRecursiveUpdate ensures that the store can watch for recursive key updates.
 func TestStoreWatchRecursiveUpdate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -601,7 +606,7 @@ func TestStoreWatchRecursiveUpdate(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo/bar")
 }
 
-// Ensure that the store can watch for key deletions.
+// TestStoreWatchDelete ensures that the store can watch for key deletions.
 func TestStoreWatchDelete(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -616,7 +621,7 @@ func TestStoreWatchDelete(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo")
 }
 
-// Ensure that the store can watch for recursive key deletions.
+// TestStoreWatchRecursiveDelete ensures that the store can watch for recursive key deletions.
 func TestStoreWatchRecursiveDelete(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -632,7 +637,7 @@ func TestStoreWatchRecursiveDelete(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo/bar")
 }
 
-// Ensure that the store can watch for CAS updates.
+// TestStoreWatchCompareAndSwap ensures that the store can watch for CAS updates.
 func TestStoreWatchCompareAndSwap(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -647,7 +652,8 @@ func TestStoreWatchCompareAndSwap(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo")
 }
 
-// Ensure that the store can watch for recursive CAS updates.
+// TestStoreWatchRecursiveCompareAndSwap ensures that the
+// store can watch for recursive CAS updates.
 func TestStoreWatchRecursiveCompareAndSwap(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -662,7 +668,7 @@ func TestStoreWatchRecursiveCompareAndSwap(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo/bar")
 }
 
-// Ensure that the store can watch in streaming mode.
+// TestStoreWatchStream ensures that the store can watch in streaming mode.
 func TestStoreWatchStream(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -694,7 +700,8 @@ func TestStoreWatchStream(t *testing.T) {
 	}
 }
 
-// Ensure that the store can watch for hidden keys as long as it's an exact path match.
+// TestStoreWatchCreateWithHiddenKey ensure that the store can
+// watch for hidden keys as long as it's an exact path match.
 func TestStoreWatchCreateWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -711,7 +718,8 @@ func TestStoreWatchCreateWithHiddenKey(t *testing.T) {
 	}
 }
 
-// Ensure that the store doesn't see hidden key creates without an exact path match in recursive mode.
+// TestStoreWatchRecursiveCreateWithHiddenKey ensures that the store doesn't
+// see hidden key creates without an exact path match in recursive mode.
 func TestStoreWatchRecursiveCreateWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	w, _ := s.Watch("/foo", true, false, 0)
@@ -733,7 +741,8 @@ func TestStoreWatchRecursiveCreateWithHiddenKey(t *testing.T) {
 	}
 }
 
-// Ensure that the store doesn't see hidden key updates.
+// TestStoreWatchUpdateWithHiddenKey ensures that the store
+// doesn't see hidden key updates.
 func TestStoreWatchUpdateWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	s.Create("/_foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -746,7 +755,8 @@ func TestStoreWatchUpdateWithHiddenKey(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store doesn't see hidden key updates without an exact path match in recursive mode.
+// TestStoreWatchRecursiveUpdateWithHiddenKey ensures that the store doesn't
+// see hidden key updates without an exact path match in recursive mode.
 func TestStoreWatchRecursiveUpdateWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	s.Create("/foo/_bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -756,7 +766,7 @@ func TestStoreWatchRecursiveUpdateWithHiddenKey(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store can watch for key deletions.
+// TestStoreWatchDeleteWithHiddenKey ensures that the store can watch for key deletions.
 func TestStoreWatchDeleteWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 2
@@ -771,7 +781,8 @@ func TestStoreWatchDeleteWithHiddenKey(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store doesn't see hidden key deletes without an exact path match in recursive mode.
+// TestStoreWatchRecursiveDeleteWithHiddenKey ensures that the store doesn't see
+// hidden key deletes without an exact path match in recursive mode.
 func TestStoreWatchRecursiveDeleteWithHiddenKey(t *testing.T) {
 	s := v2store.New()
 	s.Create("/foo/_bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -781,7 +792,8 @@ func TestStoreWatchRecursiveDeleteWithHiddenKey(t *testing.T) {
 	testutil.AssertNil(t, e)
 }
 
-// Ensure that the store does see hidden key creates if watching deeper than a hidden key in recursive mode.
+// TestStoreWatchRecursiveCreateDeeperThanHiddenKey ensures that the store does see
+// hidden key creates if watching deeper than a hidden key in recursive mode.
 func TestStoreWatchRecursiveCreateDeeperThanHiddenKey(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64 = 1
@@ -795,7 +807,7 @@ func TestStoreWatchRecursiveCreateDeeperThanHiddenKey(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/_foo/bar/baz")
 }
 
-// Ensure that slow consumers are handled properly.
+// TestStoreWatchSlowConsumer ensures that slow consumers are handled properly.
 //
 // Since Watcher.EventChan() has a buffer of size 100 we can only queue 100
 // event per watcher. If the consumer cannot consume the event on time and

--- a/tests/integration/v3_election_test.go
+++ b/tests/integration/v3_election_test.go
@@ -174,7 +174,7 @@ func TestElectionFailover(t *testing.T) {
 	}
 }
 
-// TestElectionSessionRelock ensures that campaigning twice on the same election
+// TestElectionSessionRecampaign ensures that campaigning twice on the same election
 // with the same lock will Proclaim instead of deadlocking.
 func TestElectionSessionRecampaign(t *testing.T) {
 	integration.BeforeTest(t)

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -87,7 +87,7 @@ func TestV3PutOverwrite(t *testing.T) {
 	}
 }
 
-// TestPutRestart checks if a put after an unrelated member restart succeeds
+// TestV3PutRestart checks if a put after an unrelated member restart succeeds
 func TestV3PutRestart(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
@@ -395,7 +395,7 @@ func TestV3TxnDuplicateKeys(t *testing.T) {
 	}
 }
 
-// Testv3TxnRevision tests that the transaction header revision is set as expected.
+// TestV3TxnRevision tests that the transaction header revision is set as expected.
 func TestV3TxnRevision(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
@@ -445,7 +445,7 @@ func TestV3TxnRevision(t *testing.T) {
 	}
 }
 
-// Testv3TxnCmpHeaderRev tests that the txn header revision is set as expected
+// TestV3TxnCmpHeaderRev tests that the txn header revision is set as expected
 // when compared to the Succeeded field in the txn response.
 func TestV3TxnCmpHeaderRev(t *testing.T) {
 	integration.BeforeTest(t)
@@ -613,7 +613,7 @@ func TestV3TxnRangeCompare(t *testing.T) {
 	}
 }
 
-// TestV3TxnNested tests nested txns follow paths as expected.
+// TestV3TxnNestedPath tests nested txns follow paths as expected.
 func TestV3TxnNestedPath(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// TestV3LeasePrmote ensures the newly elected leader can promote itself
+// TestV3LeasePromote ensures the newly elected leader can promote itself
 // to the primary lessor, refresh the leases and start to manage leases.
 // TODO: use customized clock to make this test go faster?
 func TestV3LeasePromote(t *testing.T) {
@@ -108,7 +108,7 @@ func TestV3LeaseRevoke(t *testing.T) {
 	})
 }
 
-// TestV3LeaseGrantById ensures leases may be created by a given id.
+// TestV3LeaseGrantByID ensures leases may be created by a given id.
 func TestV3LeaseGrantByID(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -1033,7 +1033,7 @@ func TestWatchWithProgressNotify(t *testing.T) {
 	}
 }
 
-// TestV3WatcMultiOpenhClose opens many watchers concurrently on multiple streams.
+// TestV3WatchClose opens many watchers concurrently on multiple streams.
 func TestV3WatchClose(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1, UseBridge: true})


### PR DESCRIPTION
# Motivation
[Issue 14671](https://github.com/etcd-io/etcd/issues/14827)

# Changes
1. `TestGoFiles` & `XTestGoFiles` added in shell func `go_srcs_in_module`. 
2. Test file comments fixes as per `goword`.

# Summary
The shell func `go_srcs_in_module` which originally was listing only go src files is made to list go test files too. This is used by `verify-license-header` which checks for copyright headers in go files. Making the func to list test files will help in identifying the go test files that miss copyright headers. 

Go template terminology:
    1. `GoFiles` - for go source files
    2. `TestGoFiles` - for go test files which share the same package names
    3. `XTestGoFiles` - for go test files that belong to `_test` packages
> TestGoFiles & XTestGoFiles are added as part of this change.

As `go_srcs_in_module` is used by other verifications too, the comments in different tests are fixed to make it `verify-goword` compliant.

# Related Issues
Closes #14827 