### PR TITLE
clientv3: create keepAliveCtxCloser goroutine only if ctx can be canc…

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -294,7 +294,9 @@ func (l *lessor) KeepAlive(ctx context.Context, id LeaseID) (<-chan *LeaseKeepAl
 	}
 	l.mu.Unlock()
 
-	go l.keepAliveCtxCloser(ctx, id, ka.donec)
+	if ctx.Done() != nil {
+		go l.keepAliveCtxCloser(ctx, id, ka.donec)
+	}
 	l.firstKeepAliveOnce.Do(func() {
 		go l.recvKeepAliveLoop()
 		go l.deadlineLoop()


### PR DESCRIPTION
We always create a `keepAliveCtxCloser` goroutine to eagerly update `keepAlive` when ctx is done.
But if ctx can never be canceled, there is no need to start a redundant goroutine.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
