### PR TITLE
The node fails to restart after being removed

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -174,10 +174,6 @@ func (rc *raftNode) publishEntries(ents []raftpb.Entry) (<-chan struct{}, bool) 
 					rc.transport.AddPeer(types.ID(cc.NodeID), []string{string(cc.Context)})
 				}
 			case raftpb.ConfChangeRemoveNode:
-				if cc.NodeID == uint64(rc.id) {
-					log.Println("I've been removed from the cluster! Shutting down.")
-					return nil, false
-				}
 				rc.transport.RemovePeer(types.ID(cc.NodeID))
 			}
 		}


### PR DESCRIPTION
If a node is removed via confChangeC, the removal will be replayed when recovering from the log on restart, resulting in a restart failure.

```
 cc := raftpb.ConfChange{ 
     Type:   raftpb.ConfChangeRemoveNode, 
     NodeID: nodeId, 
 } 
 r.confChangeC <- cc
```

```
case raftpb.ConfChangeRemoveNode:
    if cc.NodeID == r.id {
        logger.Info().Uint64("node", r.id).Msg("[raft] node is removed from the cluster. shutting down.")
	return nil, false
    }
    r.transport.RemovePeer(types.ID(cc.NodeID))
}
```
