### PR TITLE
tests/linearizability: force stop cluster with signal kill

### DIFF
--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -163,7 +163,7 @@ func TestLinearizability(t *testing.T) {
 				retries:             3,
 				waitBetweenTriggers: waitBetweenFailpointTriggers,
 			}, *scenario.traffic)
-			clus.Stop()
+			forcestopCluster(clus)
 			longestHistory, remainingEvents := pickLongestHistory(events)
 			validateEventsMatch(t, longestHistory, remainingEvents)
 			operations = patchOperationBasedOnWatchEvents(operations, longestHistory)
@@ -454,4 +454,12 @@ func testResultsDirectory(t *testing.T) (string, error) {
 		return path, err
 	}
 	return path, nil
+}
+
+// forcestopCluster stops the etcd member with signal kill.
+func forcestopCluster(clus *e2e.EtcdProcessCluster) error {
+	for _, member := range clus.Procs {
+		member.Kill()
+	}
+	return clus.Stop()
 }


### PR DESCRIPTION
When the linearizability test cases run with three members, it might take
7-8s to stop three members, especially stopping the leader. The leader
will transfer the leadership and it might take more time to stop peer
listener.

<details>
<summary>Click to check the log!</summary>

```plain
2023-02-02T08:19:15.2472384Z     logger.go:130: 2023-02-02T08:19:15.245Z	INFO	stopping server...	{"name": "TestLinearizabilityClusterOfSize3LowTraffic-test-2"}
2023-02-02T08:19:15.2473286Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:15.245Z","caller":"osutil/interrupt_unix.go:65","msg":"received signal; shutting down","signal":"terminated"}
2023-02-02T08:19:15.2474776Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:15.245Z","caller":"embed/etcd.go:392","msg":"closing etcd server","name":"TestLinearizabilityClusterOfSize3LowTraffic-test-2","data-dir":"/tmp/TestLinearizabilityClusterOfSize3LowTraffic780347105/003","advertise-peer-urls":["http://localhost:20013"],"advertise-client-urls":["http://localhost:20010"]}
2023-02-02T08:19:15.2476169Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:15.245Z","caller":"embed/serve.go:120","msg":"stopping grpc server due to error","error":"accept tcp 127.0.0.1:20010: use of closed network connection"}
2023-02-02T08:19:15.2477260Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:15.245Z","caller":"embed/serve.go:122","msg":"stopped grpc server due to error","error":"accept tcp 127.0.0.1:20010: use of closed network connection"}
2023-02-02T08:19:15.2478855Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"error","ts":"2023-02-02T08:19:15.245Z","caller":"embed/etcd.go:775","msg":"setting up serving from embedded etcd failed.","error":"accept tcp 127.0.0.1:20010: use of closed network connection","stacktrace":"go.etcd.io/etcd/server/v3/embed.(*Etcd).errHandler\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:775\ngo.etcd.io/etcd/server/v3/embed.(*Etcd).serveClients.func1\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:732"}
2023-02-02T08:19:22.2009431Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"error","ts":"2023-02-02T08:19:15.245Z","caller":"embed/etcd.go:775","msg":"setting up serving from embedded etcd failed.","error":"http: Server closed","stacktrace":"go.etcd.io/etcd/server/v3/embed.(*Etcd).errHandler\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:775\ngo.etcd.io/etcd/server/v3/embed.(*serveCtx).serve.func3\n\tgo.etcd.io/etcd/server/v3/embed/serve.go:159"}
2023-02-02T08:19:22.2011251Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:15.245Z","caller":"etcdserver/server.go:1256","msg":"leadership transfer failed","local-member-id":"9b0ed86c9976a482","error":"etcdserver: unhealthy cluster"}
2023-02-02T08:19:22.2013191Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:19.840Z","caller":"rafthttp/stream.go:194","msg":"lost TCP streaming connection with remote peer","stream-writer-type":"stream MsgApp v2","local-member-id":"9b0ed86c9976a482","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2014530Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:19.843Z","caller":"rafthttp/stream.go:194","msg":"lost TCP streaming connection with remote peer","stream-writer-type":"stream MsgApp v2","local-member-id":"9b0ed86c9976a482","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2016118Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:22.199Z","caller":"etcdserver/cluster_util.go:252","msg":"failed to reach the peer URL","address":"http://localhost:20008/version","remote-member-id":"b078ae59d09754c4","error":"Get \"http://localhost:20008/version\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}
2023-02-02T08:19:22.2017607Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:22.199Z","caller":"etcdserver/cluster_util.go:156","msg":"failed to get version","remote-member-id":"b078ae59d09754c4","error":"Get \"http://localhost:20008/version\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}
2023-02-02T08:19:22.2019280Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:22.199Z","caller":"etcdserver/cluster_util.go:252","msg":"failed to reach the peer URL","address":"http://localhost:20003/version","remote-member-id":"f2d60a7c86d2c4e1","error":"Get \"http://localhost:20003/version\": dial tcp [::1]:20003: connect: connection refused"}
2023-02-02T08:19:22.2020814Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"warn","ts":"2023-02-02T08:19:22.199Z","caller":"etcdserver/cluster_util.go:156","msg":"failed to get version","remote-member-id":"f2d60a7c86d2c4e1","error":"Get \"http://localhost:20003/version\": dial tcp [::1]:20003: connect: connection refused"}
2023-02-02T08:19:22.2022670Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.200Z","caller":"rafthttp/peer.go:316","msg":"stopping remote peer","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2024681Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.200Z","caller":"rafthttp/stream.go:294","msg":"stopped TCP streaming connection with remote peer","stream-writer-type":"stream MsgApp v2","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2025880Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.200Z","caller":"rafthttp/stream.go:294","msg":"stopped TCP streaming connection with remote peer","stream-writer-type":"stream Message","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2027294Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.200Z","caller":"rafthttp/pipeline.go:85","msg":"stopped HTTP pipelining with remote peer","local-member-id":"9b0ed86c9976a482","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2038820Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.200Z","caller":"rafthttp/stream.go:442","msg":"stopped stream reader with remote peer","stream-reader-type":"stream MsgApp v2","local-member-id":"9b0ed86c9976a482","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2040524Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/stream.go:442","msg":"stopped stream reader with remote peer","stream-reader-type":"stream Message","local-member-id":"9b0ed86c9976a482","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2041867Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/peer.go:321","msg":"stopped remote peer","remote-peer-id":"b078ae59d09754c4"}
2023-02-02T08:19:22.2043289Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/peer.go:316","msg":"stopping remote peer","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2044693Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/stream.go:294","msg":"stopped TCP streaming connection with remote peer","stream-writer-type":"stream MsgApp v2","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2046171Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/stream.go:294","msg":"stopped TCP streaming connection with remote peer","stream-writer-type":"stream Message","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2047500Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.201Z","caller":"rafthttp/pipeline.go:85","msg":"stopped HTTP pipelining with remote peer","local-member-id":"9b0ed86c9976a482","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2049027Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.202Z","caller":"rafthttp/stream.go:442","msg":"stopped stream reader with remote peer","stream-reader-type":"stream MsgApp v2","local-member-id":"9b0ed86c9976a482","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2050553Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.202Z","caller":"rafthttp/stream.go:442","msg":"stopped stream reader with remote peer","stream-reader-type":"stream Message","local-member-id":"9b0ed86c9976a482","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2051771Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.202Z","caller":"rafthttp/peer.go:321","msg":"stopped remote peer","remote-peer-id":"f2d60a7c86d2c4e1"}
2023-02-02T08:19:22.2052771Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.203Z","caller":"embed/etcd.go:580","msg":"stopping serving peer traffic","address":"127.0.0.1:20011"}
2023-02-02T08:19:22.2054441Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"error","ts":"2023-02-02T08:19:22.203Z","caller":"embed/etcd.go:775","msg":"setting up serving from embedded etcd failed.","error":"accept tcp 127.0.0.1:20011: use of closed network connection","stacktrace":"go.etcd.io/etcd/server/v3/embed.(*Etcd).errHandler\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:775\ngo.etcd.io/etcd/server/v3/embed.(*Etcd).servePeers.func3\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:602"}
2023-02-02T08:19:22.2055733Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.203Z","caller":"embed/etcd.go:585","msg":"stopped serving peer traffic","address":"127.0.0.1:20011"}
2023-02-02T08:19:22.6152698Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.203Z","caller":"embed/etcd.go:394","msg":"closed etcd server","name":"TestLinearizabilityClusterOfSize3LowTraffic-test-2","data-dir":"/tmp/TestLinearizabilityClusterOfSize3LowTraffic780347105/003","advertise-peer-urls":["http://localhost:20013"],"advertise-client-urls":["http://localhost:20010"]}
2023-02-02T08:19:22.6154945Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.203Z","caller":"verify/verify.go:57","msg":"verification of persisted state","data-dir":"/tmp/TestLinearizabilityClusterOfSize3LowTraffic780347105/003"}
2023-02-02T08:19:22.6156789Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.217Z","caller":"verify/verify.go:125","msg":"verification: consistentIndex OK","backend-consistent-index":1257,"hardstate-commit":1257}
2023-02-02T08:19:22.6158242Z /home/runner/work/etcd/etcd/bin/etcd (TestLinearizabilityClusterOfSize3LowTraffic-test-2) (12503): {"level":"info","ts":"2023-02-02T08:19:22.219Z","caller":"verify/verify.go:68","msg":"verification of persisted state successful","data-dir":"/tmp/TestLinearizabilityClusterOfSize3LowTraffic780347105/003"}
2023-02-02T08:19:22.6159498Z     logger.go:130: 2023-02-02T08:19:22.221Z	INFO	stopped server.	{"name": "TestLinearizabilityClusterOfSize3LowTraffic-test-2"}
```

