### PR TITLE
Added 'secrets.GITHUB_TOKEN' for the static-analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,5 +17,6 @@ jobs:
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
         with:
           version: '3.14.0'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: make verify
       - run: make fix


### PR DESCRIPTION
We are constantly getting this error recently,

```
Run arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3
  with:
    version: 3.14.0
    include-pre-releases: false
Error: API rate limit exceeded for 40.84.170.113. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

See https://github.com/etcd-io/etcd/actions/runs/3783950658/jobs/6432877430 

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
