### PR TITLE
server: Separate internal txn functions for recursion and have public function create transaction and trace

### DIFF
--- a/server/etcdserver/apply/apply_auth.go
+++ b/server/etcdserver/apply/apply_auth.go
@@ -24,7 +24,6 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	"go.etcd.io/etcd/server/v3/lease"
-	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
 type authApplierV3 struct {
@@ -65,7 +64,7 @@ func (aa *authApplierV3) Apply(ctx context.Context, r *pb.InternalRaftRequest, s
 	return ret
 }
 
-func (aa *authApplierV3) Put(ctx context.Context, txn mvcc.TxnWrite, r *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
+func (aa *authApplierV3) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
 	if err := aa.as.IsPutPermitted(&aa.authInfo, r.Key); err != nil {
 		return nil, nil, err
 	}
@@ -84,17 +83,17 @@ func (aa *authApplierV3) Put(ctx context.Context, txn mvcc.TxnWrite, r *pb.PutRe
 			return nil, nil, err
 		}
 	}
-	return aa.applierV3.Put(ctx, txn, r)
+	return aa.applierV3.Put(ctx, r)
 }
 
-func (aa *authApplierV3) Range(ctx context.Context, txn mvcc.TxnRead, r *pb.RangeRequest) (*pb.RangeResponse, error) {
+func (aa *authApplierV3) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, error) {
 	if err := aa.as.IsRangePermitted(&aa.authInfo, r.Key, r.RangeEnd); err != nil {
 		return nil, err
 	}
-	return aa.applierV3.Range(ctx, txn, r)
+	return aa.applierV3.Range(ctx, r)
 }
 
