### PR TITLE
tests/integration/clientv3: fix flaky TestMemberPromoteMemberNotLearner

### DIFF
--- a/tests/integration/clientv3/cluster_test.go
+++ b/tests/integration/clientv3/cluster_test.go
@@ -325,6 +325,9 @@ func TestMemberPromoteMemberNotLearner(t *testing.T) {
 		if !strings.Contains(err.Error(), expectedErrKeywords) {
 			t.Fatalf("expect error to contain %s, got %s", expectedErrKeywords, err.Error())
 		}
+		// avoid raft rejects the next configuration change due to slowness of raftLog.applied advance
+		// caused by slow fdatasync
+		guaranteeRaftAppliedIndexAdvance(t, clus.Members[leaderIdx].GRPCURL(), clus.Members[leaderIdx].ClientURLs[0])
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/15528

Analysis is summarized in https://github.com/etcd-io/etcd/issues/15528#issuecomment-1502077331

> etcd server apply and raftLog.applied increment is asynchronous. Because the test tries member promote back to back 3 consecutive times immediately, the configuration change apply failed as expected but raftLog.applied may not yet advanced so raft rejects the next configuration change until the current pending one finishes. 

So Fix is to ensure raftLog.applied advancement

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
