### PR TITLE
[3.4] etctserver: add failpoints walBeforeSync and walAfterSync

### DIFF
--- a/build
+++ b/build
@@ -16,7 +16,7 @@ GO_LDFLAGS="$GO_LDFLAGS -X ${REPO_PATH}/version.GitSHA=${GIT_SHA}"
 toggle_failpoints() {
 	mode="$1"
 	if command -v gofail >/dev/null 2>&1; then
-		gofail "$mode" etcdserver/ mvcc/backend/
+		gofail "$mode" etcdserver/ mvcc/backend/ wal/
 	elif [[ "$mode" != "disable" ]]; then
 		echo "FAILPOINTS set but gofail not found"
 		exit 1

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -949,7 +949,10 @@ func (w *WAL) Save(st raftpb.HardState, ents []raftpb.Entry) error {
 	}
 	if curOff < SegmentSizeBytes {
 		if mustSync {
-			return w.sync()
+			// gofail: var walBeforeSync struct{}
+			err = w.sync()
+			// gofail: var walAfterSync struct{}
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/15252 to 3.4.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

cc @serathius @spzala 

