### PR TITLE
tests: increase maxWatchDelay to prevent flaky TestWatchDelay*

### DIFF
--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -57,25 +57,25 @@ var tcs = []testCase{
 	{
 		name:          "NoTLS",
 		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "TLS",
 		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: e2e.ClientTLS}},
-		maxWatchDelay: 2 * time.Second,
+		maxWatchDelay: 3 * time.Second,
 		dbSizeBytes:   500 * Kilo,
 	},
 	{
 		name:          "SeparateHttpNoTLS",
 		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, ClientHttpSeparate: true},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "SeparateHttpTLS",
 		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: e2e.ClientTLS}, ClientHttpSeparate: true},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 }


### PR DESCRIPTION
value is selected empirically after spot checking some logs of flaky workflows

fixes: https://github.com/etcd-io/etcd/issues/15634


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
