### PR TITLE
CHANGELOG: Add entries for timestamp resolution fixes.

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -19,6 +19,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### Other
 - Updated [base image from base-debian11 to static-debian11 and removed dependency on busybox](https://github.com/etcd-io/etcd/pull/15038).
 
+### Package `pkg/logutil`
+- Fix [aligning zap log timestamp resolution to microseconds](https://github.com/etcd-io/etcd/pull/15241). Etcd now uses zap timestamp format: `2006-01-02T15:04:05.999999Z0700` (microsecond instead of milliseconds precision).
+
 ### Package `netutil`
 - Fix [consistently format IPv6 addresses for comparison](https://github.com/etcd-io/etcd/pull/15188)
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.8 (TBD)
 
+### Package `client/pkg/v3`
+- Fix [aligning zap log timestamp resolution to microseconds](https://github.com/etcd-io/etcd/pull/15240). Etcd now uses zap timestamp format: `2006-01-02T15:04:05.999999Z0700` (microsecond instead of milliseconds precision).
+
 ### Package `netutil`
 - Fix [consistently format IPv6 addresses for comparison](https://github.com/etcd-io/etcd/pull/15187)
 


### PR DESCRIPTION
Historic capnslog timestamps are in microsecond resolution. We need to match that when we migrate to the zap logger.

3.6:  https://github.com/etcd-io/etcd/pull/15239 (Note one further change incoming for 3.6 zap logging timestamps to migrate to `RFC3339NanoTimeEncoder`)
3.5 Backport: https://github.com/etcd-io/etcd/pull/15240
3.4 Backport: https://github.com/etcd-io/etcd/pull/15241  