### PR TITLE
[3.5] Backport update to latest go 1.19.7 release

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: |
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.19.6
+GO_VERSION ?= 1.19.7
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/api/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/coreos/go-semver v0.3.0

--- a/client/pkg/go.mod
+++ b/client/pkg/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/client/pkg/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/coreos/go-systemd/v22 v22.3.2

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/client/v2
 
-go 1.17
+go 1.19
 
 require (
 	github.com/json-iterator/go v1.1.11

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/client/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/dustin/go-humanize v1.0.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/pkg/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/creack/pty v1.1.11

--- a/raft/go.mod
+++ b/raft/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/raft/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/cockroachdb/datadriven v1.0.2

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/tools/v3
 
-go 1.17
+go 1.19
 
 require (
 	github.com/akhenakh/hunspellgo v0.0.0-20160221122622-9db38fa26e19 // indirect


### PR DESCRIPTION
Mitigates CVE-2023-24532, refer: https://groups.google.com/g/golang-dev/c/3wmx8i5WvNY/m/AEOlccrGAwAJ?utm_medium=email&utm_source=footer

Relates to https://github.com/etcd-io/etcd/issues/15426

/area security


Note: I somehow missed some nested `go.mod` updates from `1.17` to `1.19` when I previously backported `1.19.6` update so I am tidying up those in this pull request also.