### PR TITLE
add linearizability nightlies for release 3.4/3.5

### DIFF
--- a/.github/workflows/linearizability-nightly.yaml
+++ b/.github/workflows/linearizability-nightly.yaml
@@ -1,25 +1,31 @@
 name: Linearizability Nightly
 on:
-  # schedules always run against the main branch
+  # schedules always run against the main branch, hence we have to create separate jobs
+  # with individual checkout actions for each of the active release branches
   schedule:
-    - cron: '25 9 * * *'
+    - cron: '25 9 * * *' # runs every day at 09:25 UTC
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  test-main:
     # GHA has a maximum amount of 6h execution time, we try to get done within 3h
     timeout-minutes: 180
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: "1.19.3"
-    - run: |
-        make gofail-enable
-        make build
-        mkdir -p /tmp/linearizability
-        cat server/etcdserver/raft.fail.go
-        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 500 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        path: /tmp/linearizability/*
+    uses: ./.github/workflows/linearizability-workflow.yaml
+    with:
+      ref: main
+      count: 500
+      timeoutDuration: 3h
+  test-3.5:
+    timeout-minutes: 180
+    uses: ./.github/workflows/linearizability-workflow.yaml
+    with:
+      ref: release-3.5
+      count: 500
+      timeoutDuration: 3h
+      goVersion: '1.16.15'
+  test-3.4:
+    timeout-minutes: 180
+    uses: ./.github/workflows/linearizability-workflow.yaml
+    with:
+      ref: release-3.4
+      count: 500
+      timeoutDuration: 3h
+      goVersion: '1.16.15'

--- a/.github/workflows/linearizability-workflow.yaml
+++ b/.github/workflows/linearizability-workflow.yaml
@@ -1,0 +1,39 @@
+name: Reusable Linearizability Workflow
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      count:
+        required: true
+        type: number
+      timeoutDuration:
+        required: false
+        type: string
+        default: '30m'
+      goVersion:
+        required: false
+        type: string
+        default: '1.19.3'
+permissions: read-all
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ inputs.goVersion }}
+      - run: |
+          make gofail-enable
+          make build
+          mkdir -p /tmp/linearizability
+          cat server/etcdserver/raft.fail.go
+          EXPECT_DEBUG=true TIMEOUT=${{ inputs.timeoutDuration }} GO_TEST_FLAGS='-v --count ${{ inputs.count }} --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          path: /tmp/linearizability/*

--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -3,19 +3,7 @@ on: [push, pull_request]
 permissions: read-all
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: "1.19.3"
-    - run: |
-        make gofail-enable
-        make build
-        mkdir -p /tmp/linearizability
-        cat server/etcdserver/raft.fail.go
-        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 60 --failfast --run TestLinearizability' RESULTS_DIR=/tmp/linearizability make test-linearizability
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        path: /tmp/linearizability/*
+    uses: ./.github/workflows/linearizability-workflow.yaml
+    with:
+      ref: ${{ github.ref }}
+      count: 60


### PR DESCRIPTION
This CL refactors the tests to reuse a single workflow that has parameters. This is then reused for PRs/pushes and the nightlies.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>

