### PR TITLE
etcdproxy: Added flag for enabling/disabling cache.

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -66,6 +66,7 @@ var (
 	grpcProxyDNSClusterServiceName     string
 	grpcProxyInsecureDiscovery         bool
 	grpcProxyDataDir                   string
+	grpcProxyEnableCache               bool
 	grpcMaxCallSendMsgSize             int
 	grpcMaxCallRecvMsgSize             int
 
@@ -144,6 +145,7 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grpcProxyNamespace, "namespace", "", "string to prefix to all keys for namespacing requests")
 	cmd.Flags().BoolVar(&grpcProxyEnablePprof, "enable-pprof", false, `Enable runtime profiling data via HTTP server. Address is at client URL + "/debug/pprof/"`)
 	cmd.Flags().StringVar(&grpcProxyDataDir, "data-dir", "default.proxy", "Data directory for persistent data")
+	cmd.Flags().BoolVar(&grpcProxyEnableCache, "enable-cache", true, "Enable cache for serializable range requests (enabled by default)")
 	cmd.Flags().IntVar(&grpcMaxCallSendMsgSize, "max-send-bytes", defaultGRPCMaxCallSendMsgSize, "message send limits in bytes (default value is 1.5 MiB)")
 	cmd.Flags().IntVar(&grpcMaxCallRecvMsgSize, "max-recv-bytes", math.MaxInt32, "message receive limits in bytes (default value is math.MaxInt32)")
 	cmd.Flags().DurationVar(&grpcKeepAliveMinTime, "grpc-keepalive-min-time", embed.DefaultGRPCKeepAliveMinTime, "Minimum interval duration that a client should wait before pinging proxy.")
@@ -435,7 +437,7 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 		client.KV, _, _ = leasing.NewKV(client, grpcProxyLeasing)
 	}
 
-	kvp, _ := grpcproxy.NewKvProxy(client)
+	kvp, _ := grpcproxy.NewKvProxy(client, grpcproxy.WithCache(grpcProxyEnableCache))
 	watchp, _ := grpcproxy.NewWatchProxy(client.Ctx(), lg, client)
 	if grpcProxyResolverPrefix != "" {
 		grpcproxy.Register(lg, client, grpcProxyResolverPrefix, grpcProxyAdvertiseClientURL, grpcProxyResolverTTL)


### PR DESCRIPTION
Originally discussed in [issue 14665](https://github.com/etcd-io/etcd/issues/14665#issuecomment-1419836385)

Currently cache may have stale data, and the only option for clients to resolve it is to use linearizable reads, which can be not easy for big codebase and make it impossible to transparently replace etcd cluster with grpc proxy.
New flag adds second option to solve stale reads problem (serializable reads still has less garantuess, but at least they are eventually consistent).

cc @ahrtr @Hexta 
