### PR TITLE
changelog: add items to cover the bumping of bbolt to v1.3.7

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -14,6 +14,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### Dependency
 - Upgrade [github.com/grpc-ecosystem/grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway/releases) from [v1.9.5](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v1.9.5) to [v1.11.0](https://github.com/grpc-ecosystem/grpc-gateway/releases/tag/v1.11.0).
+- Bump bbolt to [v1.3.7](https://github.com/etcd-io/etcd/pull/15223).
 
 ### Other
 - Updated [base image from base-debian11 to static-debian11 and removed dependency on busybox](https://github.com/etcd-io/etcd/pull/15038).

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### Package `netutil`
 - Fix [consistently format IPv6 addresses for comparison](https://github.com/etcd-io/etcd/pull/15187)
 
+### Dependency
+- Bump bbolt to [v1.3.7](https://github.com/etcd-io/etcd/pull/15222).
+
 <hr>
 
 ## v3.5.7 (2023-01-20)
@@ -31,7 +34,6 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### Go
 - Require [Go 1.17+](https://github.com/etcd-io/etcd/pull/15019).
 - Compile with [Go 1.17+](https://go.dev/doc/devel/release#go1.17)
-
 
 <hr>
 


### PR DESCRIPTION
Linked to https://github.com/etcd-io/etcd/pull/15221

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
