### PR TITLE
Automate adding area/testing label to flake issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-flake.yml
+++ b/.github/ISSUE_TEMPLATE/test-flake.yml
@@ -3,6 +3,7 @@ name: Flaking Test
 description: Report flaky tests
 labels:
   - type/flake
+  - area/testing
 body:
   - type: textarea
     id: workflows


### PR DESCRIPTION
Automate the `area/testing` triage label for flake issues.  We had a few recently and currently it's added manually.