### PR TITLE
*: use strings.Builder instead of bytes.Buffer

### DIFF
--- a/client/pkg/types/id.go
+++ b/client/pkg/types/id.go
@@ -15,8 +15,8 @@
 package types
 
 import (
-	"bytes"
 	"strconv"
+	"strings"
 )
 
 // ID represents a generic identifier which is canonically
@@ -42,7 +42,7 @@ func (p IDSlice) Less(i, j int) bool { return uint64(p[i]) < uint64(p[j]) }
 func (p IDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 func (p IDSlice) String() string {
-	var b bytes.Buffer
+	var b strings.Builder
 	if p.Len() > 0 {
 		b.WriteString(p[0].String())
 	}

--- a/contrib/raftexample/kvstore.go
+++ b/contrib/raftexample/kvstore.go
@@ -19,6 +19,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"log"
+	"strings"
 	"sync"
 
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
@@ -63,7 +64,7 @@ func (s *kvstore) Lookup(key string) (string, bool) {
 }
 
 func (s *kvstore) Propose(k string, v string) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	if err := gob.NewEncoder(&buf).Encode(kv{k, v}); err != nil {
 		log.Fatal(err)
 	}

--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -15,11 +15,11 @@
 package command
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -58,7 +58,7 @@ func printJSON(v interface{}) {
 }
 
 func printMemberListWithHexJSON(r clientv3.MemberListResponse) {
-	var buffer bytes.Buffer
+	var buffer strings.Builder
 	var b []byte
 	buffer.WriteString("{\"header\":{\"cluster_id\":\"")
 	b = strconv.AppendUint(nil, r.Header.ClusterId, 16)

--- a/pkg/cobrautl/help.go
+++ b/pkg/cobrautl/help.go
@@ -17,7 +17,6 @@
 package cobrautl
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -103,7 +102,7 @@ GLOBAL OPTIONS:
 }
 
 func etcdFlagUsages(flagSet *pflag.FlagSet) string {
-	x := new(bytes.Buffer)
+	x := new(strings.Builder)
 
 	flagSet.VisitAll(func(flag *pflag.Flag) {
 		if len(flag.Deprecated) > 0 {

--- a/pkg/report/timeseries.go
+++ b/pkg/report/timeseries.go
@@ -15,12 +15,12 @@
 package report
 
 import (
-	"bytes"
 	"encoding/csv"
 	"fmt"
 	"log"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -119,7 +119,7 @@ func (sp *secondPoints) getTimeSeries() TimeSeries {
 }
 
 func (t TimeSeries) String() string {
-	buf := new(bytes.Buffer)
+	buf := new(strings.Builder)
 	wr := csv.NewWriter(buf)
 	if err := wr.Write([]string{"UNIX-SECOND", "MIN-LATENCY-MS", "AVG-LATENCY-MS", "MAX-LATENCY-MS", "AVG-THROUGHPUT"}); err != nil {
 		log.Fatal(err)

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -16,10 +16,10 @@
 package traceutil
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -44,7 +44,7 @@ func writeFields(fields []Field) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString("{")
 	for _, f := range fields {
 		buf.WriteString(f.format())

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -15,7 +15,6 @@
 package membership
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/binary"
@@ -215,7 +214,7 @@ func (c *RaftCluster) ClientURLs() []string {
 func (c *RaftCluster) String() string {
 	c.Lock()
 	defer c.Unlock()
-	b := &bytes.Buffer{}
+	b := &strings.Builder{}
 	fmt.Fprintf(b, "{ClusterID:%s ", c.cid)
 	var ms []string
 	for _, m := range c.members {

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -345,7 +344,7 @@ func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry
 		"Request":       printRequest,
 		"ConfigChange":  printConfChange,
 		"UnknownNormal": printUnknownNormal}
-	var stderr bytes.Buffer
+	var stderr strings.Builder
 	args := strings.Split(streamdecoder, " ")
 	cmd := exec.Command(args[0], args[1:]...)
 	stdin, err := cmd.StdinPipe()

--- a/tools/proto-annotations/cmd/etcd_version.go
+++ b/tools/proto-annotations/cmd/etcd_version.go
@@ -15,10 +15,10 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/coreos/go-semver/semver"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -45,7 +45,7 @@ func printEtcdVersion() []error {
 	sort.Slice(annotations, func(i, j int) bool {
 		return annotations[i].fullName < annotations[j].fullName
 	})
-	output := &bytes.Buffer{}
+	output := &strings.Builder{}
 	for _, a := range annotations {
 		newErrs := a.Validate()
 		if len(newErrs) == 0 {


### PR DESCRIPTION
strings.Builder uses *(*string)(unsafe.Pointer(&b.buf)) to save the application memory operation when converting to a string

Updates https://github.com/etcd-io/etcd/issues/15910