### PR TITLE
CHANGELOG: Add entries for 3.4 and 3.5 go version 1.19.

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,6 +4,14 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
+## v3.4.25 (TBD)
+
+### Go
+- Require [Go 1.19+](https://github.com/etcd-io/etcd/pull/15333).
+- Compile with [Go 1.19+](https://go.dev/doc/devel/release#go1.19)
+
+<hr>
+
 ## v3.4.24 (2023-02-16)
 
 ### etcd server

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -21,6 +21,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### Other
 - [Remove nsswitch.conf from docker image](https://github.com/etcd-io/etcd/pull/15161)
 
+### Go
+- Require [Go 1.19+](https://github.com/etcd-io/etcd/pull/15337).
+- Compile with [Go 1.19+](https://go.dev/doc/devel/release#go1.19)
+
 <hr>
 
 ## v3.5.7 (2023-01-20)


### PR DESCRIPTION
We recently backported moving to go 1.19.6 to 3.4 and 3.5. This pull request adds `CHANGELOG` entries for these for the next release of both versions.

Relates to issue #15332

Refer backport prs:
 - 3.4 #15333 
 - 3.5 #15337 