### PR TITLE
Run robustness tests on arm64

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
-    runs-on: [Linux, ARM64]
+    runs-on: [self-hosted, Linux, ARM64]
     needs: goversion
     strategy:
       fail-fast: true

--- a/.github/workflows/robustness-nightly.yaml
+++ b/.github/workflows/robustness-nightly.yaml
@@ -14,6 +14,14 @@ jobs:
       count: 100
       testTimeout: 200m
       artifactName: main
+  main-arm64:
+    uses: ./.github/workflows/robustness-template.yaml
+    with:
+      etcdBranch: main
+      count: 100
+      testTimeout: 200m
+      artifactName: main-arm64
+      runs-on: "['self-hosted', 'Linux', 'ARM64']"
   release-35:
     uses: ./.github/workflows/robustness-template.yaml
     with:

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -15,13 +15,17 @@ on:
       artifactName:
         required: true
         type: string
+      runs-on:
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
 permissions: read-all
 jobs:
   goversion:
     uses: ./.github/workflows/go-version.yaml
   test:
     timeout-minutes: 210
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runs-on) }}
     needs: goversion
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/robustness.yaml
+++ b/.github/workflows/robustness.yaml
@@ -9,3 +9,11 @@ jobs:
       count: 15
       testTimeout: 30m
       artifactName: main
+  main-arm64:
+    uses: ./.github/workflows/robustness-template.yaml
+    with:
+      etcdBranch: main
+      count: 15
+      testTimeout: 30m
+      artifactName: main-arm64
+      runs-on: "['self-hosted', 'Linux', 'ARM64']"

--- a/.github/workflows/robustness.yaml
+++ b/.github/workflows/robustness.yaml
@@ -9,11 +9,3 @@ jobs:
       count: 15
       testTimeout: 30m
       artifactName: main
-  main-arm64:
-    uses: ./.github/workflows/robustness-template.yaml
-    with:
-      etcdBranch: main
-      count: 15
-      testTimeout: 30m
-      artifactName: main-arm64
-      runs-on: "['self-hosted', 'Linux', 'ARM64']"

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
-    runs-on: [Linux, ARM64]
+    runs-on: [self-hosted, Linux, ARM64]
     needs: goversion
     strategy:
       fail-fast: false


### PR DESCRIPTION
In order to progress tier one support for `arm64` we need to get nightly on per pull request actions workflows running our robustness test suite on the `arm64` platform.

This pull request completes the work started in https://github.com/etcd-io/etcd/pull/15310:
- Robustness template updated to support dynamic `runs-on`.
- New `main-arm64` jobs added to robustness nightly workflow.

Additionally this pull request adds the [recommended `self-hosted` label](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-self-hosted-runners) to existing `arm64` tests and e2e workflows.

Relates to https://github.com/etcd-io/etcd/issues/14748

cc @serathius, @ahrtr, @chaochn47

