### PR TITLE
Linearizability issue14890

### DIFF
--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -13,7 +13,7 @@ jobs:
         make build
         mkdir -p /tmp/linearizability
         cat server/etcdserver/raft.fail.go
-        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 60 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
+        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 1 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
     - uses: actions/upload-artifact@v2
       if: always()
       with:

--- a/client/v2/keys.go
+++ b/client/v2/keys.go
@@ -147,7 +147,7 @@ type WatcherOptions struct {
 
 type CreateInOrderOptions struct {
 	// TTL defines a period of time after-which the Node should
-	// expire and no longer exist. Values <= 0 are ignored. Given
+	// expire and no longer exist. Elements <= 0 are ignored. Given
 	// that the zero-value is ignored, TTL cannot be used to set
 	// a TTL of 0.
 	TTL time.Duration
@@ -177,7 +177,7 @@ type SetOptions struct {
 	PrevExist PrevExistType
 
 	// TTL defines a period of time after-which the Node should
-	// expire and no longer exist. Values <= 0 are ignored. Given
+	// expire and no longer exist. Elements <= 0 are ignored. Given
 	// that the zero-value is ignored, TTL cannot be used to set
 	// a TTL of 0.
 	TTL time.Duration

--- a/tests/linearizability/append_model.go
+++ b/tests/linearizability/append_model.go
@@ -1,0 +1,138 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linearizability
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/anishathalye/porcupine"
+)
+
+const (
+	Append Operation = "append"
+)
+
+type AppendRequest struct {
+	Op         Operation
+	Key        string
+	AppendData string
+}
+
+type AppendResponse struct {
+	GetData string
+}
+
+type AppendState struct {
+	Key      string
+	Elements []string
+}
+
+var appendModel = porcupine.Model{
+	Init: func() interface{} { return "{}" },
+	Step: func(st interface{}, in interface{}, out interface{}) (bool, interface{}) {
+		var state AppendState
+		err := json.Unmarshal([]byte(st.(string)), &state)
+		if err != nil {
+			panic(err)
+		}
+		ok, state := appendModelStep(state, in.(AppendRequest), out.(AppendResponse))
+		data, err := json.Marshal(state)
+		if err != nil {
+			panic(err)
+		}
+		return ok, string(data)
+	},
+	DescribeOperation: func(in, out interface{}) string {
+		request := in.(AppendRequest)
+		response := out.(AppendResponse)
+		switch request.Op {
+		case Get:
+			elements := strings.Split(response.GetData, ",")
+			return fmt.Sprintf("get(%q) -> %q", request.Key, elements[len(elements)-1])
+		case Append:
+			return fmt.Sprintf("append(%q, %q)", request.Key, request.AppendData)
+		default:
+			return "<invalid>"
+		}
+	},
+}
+
+func appendModelStep(state AppendState, request AppendRequest, response AppendResponse) (bool, AppendState) {
+	if request.Key == "" {
+		panic("invalid request")
+	}
+	if state.Key == "" {
+		return true, initAppendState(request, response)
+	}
+	if state.Key != request.Key {
+		panic("Multiple keys not supported")
+	}
+	switch request.Op {
+	case Get:
+		return stepAppendGet(state, request, response)
+	case Append:
+		return stepAppend(state, request, response)
+	default:
+		panic("Unknown operation")
+	}
+}
+
+func initAppendState(request AppendRequest, response AppendResponse) AppendState {
+	state := AppendState{
+		Key: request.Key,
+	}
+	switch request.Op {
+	case Get:
+		state.Elements = elements(response)
+	case Append:
+		state.Elements = []string{request.AppendData}
+	default:
+		panic("Unknown operation")
+	}
+	return state
+}
+
+func stepAppendGet(state AppendState, request AppendRequest, response AppendResponse) (bool, AppendState) {
+	newElements := elements(response)
+	if len(newElements) < len(state.Elements) {
+		return false, state
+	}
+
+	for i := 0; i < len(state.Elements); i++ {
+		if state.Elements[i] != newElements[i] {
+			return false, state
+		}
+	}
+	state.Elements = newElements
+	return true, state
+}
+
+func stepAppend(state AppendState, request AppendRequest, response AppendResponse) (bool, AppendState) {
+	if request.AppendData == "" {
+		panic("unsupported empty appendData")
+	}
+	state.Elements = append(state.Elements, request.AppendData)
+	return true, state
+}
+
+func elements(response AppendResponse) []string {
+	elements := strings.Split(response.GetData, ",")
+	if len(elements) == 1 && elements[0] == "" {
+		elements = []string{}
+	}
+	return elements
+}

--- a/tests/linearizability/append_model_test.go
+++ b/tests/linearizability/append_model_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linearizability
+
+import (
+	"testing"
+)
+
+func TestAppendModel(t *testing.T) {
+	tcs := []struct {
+		name       string
+		operations []testAppendOperation
+	}{
+		{
+			name: "Append appends",
+			operations: []testAppendOperation{
+				{req: AppendRequest{Key: "key", Op: Append, AppendData: "1"}, resp: AppendResponse{}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1"}},
+				{req: AppendRequest{Key: "key", Op: Append, AppendData: "2"}, resp: AppendResponse{}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1,3"}, failure: true},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1,2"}},
+			},
+		},
+		{
+			name: "Get validates prefix matches",
+			operations: []testAppendOperation{
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: ""}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1"}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "2"}, failure: true},
+				{req: AppendRequest{Key: "key", Op: Append, AppendData: "2"}, resp: AppendResponse{}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1,3"}, failure: true},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "1,2,3"}},
+				{req: AppendRequest{Key: "key", Op: Get}, resp: AppendResponse{GetData: "2,3"}, failure: true},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		var ok bool
+		t.Run(tc.name, func(t *testing.T) {
+			state := appendModel.Init()
+			for _, op := range tc.operations {
+				t.Logf("state: %v", state)
+				ok, state = appendModel.Step(state, op.req, op.resp)
+				if ok != !op.failure {
+					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.failure, ok, appendModel.DescribeOperation(op.req, op.resp))
+				}
+			}
+		})
+	}
+}
+
+type testAppendOperation struct {
+	req     AppendRequest
+	resp    AppendResponse
+	failure bool
+}

--- a/tests/linearizability/history.go
+++ b/tests/linearizability/history.go
@@ -123,7 +123,7 @@ func (h *appendableHistory) appendFailed(request EtcdRequest, start time.Time, e
 	})
 	// Operations of single client needs to be sequential.
 	// As we don't know return time of failed operations, all new writes need to be done with new client id.
-	h.id = h.idProvider.ClientId()
+	//h.id = h.idProvider.ClientId()
 }
 
 type history struct {

--- a/tests/linearizability/model.go
+++ b/tests/linearizability/model.go
@@ -27,19 +27,23 @@ const (
 	Get    Operation = "get"
 	Put    Operation = "put"
 	Delete Operation = "delete"
+	Txn    Operation = "txn"
 )
 
 type EtcdRequest struct {
-	Op      Operation
-	Key     string
-	PutData string
+	Op            Operation
+	Key           string
+	PutData       string
+	TxnExpectData string
+	TxnNewData    string
 }
 
 type EtcdResponse struct {
-	GetData  string
-	Revision int64
-	Deleted  int64
-	Err      error
+	GetData      string
+	Revision     int64
+	Deleted      int64
+	TxnSucceeded bool
+	Err          error
 }
 
 type EtcdState struct {
@@ -48,7 +52,7 @@ type EtcdState struct {
 }
 
 func (resp EtcdResponse) Equals(other EtcdResponse) bool {
-	return resp.GetData == other.GetData && resp.Revision == other.Revision && resp.Deleted == other.Deleted && resp.Err == other.Err
+	return resp.GetData == other.GetData && resp.Revision == other.Revision && resp.Deleted == other.Deleted && resp.Err == other.Err && resp.TxnSucceeded == other.TxnSucceeded
 }
 
 var etcdModel = porcupine.Model{
@@ -87,6 +91,12 @@ var etcdModel = porcupine.Model{
 				return fmt.Sprintf("delete(%q) -> %s", request.Key, response.Err)
 			} else {
 				return fmt.Sprintf("delete(%q) -> ok, rev: %d deleted:%d", request.Key, response.Revision, response.Deleted)
+			}
+		case Txn:
+			if response.Err != nil {
+				return fmt.Sprintf("txn(if(value(%q)=%q).then(put(%q, %q)) -> %s", request.Key, request.TxnExpectData, request.Key, request.TxnNewData, response.Err)
+			} else {
+				return fmt.Sprintf("txn(if(value(%q)=%q).then(put(%q, %q)) -> %v, rev: %d", request.Key, request.TxnExpectData, request.Key, request.TxnNewData, response.TxnSucceeded, response.Revision)
 			}
 		default:
 			return "<invalid>"
@@ -151,6 +161,14 @@ func initValueRevision(request EtcdRequest, response EtcdResponse) (ok bool, v v
 			Value:    "",
 			Revision: response.Revision,
 		}
+	case Txn:
+		if response.TxnSucceeded {
+			return true, valueRevision{
+				Value:    request.TxnNewData,
+				Revision: response.Revision,
+			}
+		}
+		return false, valueRevision{}
 	default:
 		panic("Unknown operation")
 	}
@@ -169,6 +187,12 @@ func (v *valueRevision) handle(request EtcdRequest) EtcdResponse {
 			v.Value = ""
 			v.Revision += 1
 			response.Deleted = 1
+		}
+	case Txn:
+		if v.Value == request.TxnExpectData {
+			v.Value = request.TxnNewData
+			v.Revision += 1
+			response.TxnSucceeded = true
 		}
 	default:
 		panic("unsupported operation")

--- a/tests/linearizability/model_test.go
+++ b/tests/linearizability/model_test.go
@@ -43,6 +43,12 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
+			name: "First Txn can start from non-zero revision",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "", TxnNewData: "42"}, resp: EtcdResponse{Revision: 42}},
+			},
+		},
+		{
 			name: "Get response data should match put",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
@@ -70,7 +76,7 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Put can fail and be lost",
+			name: "Put can fail and be lost before get",
 			operations: []testOperation{
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "1"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
@@ -81,17 +87,37 @@ func TestModel(t *testing.T) {
 			},
 		},
 		{
-			name: "Put can fail but be persisted and increase revision before put",
+			name: "Put can fail and be lost before put",
 			operations: []testOperation{
-				// One failed request, one persisted.
 				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
-				// Two failed request, two persisted.
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
-				{req: EtcdRequest{Op: Put, Key: "key", PutData: "6"}, resp: EtcdResponse{Revision: 6}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}},
 			},
+		},
+		{
+			name: "Put can fail and be lost before delete",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+			},
+		},
+		{
+			name: "Put can fail and be lost before txn failed",
+			operations: []testOperation{
+				// Txn failure
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 1}},
+				// Txn success
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Revision: 2}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{TxnSucceeded: true, Revision: 3}},
+			},
+		},
+		{
+			name:       "Put can fail and be lost before txn success",
+			operations: []testOperation{},
 		},
 		{
 			name: "Put can fail but be persisted and increase revision before get",
@@ -127,6 +153,21 @@ func TestModel(t *testing.T) {
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "9"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Put, Key: "key", PutData: "10"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 10}},
+			},
+		},
+		{
+			name: "Put can fail but be persisted before txn",
+			operations: []testOperation{
+				// Txn success
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2"}, resp: EtcdResponse{TxnSucceeded: true, Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2"}, resp: EtcdResponse{TxnSucceeded: true, Revision: 3}},
+				// Txn failure
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "5"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 5, GetData: "5"}},
 			},
 		},
 		{
@@ -214,6 +255,141 @@ func TestModel(t *testing.T) {
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
 				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Revision: 4}},
