### PR TITLE
Return default snapshot count to 10,000

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -73,6 +73,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Graduated [`--experimental-warning-unary-request-duration` to `--warning-unary-request-duration`](https://github.com/etcd-io/etcd/pull/14414). Note the experimental flag is deprecated and will be decommissioned in v3.7.
 - Add [field `hash_revision` into `HashKVResponse`](https://github.com/etcd-io/etcd/pull/14537).
 - Add [`etcd --experimental-snapshot-catch-up-entries`](https://github.com/etcd-io/etcd/pull/15033) flag to configure number of entries for a slow follower to catch up after compacting the the raft storage entries and defaults to 5k. 
+- Decreased [`--snapshot-count` default value from 100,000 to 10,000](https://github.com/etcd-io/etcd/pull/15408)
 
 ### etcd grpc-proxy
 

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -54,7 +54,7 @@ Member:
     Path to the data directory.
   --wal-dir ''
     Path to the dedicated wal directory.
-  --snapshot-count '100000'
+  --snapshot-count '10000'
     Number of committed transactions to trigger a snapshot to disk.
   --heartbeat-interval '100'
     Time (in milliseconds) of a heartbeat interval.

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -74,7 +74,7 @@ import (
 )
 
 const (
-	DefaultSnapshotCount = 100000
+	DefaultSnapshotCount = 10000
 
 	// DefaultSnapshotCatchUpEntries is the number of entries for a slow follower
 	// to catch-up after compacting the raft storage entries.

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -148,7 +148,7 @@ type EtcdProcessClusterConfig struct {
 
 	MetricsURLScheme string
 
-	SnapshotCount          int // default is 100000
+	SnapshotCount          int // default is 10000
 	SnapshotCatchUpEntries int // default is 5000
 
 	Client        ClientConfig


### PR DESCRIPTION
The 100k value was justified when storev2 was being dumped completely with every snapshot.  

With storev2 being decommissioned we should consider checkpointing more frequently for faster recovery and to avoid issues with purging wal files.

This pull request aims to generate discussion and hopefully consensus if now is the right time to return to the previous 10,000 snapshot count.

Note: If this pr is accepted I will raise the corresponding one for 3.6 documentation update.

Fixes #15360 
/area performance