### PR TITLE
Fix gofmt for client/pkg/fileutil/preallocate.go

### DIFF
--- a/client/pkg/fileutil/preallocate.go
+++ b/client/pkg/fileutil/preallocate.go
@@ -19,8 +19,8 @@ import (
 	"os"
 )
 
-// Preallocate tries to allocate the space for given file. This 
-// operation is only supported on darwin and linux by a few 
+// Preallocate tries to allocate the space for given file. This
+// operation is only supported on darwin and linux by a few
 // filesystems (APFS, btrfs, ext4, etc.).
 // If the operation is unsupported, no error will be returned.
 // Otherwise, the error encountered will be returned.


### PR DESCRIPTION
The recent pull request https://github.com/etcd-io/etcd/pull/15281 updated a comment for a function but caused a format error due to trailing spaces. 

This is a quick fix to address after running `./scripts/fix.sh`.

Fixes #15692