### PR TITLE
etcdctl: fix stdin read for put command

### DIFF
--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -171,11 +172,12 @@ func argOrStdin(args []string, stdin io.Reader, i int) (string, error) {
 	if i < len(args) {
 		return args[i], nil
 	}
-	bytes, err := io.ReadAll(stdin)
-	if string(bytes) == "" || err != nil {
+	s := bufio.NewScanner(os.Stdin)
+	s.Scan()
+	if string(s.Text()) == "" {
 		return "", errors.New("no available argument and stdin")
 	}
-	return string(bytes), nil
+	return string(s.Text()), nil
 }
 
 func dialTimeoutFromCmd(cmd *cobra.Command) time.Duration {


### PR DESCRIPTION
When call the command `etcdctl put key` without a value, the command hang waiting for an input in stdin, but even if you type a value, nothing happen and it still hang forever.

```go
// change
io.ReadAll(stdin)
// to
bufio.NewScanner(os.Stdin)
```

This way it can read from stdin pipe or typing in the stdin.

```bash
$ echo 'myvalue' | etcdctl put mykey
# or
$ etcdctl put mykey
myvalue
```

This keep the behavior if an empty value is passed, it returns an error.

```bash
$ echo '' | etcdctl put mykey
Error: put command needs 1 argument and input from stdin or 2 arguments
exit status 128
# or
$ etcdctl put mykey

Error: put command needs 1 argument and input from stdin or 2 arguments
exit status 128
```