### PR TITLE
Add initial .devcontainer for go 1.19

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1.19-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		  "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		  "ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [2379, 2380],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "make build"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+}


### PR DESCRIPTION
When the devcontainer starts it will run `make build` to ensure compiled etcd binaries are immediately available for use.

I've confirmed `make test` is also successfully running unit and integration tests within the container.

Standard etcd ports are forwarded in-case the user wants to interact with the etcd components from outside the container.

This is just an initial proposal and creates a foundation that other contributors can add to moving forward.

Fixes #15377