### PR TITLE
[3.4] Security: use distroless base image to address critical Vulnerabilities

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base:bullseye-v1.y.z when patched
-FROM debian:bullseye-20210927
+FROM --platform=linux/amd64 busybox:1.34.1 as source
+FROM --platform=linux/amd64 gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-arm64:bullseye-1.y.z when patched
-FROM arm64v8/debian:bullseye-20210927
+FROM --platform=linux/arm64 busybox:1.34.1 as source
+FROM --platform=linux/arm64 gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,5 +1,8 @@
-# TODO: move to k8s.gcr.io/build-image/debian-base-ppc64le:bullseye-1.y.z when patched
-FROM ppc64le/debian:bullseye-20210927
+FROM --platform=linux/ppc64le busybox:1.34.1 as source
+FROM --platform=linux/ppc64le gcr.io/distroless/base-debian11
+
+COPY --from=source /bin/sh /bin/sh
+COPY --from=source /bin/mkdir /bin/mkdir
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
Command:
```
trivy image --severity CRITICAL gcr.io/etcd-development/etcd:v3.4.22 
```

Report:

<img width="1228" alt="Screen Shot 2022-12-19 at 08 07 18" src="https://user-images.githubusercontent.com/30739825/208326679-7e7b6e7f-8cf3-47fd-9854-c7f46981aca2.png">

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @mitake @ptabor @serathius @spzala 