### PR TITLE
etcd: add `trivy-nightly-scan` for etcd images

### DIFF
--- a/.github/workflows/trivy-nightly-scan.yaml
+++ b/.github/workflows/trivy-nightly-scan.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # master
         with:
           image-ref: 'gcr.io/etcd-development/etcd:${{ matrix.versions }}'
           severity: 'CRITICAL,HIGH'
@@ -29,6 +29,6 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-nightly-scan.yaml
+++ b/.github/workflows/trivy-nightly-scan.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
+permissions: read-all 
 jobs:
   nightly-scan:
     name: Trivy Scan nightly

--- a/.github/workflows/trivy-nightly-scan.yaml
+++ b/.github/workflows/trivy-nightly-scan.yaml
@@ -1,0 +1,34 @@
+name: Trivy Nightly Scan
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  nightly-scan:
+    name: Trivy Scan nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        # maintain the versions of etcd that need to be actively
+        # security scanned
+        versions: [v3.4.22, v3.5.6]
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'gcr.io/etcd-development/etcd:${{ matrix.versions }}'
+          severity: 'CRITICAL,HIGH'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR will add `trivy-nightly-scan` for etcd images with versions `3.4.22` and `3.5.6` to scan for vulnerabilities everyday at 2AM UTC.

Fixes: #14908

Signed-off-by: ArkaSaha30 <arkasaha30@gmail.com>