### PR TITLE
Do not run arm64 jobs on forks

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -5,6 +5,8 @@ on:
 permissions: read-all
 jobs:
   test:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'etcd-io/etcd'
     runs-on: [Linux, ARM64]
     strategy:
       fail-fast: true

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -4,6 +4,8 @@ on:
     - cron: '30 1 * * *' # runs daily at 1:30 am.
 jobs:
   test:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'etcd-io/etcd'
     runs-on: [Linux, ARM64]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using the tip from [1]. 

[1] https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository

Signed-off-by: Davanum Srinivas <davanum@gmail.com>
