### PR TITLE
etcd-dump-logs: Make the tests work again.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/spf13/cobra v1.6.1
+	github.com/stretchr/testify v1.8.1
 	go.etcd.io/bbolt v1.3.6
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0
@@ -76,7 +77,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -15,13 +15,14 @@
 package main
 
 import (
-	"bytes"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/zap/zaptest"
 
@@ -40,6 +41,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// TODO(ptabor): The test does not run by default from ./scripts/test.sh.
 	dumpLogsBinary := path.Join(binDir + "/etcd-dump-logs")
 	if !fileutil.Exist(dumpLogsBinary) {
 		t.Skipf("%q does not exist", dumpLogsBinary)
@@ -116,16 +118,11 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Equal(actual, expected) {
-				t.Errorf(`Got input of length %d, wanted input of length %d
-==== BEGIN RECEIVED FILE ====
-%s
-==== END RECEIVED FILE ====
-==== BEGIN EXPECTED FILE ====
-%s
-==== END EXPECTED FILE ====
-`, len(actual), len(expected), actual, expected)
-			}
+
+			assert.EqualValues(t, string(expected), string(actual))
+			// The output files contains a lot of trailing whitespaces... difficult to diagnose without printing them explicitly.
+			// TODO(ptabor): Get rid of the whitespaces both in code and the test-files.
+			assert.EqualValues(t, strings.ReplaceAll(string(expected), " ", "_"), strings.ReplaceAll(string(actual), " ", "_"))
 		})
 	}
 

--- a/tools/etcd-dump-logs/expectedoutput/decoder_correctoutputformat.output
+++ b/tools/etcd-dump-logs/expectedoutput/decoder_correctoutputformat.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data	decoder_status	decoded_data
    1	         1	conf	method=ConfChangeAddNode id=2	ERROR	jhjaajjjahjbbbjj
@@ -29,7 +29,7 @@ term	     index	type	data	decoder_status	decoded_data
   15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 	OK	jhajebddajjajefefafdfecaabjegjfagcgccaaajj
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 	OK	jhaaeaddjgjajefefafdfeca
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 	OK	jhabfbddjgjajefefafdfeca
-  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 	OK	jhacfaddjejajefefafdfecaabjegjfagcgccb
+  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"<value removed>" > 	OK	jhacfaddjejajefefafdfecaabjegjfagcgccb
   19	        25	norm	ID:20 auth_user_grant_role:<user:"user1" role:"role1" > 	OK	jhadhbdejejajegegcfegbcaabjegbfffcfeca
   20	        26	norm	ID:21 auth_user_revoke_role:<name:"user2" role:"role2" > 	OK	jhaehadejejajegegcfegbcbabjegbfffcfecb
   21	        27	norm	ID:22 auth_user_list:<> 	ERROR	jhafibdejj

--- a/tools/etcd-dump-logs/expectedoutput/decoder_wrongoutputformat.output
+++ b/tools/etcd-dump-logs/expectedoutput/decoder_wrongoutputformat.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data	decoder_status	decoded_data
    1	         1	conf	method=ConfChangeAddNode id=2	decoder output format is not right, print output anyway	jhjaajjjahjbbbjj
@@ -29,7 +29,7 @@ term	     index	type	data	decoder_status	decoded_data
   15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 	decoder output format is not right, print output anyway	jhajebddajjajefefafdfecaabjegjfagcgccaaajj
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 	decoder output format is not right, print output anyway	jhaaeaddjgjajefefafdfeca
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 	decoder output format is not right, print output anyway	jhabfbddjgjajefefafdfeca
-  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 	decoder output format is not right, print output anyway	jhacfaddjejajefefafdfecaabjegjfagcgccb
+  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"<value removed>" > 	decoder output format is not right, print output anyway	jhacfaddjejajefefafdfecaabjegjfagcgccb
   19	        25	norm	ID:20 auth_user_grant_role:<user:"user1" role:"role1" > 	decoder output format is not right, print output anyway	jhadhbdejejajegegcfegbcaabjegbfffcfeca
   20	        26	norm	ID:21 auth_user_revoke_role:<name:"user2" role:"role2" > 	decoder output format is not right, print output anyway	jhaehadejejajegegcfegbcbabjegbfffcfecb
   21	        27	norm	ID:22 auth_user_list:<> 	decoder output format is not right, print output anyway	jhafibdejj

--- a/tools/etcd-dump-logs/expectedoutput/listAll.output
+++ b/tools/etcd-dump-logs/expectedoutput/listAll.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    1	         1	conf	method=ConfChangeAddNode id=2
@@ -29,7 +29,7 @@ term	     index	type	data
   15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
