### PR TITLE
test(client): add `credentials_test.go`

### DIFF
--- a/client/v3/credentials/credentials_test.go
+++ b/client/v3/credentials/credentials_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentials
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+)
+
+func TestUpdateAuthToken(t *testing.T) {
+	bundle := NewBundle(Config{})
+	ctx := context.TODO()
+
+	metadataBeforeUpdate, _ := bundle.PerRPCCredentials().GetRequestMetadata(ctx)
+	assert.Empty(t, metadataBeforeUpdate)
+
+	bundle.UpdateAuthToken("abcdefg")
+
+	metadataAfterUpdate, _ := bundle.PerRPCCredentials().GetRequestMetadata(ctx)
+	assert.Equal(t, metadataAfterUpdate[rpctypes.TokenFieldNameGRPC], "abcdefg")
+}


### PR DESCRIPTION
Signed-off-by: wafuwafu13 <mariobaske@i.softbank.jp>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
