### PR TITLE
Change the minimum recommended etcd versions to run in production to 3.4.22+ and 3.5.6+

### DIFF
--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -2,7 +2,7 @@
 
 ## Production recommendation
 
-The minimum recommended etcd versions to run in **production** are v3.4.8+ and v3.5.4+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
+The minimum recommended etcd versions to run in **production** are v3.4.22+ and v3.5.6+. Refer to the [versioning policy](https://etcd.io/docs/v3.5/op-guide/versioning/) for more details.
 
 ### v3.5 data corruption issue 
 


### PR DESCRIPTION
Please read https://groups.google.com/g/etcd-dev/c/8S7u6NqW6C4

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @mitake @ptabor @serathius @spzala 
