### PR TITLE
externalize snapshot catchup entries to etcd flag

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -67,6 +67,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [Protection on maintenance request when auth is enabled](https://github.com/etcd-io/etcd/pull/14663).
 - Graduated [`--experimental-warning-unary-request-duration` to `--warning-unary-request-duration`](https://github.com/etcd-io/etcd/pull/14414). Note the experimental flag is deprecated and will be decommissioned in v3.7.
 - Add [field `hash_revision` into `HashKVResponse`](https://github.com/etcd-io/etcd/pull/14537).
+- Add [`etcd --experimental-snapshot-catch-up-entries`](https://github.com/etcd-io/etcd/pull/15033) flag to configure number of entries for a slow follower to catch up after compacting the the raft storage entries and defaults to 5k. 
 
 ### etcd grpc-proxy
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -56,7 +56,6 @@ type ServerConfig struct {
 	// We expect the follower has a millisecond level latency with the leader.
 	// The max throughput is around 10K. Keep a 5K entries is enough for helping
 	// follower to catch up.
-	// WARNING: only change this for tests. Always use "DefaultSnapshotCatchUpEntries"
 	SnapshotCatchUpEntries uint64
 
 	MaxSnapFiles uint

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -156,9 +156,7 @@ type Config struct {
 	// We expect the follower has a millisecond level latency with the leader.
 	// The max throughput is around 10K. Keep a 5K entries is enough for helping
 	// follower to catch up.
-	// WARNING: only change this for tests.
-	// Always use "DefaultSnapshotCatchUpEntries"
-	SnapshotCatchUpEntries uint64
+	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
 
 	MaxSnapFiles uint `json:"max-snapshots"`
 	MaxWalFiles  uint `json:"max-wals"`

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -279,6 +279,7 @@ func newConfig() *config {
 	fs.UintVar(&cfg.ec.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
 	fs.IntVar(&cfg.ec.ExperimentalMaxLearners, "experimental-max-learners", membership.DefaultMaxLearners, "Sets the maximum number of learners that can be available in the cluster membership.")
 	fs.DurationVar(&cfg.ec.ExperimentalWaitClusterReadyTimeout, "experimental-wait-cluster-ready-timeout", cfg.ec.ExperimentalWaitClusterReadyTimeout, "Maximum duration to wait for the cluster to be ready.")
+	fs.Uint64Var(&cfg.ec.SnapshotCatchUpEntries, "experimental-snapshot-catchup-entries", cfg.ec.SnapshotCatchUpEntries, "Number of entries for a slow follower to catch up after compacting the the raft storage entries.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -269,6 +269,8 @@ Experimental feature:
     Set the max number of learner members allowed in the cluster membership.
   --experimental-wait-cluster-ready-timeout '5s'
     Set the maximum time duration to wait for the cluster to be ready.
+  --experimental-snapshot-catch-up-entries '5000'
+    Number of entries for a slow follower to catch up after compacting the the raft storage entries.
 
 Unsafe feature:
   --force-new-cluster 'false'

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -147,7 +147,8 @@ type EtcdProcessClusterConfig struct {
 
 	MetricsURLScheme string
 
-	SnapshotCount int // default is 10000
+	SnapshotCount          int // default is 100000
+	SnapshotCatchUpEntries int // default is 5000
 
 	Client        ClientConfig
 	IsPeerTLS     bool
@@ -221,6 +222,10 @@ func WithKeepDataDir(keep bool) EPClusterOption {
 
 func WithSnapshotCount(count int) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.SnapshotCount = count }
+}
+
+func WithSnapshotCatchUpEntries(count int) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.SnapshotCatchUpEntries = count }
 }
 
 func WithClusterSize(size int) EPClusterOption {
@@ -547,6 +552,9 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 	}
 	if cfg.ExperimentalWarningUnaryRequestDuration != 0 {
 		args = append(args, "--experimental-warning-unary-request-duration", cfg.ExperimentalWarningUnaryRequestDuration.String())
+	}
+	if cfg.SnapshotCatchUpEntries > 0 {
+		args = append(args, "--experimental-snapshot-catchup-entries", fmt.Sprintf("%d", cfg.SnapshotCatchUpEntries))
 	}
 	envVars := map[string]string{}
 	for key, value := range cfg.EnvVars {


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow. 

Motivation
1. It can benefit one-node cluster with limited resource (e.g memory) without any performance impact. 
2. For multi-node cluster, setting a small value for DefaultSnapshotCatchUpEntries can reduce the memory usage while less tolerant of network events that will cause snapshot transfer (reduced availability).
3. It can benefit the E2E test cases to speed up test time and improve development velocity.

Questions
1. open to discussion if we want to mark this flag as `experimental`.
2. should we set a lower bound limit on the snapshot catchup entries count? 

Related https://github.com/etcd-io/etcd/pull/14819 and https://github.com/etcd-io/etcd/pull/15013#discussion_r1051683699
