### PR TITLE
tests: Deflake TestEtcdGrpcResolverRoundRobin

### DIFF
--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -93,7 +93,7 @@ func testEtcdGrpcResolver(t *testing.T, lbPolicy string) {
 
 	// Send more requests
 	lastResponse := []byte{'1'}
-	totalRequests := 100
+	totalRequests := 1000
 	for i := 1; i < totalRequests; i++ {
 		resp, err := c.UnaryCall(context.TODO(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
 		if err != nil {
@@ -111,7 +111,7 @@ func testEtcdGrpcResolver(t *testing.T, lbPolicy string) {
 	// If the load balancing policy is pick first then return payload should equal number of requests
 	t.Logf("Last response: %v", string(lastResponse))
 	if lbPolicy == "pick_first" {
-		if string(lastResponse) != "100" {
+		if string(lastResponse) != "1000" {
 			t.Fatalf("unexpected total responses from foo: %s", string(lastResponse))
 		}
 	}
@@ -123,9 +123,9 @@ func testEtcdGrpcResolver(t *testing.T, lbPolicy string) {
 			t.Fatalf("couldn't convert to int: %s", string(lastResponse))
 		}
 
-		// Allow 10% tolerance as round robin is not perfect and we don't want the test to flake
+		// Allow 15% tolerance as round robin is not perfect and we don't want the test to flake
 		expected := float64(totalRequests) * 0.5
-		assert.InEpsilon(t, float64(expected), float64(responses), 0.1, "unexpected total responses from foo: %s", string(lastResponse))
+		assert.InEpsilon(t, float64(expected), float64(responses), 0.15, "unexpected total responses from foo: %s", string(lastResponse))
 	}
 }
 


### PR DESCRIPTION
The flake is as a result of the new test case I introduced in #15577. The test case was sending 100 requests using a round robin resolver against two endpoints and expecting roughly half to go to each server, with a 10% total tolerance (so 5% either side of 50).

In the identified flake 61 requests went to first server and 39 to the second so more than the 5% either side threshold.

To try and address that I am going to increase number of requests  to 1,000 which should reduce run to run variability by increasing sample size. Additionally I will increase allowed tolerance to 15%.

These two changes in combination are expected to reduce the chance this flake can happen.

Fixes: #15794