### PR TITLE
Bump go to 1.19.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.4"
+          go-version: "1.19.5"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -8,5 +8,5 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: make -C contrib/mixin tools test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: GOARCH=amd64 CPU=4 make fuzz
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure()

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.4"
+          go-version: "1.19.5"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@v0.0.0-20221208180742-f2dca5ff4cc3 && govulncheck ./...

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/linearizability-nightly.yaml
+++ b/.github/workflows/linearizability-nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: |
         make gofail-enable
         make build

--- a/.github/workflows/linearizability.yaml
+++ b/.github/workflows/linearizability.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: |
         make gofail-enable
         make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: |
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.4"
+          go-version: "1.19.5"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.4"
+        go-version: "1.19.5"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/tests/functional/Dockerfile
+++ b/tests/functional/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf check-update || true \
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
-ENV GO_VERSION 1.19.4
+ENV GO_VERSION 1.19.5
 ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang
 RUN rm -rf ${GOROOT} \
   && curl -s ${GO_DOWNLOAD_URL}/go${GO_VERSION}.linux-amd64.tar.gz | tar -v -C /usr/local/ -xz \

--- a/tests/manual/Makefile
+++ b/tests/manual/Makefile
@@ -1,5 +1,5 @@
 TMP_DOCKERFILE:=$(shell mktemp)
-GO_VERSION ?= 1.19.4
+GO_VERSION ?= 1.19.5
 TMP_DIR_MOUNT_FLAG = --tmpfs=/tmp:exec
 ifdef HOST_TMP_DIR
 	TMP_DIR_MOUNT_FLAG = --mount type=bind,source=$(HOST_TMP_DIR),destination=/tmp


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

[release go1.19.5](https://golang.google.cn/doc/devel/release#go1.19)
```
go1.19.5 (released 2023-01-10) includes fixes to the compiler, the linker, and the crypto/x509, net/http, sync/atomic, and syscall packages. See the [Go 1.19.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.5+label%3ACherryPickApproved) on our issue tracker for details.
```