### PR TITLE
[3.4] embed: fix nil pointer dereference when stopServer

### DIFF
--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -133,6 +133,8 @@ type etcdProcessClusterConfig struct {
 	WatchProcessNotifyInterval time.Duration
 
 	debug bool
+
+	stopSignal os.Signal
 }
 
 // newEtcdProcessCluster launches a new cluster from etcd processes, returning
@@ -151,11 +153,19 @@ func newEtcdProcessCluster(cfg *etcdProcessClusterConfig) (*etcdProcessCluster, 
 			epc.Close()
 			return nil, err
 		}
+
 		epc.procs[i] = proc
 	}
 
 	if err := epc.Start(); err != nil {
 		return nil, err
+	}
+
+	// overwrite the default signal
+	if cfg.stopSignal != nil {
+		for _, proc := range epc.procs {
+			proc.WithStopSignal(cfg.stopSignal)
+		}
 	}
 	return epc, nil
 }


### PR DESCRIPTION
Since v3.4.25, ETCD server introduces http-only urls flag to expose gRPC-only endpoints. When user enables this feature, the stopServer will panic during terminating. If the server is leader, it won't have chance to transfer the leadership.

```
Jul 07 14:43:04  etcd[11502]: received terminated signal, shutting down...
Jul 07 14:43:04  etcd[11502]: WARNING: 2023/07/07 14:43:04 grpc: addrConn.createTransport failed to connect to {0.0.0.0:2379  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp 0.0.0.0:2379: connect: connection refused". Reconnecting...Jul 07 14:43:04  etcd[11502]: WARNING: 2023/07/07 14:43:04 grpc: addrConn.createTransport failed to connect to {0.0.0.0:2379  <nil> 0 <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp 0.0.0.0:2379: connect: connection refused". Reconnecting...
Jul 07 14:43:04  etcd[11502]: panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                                           Jul 07 14:43:04  etcd[11502]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x130 pc=0x9ccd45]
Jul 07 14:43:04  etcd[11502]: goroutine 225 [running]:
Jul 07 14:43:04  etcd[11502]: google.golang.org/grpc.(*Server).Stop(0x0)
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/pkg/mod/google.golang.org/grpc@v1.26.0/server.go:1390 +0x45
Jul 07 14:43:04  etcd[11502]: go.etcd.io/etcd/embed.stopServers.func1()
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/src/go.etcd.io/etcd/embed/etcd.go:431 +0x3c
Jul 07 14:43:04  etcd[11502]: go.etcd.io/etcd/embed.stopServers({0x115a558, 0xc000278b70}, 0xc00024f248)
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/src/go.etcd.io/etcd/embed/etcd.go:438 +0x7d
Jul 07 14:43:04  etcd[11502]: go.etcd.io/etcd/embed.(*Etcd).Close(0xc0004d6600)
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/src/go.etcd.io/etcd/embed/etcd.go:392 +0x835
Jul 07 14:43:04  etcd[11502]: go.etcd.io/etcd/pkg/osutil.HandleInterrupts.func1()
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/src/go.etcd.io/etcd/pkg/osutil/interrupt_unix.go:70 +0x284
Jul 07 14:43:04  etcd[11502]: created by go.etcd.io/etcd/pkg/osutil.HandleInterrupts
Jul 07 14:43:04  etcd[11502]:         /home/fuwei/go/src/go.etcd.io/etcd/pkg/osutil/interrupt_unix.go:53 +0xce
Jul 07 14:43:04  systemd[1]: etcd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
