### PR TITLE
Ensure arm64 runners start with a clean checkout

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -17,6 +17,12 @@ jobs:
         target:
         - linux-arm64-e2e
     steps:
+    - name: 'Cleanup build folder'
+      run: |
+        ls -la ./
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        ls -la ./
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:

--- a/.github/workflows/robustness-nightly.yaml
+++ b/.github/workflows/robustness-nightly.yaml
@@ -22,6 +22,7 @@ jobs:
       testTimeout: 200m
       artifactName: main-arm64
       runs-on: "['self-hosted', 'Linux', 'ARM64']"
+      clean: 'true'
   release-35:
     uses: ./.github/workflows/robustness-template.yaml
     with:

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: "['ubuntu-latest']"
+      clean:
+        required: false
+        type: string
+        default: 'false'
 permissions: read-all
 jobs:
   goversion:
@@ -28,6 +32,12 @@ jobs:
     runs-on: ${{ fromJson(inputs.runs-on) }}
     needs: goversion
     steps:
+    - name: 'Cleanup build folder'
+      run: |
+        ls -la ./
+        if [ ${{ inputs.clean }} == "true" ]; then rm -rf ./* || true; fi
+        if [ ${{ inputs.clean }} == "true" ]; then rm -rf ./.??* || true; fi
+        ls -la ./
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:

--- a/.github/workflows/tests-arm64.yaml
+++ b/.github/workflows/tests-arm64.yaml
@@ -20,6 +20,12 @@ jobs:
         - linux-arm64-integration-4-cpu
         - linux-arm64-unit-4-cpu-race
     steps:
+    - name: 'Cleanup build folder'
+      run: |
+        ls -la ./
+        rm -rf ./* || true
+        rm -rf ./.??* || true
+        ls -la ./
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:


### PR DESCRIPTION
As identified in https://github.com/etcd-io/etcd/issues/15647 we need to ensure that our arm64 runners are going to start with a fresh checkout each time they start a job.

An idea was mentioned in [stackoverflow](https://stackoverflow.com/questions/70483902/how-to-actually-clean-up-the-repository-on-self-hosted-runner-after-github-actio)  that I would like to propose. That is to have a pre-checkout step for all our `arm64` jobs that will clear the directory and ensure a fresh checkout.

cc @chaochn47, @serathius, @ahrtr 