### PR TITLE
[3.5] server/embed: fix data race when start insecure grpc

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -142,6 +142,9 @@ func fetchGrpcGateway(endpoint string, httpVersion string, connType clientConnTy
 	}
 	req := cURLReq{endpoint: "/v3/kv/range", value: string(rangeData), timeout: 5, httpVersion: httpVersion}
 	respData, err := curl(endpoint, "POST", req, connType)
+	if err != nil {
+		return err
+	}
 	return validateGrpcgatewayRangeReponse([]byte(respData))
 }
 


### PR DESCRIPTION
There are two goroutines accessing the `gs` grpc server var. Before insecure `gs` server start, the `gs` can be changed to secure server and then the client will fail to connect to etcd with insecure request. It is data-race. We should use argument for reference in the new goroutine.

fix: #15495


(cherry picked from commit a9988e2625eede1af81d189b5f2ecf7d4af3edf1)


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cherry-pick: #15509 
