### PR TITLE
fix doc etcdd.io -> etcd.io

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,4 +1,4 @@
 This directory includes etcd project internal documentation for new and existing contributors.
 
-For user and developer documentation please go to [etcdd.io](https://etcd.io/),
+For user and developer documentation please go to [etcd.io](https://etcd.io/),
 which is developed in [website](https://github.com/etcd-io/website/) repo.


### PR DESCRIPTION
document: fix doc with syntax error

Change etcdd.io -> etcd.io

Signed-off-by: ZhengSheng0524 <j13tw@yahoo.com.tw>