-func (aa *authApplierV3) DeleteRange(txn mvcc.TxnWrite, r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+func (aa *authApplierV3) DeleteRange(r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
 	if err := aa.as.IsDeleteRangePermitted(&aa.authInfo, r.Key, r.RangeEnd); err != nil {
 		return nil, err
 	}
@@ -105,7 +104,7 @@ func (aa *authApplierV3) DeleteRange(txn mvcc.TxnWrite, r *pb.DeleteRangeRequest
 		}
 	}
 
-	return aa.applierV3.DeleteRange(txn, r)
+	return aa.applierV3.DeleteRange(r)
 }
 
 func (aa *authApplierV3) Txn(ctx context.Context, rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -445,7 +445,7 @@ func TestAuthApplierV3_Put(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.Put(ctx, nil, tc.request)
+			_, _, err := authApplier.Put(ctx, tc.request)
 			require.Equalf(t, tc.expectError, err, "Put returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -466,7 +466,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// The user should be able to put the key
 	setAuthInfo(authApplier, userWriteOnly)
-	_, _, err = authApplier.Put(ctx, nil, &pb.PutRequest{
+	_, _, err = authApplier.Put(ctx, &pb.PutRequest{
 		Key:   []byte(key),
 		Value: []byte("1"),
 		Lease: LeaseId,
@@ -475,7 +475,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// Put a key under the lease outside user's key range
 	setAuthInfo(authApplier, userRoot)
-	_, _, err = authApplier.Put(ctx, nil, &pb.PutRequest{
+	_, _, err = authApplier.Put(ctx, &pb.PutRequest{
 		Key:   []byte(keyOutsideRange),
 		Value: []byte("1"),
 		Lease: LeaseId,
@@ -484,7 +484,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// The user should not be able to put the key anymore
 	setAuthInfo(authApplier, userWriteOnly)
-	_, _, err = authApplier.Put(ctx, nil, &pb.PutRequest{
+	_, _, err = authApplier.Put(ctx, &pb.PutRequest{
 		Key:   []byte(key),
 		Value: []byte("1"),
 		Lease: LeaseId,
@@ -532,7 +532,7 @@ func TestAuthApplierV3_Range(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, err := authApplier.Range(ctx, nil, tc.request)
+			_, err := authApplier.Range(ctx, tc.request)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -596,7 +596,7 @@ func TestAuthApplierV3_DeleteRange(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, err := authApplier.DeleteRange(nil, tc.request)
+			_, err := authApplier.DeleteRange(tc.request)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -703,7 +703,7 @@ func TestAuthApplierV3_LeaseRevoke(t *testing.T) {
 
 	// Put a key under the lease outside user's key range
 	setAuthInfo(authApplier, userRoot)
-	_, _, err = authApplier.Put(ctx, nil, &pb.PutRequest{
+	_, _, err = authApplier.Put(ctx, &pb.PutRequest{
 		Key:   []byte(keyOutsideRange),
 		Value: []byte("1"),
 		Lease: LeaseId,

--- a/server/etcdserver/apply/corrupt.go
+++ b/server/etcdserver/apply/corrupt.go
@@ -20,7 +20,6 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
-	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
 type applierV3Corrupt struct {
@@ -29,15 +28,15 @@ type applierV3Corrupt struct {
 
 func newApplierV3Corrupt(a applierV3) *applierV3Corrupt { return &applierV3Corrupt{a} }
 
-func (a *applierV3Corrupt) Put(_ context.Context, _ mvcc.TxnWrite, _ *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
+func (a *applierV3Corrupt) Put(_ context.Context, _ *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
 	return nil, nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) Range(_ context.Context, _ mvcc.TxnRead, _ *pb.RangeRequest) (*pb.RangeResponse, error) {
+func (a *applierV3Corrupt) Range(_ context.Context, _ *pb.RangeRequest) (*pb.RangeResponse, error) {
 	return nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) DeleteRange(_ mvcc.TxnWrite, _ *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+func (a *applierV3Corrupt) DeleteRange(_ *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
 	return nil, errors.ErrCorrupt
 }
 

--- a/server/etcdserver/apply/uber_applier.go
+++ b/server/etcdserver/apply/uber_applier.go
@@ -153,13 +153,13 @@ func (a *uberApplier) dispatch(ctx context.Context, r *pb.InternalRaftRequest, s
 	switch {
 	case r.Range != nil:
 		op = "Range"
-		ar.Resp, ar.Err = a.applyV3.Range(ctx, nil, r.Range)
+		ar.Resp, ar.Err = a.applyV3.Range(ctx, r.Range)
 	case r.Put != nil:
 		op = "Put"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.Put(ctx, nil, r.Put)
+		ar.Resp, ar.Trace, ar.Err = a.applyV3.Put(ctx, r.Put)
 	case r.DeleteRange != nil:
 		op = "DeleteRange"
-		ar.Resp, ar.Err = a.applyV3.DeleteRange(nil, r.DeleteRange)
+		ar.Resp, ar.Err = a.applyV3.DeleteRange(r.DeleteRange)
 	case r.Txn != nil:
 		op = "Txn"
 		ar.Resp, ar.Trace, ar.Err = a.applyV3.Txn(ctx, r.Txn)

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -131,7 +131,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		return s.authStore.IsRangePermitted(ai, r.Key, r.RangeEnd)
 	}
 
-	get := func() { resp, err = txn.Range(ctx, s.Logger(), s.KV(), nil, r) }
+	get := func() { resp, err = txn.Range(ctx, s.Logger(), s.KV(), r) }
 	if serr := s.doSerialize(ctx, chk, get); serr != nil {
 		err = serr
 		return nil, err


### PR DESCRIPTION
cc @ahrtr @fuweid @jmhbnz @wenjiaswe 

Functions `Range`, `Put`, `DeleteRange` and `Txn` are public function that can be called by both applier and recursively by `Txn`. The top call is responsible for opening/closing a transaction and trace. This complicated code as depending type of call it needed to manage transaction or not. This PR simplifies the code by separating the recursive vs external call, thus creating a begining point for traces and transactions. 