### PR TITLE
tests: deflake TestKVDelete/ClientAutoTLS

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,10 +27,10 @@ jobs:
         echo "${TARGET}"
         case "${TARGET}" in
           linux-amd64-e2e)
-            GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e-release
+            VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e-release
             ;;
           linux-386-e2e)
-            GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e
+            VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e
             ;;
           *)
             echo "Failed to find target"

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -124,7 +124,7 @@ func TestKVDelete(t *testing.T) {
 	testRunner.BeforeTest(t)
 	for _, tc := range clusterTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()


### PR DESCRIPTION
For the sub test TestKVDelete/ClientAutoTLS, the timeout might be caused by IO or task scheduled. It's really hard to reproduce this case. And we don't add `VERBOSE=1` for e2e test, the pipeline doesn't show the `EXPECT_DEBUG` log in time. It's also hard to debug when flaky case show. ~~So, this patch adds `readAt` timestamp to `EXPECT_DEBUG` log.~~ So, this patch will enable `VERBOSE=1` to get timestamp in time.

And the one operation `del a c -w json` will be performed after two seconds delay, we can increase the timeout from 15s to 30s just in case that the put or del operations take more time in unstable env.

```
Warning: Keys between "a" and "c" will be deleted. Please interrupt the
command within next 2 seconds to cancel.
```

Close: #14762

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
