### PR TITLE
Refactor `contrib/raftexample` using interfaces to better separate concerns

### DIFF
--- a/contrib/raftexample/httpapi.go
+++ b/contrib/raftexample/httpapi.go
@@ -114,7 +114,9 @@ func (h *httpKVAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // serveHTTPKVAPI starts a key-value server with a GET/PUT API and listens.
-func serveHTTPKVAPI(kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, errorC <-chan error) {
+func serveHTTPKVAPI(
+	kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, done <-chan struct{},
+) {
 	srv := http.Server{
 		Addr: ":" + strconv.Itoa(port),
 		Handler: &httpKVAPI{
@@ -129,7 +131,6 @@ func serveHTTPKVAPI(kv KVStore, port int, confChangeC chan<- raftpb.ConfChange, 
 	}()
 
 	// exit when raft goes down
-	if err, ok := <-errorC; ok {
-		log.Fatal(err)
-	}
+	<-done
+	_ = srv.Close()
 }

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -144,7 +144,7 @@ func (fsm kvfsm) applyCommits(commit *commit) error {
 
 // ProcessCommits() reads commits from `commitC` and applies them into
 // the kvstore until that channel is closed.
-func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
+func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
 	for commit := range commitC {
 		if commit == nil {
 			// This is a request that we load a snapshot.
@@ -153,10 +153,11 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
 		}
 
 		if err := fsm.applyCommits(commit); err != nil {
-			log.Fatalf("raftexample: %v", err)
+			return err
 		}
 	}
 	if err, ok := <-errorC; ok {
-		log.Fatal(err)
+		return err
 	}
+	return nil
 }

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -54,7 +54,6 @@ func newKVStore(snapshotStorage SnapshotStorage, proposeC chan<- string) (*kvsto
 	fsm := kvfsm{
 		kvs: s,
 	}
-	fsm.LoadAndApplySnapshot()
 	return s, fsm
 }
 

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -126,10 +126,10 @@ func (fsm kvfsm) TakeSnapshot() ([]byte, error) {
 	return json.Marshal(fsm.kvs.kvStore)
 }
 
-// applyCommits decodes and applies each of the commits in `commit` to
+// ApplyCommits decodes and applies each of the commits in `commit` to
 // the current state, then signals that it is done by closing
 // `commit.applyDoneC`.
-func (fsm kvfsm) applyCommits(commit *commit) error {
+func (fsm kvfsm) ApplyCommits(commit *commit) error {
 	for _, data := range commit.data {
 		var dataKv kv
 		dec := gob.NewDecoder(bytes.NewBufferString(data))
@@ -152,7 +152,7 @@ func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) err
 			continue
 		}
 
-		if err := fsm.applyCommits(commit); err != nil {
+		if err := fsm.ApplyCommits(commit); err != nil {
 			return err
 		}
 	}

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -140,23 +140,3 @@ func (fsm kvfsm) ApplyCommits(commit *commit) error {
 	close(commit.applyDoneC)
 	return nil
 }
-
-// ProcessCommits() reads commits from `commitC` and applies them into
-// the kvstore until that channel is closed.
-func (fsm kvfsm) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
-	for commit := range commitC {
-		if commit == nil {
-			// This is a request that we load a snapshot.
-			fsm.LoadAndApplySnapshot()
-			continue
-		}
-
-		if err := fsm.ApplyCommits(commit); err != nil {
-			return err
-		}
-	}
-	if err, ok := <-errorC; ok {
-		return err
-	}
-	return nil
-}

--- a/contrib/raftexample/kvstore_test.go
+++ b/contrib/raftexample/kvstore_test.go
@@ -22,19 +22,22 @@ import (
 func Test_kvstore_snapshot(t *testing.T) {
 	tm := map[string]string{"foo": "bar"}
 	s := &kvstore{kvStore: tm}
+	fsm := kvfsm{
+		kvs: s,
+	}
 
 	v, _ := s.Lookup("foo")
 	if v != "bar" {
 		t.Fatalf("foo has unexpected value, got %s", v)
 	}
 
-	data, err := s.getSnapshot()
+	data, err := fsm.TakeSnapshot()
 	if err != nil {
 		t.Fatal(err)
 	}
 	s.kvStore = nil
 
-	if err := s.recoverFromSnapshot(data); err != nil {
+	if err := fsm.RestoreSnapshot(data); err != nil {
 		t.Fatal(err)
 	}
 	v, _ = s.Lookup("foo")

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -54,7 +54,11 @@ func main() {
 		proposeC, confChangeC,
 	)
 
-	go fsm.ProcessCommits(commitC, errorC)
+	go func() {
+		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
+	}()
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	cluster := flag.String("cluster", "http://127.0.0.1:9021", "comma separated cluster peers")
-	id := flag.Int("id", 1, "node ID")
+	id := flag.Uint64("id", 1, "node ID")
 	kvport := flag.Int("port", 9121, "key-value server port")
 	join := flag.Bool("join", false, "join an existing cluster")
 	flag.Parse()

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -46,15 +46,15 @@ func main() {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 
 	commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
-		kvs.getSnapshot, snapshotStorage,
+		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
-	go kvs.processCommits(commitC, errorC)
+	go fsm.ProcessCommits(commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -36,11 +36,11 @@ func main() {
 	// raft provides a commit stream for the proposals from the http api
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotStorageReady := newRaftNode(
+	commitC, errorC, snapshotStorage := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC,
 	)
 
-	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
+	kvs = newKVStore(snapshotStorage, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -46,7 +46,7 @@ func main() {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(proposeC)
 
 	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -49,14 +49,14 @@ func main() {
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
 	fsm.LoadAndApplySnapshot()
 
-	commitC, errorC := startRaftNode(
+	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+		if err := rc.ProcessCommits(commitC, errorC); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -47,6 +47,7 @@ func main() {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	fsm.LoadAndApplySnapshot()
 
 	commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -47,7 +47,6 @@ func main() {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
-	fsm.LoadAndApplySnapshot()
 
 	rc, commitC, errorC := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -61,5 +61,5 @@ func main() {
 	}()
 
 	// the key-value http handler will propose updates to raft
-	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)
+	serveHTTPKVAPI(kvs, *kvport, confChangeC, rc.Done())
 }

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -36,9 +36,11 @@ func main() {
 	// raft provides a commit stream for the proposals from the http api
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotterReady := newRaftNode(*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC)
+	commitC, errorC, snapshotStorageReady := newRaftNode(
+		*id, strings.Split(*cluster, ","), *join, getSnapshot, proposeC, confChangeC,
+	)
 
-	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
+	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
 
 	// the key-value http handler will propose updates to raft
 	serveHTTPKVAPI(kvs, *kvport, confChangeC, errorC)

--- a/contrib/raftexample/main.go
+++ b/contrib/raftexample/main.go
@@ -48,14 +48,14 @@ func main() {
 
 	kvs, fsm := newKVStore(proposeC)
 
-	rc, commitC, errorC := startRaftNode(
+	rc := startRaftNode(
 		*id, strings.Split(*cluster, ","), *join,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := rc.ProcessCommits(commitC, errorC); err != nil {
+		if err := rc.ProcessCommits(); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -127,6 +127,14 @@ func newRaftNode(
 		snapshotStorageReady: make(chan SnapshotStorage, 1),
 		// rest of structure populated after WAL replay
 	}
+
+	snapshotLogger := zap.NewExample()
+	var err error
+	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
+	if err != nil {
+		log.Fatalf("raftexample: %v", err)
+	}
+
 	go rc.startRaft()
 	return commitC, errorC, rc.snapshotStorageReady
 }
@@ -288,13 +296,6 @@ func (rc *raftNode) writeError(err error) {
 }
 
 func (rc *raftNode) startRaft() {
-	snapshotLogger := zap.NewExample()
-	var err error
-	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
-	if err != nil {
-		log.Fatalf("raftexample: %v", err)
-	}
-
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
 

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -100,6 +100,11 @@ type FSM interface {
 	// bytes that can be saved or loaded by a `SnapshotStorage`.
 	TakeSnapshot() ([]byte, error)
 
+	// RestoreSnapshot restores the finite state machine to the state
+	// represented by `snapshot` (which, in turn, was returned by
+	// `TakeSnapshot`).
+	RestoreSnapshot(snapshot []byte) error
+
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -150,6 +150,8 @@ func startRaftNode(
 		// rest of structure populated after WAL replay
 	}
 
+	rc.fsm.LoadAndApplySnapshot()
+
 	oldwal := wal.Exist(rc.waldir)
 	rc.wal = rc.replayWAL()
 

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -105,6 +105,10 @@ type FSM interface {
 	// `TakeSnapshot`).
 	RestoreSnapshot(snapshot []byte) error
 
+	// LoadAndApplySnapshot loads the most recent snapshot from the
+	// snapshot storage (if any) and applies it to the current state.
+	LoadAndApplySnapshot()
+
 	// ApplyCommits applies the changes from `commit` to the finite
 	// state machine. `commit` is never `nil`. (By contrast, the
 	// commits that are handled by `ProcessCommits()` can be `nil` to

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -108,7 +108,7 @@ type FSM interface {
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.
-	ProcessCommits(commitC <-chan *commit, errorC <-chan error)
+	ProcessCommits(commitC <-chan *commit, errorC <-chan error) error
 }
 
 // startRaftNode initiates a raft instance and returns a committed log entry

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -53,7 +53,6 @@ type raftNode struct {
 	peers       []string // raft peer URLs
 	join        bool     // node is joining an existing cluster
 	waldir      string   // path to WAL directory
-	snapdir     string   // path to snapshot directory
 	getSnapshot func() ([]byte, error)
 
 	confState     raftpb.ConfState
@@ -115,7 +114,6 @@ func startRaftNode(
 		peers:       peers,
 		join:        join,
 		waldir:      fmt.Sprintf("raftexample-%d", id),
-		snapdir:     fmt.Sprintf("raftexample-%d-snap", id),
 		getSnapshot: getSnapshot,
 		snapCount:   defaultSnapshotCount,
 		stopc:       make(chan struct{}),
@@ -129,7 +127,8 @@ func startRaftNode(
 
 	snapshotLogger := zap.NewExample()
 	var err error
-	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, rc.snapdir)
+	snapdir := fmt.Sprintf("raftexample-%d-snap", id)
+	rc.snapshotStorage, err = newSnapshotStorage(snapshotLogger, snapdir)
 	if err != nil {
 		log.Fatalf("raftexample: %v", err)
 	}

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -105,6 +105,12 @@ type FSM interface {
 	// `TakeSnapshot`).
 	RestoreSnapshot(snapshot []byte) error
 
+	// ApplyCommits applies the changes from `commit` to the finite
+	// state machine. `commit` is never `nil`. (By contrast, the
+	// commits that are handled by `ProcessCommits()` can be `nil` to
+	// signal that a snapshot should be loaded.)
+	ApplyCommits(commit *commit) error
+
 	// ProcessCommits reads committed updates (and requests to restore
 	// snapshots) from `commitC` and applies them to the finite state
 	// machine.

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -62,14 +62,15 @@ func newCluster(n int) *cluster {
 	}
 
 	for i := range clus.peers {
-		os.RemoveAll(fmt.Sprintf("raftexample-%d", i+1))
-		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", i+1))
+		id := uint64(i + 1)
+		os.RemoveAll(fmt.Sprintf("raftexample-%d", id))
+		os.RemoveAll(fmt.Sprintf("raftexample-%d-snap", id))
 		clus.proposeC[i] = make(chan string, 1)
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
 		clus.commitC[i], clus.errorC[i], _ = startRaftNode(
-			i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
+			id, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
 		)
 	}
 

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -41,7 +41,8 @@ type peer struct {
 
 type nullFSM struct{}
 
-func (nullFSM) ProcessCommits(commitC <-chan *commit, errorC <-chan error) {
+func (nullFSM) ProcessCommits(commitC <-chan *commit, errorC <-chan error) error {
+	return nil
 }
 
 func (nullFSM) TakeSnapshot() ([]byte, error) {
@@ -224,7 +225,11 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		proposeC, confChangeC,
 	)
 
-	go fsm.ProcessCommits(commitC, errorC)
+	go func() {
+		if err := fsm.ProcessCommits(commitC, errorC); err != nil {
+			log.Fatalf("raftexample: %v", err)
+		}
+	}()
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -153,12 +153,13 @@ func TestProposeOnCommit(t *testing.T) {
 			}
 			donec <- struct{}{}
 			for range cC {
-				// acknowledge the commits from other nodes so
-				// raft continues to make progress
+				// Acknowledge the rest of the commits (including
+				// those from other nodes) without feeding them back
+				// in so that raft can finish.
 			}
 		}(clus.proposeC[i], clus.commitC[i], clus.errorC[i])
 
-		// one message feedback per node
+		// Trigger the whole cascade by sending one message per node:
 		go func(i int) { clus.proposeC[i] <- "foo" }(i)
 	}
 

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -109,7 +109,8 @@ func (clus *cluster) Close() (err error) {
 		}()
 		close(peer.proposeC)
 		// wait for channel to close
-		if erri := <-peer.errorC; erri != nil {
+		<-peer.node.Done()
+		if erri := peer.node.Err(); erri != nil {
 			err = erri
 		}
 		// clean intermediates

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -33,8 +33,6 @@ import (
 
 type peer struct {
 	node        *raftNode
-	commitC     <-chan *commit
-	errorC      <-chan error
 	proposeC    chan string
 	confChangeC chan raftpb.ConfChange
 	fsm         FSM
@@ -87,7 +85,7 @@ func newCluster(fsms ...FSM) *cluster {
 			log.Fatalf("raftexample: %v", err)
 		}
 
-		peer.node, peer.commitC, peer.errorC = startRaftNode(
+		peer.node = startRaftNode(
 			id, clus.peerNames, false,
 			peer.fsm, snapshotStorage,
 			peer.proposeC, peer.confChangeC,
@@ -111,7 +109,7 @@ func (clus *cluster) Close() (err error) {
 	for _, peer := range clus.peers {
 		peer := peer
 		go func() {
-			for range peer.commitC {
+			for range peer.node.commitC {
 				// drain pending commits
 			}
 		}()
@@ -197,7 +195,7 @@ func TestProposeOnCommit(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := fsm.peer.node.ProcessCommits(fsm.peer.commitC, fsm.peer.errorC); err != nil {
+			if err := fsm.peer.node.ProcessCommits(); err != nil {
 				t.Error("ProcessCommits returned error", err)
 			}
 		}()
@@ -243,7 +241,7 @@ func TestCloseProposerInflight(t *testing.T) {
 	}()
 
 	// wait for one message
-	if c, ok := <-clus.peers[0].commitC; !ok || c.data[0] != "foo" {
+	if c, ok := <-clus.peers[0].node.commitC; !ok || c.data[0] != "foo" {
 		t.Fatalf("Commit failed")
 	}
 
@@ -269,14 +267,14 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	kvs, fsm := newKVStore(proposeC)
 
-	node, commitC, errorC := startRaftNode(
+	node := startRaftNode(
 		id, clusters, false,
 		fsm, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
 	go func() {
-		if err := node.ProcessCommits(commitC, errorC); err != nil {
+		if err := node.ProcessCommits(); err != nil {
 			log.Fatalf("raftexample: %v", err)
 		}
 	}()
@@ -367,7 +365,7 @@ func TestAddNewNode(t *testing.T) {
 		proposeC <- "foo"
 	}()
 
-	if c, ok := <-clus.peers[0].commitC; !ok || c.data[0] != "foo" {
+	if c, ok := <-clus.peers[0].node.commitC; !ok || c.data[0] != "foo" {
 		t.Fatalf("Commit failed")
 	}
 }
@@ -401,7 +399,7 @@ func TestSnapshot(t *testing.T) {
 		clus.peers[0].proposeC <- "foo"
 	}()
 
-	c := <-clus.peers[0].commitC
+	c := <-clus.peers[0].node.commitC
 
 	select {
 	case <-sw.C:

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -44,6 +44,10 @@ func (sw snapshotWatcher) TakeSnapshot() ([]byte, error) {
 	return nil, nil
 }
 
+func (sw snapshotWatcher) RestoreSnapshot(snapshot []byte) error {
+	panic("not implemented")
+}
+
 type cluster struct {
 	peers            []string
 	commitC          []<-chan *commit

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -196,9 +196,6 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	confChangeC := make(chan raftpb.ConfChange)
 	defer close(confChangeC)
 
-	var kvs *kvstore
-	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-
 	id := uint64(1)
 	snapshotLogger := zap.NewExample()
 	snapdir := fmt.Sprintf("raftexample-%d-snap", id)
@@ -207,13 +204,15 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		log.Fatalf("raftexample: %v", err)
 	}
 
+	kvs := newKVStore(snapshotStorage, proposeC)
+
 	commitC, errorC := startRaftNode(
 		id, clusters, false,
-		getSnapshot, snapshotStorage,
+		kvs.getSnapshot, snapshotStorage,
 		proposeC, confChangeC,
 	)
 
-	kvs = newKVStore(snapshotStorage, proposeC, commitC, errorC)
+	go kvs.processCommits(commitC, errorC)
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -50,9 +50,6 @@ func (nullFSM) RestoreSnapshot(snapshot []byte) error {
 	return nil
 }
 
-func (nullFSM) LoadAndApplySnapshot() {
-}
-
 func (nullFSM) ApplyCommits(commit *commit) error {
 	return nil
 }
@@ -221,7 +218,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 		log.Fatalf("raftexample: %v", err)
 	}
 
-	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	kvs, fsm := newKVStore(proposeC)
 
 	node, commitC, errorC := startRaftNode(
 		id, clusters, false,

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -53,6 +53,10 @@ func (nullFSM) RestoreSnapshot(snapshot []byte) error {
 	return nil
 }
 
+func (nullFSM) ApplyCommits(commit *commit) error {
+	return nil
+}
+
 type cluster struct {
 	peerNames []string
 	peers     []*peer

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -222,7 +222,6 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
-	fsm.LoadAndApplySnapshot()
 
 	node, commitC, errorC := startRaftNode(
 		id, clusters, false,
@@ -314,7 +313,7 @@ func TestAddNewNode(t *testing.T) {
 
 	startRaftNode(
 		id, append(clus.peerNames, newNodeURL), true,
-		nil, snapshotStorage,
+		nullFSM{}, snapshotStorage,
 		proposeC, confChangeC,
 	)
 

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -53,6 +53,9 @@ func (nullFSM) RestoreSnapshot(snapshot []byte) error {
 	return nil
 }
 
+func (nullFSM) LoadAndApplySnapshot() {
+}
+
 func (nullFSM) ApplyCommits(commit *commit) error {
 	return nil
 }
@@ -222,6 +225,7 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	}
 
 	kvs, fsm := newKVStore(snapshotStorage, proposeC)
+	fsm.LoadAndApplySnapshot()
 
 	commitC, errorC := startRaftNode(
 		id, clusters, false,

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -148,8 +148,10 @@ func TestProposeOnCommit(t *testing.T) {
 				select {
 				case proposeC <- c.data[0]:
 					continue
-				case err := <-peer.errorC:
-					t.Errorf("eC message (%v)", err)
+				case <-peer.node.Done():
+					if err := peer.node.Err(); err != nil {
+						t.Errorf("peer error (%v)", err)
+					}
 				}
 			}
 			donec <- struct{}{}

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -68,7 +68,9 @@ func newCluster(n int) *cluster {
 		clus.confChangeC[i] = make(chan raftpb.ConfChange, 1)
 		fn, snapshotTriggeredC := getSnapshotFn()
 		clus.snapshotTriggeredC[i] = snapshotTriggeredC
-		clus.commitC[i], clus.errorC[i], _ = newRaftNode(i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i])
+		clus.commitC[i], clus.errorC[i], _ = newRaftNode(
+			i+1, clus.peers, false, fn, clus.proposeC[i], clus.confChangeC[i],
+		)
 	}
 
 	return clus
@@ -182,9 +184,9 @@ func TestPutAndGetKeyValue(t *testing.T) {
 
 	var kvs *kvstore
 	getSnapshot := func() ([]byte, error) { return kvs.getSnapshot() }
-	commitC, errorC, snapshotterReady := newRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
+	commitC, errorC, snapshotStorageReady := newRaftNode(1, clusters, false, getSnapshot, proposeC, confChangeC)
 
-	kvs = newKVStore(<-snapshotterReady, proposeC, commitC, errorC)
+	kvs = newKVStore(<-snapshotStorageReady, proposeC, commitC, errorC)
 
 	srv := httptest.NewServer(&httpKVAPI{
 		store:       kvs,


### PR DESCRIPTION
I come to etcd by way of evaluating `go.etcd.io/raft` for use in a project. When I saw that there was a sample application [`raftexample`](https://github.com/etcd-io/etcd/tree/main/contrib/raftexample) showing how to use the module, I started reading it, hoping that this would make it obvious what components I would have to implement to use raft in my own application.

But unfortunately, it wasn't easy to figure that out from the source code of `raftexample`. True, it provides a nice end-to-end example. Also, `raftNode` is a fairly nice abstraction, showing how to deal with the channels going into and coming out of the raft library. But I didn't find the interface between `raftNode` and the "application code" super transparent. For example,

* It is not obvious what features the `Snapshotter` must provide.
* It's hard to see the boundary between the raft code and the finite state machine being driven by it. `kvstore` is the FSM, but it also does things like read straight out of raft-managed channels and interact directly with the snapshotter.
* `httpKVAPI` contains a pointer to the whole `kvstore`, even though it really only interacts with its "public" interface, `Propose()` and `Lookup()`.
* The design forces an awkward initialization step, where `main()` creates a `getSnaphost` function that closes over an initialized variable (`kvs`) then passes that function into `newRaftNode()`. That function returns a `shapshotterReady <-chan *snap.Snapshotter` channel from which `main()` reads a `Snapshotter`. It was unclear how much of this was essential complexity and how much could be avoided. (It turns out that most of this complexity can be avoided.)
* `newRaftNode()` returns `commitC`, which is handed on to `newKVStore()` and read from a goroutine in that type. It seems like it would be simpler for `raftNode` to read from `commitC` and invoke `kvstore` methods to trigger commits.
* `newRaftNode()` returns `errorC`, to which it writes an error if there is a problem. But multiple pieces of code try to read from that channel, and the semantics of Go channels make it indeterminate which one will discover that there was an error. (In general, error reporting is somewhat inconsistent.)

This PR consists of a series of refactorings that attempt to fix a bunch of the problems listed above:

* It introduces a few interfaces and uses them to better separate concerns:
    * `SnapshotStorage` represents permanent storage for snapshots. It only needs to know how to read and write them:
        ```
        type SnapshotStorage interface {
            SaveSnap(snapshot raftpb.Snapshot) error
            Load() (*raftpb.Snapshot, error)
            LoadNewestAvailable(walSnaps []walpb.Snapshot) (*raftpb.Snapshot, error)
        }
        ```
    * `FSM` represents the finite state machine that `raftNode` is able to drive. It only has to know how to take and restore snapshots and to apply commits:
        ```
        type FSM interface {
            TakeSnapshot() ([]byte, error)
            RestoreSnapshot(snapshot []byte) error
            ApplyCommits(commit *commit) error
        }
        ```
    * `KVStore` represents the interface that `httpKVAPI` uses to interact with the key-value store. Note that this interface only exposes application-level concepts and doesn't really expose anything about raft, but internally it has to know how to serialize its calls into log entries that can be managed by raft:
        ```
        type KVStore interface {
            Propose(k, v string)
            Lookup(k string) (string, bool)
        }
        ```

* `kvstore` now presents a `KVStore` face to `httpKVAPI` and a `FSM` face to `raftNode`, but itself is now a passive type (no internal goroutines).

* Now `raftNode` implements more of the raft data flows internally; in particular, its `ProcessCommits()` method reads commits from `commitC` and applies them to the `kvstore` via the `FSM` interface.

* Now `main()` creates the snapshotter and passes it to `raftNode`. This eliminates the complexity of `snapshotterReady`.

* `raftNode` now has `Done()` and `Err()` methods (replacing the `errorC` channel) that the caller can use to find out when it is done and whether it experienced any errors.

I think these changes make the code easier to read, and more importantly, make it easier for the reader to figure out would they would have to change to use the raft module within their own application, even if that application doesn't happen to be a key-value store.

This is a long patch series, but each commit is a self-contained step, meant to be readable/reviewable independently, and the tests pass after each commit. I'd be happy to break it up into multiple smaller PRs if that is preferable.

Along the way I fixed a couple of other minor problems, such as the ambiguity about error reporting mentioned above, and in the strange `TestProposeOnCommit()` test. See the commit messages for more information.

I only changed code within `contrib/raftexample`. But within that package, I have changed some internal interfaces. I assume that since this is just demonstration code, there are no backwards-compatibility promises made about this package. For the same reason, I have introduced some interfaces where there were none before, which will probably decrease performance very slightly and maybe force a few more allocations. Again, my goal was to make the code easier to understand, and I assume that preserving uncompromising performance is a lower priority than clarity.

I think that some further refactoring would be nice, to better delineate the interfaces between `raftNode` and the write-ahead log, and perhaps between `raftNode` and the transport layer. But I'll wait to see how this PR is received before proceeding.

I hope this is helpful!
