### PR TITLE
tests: Reduce number of runs in nightly action

### DIFF
--- a/.github/workflows/linearizability-nightly.yaml
+++ b/.github/workflows/linearizability-nightly.yaml
@@ -18,7 +18,7 @@ jobs:
         make build
         mkdir -p /tmp/linearizability
         cat server/etcdserver/raft.fail.go
-        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 500 --failfast --run TestLinearizability --timeout=170m' RESULTS_DIR=/tmp/linearizability make test-linearizability
+        EXPECT_DEBUG=true GO_TEST_FLAGS='-v --count 300 --failfast --run TestLinearizability --timeout=170m' RESULTS_DIR=/tmp/linearizability make test-linearizability
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: always()
       with:


### PR DESCRIPTION
Single run takes up to 30s. Let's reduce number of runs to reduce chance of timeout.

cc @ahrtr @tjungblu @ptabor 
