### PR TITLE
etcdutl: update description for `--mark-compacted and` and `--bump-revision` flags in snapshot restore command

### DIFF
--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -77,8 +77,8 @@ func NewSnapshotRestoreCommand() *cobra.Command {
 	cmd.Flags().StringVar(&restorePeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster")
 	cmd.Flags().StringVar(&restoreName, "name", defaultName, "Human-readable name for this member")
 	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")
-	cmd.Flags().Uint64Var(&revisionBump, "bump-revision", 0, "How much to increase the latest revision after restore (required if --mark-compacted)")
-	cmd.Flags().BoolVar(&markCompacted, "mark-compacted", false, "Mark the latest revision after restore as the point of scheduled compaction (required if --bump-revision > 0)")
+	cmd.Flags().Uint64Var(&revisionBump, "bump-revision", 0, "How much to increase the latest revision after restore")
+	cmd.Flags().BoolVar(&markCompacted, "mark-compacted", false, "Mark the latest revision after restore as the point of scheduled compaction (required if --bump-revision > 0, disallowed otherwise)")
 
 	cmd.MarkFlagDirname("data-dir")
 	cmd.MarkFlagDirname("wal-dir")


### PR DESCRIPTION
It's really weird to have circular description between `--bump-revision` and `--mark-compacted`,
- description `required if --mark-compacted` for flag `--bump-revision`
- description `required if --bump-revision > 0` for flag `--mark-compacted`

Actually `--mark-compacted` is determined entirely by `--bump-revision`,
- It (--mark-compacted) isn't allowed if users do not bump revision
- It (--mark-compacted) must be specified if users bump the revision

So we only need to add the description(restrictions) to flag `--mark-compacted`. See also https://github.com/etcd-io/etcd/pull/16029#issuecomment-1612703238