### PR TITLE
Remove unncessary locking in encoder

### DIFF
--- a/server/storage/wal/encoder.go
+++ b/server/storage/wal/encoder.go
@@ -19,7 +19,6 @@ import (
 	"hash"
 	"io"
 	"os"
-	"sync"
 
 	"go.etcd.io/etcd/pkg/v3/crc"
 	"go.etcd.io/etcd/pkg/v3/ioutil"
@@ -32,7 +31,6 @@ import (
 const walPageBytes = 8 * minSectorSize
 
 type encoder struct {
-	mu sync.Mutex
 	bw *ioutil.PageWriter
 
 	crc       hash.Hash32
@@ -60,9 +58,6 @@ func newFileEncoder(f *os.File, prevCrc uint32) (*encoder, error) {
 }
 
 func (e *encoder) encode(rec *walpb.Record) error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	e.crc.Write(rec.Data)
 	rec.Crc = e.crc.Sum32()
 	var (
@@ -108,8 +103,6 @@ func encodeFrameSize(dataBytes int) (lenField uint64, padBytes int) {
 }
 
 func (e *encoder) flush() error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	return e.bw.Flush()
 }
 

--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -825,6 +825,9 @@ func (w *WAL) sync() error {
 }
 
 func (w *WAL) Sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	return w.sync()
 }
 


### PR DESCRIPTION
Hey folks,

While working on [vectorized writes on bbolt](https://github.com/etcd-io/bbolt/pull/339#issuecomment-1331093881), we found some very excessive amount of futex syscalls. I've been going through the hot path of the WAL and found an unnecessary locking on the encoder that is perfectly covered through the `wal.mu` mutex already. 

Tests are passing fine for me, but would appreciate another close look from two of you on this. Testing locally this improves throughput by up to 20%.

---
The encoder is already protected by the wal.mu on all paths. Removing this lock yields up to 20% more throughput when measured with etcdctl check perf.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

