### PR TITLE
etcdserver: return `membership.ErrIDNotFound` when the memberID not found

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -1484,6 +1484,10 @@ func (s *EtcdServer) mayPromoteMember(id types.ID) error {
 // Note: it will return nil if member is not found in cluster or if member is not learner.
 // These two conditions will be checked before toApply phase later.
 func (s *EtcdServer) isLearnerReady(id uint64) error {
+	if err := s.waitAppliedIndex(); err != nil {
+		return err
+	}
+
 	rs := s.raftStatus()
 
 	// leader's raftStatus.Progress is not nil
@@ -1503,12 +1507,16 @@ func (s *EtcdServer) isLearnerReady(id uint64) error {
 		}
 	}
 
-	if isFound {
-		leaderMatch := rs.Progress[leaderID].Match
-		// the learner's Match not caught up with leader yet
-		if float64(learnerMatch) < float64(leaderMatch)*readyPercent {
-			return errors.ErrLearnerNotReady
-		}
+	// We should return an error in API directly, to avoid the request
+	// being unnecessarily delivered to raft.
+	if !isFound {
+		return membership.ErrIDNotFound
+	}
+
+	leaderMatch := rs.Progress[leaderID].Match
+	// the learner's Match not caught up with leader yet
+	if float64(learnerMatch) < float64(leaderMatch)*readyPercent {
+		return errors.ErrLearnerNotReady
 	}
 
 	return nil


### PR DESCRIPTION
This PR should fix the failure in https://github.com/etcd-io/etcd/actions/runs/3908224614/jobs/6678181444 
```
cluster_test.go:259: expecting promote not ready learner to fail, got no error
```

The existing test cases `TestMemberPromote*` in [cluster_test.go](https://github.com/etcd-io/etcd/blob/main/tests/integration/clientv3/cluster_test.go) already covers the code path updated in this PR.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
