### PR TITLE
[3.4] fix release.sh: git_assert_branch_in_sync not exist in 3.4

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -6,7 +6,7 @@ source ./scripts/test_lib.sh
 
 VER=$1
 PROJ="etcd"
-REPOSITORY="${REPOSITORY:-git@github.com:etcd-io/etcd.git}"
+REPOSITORY="${REPOSITORY:-https://github.com/etcd-io/etcd.git}"
 
 if [ -z "$1" ]; then
 	echo "Usage: ${0} VERSION" >> /dev/stderr

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,8 +69,6 @@ main() {
     cd "${reldir}/etcd" || exit 2
     git checkout "${BRANCH}" || exit 2
     git pull origin
-
-    git_assert_branch_in_sync || exit 2
   fi
   
   # If a release version tag already exists, use it.


### PR DESCRIPTION
The `git_assert_branch_in_sync` doesn't exist in 3.4, so let's just remove it.

The issue was introduced in https://github.com/etcd-io/etcd/commit/49d05f88c31c71a48368bf20927cd8ba61a3bf1a. In our workflow, it always run in `in-place` mode, so it never triggers the branch.


