### PR TITLE
expose op.isOptsWithFromKey and op.isOptsWithPrefix

### DIFF
--- a/client/v3/op.go
+++ b/client/v3/op.go
@@ -124,6 +124,10 @@ func (op Op) IsKeysOnly() bool { return op.keysOnly }
 // IsCountOnly returns whether countOnly is set.
 func (op Op) IsCountOnly() bool { return op.countOnly }
 
+func (op Op) IsOptsWithFromKey() bool { return op.isOptsWithFromKey }
+
+func (op Op) IsOptsWithPrefix() bool { return op.isOptsWithPrefix }
+
 // MinModRev returns the operation's minimum modify revision.
 func (op Op) MinModRev() int64 { return op.minModRev }
 

--- a/client/v3/op_test.go
+++ b/client/v3/op_test.go
@@ -78,24 +78,28 @@ func TestIsSortOptionValid(t *testing.T) {
 
 func TestIsOptsWithPrefix(t *testing.T) {
 	optswithprefix := []OpOption{WithPrefix()}
-	if !IsOptsWithPrefix(optswithprefix) {
+	op := OpGet("key", optswithprefix...)
+	if !IsOptsWithPrefix(optswithprefix) || !op.IsOptsWithPrefix() {
 		t.Errorf("IsOptsWithPrefix = false, expected true")
 	}
 
 	optswithfromkey := []OpOption{WithFromKey()}
-	if IsOptsWithPrefix(optswithfromkey) {
+	op = OpGet("key", optswithfromkey...)
+	if IsOptsWithPrefix(optswithfromkey) || op.IsOptsWithPrefix() {
 		t.Errorf("IsOptsWithPrefix = true, expected false")
 	}
 }
 
 func TestIsOptsWithFromKey(t *testing.T) {
 	optswithfromkey := []OpOption{WithFromKey()}
-	if !IsOptsWithFromKey(optswithfromkey) {
+	op := OpGet("key", optswithfromkey...)
+	if !IsOptsWithFromKey(optswithfromkey) || !op.IsOptsWithFromKey() {
 		t.Errorf("IsOptsWithFromKey = false, expected true")
 	}
 
 	optswithprefix := []OpOption{WithPrefix()}
-	if IsOptsWithFromKey(optswithprefix) {
+	op = OpGet("key", optswithprefix...)
+	if IsOptsWithFromKey(optswithprefix) || op.IsOptsWithFromKey() {
 		t.Errorf("IsOptsWithFromKey = true, expected false")
 	}
 }


### PR DESCRIPTION
Fix #16217

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
