### PR TITLE
remove stack log when restore snapshot

### DIFF
--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -30,7 +30,7 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/client/pkg/v3/types"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/snapshot"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
@@ -251,7 +251,6 @@ func (s *v3Manager) Restore(cfg RestoreConfig) error {
 		zap.String("wal-dir", s.walDir),
 		zap.String("data-dir", dataDir),
 		zap.String("snap-dir", s.snapDir),
-		zap.Stack("stack"),
 	)
 
 	if err = s.saveDB(); err != nil {


### PR DESCRIPTION
### before
```
./bin/etcdutl snapshot restore a.snap --data-dir=./a-cluster
2023-06-13T16:09:36+08:00       info    snapshot/v3_snapshot.go:248     restoring snapshot      {"path": "a.snap", "wal-dir": "a-cluster/member/wal", "data-dir": "./a-cluster", "snap-dir": "a-cluster/member/snap", "stack": "go.etcd.io/etcd/etcdutl/v3/snapshot.(*v3Manager).Restore\n\tgo.etcd.io/etcd/etcdutl/v3/snapshot/v3_snapshot.go:254\ngo.etcd.io/etcd/etcdutl/v3/etcdutl.SnapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdutl/v3/etcdutl/snapshot_command.go:147\ngo.etcd.io/etcd/etcdutl/v3/etcdutl.snapshotRestoreCommandFunc\n\tgo.etcd.io/etcd/etcdutl/v3/etcdutl/snapshot_command.go:117\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:856\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.1.3/command.go:960\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:897\nmain.Start\n\tgo.etcd.io/etcd/etcdutl/v3/ctl.go:50\nmain.main\n\tgo.etcd.io/etcd/etcdutl/v3/main.go:23\nruntime.main\n\truntime/proc.go:250"}
2023-06-13T16:09:36+08:00       info    membership/store.go:141 Trimming membership information from the backend...
2023-06-13T16:09:36+08:00       info    membership/cluster.go:421       added member    {"cluster-id": "cdf818194e3a8c32", "local-member-id": "0", "added-peer-id": "8e9e05c52164694d", "added-peer-peer-urls": ["http://localhost:2380"]}
2023-06-13T16:09:36+08:00       info    snapshot/v3_snapshot.go:269     restored snapshot       {"path": "a.snap", "wal-dir": "a-cluster/member/wal", "data-dir": "./a-cluster", "snap-dir": "a-cluster/member/snap"}
```

### after 
```
./bin/etcdutl snapshot restore a.snap --data-dir=./a-cluster
2023-06-13T16:45:18+08:00       info    snapshot/v3_snapshot.go:248     restoring snapshot      {"path": "a.snap", "wal-dir": "a-cluster/member/wal", "data-dir": "./a-cluster", "snap-dir": "a-cluster/member/snap"}
2023-06-13T16:45:18+08:00       info    membership/store.go:141 Trimming membership information from the backend...
2023-06-13T16:45:18+08:00       info    membership/cluster.go:421       added member    {"cluster-id": "cdf818194e3a8c32", "local-member-id": "0", "added-peer-id": "8e9e05c52164694d", "added-peer-peer-urls": ["http://localhost:2380"]}
2023-06-13T16:45:18+08:00       info    snapshot/v3_snapshot.go:268     restored snapshot       {"path": "a.snap", "wal-dir": "a-cluster/member/wal", "data-dir": "./a-cluster", "snap-dir": "a-cluster/member/snap"}
```