### PR TITLE
[3.5] Backport Makefile recipes for common test commands

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,10 +25,10 @@ jobs:
         echo "${TARGET}"
         case "${TARGET}" in
           linux-amd64-e2e)
-            PASSES='build release e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh
+            CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' make test-e2e-release
             ;;
           linux-386-e2e)
-            GOARCH=386 PASSES='build e2e' CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' ./test.sh
+            GOARCH=386 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' make test-e2e
             ;;
           *)
             echo "Failed to find target"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,16 +33,16 @@ jobs:
             GOARCH=amd64 PASSES='fmt bom dep' ./test.sh
             ;;
           linux-amd64-integration-1-cpu)
-            GOARCH=amd64 CPU=1 PASSES='integration' RACE='false' ./test.sh
+            GOARCH=amd64 CPU=1 RACE='false' make test-integration
             ;;
           linux-amd64-integration-2-cpu)
-            GOARCH=amd64 CPU=2 PASSES='integration' RACE='false' ./test.sh
+            GOARCH=amd64 CPU=2 RACE='false' make test-integration
             ;;
           linux-amd64-integration-4-cpu)
-            GOARCH=amd64 CPU=4 PASSES='integration' RACE='false' ./test.sh
+            GOARCH=amd64 CPU=4 RACE='false' make test-integration
             ;;
           linux-amd64-unit-4-cpu-race)
-            GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test.sh -p=2
+            GOARCH=amd64 RACE='true' CPU='4' GO_TEST_FLAGS='-p=2' make test-unit
             ;;
           all-build)
             GOARCH=amd64 PASSES='build' ./test.sh
@@ -56,7 +56,7 @@ jobs:
             GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=s390x ./build.sh
             ;;
           linux-386-unit-1-cpu)
-            GOARCH=386 PASSES='unit' RACE='false' CPU='1' ./test -p=4
+            GOARCH=386 RACE='false' CPU='1' GO_TEST_FLAGS='-p=4' make test-unit
             ;;
           *)
             echo "Failed to find target"

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,22 @@ test-full:
 	$(info log-file: test-$(TEST_SUFFIX).log)
 	PASSES="fmt build release unit integration functional e2e grpcproxy" ./test.sh 2<&1 | tee test-$(TEST_SUFFIX).log
 
+.PHONY: test-unit
+test-unit:
+	PASSES="unit" ./test.sh $(GO_TEST_FLAGS)
+
+.PHONY: test-integration
+test-integration:
+	PASSES="integration" ./test.sh $(GO_TEST_FLAGS)
+
+.PHONY: test-e2e
+test-e2e:
+	PASSES="build e2e" ./test.sh $(GO_TEST_FLAGS)
+
+.PHONY: test-e2e-release
+test-e2e-release:
+	PASSES="build release e2e" ./test.sh $(GO_TEST_FLAGS)
+
 ensure-docker-test-image-exists:
 	make pull-docker-test || ( echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test )
 


### PR DESCRIPTION
This pull request is a minimal backport to ensure the three Makefile recipes (`test-unit`, `test-integration` and `test-e2e-release`) required for our scheduled nightly `arm64` workflows are present in the `release-3.5` branch.

This is a requirement to be able to progress https://github.com/etcd-io/etcd/issues/16176 and will allow us to simplify these workflow templates as both `release-3.5` and `main` will be able to execute the same test commands.

Once this pull request is merged a follow-up pull request can be raised for `main` to simplify how test commands are specified in the following workflows:
- e2e-release - https://github.com/etcd-io/etcd/blob/main/.github/workflows/e2e-arm64-nightly.yaml#L19
- integration - https://github.com/etcd-io/etcd/blob/main/.github/workflows/tests-arm64-nightly.yaml#L20
- unit - https://github.com/etcd-io/etcd/blob/main/.github/workflows/tests-arm64-nightly.yaml#L21