</details>

In order to reduce the runtime, this commit is using signal kill to force
stop members instead of graceful shutdown.

REF: https://github.com/etcd-io/etcd/issues/15086

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

------------

```bash
ghacli --owner fuweid -repo etcd run ls --workflow-id linearizability.yaml --limit 6 --created "2023-02-03" --jobs "test / test"
ID          NAME             EVENT  BRANCH                               HEAD(MESSAGE)                                                     SHA       STATUS   JOB(test / test)  CREATED
4085566508  Linearizability  push   linearizability-forcestop-cluster-2  tests: forcestop member procs with signal kill                    2183a55b  success  10m57s            2023-02-03T15:30:34Z
4085564371  Linearizability  push   linearizability-forcestop-cluster-1  tests: forcestop member procs with signal kill                    2183a55b  success  10m50s            2023-02-03T15:30:16Z
4085557593  Linearizability  push   main-3                               Merge pull request #15233 from kevinzs2048/wip-integration-arm64  712bd8a8  success  13m41s            2023-02-03T15:29:26Z
4085555828  Linearizability  push   main-2                               Merge pull request #15233 from kevinzs2048/wip-integration-arm64  712bd8a8  success  13m51s            2023-02-03T15:29:14Z
4085490633  Linearizability  push   main-1                               Merge pull request #15233 from kevinzs2048/wip-integration-arm64  712bd8a8  success  13m23s            2023-02-03T15:20:58Z
4085374879  Linearizability  push   linearizability-forcestop-cluster    tests: forcestop member procs with signal kill                    2183a55b  success  10m48s            2023-02-03T15:07:13Z
```

Before change: it takes 13min38s
After: It takes 10min52s
