### PR TITLE
Adds a reusable workflow to setup the GoVersion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,11 @@ on: [push, pull_request]
 permissions: read-all
 
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   build:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +25,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.8"
+          go-version: ${{ needs.goversion.outputs.goversion }}
       - env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -2,13 +2,16 @@ name: Test contrib/mixin
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: |
         set -euo pipefail
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,8 +2,11 @@ name: Coverage
 on: [push]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   coverage:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: false
       matrix:
@@ -13,7 +16,7 @@ jobs:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - env:
         TARGET: ${{ matrix.target }}
       run: |

--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -4,10 +4,13 @@ on:
     - cron: '0 1 * * *' # runs daily at 1am.
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
     runs-on: [Linux, ARM64]
+    needs: goversion
     strategy:
       fail-fast: true
       matrix:
@@ -18,7 +21,7 @@ jobs:
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         ref: main
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,8 +2,11 @@ name: E2E
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: true
       matrix:
@@ -14,7 +17,7 @@ jobs:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -2,8 +2,11 @@ name: Fuzzing v3rpc
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   fuzzing:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: false
     env:
@@ -12,7 +15,7 @@ jobs:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: |
         set -euo pipefail
 

--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,0 +1,22 @@
+name: Go version setup
+
+env:
+  GO_VERSION: "1.19.8"
+
+on:
+  workflow_call:
+    outputs:
+      goversion:
+        value: ${{ jobs.version.outputs.goversion }}
+
+jobs:
+  version:
+    name: Set Go version variable for all the workflows
+    runs-on: ubuntu-latest
+    outputs:
+      goversion: ${{ steps.step1.outputs.goversion }}
+    steps:
+      - id: step1
+        run: |
+          echo "Go Version: $GO_VERSION"
+          echo "goversion=$GO_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -2,13 +2,16 @@ name: Go Vulnerability Checker
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.8"
+          go-version: ${{ needs.goversion.outputs.goversion }}
       - run: date
       - run: |
           set -euo pipefail

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -2,8 +2,11 @@ name: grpcProxy-tests
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: true
       matrix:
@@ -14,7 +17,7 @@ jobs:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,13 +2,16 @@ name: Release
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   main:
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - name: release
       run: |
         set -euo pipefail

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -17,14 +17,17 @@ on:
         type: string
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     timeout-minutes: 210
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: '1.19.8'
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - name: test-robustness
       env:
         ETCD_BRANCH: "${{ inputs.etcdBranch }}"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -2,13 +2,16 @@ name: Static Analysis
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   run:
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
-          go-version: "1.19.8"
+          go-version: ${{ needs.goversion.outputs.goversion }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -3,10 +3,13 @@ on:
   schedule:
     - cron: '30 1 * * *' # runs daily at 1:30 am.
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
     runs-on: [Linux, ARM64]
+    needs: goversion
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +23,7 @@ jobs:
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         ref: main
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,8 +2,11 @@ name: Tests
 on: [push, pull_request]
 permissions: read-all
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: false
       matrix:
@@ -17,7 +20,7 @@ jobs:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,7 +112,7 @@ main() {
   # Check go version.
   log_callout "Check go version"
   local go_version current_go_version
-  go_version="go$(grep go-version .github/workflows/build.yaml | awk '{print $2}' | tr -d '"')"
+  go_version="go$(grep -oP '(?<=GO_VERSION:\s")[^"]*' .github/workflows/go-version.yaml | tr -d ' ')"
   current_go_version=$(go version | awk '{ print $3 }')
   if [[ "${current_go_version}" != "${go_version}" ]]; then
     log_error "Current go version is ${current_go_version}, but etcd ${RELEASE_VERSION} requires ${go_version} (see .github/workflows/build.yaml)."


### PR DESCRIPTION
Adds a reusable workflow to setup the GoVersion. 
The output of this workflow will be used in the other workflows to reduce maintenance burden for the project  and also increase speed of adoption for new patch releases.

Related to https://github.com/etcd-io/etcd/issues/15674
