### PR TITLE
chore: use Getter in WarnOfExpensiveReadOnlyTxnRequest 

### DIFF
--- a/server/etcdserver/txn/util.go
+++ b/server/etcdserver/txn/util.go
@@ -61,10 +61,10 @@ func WarnOfExpensiveReadOnlyTxnRequest(lg *zap.Logger, warningApplyDuration time
 	if !isNil(txnResponse) {
 		var resps []string
 		for _, r := range txnResponse.Responses {
-			switch op := r.Response.(type) {
+			switch r.Response.(type) {
 			case *pb.ResponseOp_ResponseRange:
-				if op.ResponseRange != nil {
-					resps = append(resps, fmt.Sprintf("range_response_count:%d", len(op.ResponseRange.Kvs)))
+				if op := r.GetResponseRange(); op != nil {
+					resps = append(resps, fmt.Sprintf("range_response_count:%d", len(op.GetKvs())))
 				} else {
 					resps = append(resps, "range_response:nil")
 				}

--- a/server/etcdserver/txn/util_test.go
+++ b/server/etcdserver/txn/util_test.go
@@ -19,12 +19,19 @@ import (
 	"time"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+
 	"go.uber.org/zap/zaptest"
 )
 
 // TestWarnOfExpensiveReadOnlyTxnRequest verifies WarnOfExpensiveReadOnlyTxnRequest
 // never panic no matter what data the txnResponse contains.
 func TestWarnOfExpensiveReadOnlyTxnRequest(t *testing.T) {
+	kvs := []*mvccpb.KeyValue{
+		&mvccpb.KeyValue{Key: []byte("k1"), Value: []byte("v1")},
+		&mvccpb.KeyValue{Key: []byte("k2"), Value: []byte("v2")},
+	}
+
 	testCases := []struct {
 		name    string
 		txnResp *pb.TxnResponse
@@ -35,7 +42,9 @@ func TestWarnOfExpensiveReadOnlyTxnRequest(t *testing.T) {
 				Responses: []*pb.ResponseOp{
 					{
 						Response: &pb.ResponseOp_ResponseRange{
-							ResponseRange: &pb.RangeResponse{},
+							ResponseRange: &pb.RangeResponse{
+								Kvs: kvs,
+							},
 						},
 					},
 					{
@@ -58,6 +67,13 @@ func TestWarnOfExpensiveReadOnlyTxnRequest(t *testing.T) {
 					{
 						Response: &pb.ResponseOp_ResponseRange{
 							ResponseRange: nil,
+						},
+					},
+					{
+						Response: &pb.ResponseOp_ResponseRange{
+							ResponseRange: &pb.RangeResponse{
+								Kvs: kvs,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
The pb provides an accessor method to get field and it will not panic if
the owner is nil. And add non-empty RangeRespone into the test case.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

ping @ahrtr 
