### PR TITLE
tests/linearizability: add client option and refactor history Merge

### DIFF
--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -33,7 +33,7 @@ func TestAuthEnable(t *testing.T) {
 	defer clus.Close()
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
-		require.NoErrorf(t, setupAuth(cc, []authRole{}, []authUser{rootUser}), "failed to enable auth")
+		require.NoErrorf(t, setupAuth(cc, []AuthRole{}, []AuthUser{RootUser}), "failed to enable auth")
 	})
 }
 
@@ -46,10 +46,10 @@ func TestAuthDisable(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		require.NoError(t, cc.Put(ctx, "hoo", "a", config.PutOptions{}))
-		require.NoErrorf(t, setupAuth(cc, []authRole{testRole}, []authUser{rootUser, testUser}), "failed to enable auth")
+		require.NoErrorf(t, setupAuth(cc, []AuthRole{TestRole}, []AuthUser{RootUser, TestUser}), "failed to enable auth")
 
-		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(rootUserName, rootPassword)))
-		testUserAuthClient := testutils.MustClient(clus.Client(WithAuth(testUserName, testPassword)))
+		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(RootUserName, RootPassword)))
+		testUserAuthClient := testutils.MustClient(clus.Client(WithAuth(TestUserName, TestPassword)))
 
 		// test-user doesn't have the permission, it must fail
 		require.Error(t, testUserAuthClient.Put(ctx, "hoo", "bar", config.PutOptions{}))
@@ -75,9 +75,9 @@ func TestAuthGracefulDisable(t *testing.T) {
 	defer clus.Close()
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
-		require.NoErrorf(t, setupAuth(cc, []authRole{}, []authUser{rootUser}), "failed to enable auth")
+		require.NoErrorf(t, setupAuth(cc, []AuthRole{}, []AuthUser{RootUser}), "failed to enable auth")
 		donec := make(chan struct{})
-		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(rootUserName, rootPassword)))
+		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(RootUserName, RootPassword)))
 
 		go func() {
 			defer close(donec)
@@ -124,8 +124,8 @@ func TestAuthStatus(t *testing.T) {
 		require.NoError(t, err)
 		require.Falsef(t, resp.Enabled, "want auth not enabled but enabled")
 
-		require.NoErrorf(t, setupAuth(cc, []authRole{}, []authUser{rootUser}), "failed to enable auth")
-		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(rootUserName, rootPassword)))
+		require.NoErrorf(t, setupAuth(cc, []AuthRole{}, []AuthUser{RootUser}), "failed to enable auth")
+		rootAuthClient := testutils.MustClient(clus.Client(WithAuth(RootUserName, RootPassword)))
 		resp, err = rootAuthClient.AuthStatus(ctx)
 		require.NoError(t, err)
 		require.Truef(t, resp.Enabled, "want enabled but got not enabled")

