### PR TITLE
[concept] add livez/readyz for etcd

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -744,6 +744,8 @@ func (e *Etcd) serveClients() (err error) {
 	etcdhttp.HandleVersion(mux, e.Server)
 	etcdhttp.HandleMetrics(mux)
 	etcdhttp.HandleHealth(e.cfg.logger, mux, e.Server)
+	etcdhttp.HandleLivez(e.cfg.logger, mux, e.Server)
+	etcdhttp.HandleReadyz(e.cfg.logger, mux, e.Server)
 
 	var gopts []grpc.ServerOption
 	if e.cfg.GRPCKeepAliveMinTime > time.Duration(0) {
@@ -831,6 +833,8 @@ func (e *Etcd) serveMetrics() (err error) {
 		metricsMux := http.NewServeMux()
 		etcdhttp.HandleMetrics(metricsMux)
 		etcdhttp.HandleHealth(e.cfg.logger, metricsMux, e.Server)
+		etcdhttp.HandleLivez(e.cfg.logger, metricsMux, e.Server)
+		etcdhttp.HandleReadyz(e.cfg.logger, metricsMux, e.Server)
 
 		for _, murl := range e.cfg.ListenMetricsUrls {
 			tlsInfo := &e.cfg.ClientTLSInfo

--- a/server/etcdserver/api/etcdhttp/health.go
+++ b/server/etcdserver/api/etcdhttp/health.go
@@ -67,8 +67,7 @@ func HandleLivez(lg *zap.Logger, mux *http.ServeMux, srv ServerHealth) {
 		if h := checkAlarms(lg, srv, excludedAlarms, endpoint); h.Health != "true" {
 			return h
 		}
-		// TODO(logicalhan) should we require quorum for livez?
-		return checkAPI(lg, srv, serializable)
+		return checkAPI(lg, srv, true)
 	}, PathLivez, []string{etcdserverpb.AlarmType_NOSPACE.String()}...))
 }
 
@@ -79,7 +78,7 @@ func HandleReadyz(lg *zap.Logger, mux *http.ServeMux, srv ServerHealth) {
 		if h := checkAlarms(lg, srv, excludedAlarms, endpoint); h.Health != "true" {
 			return h
 		}
-		return checkAPI(lg, srv, serializable)
+		return checkAPI(lg, srv, false)
 	}, PathReadyz))
 }
 

--- a/server/etcdserver/api/etcdhttp/health_test.go
+++ b/server/etcdserver/api/etcdhttp/health_test.go
@@ -25,13 +25,14 @@ import (
 
 	"go.uber.org/zap/zaptest"
 
+	"go.etcd.io/raft/v3"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/auth"
 	"go.etcd.io/etcd/server/v3/config"
 	"go.etcd.io/etcd/server/v3/etcdserver"
-	"go.etcd.io/raft/v3"
 )
 
 type fakeStats struct{}
@@ -185,9 +186,225 @@ func TestHealthHandler(t *testing.T) {
 	}
 }
 
