### PR TITLE
workflow: grant only read permission to all workflows

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,4 +1,5 @@
 name: Go version setup
+permissions: read-all
 
 on:
   workflow_call:

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -2,6 +2,7 @@ name: Tests-arm64
 on:
   schedule:
     - cron: '30 1 * * *' # runs daily at 1:30 am.
+permissions: read-all
 jobs:
   goversion:
     uses: ./.github/workflows/go-version.yaml


### PR DESCRIPTION
Grant readonly permission to workflows. We already did this, but missing for two workflows.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
