### PR TITLE
Verify consistent index is latest at the time of snapshot

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1017,6 +1017,9 @@ func TestSyncTrigger(t *testing.T) {
 
 // TestSnapshot should snapshot the store and cut the persistent
 func TestSnapshot(t *testing.T) {
+	revertFunc := verify.DisableVerifications()
+	defer revertFunc()
+
 	be, _ := betesting.NewDefaultTmpBackend(t)
 
 	s := raft.NewMemoryStorage()


### PR DESCRIPTION
Related to https://github.com/etcd-io/etcd/issues/12913

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
