### PR TITLE
pkg/schedule: correct comparison for FIFO schedule test

### DIFF
--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -38,9 +38,6 @@ func TestFIFOSchedule(t *testing.T) {
 				t.Fatalf("job#%d: got %d, want %d", i, next, i)
 			}
 			next = i + 1
-			if next%3 == 0 {
-				panic("fifo panic")
-			}
 		})
 	}
 
@@ -54,7 +51,7 @@ func TestFIFOSchedule(t *testing.T) {
 	}
 
 	s.WaitFinish(100)
-	if s.Scheduled() != 100 {
-		t.Errorf("scheduled = %d, want %d", s.Scheduled(), 100)
+	if s.Finished() != 100 {
+		t.Errorf("finished = %d, want %d", s.Finished(), 100)
 	}
 }


### PR DESCRIPTION
After executing WaitFinish, compare the Finished value with `100`
