### PR TITLE
[20230530] Bump dependencies identified by dependabot

### DIFF
--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gyuho/gocovmerge v0.0.0-20171205171859-50c7e6afd535
 	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f
 	github.com/mgechev/revive v1.3.2
-	github.com/mikefarah/yq/v4 v4.33.3
+	github.com/mikefarah/yq/v4 v4.34.1
 	go.etcd.io/gofail v0.1.0
 	go.etcd.io/protodoc v0.0.0-20180829002748-484ab544e116
 	go.etcd.io/raft/v3 v3.0.0-20221201111702-eaa6808e1f7a

--- a/tools/mod/go.sum
+++ b/tools/mod/go.sum
@@ -158,8 +158,8 @@ github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8c
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.3.2 h1:Wb8NQKBaALBJ3xrrj4zpwJwqwNA6nDpyJSEQWcCka6U=
 github.com/mgechev/revive v1.3.2/go.mod h1:UCLtc7o5vg5aXCwdUTU1kEBQ1v+YXPAkYDIDXbrs5I0=
-github.com/mikefarah/yq/v4 v4.33.3 h1:cu6JxWAL82bpLCJTLYP3ILZ/3gXF1YfvYBCMRdnY/xA=
-github.com/mikefarah/yq/v4 v4.33.3/go.mod h1:ajAKq75gdANZHzkWu5shY2QZHpg8HOHVSyscC1+OAIs=
+github.com/mikefarah/yq/v4 v4.34.1 h1:7W+SZXvu1yOxpVXS7Hi5a34nU/gdYPjWMNQqoSlfbxo=
+github.com/mikefarah/yq/v4 v4.34.1/go.mod h1:B2JxXiGKqEaU+GTcNwOZ/RQFelq9e6TFIDLRVVFHAu4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=


### PR DESCRIPTION
Summary of actions:

- [ ] https://github.com/etcd-io/etcd/pull/15980 should be merged directly.
- [ ] https://github.com/etcd-io/etcd/pull/15977 should be closed because of pure indirect. It's used by https://github.com/prometheus/client_golang/tree/v1.15.1 which is latest tag we can have.
- [ ] https://github.com/etcd-io/etcd/pull/15976 should be closed because of pure indirect. It's used by https://github.com/cheggaaa/pb/tree/v3.1.2 which is latest tag we can have.
- [ ] https://github.com/etcd-io/etcd/pull/15975 should be closed because of pure indirect. It's used by https://github.com/mikefarah/yq/tree/v4.34.1 which is latest tag we can have. And they already bumps version in https://github.com/mikefarah/yq/commit/845d4ae38915c31cc76ab968393657cceaec60fc. It will be fixed by next bump.
- [ ] https://github.com/etcd-io/etcd/pull/15974 handled by this pr. should be closed.
- [ ] https://github.com/etcd-io/etcd/pull/15973 should be closed because of pure indirect. It's used by https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.11.2. We need to bump grpc version and genproto during bumping the otlptracegrpc version. It should be handled in the single pull request. 
- [ ] https://github.com/etcd-io/etcd/pull/15972  should be closed because of pure indirect. It's used by https://github.com/prometheus/client_golang/tree/v1.15.1 which is latest tag we can have.
- [ ] https://github.com/etcd-io/etcd/pull/15971 should be closed because of pure indirect. It's used by https://pkg.go.dev/go.uber.org/zap@v1.24.0 which is latest tag we can have. This dep will be removed by next zap bump, details in https://github.com/uber-go/zap/pull/1253

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
