### PR TITLE
fix flaking auth member remove test

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -40,6 +40,9 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/apply"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
 
+	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/membershippb"
 	"go.etcd.io/etcd/api/v3/version"
@@ -69,8 +72,6 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 	"go.etcd.io/etcd/server/v3/storage/schema"
-	"go.etcd.io/raft/v3"
-	"go.etcd.io/raft/v3/raftpb"
 )
 
 const (

--- a/tests/common/e2e_test.go
+++ b/tests/common/e2e_test.go
@@ -77,3 +77,7 @@ func e2eClusterTestCases() []testCase {
 func WithAuth(userName, password string) config.ClientOption {
 	return e2e.WithAuth(userName, password)
 }
+
+func WithEndpoints(endpoints []string) config.ClientOption {
+	return e2e.WithEndpoints(endpoints)
+}

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -55,3 +55,7 @@ func integrationClusterTestCases() []testCase {
 func WithAuth(userName, password string) config.ClientOption {
 	return integration.WithAuth(userName, password)
 }
+
+func WithEndpoints(endpoints []string) config.ClientOption {
+	return integration.WithEndpoints(endpoints)
+}

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -272,3 +272,14 @@ func memberToRemove(ctx context.Context, t *testing.T, client intf.Client, clust
 	}
 	return memberId, clusterId
 }
+
+func getMemberIDToEndpoints(ctx context.Context, t *testing.T, clus intf.Cluster) (memberIDToEndpoints map[uint64]string) {
+	memberIDToEndpoints = make(map[uint64]string, len(clus.Endpoints()))
+	for _, ep := range clus.Endpoints() {
+		cc := testutils.MustClient(clus.Client(WithEndpoints([]string{ep})))
+		gresp, err := cc.Get(ctx, "health", config.GetOptions{})
+		require.NoError(t, err)
+		memberIDToEndpoints[gresp.Header.MemberId] = ep
+	}
+	return memberIDToEndpoints
+}

--- a/tests/common/unit_test.go
+++ b/tests/common/unit_test.go
@@ -36,3 +36,7 @@ func unitClusterTestCases() []testCase {
 func WithAuth(userName, password string) config.ClientOption {
 	return func(any) {}
 }
+
+func WithEndpoints(endpoints []string) config.ClientOption {
+	return func(any) {}
+}

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1466,6 +1466,13 @@ func WithAuth(userName, password string) framecfg.ClientOption {
 	}
 }
 
+func WithEndpoints(endpoints []string) framecfg.ClientOption {
+	return func(c any) {
+		cfg := c.(*clientv3.Config)
+		cfg.Endpoints = endpoints
+	}
+}
+
 func (c *Cluster) newClientCfg() (*clientv3.Config, error) {
 	cfg := &clientv3.Config{
 		Endpoints:          c.Endpoints(),


### PR DESCRIPTION
Before the fix, 

```
taskset -c 1 go test -v -failfast -count 100 -run TestAuthMemberRemove --tags integration
```

can reproduce the error. 

It was reported in the [Mesure Test Flakiness workflow](https://github.com/etcd-io/etcd/actions/runs/4585850341/jobs/8098223054)

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