+func TestReadyzHandler(t *testing.T) {
+	// define the input and expected output
+	// input: alarms, and healthCheckURL
+	tests := []struct {
+		name           string
+		alarms         []*pb.AlarmMember
+		healthCheckURL string
+		apiError       error
+
+		expectStatusCode int
+		expectHealth     string
+	}{
+		{
+			name:             "Healthy if no alarm",
+			alarms:           []*pb.AlarmMember{},
+			healthCheckURL:   "/readyz",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if NOSPACE alarm is on",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}},
+			healthCheckURL:   "/readyz",
+			expectStatusCode: http.StatusServiceUnavailable,
+			expectHealth:     "false",
+		},
+		{
+			name:             "Healthy if NOSPACE alarm is on and excluded",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}},
+			healthCheckURL:   "/readyz?exclude=NOSPACE",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy if NOSPACE alarm is excluded",
+			alarms:           []*pb.AlarmMember{},
+			healthCheckURL:   "/readyz?exclude=NOSPACE",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy if multiple NOSPACE alarms are on and excluded",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(1), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(2), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(3), Alarm: pb.AlarmType_NOSPACE}},
+			healthCheckURL:   "/readyz?exclude=NOSPACE",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if NOSPACE alarms is excluded and CORRUPT is on",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
+			healthCheckURL:   "/readyz?exclude=NOSPACE",
+			expectStatusCode: http.StatusServiceUnavailable,
+			expectHealth:     "false",
+		},
+		{
+			name:             "Unhealthy if both NOSPACE and CORRUPT are on and excluded",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
+			healthCheckURL:   "/readyz?exclude=NOSPACE&exclude=CORRUPT",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy even if authentication failed",
+			healthCheckURL:   "/readyz",
+			apiError:         auth.ErrUserEmpty,
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy even if authorization failed",
+			healthCheckURL:   "/readyz",
+			apiError:         auth.ErrPermissionDenied,
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if api is not available",
+			healthCheckURL:   "/readyz",
+			apiError:         fmt.Errorf("Unexpected error"),
+			expectStatusCode: http.StatusServiceUnavailable,
+			expectHealth:     "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			HandleReadyz(zaptest.NewLogger(t), mux, &fakeHealthServer{
+				fakeServer: fakeServer{alarms: tt.alarms},
+				health:     tt.expectHealth,
+				apiError:   tt.apiError,
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			res, err := ts.Client().Do(&http.Request{Method: http.MethodGet, URL: testutil.MustNewURL(t, ts.URL+tt.healthCheckURL)})
+			if err != nil {
+				t.Errorf("fail serve http request %s %v", tt.healthCheckURL, err)
+			}
+			if res == nil {
+				t.Errorf("got nil http response with http request %s", tt.healthCheckURL)
+				return
+			}
+			if res.StatusCode != tt.expectStatusCode {
+				t.Errorf("want statusCode %d but got %d", tt.expectStatusCode, res.StatusCode)
+			}
+			health, err := parseHealthOutput(res.Body)
+			if err != nil {
+				t.Errorf("fail parse health check output %v", err)
+			}
+			if health.Health != tt.expectHealth {
+				t.Errorf("want health %s but got %s", tt.expectHealth, health.Health)
+			}
+		})
+	}
+}
+
+func TestLivezHandler(t *testing.T) {
+	// define the input and expected output
+	// input: alarms, and healthCheckURL
+	tests := []struct {
+		name           string
+		alarms         []*pb.AlarmMember
+		healthCheckURL string
+		apiError       error
+
+		expectStatusCode int
+		expectHealth     string
+	}{
+		{
+			name:             "Healthy if no alarm",
+			alarms:           []*pb.AlarmMember{},
+			healthCheckURL:   "/livez",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if NOSPACE alarm is on",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}},
+			healthCheckURL:   "/livez",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if NOSPACE alarms is excluded and CORRUPT is on",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
+			healthCheckURL:   "/livez?exclude=NOSPACE",
+			expectStatusCode: http.StatusServiceUnavailable,
+			expectHealth:     "false",
+		},
+		{
+			name:             "Unhealthy if both NOSPACE and CORRUPT are on and excluded",
+			alarms:           []*pb.AlarmMember{{MemberID: uint64(0), Alarm: pb.AlarmType_NOSPACE}, {MemberID: uint64(1), Alarm: pb.AlarmType_CORRUPT}},
+			healthCheckURL:   "/livez?exclude=NOSPACE&exclude=CORRUPT",
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy even if authentication failed",
+			healthCheckURL:   "/livez",
+			apiError:         auth.ErrUserEmpty,
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Healthy even if authorization failed",
+			healthCheckURL:   "/livez",
+			apiError:         auth.ErrPermissionDenied,
+			expectStatusCode: http.StatusOK,
+			expectHealth:     "true",
+		},
+		{
+			name:             "Unhealthy if api is not available",
+			healthCheckURL:   "/livez",
+			apiError:         fmt.Errorf("Unexpected error"),
+			expectStatusCode: http.StatusServiceUnavailable,
+			expectHealth:     "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			HandleLivez(zaptest.NewLogger(t), mux, &fakeHealthServer{
+				fakeServer: fakeServer{alarms: tt.alarms},
+				health:     tt.expectHealth,
+				apiError:   tt.apiError,
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			res, err := ts.Client().Do(&http.Request{Method: http.MethodGet, URL: testutil.MustNewURL(t, ts.URL+tt.healthCheckURL)})
+			if err != nil {
+				t.Errorf("fail serve http request %s %v", tt.healthCheckURL, err)
+			}
+			if res == nil {
+				t.Errorf("got nil http response with http request %s", tt.healthCheckURL)
+				return
+			}
+			if res.StatusCode != tt.expectStatusCode {
+				t.Errorf("want statusCode %d but got %d", tt.expectStatusCode, res.StatusCode)
+			}
+
+			health, err := parseHealthOutput(res.Body)
+
+			if err != nil {
+				t.Errorf("fail parse health check output %v", err)
+			}
+			if health.Health != tt.expectHealth {
+				t.Errorf("want health %s but got %s", tt.expectHealth, health.Health)
+			}
+		})
+	}
+}
+
 func parseHealthOutput(body io.Reader) (Health, error) {
 	obj := Health{}
 	d, derr := io.ReadAll(body)
+	println(string(d))
 	if derr != nil {
 		return obj, derr
 	}

--- a/server/proxy/grpcproxy/health.go
+++ b/server/proxy/grpcproxy/health.go
@@ -32,7 +32,8 @@ func HandleHealth(lg *zap.Logger, mux *http.ServeMux, c *clientv3.Client) {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
-	mux.Handle(etcdhttp.PathHealth, etcdhttp.NewHealthHandler(lg, func(excludedAlarms etcdhttp.AlarmSet, serializable bool) etcdhttp.Health { return checkHealth(c) }))
+	mux.Handle(etcdhttp.PathHealth, etcdhttp.NewHealthHandler(lg,
+		func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health { return checkHealth(c) }, etcdhttp.PathHealth))
 }
 
 // HandleProxyHealth registers health handler on '/proxy/health'.
@@ -40,7 +41,7 @@ func HandleProxyHealth(lg *zap.Logger, mux *http.ServeMux, c *clientv3.Client) {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
-	mux.Handle(etcdhttp.PathProxyHealth, etcdhttp.NewHealthHandler(lg, func(excludedAlarms etcdhttp.AlarmSet, serializable bool) etcdhttp.Health { return checkProxyHealth(c) }))
+	mux.Handle(etcdhttp.PathProxyHealth, etcdhttp.NewHealthHandler(lg, func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health { return checkProxyHealth(c) }, etcdhttp.PathProxyMetrics))
 }
 
 func checkHealth(c *clientv3.Client) etcdhttp.Health {

--- a/server/proxy/grpcproxy/health.go
+++ b/server/proxy/grpcproxy/health.go
@@ -33,7 +33,9 @@ func HandleHealth(lg *zap.Logger, mux *http.ServeMux, c *clientv3.Client) {
 		lg = zap.NewNop()
 	}
 	mux.Handle(etcdhttp.PathHealth, etcdhttp.NewHealthHandler(lg,
-		func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health { return checkHealth(c) }, etcdhttp.PathHealth))
+		func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health {
+			return checkHealth(c)
+		}, etcdhttp.PathHealth))
 }
 
 // HandleProxyHealth registers health handler on '/proxy/health'.