-  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 
+  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"<value removed>" > 
   19	        25	norm	ID:20 auth_user_grant_role:<user:"user1" role:"role1" > 
   20	        26	norm	ID:21 auth_user_revoke_role:<name:"user2" role:"role2" > 
   21	        27	norm	ID:22 auth_user_list:<> 

--- a/tools/etcd-dump-logs/expectedoutput/listConfigChange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listConfigChange.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    1	         1	conf	method=ConfChangeAddNode id=2

--- a/tools/etcd-dump-logs/expectedoutput/listConfigChangeIRRCompaction.output
+++ b/tools/etcd-dump-logs/expectedoutput/listConfigChangeIRRCompaction.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    1	         1	conf	method=ConfChangeAddNode id=2

--- a/tools/etcd-dump-logs/expectedoutput/listIRRCompaction.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRCompaction.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    8	        14	norm	ID:9 compaction:<physical:true > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRDeleteRange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRDeleteRange.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    6	        12	norm	ID:7 delete_range:<key:"0" range_end:"9" prev_kv:true > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRLeaseGrant.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRLeaseGrant.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    9	        15	norm	ID:10 lease_grant:<TTL:1 ID:1 > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRLeaseRevoke.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRLeaseRevoke.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
   10	        16	norm	ID:11 lease_revoke:<ID:2 > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRPut.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRPut.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    5	        11	norm	ID:6 put:<key:"foo1" value:"bar1" lease:1 ignore_lease:true > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRRange.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRRange.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    4	        10	norm	ID:5 range:<key:"1" range_end:"hi" limit:6 revision:1 sort_order:ASCEND max_mod_revision:20000 max_create_revision:20000 > 

--- a/tools/etcd-dump-logs/expectedoutput/listIRRTxn.output
+++ b/tools/etcd-dump-logs/expectedoutput/listIRRTxn.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    7	        13	norm	ID:8 txn:<success:<request_delete_range:<key:"a" range_end:"b" > > failure:<request_delete_range:<key:"a" range_end:"b" > > > 

--- a/tools/etcd-dump-logs/expectedoutput/listInternalRaftRequest.output
+++ b/tools/etcd-dump-logs/expectedoutput/listInternalRaftRequest.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    4	        10	norm	ID:5 range:<key:"1" range_end:"hi" limit:6 revision:1 sort_order:ASCEND max_mod_revision:20000 max_create_revision:20000 > 
@@ -20,7 +20,7 @@ term	     index	type	data
   15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
-  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 
+  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"<value removed>" > 
   19	        25	norm	ID:20 auth_user_grant_role:<user:"user1" role:"role1" > 
   20	        26	norm	ID:21 auth_user_revoke_role:<name:"user2" role:"role2" > 
   21	        27	norm	ID:22 auth_user_list:<> 

--- a/tools/etcd-dump-logs/expectedoutput/listNormal.output
+++ b/tools/etcd-dump-logs/expectedoutput/listNormal.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    3	         5	norm	noop
@@ -25,7 +25,7 @@ term	     index	type	data
   15	        21	norm	ID:16 auth_user_add:<name:"name1" password:"pass1" options:<> > 
   16	        22	norm	ID:17 auth_user_delete:<name:"name1" > 
   17	        23	norm	ID:18 auth_user_get:<name:"name1" > 
-  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"pass2" > 
+  18	        24	norm	ID:19 auth_user_change_password:<name:"name1" password:"<value removed>" > 
   19	        25	norm	ID:20 auth_user_grant_role:<user:"user1" role:"role1" > 
   20	        26	norm	ID:21 auth_user_revoke_role:<name:"user2" role:"role2" > 
   21	        27	norm	ID:22 auth_user_list:<> 

--- a/tools/etcd-dump-logs/expectedoutput/listRequest.output
+++ b/tools/etcd-dump-logs/expectedoutput/listRequest.output
@@ -3,7 +3,7 @@ empty
 Start dumping log entries from snapshot.
 WAL metadata:
 nodeID=0 clusterID=0 term=0 commitIndex=0 vote=0
-WAL entries:
+WAL entries: 34
 lastIndex=34
 term	     index	type	data
    3	         5	norm	noop


### PR DESCRIPTION
The tests are subtle as they skip if the binary is not generated in the local directory.

$ go build . && go test
PASS
ok      go.etcd.io/etcd/v3/tools/etcd-dump-logs 0.769s

Signed-off-by: Piotr Tabor <ptab@google.com>
