### PR TITLE
[3.4] etcdserver: intentionally set the memberID as 0 in corruption alarm

### DIFF
--- a/etcdserver/corrupt.go
+++ b/etcdserver/corrupt.go
@@ -207,8 +207,12 @@ func (s *EtcdServer) checkHashKV() error {
 			return
 		}
 		alarmed = true
+		// It isn't clear which member's data is corrupted, so we
+		// intentionally set the memberID as 0. We will identify
+		// the corrupted members using quorum in 3.6. Please see
+		// discussion in https://github.com/etcd-io/etcd/pull/14828.
 		a := &pb.AlarmRequest{
-			MemberID: uint64(id),
+			MemberID: 0,
 			Action:   pb.AlarmRequest_ACTIVATE,
 			Alarm:    pb.AlarmType_CORRUPT,
 		}


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/14849

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
