### PR TITLE
tests: Use watch events to patch history to speed up linearization

### DIFF
--- a/tests/linearizability/history.go
+++ b/tests/linearizability/history.go
@@ -197,11 +197,15 @@ func getRequest(key string) EtcdRequest {
 }
 
 func getResponse(value string, revision int64) EtcdResponse {
-	return EtcdResponse{Result: []EtcdOperationResult{{Value: value}}, Revision: revision}
+	return EtcdResponse{OpsResult: []EtcdOperationResult{{Value: value}}, Revision: revision}
 }
 
 func failedResponse(err error) EtcdResponse {
 	return EtcdResponse{Err: err}
+}
+
+func unknownResponse(revision int64) EtcdResponse {
+	return EtcdResponse{ResultUnknown: true, Revision: revision}
 }
 
 func putRequest(key, value string) EtcdRequest {
@@ -209,7 +213,7 @@ func putRequest(key, value string) EtcdRequest {
 }
 
 func putResponse(revision int64) EtcdResponse {
-	return EtcdResponse{Result: []EtcdOperationResult{{}}, Revision: revision}
+	return EtcdResponse{OpsResult: []EtcdOperationResult{{}}, Revision: revision}
 }
 
 func deleteRequest(key string) EtcdRequest {
@@ -217,7 +221,7 @@ func deleteRequest(key string) EtcdRequest {
 }
 
 func deleteResponse(deleted int64, revision int64) EtcdResponse {
-	return EtcdResponse{Result: []EtcdOperationResult{{Deleted: deleted}}, Revision: revision}
+	return EtcdResponse{OpsResult: []EtcdOperationResult{{Deleted: deleted}}, Revision: revision}
 }
 
 func txnRequest(key, expectValue, newValue string) EtcdRequest {
@@ -229,7 +233,7 @@ func txnResponse(succeeded bool, revision int64) EtcdResponse {
 	if succeeded {
 		result = []EtcdOperationResult{{}}
 	}
-	return EtcdResponse{Result: result, TxnFailure: !succeeded, Revision: revision}
+	return EtcdResponse{OpsResult: result, TxnResult: !succeeded, Revision: revision}
 }
 
 func putWithLeaseRequest(key, value string, leaseID int64) EtcdRequest {
@@ -241,7 +245,7 @@ func leaseGrantRequest(leaseID int64) EtcdRequest {
 }
 
 func leaseGrantResponse(revision int64) EtcdResponse {
-	return EtcdResponse{Result: []EtcdOperationResult{{}}, Revision: revision}
+	return EtcdResponse{OpsResult: []EtcdOperationResult{{}}, Revision: revision}
 }
 
 func leaseRevokeRequest(leaseID int64) EtcdRequest {
@@ -249,7 +253,7 @@ func leaseRevokeRequest(leaseID int64) EtcdRequest {
 }
 
 func leaseRevokeResponse(revision int64) EtcdResponse {
-	return EtcdResponse{Result: []EtcdOperationResult{{}}, Revision: revision}
+	return EtcdResponse{OpsResult: []EtcdOperationResult{{}}, Revision: revision}
 }
 
 type history struct {

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/anishathalye/porcupine"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
@@ -102,7 +104,9 @@ func TestLinearizability(t *testing.T) {
 				clientCount: 8,
 				traffic:     DefaultTraffic,
 			})
-			validateEventsMatch(t, events)
+			longestHistory, remainingEvents := pickLongestHistory(events)
+			validateEventsMatch(t, longestHistory, remainingEvents)
+			operations = patchOperationBasedOnWatchEvents(operations, longestHistory)
 			checkOperationsAndPersistResults(t, operations, clus)
 		})
 	}
@@ -131,6 +135,75 @@ func testLinearizability(ctx context.Context, t *testing.T, clus *e2e.EtcdProces
 	})
 	g.Wait()
 	return operations, events
+}
+
+func patchOperationBasedOnWatchEvents(operations []porcupine.Operation, watchEvents []watchEvent) []porcupine.Operation {
+	newOperations := make([]porcupine.Operation, 0, len(operations))
+	persisted := map[EtcdOperation]watchEvent{}
+	for _, op := range watchEvents {
+		persisted[op.Op] = op
+	}
+	lastObservedEventTime := watchEvents[len(watchEvents)-1].Time
+
+	for _, op := range operations {
+		resp := op.Output.(EtcdResponse)
+		if resp.Err == nil || op.Call > lastObservedEventTime.UnixNano() {
+			// No need to patch successfully requests and cannot patch requests outside observed window.
+			newOperations = append(newOperations, op)
+			continue
+		}
+		event, hasUniqueWriteOperation := matchWatchEvent(op, persisted)
+		if event != nil {
+			// Set revision and time based on watchEvent.
+			op.Return = event.Time.UnixNano()
+			op.Output = EtcdResponse{
+				Revision:      event.Revision,
+				ResultUnknown: true,
+			}
+			newOperations = append(newOperations, op)
+			continue
+		}
+		if hasWriteOperation(op) && !hasUniqueWriteOperation {
+			// Leave operation as it is as we cannot match non-unique operations to watch events.
+			newOperations = append(newOperations, op)
+			continue
+		}
+		// Remove non persisted operations
+	}
+	return newOperations
+}
+
+func matchWatchEvent(op porcupine.Operation, watchEvents map[EtcdOperation]watchEvent) (event *watchEvent, hasUniqueWriteOperation bool) {
+	request := op.Input.(EtcdRequest)
+	for _, etcdOp := range request.Ops {
+		if isWrite(etcdOp.Type) && inUnique(etcdOp.Type) {
+			// We expect all put to be unique as they write unique value.
+			hasUniqueWriteOperation = true
+			opType := etcdOp.Type
+			if opType == PutWithLease {
+				opType = Put
+			}
+			event, ok := watchEvents[EtcdOperation{
+				Type:  opType,
+				Key:   etcdOp.Key,
+				Value: etcdOp.Value,
+			}]
+			if ok {
+				return &event, hasUniqueWriteOperation
+			}
+		}
+	}
+	return nil, hasUniqueWriteOperation
+}
+
+func hasWriteOperation(op porcupine.Operation) bool {
+	request := op.Input.(EtcdRequest)
+	for _, etcdOp := range request.Ops {
+		if isWrite(etcdOp.Type) {
+			return true
+		}
+	}
+	return false
 }
 
 func triggerFailpoints(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessCluster, config FailpointConfig) {
@@ -213,20 +286,18 @@ type trafficConfig struct {
 	traffic     Traffic
 }
 
-func validateEventsMatch(t *testing.T, ops [][]watchEvent) {
-	// Move longest history to ops[0]
-	maxLength := len(ops[0])
-	for i := 1; i < len(ops); i++ {
-		if len(ops[i]) > maxLength {
-			maxLength = len(ops[i])
-			ops[0], ops[i] = ops[i], ops[0]
-		}
-	}
+func pickLongestHistory(ops [][]watchEvent) (longest []watchEvent, rest [][]watchEvent) {
+	sort.Slice(ops, func(i, j int) bool {
+		return len(ops[i]) > len(ops[j])
+	})
+	return ops[0], ops[1:]
+}
 
-	for i := 1; i < len(ops); i++ {
-		length := len(ops[i])
+func validateEventsMatch(t *testing.T, longestHistory []watchEvent, other [][]watchEvent) {
+	for i := 0; i < len(other); i++ {
+		length := len(other[i])
 		// We compare prefix of watch events, as we are not guaranteed to collect all events from each node.
-		if diff := cmp.Diff(ops[0][:length], ops[i][:length]); diff != "" {
+		if diff := cmp.Diff(longestHistory[:length], other[i][:length], cmpopts.IgnoreFields(watchEvent{}, "Time")); diff != "" {
 			t.Errorf("Events in watches do not match, %s", diff)
 		}
 	}


### PR DESCRIPTION
cc @ahrtr @ptabor 