### PR TITLE
[3.4] tests: Avoid testing package root tests in e2e 

### DIFF
--- a/test
+++ b/test
@@ -340,7 +340,7 @@ function e2e_pass {
 		USERTIMEOUT="${TIMEOUT}"
 	fi
 
-	go test -timeout "${USERTIMEOUT}" -v -cpu "${TEST_CPUS}" "${RUN_ARG}"  "$@" "${REPO_PATH}/tests/e2e"
+	go test -timeout "${USERTIMEOUT}" -v -cpu "${TEST_CPUS}" ${RUN_ARG}  "$@" "${REPO_PATH}/tests/e2e"
 }
 
 function integration_e2e_pass {


### PR DESCRIPTION
Changes invocation from `go test -timeout 30m -v -cpu 1,2,4 '' -v --count 1 go.etcd.io/etcd/tests/e2e` to `go test -timeout 30m -v -cpu 1,2,4 -v --count 1 go.etcd.io/etcd/tests/e2e` (removes ''). Those braces caused tests run in root package instead of e2e.

Logs from a failed run https://github.com/etcd-io/etcd/actions/runs/4533349980/jobs/7986037591:
```
=== RUN   TestMain
    main_test.go:32: skip launching etcd server when invoked via go test
--- SKIP: TestMain (0.00s)
=== RUN   TestMain
    main_test.go:32: skip launching etcd server when invoked via go test
--- SKIP: TestMain (0.00s)
=== RUN   TestMain
    main_test.go:32: skip launching etcd server when invoked via go test
--- SKIP: TestMain (0.00s)
PASS
ok  	go.etcd.io/etcd	0.020s
Error: Process completed with exit code 143.
```
cc @ahrtr @ptabor 
