### PR TITLE
Ensure release is run for arm64 e2e nightly tests

### DIFF
--- a/.github/workflows/e2e-arm64-nightly.yaml
+++ b/.github/workflows/e2e-arm64-nightly.yaml
@@ -16,4 +16,4 @@ jobs:
     uses: ./.github/workflows/e2e-arm64-template.yaml
     with:
       etcdBranch: release-3.5
-      e2eTestCmd: PASSES='build e2e' COVER='false' ./test.sh
+      e2eTestCmd: PASSES='build release e2e' COVER='false' ./test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -559,8 +559,30 @@ function dep_pass {
 
 function release_pass {
   rm -f ./bin/etcd-last-release
-  # to grab latest patch release; bump this up for every minor release
-  UPGRADE_VER=$(git tag -l --sort=-version:refname "v3.5.*" | head -1 | cut -d- -f1)
+
+  # Work out the previous release based on the version reported by etcd binary
+  binary_version=$(./bin/etcd --version | grep --only-matching --perl-regexp '(?<=etcd Version: )\d+\.\d+')
+  binary_major=$(echo "${binary_version}" | cut -d '.' -f 1)
+  binary_minor=$(echo "${binary_version}" | cut -d '.' -f 2)
+  previous_minor=$((binary_minor - 1))
+
+  # Handle the edge case where we go to a new major version
+  # When this happens we obtain latest minor release of previous major
+  if [ "${binary_minor}" -eq 0 ]; then
+    binary_major=$((binary_major - 1))
+    previous_minor=$(git ls-remote --tags https://github.com/etcd-io/etcd.git \
+    | grep --only-matching --perl-regexp "(?<=v)${binary_major}.\d.[\d]+?(?=[\^])" \
+    | sort --numeric-sort --key 1.3 | tail -1 | cut -d '.' -f 2)
+  fi
+  
+  # This gets a list of all remote tags for the release branch in regex
+  # Sort key is used to sort numerically by patch version
+  # Latest version is then stored for use below
+  UPGRADE_VER=$(git ls-remote --tags https://github.com/etcd-io/etcd.git \
+    | grep --only-matching --perl-regexp "(?<=v)${binary_major}.${previous_minor}.[\d]+?(?=[\^])" \
+    | sort --numeric-sort --key 1.5 | tail -1 | sed 's/^/v/')
+  log_callout "Found latest release: ${UPGRADE_VER}."
+
   if [ -n "${MANUAL_VER:-}" ]; then
     # in case, we need to test against different version
     UPGRADE_VER=$MANUAL_VER


### PR DESCRIPTION
Recently in https://github.com/etcd-io/etcd/pull/16152 we extended our `arm64` nightly test coverage to include `release-3.5` as  a requirement for being able to announce tier1 support for `arm64`.

When these were merged the `PASSES` for the test command was `PASSES='build e2e'`.   To truly have alignment between what we run for `arm64` vs `amd64` we need to update that to `PASSES='build release e2e'`.

Now that the first iteration of the tests have been merged and are passing successfully overnight I would now like to fix the alignment so both architectures run the exact same command.

This is a pre step before I can start work on https://github.com/etcd-io/etcd/issues/16176.