### PR TITLE
Simplify go data race detection controls

### DIFF
--- a/.github/workflows/e2e-arm64-template.yaml
+++ b/.github/workflows/e2e-arm64-template.yaml
@@ -44,7 +44,7 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-arm64-e2e)
-              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true RACE=true ${{ inputs.e2eTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true ${{ inputs.e2eTestCmd }}
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,10 +27,10 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-amd64-e2e)
-              VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e-release
+              VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
               ;;
             linux-386-e2e)
-              VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true RACE=true make test-e2e
+              VERBOSE=1 GOOS=linux GOARCH=386 CPU=4 EXPECT_DEBUG=true make test-e2e
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -26,10 +26,10 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-amd64-grpcproxy-integration)
-              GOOS=linux GOARCH=amd64 CPU=4 RACE=true make test-grpcproxy-integration
+              GOOS=linux GOARCH=amd64 CPU=4 make test-grpcproxy-integration
               ;;
             linux-amd64-grpcproxy-e2e)
-              GOOS=linux GOARCH=amd64 CPU=4 RACE=true make test-grpcproxy-e2e
+              GOOS=linux GOARCH=amd64 CPU=4 make test-grpcproxy-e2e
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/tests-arm64-nightly.yaml
+++ b/.github/workflows/tests-arm64-nightly.yaml
@@ -17,6 +17,6 @@ jobs:
     uses: ./.github/workflows/tests-arm64-template.yaml
     with:
       etcdBranch: release-3.5
-      integrationTestCmd: PASSES='integration' RACE='false' ./test.sh
+      integrationTestCmd: PASSES='integration' ./test.sh
       unitTestCmd: PASSES='unit' CPU='4' ./test.sh -p=2
       gofailMake: "no"

--- a/.github/workflows/tests-arm64-template.yaml
+++ b/.github/workflows/tests-arm64-template.yaml
@@ -34,7 +34,7 @@ jobs:
           - linux-arm64-integration-1-cpu
           - linux-arm64-integration-2-cpu
           - linux-arm64-integration-4-cpu
-          - linux-arm64-unit-4-cpu-race
+          - linux-arm64-unit-4-cpu
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
@@ -67,8 +67,8 @@ jobs:
               if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
               GOOS=linux GOARCH=arm64 CPU=4 ${{ inputs.integrationTestCmd }}
               ;;
-            linux-arm64-unit-4-cpu-race)
-              GOOS=linux GOARCH=arm64 CPU=4 RACE=true ${{ inputs.unitTestCmd }}
+            linux-arm64-unit-4-cpu)
+              GOOS=linux GOARCH=arm64 CPU=4 ${{ inputs.unitTestCmd }}
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
           - linux-amd64-integration-1-cpu
           - linux-amd64-integration-2-cpu
           - linux-amd64-integration-4-cpu
-          - linux-amd64-unit-4-cpu-race
+          - linux-amd64-unit-4-cpu
           - linux-386-unit-1-cpu
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -42,8 +42,8 @@ jobs:
               make gofail-enable
               GOOS=linux GOARCH=amd64 CPU=4 make test-integration
               ;;
-            linux-amd64-unit-4-cpu-race)
-              GOOS=linux GOARCH=amd64 CPU=4 RACE=true GO_TEST_FLAGS='-p=2' make test-unit
+            linux-amd64-unit-4-cpu)
+              GOOS=linux GOARCH=amd64 CPU=4 GO_TEST_FLAGS='-p=2' make test-unit
               ;;
             linux-386-unit-1-cpu)
               GOOS=linux GOARCH=386 CPU=1 GO_TEST_FLAGS='-p=4' make test-unit

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -68,7 +68,7 @@ fi
 
 # determine whether target supports race detection
 if [ -z "${RACE:-}" ] ; then
-  if [ "$GOARCH" == "amd64" ]; then
+  if [ "$GOARCH" == "amd64" ] || [ "$GOARCH" == "arm64" ]; then
     RACE="--race"
   else
     RACE="--race=false"


### PR DESCRIPTION
Use [data race detection](https://go.dev/doc/articles/race_detector) by default for all `amd64` and `arm64` tests.  This is already happening for `amd64` although may have been unexpected.  This pull request aligns both `arm64` so both platforms are treated the same.

Also removes now extraneous parameters in github workflows to centralise the control for race to the defaults defined in `scripts/test.sh`.

Fixes #16315