### PR TITLE
tests/robustness: Disable blackhole until snapshot for v3.5 and v3.4

### DIFF
--- a/tests/robustness/failpoints.go
+++ b/tests/robustness/failpoints.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/zap"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
-	"go.etcd.io/etcd/api/v3/version"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -403,12 +402,7 @@ func (tb triggerBlackhole) Trigger(t *testing.T, ctx context.Context, member e2e
 }
 
 func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, process e2e.EtcdProcess) bool {
-	v, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
-	if err != nil {
-		panic(err)
-	}
-	// TODO: Deflake waiting for snapshot for v3.4.X
-	if tb.waitTillSnapshot && v.LessThan(version.V3_5) {
+	if tb.waitTillSnapshot && config.SnapshotCatchUpEntries > 100 {
 		return false
 	}
 	return config.ClusterSize > 1 && process.PeerProxy() != nil

--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -102,12 +102,14 @@ func TestRobustness(t *testing.T) {
 			e2e.WithClusterSize(1),
 		),
 	})
-	if v.Compare(version.V3_5) >= 0 {
+	// TODO: Deflake waiting for waiting until snapshot for etcd versions that don't support setting snapshot catchup entries.
+	if v.Compare(version.V3_6) >= 0 {
 		scenarios = append(scenarios, testScenario{
 			name:      "Issue15271",
 			failpoint: BlackholeUntilSnapshot,
 			traffic:   traffic.HighTraffic,
 			cluster: *e2e.NewConfig(
+				e2e.WithSnapshotCatchUpEntries(100),
 				e2e.WithSnapshotCount(100),
 				e2e.WithPeerProxy(true),
 				e2e.WithIsPeerTLS(true),


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/15913