### PR TITLE
tests/framwork/e2e/cluster.go: revert back to sequential cluster stop to reduce e2e test run time

### DIFF
--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -856,6 +856,22 @@ func (epc *EtcdProcessCluster) rollingStart(f func(ep EtcdProcess) error) error 
 }
 
 func (epc *EtcdProcessCluster) Stop() (err error) {
+	for _, p := range epc.Procs {
+		if p == nil {
+			continue
+		}
+		if curErr := p.Stop(); curErr != nil {
+			if err != nil {
+				err = fmt.Errorf("%v; %v", err, curErr)
+			} else {
+				err = curErr
+			}
+		}
+	}
+	return err
+}
+
+func (epc *EtcdProcessCluster) ConcurrentStop() (err error) {
 	errCh := make(chan error, len(epc.Procs))
 	for i := range epc.Procs {
 		if epc.Procs[i] == nil {

--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -279,5 +279,5 @@ func forcestopCluster(clus *e2e.EtcdProcessCluster) error {
 	for _, member := range clus.Procs {
 		member.Kill()
 	}
-	return clus.Stop()
+	return clus.ConcurrentStop()
 }


### PR DESCRIPTION
Fix: https://github.com/etcd-io/etcd/issues/15497

Before:

It is 28.9mins which is close to 30mins timeout
```
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' 'go.etcd.io/etcd/tests/v3/common' '--tags=e2e' '-timeout=30m')
ok  	go.etcd.io/etcd/tests/v3/common	1735.430s
```
https://github.com/etcd-io/etcd/actions/runs/4602707842/jobs/8131973032?pr=15580

After:

15mins
```
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' 'go.etcd.io/etcd/tests/v3/common' '--tags=e2e' '-timeout=30m')
ok  	go.etcd.io/etcd/tests/v3/common	902.535s
```

~~**Note: this change is meant to optimize 'go.etcd.io/etcd/tests/v3/common' test latency not for all the e2e tests**~~

~~After force stop on 3 node cluster created in `PeerTLS / PeerAutoTLS`~~
~~It is reduced to 19.9mins. ~~
```
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' 'go.etcd.io/etcd/tests/v3/common' '--tags=e2e' '-timeout=30m')
ok  	go.etcd.io/etcd/tests/v3/common	1199.148s
```
~~https://github.com/etcd-io/etcd/actions/runs/4663910234/jobs/8255664805?pr=15637~~

---
~~TODO:~~
~~If we fix the issue mentioned in https://github.com/etcd-io/etcd/issues/15497#issuecomment-1496376344, I am sure it will be dropped much more and close to the old e2e test runtime duration.~~
```
% (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' 'go.etcd.io/etcd/tests/v3/e2e' '-timeout=30m')
ok  	go.etcd.io/etcd/tests/v3/e2e	690.138s
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
