### PR TITLE
Add example format for initial-cluster in configuration file

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -57,7 +57,8 @@ discovery-proxy:
 # DNS domain used to bootstrap initial cluster.
 discovery-srv:
 
-# Initial cluster configuration for bootstrapping.
+# Comma separated string of initial cluster configuration for bootstrapping.
+# Example: initial-cluster: "infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380"
 initial-cluster:
 
 # Initial cluster token for the etcd cluster during bootstrap.


### PR DESCRIPTION
In discussion https://github.com/etcd-io/etcd/discussions/15837 an etcd user wasn't clear about how to specify `initial-cluster` in the configuration file which led to their cluster not starting, and unfortunately our [sample configuration file](https://github.com/etcd-io/etcd/blob/main/etcd.conf.yml.sample) currently doesn't provide any real guidance on this.

Let's help our users get it right the first time by adding a quick example format to the config file.

Longer term we should also investigate better handling of spaces in these strings so a more expressive dictionary style could be freely used as well.

