### PR TITLE
Update 3.4 and 3.5 changelogs for compile with 1.19.9.

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,6 +4,12 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
+## v3.4.26 (tbd)
+
+### Dependencies
+- Compile binaries using [go 1.19.9](https://github.com/etcd-io/etcd/pull/15823)
+
+
 ## v3.4.25 (2023-04-14)
 
 ### etcd server

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,6 +4,12 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.9 (tbd)
+
+### Dependencies
+- Compile binaries using [go 1.19.9](https://github.com/etcd-io/etcd/pull/15822).
+
+
 ## v3.5.8 (2023-04-13)
 
 ### etcd server


### PR DESCRIPTION
We recently backported:
 - https://github.com/etcd-io/etcd/pull/15823
 - https://github.com/etcd-io/etcd/pull/15822

Let's prep the changelog to show which go release binaries would compile with.

There could be more go patch releases between now and the next releases but we can always tweak it later to take those into account.