### PR TITLE
Improve support for failed requests in linearizability tests

### DIFF
--- a/tests/linearizability/client.go
+++ b/tests/linearizability/client.go
@@ -70,9 +70,9 @@ func (c *recordingClient) Get(ctx context.Context, key string) error {
 	}
 	c.operations = append(c.operations, porcupine.Operation{
 		ClientId: c.id,
-		Input:    etcdRequest{op: Get, key: key},
+		Input:    EtcdRequest{Op: Get, Key: key},
 		Call:     callTime.UnixNano(),
-		Output:   etcdResponse{getData: readData, revision: resp.Header.Revision},
+		Output:   EtcdResponse{GetData: readData, Revision: resp.Header.Revision},
 		Return:   returnTime.UnixNano(),
 	})
 	return nil
@@ -85,9 +85,9 @@ func (c *recordingClient) Put(ctx context.Context, key, value string) error {
 	if err != nil {
 		c.failed = append(c.failed, porcupine.Operation{
 			ClientId: c.id,
-			Input:    etcdRequest{op: Put, key: key, putData: value},
+			Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
 			Call:     callTime.UnixNano(),
-			Output:   etcdResponse{err: err},
+			Output:   EtcdResponse{Err: err},
 			Return:   0, // For failed writes we don't know when request has really finished.
 		})
 		// Operations of single client needs to be sequential.
@@ -101,9 +101,9 @@ func (c *recordingClient) Put(ctx context.Context, key, value string) error {
 	}
 	c.operations = append(c.operations, porcupine.Operation{
 		ClientId: c.id,
-		Input:    etcdRequest{op: Put, key: key, putData: value},
+		Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
 		Call:     callTime.UnixNano(),
-		Output:   etcdResponse{err: err, revision: revision},
+		Output:   EtcdResponse{Err: err, Revision: revision},
 		Return:   returnTime.UnixNano(),
 	})
 	return nil
@@ -116,9 +116,9 @@ func (c *recordingClient) Delete(ctx context.Context, key string) error {
 	if err != nil {
 		c.failed = append(c.failed, porcupine.Operation{
 			ClientId: c.id,
-			Input:    etcdRequest{op: Delete, key: key},
+			Input:    EtcdRequest{Op: Delete, Key: key},
 			Call:     callTime.UnixNano(),
-			Output:   etcdResponse{err: err},
+			Output:   EtcdResponse{Err: err},
 			Return:   0, // For failed writes we don't know when request has really finished.
 		})
 		// Operations of single client needs to be sequential.
@@ -134,9 +134,9 @@ func (c *recordingClient) Delete(ctx context.Context, key string) error {
 	}
 	c.operations = append(c.operations, porcupine.Operation{
 		ClientId: c.id,
-		Input:    etcdRequest{op: Delete, key: key},
+		Input:    EtcdRequest{Op: Delete, Key: key},
 		Call:     callTime.UnixNano(),
-		Output:   etcdResponse{revision: revision, deleted: deleted, err: err},
+		Output:   EtcdResponse{Revision: revision, Deleted: deleted, Err: err},
 		Return:   returnTime.UnixNano(),
 	})
 	return nil

--- a/tests/linearizability/client.go
+++ b/tests/linearizability/client.go
@@ -18,20 +18,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/anishathalye/porcupine"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
 type recordingClient struct {
-	client clientv3.Client
-
-	// id of the next write operation. If needed a new id might be requested from idProvider.
-	id         int
-	idProvider idProvider
-
-	operations []porcupine.Operation
-	failed     []porcupine.Operation
+	client  clientv3.Client
+	history *history
 }
 
 func NewClient(endpoints []string, ids idProvider) (*recordingClient, error) {
@@ -45,11 +38,8 @@ func NewClient(endpoints []string, ids idProvider) (*recordingClient, error) {
 		return nil, err
 	}
 	return &recordingClient{
-		client:     *cc,
-		id:         ids.ClientId(),
-		idProvider: ids,
-		operations: []porcupine.Operation{},
-		failed:     []porcupine.Operation{},
+		client:  *cc,
+		history: NewHistory(ids),
 	}, nil
 }
 
@@ -64,17 +54,7 @@ func (c *recordingClient) Get(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
-	var readData string
-	if len(resp.Kvs) == 1 {
-		readData = string(resp.Kvs[0].Value)
-	}
-	c.operations = append(c.operations, porcupine.Operation{
-		ClientId: c.id,
-		Input:    EtcdRequest{Op: Get, Key: key},
-		Call:     callTime.UnixNano(),
-		Output:   EtcdResponse{GetData: readData, Revision: resp.Header.Revision},
-		Return:   returnTime.UnixNano(),
-	})
+	c.history.AppendGet(key, callTime, returnTime, resp)
 	return nil
 }
 
@@ -82,81 +62,14 @@ func (c *recordingClient) Put(ctx context.Context, key, value string) error {
 	callTime := time.Now()
 	resp, err := c.client.Put(ctx, key, value)
 	returnTime := time.Now()
-	if err != nil {
-		c.failed = append(c.failed, porcupine.Operation{
-			ClientId: c.id,
-			Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
-			Call:     callTime.UnixNano(),
-			Output:   EtcdResponse{Err: err},
-			Return:   0, // For failed writes we don't know when request has really finished.
-		})
-		// Operations of single client needs to be sequential.
-		// As we don't know return time of failed operations, all new writes need to be done with new client id.
-		c.id = c.idProvider.ClientId()
-		return err
-	}
-	var revision int64
-	if resp != nil && resp.Header != nil {
-		revision = resp.Header.Revision
-	}
-	c.operations = append(c.operations, porcupine.Operation{
-		ClientId: c.id,
-		Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
-		Call:     callTime.UnixNano(),
-		Output:   EtcdResponse{Err: err, Revision: revision},
-		Return:   returnTime.UnixNano(),
-	})
-	return nil
+	c.history.AppendPut(key, value, callTime, returnTime, resp, err)
+	return err
 }
 
 func (c *recordingClient) Delete(ctx context.Context, key string) error {
 	callTime := time.Now()
 	resp, err := c.client.Delete(ctx, key)
 	returnTime := time.Now()
-	if err != nil {
-		c.failed = append(c.failed, porcupine.Operation{
-			ClientId: c.id,
-			Input:    EtcdRequest{Op: Delete, Key: key},
-			Call:     callTime.UnixNano(),
-			Output:   EtcdResponse{Err: err},
-			Return:   0, // For failed writes we don't know when request has really finished.
-		})
-		// Operations of single client needs to be sequential.
-		// As we don't know return time of failed operations, all new writes need to be done with new client id.
-		c.id = c.idProvider.ClientId()
-		return err
-	}
-	var revision int64
-	var deleted int64
-	if resp != nil && resp.Header != nil {
-		revision = resp.Header.Revision
-		deleted = resp.Deleted
-	}
-	c.operations = append(c.operations, porcupine.Operation{
-		ClientId: c.id,
-		Input:    EtcdRequest{Op: Delete, Key: key},
-		Call:     callTime.UnixNano(),
-		Output:   EtcdResponse{Revision: revision, Deleted: deleted, Err: err},
-		Return:   returnTime.UnixNano(),
-	})
+	c.history.AppendDelete(key, callTime, returnTime, resp, err)
 	return nil
-}
-
-func (c *recordingClient) Operations() []porcupine.Operation {
-	operations := make([]porcupine.Operation, 0, len(c.operations)+len(c.failed))
-	var maxTime int64
-	for _, op := range c.operations {
-		operations = append(operations, op)
-		if op.Return > maxTime {
-			maxTime = op.Return
-		}
-	}
-	for _, op := range c.failed {
-		if op.Call > maxTime {
-			continue
-		}
-		op.Return = maxTime + 1
-		operations = append(operations, op)
-	}
-	return operations
 }

--- a/tests/linearizability/client.go
+++ b/tests/linearizability/client.go
@@ -30,7 +30,7 @@ type recordingClient struct {
 	operations []porcupine.Operation
 }
 
-func NewClient(endpoints []string, id int) (*recordingClient, error) {
+func NewClient(endpoints []string, ids idProvider) (*recordingClient, error) {
 	cc, err := clientv3.New(clientv3.Config{
 		Endpoints:            endpoints,
 		Logger:               zap.NewNop(),
@@ -42,7 +42,7 @@ func NewClient(endpoints []string, id int) (*recordingClient, error) {
 	}
 	return &recordingClient{
 		client:     *cc,
-		id:         id,
+		id:         ids.ClientId(),
 		operations: []porcupine.Operation{},
 	}, nil
 }

--- a/tests/linearizability/client.go
+++ b/tests/linearizability/client.go
@@ -24,7 +24,7 @@ import (
 
 type recordingClient struct {
 	client  clientv3.Client
-	history *history
+	history *appendableHistory
 }
 
 func NewClient(endpoints []string, ids idProvider) (*recordingClient, error) {
@@ -39,7 +39,7 @@ func NewClient(endpoints []string, ids idProvider) (*recordingClient, error) {
 	}
 	return &recordingClient{
 		client:  *cc,
-		history: NewHistory(ids),
+		history: newAppendableHistory(ids),
 	}, nil
 }
 

--- a/tests/linearizability/history.go
+++ b/tests/linearizability/history.go
@@ -113,6 +113,7 @@ func (h *appendableHistory) AppendDelete(key string, start, end time.Time, resp 
 type history struct {
 	successful []porcupine.Operation
 	// failed requests are kept separate as we don't know return time of failed operations.
+	// Based on https://github.com/anishathalye/porcupine/issues/10
 	failed []porcupine.Operation
 }
 
@@ -137,6 +138,8 @@ func (h history) Operations() []porcupine.Operation {
 			maxTime = op.Return
 		}
 	}
+	// Failed requests don't have a known return time.
+	// We simulate Infinity by using return time of latest successfully request.
 	for _, op := range h.failed {
 		if op.Call > maxTime {
 			continue

--- a/tests/linearizability/history.go
+++ b/tests/linearizability/history.go
@@ -1,0 +1,129 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linearizability
+
+import (
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type history struct {
+	// id of the next write operation. If needed a new id might be requested from idProvider.
+	id         int
+	idProvider idProvider
+
+	operations []porcupine.Operation
+	failed     []porcupine.Operation
+}
+
+func NewHistory(ids idProvider) *history {
+	return &history{
+		id:         ids.ClientId(),
+		idProvider: ids,
+		operations: []porcupine.Operation{},
+		failed:     []porcupine.Operation{},
+	}
+}
+
+func (h *history) AppendGet(key string, start, end time.Time, resp *clientv3.GetResponse) {
+	var readData string
+	if len(resp.Kvs) == 1 {
+		readData = string(resp.Kvs[0].Value)
+	}
+	h.operations = append(h.operations, porcupine.Operation{
+		ClientId: h.id,
+		Input:    EtcdRequest{Op: Get, Key: key},
+		Call:     start.UnixNano(),
+		Output:   EtcdResponse{GetData: readData, Revision: resp.Header.Revision},
+		Return:   end.UnixNano(),
+	})
+}
+
+func (h *history) AppendPut(key, value string, start, end time.Time, resp *clientv3.PutResponse, err error) {
+	if err != nil {
+		h.failed = append(h.failed, porcupine.Operation{
+			ClientId: h.id,
+			Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
+			Call:     start.UnixNano(),
+			Output:   EtcdResponse{Err: err},
+			Return:   0, // For failed writes we don't know when request has really finished.
+		})
+		// Operations of single client needs to be sequential.
+		// As we don't know return time of failed operations, all new writes need to be done with new client id.
+		h.id = h.idProvider.ClientId()
+		return
+	}
+	var revision int64
+	if resp != nil && resp.Header != nil {
+		revision = resp.Header.Revision
+	}
+	h.operations = append(h.operations, porcupine.Operation{
+		ClientId: h.id,
+		Input:    EtcdRequest{Op: Put, Key: key, PutData: value},
+		Call:     start.UnixNano(),
+		Output:   EtcdResponse{Err: err, Revision: revision},
+		Return:   end.UnixNano(),
+	})
+}
+
+func (h *history) AppendDelete(key string, start, end time.Time, resp *clientv3.DeleteResponse, err error) {
+	if err != nil {
+		h.failed = append(h.failed, porcupine.Operation{
+			ClientId: h.id,
+			Input:    EtcdRequest{Op: Delete, Key: key},
+			Call:     start.UnixNano(),
+			Output:   EtcdResponse{Err: err},
+			Return:   0, // For failed writes we don't know when request has really finished.
+		})
+		// Operations of single client needs to be sequential.
+		// As we don't know return time of failed operations, all new writes need to be done with new client id.
+		h.id = h.idProvider.ClientId()
+		return
+	}
+	var revision int64
+	var deleted int64
+	if resp != nil && resp.Header != nil {
+		revision = resp.Header.Revision
+		deleted = resp.Deleted
+	}
+	h.operations = append(h.operations, porcupine.Operation{
+		ClientId: h.id,
+		Input:    EtcdRequest{Op: Delete, Key: key},
+		Call:     start.UnixNano(),
+		Output:   EtcdResponse{Revision: revision, Deleted: deleted, Err: err},
+		Return:   end.UnixNano(),
+	})
+}
+
+func (h *history) Operations() []porcupine.Operation {
+	operations := make([]porcupine.Operation, 0, len(h.operations)+len(h.failed))
+	var maxTime int64
+	for _, op := range h.operations {
+		operations = append(operations, op)
+		if op.Return > maxTime {
+			maxTime = op.Return
+		}
+	}
+	for _, op := range h.failed {
+		if op.Call > maxTime {
+			continue
+		}
+		op.Return = maxTime + 1
+		operations = append(operations, op)
+	}
+	return operations
+}

--- a/tests/linearizability/id.go
+++ b/tests/linearizability/id.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linearizability
+
+import "sync/atomic"
+
+type idProvider interface {
+	ClientId() int
+	RequestId() int
+}
+
+func newIdProvider() idProvider {
+	return &atomicProvider{}
+}
+
+type atomicProvider struct {
+	clientId  atomic.Int64
+	requestId atomic.Int64
+}
+
+func (id *atomicProvider) ClientId() int {
+	// Substract one as ClientId should start from zero.
+	return int(id.clientId.Add(1) - 1)
+}
+
+func (id *atomicProvider) RequestId() int {
+	return int(id.requestId.Add(1))
+}

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -162,7 +162,7 @@ func simulateTraffic(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessClu
 
 			config.traffic.Run(ctx, c, limiter, ids)
 			mux.Lock()
-			operations = append(operations, c.Operations()...)
+			operations = append(operations, c.history.Operations()...)
 			mux.Unlock()
 		}(c)
 	}

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -162,7 +162,7 @@ func simulateTraffic(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessClu
 
 			config.traffic.Run(ctx, c, limiter, ids)
 			mux.Lock()
-			operations = append(operations, c.operations...)
+			operations = append(operations, c.Operations()...)
 			mux.Unlock()
 		}(c)
 	}

--- a/tests/linearizability/model.go
+++ b/tests/linearizability/model.go
@@ -139,8 +139,7 @@ func initState(request EtcdRequest, response EtcdResponse) EtcdState {
 }
 
 func stepGet(state EtcdState, request EtcdRequest, response EtcdResponse) (bool, EtcdState) {
-	if state.Value == response.GetData && state.LastRevision <= response.Revision {
-		state.LastRevision = response.Revision
+	if state.Value == response.GetData && state.LastRevision == response.Revision {
 		state.FailedWrite = nil
 		return true, state
 	}

--- a/tests/linearizability/model_test.go
+++ b/tests/linearizability/model_test.go
@@ -37,10 +37,17 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Get response data should match PUT",
+			name: "First delete can start from non-zero revision",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Revision: 42}},
+			},
+		},
+		{
+			name: "Get response data should match put",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
 			},
 		},
@@ -50,15 +57,19 @@ func TestModel(t *testing.T) {
 				{req: EtcdRequest{Op: Put, Key: "key"}, resp: EtcdResponse{Revision: 2}},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Put, Key: "key"}, resp: EtcdResponse{Revision: 3}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 5}},
 			},
 		},
 		{
-			name: "Put bumps revision",
+			name: "Put must increase revision at least by 1",
 			operations: []testOperation{
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}, failure: true},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
 			},
 		},
 		{
@@ -66,24 +77,60 @@ func TestModel(t *testing.T) {
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}, failure: true},
 			},
 		},
 		{
-			name: "Put can fail but bump revision",
+			name: "Put can fail but bump revision before put",
 			operations: []testOperation{
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "6"}, resp: EtcdResponse{Revision: 6}},
 			},
 		},
 		{
-			name: "Put can fail but be persisted and bump revision",
+			name: "Put can fail but be persisted before get",
 			operations: []testOperation{
+				// One failed request, one persisted.
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "3", Revision: 2}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "3", Revision: 3}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "3", Revision: 4}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "4", Revision: 4}},
+			},
+		},
+		{
+			name: "Put can fail but be persisted and increase revision before delete",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 3}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "6"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 7}},
+				// Two failed request, one persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "8"}, resp: EtcdResponse{Revision: 8}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "9"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "10"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 10}},
 			},
 		},
 		{
@@ -94,6 +141,83 @@ func TestModel(t *testing.T) {
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}},
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 0, Revision: 3}, failure: true},
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 0, Revision: 2}},
+			},
+		},
+		{
+			name: "Delete clears value",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}},
+			},
+		},
+		{
+			name: "Delete can fail and be lost before get",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}, failure: true},
+			},
+		},
+		{
+			name: "Delete can fail and be lost before delete",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}},
+			},
+		},
+		{
+			name: "Delete can fail and be lost before put",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
+			},
+		},
+		{
+			name: "Delete can fail but be persisted before get",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}},
+				// Two failed request, one persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 4}},
+			},
+		},
+		{
+			name: "Delete can fail but be persisted before put",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				// Two failed request, one persisted.
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "5"}, resp: EtcdResponse{Revision: 5}},
+			},
+		},
+		{
+			name: "Delete can fail but be persisted before delete",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				// Two failed request, one persisted.
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Revision: 4}},
 			},
 		},
 	}

