### PR TITLE
[3.4] backports #11990 #12933

### DIFF
--- a/etcdctl/ctlv3/command/get_command.go
+++ b/etcdctl/ctlv3/command/get_command.go
@@ -31,6 +31,7 @@ var (
 	getFromKey     bool
 	getRev         int64
 	getKeysOnly    bool
+	getCountOnly   bool
 	printValueOnly bool
 )
 
@@ -50,6 +51,7 @@ func NewGetCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&getFromKey, "from-key", false, "Get keys that are greater than or equal to the given key using byte compare")
 	cmd.Flags().Int64Var(&getRev, "rev", 0, "Specify the kv revision")
 	cmd.Flags().BoolVar(&getKeysOnly, "keys-only", false, "Get only the keys")
+	cmd.Flags().BoolVar(&getCountOnly, "count-only", false, "Get only the count")
 	cmd.Flags().BoolVar(&printValueOnly, "print-value-only", false, `Only write values when using the "simple" output format`)
 	return cmd
 }
@@ -62,6 +64,12 @@ func getCommandFunc(cmd *cobra.Command, args []string) {
 	cancel()
 	if err != nil {
 		ExitWithError(ExitError, err)
+	}
+
+	if getCountOnly {
+		if _, fields := display.(*fieldsPrinter); !fields {
+			ExitWithError(ExitBadArgs, fmt.Errorf("--count-only is only for `--write-out=fields`"))
+		}
 	}
 
 	if printValueOnly {
@@ -81,6 +89,10 @@ func getGetOp(args []string) (string, []clientv3.OpOption) {
 
 	if getPrefix && getFromKey {
 		ExitWithError(ExitBadArgs, fmt.Errorf("`--prefix` and `--from-key` cannot be set at the same time, choose one"))
+	}
+
+	if getKeysOnly && getCountOnly {
+		ExitWithError(ExitBadArgs, fmt.Errorf("`--keys-only` and `--count-only` cannot be set at the same time, choose one"))
 	}
 
 	opts := []clientv3.OpOption{}
@@ -157,6 +169,10 @@ func getGetOp(args []string) (string, []clientv3.OpOption) {
 
 	if getKeysOnly {
 		opts = append(opts, clientv3.WithKeysOnly())
+	}
+
+	if getCountOnly {
+		opts = append(opts, clientv3.WithCountOnly())
 	}
 
 	return key, opts

--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -82,6 +82,12 @@ type Snapshot interface {
 	Close() error
 }
 
+type txReadBufferCache struct {
+	mu         sync.Mutex
+	buf        *txReadBuffer
+	bufVersion uint64
+}
+
 type backend struct {
 	// size and commits are used with atomic operations so they must be
 	// 64-bit aligned, otherwise 32-bit tests will crash
@@ -104,6 +110,11 @@ type backend struct {
 	batchTx       *batchTxBuffered
 
 	readTx *readTx
+	// txReadBufferCache mirrors "txReadBuffer" within "readTx" -- readTx.baseReadTx.buf.
+	// When creating "concurrentReadTx":
+	// - if the cache is up-to-date, "readTx.baseReadTx.buf" copy can be skipped
+	// - if the cache is empty or outdated, "readTx.baseReadTx.buf" copy is required
+	txReadBufferCache txReadBufferCache
 
 	stopc chan struct{}
 	donec chan struct{}
@@ -176,10 +187,16 @@ func newBackend(bcfg BackendConfig) *backend {
 
 		readTx: &readTx{
 			buf: txReadBuffer{
-				txBuffer: txBuffer{make(map[string]*bucketBuffer)},
+				txBuffer:   txBuffer{make(map[string]*bucketBuffer)},
+				bufVersion: 0,
 			},
 			buckets: make(map[string]*bolt.Bucket),
 			txWg:    new(sync.WaitGroup),
+		},
+		txReadBufferCache: txReadBufferCache{
+			mu:         sync.Mutex{},
+			bufVersion: 0,
+			buf:        nil,
 		},
 
 		stopc: make(chan struct{}),
@@ -187,6 +204,7 @@ func newBackend(bcfg BackendConfig) *backend {
 
 		lg: bcfg.Logger,
 	}
+
 	b.batchTx = newBatchTxBuffered(b)
 	go b.run()
 	return b
@@ -209,9 +227,67 @@ func (b *backend) ConcurrentReadTx() ReadTx {
 	defer b.readTx.RUnlock()
 	// prevent boltdb read Tx from been rolled back until store read Tx is done. Needs to be called when holding readTx.RLock().
 	b.readTx.txWg.Add(1)
+
 	// TODO: might want to copy the read buffer lazily - create copy when A) end of a write transaction B) end of a batch interval.
+
+	// inspect/update cache recency iff there's no ongoing update to the cache
+	// this falls through if there's no cache update
+
+	// by this line, "ConcurrentReadTx" code path is already protected against concurrent "writeback" operations
+	// which requires write lock to update "readTx.baseReadTx.buf".
+	// Which means setting "buf *txReadBuffer" with "readTx.buf.unsafeCopy()" is guaranteed to be up-to-date,
+	// whereas "txReadBufferCache.buf" may be stale from concurrent "writeback" operations.
+	// We only update "txReadBufferCache.buf" if we know "buf *txReadBuffer" is up-to-date.
+	// The update to "txReadBufferCache.buf" will benefit the following "ConcurrentReadTx" creation
+	// by avoiding copying "readTx.baseReadTx.buf".
+	b.txReadBufferCache.mu.Lock()
+
+	curCache := b.txReadBufferCache.buf
+	curCacheVer := b.txReadBufferCache.bufVersion
+	curBufVer := b.readTx.buf.bufVersion
+
+	isEmptyCache := curCache == nil
+	isStaleCache := curCacheVer != curBufVer
+
+	var buf *txReadBuffer
+	switch {
+	case isEmptyCache:
+		// perform safe copy of buffer while holding "b.txReadBufferCache.mu.Lock"
+		// this is only supposed to run once so there won't be much overhead
+		curBuf := b.readTx.buf.unsafeCopy()
+		buf = &curBuf
+	case isStaleCache:
+		// to maximize the concurrency, try unsafe copy of buffer
+		// release the lock while copying buffer -- cache may become stale again and
+		// get overwritten by someone else.
+		// therefore, we need to check the readTx buffer version again
+		b.txReadBufferCache.mu.Unlock()
+		curBuf := b.readTx.buf.unsafeCopy()
+		b.txReadBufferCache.mu.Lock()
+		buf = &curBuf
+	default:
+		// neither empty nor stale cache, just use the current buffer
+		buf = curCache
+	}
+	// txReadBufferCache.bufVersion can be modified when we doing an unsafeCopy()
+	// as a result, curCacheVer could be no longer the same as
+	// txReadBufferCache.bufVersion
+	// if !isEmptyCache && curCacheVer != b.txReadBufferCache.bufVersion
+	// then the cache became stale while copying "readTx.baseReadTx.buf".
+	// It is safe to not update "txReadBufferCache.buf", because the next following
+	// "ConcurrentReadTx" creation will trigger a new "readTx.baseReadTx.buf" copy
+	// and "buf" is still used for the current "concurrentReadTx.baseReadTx.buf".
+	if isEmptyCache || curCacheVer == b.txReadBufferCache.bufVersion {
+		// continue if the cache is never set or no one has modified the cache
+		b.txReadBufferCache.buf = buf
+		b.txReadBufferCache.bufVersion = curBufVer
+	}
+
+	b.txReadBufferCache.mu.Unlock()
+
+	// concurrentReadTx is not supposed to write to its txReadBuffer
 	return &concurrentReadTx{
-		buf:     b.readTx.buf.unsafeCopy(),
+		buf:     *buf,
 		tx:      b.readTx.tx,
 		txMu:    &b.readTx.txMu,
 		buckets: b.readTx.buckets,

--- a/mvcc/index.go
+++ b/mvcc/index.go
@@ -25,8 +25,8 @@ import (
 type index interface {
 	Get(key []byte, atRev int64) (rev, created revision, ver int64, err error)
 	Range(key, end []byte, atRev int64) ([][]byte, []revision)
-	Revisions(key, end []byte, atRev int64, limit int) []revision
-	CountRevisions(key, end []byte, atRev int64, limit int) int
+	Revisions(key, end []byte, atRev int64, limit int) ([]revision, int)
+	CountRevisions(key, end []byte, atRev int64) int
 	Put(key []byte, rev revision)
 	Tombstone(key []byte, rev revision) error
 	RangeSince(key, end []byte, rev int64) []revision
@@ -106,27 +106,27 @@ func (ti *treeIndex) visit(key, end []byte, f func(ki *keyIndex) bool) {
 	})
 }
 
-func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int) (revs []revision) {
+func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int) (revs []revision, total int) {
 	if end == nil {
 		rev, _, _, err := ti.Get(key, atRev)
 		if err != nil {
-			return nil
+			return nil, 0
 		}
-		return []revision{rev}
+		return []revision{rev}, 1
 	}
 	ti.visit(key, end, func(ki *keyIndex) bool {
 		if rev, _, _, err := ki.get(ti.lg, atRev); err == nil {
-			revs = append(revs, rev)
-			if len(revs) == limit {
-				return false
+			if limit <= 0 || len(revs) < limit {
+				revs = append(revs, rev)
 			}
+			total++
 		}
 		return true
 	})
-	return revs
+	return revs, total
 }
 
-func (ti *treeIndex) CountRevisions(key, end []byte, atRev int64, limit int) int {
+func (ti *treeIndex) CountRevisions(key, end []byte, atRev int64) int {
 	if end == nil {
 		_, _, _, err := ti.Get(key, atRev)
 		if err != nil {
@@ -138,9 +138,6 @@ func (ti *treeIndex) CountRevisions(key, end []byte, atRev int64, limit int) int
 	ti.visit(key, end, func(ki *keyIndex) bool {
 		if _, _, _, err := ki.get(ti.lg, atRev); err == nil {
 			total++
-			if total == limit {
-				return false
-			}
 		}
 		return true
 	})

--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -242,8 +242,12 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 		if r.Rev != wrev {
 			t.Errorf("#%d: rev = %d, want %d", i, r.Rev, wrev)
 		}
-		if r.Count != len(kvs) {
-			t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
+		if tt.limit <= 0 || int(tt.limit) > len(kvs) {
+			if r.Count != len(kvs) {
+				t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
+			}
+		} else if r.Count != int(tt.limit) {
+			t.Errorf("#%d: count = %d, want %d", i, r.Count, tt.limit)
 		}
 	}
 }

--- a/mvcc/kv_test.go
+++ b/mvcc/kv_test.go
@@ -219,17 +219,18 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 
 	wrev := int64(4)
 	tests := []struct {
-		limit int64
-		wkvs  []mvccpb.KeyValue
+		limit   int64
+		wcounts int64
+		wkvs    []mvccpb.KeyValue
 	}{
 		// no limit
-		{-1, kvs},
+		{-1, 3, kvs},
 		// no limit
-		{0, kvs},
-		{1, kvs[:1]},
-		{2, kvs[:2]},
-		{3, kvs},
-		{100, kvs},
+		{0, 3, kvs},
+		{1, 3, kvs[:1]},
+		{2, 3, kvs[:2]},
+		{3, 3, kvs},
+		{100, 3, kvs},
 	}
 	for i, tt := range tests {
 		r, err := f(s, []byte("foo"), []byte("foo3"), RangeOptions{Limit: tt.limit})
@@ -246,7 +247,7 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 			if r.Count != len(kvs) {
 				t.Errorf("#%d: count = %d, want %d", i, r.Count, len(kvs))
 			}
-		} else if r.Count != int(tt.limit) {
+		} else if r.Count != int(tt.wcounts) {
 			t.Errorf("#%d: count = %d, want %d", i, r.Count, tt.limit)
 		}
 	}

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -936,12 +936,12 @@ type fakeIndex struct {
 	indexCompactRespc     chan map[revision]struct{}
 }
 
-func (i *fakeIndex) Revisions(key, end []byte, atRev int64) []revision {
+func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int) []revision {
 	_, rev := i.Range(key, end, atRev)
 	return rev
 }
 
-func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
+func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64, limit int) int {
 	_, rev := i.Range(key, end, atRev)
 	return len(rev)
 }

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -941,6 +941,11 @@ func (i *fakeIndex) Revisions(key, end []byte, atRev int64) []revision {
 	return rev
 }
 
+func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
+	_, rev := i.Range(key, end, atRev)
+	return len(rev)
+}
+
 func (i *fakeIndex) Get(key []byte, atRev int64) (rev, created revision, ver int64, err error) {
 	i.Recorder.Record(testutil.Action{Name: "get", Params: []interface{}{key, atRev}})
 	r := <-i.indexGetRespc

--- a/mvcc/kvstore_test.go
+++ b/mvcc/kvstore_test.go
@@ -936,12 +936,15 @@ type fakeIndex struct {
 	indexCompactRespc     chan map[revision]struct{}
 }
 
-func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int) []revision {
+func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int) ([]revision, int) {
 	_, rev := i.Range(key, end, atRev)
-	return rev
+	if len(rev) >= limit {
+		rev = rev[:limit]
+	}
+	return rev, len(rev)
 }
 
-func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64, limit int) int {
+func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
 	_, rev := i.Range(key, end, atRev)
 	return len(rev)
 }

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -126,11 +126,11 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
 	if ro.Count {
-		total := tr.s.kvindex.CountRevisions(key, end, rev)
+		total := tr.s.kvindex.CountRevisions(key, end, rev, int(ro.Limit))
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
-	revpairs := tr.s.kvindex.Revisions(key, end, rev)
+	revpairs := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit))
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -125,14 +125,15 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 	if rev < tr.s.compactMainRev {
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
-
+	if ro.Count {
+		total := tr.s.kvindex.CountRevisions(key, end, rev)
+		tr.trace.Step("count revisions from in-memory index tree")
+		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
+	}
 	revpairs := tr.s.kvindex.Revisions(key, end, rev)
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
-	}
-	if ro.Count {
-		return &RangeResult{KVs: nil, Count: len(revpairs), Rev: curRev}, nil
 	}
 
 	limit := int(ro.Limit)

--- a/mvcc/kvstore_txn.go
+++ b/mvcc/kvstore_txn.go
@@ -126,14 +126,14 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
 	if ro.Count {
-		total := tr.s.kvindex.CountRevisions(key, end, rev, int(ro.Limit))
+		total := tr.s.kvindex.CountRevisions(key, end, rev)
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
-	revpairs := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit))
+	revpairs, total := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit))
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
-		return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
+		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
 
 	limit := int(ro.Limit)
@@ -176,7 +176,7 @@ func (tr *storeTxnRead) rangeKeys(key, end []byte, curRev int64, ro RangeOptions
 		}
 	}
 	tr.trace.Step("range keys from bolt db")
-	return &RangeResult{KVs: kvs, Count: len(revpairs), Rev: curRev}, nil
+	return &RangeResult{KVs: kvs, Count: total, Rev: curRev}, nil
 }
 
 func (tw *storeTxnWrite) put(key, value []byte, leaseID lease.LeaseID) {

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -41,9 +41,10 @@ func TestCtlV3GetPeerTLS(t *testing.T)       { testCtl(t, getTest, withCfg(confi
 func TestCtlV3GetTimeout(t *testing.T)       { testCtl(t, getTest, withDialTimeout(0)) }
 func TestCtlV3GetQuorum(t *testing.T)        { testCtl(t, getTest, withQuorum()) }
 
-func TestCtlV3GetFormat(t *testing.T)   { testCtl(t, getFormatTest) }
-func TestCtlV3GetRev(t *testing.T)      { testCtl(t, getRevTest) }
-func TestCtlV3GetKeysOnly(t *testing.T) { testCtl(t, getKeysOnlyTest) }
+func TestCtlV3GetFormat(t *testing.T)    { testCtl(t, getFormatTest) }
+func TestCtlV3GetRev(t *testing.T)       { testCtl(t, getRevTest) }
+func TestCtlV3GetKeysOnly(t *testing.T)  { testCtl(t, getKeysOnlyTest) }
+func TestCtlV3GetCountOnly(t *testing.T) { testCtl(t, getCountOnlyTest) }
 
 func TestCtlV3Del(t *testing.T)          { testCtl(t, delTest) }
 func TestCtlV3DelNoTLS(t *testing.T)     { testCtl(t, delTest, withCfg(configNoTLS)) }
@@ -232,6 +233,44 @@ func getKeysOnlyTest(cx ctlCtx) {
 	}
 	if err := spawnWithExpects(cmdArgs, "val"); err == nil {
 		cx.t.Fatalf("got value but passed --keys-only")
+	}
+}
+
+func getCountOnlyTest(cx ctlCtx) {
+	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
+	if err := spawnWithExpects(cmdArgs, "\"Count\" : 0"); err != nil {
+		cx.t.Fatal(err)
+	}
+	if err := ctlV3Put(cx, "key", "val", ""); err != nil {
+		cx.t.Fatal(err)
+	}
+	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
+	if err := spawnWithExpects(cmdArgs, "\"Count\" : 1"); err != nil {
+		cx.t.Fatal(err)
+	}
+	if err := ctlV3Put(cx, "key1", "val", ""); err != nil {
+		cx.t.Fatal(err)
+	}
+	if err := ctlV3Put(cx, "key1", "val", ""); err != nil {
+		cx.t.Fatal(err)
+	}
+	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
+	if err := spawnWithExpects(cmdArgs, "\"Count\" : 2"); err != nil {
+		cx.t.Fatal(err)
+	}
+	if err := ctlV3Put(cx, "key2", "val", ""); err != nil {
+		cx.t.Fatal(err)
+	}
+	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
+	if err := spawnWithExpects(cmdArgs, "\"Count\" : 3"); err != nil {
+		cx.t.Fatal(err)
+	}
+	expected := []string{
+		"\"Count\" : 3",
+	}
+	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key3", "--prefix", "--write-out=fields"}...)
+	if err := spawnWithExpects(cmdArgs, expected...); err == nil {
+		cx.t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
It is trying to backport two improvements into release 3.4.

* Reduce memory when Range for total or with limit count
    * #11771
    * #11990
    * #13060
* Reduce expensive deepCopy when create ConcurrentReadTx
    * #12933
    * Fixes #11783: When there is only read requests, the throughput will be limited by go-runtime gc.


<details>
<summary>Click to check rw-heatmap benchmark result</summary>

Use https://github.com/fuweid/etcd/tree/tools-use-imshow-instead-of-tripcolor to render heatmap

![backports_read](https://user-images.githubusercontent.com/17510957/211281919-a8f1f2f2-748f-49a1-861c-73482fd33d85.png)
![backports_write](https://user-images.githubusercontent.com/17510957/211282032-32acc20d-22d1-4a09-9e20-d6d03a4e8e2a.png)

[backports-based-on-v3.4.23.csv](https://github.com/etcd-io/etcd/files/10372111/backports-based-on-v3.4.23.csv)
[v3.4.23.csv](https://github.com/etcd-io/etcd/files/10372122/v3.4.23.csv)

</details>

<details>
<summary>Click to check range not-found key benchmark result</summary>

Based on steps provided by #11783, the script is like

```bash
   cd /data
    export CLIENT_PORT="23790"
    export BACKEND_SIZE="$((20 * 1024 * 1024 * 1024))"
    /root/etcd/bin/etcd --quota-backend-bytes=${BACKEND_SIZE} \
      --log-level 'error' \
      --listen-client-urls http://0.0.0.0:${CLIENT_PORT} \
      --advertise-client-urls http://127.0.0.1:${CLIENT_PORT} \
      &>/dev/null &
    sleep 5

    /root/etcd/bin/tools/benchmark --endpoints http://127.0.0.1:${CLIENT_PORT} \
       --clients 1000 --conns 100 \
       put --key-size 8 --val-size 256 --total 100000

    sleep 2

    /root/etcd/bin/tools/benchmark --endpoints http://127.0.0.1:${CLIENT_PORT} \
       --clients 1000 --conns 100 \
       range 12345678123456781234567812345678 --consistency=l --total 100000
```

* v3.4.23: Requests/sec: 26169.3610
* Backport: Requests/sec: 127041.7200
</details>

Hope it is acceptable!

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