@@ -41,7 +43,9 @@ func HandleProxyHealth(lg *zap.Logger, mux *http.ServeMux, c *clientv3.Client) {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
-	mux.Handle(etcdhttp.PathProxyHealth, etcdhttp.NewHealthHandler(lg, func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health { return checkProxyHealth(c) }, etcdhttp.PathProxyMetrics))
+	mux.Handle(etcdhttp.PathProxyHealth, etcdhttp.NewHealthHandler(lg, func(excludedAlarms etcdhttp.AlarmSet, serializable bool, endpoint string) etcdhttp.Health {
+		return checkProxyHealth(c)
+	}, etcdhttp.PathProxyMetrics))
 }
 
 func checkHealth(c *clientv3.Client) etcdhttp.Health {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1043,6 +1043,8 @@ func (m *Member) Launch() error {
 		etcdhttp.HandleVersion(handler, m.Server)
 		etcdhttp.HandleMetrics(handler)
 		etcdhttp.HandleHealth(m.Logger, handler, m.Server)
+		etcdhttp.HandleLivez(m.Logger, handler, m.Server)
+		etcdhttp.HandleReadyz(m.Logger, handler, m.Server)
 		hs := &httptest.Server{
 			Listener: ln,
 			Config: &http.Server{


### PR DESCRIPTION
This is a prototype for adding livez/readyz support to etcd. Currently I've configured the `NO_SPACE` alarm to only count towards `\readyz` since it means etcd is degraded. Whether quorum should be included in liveness is an open question.