### PR TITLE
Read Go Build Flags from env `GO_BUILD_FLAGS` (#14396)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,11 @@ Setup environment:
   - For ubuntu and debian run `sudo apt-get install build-essentials`
 - Verify that everything is installed by running `make build`
 
+Note: `make build` runs with `-v`. Other build flags can be added through env `GO_BUILD_FLAGS`, **if required**. Eg.,
+```console
+GO_BUILD_FLAGS="-buildmode=pie" make build
+```
+
 [file an issue]: https://github.com/etcd-io/etcd/issues/new/choose
 
 ## Implement your change

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build:
-	GO_BUILD_FLAGS="-v" ./scripts/build.sh
+	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v" ./scripts/build.sh
 	./bin/etcd --version
 	./bin/etcdctl version
 	./bin/etcdutl version


### PR DESCRIPTION
# Motivation
[Issue][1] #14396

# Changes
1. `make build` will read `GO_BUILD_FLAGS` from env and prepend to go build flags.
2. ~~New make target `verify-go-build-flags-from-env` to runs tests from [build-test.sh][3].~~
3. ~~A test case `default-arch-build-flags-from-env` in [github actions][4] to runs tests from [build-test.sh][3] in pipeline.~~
    1. ~~New flag `upload-artifact` and condition to enable/disable upload of result JUnit XML selectively.~~
    2. ~~Syntax change of env export as per [this guide][5].~~
        ~~export JUNIT_REPORT_DIR=$(realpath ${TARGET})~~
        ~~# Changed to~~
        ~~echo "JUNIT_REPORT_DIR=$(realpath ${TARGET})" >> $GITHUB_ENV~~
4. A note about the change is added in [CONTRIBUTING.md][7].

# Summary
`make build` to read build flags from env `GO_BUILD_FLAGS` and prepend to those in [Makefile][2] for building executables (`etcd`, `etcdctl` & `etcdutl`). ~~The tests related to the same are added in [make verify][6] for local run and [github actions][4] for pipeline.~~

# Related Issues
Closes #14396 

[1]: https://github.com/etcd-io/etcd/issues/14396
[2]: https://github.com/etcd-io/etcd/blob/main/Makefile#L3
[3]: https://github.com/etcd-io/etcd/blob/main/scripts/build-test.sh
[4]: https://github.com/etcd-io/etcd/blob/main/.github/workflows/tests.yaml
[5]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
[6]: https://github.com/etcd-io/etcd/blob/main/Makefile#L42
[7]: https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md