### PR TITLE
tests/robustness: Tune Kubernetes tests to reduce number of delete requests

### DIFF
--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -37,13 +37,13 @@ var (
 		maximalQPS:  1000,
 		clientCount: 12,
 		Traffic: kubernetesTraffic{
-			averageKeyCount: 5,
+			averageKeyCount: 10,
 			resource:        "pods",
 			namespace:       "default",
 			writeChoices: []choiceWeight[KubernetesRequestType]{
-				{choice: KubernetesUpdate, weight: 75},
-				{choice: KubernetesDelete, weight: 15},
-				{choice: KubernetesCreate, weight: 10},
+				{choice: KubernetesUpdate, weight: 90},
+				{choice: KubernetesDelete, weight: 5},
+				{choice: KubernetesCreate, weight: 5},
 			},
 		},
 	}


### PR DESCRIPTION
Having too many delete requests is bad as they are not unique requests, so linearization is more prone to timeout on them.

Going from 30% to 10%.

cc @ahrtr @ptabor @fuweid @jmhbnz @chaochn47 