### PR TITLE
feat: add riscv64 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
           - linux-arm64
           - linux-ppc64le
           - linux-s390x
+          - linux-riscv64
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -48,6 +49,9 @@ jobs:
               ;;
             linux-arm64)
               GOARCH=arm64 GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
+              ;;
+            linux-riscv64)
+              GOARCH=riscv64 GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh
               ;;
             linux-ppc64le)
               GOARCH=ppc64le GO_BUILD_FLAGS='-v -mod=readonly' ./scripts/build.sh

--- a/Dockerfile-release.riscv64
+++ b/Dockerfile-release.riscv64
@@ -1,0 +1,16 @@
+FROM --platform=linux/riscv64 scratch
+
+# TODO: use distroless once it supports riscv64
+# https://github.com/GoogleContainerTools/distroless/issues/1269
+
+ADD etcd /usr/local/bin/
+ADD etcdctl /usr/local/bin/
+ADD etcdutl /usr/local/bin/
+
+WORKDIR /var/etcd/
+WORKDIR /var/lib/etcd/
+
+EXPOSE 2379 2380
+
+# Define default command.
+CMD ["/usr/local/bin/etcd"]

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -74,6 +74,7 @@ function main {
       TARGET_ARCHS+=("arm64")
       TARGET_ARCHS+=("ppc64le")
       TARGET_ARCHS+=("s390x")
+      TARGET_ARCHS+=("riscv64")
     fi
 
     if [ ${GOOS} == "darwin" ]; then

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -24,7 +24,7 @@ pushd "${ETCD_ROOT}" >/dev/null
   log_callout "Building etcd binary..."
   ./scripts/build-binary.sh "${VERSION}"
 
-  for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
+  for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x" "riscv64"; do
     log_callout "Building ${TARGET_ARCH} docker image..."
     GOOS=linux GOARCH=${TARGET_ARCH} BINARYDIR=release/etcd-${VERSION}-linux-${TARGET_ARCH} BUILDDIR=release ./scripts/build-docker.sh "${VERSION}"
   done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -258,7 +258,7 @@ main() {
       log_warning "login failed, retrying"
     done
 
-    for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
+    for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x" "riscv64"; do
       log_callout "Pushing container images to quay.io ${RELEASE_VERSION}-${TARGET_ARCH}"
       maybe_run docker push "quay.io/coreos/etcd:${RELEASE_VERSION}-${TARGET_ARCH}"
       log_callout "Pushing container images to gcr.io ${RELEASE_VERSION}-${TARGET_ARCH}"
@@ -267,7 +267,7 @@ main() {
 
     log_callout "Creating manifest-list (multi-image)..."
 
-    for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
+    for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x" "riscv64"; do
       maybe_run docker manifest create --amend "quay.io/coreos/etcd:${RELEASE_VERSION}" "quay.io/coreos/etcd:${RELEASE_VERSION}-${TARGET_ARCH}"
       maybe_run docker manifest annotate "quay.io/coreos/etcd:${RELEASE_VERSION}" "quay.io/coreos/etcd:${RELEASE_VERSION}-${TARGET_ARCH}" --arch "${TARGET_ARCH}"
 

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -264,7 +264,7 @@ func checkSupportArch() {
 	// To add a new platform, check https://github.com/etcd-io/website/blob/main/content/en/docs/${VERSION}/op-guide/supported-platform.md.
 	// The ${VERSION} is the etcd version, e.g. v3.5, v3.6 etc.
 	switch runtime.GOARCH {
-	case "amd64", "arm64", "ppc64le", "s390x":
+	case "amd64", "arm64", "ppc64le", "s390x", "riscv64":
 		return
 	}
 	// unsupported arch only configured via environment variable


### PR DESCRIPTION
Should be marked as [Tier 3](https://etcd.io/docs/v3.5/op-guide/supported-platform/#support-tiers).
