### PR TITLE
Set Github workflows default permissions to read-only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build
 on: [push, pull_request]
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: '20 14 * * 5'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -1,5 +1,6 @@
 name: Test contrib/mixin
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,6 @@
 name: Coverage
 on: [push]
+permissions: read-all
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,11 @@
 name: E2E
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,8 +4,6 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,5 +1,6 @@
 name: functional-tests
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -1,5 +1,6 @@
 name: Fuzzing v3rpc
 on: [push, pull_request]
+permissions: read-all
 jobs:
   fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -1,5 +1,6 @@
 name: Go Vulnerability Checker
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -1,5 +1,6 @@
 name: grpcProxy-tests
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -1,5 +1,6 @@
 name: Linearizability
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/measure-test-flakiness.yaml
+++ b/.github/workflows/measure-test-flakiness.yaml
@@ -1,7 +1,6 @@
 name: Measure Test Flakiness
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/measure-test-flakiness.yaml
+++ b/.github/workflows/measure-test-flakiness.yaml
@@ -1,8 +1,11 @@
 name: Measure Test Flakiness
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"
+
+permissions: read-all
 
 jobs:
   measure-test-flakiness:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 permissions: read-all
 jobs:
   main:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,10 @@
 name: Release
 on: [push, pull_request]
+permissions: read-all
 jobs:
   main:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,5 +1,6 @@
 name: Static Analysis
 on: [push, pull_request]
+permissions: read-all
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,6 @@
 name: Tests
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #14878 

I've configured and tested all workflows using default permissions as read-only, only the release.yaml and converage.yaml I wasn't able to test. I've assumed, looking to the scripts, that the release.yaml would need a write permission on it's job, the coverage.yaml didn't seem to need any write permission.

Let me know if I've misjudged it.

Thanks!