### PR TITLE
[3.5] Backport: non mutating requests pass through quotaKVServer when NOSPACE 

### DIFF
--- a/server/etcdserver/quota.go
+++ b/server/etcdserver/quota.go
@@ -125,8 +125,13 @@ func NewBackendQuota(s *EtcdServer, name string) Quota {
 }
 
 func (b *backendQuota) Available(v interface{}) bool {
+	cost := b.Cost(v)
+	// if there are no mutating requests, it's safe to pass through
+	if cost == 0 {
+		return true
+	}
 	// TODO: maybe optimize backend.Size()
-	return b.s.Backend().Size()+int64(b.Cost(v)) < b.maxBackendBytes
+	return b.s.Backend().Size()+int64(cost) < b.maxBackendBytes
 }
 
 func (b *backendQuota) Cost(v interface{}) int {

--- a/tests/integration/v3_alarm_test.go
+++ b/tests/integration/v3_alarm_test.go
@@ -89,7 +89,7 @@ func TestV3StorageQuotaApply(t *testing.T) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	
+
 	// txn with non-mutating Ops should go through when NOSPACE alarm is raised
 	_, err = kvc0.Txn(context.TODO(), &pb.TxnRequest{
 		Compare: []*pb.Compare{

--- a/tests/integration/v3_alarm_test.go
+++ b/tests/integration/v3_alarm_test.go
@@ -89,6 +89,30 @@ func TestV3StorageQuotaApply(t *testing.T) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
+	
+	// txn with non-mutating Ops should go through when NOSPACE alarm is raised
+	_, err = kvc0.Txn(context.TODO(), &pb.TxnRequest{
+		Compare: []*pb.Compare{
+			{
+				Key:         key,
+				Result:      pb.Compare_EQUAL,
+				Target:      pb.Compare_CREATE,
+				TargetUnion: &pb.Compare_CreateRevision{CreateRevision: 0},
+			},
+		},
+		Success: []*pb.RequestOp{
+			{
+				Request: &pb.RequestOp_RequestDeleteRange{
+					RequestDeleteRange: &pb.DeleteRangeRequest{
+						Key: key,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), RequestWaitTimeout)
 	defer cancel()


### PR DESCRIPTION
This is a backport of https://github.com/etcd-io/etcd/pull/13435.

The original change had a second commit that modifies a changelog file.
The 3.5 branch does not include any changelog file, so that part was not
cherry-picked.

make build
make test 
both succeeded

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
