### PR TITLE
Add -failfast flag when the mode is fail_fast

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -293,7 +293,7 @@ function go_test {
   junit_filename_prefix=$(junitFilenamePrefix)
 
   if [ "${VERBOSE:-}" == "1" ]; then
-    goTestFlags="-v"
+    goTestFlags="-v "
   fi
 
   # Expanding patterns (like ./...) into list of packages
@@ -306,6 +306,10 @@ function go_test {
       log_error "Cannot resolve packages: ${packages}"
       return 255
     fi
+  fi
+
+  if [ "${mode}" == "fail_fast" ]; then
+    goTestFlags+="-failfast "
   fi
 
   local failures=""


### PR DESCRIPTION
Though there is mention of mode `fail_fast`, at https://github.com/etcd-io/etcd/blob/main/scripts/test_lib.sh#L252, and usages, there is no actual pass of `-failfast` flag.

_Usages locations:_
https://github.com/etcd-io/etcd/blob/main/scripts/test.sh#L163
https://github.com/etcd-io/etcd/blob/main/scripts/test.sh#L168