### PR TITLE
*: should return exitCode even if cmd isn't nil

### DIFF
--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -72,8 +72,8 @@ func TestExpectFuncTimeout(t *testing.T) {
 	}
 
 	err = ep.Close()
-	require.ErrorContains(t, err, "unexpected exit code [-1] after running [/usr/bin/tail -f /dev/null]")
-	require.Equal(t, -1, ep.exitCode)
+	require.ErrorContains(t, err, "unexpected exit code [143] after running [/usr/bin/tail -f /dev/null]")
+	require.Equal(t, 143, ep.exitCode)
 }
 
 func TestExpectFuncExitFailure(t *testing.T) {
@@ -108,8 +108,9 @@ func TestExpectFuncExitFailureStop(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "unexpected exit code [1] after running [/usr/bin/tail -x]")
 	exitCode, err := ep.ExitCode()
-	require.Equal(t, 0, exitCode)
-	require.Equal(t, err, ErrProcessRunning)
+	require.Equal(t, 1, exitCode)
+	require.NoError(t, err)
+
 	if err := ep.Stop(); err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +190,7 @@ func TestSignal(t *testing.T) {
 	go func() {
 		defer close(donec)
 		err = ep.Close()
-		assert.ErrorContains(t, err, "unexpected exit code [-1]")
+		assert.ErrorContains(t, err, "unexpected exit code [130]")
 		assert.ErrorContains(t, err, "sleep 100")
 	}()
 	select {
@@ -197,4 +198,15 @@ func TestSignal(t *testing.T) {
 		t.Fatalf("signal test timed out")
 	case <-donec:
 	}
+}
+
+func TestExitCodeAfterKill(t *testing.T) {
+	ep, err := NewExpect("sleep", "100")
+	require.NoError(t, err)
+
+	ep.Signal(os.Kill)
+	ep.Wait()
+	code, err := ep.ExitCode()
+	assert.Equal(t, 137, code)
+	assert.NoError(t, err)
 }

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -246,7 +246,14 @@ func (ep *EtcdServerProcess) Wait(ctx context.Context) error {
 		defer close(ch)
 		if ep.proc != nil {
 			ep.proc.Wait()
-			ep.cfg.lg.Info("server exited", zap.String("name", ep.cfg.Name))
+
+			exitCode, exitErr := ep.proc.ExitCode()
+
+			ep.cfg.lg.Info("server exited",
+				zap.String("name", ep.cfg.Name),
+				zap.Int("code", exitCode),
+				zap.Error(exitErr),
+			)
 		}
 	}()
 	select {
@@ -262,11 +269,16 @@ func (ep *EtcdServerProcess) IsRunning() bool {
 	if ep.proc == nil {
 		return false
 	}
-	_, err := ep.proc.ExitCode()
+
+	exitCode, err := ep.proc.ExitCode()
 	if err == expect.ErrProcessRunning {
 		return true
 	}
-	ep.cfg.lg.Info("server exited", zap.String("name", ep.cfg.Name))
+
+	ep.cfg.lg.Info("server exited",
+		zap.String("name", ep.cfg.Name),
+		zap.Int("code", exitCode),
+		zap.Error(err))
 	ep.proc = nil
 	return false
 }


### PR DESCRIPTION
For the pkg/expect package, if the process has been stopped but there is no `Close()` call, the `ExitCode()` won't return exit code correctly. The `ExitCode()` should check `exitErr` and return exit code if cmd isn't nil.

And introduces `exitCode` to return correct exit code based on the process is signaled or exited.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.


-----

Context: https://github.com/etcd-io/etcd/pull/16094#discussion_r1233134482

cc @serathius @tjungblu 

fixes: #16134
