### PR TITLE
pkg/ioutil: deflake TestPageWriterRandom

### DIFF
--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -39,8 +39,8 @@ func TestPageWriterRandom(t *testing.T) {
 	if cw.writeBytes > n {
 		t.Fatalf("wrote %d bytes to io.Writer, but only wrote %d bytes", cw.writeBytes, n)
 	}
-	if n-cw.writeBytes > pageBytes {
-		t.Fatalf("got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, pageBytes)
+	if maxPendingBytes := pageBytes + defaultBufferBytes; n-cw.writeBytes > maxPendingBytes {
+		t.Fatalf("got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, maxPendingBytes)
 	}
 	t.Logf("total writes: %d", cw.writes)
 	t.Logf("total write bytes: %d (of %d)", cw.writeBytes, n)


### PR DESCRIPTION
The PageWriter has cache buffer so that it doesn't call the Writer until the cache is almost full. Since the data's length is random, the pending bytes should be always less than cache buffer size, instead of page size.

Fix: #16255


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
