### PR TITLE
Test Arm64 etcd container in K8s cluster

### DIFF
--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -1,0 +1,34 @@
+name: Release-arm64
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  goversion:
+    uses: ./.github/workflows/go-version.yaml
+  main:
+    runs-on: [Linux, ARM64]
+    needs: goversion
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      with:
+        go-version: ${{ needs.goversion.outputs.goversion }}
+    - name: release
+      run: |
+        set -euo pipefail
+
+        git config --global user.email "github-action@etcd.io"
+        git config --global user.name "Github Action"
+        gpg --batch --gen-key <<EOF
+        %no-protection
+        Key-Type: 1
+        Key-Length: 2048
+        Subkey-Type: 1
+        Subkey-Length: 2048
+        Name-Real: Github Action
+        Name-Email: github-action@etcd.io
+        Expire-Date: 0
+        EOF
+        DRY_RUN=true ./scripts/release.sh --no-upload --no-docker-push --in-place 3.6.99
+    - name: test-image
+      run: |
+        VERSION=3.6.99 ./scripts/test_images.sh


### PR DESCRIPTION
Since the multiple architecture image issue #15505 has been sorted out, continue to introduce the test for Arm64 for local image test as it does on #15139

Again, on PR trigger first to see the test result and will change back to periodically later.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
