### PR TITLE
[3.5] Backport fixes all docker images of Architecture show amd64

### DIFF
--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -35,8 +35,10 @@ cp "${BINARYDIR}"/etcd "${BINARYDIR}"/etcdctl "${BINARYDIR}"/etcdutl "${IMAGEDIR
 cat ./"${DOCKERFILE}" > "${IMAGEDIR}"/Dockerfile
 
 if [ -z "$TAG" ]; then
-    docker build -t "gcr.io/etcd-development/etcd:${VERSION}" "${IMAGEDIR}"
-    docker build -t "quay.io/coreos/etcd:${VERSION}" "${IMAGEDIR}"
+    # Fix incorrect image "Architecture" using buildkit
+    # From https://stackoverflow.com/q/72144329/
+    DOCKER_BUILDKIT=1 docker build -t "gcr.io/etcd-development/etcd:${VERSION}" "${IMAGEDIR}"
+    DOCKER_BUILDKIT=1 docker build -t "quay.io/coreos/etcd:${VERSION}" "${IMAGEDIR}"
 else
     docker build -t "${TAG}:${VERSION}" "${IMAGEDIR}"
 fi

--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -82,3 +82,12 @@ fi
 
 echo "Succesfully tested etcd local image ${TAG}"
 
+for TARGET_ARCH in "amd64" "arm64" "ppc64le" "s390x"; do
+    ARCH_TAG=v"${VERSION}"-"${TARGET_ARCH}"
+    IMG_ARCH=$(docker inspect --format '{{.Architecture}}' "${REPOSITARY}:${ARCH_TAG}")
+    if [ "${IMG_ARCH}" != "$TARGET_ARCH" ];then
+        echo "Incorrect docker image architecture"
+        exit 1
+    fi
+    echo "Correct Architecture ${ARCH_TAG}"
+done


### PR DESCRIPTION
Cherry pick of https://github.com/etcd-io/etcd/pull/15270 on release-3.5.

https://github.com/etcd-io/etcd/pull/15270: Fixes: #15266 All docker images of Architecture show amd64