### PR TITLE
tests: exclude learner endpoint from MemberPromote

### DIFF
--- a/tests/e2e/runtime_reconfiguration_test.go
+++ b/tests/e2e/runtime_reconfiguration_test.go
@@ -173,11 +173,14 @@ func addMember(ctx context.Context, t *testing.T, epc *e2e.EtcdProcessCluster) {
 }
 
 func addMemberAsLearnerAndPromote(ctx context.Context, t *testing.T, epc *e2e.EtcdProcessCluster) {
+	endpoints := epc.EndpointsGRPC()
+
 	id, err := epc.StartNewProc(ctx, nil, t, true /* addAsLearner */)
 	require.NoError(t, err)
-	newLearnerMemberProc := epc.Procs[len(epc.Procs)-1]
-	_, err = epc.Etcdctl().MemberPromote(ctx, id)
+	_, err = epc.Etcdctl(e2e.WithEndpoints(endpoints)).MemberPromote(ctx, id)
 	require.NoError(t, err)
+
+	newLearnerMemberProc := epc.Procs[len(epc.Procs)-1]
 	require.NoError(t, newLearnerMemberProc.Etcdctl().Health(ctx))
 }
 


### PR DESCRIPTION
Noticed a few test flakes of the newly added test. Usually etcd client will pick the first server address. 

Fix is to exclude learner endpoint from `MemberPromote`. 

```
2023-07-06T08:49:21.8398626Z     runtime_reconfiguration_test.go:181: 
2023-07-06T08:49:21.8400055Z         	Error Trace:	/home/runner/work/etcd/etcd/tests/e2e/runtime_reconfiguration_test.go:181
2023-07-06T08:49:21.8401843Z         	            				/home/runner/work/etcd/etcd/tests/e2e/runtime_reconfiguration_test.go:78
2023-07-06T08:49:21.8404818Z         	Error:      	Received unexpected error:
2023-07-06T08:49:21.8411142Z         	            	[/home/runner/work/etcd/etcd/bin/etcdctl --endpoints=http://localhost:20005 endpoint health] match not found.  Set EXPECT_DEBUG for more info Errs: [unexpected exit code [1] after running [/home/runner/work/etcd/etcd/bin/etcdctl --endpoints=http://localhost:20005 endpoint health]], last lines:
2023-07-06T08:49:21.8414992Z         	            	{"level":"warn","ts":"2023-07-06T08:49:21.826085Z","logger":"client","caller":"v3@v3.6.0-alpha.0/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00036a000/localhost:20005","method":"/etcdserverpb.KV/Range","attempt":0,"error":"rpc error: code = FailedPrecondition desc = etcdserver: rpc not supported for learner"}
2023-07-06T08:49:21.8416546Z         	            	http://localhost:20005 is unhealthy: failed to commit proposal: etcdserver: rpc not supported for learner
2023-07-06T08:49:21.8417235Z         	            	Error: unhealthy cluster
2023-07-06T08:49:21.8418009Z         	            	 (expected "is healthy", got []). Try EXPECT_DEBUG=TRUE
2023-07-06T08:49:21.8418834Z         	Test:       	TestRuntimeReconfigGrowClusterSize/grow_cluster_size_from_1_to_3_with_learner
```

ref. https://github.com/etcd-io/etcd/actions/runs/5473356165/jobs/9966715425?pr=16189

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
