### PR TITLE
lease: fix potential goroutine leak in lessor_test.go

### DIFF
--- a/server/lease/lessor_test.go
+++ b/server/lease/lessor_test.go
@@ -224,7 +224,7 @@ func renew(t *testing.T, le *lessor, id LeaseID) int64 {
 		return ttl
 	case err := <-errch:
 		t.Fatalf("failed to renew lease (%v)", err)
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("timed out while renewing lease")
 	}
 	panic("unreachable")


### PR DESCRIPTION
This PR fixes a potential goroutine leak in `TestLessorRenew` and `TestLessorRenewWithCheckpointer`.

In the unlikely event that the test lease expires before `Renew` is called, the call to `Renew` enters the select statement at [server/lease/lessor.go#L412-L424](https://github.com/etcd-io/etcd/blob/main/server/lease/lessor.go#L412-L424) and remains blocked indefinitely. This is reproducible by inserting an appropriate call to `time.Sleep` before the call to `Renew`.

The fix is to move the potentially blocking call to a separate goroutine. If waiting for the call times out, the test fails and the deferred `(*lessor).Stop` method is called which will unblock the call to `Renew`.