### PR TITLE
Ensure goimports can be fixed individually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ fuzz:
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
 	verify-govet verify-license-header verify-receiver-name verify-mod-tidy verify-shellcheck \
 	verify-shellws verify-proto-annotations verify-genproto verify-goimport verify-yamllint
-fix: fix-bom fix-lint fix-yamllint
+fix: fix-goimports fix-bom fix-lint fix-yamllint
 	./scripts/fix.sh
 
 .PHONY: verify-gofmt
@@ -131,6 +131,10 @@ verify-genproto:
 .PHONY: verify-goimport
 verify-goimport:
 	PASSES="goimport" ./scripts/test.sh
+
+.PHONY: fix-goimports
+fix-goimports:
+	./scripts/fix-goimports.sh
 
 .PHONY: verify-yamllint
 verify-yamllint:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ verify-gofmt:
 verify-bom:
 	PASSES="bom" ./scripts/test.sh
 
-.PHONY: update-bom
+.PHONY: fix-bom
 fix-bom:
 	./scripts/updatebom.sh
 
@@ -88,7 +88,7 @@ verify-dep:
 verify-lint:
 	golangci-lint run --config tools/.golangci.yaml
 
-.PHONY: update-lint
+.PHONY: fix-lint
 fix-lint:
 	golangci-lint run --config tools/.golangci.yaml --fix
 

--- a/scripts/fix-goimports.sh
+++ b/scripts/fix-goimports.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./scripts/test_lib.sh
+
+ROOTDIR=$(pwd)
+
+# To fix according to newer version of go:
+# go get golang.org/dl/gotip
+# gotip download
+# GO_CMD="gotip"
+GO_CMD="go"
+
+ROOTDIR=$(pwd)
+
+function go_imports_fix {
+  GOFILES=$(run ${GO_CMD} list  --f "{{with \$d:=.}}{{range .GoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
+  TESTGOFILES=$(run ${GO_CMD} list  --f "{{with \$d:=.}}{{range .TestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
+  cd "${ROOTDIR}/tools/mod"
+  echo "${GOFILES}" "${TESTGOFILES}" | grep -v '.gw.go' | grep -v '.pb.go' | xargs -n 100 go run golang.org/x/tools/cmd/goimports -w -local go.etcd.io
+}
+
+log_callout -e "\\nFixing goimports for you...\n"
+
+run_for_modules go_imports_fix || exit 2
+
+log_success -e "\\nSUCCESS: goimports are fixed :)"

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -8,8 +8,6 @@ go mod tidy
 source ./scripts/test_lib.sh
 source ./scripts/updatebom.sh
 
-ROOTDIR=$(pwd)
-
 # To fix according to newer version of go:
 # go get golang.org/dl/gotip
 # gotip download
@@ -31,20 +29,11 @@ function bash_ws_fix {
   find ./ -name '*.sh.bak' -print0 | xargs -0 rm
 }
 
-function go_imports_fix {
-  GOFILES=$(run ${GO_CMD} list  --f "{{with \$d:=.}}{{range .GoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
-  TESTGOFILES=$(run ${GO_CMD} list  --f "{{with \$d:=.}}{{range .TestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
-  cd "${ROOTDIR}/tools/mod"
-  echo "${GOFILES}" "${TESTGOFILES}" | grep -v '.gw.go' | grep -v '.pb.go' | xargs -n 100 go run golang.org/x/tools/cmd/goimports -w -local go.etcd.io
-}
-
 log_callout -e "\\nFixing etcd code for you...\n"
 
 run_for_modules mod_tidy_fix || exit 2
 run_for_modules run ${GO_CMD} fmt || exit 2
 run_for_module tests bom_fix || exit 2
-log_callout "Fixing goimports..."
-run_for_modules go_imports_fix || exit 2
 bash_ws_fix || exit 2
 
 


### PR DESCRIPTION
Sub task of https://github.com/etcd-io/etcd/issues/13896.

This pull request proposes a new `Makefile` target `fix-goimports` to ensure this can be run individually. As a side effect `scripts/fix.sh` becomes less monolithic which if I understand correctly is part of the intent of https://github.com/etcd-io/etcd/issues/13896.

Additionally I noticed a couple of `Makefile` `PHONY` target names did not match their child target names so I have aligned these under a second commit.