### PR TITLE
resolver: cleanup of deprecated grpc resolver target.Endpoint field

### DIFF
--- a/client/v3/naming/resolver/resolver.go
+++ b/client/v3/naming/resolver/resolver.go
@@ -16,6 +16,7 @@ package resolver
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -31,9 +32,15 @@ type builder struct {
 }
 
 func (b builder) Build(target gresolver.Target, cc gresolver.ClientConn, opts gresolver.BuildOptions) (gresolver.Resolver, error) {
+	// Refer to https://github.com/grpc/grpc-go/blob/16d3df80f029f57cff5458f1d6da6aedbc23545d/clientconn.go#L1587-L1611
+	endpoint := target.URL.Path
+	if endpoint == "" {
+		endpoint = target.URL.Opaque
+	}
+	endpoint = strings.TrimPrefix(endpoint, "/")
 	r := &resolver{
 		c:      b.c,
-		target: target.Endpoint,
+		target: endpoint,
 		cc:     cc,
 	}
 	r.ctx, r.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
`grpc.resolver.Target.Endpoint` and some other fields are deprecated, URL field is suggested to use instead.
`URL.Path` is required to be stripped of "/" prefix for naming/resolver to work properly

Signed-off-by: Ramil Mirhasanov <ramil600@yahoo.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
