### PR TITLE
pkg/flags: fix UniqueURLs'Set to remove duplicates in UniqueURLs'uss

### DIFF
--- a/pkg/flags/unique_urls.go
+++ b/pkg/flags/unique_urls.go
@@ -50,7 +50,11 @@ func (us *UniqueURLs) Set(s string) error {
 	us.Values = make(map[string]struct{})
 	us.uss = make([]url.URL, 0)
 	for _, v := range ss {
-		us.Values[v.String()] = struct{}{}
+		x := v.String()
+		if _, exists := us.Values[x]; exists {
+			continue
+		}
+		us.Values[x] = struct{}{}
 		us.uss = append(us.uss, v)
 	}
 	return nil


### PR DESCRIPTION
From the name of func 'UniqueURLsFromFlag', we can tell that UniqueURLs'uss should not have duplicates. The current implemention of UniqueURLs'Set has a bug to make it unique. This PR fixes it.

Please take a look.