### PR TITLE
server/storage/schema: prefer equal to compare for equality comparisons

### DIFF
--- a/server/storage/schema/bucket.go
+++ b/server/storage/schema/bucket.go
@@ -89,8 +89,8 @@ func DefaultIgnores(bucket, key []byte) bool {
 	// consistent index & term might be changed due to v2 internal sync, which
 	// is not controllable by the user.
 	// storage version might change after wal snapshot and is not controller by user.
-	return bytes.Compare(bucket, Meta.Name()) == 0 &&
-		(bytes.Compare(key, MetaTermKeyName) == 0 || bytes.Compare(key, MetaConsistentIndexKeyName) == 0 || bytes.Compare(key, MetaStorageVersionName) == 0)
+	return bytes.Equal(bucket, Meta.Name()) &&
+		(bytes.Equal(key, MetaTermKeyName) || bytes.Equal(key, MetaConsistentIndexKeyName) || bytes.Equal(key, MetaStorageVersionName))
 }
 
 func BackendMemberKey(id types.ID) []byte {


### PR DESCRIPTION
Benchmarks show `bytes.Equal` is much faster than `bytes.Compare`[1] for equality comparisons and preferred per the example in docs[2].

[1] https://www.sobyte.net/post/2022-01/go-bytes-compare-equal/
[2] https://pkg.go.dev/bytes#Compare