### PR TITLE
fix:  specify the correct branch name of release-3.5 in workflow for…

### DIFF
--- a/.github/workflows/trivy-nightly-scan.yaml
+++ b/.github/workflows/trivy-nightly-scan.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          ref: release-3.5
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # master
         with:


### PR DESCRIPTION
In order to checkout the corresponding branch in CI/CD workflow. Specify the correct branch name in each branch.

Context
#15009 
