### PR TITLE
Replace Cmux

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -369,15 +369,6 @@
 		]
 	},
 	{
-		"project": "github.com/soheilhy/cmux",
-		"licenses": [
-			{
-				"type": "Apache License 2.0",
-				"confidence": 1
-			}
-		]
-	},
-	{
 		"project": "github.com/spf13/cobra",
 		"licenses": [
 			{

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -586,11 +586,19 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 	return cfg, nil
 }
 
-// IsClosedConnError returns true if the error is from closing listener, cmux.
+// IsClosedConnError returns true if the error is from closing listener.
 // copied from golang.org/x/net/http2/http2.go
 func IsClosedConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
 	// 'use of closed network connection' (Go <=1.8)
 	// 'use of closed file or network connection' (Go >1.8, internal/poll.ErrClosing)
-	// 'mux: listener closed' (cmux.ErrListenerClosed)
-	return err != nil && strings.Contains(err.Error(), "closed")
+	if strings.Contains(err.Error(), "closed") {
+		return true
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
@@ -386,7 +384,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/pkg/connmux/connmux.go
+++ b/pkg/connmux/connmux.go
@@ -1,0 +1,335 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmux
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+const (
+	// gracefullShutdownDuration is the time to wait before closing the listeners
+	gracefullShutdownDuration = 200 * time.Millisecond
+	// readDeadlineTimeout is the maximum time to wait for a read operation
+	readDeadlineTimeout = 1 * time.Second
+)
+
+// ConnMux can multiple multiple HTTP and GRPC connections in the same address and port.
+// It is able to multiplex connections with and without TLS.
+// ConnMux can only forward connections to one HTTP or one GRPC server.
+// If only one of those is available it will forward all connections directly.
+type ConnMux struct {
+	lg    *zap.Logger
+	root  net.Listener
+	donec chan struct{}
+
+	secure    bool // serve TLS
+	insecure  bool // serve insecure
+	tlsConfig *tls.Config
+
+	mu   sync.Mutex
+	http *muxListener
+	grpc *muxListener
+}
+
+type Config struct {
+	Logger    *zap.Logger
+	Listener  net.Listener
+	Secure    bool
+	Insecure  bool
+	TLSConfig *tls.Config
+}
+
+// New creates a new ConnMux.
+func New(cfg Config) *ConnMux {
+	// defaulting
+	if cfg.Logger == nil {
+		cfg.Logger = zap.NewNop()
+	}
+
+	return &ConnMux{
+		lg:        cfg.Logger,
+		root:      cfg.Listener,
+		insecure:  cfg.Insecure,
+		secure:    cfg.Secure,
+		tlsConfig: cfg.TLSConfig,
+		donec:     make(chan struct{}),
+	}
+}
+
+// Serve starts serving connections
+func (c *ConnMux) Serve() error {
+	for {
+		conn, err := c.root.Accept()
+		if err != nil {
+			c.lg.Error("connection error", zap.Error(err))
+			return c.Close()
+		}
+		go c.serve(conn)
+	}
+}
+
+// peekHTTP2PrefaceBytes define the bytes we need to peek to be able to differentiate between HTTP and GRPC.
+// Since GRPC uses HTTP2 we need to match the connection preface
+// https://httpwg.org/specs/rfc9113.html#preface (24 octects)
+// 3.5. HTTP/2 Connection Preface
+// The client connection preface starts with a sequence of 24 octets, which in hex notation is:
+// 0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
+// That is, the connection preface starts with the string PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n).
+// This sequence MUST be followed by a SETTINGS frame (Section 6.5), which MAY be empty.
+// 4.1. Frame Format
+// All frames begin with a fixed 9-octet header followed by a variable-length payload.
+// min peek size is 24 + 9 = 33
+const peekHTTP2PrefaceBytes = 33
+
+func (c *ConnMux) serve(conn net.Conn) {
+	// avoid to get blocked in any read operation
+	conn.SetDeadline(time.Now().Add(readDeadlineTimeout))
+	defer conn.SetReadDeadline(time.Time{})
+
+	var proxiedConn bufferedConn
+
+	buffConn := newBufferedConn(conn)
+	// Check if is TLS or plain TCP
+	b, err := buffConn.Peek(peekHTTP2PrefaceBytes)
+	if err != nil {
+		// exit since it will panic trying to detect if is TLS
+		c.lg.Error("error reading from the connection", zap.Error(err))
+		conn.Close()
+		return
+	}
+	// is TLS
+	isTLS := b[0] == 0x16
+	if isTLS {
+		if !c.secure {
+			c.lg.Error("secure connections not enabled")
+			conn.Close()
+			return
+		}
+		// Establish the TLS connection
+		tlsConn := tls.Server(buffConn, c.tlsConfig)
+		err = tlsConn.Handshake()
+		if err != nil {
+			c.lg.Error("error establishing the TLS connection", zap.Error(err))
+			conn.Close()
+			return
+		}
+
+		proxiedConn = newBufferedConn(tlsConn)
+		// It is a "new" connection obtained after the handshake so we have to do another read
+		// to get the new data, but be careful to not get blocked in the read if there are no enough data.
+		_, err = proxiedConn.Peek(peekHTTP2PrefaceBytes)
+		if err != nil {
+			// try to see how far we go, it will be discarded by the server if we route it to the wrong one
+			c.lg.Error("error reading from the TLS connection", zap.Error(err))
+		}
+	} else {
+		if !c.insecure {
+			c.lg.Error("insecure connections not enabled")
+			conn.Close()
+			return
+		}
+		proxiedConn = buffConn
+	}
+
+	// read the whole buffer
+	b, err = proxiedConn.Peek(proxiedConn.r.Buffered())
+	if err != nil && err != io.EOF {
+		c.lg.Error("error reading", zap.Error(err))
+		conn.Close()
+		return
+	}
+	c.lg.Debug("connection received", zap.String("remote address", conn.RemoteAddr().String()), zap.Int("buffer size", len(b)), zap.String("buffer content", string(b)))
+	reader := bytes.NewReader(b)
+	isHTTP2 := isHTTP2Connection(reader)
+	// if is not http2 it is not grpc
+	if !isHTTP2 {
+		c.forward(false, proxiedConn)
+	} else {
+		c.forward(isGRPCConnection(c.lg, reader), proxiedConn)
+	}
+}
+
+func (c *ConnMux) forward(isGRPC bool, conn net.Conn) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !isGRPC && c.http != nil {
+		c.lg.Debug("forwarding connection to the HTTP backend", zap.String("remote address", conn.RemoteAddr().String()))
+		select {
+		case c.http.connc <- conn:
+		case <-c.donec:
+		}
+		return
+	}
+
+	if c.grpc != nil {
+		c.lg.Debug("forwarding connection to the GRPC backend", zap.String("remote address", conn.RemoteAddr().String()))
+		select {
+		case c.grpc.connc <- conn:
+		case <-c.donec:
+		}
+		return
+	}
+
+	log.Println("unknown connection")
+	conn.Close()
+}
+
+// Close closes the listeners
+func (c *ConnMux) Close() error {
+	time.Sleep(gracefullShutdownDuration)
+	c.closeDoneChans()
+	return c.root.Close()
+}
+
+func (c *ConnMux) closeDoneChans() {
+	select {
+	case <-c.donec:
+	default:
+		close(c.donec)
+	}
+}
+
+// muxListener is the listener exposed to the HTTP and GRPC servers
+// The root listener Accept() method is overriden
+// The multiplexed servers have access to the Close() and Address()
+// methods on the root listener.
+type muxListener struct {
+	net.Listener
+	connc chan net.Conn
+	donec chan struct{}
+}
+
+var _ net.Listener = (*muxListener)(nil)
+
+func (l muxListener) Accept() (net.Conn, error) {
+	select {
+	case c, ok := <-l.connc:
+		if !ok {
+			return nil, net.ErrClosed
+		}
+		return c, nil
+	case <-l.donec:
+		return nil, net.ErrClosed
+	}
+}
+
+// HTTPListener returns a net.Listener that will receive http requests
+func (c *ConnMux) HTTPListener() net.Listener {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.http == nil {
+		c.http = &muxListener{c.root, make(chan net.Conn), c.donec}
+	}
+	return c.http
+}
+
+// GRPCListener returns a net.Listener that will receive grpc requests
+func (c *ConnMux) GRPCListener() net.Listener {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.grpc == nil {
+		c.grpc = &muxListener{c.root, make(chan net.Conn), c.donec}
+	}
+	return c.grpc
+}
+
+// bufferedConn allows to peek in the buffer of the connection
+// without advancing the reader.
+type bufferedConn struct {
+	r *bufio.Reader
+	net.Conn
+}
+
+func newBufferedConn(c net.Conn) bufferedConn {
+	return bufferedConn{bufio.NewReader(c), c}
+}
+
+func (b bufferedConn) Peek(n int) ([]byte, error) {
+	return b.r.Peek(n)
+}
+
+func (b bufferedConn) Read(p []byte) (int, error) {
+	return b.r.Read(p)
+}
+
+func isHTTP2Connection(r io.Reader) bool {
+	// check the http2 client preface
+	buf := make([]byte, len(http2.ClientPreface))
+	n, err := r.Read(buf)
+	if err != nil || n != len(http2.ClientPreface) {
+		return false
+	}
+	return bytes.Equal(buf, []byte(http2.ClientPreface))
+}
+
+func isGRPCConnection(lg *zap.Logger, r io.Reader) bool {
+	done := false
+	isGRPC := false
+	// check if len of the settings frame is 0 or the headers with the "content-type"
+	// indicates is an grpc connection.
+	framer := http2.NewFramer(io.Discard, r)
+	// use the default value for the maxDynamixTable size
+	// https://pkg.go.dev/golang.org/x/net/http2
+	// "If zero, the default value of 4096 is used."
+	hdec := hpack.NewDecoder(4096, func(hf hpack.HeaderField) {
+		// match headers names or values based on https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+		if strings.Contains(hf.Name, "grpc") {
+			isGRPC = true
+			done = true
+			lg.Debug("found grpc header", zap.String("header", hf.Name))
+			return
+		}
+		if hf.Name == "content-type" {
+			isGRPC = strings.Contains(hf.Value, "application/grpc")
+			lg.Debug("found content-type header", zap.String("content-type", hf.Value))
+		}
+		done = true
+	})
+	for {
+		f, err := framer.ReadFrame()
+		if err != nil {
+			break
+		}
+		switch f := f.(type) {
+		case *http2.SettingsFrame:
+			// Observed behavior is that etcd GRPC clients sends an empty setting frame
+			// and block waiting for an answer.
+			if f.Length == 0 {
+				isGRPC = true
+				done = true
+				lg.Debug("found setting frame with zero length")
+			}
+		case *http2.HeadersFrame:
+			hdec.Write(f.HeaderBlockFragment())
+		}
+		if done {
+			break
+		}
+	}
+	return isGRPC
+}

--- a/pkg/connmux/connmux_test.go
+++ b/pkg/connmux/connmux_test.go
@@ -1,0 +1,283 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connmux
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"net/http"
+	"net/url"
+	"testing"
+
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+func newTestConnMux(t *testing.T) *ConnMux {
+	certFile := "../../tests/fixtures/server.crt"
+	keyFile := "../../tests/fixtures/server.key.insecure"
+
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("error creating listener: %v", err)
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Errorf("failed to load TLS keys: %v", err)
+	}
+	connMux := New(Config{
+		Logger:   zap.NewExample(),
+		Listener: tcpListener,
+		Insecure: true,
+		Secure:   true,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2", "http/1.1"},
+		},
+	})
+
+	t.Logf("Listening on address %s", connMux.root.Addr().String())
+	return connMux
+}
+
+func TestConnMux(t *testing.T) {
+	connMux := newTestConnMux(t)
+	// HTTP server
+	httpL := connMux.HTTPListener()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "HTTP response Proto: %s %v\n", r.Proto, r.Header)
+	})
+	h2s := &http2.Server{}
+	httpServer := &http.Server{
+		Handler: h2c.NewHandler(mux, h2s),
+	}
+	http2.ConfigureServer(httpServer, h2s)
+	go httpServer.Serve(httpL)
+
+	// GRPC Server
+	grpcServer := grpc.NewServer()
+	testpb.RegisterTestServiceServer(grpcServer, &dummyStubServer{body: []byte("grpc response")})
+
+	grpcL := connMux.GRPCListener()
+	go grpcServer.Serve(grpcL)
+
+	go connMux.Serve()
+	defer connMux.Close()
+
+	destHost := connMux.root.Addr().String()
+	destHTTP := url.URL{Scheme: "http", Host: destHost}
+	destHTTPS := url.URL{Scheme: "https", Host: destHost}
+
+	// HTTP plain
+	t.Logf("Test HTTP1 without TLS works")
+	client := &http.Client{}
+	verifyHTTPRequest(t, client, destHTTP.String())
+
+	// HTTPS
+	t.Logf("Test HTTP1 with TLS works")
+	client.Transport = &http.Transport{TLSClientConfig: &tls.Config{
+		InsecureSkipVerify: true,
+	}}
+	verifyHTTPRequest(t, client, destHTTPS.String())
+
+	// HTTP2 plain
+	t.Logf("Test HTTP2 without TLS works")
+	client.Transport = &http2.Transport{
+		AllowHTTP: true,
+		DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
+			return net.Dial(netw, addr)
+		}}
+	verifyHTTPRequest(t, client, destHTTP.String())
+
+	// HTTP2 TLS
+	t.Logf("Test HTTP2 with TLS works")
+	client.Transport = &http2.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{http2.NextProtoTLS},
+		},
+	}
+	verifyHTTPRequest(t, client, destHTTPS.String())
+
+	// Set up a connection to the server.
+	t.Logf("Test GRPC works")
+	conn, err := grpc.Dial(destHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Errorf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	verifyGRPCRequest(t, conn)
+
+}
+
+// TestConnMuxConcurrency tests that HTTP and GRPC connections work repet
+func TestConnMuxConcurrency(t *testing.T) {
+	connMux := newTestConnMux(t)
+	// HTTP server
+	httpL := connMux.HTTPListener()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "HTTP response Proto: %s %v\n", r.Proto, r.Header)
+	})
+	h2s := &http2.Server{}
+	httpServer := &http.Server{
+		Handler: h2c.NewHandler(mux, h2s),
+	}
+	http2.ConfigureServer(httpServer, h2s)
+	go httpServer.Serve(httpL)
+
+	// GRPC Server
+	grpcServer := grpc.NewServer()
+	testpb.RegisterTestServiceServer(grpcServer, &dummyStubServer{body: []byte("grpc response")})
+
+	grpcL := connMux.GRPCListener()
+	go grpcServer.Serve(grpcL)
+
+	go connMux.Serve()
+	defer connMux.Close()
+
+	destHost := connMux.root.Addr().String()
+	destHTTP := url.URL{Scheme: "http", Host: destHost}
+	destHTTPS := url.URL{Scheme: "https", Host: destHost}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(5)
+		go func() {
+			// HTTP plain
+			defer wg.Done()
+			t.Logf("Test HTTP1 without TLS works")
+			client := &http.Client{}
+			verifyHTTPRequest(t, client, destHTTP.String())
+		}()
+
+		go func() {
+			// HTTPS
+			defer wg.Done()
+			t.Logf("Test HTTP1 with TLS works")
+			client := &http.Client{}
+			client.Transport = &http.Transport{TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			}}
+			verifyHTTPRequest(t, client, destHTTPS.String())
+		}()
+
+		go func() {
+			// HTTP2 plain
+			defer wg.Done()
+			t.Logf("Test HTTP2 without TLS works")
+			client := &http.Client{}
+			client.Transport = &http2.Transport{
+				AllowHTTP: true,
+				DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
+					return net.Dial(netw, addr)
+				}}
+			verifyHTTPRequest(t, client, destHTTP.String())
+		}()
+
+		go func() {
+			// HTTP2 TLS
+			defer wg.Done()
+			t.Logf("Test HTTP2 with TLS works")
+			client := &http.Client{}
+			client.Transport = &http2.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+					NextProtos:         []string{http2.NextProtoTLS},
+				},
+			}
+			verifyHTTPRequest(t, client, destHTTPS.String())
+		}()
+
+		go func() {
+			// Set up a connection to the server.
+			defer wg.Done()
+			t.Logf("Test GRPC works")
+			conn, err := grpc.Dial(destHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				t.Errorf("did not connect: %v", err)
+			}
+			defer conn.Close()
+			verifyGRPCRequest(t, conn)
+		}()
+	}
+	wg.Wait()
+
+}
+
+func verifyHTTPRequest(t *testing.T, client *http.Client, destination string) {
+	request, err := http.NewRequest("Get", destination, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Error(err)
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("received body: %s", string(body))
+	if !strings.Contains(string(body), "HTTP response Proto") {
+		t.Errorf("expected \"HTTP response Proto\" , got %s", body)
+	}
+
+}
+
+func verifyGRPCRequest(t *testing.T, conn grpc.ClientConnInterface) {
+	// Contact the server and print out its response.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	c := testpb.NewTestServiceClient(conn)
+
+	c.HalfDuplexCall(ctx)
+	resp, err := c.UnaryCall(context.TODO(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
+	if err != nil {
+		t.Error("failed to invoke rpc to foo (e1)", err)
+	}
+	if resp.GetPayload() == nil || !bytes.Equal(resp.GetPayload().GetBody(), []byte("grpc response")) {
+		t.Errorf("unexpected response from foo (e1): %s", resp.GetPayload().GetBody())
+	}
+
+}
+
+type dummyStubServer struct {
+	testpb.UnimplementedTestServiceServer
+	body []byte
+}
+
+func (d dummyStubServer) UnaryCall(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	return &testpb.SimpleResponse{
+		Payload: &testpb.Payload{
+			Type: testpb.PayloadType_COMPRESSABLE,
+			Body: d.body,
+		},
+	}, nil
+}

--- a/pkg/connmux/connmux_test.go
+++ b/pkg/connmux/connmux_test.go
@@ -76,7 +76,6 @@ func TestConnMux(t *testing.T) {
 	httpServer := &http.Server{
 		Handler: h2c.NewHandler(mux, h2s),
 	}
-	http2.ConfigureServer(httpServer, h2s)
 	go httpServer.Serve(httpL)
 	defer httpServer.Close()
 
@@ -158,7 +157,6 @@ func TestConnMuxConcurrency(t *testing.T) {
 	httpServer := &http.Server{
 		Handler: h2c.NewHandler(mux, h2s),
 	}
-	http2.ConfigureServer(httpServer, h2s)
 	go httpServer.Serve(httpL)
 
 	// GRPC Server
@@ -247,7 +245,7 @@ func verifyHTTPRequest(t *testing.T, client *http.Client, destination string) {
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)

--- a/pkg/connmux/doc.go
+++ b/pkg/connmux/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package connmux allows to multiplex http and grpc requests connection,
+// with and without TLS, using the same port and address.
+// The package is inspired in the existing project https://github.com/soheilhy/cmux
+// adding some features specific for the etcd use case.
+// This code is not mean to be used outside of etcd.
+
+package connmux

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -14,6 +14,8 @@ require (
 	google.golang.org/grpc v1.51.0
 )
 
+require golang.org/x/net v0.8.0
+
 require (
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -26,6 +26,7 @@ import (
 
 	etcdservergw "go.etcd.io/etcd/api/v3/etcdserverpb/gw"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
+	connmux "go.etcd.io/etcd/pkg/v3/connmux"
 	"go.etcd.io/etcd/pkg/v3/debugutil"
 	"go.etcd.io/etcd/pkg/v3/httputil"
 	"go.etcd.io/etcd/server/v3/config"
@@ -40,10 +41,10 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 
 	gw "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/soheilhy/cmux"
 	"github.com/tmc/grpc-websocket-proxy/wsproxy"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc"
 )
@@ -111,28 +112,19 @@ func (sctx *serveCtx) serve(
 
 	sctx.lg.Info("ready to serve client requests")
 
-	m := cmux.New(sctx.l)
-	var server func() error
 	onlyGRPC := splitHttp && !sctx.httpOnly
 	onlyHttp := splitHttp && sctx.httpOnly
 	grpcEnabled := !onlyHttp
 	httpEnabled := !onlyGRPC
 
-	v3c := v3client.New(s)
-	servElection := v3election.NewElectionServer(v3c)
-	servLock := v3lock.NewLockServer(v3c)
+	cfg := connmux.Config{
+		Logger:   sctx.lg,
+		Listener: sctx.l,
+	}
 
 	// Make sure serversC is closed even if we prematurely exit the function.
 	defer close(sctx.serversC)
-	var gwmux *gw.ServeMux
-	if s.Cfg.EnableGRPCGateway {
-		// GRPC gateway connects to grpc server via connection provided by grpc dial.
-		gwmux, err = sctx.registerGateway(grpcDialForRestGatewayBackends)
-		if err != nil {
-			sctx.lg.Error("registerGateway failed", zap.Error(err))
-			return err
-		}
-	}
+
 	var traffic string
 	switch {
 	case onlyGRPC:
@@ -144,55 +136,7 @@ func (sctx *serveCtx) serve(
 	}
 
 	if sctx.insecure {
-		var gs *grpc.Server
-		var srv *http.Server
-		if httpEnabled {
-			httpmux := sctx.createMux(gwmux, handler)
-			srv = &http.Server{
-				Handler:  createAccessController(sctx.lg, s, httpmux),
-				ErrorLog: logger, // do not log user error
-			}
-			if err := configureHttpServer(srv, s.Cfg); err != nil {
-				sctx.lg.Error("Configure http server failed", zap.Error(err))
-				return err
-			}
-		}
-		if grpcEnabled {
-			gs = v3rpc.Server(s, nil, nil, gopts...)
-			v3electionpb.RegisterElectionServer(gs, servElection)
-			v3lockpb.RegisterLockServer(gs, servLock)
-			if sctx.serviceRegister != nil {
-				sctx.serviceRegister(gs)
-			}
-			defer func(gs *grpc.Server) {
-				if err != nil {
-					sctx.lg.Warn("stopping insecure grpc server due to error", zap.Error(err))
-					gs.Stop()
-					sctx.lg.Warn("stopped insecure grpc server due to error", zap.Error(err))
-				}
-			}(gs)
-		}
-		if onlyGRPC {
-			server = func() error {
-				return gs.Serve(sctx.l)
-			}
-		} else {
-			server = m.Serve
-
-			httpl := m.Match(cmux.HTTP1())
-			go func(srvhttp *http.Server, tlsLis net.Listener) {
-				errHandler(srvhttp.Serve(tlsLis))
-			}(srv, httpl)
-
-			if grpcEnabled {
-				grpcl := m.Match(cmux.HTTP2())
-				go func(gs *grpc.Server, l net.Listener) {
-					errHandler(gs.Serve(l))
-				}(gs, grpcl)
-			}
-		}
-
-		sctx.serversC <- &servers{grpc: gs, http: srv}
+		cfg.Insecure = true
 		sctx.lg.Info(
 			"serving client traffic insecurely; this is strongly discouraged!",
 			zap.String("traffic", traffic),
@@ -201,95 +145,99 @@ func (sctx *serveCtx) serve(
 	}
 
 	if sctx.secure {
-		var gs *grpc.Server
-		var srv *http.Server
-
 		tlscfg, tlsErr := tlsinfo.ServerConfig()
 		if tlsErr != nil {
 			return tlsErr
 		}
 
-		if grpcEnabled {
-			gs = v3rpc.Server(s, tlscfg, nil, gopts...)
-			v3electionpb.RegisterElectionServer(gs, servElection)
-			v3lockpb.RegisterLockServer(gs, servLock)
-			if sctx.serviceRegister != nil {
-				sctx.serviceRegister(gs)
-			}
-			defer func(gs *grpc.Server) {
-				if err != nil {
-					sctx.lg.Warn("stopping secure grpc server due to error", zap.Error(err))
-					gs.Stop()
-					sctx.lg.Warn("stopped secure grpc server due to error", zap.Error(err))
-				}
-			}(gs)
-		}
-		if httpEnabled {
-			if grpcEnabled {
-				handler = grpcHandlerFunc(gs, handler)
-			}
-			httpmux := sctx.createMux(gwmux, handler)
-
-			srv = &http.Server{
-				Handler:   createAccessController(sctx.lg, s, httpmux),
-				TLSConfig: tlscfg,
-				ErrorLog:  logger, // do not log user error
-			}
-			if err := configureHttpServer(srv, s.Cfg); err != nil {
-				sctx.lg.Error("Configure https server failed", zap.Error(err))
-				return err
-			}
-		}
-
-		if onlyGRPC {
-			server = func() error { return gs.Serve(sctx.l) }
-		} else {
-			server = m.Serve
-
-			tlsl, err := transport.NewTLSListener(m.Match(cmux.Any()), tlsinfo)
-			if err != nil {
-				return err
-			}
-			go func(srvhttp *http.Server, tlsl net.Listener) {
-				errHandler(srvhttp.Serve(tlsl))
-			}(srv, tlsl)
-		}
-
-		sctx.serversC <- &servers{secure: true, grpc: gs, http: srv}
 		sctx.lg.Info(
 			"serving client traffic securely",
 			zap.String("traffic", traffic),
 			zap.String("address", sctx.l.Addr().String()),
 		)
+		cfg.Secure = true
+		cfg.TLSConfig = tlscfg
 	}
 
-	return server()
+	m := connmux.New(cfg)
+
+	v3c := v3client.New(s)
+	servElection := v3election.NewElectionServer(v3c)
+	servLock := v3lock.NewLockServer(v3c)
+
+	// Make sure serversC is closed even if we prematurely exit the function.
+	defer func() {
+		select {
+		case <-sctx.serversC:
+		default:
+			close(sctx.serversC)
+		}
+	}()
+
+	var gs *grpc.Server
+	var srv *http.Server
+
+	if grpcEnabled {
+		gs = v3rpc.Server(s, nil, nil, gopts...)
+		v3electionpb.RegisterElectionServer(gs, servElection)
+		v3lockpb.RegisterLockServer(gs, servLock)
+		if sctx.serviceRegister != nil {
+			sctx.serviceRegister(gs)
+		}
+
+		defer func(gs *grpc.Server) {
+			if err != nil {
+				sctx.lg.Warn("stopping secure grpc server due to error", zap.Error(err))
+				gs.Stop()
+				sctx.lg.Warn("stopped secure grpc server due to error", zap.Error(err))
+			}
+		}(gs)
+
+		grpcl := m.GRPCListener()
+		go func() { errHandler(gs.Serve(grpcl)) }()
+	}
+
+	var gwmux *gw.ServeMux
+	if s.Cfg.EnableGRPCGateway {
+		// GRPC gateway connects to grpc server via connection provided by grpc dial.
+		gwmux, err = sctx.registerGateway(grpcDialForRestGatewayBackends)
+		if err != nil {
+			sctx.lg.Error("registerGateway failed", zap.Error(err))
+			return err
+		}
+	}
+
+	if httpEnabled {
+		httpmux := sctx.createMux(gwmux, handler)
+
+		srv = &http.Server{
+			Handler:  createAccessController(sctx.lg, s, httpmux),
+			ErrorLog: logger, // do not log user error
+		}
+		if err := configureHttpServer(srv, s.Cfg); err != nil {
+			sctx.lg.Error("Configure http server failed", zap.Error(err))
+			return err
+		}
+		httpl := m.HTTPListener()
+		go func() { errHandler(srv.Serve(httpl)) }()
+	}
+
+	sctx.serversC <- &servers{secure: sctx.secure, grpc: gs, http: srv}
+
+	return m.Serve()
 }
 
 func configureHttpServer(srv *http.Server, cfg config.ServerConfig) error {
 	// todo (ahrtr): should we support configuring other parameters in the future as well?
-	return http2.ConfigureServer(srv, &http2.Server{
+	h2s := &http2.Server{
 		MaxConcurrentStreams: cfg.MaxConcurrentStreams,
 		// Override to avoid using priority scheduler which is affected by https://github.com/golang/go/issues/58804.
 		NewWriteScheduler: http2.NewRandomWriteScheduler,
-	})
-}
-
-// grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
-// connections or otherHandler otherwise. Given in gRPC docs.
-func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
-	if otherHandler == nil {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			grpcServer.ServeHTTP(w, r)
-		})
 	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
-			grpcServer.ServeHTTP(w, r)
-		} else {
-			otherHandler.ServeHTTP(w, r)
-		}
-	})
+	// This is needed to support HTTP2 with prior knowledge, because the connmux
+	// pass the stream without TLS
+	srv.Handler = h2c.NewHandler(srv.Handler, h2s)
+	return http2.ConfigureServer(srv, h2s)
 }
 
 type registerHandlerFunc func(context.Context, *gw.ServeMux, *grpc.ClientConn) error

--- a/server/etcdserver/api/rafthttp/transport.go
+++ b/server/etcdserver/api/rafthttp/transport.go
@@ -110,7 +110,7 @@ type Transport struct {
 	Raft        Raft       // raft state machine, to which the Transport forwards received messages and reports status
 	Snapshotter *snap.Snapshotter
 	ServerStats *stats.ServerStats // used to record general transportation statistics
-	// used to record transportation statistics with followers when
+	// LeaderStats used to record transportation statistics with followers when
 	// performing as leader in raft protocol
 	LeaderStats *stats.LeaderStats
 	// ErrorC is used to report detected critical errors, e.g.,

--- a/server/go.mod
+++ b/server/go.mod
@@ -17,8 +17,7 @@ require (
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/client_model v0.3.0
-	github.com/soheilhy/cmux v0.1.5
-	github.com/spf13/cobra v1.7.0
+	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2

--- a/server/go.sum
+++ b/server/go.sum
@@ -208,8 +208,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
@@ -338,7 +336,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=

--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -71,7 +71,13 @@ func TestConnectionMultiplexing(t *testing.T) {
 			cfg := e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: tc.serverTLS}, ClientHttpSeparate: tc.separateHttpPort}
 			clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&cfg))
 			require.NoError(t, err)
-			defer clus.Close()
+
+			defer func(clus *e2e.EtcdProcessCluster) error {
+				for _, member := range clus.Procs {
+					member.Kill()
+				}
+				return clus.Stop()
+			}(clus)
 
 			var clientScenarios []e2e.ClientConnType
 			switch tc.serverTLS {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/common v0.42.0
-	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.8.2
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -234,8 +234,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
@@ -364,7 +362,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=


### PR DESCRIPTION
The cmux project last commit is from Mar 2021 https://github.com/soheilhy/cmux
It also targets a more generic way of multiplexing connections offering different matches and doesn't offer the possibility of use the same cmux to differentiate between TLS and non-TLS.

etcd doesn't need the cmux flexibility, since the backends are always controlled by the project, and will benefit if it can support to discriminate between TLS and non-TLS.

This PR introduces a replacement from cmux targeted specifically for the etcd use case.
It uses the same method of detecting the connection, looking ahead on the connection to try to determine if is an HTTP or GRPC request.
The heuristic here are more simple, since HTTP connections are easy to identify (it always start with HTTP1/1 , see exception explanation below), and apply the following logic "if is not HTTP it has to be GRPC". In the corner case that the connection is forwarded and is not GRPC, the server will reject the connection anyway.
- There is one special case that is not covered, that is HTTP2 with prior-knowledge, but this is not common in the wild, and it wasn't supported AFAIK here, because it requires a special handler in the server)

NOTE:

I'm not familiar with the etcd code so I did a grep for cmux, but I'm not completely sure I made a 1to1 replacement, the first commit introduces the new cmux for etcd, so I appreciate some guidance and feedback