### PR TITLE
clientv3: add protection code to prevent SnapshotWithVersion from panicking

### DIFF
--- a/client/v3/maintenance.go
+++ b/client/v3/maintenance.go
@@ -239,6 +239,7 @@ func (m *maintenance) SnapshotWithVersion(ctx context.Context) (*SnapshotRespons
 	resp, err := ss.Recv()
 	if err != nil {
 		m.logAndCloseWithError(err, pw)
+		return nil, err
 	}
 	go func() {
 		// Saving response is blocking
@@ -260,10 +261,11 @@ func (m *maintenance) SnapshotWithVersion(ctx context.Context) (*SnapshotRespons
 			}
 		}
 	}()
+
 	return &SnapshotResponse{
-		Header:   resp.Header,
+		Header:   resp.GetHeader(),
 		Snapshot: &snapshotReadCloser{ctx: ctx, ReadCloser: pr},
-		Version:  resp.Version,
+		Version:  resp.GetVersion(),
 	}, err
 }
 

--- a/client/v3/snapshot/v3_snapshot.go
+++ b/client/v3/snapshot/v3_snapshot.go
@@ -68,7 +68,7 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 	start := time.Now()
 	resp, err := cli.SnapshotWithVersion(ctx)
 	if err != nil {
-		return resp.Version, err
+		return "", err
 	}
 	defer resp.Snapshot.Close()
 	lg.Info("fetching snapshot", zap.String("endpoint", cfg.Endpoints[0]))
@@ -98,17 +98,4 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 	}
 	lg.Info("saved", zap.String("path", dbPath))
 	return resp.Version, nil
-}
-
-// Save fetches snapshot from remote etcd server and saves data
-// to target path. If the context "ctx" is canceled or timed out,
-// snapshot save stream will error out (e.g. context.Canceled,
-// context.DeadlineExceeded). Make sure to specify only one endpoint
-// in client configuration. Snapshot API must be requested to a
-// selected node, and saved snapshot is the point-in-time state of
-// the selected node.
-// Deprecated: Use SaveWithVersion instead.
-func Save(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, dbPath string) error {
-	_, err := SaveWithVersion(ctx, lg, cfg, dbPath)
-	return err
 }


### PR DESCRIPTION
Unfortunately, golang doesn't have Ternary operator.

```
        panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x86443bd]
        
        goroutine 1 [running]:
        go.etcd.io/etcd/client/v3.(*maintenance).SnapshotWithVersion(0xa5cd9e0, {0x88d46a0, 0xa467860})
        	go.etcd.io/etcd/client/v3@v3.6.0-alpha.0/maintenance.go:264 +0x49d
        go.etcd.io/etcd/client/v3/snapshot.SaveWithVersion({0x88d46a0, 0xa467860}, 0xa69aa80, {{0xa66dd30, 0x1, 0x1}, 0x0, 0x1a13b8600, 0x77359400, 0x165a0bc00, ...}, ...)
        	go.etcd.io/etcd/client/v3@v3.6.0-alpha.0/snapshot/v3_snapshot.go:69 +0x42b
        go.etcd.io/etcd/etcdctl/v3/ctlv3/command.snapshotSaveCommandFunc(0xa69e000, {0xa5cd340, 0x1, 0x4})
        	go.etcd.io/etcd/etcdctl/v3/ctlv3/command/snapshot_command.go:66 +0x1ec
        github.com/spf13/cobra.(*Command).execute(0xa69e000, {0xa467650, 0x4, 0x6})
        	github.com/spf13/cobra@v1.6.1/command.go:920 +0x7c5
        github.com/spf13/cobra.(*Command).ExecuteC(0x8d2fa80)
        	github.com/spf13/cobra@v1.6.1/command.go:1044 +0x412
        github.com/spf13/cobra.(*Command).Execute(...)
        	github.com/spf13/cobra@v1.6.1/command.go:968
        go.etcd.io/etcd/etcdctl/v3/ctlv3.Start()
        	go.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:113 +0x91
        go.etcd.io/etcd/etcdctl/v3/ctlv3.MustStart()
        	go.etcd.io/etcd/etcdctl/v3/ctlv3/ctl.go:117 +0x1a
        main.main()
        	go.etcd.io/etcd/etcdctl/v3/main.go:33 +0x17
         (expected "Snapshot saved at test-auth.snapshot", got []). Try EXPECT_DEBUG=TRUE)
```

Reference: https://github.com/etcd-io/etcd/actions/runs/3731258429/jobs/6341529883

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
