### PR TITLE
tests/robustness: Implement stale reads without validation

### DIFF
--- a/tests/robustness/model/describe.go
+++ b/tests/robustness/model/describe.go
@@ -44,7 +44,7 @@ func describeEtcdResponse(request EtcdRequest, response MaybeEtcdResponse) strin
 func describeEtcdRequest(request EtcdRequest) string {
 	switch request.Type {
 	case Range:
-		return describeRangeRequest(request.Range.Key, request.Range.RangeOptions)
+		return describeRangeRequest(request.Range.Key, request.Range.Revision, request.Range.RangeOptions)
 	case Txn:
 		onSuccess := describeEtcdOperations(request.Txn.OperationsOnSuccess)
 		if len(request.Txn.Conditions) != 0 {
@@ -105,7 +105,7 @@ func describeTxnResponse(request *TxnRequest, response *TxnResponse) string {
 func describeEtcdOperation(op EtcdOperation) string {
 	switch op.Type {
 	case RangeOperation:
-		return describeRangeRequest(op.Key, op.RangeOptions)
+		return describeRangeRequest(op.Key, 0, op.RangeOptions)
 	case PutOperation:
 		if op.LeaseID != 0 {
 			return fmt.Sprintf("put(%q, %s, %d)", op.Key, describeValueOrHash(op.Value), op.LeaseID)
@@ -118,8 +118,11 @@ func describeEtcdOperation(op EtcdOperation) string {
 	}
 }
 
-func describeRangeRequest(key string, opts RangeOptions) string {
+func describeRangeRequest(key string, revision int64, opts RangeOptions) string {
 	kwargs := []string{}
+	if revision != 0 {
+		kwargs = append(kwargs, fmt.Sprintf("rev=%d", revision))
+	}
 	if opts.Limit != 0 {
 		kwargs = append(kwargs, fmt.Sprintf("limit=%d", opts.Limit))
 	}

--- a/tests/robustness/model/describe_test.go
+++ b/tests/robustness/model/describe_test.go
@@ -134,6 +134,11 @@ func TestModelDescribe(t *testing.T) {
 			resp:           rangeResponse(nil, 0, 14),
 			expectDescribe: `range("key14", limit=14) -> [], count: 0, rev: 14`,
 		},
+		{
+			req:            staleRangeRequest("key15", true, 0, 15),
+			resp:           rangeResponse(nil, 0, 15),
+			expectDescribe: `range("key15", rev=15) -> [], count: 0, rev: 15`,
+		},
 	}
 	for _, tc := range tcs {
 		assert.Equal(t, tc.expectDescribe, NonDeterministicModel.DescribeOperation(tc.req, tc.resp))

--- a/tests/robustness/model/deterministic_test.go
+++ b/tests/robustness/model/deterministic_test.go
@@ -152,6 +152,34 @@ var commonTestScenarios = []modelTestCase{
 		},
 	},
 	{
+		name: "Stale Get doesn't need to match put if asking about old revision",
+		operations: []testOperation{
+			{req: putRequest("key", "1"), resp: putResponse(2)},
+			{req: staleGetRequest("key", 1), resp: getResponse("key", "2", 2, 2)},
+			{req: staleGetRequest("key", 1), resp: getResponse("key", "1", 2, 2)},
+		},
+	},
+	{
+		name: "Stale Get need to match put if asking about matching revision",
+		operations: []testOperation{
+			{req: putRequest("key", "1"), resp: putResponse(2)},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 3, 2), expectFailure: true},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 2, 3), expectFailure: true},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "2", 2, 2), expectFailure: true},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 2, 2)},
+		},
+	},
+	{
+		name: "Stale Get need to have a proper response revision",
+		operations: []testOperation{
+			{req: putRequest("key", "1"), resp: putResponse(2)},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 2, 3), expectFailure: true},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 2, 2)},
+			{req: putRequest("key", "2"), resp: putResponse(3)},
+			{req: staleGetRequest("key", 2), resp: getResponse("key", "1", 2, 3)},
+		},
+	},
+	{
 		name: "Put must increase revision by 1",
 		operations: []testOperation{
 			{req: getRequest("key"), resp: emptyGetResponse(1)},

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -169,7 +169,7 @@ type kubernetesClient struct {
 }
 
 func (k kubernetesClient) List(ctx context.Context, key string) (*clientv3.GetResponse, error) {
-	resp, err := k.client.Range(ctx, key, true)
+	resp, err := k.client.Range(ctx, key, true, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -70,7 +70,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 
 	// Ensure that last operation is succeeds
 	time.Sleep(time.Second)
-	err = cc.Put(ctx, "tombstone", "true")
+	_, err = cc.Put(ctx, "tombstone", "true")
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -27,6 +27,7 @@ import (
 // ValidateAndReturnVisualize return visualize as porcupine.linearizationInfo used to generate visualization is private.
 func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, reports []traffic.ClientReport) (visualize func(basepath string)) {
 	validateWatch(t, cfg, reports)
+	// TODO: Validate stale reads responses.
 	allOperations := operations(reports)
 	watchEvents := uniqueWatchEvents(reports)
 	newOperations := patchOperationsWithWatchEvents(allOperations, watchEvents)


### PR DESCRIPTION
For now we just validate stale read revision, but not response content. Reason is that etcd model only stores latest version of keys, and no history like real etcd.

Validating stale read contents needs to be done outside of model as storing whole history is just to costly for linearization validation.


cc @ahrtr @ptabor @jmhbnz @chaochn47 