### PR TITLE
[3.4] Backport updating go to latest patch release 1.19.9

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,7 +1,7 @@
 name: Go version setup
 
 env:
-  GO_VERSION: "1.19.8"
+  GO_VERSION: "1.19.9"
 
 on:
   workflow_call:

--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,0 +1,22 @@
+name: Go version setup
+
+env:
+  GO_VERSION: "1.19.8"
+
+on:
+  workflow_call:
+    outputs:
+      goversion:
+        value: ${{ jobs.version.outputs.goversion }}
+
+jobs:
+  version:
+    name: Set Go version variable for all the workflows
+    runs-on: ubuntu-latest
+    outputs:
+      goversion: ${{ steps.step1.outputs.goversion }}
+    steps:
+      - id: step1
+        run: |
+          echo "Go Version: $GO_VERSION"
+          echo "goversion=$GO_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,16 @@
 name: Release
 on: [push, pull_request]
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   release:
     runs-on: ubuntu-latest
+    needs: goversion
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - name: release
       run: |
         set -euo pipefail

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,11 @@
 name: Tests
 on: [push, pull_request]
 jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
   test:
     runs-on: ubuntu-latest
+    needs: goversion
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: "1.19.8"
+        go-version: ${{ needs.goversion.outputs.goversion }}
     - run: date
     - env:
         TARGET: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.19.8
+GO_VERSION ?= 1.19.9
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -13,7 +13,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-agent.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.19.8
+  GO_VERSION=1.19.9
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -6,7 +6,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-tester.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.19.8
+  GO_VERSION=1.19.9
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,7 +83,7 @@ main() {
   # Check go version.
   log_callout "Checking go version"
   local go_version current_go_version
-  go_version="go$(grep go-version .github/workflows/tests.yaml | awk '{print $2}' | tr -d '"')"
+  go_version="go$(grep -oP '(?<=GO_VERSION:\s")[^"]*' .github/workflows/go-version.yaml | tr -d ' ')"
   current_go_version=$(go version | awk '{ print $3 }')
   if [[ "${current_go_version}" != "${go_version}" ]]; then
     log_error "Current go version is ${current_go_version}, but etcd ${RELEASE_VERSION} requires ${go_version} (see .github/workflows/tests.yaml)."


### PR DESCRIPTION
Backport the following to `release-3.4`:
- https://github.com/etcd-io/etcd/pull/15748
- https://github.com/etcd-io/etcd/pull/15821