### PR TITLE
[3.5] Backport adjusting time resolution to microseconds

### DIFF
--- a/client/pkg/logutil/zap.go
+++ b/client/pkg/logutil/zap.go
@@ -16,6 +16,7 @@ package logutil
 
 import (
 	"sort"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -46,15 +47,20 @@ var DefaultZapLoggerConfig = zap.Config{
 
 	// copied from "zap.NewProductionEncoderConfig" with some updates
 	EncoderConfig: zapcore.EncoderConfig{
-		TimeKey:        "ts",
-		LevelKey:       "level",
-		NameKey:        "logger",
-		CallerKey:      "caller",
-		MessageKey:     "msg",
-		StacktraceKey:  "stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		TimeKey:       "ts",
+		LevelKey:      "level",
+		NameKey:       "logger",
+		CallerKey:     "caller",
+		MessageKey:    "msg",
+		StacktraceKey: "stacktrace",
+		LineEnding:    zapcore.DefaultLineEnding,
+		EncodeLevel:   zapcore.LowercaseLevelEncoder,
+
+		// Custom EncodeTime function to ensure we match format and precision of historic capnslog timestamps
+		EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+			enc.AppendString(t.Format("2006-01-02T15:04:05.999999Z0700"))
+		},
+
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 	},

--- a/tests/e2e/zap_logging_test.go
+++ b/tests/e2e/zap_logging_test.go
@@ -56,7 +56,7 @@ func TestServerJsonLogging(t *testing.T) {
 		if entry.Timestamp == "" {
 			t.Errorf(`Missing "ts" key, line: %s`, line)
 		}
-		if _, err := time.Parse("2006-01-02T15:04:05.000Z0700", entry.Timestamp); entry.Timestamp != "" && err != nil {
+		if _, err := time.Parse("2006-01-02T15:04:05.999999Z0700", entry.Timestamp); entry.Timestamp != "" && err != nil {
 			t.Errorf(`Unexpected "ts" key format, err: %s`, err)
 		}
 		if entry.Caller == "" {


### PR DESCRIPTION
This is a backport of https://github.com/etcd-io/etcd/pull/15239.

Historic capnslog timestamps are in microsecond resolution. We need to match that when we migrate to the zap logger.