### PR TITLE
Updated go to latest patch release 1.19.9

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,7 +1,7 @@
 name: Go version setup
 
 env:
-  GO_VERSION: "1.19.8"
+  GO_VERSION: "1.19.9"
 
 on:
   workflow_call:


### PR DESCRIPTION
Go 1.19.9 was released 2023-05-02, we should consider updating.

https://go.dev/doc/devel/release#go1.19.minor

> The update includes three security fixes to the html/template package, as well as bug fixes to the compiler, the runtime, and the crypto/tls and syscall packages. See the [Go 1.19.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.9+label%3ACherryPickApproved) on our issue tracker for details. 