### PR TITLE
tests/robustness: Put traffic type on second place before cluster size in test name

### DIFF
--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -39,7 +39,7 @@ func TestRobustness(t *testing.T) {
 	scenarios := []testScenario{}
 	for _, traffic := range []traffic.Config{traffic.LowTraffic, traffic.HighTraffic, traffic.KubernetesTraffic} {
 		scenarios = append(scenarios, testScenario{
-			name:      "ClusterOfSize1/" + traffic.Name,
+			name:      traffic.Name + "ClusterOfSize1",
 			failpoint: RandomFailpoint,
 			traffic:   traffic,
 			cluster: *e2e.NewConfig(
@@ -62,7 +62,7 @@ func TestRobustness(t *testing.T) {
 			clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithSnapshotCatchUpEntries(100))
 		}
 		scenarios = append(scenarios, testScenario{
-			name:      "ClusterOfSize3/" + traffic.Name,
+			name:      traffic.Name + "ClusterOfSize3",
 			failpoint: RandomFailpoint,
 			traffic:   traffic,
 			watch: watchConfig{


### PR DESCRIPTION
cc @ahrtr @jmhbnz 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
