### PR TITLE
Makefile: Add target to install shellcheck binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ hack/tls-setup/certs
 /tools/proto-annotations/proto-annotations
 /tools/benchmark/benchmark
 /out
+shellcheck*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Variables
+SHELLCHECK_VERSION=v0.8.0
+
+# Build
+
 .PHONY: build
 build:
 	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v" ./scripts/build.sh
@@ -39,6 +44,12 @@ fuzz:
 
 # Static analysis
 
+.PHONY: install-shellcheck
+install-shellcheck:
+	[ -f "shellcheck" ] || \
+	wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | \
+	tar -xJv --strip-components 1 shellcheck-${SHELLCHECK_VERSION}/shellcheck
+
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
 	verify-govet verify-license-header verify-receiver-name verify-mod-tidy verify-shellcheck \
 	verify-shellws verify-proto-annotations verify-genproto
@@ -70,7 +81,7 @@ fix-lint:
 	golangci-lint run --fix
 
 .PHONY: verify-shellcheck
-verify-shellcheck:
+verify-shellcheck: install-shellcheck
 	PASSES="shellcheck" ./scripts/test.sh
 
 .PHONY: verify-goword
@@ -142,3 +153,4 @@ clean:
 	rm -rf ./coverage/*.err ./coverage/*.out
 	rm -rf ./tests/e2e/default.proxy
 	find ./ -name "127.0.0.1:*" -o -name "localhost:*" -o -name "*.log" -o -name "agent-*" -o -name "*.coverprofile" -o -name "testname-proxy-*" -delete
+	rm -rf shellcheck*

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -388,9 +388,15 @@ function cov_pass {
 ######### Code formatting checkers #############################################
 
 function shellcheck_pass {
-  if tool_exists "shellcheck" "https://github.com/koalaman/shellcheck#installing"; then
-    generic_checker run shellcheck -fgcc scripts/*.sh
+  if tool_exists "${PWD}/shellcheck" "https://github.com/koalaman/shellcheck#installing"; then
+    log_info "shellcheck binary found: ${PWD}/shellcheck"
+    generic_checker run "${PWD}/shellcheck" -fgcc scripts/*.sh
+
+    return 0
   fi
+
+  log_error "shellcheck binary not found in project root"
+  return 255
 }
 
 function shellws_pass {


### PR DESCRIPTION
# Motivation
[Issue][1] #14869

# Changes
1. New make target `install-shellcheck` to prerun in `make verify-shellcheck`.
2. function `shellcheck_pass` checks for binary in current directory (project root). Fails with exit code 255 in absence of binary.

# Summary
New make target to install [shellcheck][2] binary which runs before `verify-shellcheck`. Return code 255 in absence of shellcheck binary in project root.

# Related Issues
Closes #14869 

[1]: https://github.com/etcd-io/etcd/issues/14869
[2]: https://github.com/koalaman/shellcheck