### PR TITLE
CHANGELOG: add dep update item to 3.4

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.24 (TBD)
 
+### Dependency
+- Upgrade [github.com/grpc-ecosystem/grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway/releases) from [v1.9.5](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v1.9.5) to [v1.11.0](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v1.11.0).
+
 ### Other
 - Updated [base image from base-debian11 to static-debian11 and removed dependency on busybox](https://github.com/etcd-io/etcd/pull/15038).
 


### PR DESCRIPTION
It is used to fix grpc-gateway error handler issue.

Signed-off-by: Wei Fu <fuweid89@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