--- a/tests/linearizability/model_test.go
+++ b/tests/linearizability/model_test.go
@@ -27,91 +27,91 @@ func TestModel(t *testing.T) {
 		{
 			name: "First Get can start from non-empty value and non-zero revision",
 			operations: []testOperation{
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 42}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 42}},
 			},
 		},
 		{
 			name: "First Put can start from non-zero revision",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{revision: 42}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 42}},
 			},
 		},
 		{
 			name: "Get response data should match PUT",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 1}, failure: true},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "1", revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
 			},
 		},
 		{
 			name: "Get response revision should be equal or greater then put",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key"}, resp: etcdResponse{revision: 2}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{revision: 1}, failure: true},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{revision: 2}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{revision: 4}},
+				{req: EtcdRequest{Op: Put, Key: "key"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 4}},
 			},
 		},
 		{
 			name: "Put bumps revision",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{revision: 1}, failure: true},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
 			},
 		},
 		{
 			name: "Put can fail and be lost",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{err: errors.New("failed")}},
-				{req: etcdRequest{op: Put, key: "key", putData: "3"}, resp: etcdResponse{revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}},
 			},
 		},
 		{
 			name: "Put can fail but bump revision",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{err: errors.New("failed")}},
-				{req: etcdRequest{op: Put, key: "key", putData: "3"}, resp: etcdResponse{revision: 3}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
 			},
 		},
 		{
 			name: "Put can fail but be persisted and bump revision",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{err: errors.New("failed")}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 1}, failure: true},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
 			},
 		},
 		{
 			name: "Put can fail but be persisted later",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{err: errors.New("failed")}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{revision: 2}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 2}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "1", revision: 3}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 3}},
 			},
 		},
 		{
 			name: "Put can fail but bump revision later",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{err: errors.New("failed")}},
