### PR TITLE
server/embed: pass *sctx into defer instead captured var

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -692,17 +692,19 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 			sctx.l = transport.LimitListener(sctx.l, int(fdLimit-reservedInternalFDNum))
 		}
 
-		defer func(addr string) {
+		defer func(sctx *serveCtx) {
 			if err == nil || sctx.l == nil {
 				return
 			}
-			sctx.l.Close()
+
 			cfg.logger.Warn(
 				"closing peer listener",
-				zap.String("address", addr),
+				zap.String("address", sctx.addr),
 				zap.Error(err),
 			)
-		}(sctx.addr)
+			sctx.l.Close()
+		}(sctx)
+
 		for k := range cfg.UserHandlers {
 			sctx.userHandlers[k] = cfg.UserHandlers[k]
 		}


### PR DESCRIPTION
REF: https://github.com/etcd-io/etcd/pull/15446#discussion_r1153075486

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
