### PR TITLE
deflake member_test: enable pre-vote by default and add retry

### DIFF
--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -49,11 +50,17 @@ func TestMemberList(t *testing.T) {
 				if expectNum != gotNum {
 					t.Fatalf("number of members not equal, expect: %d, got: %d", expectNum, gotNum)
 				}
-				for _, m := range resp.Members {
-					if len(m.ClientURLs) == 0 {
-						t.Fatalf("member is not started, memberId:%d, memberName:%s", m.ID, m.Name)
+				assert.Eventually(t, func() (done bool) {
+					for _, m := range resp.Members {
+						if len(m.ClientURLs) == 0 {
+							t.Logf("member is not started, memberId:%d, memberName:%s", m.ID, m.Name)
+							done = false
+							return done
+						}
 					}
-				}
+					done = true
+					return true
+				}, time.Second*5, time.Millisecond*100)
 			})
 		})
 	}

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -37,6 +37,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
+	"go.etcd.io/raft/v3"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
@@ -59,7 +61,6 @@ import (
 	"go.etcd.io/etcd/server/v3/verify"
 	framecfg "go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
-	"go.etcd.io/raft/v3"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -662,6 +663,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 	m.ElectionTicks = ElectionTicks
 	m.InitialElectionTickAdvance = true
 	m.TickMs = uint(framecfg.TickDuration / time.Millisecond)
+	m.PreVote = true
 	m.QuotaBackendBytes = mcfg.QuotaBackendBytes
 	m.MaxTxnOps = mcfg.MaxTxnOps
 	if m.MaxTxnOps == 0 {


### PR DESCRIPTION
```
logger.go:130: 2023-03-17T21:25:24.870Z	INFO	m2.raft	found conflict at index 5 [existing term: 3, conflicting term: 7]	{"member": "m2"}
logger.go:130: 2023-03-17T21:25:24.871Z	INFO	m2.raft	replace the unstable entries from index 5	{"member": "m2"}
logger.go:130: 2023-03-17T21:25:24.871Z	INFO	m2.raft	raft.node: c9f72a2ce27a2277 elected leader 89e201e60fa5e8e5 at term 7	{"member": "m2"}
logger.go:130: 2023-03-17T21:25:24.871Z	INFO	m0.raft	raft.node: 5bd65997f89ffd02 elected leader 89e201e60fa5e8e5 at term 7	{"member": "m0"}
member_test.go:54: member is not started, memberId:14553147093137629815, memberName:m2
```
Member attributes: `clientURL` is not published due to raft election disruption. 

Enable `PreVote` to `true` will help deflake the integration test and reduce the run time. This has been enabled in e2e test since etcd v3.4. 

https://github.com/etcd-io/etcd/actions/runs/4451655149/jobs/7818558714?pr=15500

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
