### PR TITLE
tests/robustness: Move request progress field from traffic to watch c…

### DIFF
--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -48,27 +48,6 @@ var (
 			},
 		},
 	}
-	ReqProgTraffic = Config{
-		Name:            "RequestProgressTraffic",
-		minimalQPS:      100,
-		maximalQPS:      200,
-		clientCount:     8,
-		RequestProgress: true,
-		traffic: etcdTraffic{
-			keyCount:     10,
-			leaseTTL:     DefaultLeaseTTL,
-			largePutSize: 32769,
-			writeChoices: []choiceWeight[etcdRequestType]{
-				{choice: Put, weight: 45},
-				{choice: LargePut, weight: 5},
-				{choice: Delete, weight: 10},
-				{choice: MultiOpTxn, weight: 10},
-				{choice: PutWithLease, weight: 10},
-				{choice: LeaseRevoke, weight: 10},
-				{choice: CompareAndSet, weight: 10},
-			},
-		},
-	}
 	HighTraffic = Config{
 		Name:        "HighTraffic",
 		minimalQPS:  200,

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -90,12 +90,11 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 }
 
 type Config struct {
-	Name            string
-	minimalQPS      float64
-	maximalQPS      float64
-	clientCount     int
-	traffic         Traffic
-	RequestProgress bool // Request progress notifications while watching this traffic
+	Name        string
+	minimalQPS  float64
+	maximalQPS  float64
+	clientCount int
+	traffic     Traffic
 }
 
 type Traffic interface {


### PR DESCRIPTION
…onfig and pass testScenario to reduce number of arguments


cc @ahrtr @ptabor 
