### PR TITLE
etcd-mixin: Limit etcdDatabaseHighFragmentationRatio to 100MB+

### DIFF
--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -241,7 +241,7 @@
           {
             alert: 'etcdDatabaseHighFragmentationRatio',
             expr: |||
-              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/contrib/mixin/test.yaml
+++ b/contrib/mixin/test.yaml
@@ -143,13 +143,13 @@ tests:
   - interval: 1m
     input_series:
       - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '30000+0x10'
+        values: '300000000+0x10'
       - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}'
-        values: '100000+0x10'
+        values: '1000000000+0x10'
       - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '70000+0x10'
+        values: '700000000+0x10'
       - series: 'etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.1"}'
-        values: '100000+0x10'
+        values: '1000000000+0x10'
     alert_rule_test:
       - eval_time: 11m
         alertname: etcdDatabaseHighFragmentationRatio


### PR DESCRIPTION
Prometheus rule `etcdDatabaseHighFragmentationRatio` is excessively trigger happy in its current form when the etcd database is small. I think it would be better if the metrics are ignored unless total database size is 100MB+ (or something similar). When the size is small the percentage is large and there isn't a real problem with etcd so this is just creates noise.

Signed-off-by: Göran Gustafsson <gustafsson.g@gmail.com>