### PR TITLE
contrib/raftexample: fix raftexample README's raft library link.

### DIFF
--- a/contrib/raftexample/README.md
+++ b/contrib/raftexample/README.md
@@ -1,6 +1,6 @@
 # raftexample
 
-raftexample is an example usage of etcd's [raft library](../../raft). It provides a simple REST API for a key-value store cluster backed by the [Raft][raft] consensus algorithm.
+raftexample is an example usage of etcd's [raft library](https://github.com/etcd-io/raft). It provides a simple REST API for a key-value store cluster backed by the [Raft][raft] consensus algorithm.
 
 [raft]: http://raftconsensus.github.io/
 


### PR DESCRIPTION
Raft library has been moved to https://github.com/etcd-io/raft, raftexample's `raft_library` link is 404, we must change it to the new url.

Changes:
- contrib/raftexample README.