### PR TITLE
workflows: Remove non-root gomod dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,57 +6,15 @@ updates:
       interval: weekly
 
   - package-ecosystem: gomod
-    directory: /api
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /client/pkg
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /client/v2
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /client/v3
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /etcdctl
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /etcdutl
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    allow:
+    - dependency-type: all
 
   - package-ecosystem: gomod
-    directory: /pkg
+    directory: /tools/mod # Not linked from /go.mod
     schedule:
       interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /server
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /tests
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /tools/mod
-    schedule:
-      interval: weekly
-
+    allow:
+    - dependency-type: all


### PR DESCRIPTION
cc @ahrtr @ptabor @spzala 

Current configuration generates a PR per each package, even though all dependencies are also available in root go.mod.
By having dependabot only update root go.mod we will avoid a lot of spam and still be able to get all relevant dependency upgrade suggestions.