### PR TITLE
etcd-dump-logs: Expand to allow diagnosing CRC corrupted problems in WAL log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ hack/tls-setup/certs
 /tools/proto-annotations/proto-annotations
 /tools/benchmark/benchmark
 /out
+/etcd-dump-logs

--- a/server/storage/wal/decoder.go
+++ b/server/storage/wal/decoder.go
@@ -54,15 +54,20 @@ type decoder struct {
 	continueOnCrcError bool
 }
 
-func NewDecoder(r ...fileutil.FileReader) Decoder {
+func NewDecoderAdvanced(continueOnCrcError bool, r ...fileutil.FileReader) Decoder {
 	readers := make([]*fileutil.FileBufReader, len(r))
 	for i := range r {
 		readers[i] = fileutil.NewFileBufReader(r[i])
 	}
 	return &decoder{
-		brs: readers,
-		crc: crc.New(0, crcTable),
+		brs:                readers,
+		crc:                crc.New(0, crcTable),
+		continueOnCrcError: continueOnCrcError,
 	}
+}
+
+func NewDecoder(r ...fileutil.FileReader) Decoder {
+	return NewDecoderAdvanced(false, r...)
 }
 
 // Decode reads the next record out of the file.

--- a/server/storage/wal/decoder.go
+++ b/server/storage/wal/decoder.go
@@ -121,8 +121,8 @@ func (d *decoder) decodeRecord(rec *walpb.Record) error {
 		return err
 	}
 
-	// skip crc checking if the record type is crcType
-	if rec.Type != crcType {
+	// skip crc checking if the record type is CrcType
+	if rec.Type != CrcType {
 		_, err := d.crc.Write(rec.Data)
 		if err != nil {
 			return err
@@ -204,13 +204,13 @@ func (d *decoder) LastCRC() uint32 {
 
 func (d *decoder) LastOffset() int64 { return d.lastValidOff }
 
-func mustUnmarshalEntry(d []byte) raftpb.Entry {
+func MustUnmarshalEntry(d []byte) raftpb.Entry {
 	var e raftpb.Entry
 	pbutil.MustUnmarshal(&e, d)
 	return e
 }
 
-func mustUnmarshalState(d []byte) raftpb.HardState {
+func MustUnmarshalState(d []byte) raftpb.HardState {
 	var s raftpb.HardState
 	pbutil.MustUnmarshal(&s, d)
 	return s

--- a/server/storage/wal/decoder.go
+++ b/server/storage/wal/decoder.go
@@ -109,9 +109,9 @@ func (d *decoder) decodeRecord(rec *walpb.Record) error {
 		d.crc.Write(rec.Data)
 		if err := rec.Validate(d.crc.Sum32()); err != nil {
 			if d.isTornEntry(data) {
-				return io.ErrUnexpectedEOF
+				return fmt.Errorf("%w: in file '%s' at position: %d", io.ErrUnexpectedEOF, fileBufReader.FileInfo().Name(), d.lastValidOff)
 			}
-			return err
+			return fmt.Errorf("%w: in file '%s' at position: %d", err, fileBufReader.FileInfo().Name(), d.lastValidOff)
 		}
 	}
 	// record decoded as valid; point last valid offset to end of record

--- a/server/storage/wal/record_test.go
+++ b/server/storage/wal/record_test.go
@@ -57,8 +57,8 @@ func TestReadRecord(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
-		decoder := newDecoder(fileutil.NewFileReader(f))
-		e := decoder.decode(rec)
+		decoder := NewDecoder(fileutil.NewFileReader(f))
+		e := decoder.Decode(rec)
 		if !reflect.DeepEqual(rec, tt.wr) {
 			t.Errorf("#%d: block = %v, want %v", i, rec, tt.wr)
 		}
@@ -81,8 +81,8 @@ func TestWriteRecord(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	decoder := newDecoder(fileutil.NewFileReader(f))
-	err = decoder.decode(b)
+	decoder := NewDecoder(fileutil.NewFileReader(f))
+	err = decoder.Decode(b)
 	if err != nil {
 		t.Errorf("err = %v, want nil", err)
 	}

--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -50,7 +50,7 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 		case err == nil:
 			// update crc of the decoder when necessary
 			switch rec.Type {
-			case crcType:
+			case CrcType:
 				crc := decoder.LastCRC()
 				// current crc of decoder must match the crc of the record.
 				// do no need to match 0 crc, since the decoder is a new one at this case.

--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -42,22 +42,22 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 	lg.Info("repairing", zap.String("path", f.Name()))
 
 	rec := &walpb.Record{}
-	decoder := newDecoder(fileutil.NewFileReader(f.File))
+	decoder := NewDecoder(fileutil.NewFileReader(f.File))
 	for {
-		lastOffset := decoder.lastOffset()
-		err := decoder.decode(rec)
+		lastOffset := decoder.LastOffset()
+		err := decoder.Decode(rec)
 		switch {
 		case err == nil:
 			// update crc of the decoder when necessary
 			switch rec.Type {
 			case crcType:
-				crc := decoder.crc.Sum32()
+				crc := decoder.LastCRC()
 				// current crc of decoder must match the crc of the record.
 				// do no need to match 0 crc, since the decoder is a new one at this case.
 				if crc != 0 && rec.Validate(crc) != nil {
 					return false
 				}
-				decoder.updateCRC(rec.Crc)
+				decoder.UpdateCRC(rec.Crc)
 			}
 			continue
 

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -16,12 +16,12 @@ package wal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -16,6 +16,8 @@ package wal
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"testing"
@@ -43,86 +45,59 @@ func TestRepairTruncate(t *testing.T) {
 }
 
 func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expectedEnts int) {
+	lg := zaptest.NewLogger(t)
 	p := t.TempDir()
 
 	// create WAL
-	w, err := Create(zaptest.NewLogger(t), p, nil)
+	w, err := Create(lg, p, nil)
 	defer func() {
-		if err = w.Close(); err != nil {
-			t.Fatal(err)
-		}
+		// The Close might fail.
+		_ = w.Close()
 	}()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for _, es := range ents {
-		if err = w.Save(raftpb.HardState{}, es); err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, w.Save(raftpb.HardState{}, es))
 	}
 
 	offset, err := w.tail().Seek(0, io.SeekCurrent)
-	if err != nil {
-		t.Fatal(err)
-	}
-	w.Close()
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
 
-	err = corrupt(p, offset)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, corrupt(p, offset))
 
 	// verify we broke the wal
 	w, err = Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	_, _, _, err = w.ReadAll()
-	if err != io.ErrUnexpectedEOF {
-		t.Fatalf("err = %v, want error %v", err, io.ErrUnexpectedEOF)
-	}
-	w.Close()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.NoError(t, w.Close())
 
 	// repair the wal
-	if ok := Repair(zaptest.NewLogger(t), p); !ok {
-		t.Fatalf("'Repair' returned '%v', want 'true'", ok)
-	}
+	require.True(t, Repair(lg, p), "'Repair' returned 'false', want 'true'")
 
 	// read it back
-	w, err = Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	w, err = Open(lg, p, walpb.Snapshot{})
+	require.NoError(t, err)
+
 	_, _, walEnts, err := w.ReadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(walEnts) != expectedEnts {
-		t.Fatalf("len(ents) = %d, want %d", len(walEnts), expectedEnts)
-	}
+	require.NoError(t, err)
+	assert.Len(t, walEnts, expectedEnts)
 
 	// write some more entries to repaired log
 	for i := 1; i <= 10; i++ {
 		es := []raftpb.Entry{{Index: uint64(expectedEnts + i)}}
-		if err = w.Save(raftpb.HardState{}, es); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.Save(raftpb.HardState{}, es))
 	}
-	w.Close()
+	require.NoError(t, w.Close())
 
 	// read back entries following repair, ensure it's all there
-	w, err = Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	w, err = Open(lg, p, walpb.Snapshot{})
+	require.NoError(t, err)
 	_, _, walEnts, err = w.ReadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(walEnts) != expectedEnts+10 {
-		t.Fatalf("len(ents) = %d, want %d", len(walEnts), expectedEnts+10)
-	}
+	require.NoError(t, err)
+	assert.Len(t, walEnts, expectedEnts+10)
 }
 
 func makeEnts(ents int) (ret [][]raftpb.Entry) {

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -57,7 +57,7 @@ func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expect
 	require.NoError(t, err)
 
 	for _, es := range ents {
-		assert.NoError(t, w.Save(raftpb.HardState{}, es))
+		require.NoError(t, w.Save(raftpb.HardState{}, es))
 	}
 
 	offset, err := w.tail().Seek(0, io.SeekCurrent)

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -302,7 +302,7 @@ func TestCut(t *testing.T) {
 	}
 	defer f.Close()
 	nw := &WAL{
-		decoder: newDecoder(fileutil.NewFileReader(f)),
+		decoder: NewDecoder(fileutil.NewFileReader(f)),
 		start:   snap,
 	}
 	_, gst, _, err := nw.ReadAll()

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -74,16 +74,16 @@ func TestNew(t *testing.T) {
 
 	var wb bytes.Buffer
 	e := newEncoder(&wb, 0, 0)
-	err = e.encode(&walpb.Record{Type: crcType, Crc: 0})
+	err = e.encode(&walpb.Record{Type: CrcType, Crc: 0})
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
-	err = e.encode(&walpb.Record{Type: metadataType, Data: []byte("somedata")})
+	err = e.encode(&walpb.Record{Type: MetadataType, Data: []byte("somedata")})
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
 	r := &walpb.Record{
-		Type: snapshotType,
+		Type: SnapshotType,
 		Data: pbutil.MustMarshal(&walpb.Snapshot{}),
 	}
 	if err = e.encode(r); err != nil {

--- a/server/storage/wal/walpb/record.go
+++ b/server/storage/wal/walpb/record.go
@@ -14,7 +14,10 @@
 
 package walpb
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrCRCMismatch = errors.New("walpb: crc mismatch")
@@ -24,8 +27,7 @@ func (rec *Record) Validate(crc uint32) error {
 	if rec.Crc == crc {
 		return nil
 	}
-	rec.Reset()
-	return ErrCRCMismatch
+	return fmt.Errorf("%w: expected: %x computed: %x", ErrCRCMismatch, rec.Crc, crc)
 }
 
 // ValidateSnapshotForWrite ensures the Snapshot the newly written snapshot is valid.

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -52,38 +52,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 
 	p := t.TempDir()
 
-	memberdir := filepath.Join(p, "member")
-	err = os.Mkdir(memberdir, 0744)
-	if err != nil {
-		t.Fatal(err)
-	}
-	waldir := walDir(p)
-	snapdir := snapDir(p)
-
-	w, err := wal.Create(zaptest.NewLogger(t), waldir, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = os.Mkdir(snapdir, 0744)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ents := make([]raftpb.Entry, 0)
-
-	// append entries into wal log
-	appendConfigChangeEnts(&ents)
-	appendNormalRequestEnts(&ents)
-	appendNormalIRREnts(&ents)
-	appendUnknownNormalEnts(&ents)
-
-	// force commit newly appended entries
-	err = w.Save(raftpb.HardState{}, ents)
-	if err != nil {
-		t.Fatal(err)
-	}
-	w.Close()
+	mustCreateWalLog(t, p)
 
 	argtests := []struct {
 		name         string
@@ -126,6 +95,41 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 		})
 	}
 
+}
+
+func mustCreateWalLog(t *testing.T, path string) {
+	memberdir := filepath.Join(path, "member")
+	err := os.Mkdir(memberdir, 0744)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waldir := walDir(path)
+	snapdir := snapDir(path)
+
+	w, err := wal.Create(zaptest.NewLogger(t), waldir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.Mkdir(snapdir, 0744)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ents := make([]raftpb.Entry, 0)
+
+	// append entries into wal log
+	appendConfigChangeEnts(&ents)
+	appendNormalRequestEnts(&ents)
+	appendNormalIRREnts(&ents)
+	appendUnknownNormalEnts(&ents)
+
+	// force commit newly appended entries
+	err = w.Save(raftpb.HardState{}, ents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
 }
 
 func appendConfigChangeEnts(ents *[]raftpb.Entry) {

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -96,7 +96,7 @@ and output a hex encoded line of binary for each input line`)
 		if wd == "" {
 			wd = walDir(dataDir)
 		}
-		readRaw(lg, index, wd, os.Stdout)
+		readRaw(index, wd, os.Stdout)
 	}
 }
 
@@ -114,7 +114,7 @@ func readUsingReadAll(lg *zap.Logger, index *uint64, snapfile *string, dataDir s
 		walsnap.Index = *index
 	} else {
 		if *snapfile == "" {
-			ss := snap.New(zap.NewExample(), snapDir(dataDir))
+			ss := snap.New(lg, snapDir(dataDir))
 			snapshot, err = ss.Load()
 		} else {
 			snapshot, err = snap.Read(lg, filepath.Join(snapDir(dataDir), *snapfile))
@@ -381,7 +381,7 @@ func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry
 			printer(e)
 			if streamdecoder == "" {
 				fmt.Println()
-				//continue
+				continue
 			}
 
 			// if decoder is set, pass the e.Data to stdin and read the stdout from decoder

--- a/tools/etcd-dump-logs/raw.go
+++ b/tools/etcd-dump-logs/raw.go
@@ -67,7 +67,7 @@ func readRaw(lg *zap.Logger, fromIndex *uint64, waldir string, out io.Writer) {
 			continue
 		}
 		if errors.Is(err, io.EOF) {
-			lg.Info("EOF: All entries were processed")
+			fmt.Fprintf(out, "EOF: All entries were processed.\n")
 			break
 		} else {
 			lg.Error("Reading failed", zap.Error(err))

--- a/tools/etcd-dump-logs/raw.go
+++ b/tools/etcd-dump-logs/raw.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/pbutil"
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.etcd.io/raft/v3/raftpb"
+)
+
+func readRaw(lg *zap.Logger, fromIndex *uint64, waldir string, out io.Writer) {
+	var walReaders []fileutil.FileReader
+	files, err := ioutil.ReadDir(waldir)
+	if err != nil {
+		lg.Fatal("Failed to read directory.", zap.String("directory", waldir), zap.Error(err))
+	}
+	for _, finfo := range files {
+		if filepath.Ext(finfo.Name()) != ".wal" {
+			lg.Warn("Ignoring not .wal file", zap.String("filename", finfo.Name()))
+		}
+		f, err := os.Open(filepath.Join(waldir, finfo.Name()))
+		if err != nil {
+			lg.Fatal("Failed to read file", zap.String("filename", finfo.Name()), zap.Error(err))
+		}
+		walReaders = append(walReaders, fileutil.NewFileReader(f))
+	}
+	decoder := wal.NewDecoderAdvanced(true, walReaders...)
+	// The variable is used to not pollute log with multiple continuous crc errors.
+	crcDesync := false
+	for {
+		rec := walpb.Record{}
+		err := decoder.Decode(&rec)
+		if err == nil || errors.Is(err, walpb.ErrCRCMismatch) {
+			if err != nil && !crcDesync {
+				lg.Warn("Reading entry failed with CRC error", zap.Error(err))
+				crcDesync = true
+			}
+			printRec(lg, &rec, fromIndex, out)
+			if rec.Type == wal.CrcType {
+				decoder.UpdateCRC(rec.Crc)
+				crcDesync = false
+			}
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			lg.Info("EOF: All entries were processed")
+			break
+		} else {
+			lg.Error("Reading failed", zap.Error(err))
+			break
+		}
+	}
+}
+
+func printRec(lg *zap.Logger, rec *walpb.Record, fromIndex *uint64, out io.Writer) {
+	switch rec.Type {
+	case wal.MetadataType:
+		var metadata etcdserverpb.Metadata
+		pbutil.MustUnmarshal(&metadata, rec.Data)
+		fmt.Fprintf(out, "Metadata: %s\n", metadata.String())
+	case wal.CrcType:
+		fmt.Fprintf(out, "CRC: %d\n", rec.Crc)
+	case wal.EntryType:
+		e := wal.MustUnmarshalEntry(rec.Data)
+		if fromIndex == nil || e.Index >= *fromIndex {
+			fmt.Fprintf(out, "Entry: %s\n", e.String())
+		}
+	case wal.SnapshotType:
+		var snap walpb.Snapshot
+		pbutil.MustUnmarshal(&snap, rec.Data)
+		if fromIndex == nil || snap.Index >= *fromIndex {
+			fmt.Fprintf(out, "Snapshot: %s\n", snap.String())
+		}
+	case wal.StateType:
+		var state raftpb.HardState
+		pbutil.MustUnmarshal(&state, rec.Data)
+		if fromIndex == nil || state.Commit >= *fromIndex {
+			fmt.Fprintf(out, "HardState: %s\n", state.String())
+		}
+	default:
+		lg.Error("Unexpected WAL log type", zap.Int64("type", rec.Type))
+	}
+}

--- a/tools/etcd-dump-logs/raw_test.go
+++ b/tools/etcd-dump-logs/raw_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package main
 
 import (
@@ -51,5 +64,6 @@ Entry: Term:25 Index:31 Data:"\010\032\222K\007\n\005role3"
 Entry: Term:26 Index:32 Data:"\010\033\232K\033\n\005role3\022\022\010\001\022\004Keys\032\010RangeEnd" 
 Entry: Term:27 Index:33 Data:"\010\034\242K\026\n\005role3\022\003key\032\010rangeend" 
 Entry: Term:27 Index:34 Data:"?" 
+EOF: All entries were processed.
 `, out.String())
 }

--- a/tools/etcd-dump-logs/raw_test.go
+++ b/tools/etcd-dump-logs/raw_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func Test_readRaw(t *testing.T) {
+	path := t.TempDir()
+	mustCreateWalLog(t, path)
+	var out bytes.Buffer
+	readRaw(zaptest.NewLogger(t), nil, walDir(path), &out)
+	assert.Equal(t,
+		`CRC: 0
+Metadata: 
+Snapshot: 
+Entry: Term:1 Index:1 Type:EntryConfChange Data:"\010\001\020\000\030\002\"\000" 
+Entry: Term:2 Index:2 Type:EntryConfChange Data:"\010\002\020\001\030\002\"\000" 
+Entry: Term:2 Index:3 Type:EntryConfChange Data:"\010\003\020\002\030\002\"\000" 
+Entry: Term:2 Index:4 Type:EntryConfChange Data:"\010\004\020\003\030\003\"\000" 
+Entry: Term:3 Index:5 Data:"\010\000\022\000\032\006/path0\"\030{\"hey\":\"ho\",\"hi\":[\"yo\"]}(\0012\0008\000@\000H\tP\000X\001`+"`"+`\000h\000p\000x\001\200\001\000\210\001\000" 
+Entry: Term:3 Index:6 Data:"\010\001\022\004QGET\032\006/path1\"\023{\"0\":\"1\",\"2\":[\"3\"]}(\0002\0008\000@\000H\tP\000X\001`+"`"+`\000h\000p\000x\001\200\001\000\210\001\000" 
+Entry: Term:3 Index:7 Data:"\010\002\022\004SYNC\032\006/path2\"\023{\"0\":\"1\",\"2\":[\"3\"]}(\0002\0008\000@\000H\002P\000X\001`+"`"+`\000h\000p\000x\001\200\001\000\210\001\000" 
+Entry: Term:3 Index:8 Data:"\010\003\022\006DELETE\032\006/path3\"\030{\"hey\":\"ho\",\"hi\":[\"yo\"]}(\0002\0008\000@\001H\002P\000X\001`+"`"+`\000h\000p\000x\001\200\001\000\210\001\000" 
+Entry: Term:3 Index:9 Data:"\010\004\022\006RANDOM\032\246\001/path4/superlong/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path\"\030{\"hey\":\"ho\",\"hi\":[\"yo\"]}(\0002\0008\000@\000H\002P\000X\001`+"`"+`\000h\000p\000x\001\200\001\000\210\001\000" 
+Entry: Term:4 Index:10 Data:"\010\005\032\025\n\0011\022\002hi\030\006 \001(\001X\240\234\001h\240\234\001" 
+Entry: Term:5 Index:11 Data:"\010\006\"\020\n\004foo1\022\004bar1\030\0010\001" 
+Entry: Term:6 Index:12 Data:"\010\007*\010\n\0010\022\0019\030\001" 
+Entry: Term:7 Index:13 Data:"\010\0102\024\022\010\032\006\n\001a\022\001b\032\010\032\006\n\001a\022\001b" 
+Entry: Term:8 Index:14 Data:"\010\t:\002\020\001" 
+Entry: Term:9 Index:15 Data:"\010\nB\004\010\001\020\001" 
+Entry: Term:10 Index:16 Data:"\010\013J\002\010\002" 
+Entry: Term:11 Index:17 Data:"\010\014R\006\010\003\020\004\030\005" 
+Entry: Term:12 Index:18 Data:"\010\r\302>\000" 
+Entry: Term:13 Index:19 Data:"\010\016\232?\000" 
+Entry: Term:14 Index:20 Data:"\010\017\242?\031\n\006myname\022\010password\032\005token" 
+Entry: Term:15 Index:21 Data:"\010\020\342D\020\n\005name1\022\005pass1\032\000" 
+Entry: Term:16 Index:22 Data:"\010\021\352D\007\n\005name1" 
+Entry: Term:17 Index:23 Data:"\010\022\362D\007\n\005name1" 
+Entry: Term:18 Index:24 Data:"\010\023\372D\016\n\005name1\022\005pass2" 
+Entry: Term:19 Index:25 Data:"\010\024\202E\016\n\005user1\022\005role1" 
+Entry: Term:20 Index:26 Data:"\010\025\212E\016\n\005user2\022\005role2" 
+Entry: Term:21 Index:27 Data:"\010\026\222E\000" 
+Entry: Term:22 Index:28 Data:"\010\027\232E\000" 
+Entry: Term:23 Index:29 Data:"\010\030\202K\007\n\005role2" 
+Entry: Term:24 Index:30 Data:"\010\031\212K\007\n\005role1" 
+Entry: Term:25 Index:31 Data:"\010\032\222K\007\n\005role3" 
+Entry: Term:26 Index:32 Data:"\010\033\232K\033\n\005role3\022\022\010\001\022\004Keys\032\010RangeEnd" 
+Entry: Term:27 Index:33 Data:"\010\034\242K\026\n\005role3\022\003key\032\010rangeend" 
+Entry: Term:27 Index:34 Data:"?" 
+`, out.String())
+}

--- a/tools/etcd-dump-logs/raw_test.go
+++ b/tools/etcd-dump-logs/raw_test.go
@@ -18,14 +18,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zaptest"
 )
 
 func Test_readRaw(t *testing.T) {
 	path := t.TempDir()
 	mustCreateWalLog(t, path)
 	var out bytes.Buffer
-	readRaw(zaptest.NewLogger(t), nil, walDir(path), &out)
+	readRaw(nil, walDir(path), &out)
 	assert.Equal(t,
 		`CRC: 0
 Metadata: 


### PR DESCRIPTION
Before this PR diagnosing etcd not running due to crc wal log corruption landed with: 

```
$ go build ./tools/etcd-dump-logs/... && ./etcd-dump-logs ../../Downloads/data
{"level":"warn","msg":"found unexpected non-snap file; skipping","path":"gke-c10ed2ca2a3e4fb8a45f-ffba-8587271_status.txt"}
{"level":"warn","msg":"found unexpected non-snap file; skipping","path":"gke-c10ed2ca2a3e4fb8a45f-ffba-7612155_status.txt"}
Snapshot:
term=32 index=38873895 nodes=[b71f75320dc06a6c] confstate={"voters":[13195394291058371180],"auto_leave":false}
Start dumping log entries from snapshot.
2022/12/23 16:25:28 Failed reading WAL: walpb: crc mismatch
```

So we just now CRC got corrupted ... somewhere... 

With the PR:
```
$ go build ./tools/etcd-dump-logs/... && ./etcd-dump-logs --raw ../../Downloads/data > dump

2022/12/23 16:27:11 Failed reading WAL: walpb: crc mismatch: expected: 1d9658e9 computed: 37beb207: in file '0000000000000215-0000000002502c07.wal' at position: 37124224
p
```

In the dump file we see the exact record that got corrupted (index: 38856823): 
```
{"level":"warn","msg":"Reading entry failed with CRC error","error":"walpb: crc mismatch: expected: 1d9658e9 computed: 37beb207: in file '0000000000000215-0000000002502c07.wal' at position: 37124224"}
Entry: Term:32 Index:38856823 Data:"..."
HardState: term:32 vote:13195394291058371180 commit:38856823
```

We see that there were snapshots post this corruption. Last one: `Snapshot: index:38873895 term:32`

```
Entry: Term:32 Index:38882697 Data:"..."

HardState: term:32 vote:13195394291058371180 commit:38882697
```

So there were 38882697-38856823= 25874 entries written after the corruption. 

Ideally we should have a tool (based on the improved in this PR decoder) that allows to trim the WAL log file to contain just the last snapshot and all the follow up records (or just the entries that have 'index>=' `consistent_index` taken from bbolt.