### PR TITLE
[3.4] Backport fix for all docker images showing amd64 architecture

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -40,8 +40,10 @@ cp "${BINARYDIR}"/etcd "${BINARYDIR}"/etcdctl "${IMAGEDIR}"
 cat ./"${DOCKERFILE}" > "${IMAGEDIR}"/Dockerfile
 
 if [ -z "$TAG" ]; then
-    docker build -t "gcr.io/etcd-development/etcd:${VERSION}" "${IMAGEDIR}"
-    docker build -t "quay.io/coreos/etcd:${VERSION}" "${IMAGEDIR}"
+    # Fix incorrect image "Architecture" using buildkit
+    # From https://stackoverflow.com/q/72144329/
+    DOCKER_BUILDKIT=1 docker build -t "gcr.io/etcd-development/etcd:${VERSION}" "${IMAGEDIR}"
+    DOCKER_BUILDKIT=1 docker build -t "quay.io/coreos/etcd:${VERSION}" "${IMAGEDIR}"
 else
     docker build -t "${TAG}:${VERSION}" "${IMAGEDIR}"
 fi

--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -85,3 +85,18 @@ if [ "${GET}" != "${VALUE}" ]; then
 fi
 
 echo "Succesfully tested etcd local image ${TAG}"
+
+for TARGET_ARCH in "amd64" "arm64" "ppc64le"; do
+    if [ "${TARGET_ARCH}" != "amd64" ]; then
+        ARCH_TAG=v"${VERSION}"-"${TARGET_ARCH}"
+    else
+        ARCH_TAG=v"${VERSION}"
+    fi
+
+    IMG_ARCH=$(docker inspect --format '{{.Architecture}}' "${REPOSITARY}:${ARCH_TAG}")
+    if [ "${IMG_ARCH}" != "$TARGET_ARCH" ];then
+        echo "Incorrect docker image architecture"
+        exit 1
+    fi
+    echo "Correct Architecture ${ARCH_TAG}"
+done


### PR DESCRIPTION
Backport fix for docker image arch to 3.4 for inclusion in `v3.4.25`, refer #15680.

Relates to: #15266