### PR TITLE
[3.5] Backport: netutil: consistently format ipv6 addresses

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -103,7 +103,7 @@ func resolveURL(ctx context.Context, lg *zap.Logger, u url.URL) (string, error) 
 		)
 		return "", err
 	}
-	if host == "localhost" || net.ParseIP(host) != nil {
+	if host == "localhost" {
 		return "", nil
 	}
 	for ctx.Err() == nil {


### PR DESCRIPTION
This is a backport of #15153

This formats ipv6 addresses to ensure they can be compared safely

Signed-off-by: kidsan <8798449+Kidsan@users.noreply.github.com>

