### PR TITLE
tests: Fix history patch window

### DIFF
--- a/tests/linearizability/history.go
+++ b/tests/linearizability/history.go
@@ -284,12 +284,14 @@ func (h history) Operations() []porcupine.Operation {
 			maxTime = op.Return
 		}
 	}
-	// Failed requests don't have a known return time.
-	// We simulate Infinity by using return time of latest successfully request.
 	for _, op := range h.failed {
 		if op.Call > maxTime {
-			continue
+			maxTime = op.Call
 		}
+	}
+	// Failed requests don't have a known return time.
+	// Simulate Infinity by using last observed time.
+	for _, op := range h.failed {
 		op.Return = maxTime + 1
 		operations = append(operations, op)
 	}


### PR DESCRIPTION
Watch event time can be much delayed compared to requests. This created rare issues where last failed request was incorrectly discarded.