### PR TITLE
Promote etcd frequently asked questions in our bug report template and readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,14 +1,23 @@
 ---
 name: Bug Report
-description: Report a bug encountered while operating Etcd
+description: Report a bug encountered while operating etcd
 labels:
   - type/bug
 body:
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Bug report criteria
+      description: Please confirm this bug report meets the following criteria.
+      options:
+        - label: This bug report is not security related, security issues should be disclosed privately via security@etcd.io.
+        - label: This is not a support request, support requests should be raised in the etcd [discussion forums](https://github.com/etcd-io/etcd/discussions).
+        - label: You have read the etcd [bug reporting guidelines](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md).
+        - label: Existing open issues along with etcd [frequently asked questions](https://etcd.io/docs/latest/faq) have been checked and this is not a duplicate.
+
   - type: markdown
     attributes:
       value: |
-        Please read https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md
-        If this matter is security related, please disclose it privately via security@etcd.io.
         Please fill the form below and provide as much information as possible.
         Not doing so may result in your bug not being addressed in a timely manner.
 
@@ -90,4 +99,4 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: Shell

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ go get go.etcd.io/etcd/client/v3
 
 Now it's time to dig into the full etcd API and other guides.
 
-* Read the full [documentation][].
-* Explore the full gRPC [API][].
+* Read the full [documentation].
+* Review etcd [frequently asked questions].
+* Explore the full gRPC [API].
 * Set up a [multi-machine cluster][clustering].
 * Learn the [config format, env variables and flags][configuration].
 * Find [language bindings and tools][integrations].
@@ -166,7 +167,9 @@ Please refer to [community-membership.md](Documentation/contributor-guide/commun
 
 ## Reporting bugs
 
-See [reporting bugs](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md) for details about reporting any issues.
+See [reporting bugs](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md) for details about reporting any issues. Before opening an issue please check it is not covered in our [frequently asked questions].
+
+[frequently asked questions]: https://etcd.io/docs/latest/faq
 
 ## Reporting a security vulnerability
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ The easiest way to get etcd is to use one of the pre-built release binaries whic
 For more installation guides, please check out [play.etcd.io](http://play.etcd.io) and [operating etcd](https://etcd.io/docs/latest/op-guide).
 
 [github-release]: https://github.com/etcd-io/etcd/releases
-[branch-management]: https://etcd.io/docs/latest/branch_management
 
 ### Running etcd
 
@@ -74,15 +73,15 @@ This will bring up etcd listening on port 2379 for client communication and on p
 
 Next, let's set a single key, and then retrieve it:
 
-```
+```bash
 etcdctl put mykey "this is awesome"
 etcdctl get mykey
 ```
 
 etcd is now running and serving client requests. For more, please check out:
 
-- [Interactive etcd playground](http://play.etcd.io)
-- [Animated quick demo](https://etcd.io/docs/latest/demo)
+* [Interactive etcd playground](http://play.etcd.io)
+* [Animated quick demo](https://etcd.io/docs/latest/demo)
 
 ### etcd TCP ports
 
@@ -120,13 +119,13 @@ go get go.etcd.io/etcd/client/v3
 
 Now it's time to dig into the full etcd API and other guides.
 
-- Read the full [documentation][].
-- Explore the full gRPC [API][].
-- Set up a [multi-machine cluster][clustering].
-- Learn the [config format, env variables and flags][configuration].
-- Find [language bindings and tools][integrations].
-- Use TLS to [secure an etcd cluster][security].
-- [Tune etcd][tuning].
+* Read the full [documentation][].
+* Explore the full gRPC [API][].
+* Set up a [multi-machine cluster][clustering].
+* Learn the [config format, env variables and flags][configuration].
+* Find [language bindings and tools][integrations].
+* Use TLS to [secure an etcd cluster][security].
+* [Tune etcd][tuning].
 
 [documentation]: https://etcd.io/docs/latest
 [api]: https://etcd.io/docs/latest/learning/api
@@ -138,9 +137,9 @@ Now it's time to dig into the full etcd API and other guides.
 
 ## Contact
 
-- Email: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)
-- Slack: [#etcd](https://kubernetes.slack.com/messages/C3HD8ARJ5/details/) channel on Kubernetes ([get an invite](http://slack.kubernetes.io/))
-- [Community meetings](#Community-meetings)
+* Email: [etcd-dev](https://groups.google.com/forum/?hl=en#!forum/etcd-dev)
+* Slack: [#etcd](https://kubernetes.slack.com/messages/C3HD8ARJ5/details/) channel on Kubernetes ([get an invite](http://slack.kubernetes.io/))
+* [Community meetings](#community-meetings)
 
 ### Community meetings
 


### PR DESCRIPTION
This pull request completes the following subtask of our [refresh for etcd issue triage](https://github.com/etcd-io/etcd/issues/15773):

> Raise the profile of our [frequently asked questions](https://etcd.io/docs/v3.5/faq) page by adding it to key areas like issue templates and readme.

Additionally I have:
- Fixed a number of minor lint errors reported by `markdownlint` in the `README.md`.
- Refactored our bug report template to add an interactive checklist to help guide users to the right channels before opening issues, take a look at a preview below or interactive here: https://github.com/jmhbnz/etcd/issues/new?assignees=&labels=type%2Fbug&projects=&template=bug-report.yml 

![image](https://github.com/etcd-io/etcd/assets/39425256/c68652d2-9dc4-4a71-b800-b65fbc3cff0f)