### PR TITLE
[3.5] clientv3: correct the nextRev on receving progress notification response

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -848,7 +848,7 @@ func (w *watchGrpcStream) serveSubstream(ws *watcherStream, resumec chan struct{
 				}
 			} else {
 				// current progress of watch; <= store revision
-				nextRev = wr.Header.Revision
+				nextRev = wr.Header.Revision + 1
 			}
 
 			if len(wr.Events) > 0 {


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/15248 to 3.5

Signed-off-by: Benjamin Wang <wachao@vmware.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
