### PR TITLE
Add an option to keep_going with run for modules on failure

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,6 +26,9 @@
 # $ PASSES=unit PKG=./wal TESTCASE="\bTestNew\b" TIMEOUT=1m ./scripts/test.sh
 # $ PASSES=integration PKG=./client/integration TESTCASE="\bTestV2NoRetryEOF\b" TIMEOUT=1m ./scripts/test.sh
 #
+# KEEP_GOING_SUITE must be set to true to keep going with the next suite execution, passed to PASSES variable when there is a failure
+# in a particular suite.
+# KEEP_GOING_MODULE must be set to true to keep going with execution when there is failure in any module.
 #
 # Run code coverage
 # COVERDIR must either be a absolute path or a relative path to the etcd root
@@ -55,7 +58,7 @@ if [ -n "${OUTPUT_FILE}" ]; then
 fi
 
 PASSES=${PASSES:-"gofmt bom dep build unit"}
-PASSES_CONTINUE=${PASSES_CONTINUE:-false}
+KEEP_GOING_SUITE=${KEEP_GOING_SUITE:-false}
 PKG=${PKG:-}
 SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.8.0"}
 
@@ -651,7 +654,7 @@ function run_pass {
     return 0
   else
     log_error "FAIL: '${pass}' FAILED at $(date)"
-    if [ "$PASSES_CONTINUE" = true ]; then
+    if [ "$KEEP_GOING_SUITE" = true ]; then
       return 2
     else
       exit 255


### PR DESCRIPTION

The existing logic in the function run_for_modules exits the loop through modules when there is a failure.

- This change adds an environment variable  KEEP_GOING_MODULE to have the option to continue running tests in other modules even on failure with one of them.
- Also including comments in `test.sh` to describe KEEP_GOING_MODULE and KEEP_GOING_SUITE
- Changing variable PASSES_CONTINUE to KEEP_GOING_SUITE

Instead of https://github.com/etcd-io/etcd/pull/15824