+			},
+		},
+		{
+			name: "Delete can fail but be persisted before txn",
+			operations: []testOperation{
+				// Txn success
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "", TxnNewData: "1"}, resp: EtcdResponse{TxnSucceeded: true, Revision: 3}},
+				// Txn failure
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "4", TxnNewData: "5"}, resp: EtcdResponse{TxnSucceeded: false, Revision: 5}},
+			},
+		},
+		{
+			name: "Txn sets new value if value matches expected",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Revision: 1, TxnSucceeded: true}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Revision: 2, TxnSucceeded: false}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Revision: 1, TxnSucceeded: false}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Revision: 2, TxnSucceeded: true}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}},
+			},
+		},
+		{
+			name: "Txn can expect on empty key",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "", TxnNewData: "2"}, resp: EtcdResponse{Revision: 2, TxnSucceeded: true}},
+			},
+		},
+		{
+			name: "Txn doesn't do anything if value doesn't match expected",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 2, TxnSucceeded: true}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 1, TxnSucceeded: true}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 2, TxnSucceeded: false}, failure: true},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 1, TxnSucceeded: false}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "2", Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "3", Revision: 1}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "3", Revision: 2}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+			},
+		},
+		{
+			name: "Txn can fail and be lost before get",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2, GetData: "2"}, failure: true},
+			},
+		},
+		{
+			name: "Txn can fail and be lost before delete",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 2}},
+			},
+		},
+		{
+			name: "Txn can fail and be lost before put",
+			operations: []testOperation{
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 2}},
+			},
+		},
+		{
+			name: "Txn can fail but be persisted before get",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 1, GetData: "2"}, failure: true},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 2, GetData: "2"}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "3", TxnNewData: "4"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "4", TxnNewData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{Revision: 5, GetData: "5"}},
+			},
+		},
+		{
+			name: "Txn can fail but be persisted before put",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "3"}, resp: EtcdResponse{Revision: 3}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "4", TxnNewData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "5", TxnNewData: "6"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "7"}, resp: EtcdResponse{Revision: 7}},
+			},
+		},
+		{
+			name: "Txn can fail but be persisted before delete",
+			operations: []testOperation{
+				// One failed request, one persisted.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 3}},
+				// Two failed request, two persisted.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "4", TxnNewData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "5", TxnNewData: "6"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Delete, Key: "key"}, resp: EtcdResponse{Deleted: 1, Revision: 7}},
+			},
+		},
+		{
+			name: "Txn can fail but be persisted before txn",
+			operations: []testOperation{
+				// One failed request, one persisted with success.
+				{req: EtcdRequest{Op: Get, Key: "key"}, resp: EtcdResponse{GetData: "1", Revision: 1}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "1", TxnNewData: "2"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "2", TxnNewData: "3"}, resp: EtcdResponse{Revision: 3, TxnSucceeded: true}},
+				// Two failed request, two persisted with success.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "4"}, resp: EtcdResponse{Revision: 4}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "4", TxnNewData: "5"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "5", TxnNewData: "6"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "6", TxnNewData: "7"}, resp: EtcdResponse{Revision: 7, TxnSucceeded: true}},
+				// One failed request, one persisted with failure.
+				{req: EtcdRequest{Op: Put, Key: "key", PutData: "8"}, resp: EtcdResponse{Revision: 8}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "8", TxnNewData: "9"}, resp: EtcdResponse{Err: errors.New("failed")}},
+				{req: EtcdRequest{Op: Txn, Key: "key", TxnExpectData: "8", TxnNewData: "10"}, resp: EtcdResponse{Revision: 9}},
 			},
 		},
 	}

--- a/tests/linearizability/traffic.go
+++ b/tests/linearizability/traffic.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	DefaultTraffic Traffic = readWriteSingleKey{key: "key", writes: []opChance{{operation: Put, chance: 90}, {operation: Delete, chance: 5}, {operation: Txn, chance: 5}}}
+	AppendOnly     Traffic = readWriteSingleKey{key: "key", writes: []opChance{{operation: Txn, chance: 100}}}
 )
 
 type Traffic interface {


### PR DESCRIPTION
cc @ahrtr @ptabor @geetasg @tjungblu @aphyr

Failed attempt to try reproducing https://github.com/etcd-io/etcd/issues/14890

I switched linearization model to append one resembling Jepsen https://jepsen.io/analyses/etcd-3.4.3#append

For now use single key and validates exact contents.
In loop each client:
* Read the value of key
* Create Txn if value didn't change, put original value appended with unique identifier.

This approach has one advantage that failed requests can be ignored. Model doesn't check exact requests, just ensures that prefix matches. 

@aphyr From what I understood (don't know closure at all), one difference with append flow is that Jepsen compares modRevision in Txn instead value. Do you see any other differences or suggestions?