### PR TITLE
server: update defrag logic to use bolt.Compact()

### DIFF
--- a/server/storage/backend/backend_test.go
+++ b/server/storage/backend/backend_test.go
@@ -136,11 +136,14 @@ func TestBackendDefrag(t *testing.T) {
 
 	defer betesting.Close(t, b)
 
+	// Put some data a bit over the defrag limit
 	tx := b.BatchTx()
 	tx.Lock()
 	tx.UnsafeCreateBucket(schema.Test)
-	for i := 0; i < backend.DefragLimitForTest()+100; i++ {
-		tx.UnsafePut(schema.Test, []byte(fmt.Sprintf("foo_%d", i)), []byte("bar"))
+	n := int(float32(backend.DefragLimitForTest())*1.1) / 1024
+	value := make([]byte, 1024)
+	for i := 0; i < n; i++ {
+		tx.UnsafePut(schema.Test, []byte(fmt.Sprintf("foo_%d", i)), value)
 	}
 	tx.Unlock()
 	b.ForceCommit()


### PR DESCRIPTION
They are pretty much same implementation. Iterate over buckets, iterate over keys and copy from old db to new db.

One difference is that etcd implementation was setting FillPercent to 0.9 while boltdb implementation sets it to 1.0. After this change the defrag duration on my database dropped from 10.5 to 9 seconds probably because of this change.

The other difference is that boltdb implementation also handles nested buckets. Etcd does not have any nested buckets at the moment but it's nice to have that covered.

With this change, defrag limit changes from 10,000 keys to 10 MB data because bolt.Compact() API wants byte size.