-				{req: etcdRequest{op: Put, key: "key", putData: "2"}, resp: etcdResponse{revision: 2}},
-				{req: etcdRequest{op: Get, key: "key"}, resp: etcdResponse{getData: "2", revision: 2}},
-				{req: etcdRequest{op: Put, key: "key", putData: "3"}, resp: etcdResponse{revision: 4}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 4}},
 			},
 		},
 		{
 			name: "Delete only increases revision on success",
 			operations: []testOperation{
-				{req: etcdRequest{op: Put, key: "key", putData: "1"}, resp: etcdResponse{revision: 1}},
-				{req: etcdRequest{op: Delete, key: "key"}, resp: etcdResponse{deleted: 1, revision: 1}, failure: true},
-				{req: etcdRequest{op: Delete, key: "key"}, resp: etcdResponse{deleted: 1, revision: 2}},
-				{req: etcdRequest{op: Delete, key: "key"}, resp: etcdResponse{deleted: 0, revision: 3}, failure: true},
-				{req: etcdRequest{op: Delete, key: "key"}, resp: etcdResponse{deleted: 0, revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 0, Revision: 3}, failure: true},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 0, Revision: 2}},
 			},
 		},
 	}
@@ -131,7 +131,7 @@ func TestModel(t *testing.T) {
 }
 
 type testOperation struct {
-	req     etcdRequest
-	resp    etcdResponse
+	req     EtcdRequest
+	resp    EtcdResponse
 	failure bool
 }

