### PR TITLE
server: switch to semconv v1.17.0

### DIFF
--- a/server/embed/config_tracing.go
+++ b/server/embed/config_tracing.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
This is the latest semconv package used in etcd's dependencies. Switching to that version reduces the overall package dependencies of the project (and helps downstream projects which track this, e.g. Kubernetes).