### PR TITLE
Templated arm64 integration and e2e workflows for main and release-3.5

### DIFF
--- a/.github/workflows/e2e-arm64-nightly.yaml
+++ b/.github/workflows/e2e-arm64-nightly.yaml
@@ -1,0 +1,19 @@
+---
+name: E2E Arm64 Nightly
+permissions: read-all
+on:
+  # schedules always run against the main branch, hence we have to create separate jobs
+  # with individual checkout actions for each of the active release branches
+  schedule:
+    - cron: '30 1 * * *' # runs daily at 1:30 am.
+jobs:
+  main-arm64:
+    uses: ./.github/workflows/e2e-arm64-template.yaml
+    with:
+      etcdBranch: main
+      e2eTestCmd: make test-e2e-release
+  release-35-arm64:
+    uses: ./.github/workflows/e2e-arm64-template.yaml
+    with:
+      etcdBranch: release-3.5
+      e2eTestCmd: PASSES='build e2e' COVER='false' ./test.sh

--- a/.github/workflows/e2e-arm64-template.yaml
+++ b/.github/workflows/e2e-arm64-template.yaml
@@ -1,8 +1,14 @@
 ---
-name: E2E-arm64
+name: Reusable Arm64 E2E Workflow
 on:
-  schedule:
-    - cron: '0 1 * * *' # runs daily at 1am.
+  workflow_call:
+    inputs:
+      etcdBranch:
+        required: true
+        type: string
+      e2eTestCmd:
+        required: false
+        type: string
 permissions: read-all
 jobs:
   test:
@@ -20,6 +26,8 @@ jobs:
           - linux-arm64-e2e
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: "${{ inputs.etcdBranch }}"
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory '*'
       - id: goversion
@@ -36,7 +44,7 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-arm64-e2e)
-              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e-release
+              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true RACE=true ${{ inputs.e2eTestCmd }}
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/tests-arm64-nightly.yaml
+++ b/.github/workflows/tests-arm64-nightly.yaml
@@ -1,0 +1,22 @@
+---
+name: Integration Arm64 Nightly
+permissions: read-all
+on:
+  # schedules always run against the main branch, hence we have to create separate jobs
+  # with individual checkout actions for each of the active release branches
+  schedule:
+    - cron: '30 2 * * *' # runs daily at 2:30 am.
+jobs:
+  main-arm64:
+    uses: ./.github/workflows/tests-arm64-template.yaml
+    with:
+      etcdBranch: main
+      integrationTestCmd: make test-integration
+      unitTestCmd: GO_TEST_FLAGS='-p=2' make test-unit
+  release-35-arm64:
+    uses: ./.github/workflows/tests-arm64-template.yaml
+    with:
+      etcdBranch: release-3.5
+      integrationTestCmd: PASSES='integration' RACE='false' ./test.sh
+      unitTestCmd: PASSES='unit' CPU='4' ./test.sh -p=2
+      gofailMake: "no"

--- a/.github/workflows/tests-arm64-template.yaml
+++ b/.github/workflows/tests-arm64-template.yaml
@@ -1,9 +1,23 @@
 ---
-name: Tests-arm64
+name: Reusable Arm64 Integration Workflow
 on:
-  schedule:
-    - cron: '30 1 * * *' # runs daily at 1:30 am.
+  workflow_call:
+    inputs:
+      etcdBranch:
+        required: true
+        type: string
+      integrationTestCmd:
+        required: true
+        type: string
+      unitTestCmd:
+        required: true
+        type: string
+      gofailMake:
+        required: false
+        type: string
+        default: "yes"
 permissions: read-all
+
 jobs:
   test:
     # this is to prevent the job to run at forked projects
@@ -23,6 +37,8 @@ jobs:
           - linux-arm64-unit-4-cpu-race
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: "${{ inputs.etcdBranch }}"
       # https://github.com/actions/checkout/issues/1169
       - run: git config --system --add safe.directory '*'
       - id: goversion
@@ -40,19 +56,19 @@ jobs:
           export JUNIT_REPORT_DIR=$(realpath ${TARGET})
           case "${TARGET}" in
             linux-arm64-integration-1-cpu)
-              make gofail-enable
-              GOOS=linux GOARCH=arm64 CPU=1 make test-integration
+              if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
+              GOOS=linux GOARCH=arm64 CPU=1 ${{ inputs.integrationTestCmd }}
               ;;
             linux-arm64-integration-2-cpu)
-              make gofail-enable
-              GOOS=linux GOARCH=arm64 CPU=2 make test-integration
+              if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
+              GOOS=linux GOARCH=arm64 CPU=2 ${{ inputs.integrationTestCmd }}
               ;;
             linux-arm64-integration-4-cpu)
-              make gofail-enable
-              GOOS=linux GOARCH=arm64 CPU=4 make test-integration
+              if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
+              GOOS=linux GOARCH=arm64 CPU=4 ${{ inputs.integrationTestCmd }}
               ;;
             linux-arm64-unit-4-cpu-race)
-              GOOS=linux GOARCH=arm64 CPU=4 RACE=true GO_TEST_FLAGS='-p=2' make test-unit
+              GOOS=linux GOARCH=arm64 CPU=4 RACE=true ${{ inputs.unitTestCmd }}
               ;;
             *)
               echo "Failed to find target"


### PR DESCRIPTION
Follow-on from https://github.com/etcd-io/etcd/pull/16151 to setup scheduled workflows for `arm64` nightly integration and e2e suites against the `release-3.5` branch.

Arm64 integration and e2e suites now adopt a shared re-usable workflow template which is slightly customised for `main` or `release-3.5`.

Fixes https://github.com/etcd-io/etcd/issues/15832