### PR TITLE
clientv3: fix barrier.Wait() still block after barrier.Release()

### DIFF
--- a/client/v3/experimental/recipes/barrier.go
+++ b/client/v3/experimental/recipes/barrier.go
@@ -60,7 +60,7 @@ func (b *Barrier) Wait() error {
 	_, err = WaitEvents(
 		b.client,
 		b.key,
-		resp.Header.Revision,
-		[]mvccpb.Event_EventType{mvccpb.PUT, mvccpb.DELETE})
+		resp.Header.Revision+1,
+		[]mvccpb.Event_EventType{mvccpb.DELETE})
 	return err
 }

--- a/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
@@ -15,6 +15,7 @@
 package recipes_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -44,6 +45,11 @@ func testBarrier(t *testing.T, waiters int, chooseClient func() *clientv3.Client
 	}
 	if err := b.Hold(); err == nil {
 		t.Fatalf("able to double-hold barrier")
+	}
+
+	// put a random key to move the revision forward
+	if _, err := chooseClient().Put(context.Background(), "x", ""); err != nil {
+		t.Errorf("could not put x (%v)", err)
 	}
 
 	donec := make(chan struct{})


### PR DESCRIPTION
The unexpected blocking after release() can be reproduced with the following codes:

```
func TestBarrier2(t *testing.T) {
	var cli *v3.Client
	var err error
	if cli, err = v3.New(v3.Config{Endpoints: []string{"10.117.190.125:2379"}, DialTimeout: 5 * time.Second}); err != nil {
		t.Fatal(err)
	}
	defer cli.Close()
	b := recipe.NewBarrier(cli, "test-barrier")
	if err := b.Hold(); err != nil {
		t.Fatalf("could not hold barrier (%v)", err)
	}
	if err := b.Hold(); err == nil {
		t.Fatalf("able to double-hold barrier")
	}

	// this is the key step to reproduce the problem, put a random key to move the revision forward
	if _, err := cli.Put(cli.Ctx(), "x", ""); err != nil {
		t.Errorf("could not put x, err:%v", err)
	}

	donec := make(chan struct{})
	stopc := make(chan struct{})
	defer close(stopc)

	for i := 0; i < 5; i++ {
		go func() {
			br := recipe.NewBarrier(cli, "test-barrier")
			if err := br.Wait(); err != nil {
				t.Errorf("could not wait on barrier (%v)", err)
			}
			select {
			case donec <- struct{}{}:
			case <-stopc:
			}

		}()
	}

	select {
	case <-donec:
		t.Fatalf("barrier did not wait")
	default:
	}

	if err := b.Release(); err != nil {
		t.Fatalf("could not release barrier (%v)", err)
	}

	timerC := time.After(time.Duration(5*100) * time.Millisecond)
	for i := 0; i < 5; i++ {
		select {
		case <-timerC:
			t.Fatalf("barrier timed out")
		case <-donec:
		}
	}
}
```


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
