### PR TITLE
Add detailed long description for etcdctl txn

### DIFF
--- a/etcdctl/ctlv3/command/txn_command.go
+++ b/etcdctl/ctlv3/command/txn_command.go
@@ -36,7 +36,30 @@ func NewTxnCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "txn [options]",
 		Short: "Txn processes all the requests in one transaction",
-		Run:   txnCommandFunc,
+		Long: `Txn reads multiple etcd requests from standard input and applies them as a single atomic transaction.
+
+A transaction consists of three components:
+1) a list of conditions,
+2) a list of requests to apply if all the conditions are true,
+3) a list of requests to apply if any condition is false.
+
+Example interactive stdin usage:
+
+---
+etcdctl txn -i
+# compares:
+mod("key1") > "0"
+
+# success requests (get, put, delete):
+put key1 "overwrote-key1"
+
+# failure requests (get, put, delete):
+put key1 "created-key1"
+put key2 "some extra key"
+---
+
+Refer to https://github.com/etcd-io/etcd/blob/main/etcdctl/README.md#txn-options.`,
+		Run: txnCommandFunc,
 	}
 	cmd.Flags().BoolVarP(&txnInteractive, "interactive", "i", false, "Input transaction in interactive mode")
 	return cmd


### PR DESCRIPTION
`etcdctl txn --help` is currently not sufficient to be able to use the command without referring to other sources.

We can add a `Long:` description to at least explain what the stdin payload should contain and provide an example of interactive use.

Here is a preview of the proposed help output:

```bash
 james  ~  Documents  etcd   txn_help_docs                                                                                                                   11:32:18 
 ➜ ./bin/etcdctl txn --help
NAME:
        txn - Txn processes all the requests in one transaction

USAGE:
        etcdctl txn [options] [flags]

DESCRIPTION:
        TXN reads multiple etcd requests from standard input and applies them as a single atomic transaction.

        A transaction consists of:
        1) a list of conditions,
        2) a list of requests to apply if all the conditions are true,
        3) and a list of requests to apply if any condition is false.

        Example interactive stdin usage:

        ---
        etcdctl txn -i
        # compares:
        mod("key1") > "0"

        # success requests (get, put, delete):
        put key1 "overwrote-key1"

        # failure requests (get, put, delete):
        put key1 "created-key1"
        put key2 "some extra key"
        ---

        Refer to https://github.com/etcd-io/etcd/blob/main/etcdctl/README.md#txn-options.

OPTIONS:
  -h, --help[=false]            help for txn
  -i, --interactive[=false]     Input transaction in interactive mode

GLOBAL OPTIONS:
```


Fixes #15441