### PR TITLE
Add issue template for new membership nominations.

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership-request.yml
+++ b/.github/ISSUE_TEMPLATE/membership-request.yml
@@ -1,0 +1,30 @@
+name: Membership nomination
+description: Nominate new etcd members
+labels:
+- area/community
+body:
+- type: textarea
+  id: feature
+  attributes:
+    label: Who would you like to nominate?
+  validations:
+    required: true
+
+- id: requirements
+  type: checkboxes
+  attributes:
+    label: Requirements
+    options:
+    - label: I have reviewed the [community membership guidelines](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/community-membership.md)
+      required: true
+    - label: The members are actively contributing to 1 or more etcd subprojects
+      required: true
+    - label: The members are being sponsored by two current reviewers or a current maintainer.
+      required: true
+
+- type: textarea
+  id: rationale
+  attributes:
+    label: How do the new members meet the regular active contribution requirements?
+  validations:
+    required: true

--- a/Documentation/contributor-guide/community-membership.md
+++ b/Documentation/contributor-guide/community-membership.md
@@ -28,7 +28,7 @@ Members are continuously active contributors in the community.  They can have
 issues and PRs assigned to them. Members are expected to remain active 
 contributors to the community.
 
-**Defined by:** Member of the etcd GitHub organization
+**Defined by:** Member of the etcd GitHub organization.
 
 ### Requirements
 
@@ -43,6 +43,9 @@ contributors to the community.
 - Sponsored by one active maintainer or two reviewers.
     - Sponsors must be from multiple member companies to demonstrate integration across community.
     - With no objections from other maintainers
+- Open a [membership nomination] issue against the etcd-io/etcd repo
+    - Ensure your sponsors are @mentioned on the issue
+    - Make sure that the list of contributions included is representative of your work on the project.
 - Members can be removed by a supermajority of the maintainers or can resign by notifying
   the maintainers.
 
@@ -147,6 +150,7 @@ Contributor roles and responsibilities were written based on [Kubernetes communi
 
 [MAINTAINERS]: /MAINTAINERS
 [contributor guide]: /CONTRIBUTING.md
+[membership nomination]:https://github.com/etcd-io/etcd/issues/new?assignees=&labels=area%2Fcommunity&template=membership-request.yml 
 [Kubernetes community membership]: https://github.com/kubernetes/community/blob/master/community-membership.md
 [emeritus maintainers]: /README.md#etcd-emeritus-maintainers
 [security disclosure and release process]: /security/README.md


### PR DESCRIPTION
This pull request proposes adding a new github issue template for nominating new etcd org members. Currently I have only set this up to cater for the base "Member" role as this would be the one happening on the most frequent basis versus adding reviewers or maintainers.

The issue template is partially inspired by the kubernetes github organisation membership template but adjusted to be from the angle of a reviewer or maintainer raising the nomination instead of the member.

The intent of the template is to save a small amount of the creators time and ensure issues automatically have the right labels and follow a consistent approach.

Please let me know what you think of the suggested layout, happy to tweak it!