### PR TITLE
netutil: consistently format ipv6 addresses

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -103,7 +103,7 @@ func resolveURL(ctx context.Context, lg *zap.Logger, u url.URL) (string, error) 
 		)
 		return "", err
 	}
-	if host == "localhost" || net.ParseIP(host) != nil {
+	if host == "localhost" {
 		return "", nil
 	}
 	for ctx.Err() == nil {


### PR DESCRIPTION
This formats ipv6 addresses to ensure they can be compared safely



Fixes #15127 