### PR TITLE
[3.4] Test cmux

### DIFF
--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -27,14 +27,6 @@ import (
 
 const etcdProcessBasePort = 20000
 
-type clientConnType int
-
-const (
-	clientNonTLS clientConnType = iota
-	clientTLS
-	clientTLSAndNonTLS
-)
-
 var (
 	configNoTLS = etcdProcessClusterConfig{
 		clusterSize:  3,

--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -1,0 +1,152 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These tests are directly validating etcd connection multiplexing.
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
+	"go.etcd.io/etcd/pkg/testutil"
+)
+
+func TestConnectionMultiplexing(t *testing.T) {
+	defer testutil.AfterTest(t)
+	for _, tc := range []struct {
+		name      string
+		serverTLS clientConnType
+	}{
+		{
+			name:      "ServerTLS",
+			serverTLS: clientTLS,
+		},
+		{
+			name:      "ServerNonTLS",
+			serverTLS: clientNonTLS,
+		},
+		{
+			name:      "ServerTLSAndNonTLS",
+			serverTLS: clientTLSAndNonTLS,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := etcdProcessClusterConfig{clusterSize: 1, clientTLS: tc.serverTLS}
+			clus, err := newEtcdProcessCluster(&cfg)
+			require.NoError(t, err)
+			defer clus.Close()
+
+			var clientScenarios []clientConnType
+			switch tc.serverTLS {
+			case clientTLS:
+				clientScenarios = []clientConnType{clientTLS}
+			case clientNonTLS:
+				clientScenarios = []clientConnType{clientNonTLS}
+			case clientTLSAndNonTLS:
+				clientScenarios = []clientConnType{clientTLS, clientNonTLS}
+			}
+
+			for _, connType := range clientScenarios {
+				name := "ClientNonTLS"
+				if connType == clientTLS {
+					name = "ClientTLS"
+				}
+				t.Run(name, func(t *testing.T) {
+					testConnectionMultiplexing(ctx, t, clus.EndpointsV3()[0], connType)
+				})
+			}
+		})
+	}
+
+}
+
+func testConnectionMultiplexing(ctx context.Context, t *testing.T, endpoint string, connType clientConnType) {
+	switch connType {
+	case clientTLS:
+		endpoint = toTLS(endpoint)
+	case clientNonTLS:
+	default:
+		panic(fmt.Sprintf("Unsupported conn type %v", connType))
+	}
+	t.Run("etcdctl", func(t *testing.T) {
+		etcdctl := NewEtcdctl([]string{endpoint}, connType, false)
+		_, err := etcdctl.Get("a")
+		assert.NoError(t, err)
+	})
+	t.Run("clientv3", func(t *testing.T) {
+		c := newClient(t, []string{endpoint}, connType, false)
+		_, err := c.Get(ctx, "a")
+		assert.NoError(t, err)
+	})
+	t.Run("curl", func(t *testing.T) {
+		for _, httpVersion := range []string{"2", "1.1", "1.0", ""} {
+			tname := "http" + httpVersion
+			if httpVersion == "" {
+				tname = "default"
+			}
+			t.Run(tname, func(t *testing.T) {
+				assert.NoError(t, fetchGrpcGateway(endpoint, httpVersion, connType))
+				assert.NoError(t, fetchMetrics(endpoint, httpVersion, connType))
+				assert.NoError(t, fetchVersion(endpoint, httpVersion, connType))
+				assert.NoError(t, fetchHealth(endpoint, httpVersion, connType))
+				assert.NoError(t, fetchDebugVars(endpoint, httpVersion, connType))
+			})
+		}
+	})
+}
+
+func fetchGrpcGateway(endpoint string, httpVersion string, connType clientConnType) error {
+	rangeData, err := json.Marshal(&pb.RangeRequest{
+		Key: []byte("a"),
+	})
+	if err != nil {
+		return err
+	}
+	req := cURLReq{endpoint: "/v3/kv/range", value: string(rangeData), timeout: 5, httpVersion: httpVersion}
+	return curl(endpoint, "POST", req, connType, "header")
+}
+
+func fetchMetrics(endpoint string, httpVersion string, connType clientConnType) error {
+	req := cURLReq{endpoint: "/metrics", timeout: 5, httpVersion: httpVersion}
+	return curl(endpoint, "GET", req, connType, "etcd_cluster_version")
+}
+
+func fetchVersion(endpoint string, httpVersion string, connType clientConnType) error {
+	req := cURLReq{endpoint: "/version", timeout: 5, httpVersion: httpVersion}
+	return curl(endpoint, "GET", req, connType, "etcdserver")
+}
+
+func fetchHealth(endpoint string, httpVersion string, connType clientConnType) error {
+	req := cURLReq{endpoint: "/health", timeout: 5, httpVersion: httpVersion}
+	return curl(endpoint, "GET", req, connType, "health")
+}
+
+func fetchDebugVars(endpoint string, httpVersion string, connType clientConnType) error {
+	req := cURLReq{endpoint: "/debug/vars", timeout: 5, httpVersion: httpVersion}
+	return curl(endpoint, "GET", req, connType, "file_descriptor_limit")
+}
+
+func curl(endpoint string, method string, curlReq cURLReq, connType clientConnType, expect string) error {
+	args := cURLPrefixArgs(endpoint, connType, false, method, curlReq)
+	return spawnWithExpect(args, expect)
+}

--- a/tests/e2e/etcd_spawn_nocov.go
+++ b/tests/e2e/etcd_spawn_nocov.go
@@ -19,6 +19,7 @@ package e2e
 
 import (
 	"os"
+	"strings"
 
 	"go.etcd.io/etcd/pkg/expect"
 )
@@ -26,9 +27,14 @@ import (
 const noOutputLineCount = 0 // regular binaries emit no extra lines
 
 func spawnCmd(args []string) (*expect.ExpectProcess, error) {
-	if args[0] == ctlBinPath+"3" {
-		env := append(os.Environ(), "ETCDCTL_API=3")
-		return expect.NewExpectWithEnv(ctlBinPath, args[1:], env)
+	env := os.Environ()
+	switch {
+	case strings.HasSuffix(args[0], ctlBinPath+"2"):
+		env = append(env, "ETCDCTL_API=2")
+		args[0] = ctlBinPath
+	case strings.HasSuffix(args[0], ctlBinPath+"3"):
+		env = append(env, "ETCDCTL_API=3")
+		args[0] = ctlBinPath
 	}
-	return expect.NewExpect(args[0], args[1:]...)
+	return expect.NewExpectWithEnv(args[0], args[1:], env)
 }

--- a/tests/e2e/etcdctl.go
+++ b/tests/e2e/etcdctl.go
@@ -88,6 +88,16 @@ func (ctl *EtcdctlV3) cmdArgs(args ...string) []string {
 
 func (ctl *EtcdctlV3) flags() map[string]string {
 	fmap := make(map[string]string)
+	if ctl.connType == clientTLS {
+		if ctl.isAutoTLS {
+			fmap["insecure-transport"] = "false"
+			fmap["insecure-skip-tls-verify"] = "true"
+		} else {
+			fmap["cacert"] = testTLSInfo.TrustedCAFile
+			fmap["cert"] = testTLSInfo.CertFile
+			fmap["key"] = testTLSInfo.KeyFile
+		}
+	}
 	fmap["endpoints"] = strings.Join(ctl.endpoints, ",")
 	return fmap
 }

--- a/tests/e2e/etcdctl.go
+++ b/tests/e2e/etcdctl.go
@@ -1,0 +1,93 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.etcd.io/etcd/clientv3"
+)
+
+type EtcdctlV3 struct {
+	connType  clientConnType
+	isAutoTLS bool
+	endpoints []string
+}
+
+func NewEtcdctl(endpoints []string, connType clientConnType, isAutoTLS bool) *EtcdctlV3 {
+	return &EtcdctlV3{
+		endpoints: endpoints,
+		connType:  connType,
+		isAutoTLS: isAutoTLS,
+	}
+}
+
+func (ctl *EtcdctlV3) Get(key string) (*clientv3.GetResponse, error) {
+	var resp clientv3.GetResponse
+	err := ctl.spawnJsonCmd(&resp, "get", key)
+	return &resp, err
+}
+
+func (ctl *EtcdctlV3) Put(key, value string) error {
+	args := ctl.cmdArgs()
+	args = append(args, "put", key, value)
+	return spawnWithExpect(args, "OK")
+}
+
+func (ctl *EtcdctlV3) AlarmList() (*clientv3.AlarmResponse, error) {
+	var resp clientv3.AlarmResponse
+	err := ctl.spawnJsonCmd(&resp, "alarm", "list")
+	return &resp, err
+}
+
+func (ctl *EtcdctlV3) MemberList() (*clientv3.MemberListResponse, error) {
+	var resp clientv3.MemberListResponse
+	err := ctl.spawnJsonCmd(&resp, "member", "list")
+	return &resp, err
+}
+
+func (ctl *EtcdctlV3) Compact(rev int64) (*clientv3.CompactResponse, error) {
+	args := ctl.cmdArgs("compact", fmt.Sprint(rev))
+	return nil, spawnWithExpect(args, fmt.Sprintf("compacted revision %v", rev))
+}
+
+func (ctl *EtcdctlV3) spawnJsonCmd(output interface{}, args ...string) error {
+	args = append(args, "-w", "json")
+	cmd, err := spawnCmd(append(ctl.cmdArgs(), args...))
+	if err != nil {
+		return err
+	}
+	line, err := cmd.Expect("header")
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(line), output)
+}
+
+func (ctl *EtcdctlV3) cmdArgs(args ...string) []string {
+	cmdArgs := []string{ctlBinPath + "3"}
+	for k, v := range ctl.flags() {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--%s=%s", k, v))
+	}
+	return append(cmdArgs, args...)
+}
+
+func (ctl *EtcdctlV3) flags() map[string]string {
+	fmap := make(map[string]string)
+	fmap["endpoints"] = strings.Join(ctl.endpoints, ",")
+	return fmap
+}

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -1,0 +1,102 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/stringutil"
+	"go.etcd.io/etcd/pkg/transport"
+)
+
+type clientConnType int
+
+const (
+	clientNonTLS clientConnType = iota
+	clientTLS
+	clientTLSAndNonTLS
+)
+
+func newClient(t *testing.T, entpoints []string, connType clientConnType, isAutoTLS bool) *clientv3.Client {
+	tlscfg, err := tlsInfo(t, connType, isAutoTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ccfg := clientv3.Config{
+		Endpoints:   entpoints,
+		DialTimeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+	}
+	if tlscfg != nil {
+		tls, err := tlscfg.ClientConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ccfg.TLS = tls
+	}
+	c, err := clientv3.New(ccfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		c.Close()
+	})
+	return c
+}
+
+func tlsInfo(t testing.TB, connType clientConnType, isAutoTLS bool) (*transport.TLSInfo, error) {
+	switch connType {
+	case clientNonTLS, clientTLSAndNonTLS:
+		return nil, nil
+	case clientTLS:
+		if isAutoTLS {
+			tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate cert: %s", err)
+			}
+			return &tls, nil
+		}
+		panic("Unsupported non-auto tls")
+	default:
+		return nil, fmt.Errorf("config %v not supported", connType)
+	}
+}
+
+func fillEtcdWithData(ctx context.Context, c *clientv3.Client, keyCount int, valueSize uint) error {
+	g := errgroup.Group{}
+	concurrency := 10
+	keysPerRoutine := keyCount / concurrency
+	for i := 0; i < concurrency; i++ {
+		i := i
+		g.Go(func() error {
+			for j := 0; j < keysPerRoutine; j++ {
+				_, err := c.Put(ctx, fmt.Sprintf("%d", i*keysPerRoutine+j), stringutil.RandString(valueSize))
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
+	clientv2 "go.etcd.io/etcd/client"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/stringutil"
 	"go.etcd.io/etcd/pkg/transport"
@@ -71,6 +72,23 @@ func newClient(t *testing.T, entpoints []string, connType clientConnType, isAuto
 		c.Close()
 	})
 	return c
+}
+
+func newClientV2(t *testing.T, endpoints []string, connType clientConnType, isAutoTLS bool) (clientv2.Client, error) {
+	tls, err := tlsInfo(t, connType, isAutoTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := clientv2.Config{
+		Endpoints: endpoints,
+	}
+	if tls != nil {
+		cfg.Transport, err = transport.NewTransport(*tls, 5*time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return clientv2.New(cfg)
 }
 
 func tlsInfo(t testing.TB, connType clientConnType, isAutoTLS bool) (*transport.TLSInfo, error) {

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -37,6 +37,15 @@ const (
 	clientTLSAndNonTLS
 )
 
+var (
+	testTLSInfo = transport.TLSInfo{
+		KeyFile:        "../../integration/fixtures/server.key.insecure",
+		CertFile:       "../../integration/fixtures/server.crt",
+		TrustedCAFile:  "../../integration/fixtures/ca.crt",
+		ClientCertAuth: true,
+	}
+)
+
 func newClient(t *testing.T, entpoints []string, connType clientConnType, isAutoTLS bool) *clientv3.Client {
 	tlscfg, err := tlsInfo(t, connType, isAutoTLS)
 	if err != nil {
@@ -76,7 +85,7 @@ func tlsInfo(t testing.TB, connType clientConnType, isAutoTLS bool) (*transport.
 			}
 			return &tls, nil
 		}
-		panic("Unsupported non-auto tls")
+		return &testTLSInfo, nil
 	default:
 		return nil, fmt.Errorf("config %v not supported", connType)
 	}

--- a/tests/e2e/v2_curl_test.go
+++ b/tests/e2e/v2_curl_test.go
@@ -134,7 +134,8 @@ type cURLReq struct {
 
 	metricsURLScheme string
 
-	ciphers string
+	ciphers     string
+	httpVersion string
 }
 
 // cURLPrefixArgsCluster builds the beginning of a curl command for a given key
@@ -152,6 +153,9 @@ func cURLPrefixArgs(clientURL string, connType clientConnType, CN bool, method s
 	var (
 		cmdArgs = []string{"curl"}
 	)
+	if req.httpVersion != "" {
+		cmdArgs = append(cmdArgs, "--http"+req.httpVersion)
+	}
 	if req.metricsURLScheme != "https" {
 		if req.isTLS {
 			if connType != clientTLSAndNonTLS {

--- a/tests/e2e/v2_curl_test.go
+++ b/tests/e2e/v2_curl_test.go
@@ -137,32 +137,37 @@ type cURLReq struct {
 	ciphers string
 }
 
-// cURLPrefixArgs builds the beginning of a curl command for a given key
+// cURLPrefixArgsCluster builds the beginning of a curl command for a given key
 // addressed to a random URL in the given cluster.
-func cURLPrefixArgs(clus *etcdProcessCluster, method string, req cURLReq) []string {
+func cURLPrefixArgsCluster(clus *etcdProcessCluster, method string, req cURLReq) []string {
+	member := clus.procs[rand.Intn(clus.cfg.clusterSize)]
+	clientURL := member.Config().acurl
+	if req.metricsURLScheme != "" {
+		clientURL = member.EndpointsMetrics()[0]
+	}
+	return cURLPrefixArgs(clientURL, clus.cfg.clientTLS, !clus.cfg.noCN, method, req)
+}
+
+func cURLPrefixArgs(clientURL string, connType clientConnType, CN bool, method string, req cURLReq) []string {
 	var (
 		cmdArgs = []string{"curl"}
-		acurl   = clus.procs[rand.Intn(clus.cfg.clusterSize)].Config().acurl
 	)
 	if req.metricsURLScheme != "https" {
 		if req.isTLS {
-			if clus.cfg.clientTLS != clientTLSAndNonTLS {
+			if connType != clientTLSAndNonTLS {
 				panic("should not use cURLPrefixArgsUseTLS when serving only TLS or non-TLS")
 			}
 			cmdArgs = append(cmdArgs, "--cacert", caPath, "--cert", certPath, "--key", privateKeyPath)
-			acurl = toTLS(clus.procs[rand.Intn(clus.cfg.clusterSize)].Config().acurl)
-		} else if clus.cfg.clientTLS == clientTLS {
-			if !clus.cfg.noCN {
+			clientURL = toTLS(clientURL)
+		} else if connType == clientTLS {
+			if CN {
 				cmdArgs = append(cmdArgs, "--cacert", caPath, "--cert", certPath, "--key", privateKeyPath)
 			} else {
 				cmdArgs = append(cmdArgs, "--cacert", caPath, "--cert", certPath3, "--key", privateKeyPath3)
 			}
 		}
 	}
-	if req.metricsURLScheme != "" {
-		acurl = clus.procs[rand.Intn(clus.cfg.clusterSize)].EndpointsMetrics()[0]
-	}
-	ep := acurl + req.endpoint
+	ep := clientURL + req.endpoint
 
 	if req.username != "" || req.password != "" {
 		cmdArgs = append(cmdArgs, "-L", "-u", fmt.Sprintf("%s:%s", req.username, req.password), ep)
@@ -193,13 +198,13 @@ func cURLPrefixArgs(clus *etcdProcessCluster, method string, req cURLReq) []stri
 }
 
 func cURLPost(clus *etcdProcessCluster, req cURLReq) error {
-	return spawnWithExpect(cURLPrefixArgs(clus, "POST", req), req.expected)
+	return spawnWithExpect(cURLPrefixArgsCluster(clus, "POST", req), req.expected)
 }
 
 func cURLPut(clus *etcdProcessCluster, req cURLReq) error {
-	return spawnWithExpect(cURLPrefixArgs(clus, "PUT", req), req.expected)
+	return spawnWithExpect(cURLPrefixArgsCluster(clus, "PUT", req), req.expected)
 }
 
 func cURLGet(clus *etcdProcessCluster, req cURLReq) error {
-	return spawnWithExpect(cURLPrefixArgs(clus, "GET", req), req.expected)
+	return spawnWithExpect(cURLPrefixArgsCluster(clus, "GET", req), req.expected)
 }

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -243,7 +243,7 @@ func testV3CurlAuth(cx ctlCtx) {
 			lineFunc   = func(txt string) bool { return true }
 		)
 
-		cmdArgs = cURLPrefixArgs(cx.epc, "POST", cURLReq{endpoint: path.Join(p, "/auth/authenticate"), value: string(authreq)})
+		cmdArgs = cURLPrefixArgsCluster(cx.epc, "POST", cURLReq{endpoint: path.Join(p, "/auth/authenticate"), value: string(authreq)})
 		proc, err := spawnCmd(cmdArgs)
 		testutil.AssertNil(cx.t, err)
 
@@ -281,7 +281,7 @@ func testV3CurlCampaign(cx ctlCtx) {
 	if err != nil {
 		cx.t.Fatal(err)
 	}
-	cargs := cURLPrefixArgs(cx.epc, "POST", cURLReq{
+	cargs := cURLPrefixArgsCluster(cx.epc, "POST", cURLReq{
 		endpoint: path.Join(cx.apiPrefix, "/election/campaign"),
 		value:    string(cdata),
 	})

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -73,7 +73,7 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 			clus, err := newEtcdProcessCluster(&tc.config)
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus, tc.config)
+			c := newClient(t, clus.EndpointsV3(), tc.config.clientTLS, tc.config.isClientAutoTLS)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, numberOfPreexistingKeys, sizeOfPreexistingValues))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)
@@ -93,7 +93,7 @@ func TestWatchDelayForManualProgressNotification(t *testing.T) {
 			clus, err := newEtcdProcessCluster(&tc.config)
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus, tc.config)
+			c := newClient(t, clus.EndpointsV3(), tc.config.clientTLS, tc.config.isClientAutoTLS)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, numberOfPreexistingKeys, sizeOfPreexistingValues))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)
@@ -125,7 +125,7 @@ func TestWatchDelayForEvent(t *testing.T) {
 			clus, err := newEtcdProcessCluster(&tc.config)
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus, tc.config)
+			c := newClient(t, clus.EndpointsV3(), tc.config.clientTLS, tc.config.isClientAutoTLS)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, numberOfPreexistingKeys, sizeOfPreexistingValues))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)
@@ -231,13 +231,13 @@ func continuouslyExecuteGetAll(ctx context.Context, t *testing.T, g *errgroup.Gr
 	})
 }
 
-func newClient(t *testing.T, clus *etcdProcessCluster, cfg etcdProcessClusterConfig) *clientv3.Client {
-	tlscfg, err := tlsInfo(t, cfg)
+func newClient(t *testing.T, entpoints []string, connType clientConnType, isAutoTLS bool) *clientv3.Client {
+	tlscfg, err := tlsInfo(t, connType, isAutoTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
 	ccfg := clientv3.Config{
-		Endpoints:   clus.EndpointsV3(),
+		Endpoints:   entpoints,
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
@@ -258,12 +258,12 @@ func newClient(t *testing.T, clus *etcdProcessCluster, cfg etcdProcessClusterCon
 	return c
 }
 
-func tlsInfo(t testing.TB, cfg etcdProcessClusterConfig) (*transport.TLSInfo, error) {
-	switch cfg.clientTLS {
+func tlsInfo(t testing.TB, connType clientConnType, isAutoTLS bool) (*transport.TLSInfo, error) {
+	switch connType {
 	case clientNonTLS, clientTLSAndNonTLS:
 		return nil, nil
 	case clientTLS:
-		if cfg.isClientAutoTLS {
+		if isAutoTLS {
 			tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate cert: %s", err)
@@ -272,6 +272,6 @@ func tlsInfo(t testing.TB, cfg etcdProcessClusterConfig) (*transport.TLSInfo, er
 		}
 		panic("Unsupported non-auto tls")
 	default:
-		return nil, fmt.Errorf("config %v not supported", cfg)
+		return nil, fmt.Errorf("config %v not supported", connType)
 	}
 }

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -26,13 +26,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/pkg/stringutil"
-	"go.etcd.io/etcd/pkg/testutil"
-	"go.etcd.io/etcd/pkg/transport"
-	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/testutil"
 )
 
 const (
@@ -176,25 +173,6 @@ func validateWatchDelay(t *testing.T, watch clientv3.WatchChan) {
 	}
 }
 
-func fillEtcdWithData(ctx context.Context, c *clientv3.Client, keyCount int, valueSize uint) error {
-	g := errgroup.Group{}
-	concurrency := 10
-	keysPerRoutine := keyCount / concurrency
-	for i := 0; i < concurrency; i++ {
-		i := i
-		g.Go(func() error {
-			for j := 0; j < keysPerRoutine; j++ {
-				_, err := c.Put(ctx, fmt.Sprintf("%d", i*keysPerRoutine+j), stringutil.RandString(valueSize))
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	}
-	return g.Wait()
-}
-
 func continuouslyExecuteGetAll(ctx context.Context, t *testing.T, g *errgroup.Group, c *clientv3.Client) {
 	mux := sync.RWMutex{}
 	size := 0
@@ -229,49 +207,4 @@ func continuouslyExecuteGetAll(ctx context.Context, t *testing.T, g *errgroup.Gr
 		}
 		return nil
 	})
-}
-
-func newClient(t *testing.T, entpoints []string, connType clientConnType, isAutoTLS bool) *clientv3.Client {
-	tlscfg, err := tlsInfo(t, connType, isAutoTLS)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ccfg := clientv3.Config{
-		Endpoints:   entpoints,
-		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
-	}
-	if tlscfg != nil {
-		tls, err := tlscfg.ClientConfig()
-		if err != nil {
-			t.Fatal(err)
-		}
-		ccfg.TLS = tls
-	}
-	c, err := clientv3.New(ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		c.Close()
-	})
-	return c
-}
-
-func tlsInfo(t testing.TB, connType clientConnType, isAutoTLS bool) (*transport.TLSInfo, error) {
-	switch connType {
-	case clientNonTLS, clientTLSAndNonTLS:
-		return nil, nil
-	case clientTLS:
-		if isAutoTLS {
-			tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
-			if err != nil {
-				return nil, fmt.Errorf("failed to generate cert: %s", err)
-			}
-			return &tls, nil
-		}
-		panic("Unsupported non-auto tls")
-	default:
-		return nil, fmt.Errorf("config %v not supported", connType)
-	}
 }


### PR DESCRIPTION
Regression testing for https://github.com/etcd-io/etcd/issues/15402

Ensures that all etcd endpoints listed in https://github.com/etcd-io/etcd/issues/15402 are available in every combination of TLS and http version.

Unfortunately needed to backport a lot of features from e2e test framework.

cc @ahrtr @ptabor 
