### PR TITLE
etcdserver: create separate goroutine to accept grpc tls connection

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -176,7 +176,8 @@ func (sctx *serveCtx) serve(
 		if sctx.serviceRegister != nil {
 			sctx.serviceRegister(gs)
 		}
-		handler = grpcHandlerFunc(gs, handler)
+		grpcl := m.Match(cmux.HTTP2())
+		go func() { errHandler(gs.Serve(grpcl)) }()
 
 		var gwmux *gw.ServeMux
 		if s.Cfg.EnableGRPCGateway {


### PR DESCRIPTION
Try to resolve https://github.com/etcd-io/etcd/issues/15402

This solution has a major issue... the HTTP requests (e.g /health, /metrics, etc.) can't go through HTTP/2. Probably this issue should be resolved in `github.com/soheilhy/cmux`?

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
