### PR TITLE
Linearizability recreate cluster

### DIFF
--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -13,7 +13,7 @@ jobs:
         make build
         mkdir -p /tmp/linearizability
         cat server/etcdserver/raft.fail.go
-        EXPECT_DEBUG=true GO_TEST_FLAGS=-v RESULTS_DIR=/tmp/linearizability make test-linearizability
+        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 60 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
     - uses: actions/upload-artifact@v2
       if: always()
       with:

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -119,8 +119,8 @@ func triggerFailpoints(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessC
 	var err error
 	successes := 0
 	failures := 0
-	time.Sleep(config.waitBetweenTriggers)
 	for successes < config.count && failures < config.count {
+		time.Sleep(config.waitBetweenTriggers)
 		err = config.failpoint.Trigger(t, ctx, clus)
 		if err != nil {
 			t.Logf("Failed to trigger failpoint %q, err: %v\n", config.failpoint.Name(), err)
@@ -128,8 +128,8 @@ func triggerFailpoints(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessC
 			continue
 		}
 		successes++
-		time.Sleep(config.waitBetweenTriggers)
 	}
+	time.Sleep(config.waitBetweenTriggers)
 	if successes < config.count || failures >= config.count {
 		return fmt.Errorf("failed to trigger failpoints enough times, err: %v", err)
 	}

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -34,8 +34,6 @@ const (
 	minimalQPS = 100.0
 	// maximalQPS limits number of requests send to etcd to avoid linearizability analysis taking too long.
 	maximalQPS = 200.0
-	// failpointTriggersCount
-	failpointTriggersCount = 60
 	// waitBetweenFailpointTriggers
 	waitBetweenFailpointTriggers = time.Second
 )
@@ -74,23 +72,21 @@ func TestLinearizability(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		for i := 0; i < failpointTriggersCount; i++ {
-			t.Run(tc.name, func(t *testing.T) {
-				failpoint := FailpointConfig{
-					failpoint:           tc.failpoint,
-					count:               1,
-					retries:             3,
-					waitBetweenTriggers: waitBetweenFailpointTriggers,
-				}
-				traffic := trafficConfig{
-					minimalQPS:  minimalQPS,
-					maximalQPS:  maximalQPS,
-					clientCount: 8,
-					traffic:     DefaultTraffic,
-				}
-				testLinearizability(context.Background(), t, tc.config, failpoint, traffic)
-			})
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			failpoint := FailpointConfig{
+				failpoint:           tc.failpoint,
+				count:               1,
+				retries:             3,
+				waitBetweenTriggers: waitBetweenFailpointTriggers,
+			}
+			traffic := trafficConfig{
+				minimalQPS:  minimalQPS,
+				maximalQPS:  maximalQPS,
+				clientCount: 8,
+				traffic:     DefaultTraffic,
+			}
+			testLinearizability(context.Background(), t, tc.config, failpoint, traffic)
+		})
 	}
 }
 

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -74,20 +74,22 @@ func TestLinearizability(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			failpoint := FailpointConfig{
-				failpoint:           tc.failpoint,
-				count:               failpointTriggersCount,
-				waitBetweenTriggers: waitBetweenFailpointTriggers,
-			}
-			traffic := trafficConfig{
-				minimalQPS:  minimalQPS,
-				maximalQPS:  maximalQPS,
-				clientCount: 8,
-				traffic:     DefaultTraffic,
-			}
-			testLinearizability(context.Background(), t, tc.config, failpoint, traffic)
-		})
+		for i := 0; i < failpointTriggersCount; i++ {
+			t.Run(tc.name, func(t *testing.T) {
+				failpoint := FailpointConfig{
+					failpoint:           tc.failpoint,
+					count:               1,
+					waitBetweenTriggers: waitBetweenFailpointTriggers,
+				}
+				traffic := trafficConfig{
+					minimalQPS:  minimalQPS,
+					maximalQPS:  maximalQPS,
+					clientCount: 8,
+					traffic:     DefaultTraffic,
+				}
+				testLinearizability(context.Background(), t, tc.config, failpoint, traffic)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
This testing short history makes validating linearizability faster and reduces chances of going into exponential complexity. 
Downside it that repeated runs will override same report files. To avoid that I changed tests to run with failfast so report from last fail is preserved.

Re-run test 5 times confirming that this doesn't increase flakiness.