### PR TITLE
security: bump golang to 1.19.8 to fix four CVEs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.8"
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: |
         set -euo pipefail
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         ref: main
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: |
         set -euo pipefail
 

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.8"
       - run: date
       - run: |
           set -euo pipefail

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - name: release
       run: |
         set -euo pipefail

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: '1.19.7'
+        go-version: '1.19.8'
     - name: test-robustness
       env:
         ETCD_BRANCH: "${{ inputs.etcdBranch }}"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.8"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         ref: main
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.8"
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/tests/manual/Makefile
+++ b/tests/manual/Makefile
@@ -1,5 +1,5 @@
 TMP_DOCKERFILE:=$(shell mktemp)
-GO_VERSION ?= 1.19.7
+GO_VERSION ?= 1.19.8
 TMP_DIR_MOUNT_FLAG = --tmpfs=/tmp:exec
 ifdef HOST_TMP_DIR
 	TMP_DIR_MOUNT_FLAG = --mount type=bind,source=$(HOST_TMP_DIR),destination=/tmp


### PR DESCRIPTION
See https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8/m/OV40vnafAwAJ

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
