### PR TITLE
[3.5] etcdserver: add failpoints walBeforeSync and walAfterSync

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS}" "GOOS=${GOOS}" 
 toggle_failpoints() {
   mode="$1"
   if command -v gofail >/dev/null 2>&1; then
-    run gofail "$mode" server/etcdserver/ server/mvcc/backend/
+    run gofail "$mode" server/etcdserver/ server/mvcc/backend/ server/wal/
   elif [[ "$mode" != "disable" ]]; then
     log_error "FAILPOINTS set but gofail not found"
     exit 1

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -939,7 +939,10 @@ func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
 	}
 	if curOff < SegmentSizeBytes {
 		if mustSync {
-			return w.sync()
+			// gofail: var walBeforeSync struct{}
+			err = w.sync()
+			// gofail: var walAfterSync struct{}
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/15252 to 3.5


Signed-off-by: Benjamin Wang <wachao@vmware.com>


cc @serathius @spzala 
