### PR TITLE
Changelog: modify dependencies bumping go to 1.19.12

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,14 +4,14 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.28 (tbd)
 
-### Dependencies
-- Compile binaries using [go 1.19.11](https://github.com/etcd-io/etcd/pull/16228).
-
 ### etcd server
 - Improve [Skip getting authInfo from incoming context when auth is disabled](https://github.com/etcd-io/etcd/pull/16240)
 
 ### Package `clientv3`
 - Fix [Reset auth token when failing to authenticate due to auth being disabled](https://github.com/etcd-io/etcd/pull/16240)
+
+### Dependencies
+- Compile binaries using [go 1.19.12](https://github.com/etcd-io/etcd/pull/16353).
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -26,7 +26,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [Reset auth token when failing to authenticate due to auth being disabled](https://github.com/etcd-io/etcd/pull/16241)
 
 ### Dependencies
-- Compile binaries using [go 1.19.11](https://github.com/etcd-io/etcd/pull/16227).
+- Compile binaries using [go 1.19.12](https://github.com/etcd-io/etcd/pull/16352).
 
 <hr>
 


### PR DESCRIPTION
issue #16343 : Update golang patch version to latest 1.19.12 release
backport prs:  #16352 #16353 