### PR TITLE
tests: Deflake TestEtcdGrpcResolverRoundRobin

### DIFF
--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -123,9 +123,9 @@ func testEtcdGrpcResolver(t *testing.T, lbPolicy string) {
 			t.Fatalf("couldn't convert to int: %s", string(lastResponse))
 		}
 
-		// Allow 15% tolerance as round robin is not perfect and we don't want the test to flake
+		// Allow 25% tolerance as round robin is not perfect and we don't want the test to flake
 		expected := float64(totalRequests) * 0.5
-		assert.InEpsilon(t, float64(expected), float64(responses), 0.15, "unexpected total responses from foo: %s", string(lastResponse))
+		assert.InEpsilon(t, float64(expected), float64(responses), 0.25, "unexpected total responses from foo: %s", string(lastResponse))
 	}
 }
 


### PR DESCRIPTION
Some further and hopefully final tuning for this test case to fix a recent flake. This change increases the threshold to allow a total range of deviation of 25% so +/- 12.5% either side of expected roughly half of requests to go to each endpoint.

Fixes #15794