### PR TITLE
Bump to go 1.19.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.5"
+          go-version: "1.19.6"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -8,5 +8,5 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: make -C contrib/mixin tools test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         ref: main
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: GOARCH=amd64 CPU=4 make fuzz
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure()

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.5"
+          go-version: "1.19.6"
       - run: date
       - run: go install golang.org/x/vuln/cmd/govulncheck@v0.0.0-20221208180742-f2dca5ff4cc3 && govulncheck ./...

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/linearizability-template.yaml
+++ b/.github/workflows/linearizability-template.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: '1.19.5'
+        go-version: '1.19.6'
     - name: build
       env:
         GITHUB_REF: ${{ inputs.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: |
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.5"
+          go-version: "1.19.6"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         ref: main
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
-        go-version: "1.19.5"
+        go-version: "1.19.6"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/tests/manual/Makefile
+++ b/tests/manual/Makefile
@@ -1,5 +1,5 @@
 TMP_DOCKERFILE:=$(shell mktemp)
-GO_VERSION ?= 1.19.5
+GO_VERSION ?= 1.19.6
 TMP_DIR_MOUNT_FLAG = --tmpfs=/tmp:exec
 ifdef HOST_TMP_DIR
 	TMP_DIR_MOUNT_FLAG = --mount type=bind,source=$(HOST_TMP_DIR),destination=/tmp


### PR DESCRIPTION
Go 1.19.6 (released 2023-02-14) includes important security and bug fixes.

Refer: https://go.dev/doc/devel/release#go1.19 

Fixes: #15327
