### PR TITLE
add etcd test analyzer build and integrate into measure-test-flakiness workflow

### DIFF
--- a/.github/workflows/measure-test-flakiness.yaml
+++ b/.github/workflows/measure-test-flakiness.yaml
@@ -2,7 +2,7 @@ name: Measure Test Flakiness
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * 0" # run every Sunday at midnight
 
 permissions: read-all
 
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-    - run: "./scripts/measure-test-flakiness.sh"
-      env:
+    - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+
+        ./scripts/measure-test-flakiness.sh
+        make bin/etcd-test-analyzer
+        bin/etcd-test-analyzer run -token $GITHUB_TOKEN -max-age=168h -workflow Tests -branch main

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,17 @@ build:
 tools:
 	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v" ./scripts/build_tools.sh
 
+TEMP_TEST_ANALYZER_DIR=/tmp/etcd-test-analyzer
+TEST_ANALYZER_BIN=${PWD}/bin
+bin/etcd-test-analyzer: $(TEMP_TEST_ANALYZER_DIR)/*
+	make -C ${TEMP_TEST_ANALYZER_DIR} build
+	mkdir -p ${TEST_ANALYZER_BIN}
+	install ${TEMP_TEST_ANALYZER_DIR}/bin/etcd-test-analyzer ${TEST_ANALYZER_BIN}
+	${TEST_ANALYZER_BIN}/etcd-test-analyzer -h
+
+$(TEMP_TEST_ANALYZER_DIR)/*:
+	git clone "https://github.com/endocrimes/etcd-test-analyzer.git" ${TEMP_TEST_ANALYZER_DIR}
+
 # Tests
 
 GO_TEST_FLAGS?=


### PR DESCRIPTION
The PR is to address the ask from https://github.com/etcd-io/etcd/issues/13167#issuecomment-1474791002. @serathius

The workflow stays running every Sunday midnight. 

Measure-test-flakiness workflow output will additionally show the top contributor of the failed Tests name in Test/Test-arm workflow (only covers integration tests right now) in the past 1 week.

Example output https://github.com/chaochn47/etcd/actions/runs/4546435089/jobs/8015061879

---

Running against E2E workflows does not produce meaningful output, need to investigate more in the tool
```
dev-dsk-chaochn-2c-a26acd76 % bin/etcd-test-analyzer run -token $GITHUB_TOKEN -max-age=168h -workflow E2E -branch main
Fetching workflow runs from GitHub
Analyzing workflow "E2E"
    [E2E]: Finding workflow runs
    [E2E]: Downloading artifacts
    [E2E]: Downloading artifacts for E2E to "/tmp/test-results-2184436320"
    ...
Runs: 0, Pass: 0, Fail: 0, Pcnt: NaN
Analyzing workflow "E2E-arm64"
    [E2E-arm64]: Finding workflow runs
    [E2E-arm64]: Downloading artifacts
    [E2E-arm64]: Downloading artifacts for E2E-arm64 to "/tmp/test-results-2423396168"
    [E2E-arm64]: no artifacts found
    ...
```

Maybe @endocrimes can help shed lights on the issue. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
