### PR TITLE
server: Remove Lock/Unlock from ReadTx 

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -45,6 +45,8 @@ type Bucket interface {
 
 type BatchTx interface {
 	ReadTx
+	Lock()
+	Unlock()
 	UnsafeCreateBucket(bucket Bucket)
 	UnsafeDeleteBucket(bucket Bucket)
 	UnsafePut(bucket Bucket, key []byte, value []byte)

--- a/server/storage/backend/read_tx.go
+++ b/server/storage/backend/read_tx.go
@@ -26,13 +26,6 @@ import (
 // is known to never overwrite any key so range is safe.
 
 type ReadTx interface {
-	// Lock and Unlock should only be used in the following three cases:
-	// 1. When committing a transaction. Because it will reset the read tx, including the buffer;
-	// 2. When writing the pending data back to read buf, because obviously no reading is allowed when writing the read buffer;
-	// 3. When performing defragmentation, because again it will reset the read tx, including the read buffer.
-	Lock()
-	Unlock()
-	// RLock and RUnlock should be used for all other cases.
 	RLock()
 	RUnlock()
 

--- a/server/storage/schema/confstate_test.go
+++ b/server/storage/schema/confstate_test.go
@@ -54,8 +54,8 @@ func TestMustUnsafeSaveConfStateToBackend(t *testing.T) {
 
 	t.Run("missing", func(t *testing.T) {
 		tx := be.ReadTx()
-		tx.Lock()
-		defer tx.Unlock()
+		tx.RLock()
+		defer tx.RUnlock()
 		assert.Nil(t, UnsafeConfStateFromBackend(lg, tx))
 	})
 
@@ -71,8 +71,8 @@ func TestMustUnsafeSaveConfStateToBackend(t *testing.T) {
 
 	t.Run("read", func(t *testing.T) {
 		tx := be.ReadTx()
-		tx.Lock()
-		defer tx.Unlock()
+		tx.RLock()
+		defer tx.RUnlock()
 		assert.Equal(t, confState, *UnsafeConfStateFromBackend(lg, tx))
 	})
 }


### PR DESCRIPTION
Simple is better. Why have `Lock` on read transaction, why have `Rlock` on write transaction. It's bad Go practice to share interface between objects that interpret it differently.  `ReadTxn` and `BatchTxn` serve different purpose with different side effect, they should not share the same interface.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
