### PR TITLE
pkg/expect: avoid hardcoding when checking ErrProcessDone

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -286,7 +286,7 @@ func (ep *ExpectProcess) ExitError() error {
 // Stop signals the process to terminate via SIGTERM
 func (ep *ExpectProcess) Stop() error {
 	err := ep.Signal(syscall.SIGTERM)
-	if err != nil && strings.Contains(err.Error(), "os: process already finished") {
+	if err != nil && errors.Is(err, os.ErrProcessDone) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
ExpectProcess's Stop method uses 'strings.Contains' to check the returned err, however, this can be avoided. os.ErrProcessDone's error message is the same as the hardcoded string. So I think this explicit error is what this method wants to compare.