### PR TITLE
 [3.4] Backport update to latest go 1.19.7 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: |
         git config --global user.email "github-action@etcd.io"
         git config --global user.name "Github Action"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.6"
+        go-version: "1.19.7"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.19.6
+GO_VERSION ?= 1.19.7
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -13,7 +13,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-agent.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.19.6
+  GO_VERSION=1.19.7
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -6,7 +6,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-tester.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.19.6
+  GO_VERSION=1.19.7
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 


### PR DESCRIPTION
Mitigates CVE-2023-24532, refer: https://groups.google.com/g/golang-dev/c/3wmx8i5WvNY/m/AEOlccrGAwAJ?utm_medium=email&utm_source=footer

Relates to https://github.com/etcd-io/etcd/issues/15426

/area security