### PR TITLE
changelog: added non mutating requests pass through quotaKVServer when NOSPACE in 3.7

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### etcd server
 - Fix [Remove memberID from data corrupt alarm](https://github.com/etcd-io/etcd/pull/14852).
+- Fix [non mutating requests pass through quotaKVServer when NOSPACE](https://github.com/etcd-io/etcd/pull/14884)
 
 
 <hr>


### PR DESCRIPTION
added non mutating requests pass through quotaKVServer when NOSPACE in 3.7

3.5 Backport PR
https://github.com/etcd-io/etcd/pull/14884



Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
