### PR TITLE
test: correct the logic of comparing revision in linearizablity/watch.go

### DIFF
--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -144,9 +144,7 @@ func TestLinearizability(t *testing.T) {
 				e2e.WithSnapshotCount(100),
 			),
 		},
-		// TODO: investigate periodic `Model is not linearizable` failures
-		// see https://github.com/etcd-io/etcd/pull/15104#issuecomment-1416371288
-		/*{
+		{
 			name:      "Snapshot",
 			failpoint: RandomSnapshotFailpoint,
 			traffic:   &HighTraffic,
@@ -156,7 +154,7 @@ func TestLinearizability(t *testing.T) {
 				e2e.WithSnapshotCatchUpEntries(100),
 				e2e.WithPeerProxy(true),
 			),
-		},*/
+		},
 	}...)
 	for _, scenario := range scenarios {
 		if scenario.traffic == nil {


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/15271

Note that there are two revisions:
1. The revision in the response header;
2. The ModRevision in each event.

Note that in each watchResponse, the highest event.ModRevision may be less than the header.Revision. 

Let's work with an example. Assuming the latest header.Revision and (highest) event.ModRevision are both 1000, but the etcdserver is somehow partitioned status, and when it comes back to normal, it syncs the latest logs (e.g. sync a snapshot) from the leader, and it's latest revision may jump to 4000 directly. But the client side still need to receive events starting from 1001. In this case, what the client will receive in the first watchResponse will be something like below,
- watchResponse.Header.Revision: 4000
- First event.ModRevision: 1001
- Last event.ModRevision: 2000 (1000 + len(response.Events) ); Note that this value may be less than resp.Header.Revision (4000 in this example). Note the maximum revisions sent at a time is [1000](https://github.com/etcd-io/etcd/blob/87e271701b3449c35d9ef41f855c7792488773ce/server/storage/mvcc/watcher_group.go#L29).


Signed-off-by: Benjamin Wang <wachao@vmware.com>