--- a/tests/common/auth_util.go
+++ b/tests/common/auth_util.go
@@ -24,48 +24,48 @@ import (
 )
 
 const (
-	rootUserName = "root"
-	rootRoleName = "root"
-	rootPassword = "rootPassword"
-	testUserName = "test-user"
-	testRoleName = "test-role"
-	testPassword = "pass"
+	RootUserName = "root"
+	RootRoleName = "root"
+	RootPassword = "rootPassword"
+	TestUserName = "test-user"
+	TestRoleName = "test-role"
+	TestPassword = "pass"
 )
 
 var (
-	rootUser = authUser{user: rootUserName, pass: rootPassword, role: rootRoleName}
-	testUser = authUser{user: testUserName, pass: testPassword, role: testRoleName}
+	RootUser = AuthUser{User: RootUserName, Pass: RootPassword, Role: RootRoleName}
+	TestUser = AuthUser{User: TestUserName, Pass: TestPassword, Role: TestRoleName}
 
-	testRole = authRole{
-		role:       testRoleName,
-		permission: clientv3.PermissionType(clientv3.PermReadWrite),
-		key:        "foo",
-		keyEnd:     "",
+	TestRole = AuthRole{
+		Role:       TestRoleName,
+		Permission: clientv3.PermissionType(clientv3.PermReadWrite),
+		Key:        "foo",
+		KeyEnd:     "",
 	}
 )
 
-type authRole struct {
-	role       string
-	permission clientv3.PermissionType
-	key        string
-	keyEnd     string
+type AuthRole struct {
+	Role       string
+	Permission clientv3.PermissionType
+	Key        string
+	KeyEnd     string
 }
 
-type authUser struct {
-	user string
-	pass string
-	role string
+type AuthUser struct {
+	User string
+	Pass string
+	Role string
 }
 
-func createRoles(c interfaces.Client, roles []authRole) error {
+func createRoles(c interfaces.Client, roles []AuthRole) error {
 	for _, r := range roles {
 		// add role
-		if _, err := c.RoleAdd(context.TODO(), r.role); err != nil {
+		if _, err := c.RoleAdd(context.TODO(), r.Role); err != nil {
 			return fmt.Errorf("RoleAdd failed: %w", err)
 		}
 
 		// grant permission to role
-		if _, err := c.RoleGrantPermission(context.TODO(), r.role, r.key, r.keyEnd, r.permission); err != nil {
+		if _, err := c.RoleGrantPermission(context.TODO(), r.Role, r.Key, r.KeyEnd, r.Permission); err != nil {
 			return fmt.Errorf("RoleGrantPermission failed: %w", err)
 		}
 	}
@@ -73,15 +73,15 @@ func createRoles(c interfaces.Client, roles []authRole) error {
 	return nil
 }
 
-func createUsers(c interfaces.Client, users []authUser) error {
+func createUsers(c interfaces.Client, users []AuthUser) error {
 	for _, u := range users {
 		// add user
-		if _, err := c.UserAdd(context.TODO(), u.user, u.pass, config.UserAddOptions{}); err != nil {
+		if _, err := c.UserAdd(context.TODO(), u.User, u.Pass, config.UserAddOptions{}); err != nil {
 			return fmt.Errorf("UserAdd failed: %w", err)
 		}
 
 		// grant role to user
-		if _, err := c.UserGrantRole(context.TODO(), u.user, u.role); err != nil {
+		if _, err := c.UserGrantRole(context.TODO(), u.User, u.Role); err != nil {
 			return fmt.Errorf("UserGrantRole failed: %w", err)
 		}
 	}
@@ -89,7 +89,7 @@ func createUsers(c interfaces.Client, users []authUser) error {
 	return nil
 }
 
-func setupAuth(c interfaces.Client, roles []authRole, users []authUser) error {
+func setupAuth(c interfaces.Client, roles []AuthRole, users []AuthUser) error {
 	// create roles
 	if err := createRoles(c, roles); err != nil {
 		return err

--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -177,24 +177,24 @@ func testStatusWithAuth(t *testing.T, expectConnectionError, expectOperationErro
 }
 
 func setupAuthForMaintenanceTest(c intf.Client) error {
-	roles := []authRole{
+	roles := []AuthRole{
 		{
-			role:       "role0",
-			permission: clientv3.PermissionType(clientv3.PermReadWrite),
-			key:        "foo",
+			Role:       "role0",
+			Permission: clientv3.PermissionType(clientv3.PermReadWrite),
+			Key:        "foo",
 		},
 	}
 
-	users := []authUser{
+	users := []AuthUser{
 		{
-			user: "root",
-			pass: "rootPass",
-			role: "root",
+			User: "root",
+			Pass: "rootPass",
+			Role: "root",
 		},
 		{
-			user: "user0",
-			pass: "user0Pass",
-			role: "role0",
+			User: "user0",
+			Pass: "user0Pass",
+			Role: "role0",
 		},
 	}
 

--- a/tests/linearizability/client.go
+++ b/tests/linearizability/client.go
@@ -22,6 +22,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/linearizability/identity"
 	"go.etcd.io/etcd/tests/v3/linearizability/model"
 )
@@ -32,13 +33,17 @@ type recordingClient struct {
 	baseTime time.Time
 }
 
-func NewClient(endpoints []string, ids identity.Provider, baseTime time.Time) (*recordingClient, error) {
-	cc, err := clientv3.New(clientv3.Config{
+func NewClient(endpoints []string, ids identity.Provider, baseTime time.Time, opts ...config.ClientOption) (*recordingClient, error) {
+	cfg := &clientv3.Config{
 		Endpoints:            endpoints,
 		Logger:               zap.NewNop(),
 		DialKeepAliveTime:    1 * time.Millisecond,
 		DialKeepAliveTimeout: 5 * time.Millisecond,
-	})
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	cc, err := clientv3.New(*cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/linearizability/linearizability_test.go
+++ b/tests/linearizability/linearizability_test.go
@@ -407,7 +407,7 @@ func simulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 
 			config.traffic.Run(ctx, clientId, c, limiter, ids, lm)
 			mux.Lock()
-			h = h.Merge(c.history.History)
+			h.Merge(c.history.History)
 			mux.Unlock()
 		}(c, i)
 	}

--- a/tests/linearizability/model/history.go
+++ b/tests/linearizability/model/history.go
@@ -382,19 +382,12 @@ type History struct {
 	failed []porcupine.Operation
 }
 
-func (h History) Merge(h2 History) History {
-	result := History{
-		successful: make([]porcupine.Operation, 0, len(h.successful)+len(h2.successful)),
-		failed:     make([]porcupine.Operation, 0, len(h.failed)+len(h2.failed)),
-	}
-	result.successful = append(result.successful, h.successful...)
-	result.successful = append(result.successful, h2.successful...)
-	result.failed = append(result.failed, h.failed...)
-	result.failed = append(result.failed, h2.failed...)
-	return result
+func (h *History) Merge(h2 History) {
+	h.successful = append(h.successful, h2.successful...)
+	h.failed = append(h.failed, h2.failed...)
 }
 
-func (h History) Operations() []porcupine.Operation {
+func (h *History) Operations() []porcupine.Operation {
 	operations := make([]porcupine.Operation, 0, len(h.successful)+len(h.failed))
 	var maxTime int64
 	for _, op := range h.successful {


### PR DESCRIPTION
An incremental change to add auth support in linearizable test. 
1. make root user and test user accessible from outside of the `test/common` package
2. add client option
3. history merge can be simplified

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
