### PR TITLE
Create a nightly job for linearizability tests

### DIFF
--- a/.github/workflows/linearizability-nightly.yaml
+++ b/.github/workflows/linearizability-nightly.yaml
@@ -1,0 +1,25 @@
+name: Linearizability Nightly
+on:
+  # schedules always run against the main branch
+  schedule:
+    - cron: '25 9 * * *'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # GHA has a maximum amount of 6h execution time, we try to get done within 3h
+    timeout-minutes: 180
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.19.3"
+    - run: |
+        make gofail-enable
+        make build
+        mkdir -p /tmp/linearizability
+        cat server/etcdserver/raft.fail.go
+        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 500 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        path: /tmp/linearizability/*


### PR DESCRIPTION
Start with a simple job against main that runs for 3h by repeating it more often than the PR job.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

---

fix for #14045 
- [x]  Add a periodic (once a day?) long running (1h?) github action that runs linearizability tests

I didn't find a much better way to make it run for longer, I basically just incremented the --count by two orders of manitude. Let me know if there's a nicer way, happy to implement that.

The caveat with the schedule is that this is only for the main branch, we have to maybe split the jobs up to checkout the respective release branches in parallel and run the tests.
