### PR TITLE
test: add CompactionSleepInterval in FakeStore's config

### DIFF
--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -894,7 +894,10 @@ func newFakeStore(lg *zap.Logger) *store {
 		Recorder:   &testutil.RecorderBuffered{},
 		rangeRespc: make(chan rangeResp, 5)}}
 	s := &store{
-		cfg:            StoreConfig{CompactionBatchLimit: 10000},
+		cfg: StoreConfig{
+			CompactionBatchLimit:    10000,
+			CompactionSleepInterval: minimumBatchInterval,
+		},
 		b:              b,
 		le:             &lease.FakeLessor{},
 		kvindex:        newFakeIndex(),


### PR DESCRIPTION
After setting the ComparionSleepInterval, we can use time.Ticker instead of time.After to optimize the scheduleComparison(), otherwise it will fail in the 'TestStoreCompact(t)' test.

Signed-off-by: guozhao <guozhao@360.cn>