--- a/tests/linearizability/model_test.go
+++ b/tests/linearizability/model_test.go
@@ -52,24 +52,21 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Get response revision should be equal or greater then put",
+			name: "Get revision should be equal to put",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key"}, resp: EtcdResponse{Revision: 2}},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 3}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}},
-				{req: EtcdRequest{Op: Put, Key: "key"}, resp: EtcdResponse{Revision: 3}},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2}, failure: true},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 5}},
 			},
 		},
 		{
-			name: "Put must increase revision at least by 1",
+			name: "Put must increase revision by 1",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 3}, failure: true},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}, failure: true},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
 			},
 		},
 		{
@@ -79,11 +76,12 @@ func TestModel(t *testing.T) {
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 2}, failure: true},
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}, failure: true},
 			},
 		},
 		{
-			name: "Put can fail but bump revision before put",
+			name: "Put can fail but be persisted and increase revision before put",
 			operations: []testOperation{
 				// One failed request, one persisted.
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
@@ -96,7 +94,7 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Put can fail but be persisted before get",
+			name: "Put can fail but be persisted and increase revision before get",
 			operations: []testOperation{
 				// One failed request, one persisted.
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},

--- a/tests/linearizability/model_test.go
+++ b/tests/linearizability/model_test.go
@@ -87,24 +87,6 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Put can fail but be persisted later",
-			operations: []testOperation{
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 3}},
-			},
-		},
-		{
-			name: "Put can fail but bump revision later",
-			operations: []testOperation{
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
-				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 4}},
-			},
-		},
-		{
 			name: "Delete only increases revision on success",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},


### PR DESCRIPTION
Based on recommendations in porcupine issues, failed requests should be marked as they failed at the end of test. This allows to stop aggregating errors within model making it:
* Much simpler to implement. Handling all the edge cases turned out to be very hard as we added new methods like delete.
* Much more accurate. Now we can validate revision being continuous as failed request cannot just pop up.

Only downside is history visualization is much less readable. 