### PR TITLE
pkg/schedule: correct comparison for FIFO schedule test

### DIFF
--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -54,7 +54,7 @@ func TestFIFOSchedule(t *testing.T) {
 	}
 
 	s.WaitFinish(100)
-	if s.Scheduled() != 100 {
-		t.Errorf("scheduled = %d, want %d", s.Scheduled(), 100)
+	if s.Finished() != 100 {
+		t.Errorf("finished = %d, want %d", s.Finished(), 100)
 	}
 }


### PR DESCRIPTION
Compare the `Finished` with expected value after executing `WaitFinish`. 

Signed-off-by: dbadoy4874 <dbadoy4874@gmail.com>
