### PR TITLE
raftexample: apply conf change entries before send message

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -460,12 +460,12 @@ func (rc *raftNode) serveChannels() {
 				rc.publishSnapshot(rd.Snapshot)
 			}
 			rc.raftStorage.Append(rd.Entries)
-			rc.transport.Send(rc.processMessages(rd.Messages))
 			applyDoneC, ok := rc.publishEntries(rc.entriesToApply(rd.CommittedEntries))
 			if !ok {
 				rc.stop()
 				return
 			}
+			rc.transport.Send(rc.processMessages(rd.Messages))
 			rc.maybeTriggerSnapshot(applyDoneC)
 			rc.node.Advance()
 


### PR DESCRIPTION
Update raftexample to apply conf changes before send raft.Ready.Messages. Candidate or follower needs to wait for all pending conf changes. Otherwise there might be incorrectly count votes.
This PR introduces the fix from #7595 and pr num [7706](https://github.com/etcd-io/etcd/pull/7706).

Same logic as [etcdserver/raft.go at main](https://github.com/etcd-io/etcd/blob/main/server/etcdserver/raft.go#L278)
Since conf changes are applied directly in publishEntries, it doesn't need to wait for the applyDoneC.