### PR TITLE
Document defining ciphers in example etcd config file

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -138,3 +138,9 @@ force-new-cluster: false
 
 auto-compaction-mode: periodic
 auto-compaction-retention: "1"
+
+# Limit etcd to a specific set of tls cipher suites
+cipher-suites: [
+  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+]


### PR DESCRIPTION
This pull request proposes to update our `etcd.conf.yml` with an example for setting `cipher-suites`.

This topic has come up in discussions and issues and it appears there has been some confusion about how it should be done, so let's provide a concrete example.

Relates to:
  - https://github.com/etcd-io/etcd/discussions/15547
  - https://github.com/etcd-io/etcd/discussions/15476
  - https://github.com/etcd-io/etcd/issues/12461
  - https://github.com/etcd-io/etcd/issues/11587