### PR TITLE
Show darwin as supported in fileutil.Preallocate docstring

### DIFF
--- a/client/pkg/fileutil/preallocate.go
+++ b/client/pkg/fileutil/preallocate.go
@@ -19,9 +19,9 @@ import (
 	"os"
 )
 
-// Preallocate tries to allocate the space for given
-// file. This operation is only supported on linux by a
-// few filesystems (btrfs, ext4, etc.).
+// Preallocate tries to allocate the space for given file. This 
+// operation is only supported on darwin and linux by a few 
+// filesystems (APFS, btrfs, ext4, etc.).
 // If the operation is unsupported, no error will be returned.
 // Otherwise, the error encountered will be returned.
 func Preallocate(f *os.File, sizeInBytes int64, extendFile bool) error {


### PR DESCRIPTION
`fileutil.Preallocate` function is supported on Darwin yet it is not documented. This fix the issue by updating the docstring.