### PR TITLE
tests: cleanup unnecessary assignment in cluster.go

### DIFF
--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -783,7 +783,7 @@ func (m *Member) listenGRPC() error {
 	}
 
 	addr := grpcListener.Addr().String()
-	host, port, err = net.SplitHostPort(addr)
+	_, port, err = net.SplitHostPort(addr)
 	if err != nil {
 		return fmt.Errorf("failed to parse grpc listen port from address %s (%v)", addr, err)
 	}


### PR DESCRIPTION
Please review this simple patch on [tests/framework/integration/cluster.go].

It looks unnecessary to assign the value returned by `net.SplitHostPort` to variable `host`.

[tests/framework/integration/cluster.go]:
<https://github.com/etcd-io/etcd/blob/main/tests/framework/integration/cluster.go>