### PR TITLE
Asking for approval to regain maintainer status

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,5 +14,6 @@ Hitoshi Mitake <h.mitake@gmail.com> (@mitake) pkg:*
 Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com> (@serathius) pkg:*
 Piotr Tabor <piotr.tabor@gmail.com> (@ptabor) pkg:*
 Sahdev Zala <spzala@us.ibm.com> (@spzala) pkg:*
+Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com> (@wenjiaswe) pkg:*
 
 # REVIEWERS

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ These emeritus maintainers dedicated a part of their career to etcd and reviewed
 * Joe Betz
 * Gyuho Lee
 * Jingyi Hu
-* Wenjia Zhang
 * Xiang Li
 * Ben Darnell
 * Sam Batschelet


### PR DESCRIPTION
I am sending this PR to ask for approval to regain maintainer status.

Recent activities:
- https://github.com/etcd-io/etcd/pull/16193 merged
- https://github.com/etcd-io/etcd/pull/16194 merged

Plan forward:
- Currently working on design doc for https://github.com/etcd-io/etcd/issues/16007
- Regular issue triage, feature development
- Help with [community meetings](https://github.com/etcd-io/etcd/pull/16189#discussion_r1255308042), [KubeCon](https://github.com/etcd-io/etcd/discussions/16186)
- And anything else

Reference:
- Started being etcd maintainer in January 2021: https://github.com/etcd-io/etcd/pull/12624
- Retired in September 2022: https://github.com/etcd-io/etcd/pull/14373

I have not been active in OSS etcd community for a while but I have been working on kubernetes and etcd the whole time. And I am looking forward to coming back to contribute more. Per requirement [here](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/community-membership.md#retiring), I am writing to ask for approval and regain maintainer status if that's ok. Thank you all very much for considering!

cc @serathius @ahrtr @spzala @ptabor @mitake 
