### PR TITLE
etcdutl: fix db double closed

### DIFF
--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -340,13 +340,8 @@ func (s *v3Manager) copyAndVerifyDB() error {
 	if dberr != nil {
 		return dberr
 	}
-	dbClosed := false
-	defer func() {
-		if !dbClosed {
-			db.Close()
-			dbClosed = true
-		}
-	}()
+	defer db.Close()
+
 	if _, err := io.Copy(db, srcf); err != nil {
 		return err
 	}
@@ -383,7 +378,7 @@ func (s *v3Manager) copyAndVerifyDB() error {
 	}
 
 	// db hash is OK, can now modify DB so it can be part of a new cluster
-	db.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
 #11838 fix `db` may not be closed，but  in `768da4` missing line: `dbClosed = true`（`git bisect` is very useful ）

if `copyAndVerifyDB` return nil, `db` is closed twice.
