### PR TITLE
Add new job for nightly release35 arm64 robustness

### DIFF
--- a/.github/workflows/robustness-nightly.yaml
+++ b/.github/workflows/robustness-nightly.yaml
@@ -30,6 +30,13 @@ jobs:
       count: 100
       testTimeout: 200m
       artifactName: release-35
+  release-35-arm64:
+    uses: ./.github/workflows/robustness-template-arm64.yaml
+    with:
+      etcdBranch: release-3.5
+      count: 100
+      testTimeout: 200m
+      artifactName: release-35-arm64
   release-34:
     uses: ./.github/workflows/robustness-template.yaml
     with:


### PR DESCRIPTION
In https://github.com/etcd-io/etcd/pull/15886 we introduced an `arm64` nightly job for robustness running against `main` branch.

This pr extends that to include a job for `release-3.5`, in support of announcing tier 1 support for arm64 for 3.5+.