### PR TITLE
Update 3.4 and 3.5 changelogs for compile with 1.19.10

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -9,6 +9,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### etcd server
 - Fix [corruption check may get a `ErrCompacted` error when server has just been compacted](https://github.com/etcd-io/etcd/pull/16047)
 
+### Dependencies
+- Compile binaries using [go 1.19.10](https://github.com/etcd-io/etcd/pull/16038).
+
 ## v3.4.26 (2023-05-12)
 
 ### etcd server

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 - Fix [corruption check may get a `ErrCompacted` error when server has just been compacted](https://github.com/etcd-io/etcd/pull/16048)
 
+### Dependencies
+- Compile binaries using [go 1.19.10](https://github.com/etcd-io/etcd/pull/16033).
+
 ### etcd grpc-proxy
 - Fix [Memberlist results not updated when proxy node down](https://github.com/etcd-io/etcd/pull/15907).
 


### PR DESCRIPTION
We recently backported:
- https://github.com/etcd-io/etcd/pull/16038
- https://github.com/etcd-io/etcd/pull/16033