### PR TITLE
[3.4] grpc-gateway: update version to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.0.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/grpc-ecosystem/grpc-gateway v1.9.5
+	github.com/grpc-ecosystem/grpc-gateway v1.11.0
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/json-iterator/go v1.1.11
 	github.com/modern-go/reflect2 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
-github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1QAp/SlnNrZhI=
-github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.11.0 h1:aT5ISUniaOTErogCQ+4pGoYNBB6rm6Fq3g1v8QwYGas=
+github.com/grpc-ecosystem/grpc-gateway v1.11.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -343,7 +343,12 @@ func testV3CurlProclaimMissiongLeaderKey(cx ctlCtx) {
 	if err = cURLPost(cx.epc, cURLReq{
 		endpoint: path.Join(cx.apiPrefix, "/election/proclaim"),
 		value:    string(pdata),
-		expected: `{"error":"\"leader\" field must be provided","message":"\"leader\" field must be provided","code":2}`,
+		// NOTE: The order of json fields is aligned with the runtime.errorBody
+		//
+		// REF:
+		// 1. https://github.com/grpc-ecosystem/grpc-gateway/blob/v1.11.0/runtime/errors.go#L73
+		// 2. https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto#L82
+		expected: `{"error":"\"leader\" field must be provided","code":2,"message":"\"leader\" field must be provided"}`,
 	}); err != nil {
 		cx.t.Fatalf("failed post proclaim request (%s) (%v)", cx.apiPrefix, err)
 	}
@@ -359,7 +364,12 @@ func testV3CurlResignMissiongLeaderKey(cx ctlCtx) {
 	if err := cURLPost(cx.epc, cURLReq{
 		endpoint: path.Join(cx.apiPrefix, "/election/resign"),
 		value:    `{}`,
-		expected: `{"error":"\"leader\" field must be provided","message":"\"leader\" field must be provided","code":2}`,
+		// NOTE: The order of json fields is aligned with the runtime.errorBody
+		//
+		// REF:
+		// 1. https://github.com/grpc-ecosystem/grpc-gateway/blob/v1.11.0/runtime/errors.go#L73
+		// 2. https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto#L82
+		expected: `{"error":"\"leader\" field must be provided","code":2,"message":"\"leader\" field must be provided"}`,
 	}); err != nil {
 		cx.t.Fatalf("failed post resign request (%s) (%v)", cx.apiPrefix, err)
 	}


### PR DESCRIPTION
The issue is caused by hand-crafted protobuf message. The runtime.errorBody defines two protobuf fields with same number. We need to upgrade the version to fix it. Otherwise, the client side won't receive any errors from server side because of panic.

```
mismatching field: runtime.errorBody.error, want runtime.errorBody.message
```
It can fix the cases

PASSES="build grpcproxy" CPU=4 RACE=true ./test -run TestV3CurlLeaseRevokeNoTLS

The original error is like:

```
v3_curl_lease_test.go:109: testV3CurlLeaseRevoke: prefix (/v3) endpoint (/kv/lease/revoke): error (read /dev/ptmx: input/output error (expected "etcdserver: requested lease not found", got ["curl: (52) Empty reply from server\r\n"])), wanted etcdserver: requested lease not found
    v3_curl_lease_test.go:109: testV3CurlLeaseRevoke: prefix (/v3beta) endpoint (/kv/lease/revoke): error (read /dev/ptmx: input/output error (expected "etcdserver: requested lease not found", got ["curl: (52) Empty reply from server\r\n"])), wanted etcdserver: requested lease not found
```

The `Empty reply from server` is caused by panic and server recover it
but it doesn't have chance to reply to client.

Signed-off-by: Wei Fu <fuweid89@gmail.com>

-----

There is the diff between two versions https://github.com/grpc-ecosystem/grpc-gateway/compare/v1.9.5...v1.11.0.
And the key change is https://github.com/grpc-ecosystem/grpc-gateway/pull/1016. 
Most of the changes is related to code generator. IMO, it is safe to upgrade.

-----

Currently, the CI has issue. 
In https://github.com/fuweid/etcd/actions/runs/3900630221/jobs/6661513578

```
PASS
Too many goroutines running after all test(s).
1 instances of:
context.propagateCancel.func1()
	/opt/hostedtoolcache/go/1.17.13/x64/src/context/context.go:279 +0xe6
created by context.propagateCancel
	/opt/hostedtoolcache/go/1.17.13/x64/src/context/context.go:278 +0x265
1 instances of:
go.etcd.io/etcd/clientv3.(*watchGrpcStream).serveSubstream.func1()
	/home/runner/work/etcd/etcd/clientv3/watch.go:830 +0xdb
go.etcd.io/etcd/clientv3.(*watchGrpcStream).serveSubstream(...)
	/home/runner/work/etcd/etcd/clientv3/watch.go:855 +0x9f0
created by go.etcd.io/etcd/clientv3.(*watchGrpcStream).run
	/home/runner/work/etcd/etcd/clientv3/watch.go:556 +0xb75
1 instances of:
sync.runtime_Semacquire(...)
	/opt/hostedtoolcache/go/1.17.13/x64/src/runtime/sema.go:56 +0x25
sync.(*WaitGroup).Wait(...)
	/opt/hostedtoolcache/go/1.17.13/x64/src/sync/waitgroup.go:130 +0xea
go.etcd.io/etcd/clientv3.(*watchGrpcStream).run.func1()
	/home/runner/work/etcd/etcd/clientv3/watch.go:525 +0x316
go.etcd.io/etcd/clientv3.(*watchGrpcStream).run(...)
	/home/runner/work/etcd/etcd/clientv3/watch.go:722 +0x2f40
created by go.etcd.io/etcd/clientv3.(*watcher).newWatcherGrpcStream
	/home/runner/work/etcd/etcd/clientv3/watch.go:291 +0x6b9
FAIL	go.etcd.io/etcd/integration	288.014s
FAIL
```

The CI shows success but it fails actually.  Still need time to figure it out.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
