### PR TITLE
tests linearizability: trigger snapshot related failpoints

### DIFF
--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -142,6 +142,19 @@ func TestLinearizability(t *testing.T) {
 				e2e.WithSnapshotCount(100),
 			),
 		},
+		// TODO: investigate periodic `Model is not linearizable` failures
+		// see https://github.com/etcd-io/etcd/pull/15104#issuecomment-1416371288
+		/*{
+			name:      "Snapshot",
+			failpoint: RandomSnapshotFailpoint,
+			traffic:   &HighTraffic,
+			config: *e2e.NewConfig(
+				e2e.WithGoFailEnabled(true),
+				e2e.WithSnapshotCount(100),
+				e2e.WithSnapshotCatchUpEntries(100),
+				e2e.WithPeerProxy(true),
+			),
+		},*/
 	}...)
 	for _, scenario := range scenarios {
 		if scenario.traffic == nil {


### PR DESCRIPTION
fixes https://github.com/etcd-io/etcd/issues/14726, except `raftBeforeFollowerSend`

Signed-off-by: Bogdan Kanivets <bkanivets@apple.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
