### PR TITLE
[3.4] Backport #16272 to 3.4

### DIFF
--- a/pkg/flags/unique_urls.go
+++ b/pkg/flags/unique_urls.go
@@ -49,7 +49,11 @@ func (us *UniqueURLs) Set(s string) error {
 	us.Values = make(map[string]struct{})
 	us.uss = make([]url.URL, 0)
 	for _, v := range ss {
-		us.Values[v.String()] = struct{}{}
+		x := v.String()
+		if _, exists := us.Values[x]; exists {
+			continue
+		}
+		us.Values[x] = struct{}{}
 		us.uss = append(us.uss, v)
 	}
 	return nil


### PR DESCRIPTION
Backport: https://github.com/etcd-io/etcd/pull/16272
Fix UniqueURLs'Set to remove duplicates in UniqueURLs'uss.

Fixes: https://github.com/etcd-io/etcd/issues/16307

TODO: changelog for 3.4 after this pr is merged.