### PR TITLE
server/auth: fix auth panic bug when user changes password

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -493,7 +493,8 @@ func (as *authStore) UserChangePassword(r *pb.AuthUserChangePasswordRequest) (*p
 	var password []byte
 	var err error
 
-	if !user.Options.NoPassword {
+	// Backward compatible with old versions of etcd, user options is nil
+	if user.Options == nil || !user.Options.NoPassword {
 		password, err = as.selectPassword(r.Password, r.HashedPassword)
 		if err != nil {
 			return nil, ErrNoPasswordUser

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -114,10 +114,26 @@ func setupAuthStore(t *testing.T) (store *authStore, teardownfunc func(t *testin
 		t.Fatal(err)
 	}
 
+	// The UserAdd function cannot generate old etcd version user data (user's option is nil)
+	// add special users through the underlying interface
+	addUserWithNoOption(as)
+
 	tearDown := func(_ *testing.T) {
 		as.Close()
 	}
 	return as, tearDown
+}
+
+func addUserWithNoOption(as *authStore) {
+	tx := as.be.BatchTx()
+	tx.Lock()
+	defer tx.Unlock()
+	tx.UnsafePutUser(&authpb.User{
+		Name:     []byte("foo-no-user-options"),
+		Password: []byte("bar"),
+	})
+	as.commitRevision(tx)
+	as.refreshRangePermCache(tx)
 }
 
 func enableAuthAndCreateRoot(as *authStore) error {
@@ -191,8 +207,8 @@ func TestRecoverWithEmptyRangePermCache(t *testing.T) {
 		t.Fatalf("expected auth enabled got disabled")
 	}
 
-	if len(as.rangePermCache) != 2 {
-		t.Fatalf("rangePermCache should have permission information for 2 users (\"root\" and \"foo\"), but has %d information", len(as.rangePermCache))
+	if len(as.rangePermCache) != 3 {
+		t.Fatalf("rangePermCache should have permission information for 3 users (\"root\" and \"foo\",\"foo-no-user-options\"), but has %d information", len(as.rangePermCache))
 	}
 	if _, ok := as.rangePermCache["root"]; !ok {
 		t.Fatal("user \"root\" should be created by setupAuthStore() but doesn't exist in rangePermCache")
@@ -322,6 +338,12 @@ func TestUserChangePassword(t *testing.T) {
 	}
 	if err != ErrUserNotFound {
 		t.Fatalf("expected %v, got %v", ErrUserNotFound, err)
+	}
+
+	// change a user（user option is nil) password
+	_, err = as.UserChangePassword(&pb.AuthUserChangePasswordRequest{Name: "foo-no-user-options", HashedPassword: encodePassword("bar")})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## What happened?

When the etcd cluster is migrated from the old version before 3.5 to the version 3.5+, if user changes the password will trigger a panic bug.

<img width="978" alt="image" src="https://user-images.githubusercontent.com/2403673/223943449-d945a794-61ab-4dfd-b43e-a0fb82a12c9c.png">


## Reason

Old etcd version user's option is nil.  I checked the code and found that user.Options.NoPassword is always false. It seems that there is no need to check here, and it is not allowed to set an empty password.
