### PR TITLE
Adjust time resolution to microseconds

### DIFF
--- a/client/pkg/logutil/zap.go
+++ b/client/pkg/logutil/zap.go
@@ -16,6 +16,7 @@ package logutil
 
 import (
 	"sort"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -46,15 +47,20 @@ var DefaultZapLoggerConfig = zap.Config{
 
 	// copied from "zap.NewProductionEncoderConfig" with some updates
 	EncoderConfig: zapcore.EncoderConfig{
-		TimeKey:        "ts",
-		LevelKey:       "level",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		MessageKey:     "msg",
-		StacktraceKey:  "stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		TimeKey:       "ts",
+		LevelKey:      "level",
+		NameKey:       "logger",
+		CallerKey:     "caller",
+		MessageKey:    "msg",
+		StacktraceKey: "stacktrace",
+		LineEnding:    zapcore.DefaultLineEnding,
+		EncodeLevel:   zapcore.LowercaseLevelEncoder,
+
+		// Custom EncodeTime function to ensure we match format and precision of historic capnslog timestamps
+		EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.Format("2006-01-02T15:04:05.999999Z0700"))
+		},
+
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 	},

--- a/tests/e2e/zap_logging_test.go
+++ b/tests/e2e/zap_logging_test.go
@@ -57,7 +57,7 @@ func TestServerJsonLogging(t *testing.T) {
 		if entry.Timestamp == "" {
 			t.Errorf(`Missing "ts" key, line: %s`, line)
 		}
-		if _, err := time.Parse("2006-01-02T15:04:05.000Z0700", entry.Timestamp); entry.Timestamp != "" && err != nil {
+		if _, err := time.Parse("2006-01-02T15:04:05.999999Z0700", entry.Timestamp); entry.Timestamp != "" && err != nil {
 			t.Errorf(`Unexpected "ts" key format, err: %s`, err)
 		}
 		if entry.Caller == "" {


### PR DESCRIPTION
Historic capnslog timestamps are in microsecond resolution. We need to match that when we migrate to the zap logger.

The standard zap time encoder options are listed here: https://github.com/uber-go/zap/blob/077b03eb1c5f4ed0703209766e4c897bb88ae6fb/zapcore/encoder.go#L171 

Unfortunately none of these completely matched both the precision and format of the historic capnslog format so I've added a custom encoder function that matches exactly.  

Here is a comparison:

| Format | Example |
| ------------- | ------------- |
| Old capnslog  | 2023-02-02 13:50:27.813478 |
| Zap RFC3339NanoTimeEncoder  | 2023-02-03T20:08:58.299954658+13:00  |
| Zap RFC3339TimeEncoder  | 2023-02-03T20:09:52+13:00  |
| Zap EpochMillisTimeEncoder  | 1675408253432.4639  |
| Zap EpochNanosTimeEncoder  | 1675408290557930192 |
| Zap custom function | 2023-02-03 20:12:20.789477 |

Fixes #15236.

Edit: Here is a sample of the new log output:

```bash
 ➜ ./bin/etcd --logger=zap
{"level":"warn","ts":"2023-02-03 20:42:37.898898","caller":"embed/config.go:790","msg":"it isn't recommended to use default name, please set a value for --name. Note that etcd might run into 
issue when multiple members have the same default name","name":"default"}
{"level":"info","ts":"2023-02-03 20:42:37.898953","caller":"etcdmain/etcd.go:64","msg":"Running: ","args":["./bin/etcd","--logger=zap"]}
{"level":"warn","ts":"2023-02-03 20:42:37.898969","caller":"etcdmain/etcd.go:96","msg":"'data-dir' was empty; using default","data-dir":"default.etcd"}
{"level":"info","ts":"2023-02-03 20:42:37.898997","caller":"etcdmain/etcd.go:107","msg":"server has already been initialized","data-dir":"default.etcd","dir-type":"member"}
{"level":"warn","ts":"2023-02-03 20:42:37.899006","caller":"embed/config.go:790","msg":"it isn't recommended to use default name, please set a value for --name. Note that etcd might run into 
issue when multiple members have the same default name","name":"default"}
```
