### PR TITLE
close the session to avoid leak goroutine

### DIFF
--- a/server/proxy/grpcproxy/register.go
+++ b/server/proxy/grpcproxy/register.go
@@ -69,10 +69,12 @@ func registerSession(lg *zap.Logger, c *clientv3.Client, prefix string, addr str
 
 	em, err := endpoints.NewManager(c, prefix)
 	if err != nil {
+		ss.Close()
 		return nil, err
 	}
 	endpoint := endpoints.Endpoint{Addr: addr, Metadata: getMeta()}
 	if err = em.AddEndpoint(c.Ctx(), prefix+"/"+addr, endpoint, clientv3.WithLease(ss.Lease())); err != nil {
+		ss.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
In func `NewSession`
https://github.com/etcd-io/etcd/blob/e04120042e0c05143816679804cab46e84bc96c3/client/v3/concurrency/session.go#L67-L72
It create a new goroutine to eat messages until keep alive channel closes.
However, the `s.Close` is missed some branch of   `registerSession` (L72 and L75)
https://github.com/etcd-io/etcd/blob/e04120042e0c05143816679804cab46e84bc96c3/client/v3/concurrency/session.go#L92-L105
https://github.com/etcd-io/etcd/blob/e04120042e0c05143816679804cab46e84bc96c3/server/proxy/grpcproxy/register.go#L64-L85
As `registerSession` will return nil instead of the created session, it seems we cannot close it from its callee, with will cause some leak routines. For example,
```
        [Goroutine 16 in state chan send, with go.etcd.io/etcd/client/pkg/v3/testutil.(*recorderStream).Record on top of the stack:
        goroutine 16 [chan send]:
        go.etcd.io/etcd/client/pkg/v3/testutil.(*recorderStream).Record(0xc0003ae7d0, {{0xe00cb0, 0x7}, {0xc0002cc060, 0x1, 0x1}})
                /tool/etcd/client/pkg/testutil/recorder.go:112 +0x7f
        go.etcd.io/etcd/server/v3/etcdserver.(*nodeRecorder).Propose(0xc000190348, {0xf65b08?, 0xc00049a3f0?}, {0xc0004a20c0, 0x31, 0x31})
                /tool/etcd/server/etcdserver/server_test.go:1815 +0xfa
        go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).sync.func1()
                /tool/etcd/server/etcdserver/server.go:1699 +0x43
        go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach.func1()
                /tool/etcd/server/etcdserver/server.go:2425 +0x64
        created by go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach
                /tool/etcd/server/etcdserver/server.go:2423 +0x119
```
