### PR TITLE
[3.5] Security: use distroless base image to address critical Vulnerabilities

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
-FROM debian:bullseye-20220328
+FROM --platform=linux/amd64 busybox:1.34.1 as source
+FROM --platform=linux/amd64 gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
-FROM arm64v8/debian:bullseye-20220328
+FROM --platform=linux/arm64 busybox:1.34.1 as source
+FROM --platform=linux/arm64 gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
-FROM ppc64le/debian:bullseye-20220328
+FROM --platform=linux/ppc64le busybox:1.34.1 as source
+FROM --platform=linux/ppc64le gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,5 +1,9 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-s390x:bullseye-1.y.z when patched
-FROM s390x/debian:bullseye-20220328
+FROM --platform=linux/s390x busybox:1.34.1 as source
+FROM --platform=linux/s390x gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
+
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Command:
```
trivy image --severity CRITICAL gcr.io/etcd-development/etcd:v3.5.6 
```

See report:
<img width="1314" alt="Screen Shot 2022-12-19 at 07 52 44" src="https://user-images.githubusercontent.com/30739825/208326095-3245b559-3122-48e4-96be-077ada1e64e6.png">


Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @mitake @ptabor @serathius @spzala 
