### PR TITLE
etcdserver: correct the old name of notifyc in comments

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -65,7 +65,7 @@ func init() {
 // toApply contains entries, snapshot to be applied. Once
 // an toApply is consumed, the entries will be persisted to
 // to raft storage concurrently; the application must read
-// raftDone before assuming the raft messages are stable.
+// notifyc before assuming the raft messages are stable.
 type toApply struct {
 	entries  []raftpb.Entry
 	snapshot raftpb.Snapshot
@@ -269,7 +269,7 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 				r.raftStorage.Append(rd.Entries)
 
 				if !islead {
-					// finish processing incoming messages before we signal raftdone chan
+					// finish processing incoming messages before we signal notifyc chan
 					msgs := r.processMessages(rd.Messages)
 
 					// now unblocks 'applyAll' that waits on Raft log disk writes before triggering snapshots


### PR DESCRIPTION
Hi there,

I am trying to learn the source code of etcd. I figure out there is a typo in the comments, and am trying to fix it. I hope this easy commit can be a start of my open source contribution. I understand this might be too easy. I will keep an eye on the good first issues and try to fix them first.

The old name(raftDone) of the channel(notifyc) which indicates the apply has been completed is left unchanged in the comments, resulting in confusion when reading the source code.

Signed-off-by: Jiaming Cao <alan.c.19971111@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
