### PR TITLE
etcdserver: use time.Ticker instead of time.After

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2206,6 +2206,8 @@ func (s *EtcdServer) monitorKVHash() {
 	if t == 0 {
 		return
 	}
+	checkTicker := time.NewTicker(t)
+	defer checkTicker.Stop()
 
 	lg := s.Logger()
 	lg.Info(
@@ -2217,7 +2219,7 @@ func (s *EtcdServer) monitorKVHash() {
 		select {
 		case <-s.stopping:
 			return
-		case <-time.After(t):
+		case <-checkTicker.C:
 		}
 		if !s.isLeader() {
 			continue

--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -607,12 +607,15 @@ func (le *lessor) Stop() {
 func (le *lessor) runLoop() {
 	defer close(le.doneC)
 
+	delayTicker := time.NewTicker(500 * time.Millisecond)
+	defer delayTicker.Stop()
+
 	for {
 		le.revokeExpiredLeases()
 		le.checkpointScheduledLeases()
 
 		select {
-		case <-time.After(500 * time.Millisecond):
+		case <-delayTicker.C:
 		case <-le.stopC:
 			return
 		}


### PR DESCRIPTION
Using time.After will create a new Timer in each cycle, In these cases, it is better to use time.Ticker.

Signed-off-by: Zhao Guo <guozhao-coder@foxmail.com>
