### PR TITLE
tests/robustness: use monotonic clock for watch events

### DIFF
--- a/tests/robustness/traffic/client.go
+++ b/tests/robustness/traffic/client.go
@@ -32,7 +32,10 @@ import (
 // clientv3.Client) that records all the requests and responses made. Doesn't
 // allow for concurrent requests to confirm to model.AppendableHistory requirements.
 type RecordingClient struct {
-	client   clientv3.Client
+	client clientv3.Client
+	// baseTime is needed to achieve monotonic clock reading.
+	// Only time-measuring operations should be used to record time.
+	// see https://github.com/golang/go/blob/master/src/time/time.go#L17
 	baseTime time.Time
 	// mux ensures order of request appending.
 	mux     sync.Mutex

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -35,7 +35,7 @@ var (
 	MultiOpTxnOpCount       = 4
 )
 
-func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster, config Config, finish <-chan struct{}) []porcupine.Operation {
+func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster, config Config, finish <-chan struct{}, baseTime time.Time) []porcupine.Operation {
 	mux := sync.Mutex{}
 	endpoints := clus.EndpointsGRPC()
 
@@ -45,7 +45,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 	limiter := rate.NewLimiter(rate.Limit(config.maximalQPS), 200)
 
 	startTime := time.Now()
-	cc, err := NewClient(endpoints, ids, startTime)
+	cc, err := NewClient(endpoints, ids, baseTime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 	wg := sync.WaitGroup{}
 	for i := 0; i < config.clientCount; i++ {
 		wg.Add(1)
-		c, err := NewClient([]string{endpoints[i%len(endpoints)]}, ids, startTime)
+		c, err := NewClient([]string{endpoints[i%len(endpoints)]}, ids, baseTime)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
see: https://github.com/etcd-io/etcd/pull/15323
For consistency watch events should also use only time-measurement operations.

fixes: https://github.com/etcd-io/etcd/issues/15328


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
