### PR TITLE
test: fix unit test Instability

### DIFF
--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -269,7 +269,7 @@ func TestCompactHashCheck(t *testing.T) {
 					{peerInfo: peerInfo{id: 42}, resp: &pb.HashKVResponse{CompactRevision: 1, Hash: 2}},
 					{peerInfo: peerInfo{id: 43}, resp: &pb.HashKVResponse{CompactRevision: 1, Hash: 2}},
 					{peerInfo: peerInfo{id: 44}, resp: &pb.HashKVResponse{CompactRevision: 1, Hash: 7}},
-					{peerInfo: peerInfo{id: 45}, resp: &pb.HashKVResponse{CompactRevision: 1, Hash: 8}},
+					{peerInfo: peerInfo{id: 45}, resp: &pb.HashKVResponse{CompactRevision: 1, Hash: 7}},
 				},
 			},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "Hashes()", "PeerHashByRev(2)", "MemberId()", "TriggerCorruptAlarm(44)", "TriggerCorruptAlarm(45)"},


### PR DESCRIPTION
When two members in a 5 member cluster are corrupted, and they have different hashes, etcd will raise alarm for both members, but the order isn't guaranteed. But if the two corrupted members have the same hash, then the order is guaranteed. The leader always raise alarm in the same order as the member list.

Refer to: https://github.com/etcd-io/etcd/actions/runs/3569072873/jobs/5998638380 

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @ptabor @serathius @spzala 
