### PR TITLE
Backport fix to e2e release version identifcation

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "${TARGET}"
         case "${TARGET}" in
           linux-amd64-e2e)
-            PASSES='build release e2e' MANUAL_VER=v3.4.7 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh
+            PASSES='build release e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh
             ;;
           linux-386-e2e)
             GOARCH=386 PASSES='build e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh


### PR DESCRIPTION
Currently `release-3.5` e2e tests for `amd64` are relying on a hardcoded version, currently `v.3.4.7`. Refer: https://github.com/etcd-io/etcd/actions/runs/5603021362/job/15178839191#step:6:932 

```bash
'release' started at Wed Jul 19 19:00:50 UTC 2023
Downloading etcd-v3.4.7-linux-amd64.tar.gz
```

I believe this hard coded version was put in place because by default the github `checkout` action does a shallow clone, meaning our reliance on checking for local repository tags fails.

Recently we fixed this for `main` in  https://github.com/etcd-io/etcd/pull/16230 by instead updating `test.sh` to check the list of remote repository tags.

This looks to be working well after merge so I would like to suggest we backport it to `release-3.5`.

