### PR TITLE
etcdserver: add failpoints apiBeforeSendTimedProgress and apiAfterSendTimedProgress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ GOFAIL_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} go.etcd.io/g
 
 .PHONY: gofail-enable
 gofail-enable: install-gofail
-	gofail enable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
+	gofail enable server/etcdserver/ server/etcdserver/api/v3rpc/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
 	cd ./server && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdutl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdctl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
@@ -123,7 +123,7 @@ gofail-enable: install-gofail
 
 .PHONY: gofail-disable
 gofail-disable: install-gofail
-	gofail disable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
+	gofail disable server/etcdserver/ server/etcdserver/api/v3rpc/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
 	cd ./server && go mod tidy
 	cd ./etcdutl && go mod tidy
 	cd ./etcdctl && go mod tidy

--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -513,12 +513,14 @@ func (sws *serverWatchStream) sendLoop() {
 
 		case <-progressTicker.C:
 			sws.mu.Lock()
+			// gofail: var apiBeforeSendTimedProgress struct{}
 			for id, ok := range sws.progress {
 				if ok {
 					sws.watchStream.RequestProgress(id)
 				}
 				sws.progress[id] = true
 			}
+			// gofail: var apiAfterSendTimedProgress struct{}
 			sws.mu.Unlock()
 
 		case <-sws.closec:

--- a/tests/linearizability/watch.go
+++ b/tests/linearizability/watch.go
@@ -86,13 +86,13 @@ func validateMemberWatchResponses(t *testing.T, responses []watchResponse, expec
 	var lastRevision int64 = 1
 	for _, resp := range responses {
 		if resp.Header.Revision < lastRevision {
-			t.Errorf("Revision should never decrease")
+			t.Errorf("Revision should never decrease, last: %d, latest: %d", lastRevision, resp.Header.Revision)
 		}
 		if resp.IsProgressNotify() && resp.Header.Revision == lastRevision {
 			gotProgressNotify = true
 		}
 		if resp.Header.Revision == lastRevision && len(resp.Events) != 0 {
-			t.Errorf("Got two non-empty responses about same revision")
+			t.Errorf("Got two non-empty responses about same revision: %d", lastRevision)
 		}
 		for _, event := range resp.Events {
 			if event.Kv.ModRevision != lastRevision+1 {
@@ -101,7 +101,7 @@ func validateMemberWatchResponses(t *testing.T, responses []watchResponse, expec
 			lastRevision = event.Kv.ModRevision
 		}
 		if resp.Header.Revision != lastRevision {
-			t.Errorf("Expect response revision equal last event mod revision")
+			t.Errorf("Expect response revision equal last event mod revision, last: %d, latest: %d", lastRevision, resp.Header.Revision)
 		}
 		lastRevision = resp.Header.Revision
 	}


### PR DESCRIPTION
Try to reproduce the duplicated event. Note I don't expect it can reliably reproduce the duplicated event issue. But adding new failpoints is good anyway.

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
