### PR TITLE
CHANGELOG: add 'server/embed: fix data race when starting both secure & insecure gRPC servers on the same address' into 3.4/3.5

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.25 (TBD)
 
+### etcd server
+- Fix [server/embed: fix data race when starting both secure & insecure gRPC servers on the same address](https://github.com/etcd-io/etcd/pull/15518)
+
 ### Go
 - Require [Go 1.19+](https://github.com/etcd-io/etcd/pull/15333).
 - Compile with [Go 1.19+](https://go.dev/doc/devel/release#go1.19)

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.8 (TBD)
 
+### etcd server
+- Fix [server/embed: fix data race when starting both secure & insecure gRPC servers on the same address](https://github.com/etcd-io/etcd/pull/15517)
+
 ### Package `client/pkg/v3`
 - Fix [aligning zap log timestamp resolution to microseconds](https://github.com/etcd-io/etcd/pull/15240). Etcd now uses zap timestamp format: `2006-01-02T15:04:05.999999Z0700` (microsecond instead of milliseconds precision).
 


### PR DESCRIPTION
Add item **server/embed: fix data race when starting both secure & insecure gRPC servers on the same address** to 3.4/3.5 changelog.

REF: #15509


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
