### PR TITLE
changelog: add items for both 3.4 and 3.5 changelog to cover the case of removing memberid from corrupt alarm

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -9,6 +9,8 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### Package `clientv3`
 - Fix [Refreshing token on CommonName based authentication causes segmentation violation in client](https://github.com/etcd-io/etcd/pull/14792).
 
+### etcd server
+- Fix [Remove memberID from data corrupt alarm](https://github.com/etcd-io/etcd/pull/14853).
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,6 +4,14 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.7 (TBD)
+
+### etcd server
+- Fix [Remove memberID from data corrupt alarm](https://github.com/etcd-io/etcd/pull/14852).
+
+
+<hr>
+
 ## v3.5.6 (2022-11-21)
 
 ### etcd server


### PR DESCRIPTION
Related issue: https://github.com/etcd-io/etcd/issues/14849

PRs:
- 3.5: https://github.com/etcd-io/etcd/pull/14852
- 3.4: https://github.com/etcd-io/etcd/pull/14853

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
