### PR TITLE
v3rpc/rpctypes: added GRPCStatus for EtcdError

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -238,6 +238,10 @@ func (e EtcdError) Code() codes.Code {
 	return e.code
 }
 
+func (e EtcdError) GRPCStatus() *status.Status {
+	return status.New(e.code, e.desc)
+}
+
 func (e EtcdError) Error() string {
 	return e.desc
 }

--- a/api/v3rpc/rpctypes/error_test.go
+++ b/api/v3rpc/rpctypes/error_test.go
@@ -29,14 +29,24 @@ func TestConvert(t *testing.T) {
 	if e1.Error() != e2.Error() {
 		t.Fatalf("expected %q == %q", e1.Error(), e2.Error())
 	}
-	if ev1, ok := status.FromError(e1); ok && ev1.Code() != e3.(EtcdError).Code() {
+	if ev1, ok := status.FromError(e1); !ok {
+		t.Fatalf("expected error to be compatable")
+	} else if ev1.Code() != e3.(EtcdError).Code() {
 		t.Fatalf("expected them to be equal, got %v / %v", ev1.Code(), e3.(EtcdError).Code())
 	}
 
 	if e1.Error() == e3.Error() {
 		t.Fatalf("expected %q != %q", e1.Error(), e3.Error())
 	}
-	if ev2, ok := status.FromError(e2); ok && ev2.Code() != e3.(EtcdError).Code() {
+	if ev2, ok := status.FromError(e2); !ok {
+		t.Fatalf("expected error to be compatable")
+	} else if ev2.Code() != e3.(EtcdError).Code() {
 		t.Fatalf("expected them to be equal, got %v / %v", ev2.Code(), e3.(EtcdError).Code())
+	}
+
+	if ev3, ok := status.FromError(e3); !ok {
+		t.Fatalf("expected error to be compatable")
+	} else if ev3.Code() != e3.(EtcdError).Code() {
+		t.Fatalf("expected them to be equal, got %v / %v", ev3.Code(), e3.(EtcdError).Code())
 	}
 }

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -24,6 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/zap"
@@ -170,6 +173,11 @@ func TestIsHaltErr(t *testing.T) {
 		isHaltErr(context.TODO(), rpctypes.ErrGRPCNoLeader),
 		false,
 		fmt.Sprintf(`error "%v" should not be halt error`, rpctypes.ErrGRPCNoLeader),
+	)
+	assert.Equal(t,
+		isHaltErr(context.TODO(), rpctypes.ErrNoLeader),
+		false,
+		fmt.Sprintf(`error "%v" should not be halt error`, rpctypes.ErrNoLeader),
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
 	assert.Equal(t,
@@ -372,6 +380,15 @@ func TestClientRejectOldCluster(t *testing.T) {
 
 	}
 
+}
+
+func TestToErrStatusCode(t *testing.T) {
+	err := toErr(context.TODO(), rpctypes.ErrGRPCNoLeader)
+
+	assert.Equal(t, rpctypes.ErrNoLeader, err)
+	se, ok := status.FromError(err)
+	assert.True(t, ok, "err isn't compatible")
+	assert.Equal(t, codes.Unavailable, se.Code())
 }
 
 type mockMaintenance struct {


### PR DESCRIPTION
Problem: grpc status.FromError can't extract code and defaults to Unknown. This causes isHaltErr to always return true and prevent watch retry on Unavailable errors.

Solution: implement GRPCStatus() *Status for EtcdError

fixes: https://github.com/etcd-io/etcd/issues/15539


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
