### PR TITLE
clientv3: remove the experimental gRPC API grpccredentials.Bundle

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -69,7 +69,7 @@ type Client struct {
 	Username string
 	// Password is a password for authentication.
 	Password        string
-	authTokenBundle credentials.Bundle
+	authTokenBundle credentials.PerRPCCredentialsBundle
 
 	callOpts []grpc.CallOption
 
@@ -338,7 +338,7 @@ func (c *Client) credentialsForEndpoint(ep string) grpccredentials.TransportCred
 		if c.creds != nil {
 			return c.creds
 		}
-		return credentials.NewBundle(credentials.Config{}).TransportCredentials()
+		return credentials.NewTransportCredential(nil)
 	default:
 		panic(fmt.Errorf("unsupported CredsRequirement: %v", r))
 	}
@@ -350,7 +350,7 @@ func newClient(cfg *Config) (*Client, error) {
 	}
 	var creds grpccredentials.TransportCredentials
 	if cfg.TLS != nil {
-		creds = credentials.NewBundle(credentials.Config{TLSConfig: cfg.TLS}).TransportCredentials()
+		creds = credentials.NewTransportCredential(cfg.TLS)
 	}
 
 	// use a temporary skeleton client to bootstrap first connection
@@ -389,7 +389,7 @@ func newClient(cfg *Config) (*Client, error) {
 	if cfg.Username != "" && cfg.Password != "" {
 		client.Username = cfg.Username
 		client.Password = cfg.Password
-		client.authTokenBundle = credentials.NewBundle(credentials.Config{})
+		client.authTokenBundle = credentials.NewPerRPCCredentialBundle()
 	}
 	if cfg.MaxCallSendMsgSize > 0 || cfg.MaxCallRecvMsgSize > 0 {
 		if cfg.MaxCallRecvMsgSize > 0 && cfg.MaxCallSendMsgSize > cfg.MaxCallRecvMsgSize {

--- a/client/v3/credentials/credentials.go
+++ b/client/v3/credentials/credentials.go
@@ -19,7 +19,6 @@ package credentials
 import (
 	"context"
 	"crypto/tls"
-	"net"
 	"sync"
 
 	grpccredentials "google.golang.org/grpc/credentials"
@@ -27,84 +26,43 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
-// Config defines gRPC credential configuration.
-type Config struct {
-	TLSConfig *tls.Config
+func NewTransportCredential(cfg *tls.Config) grpccredentials.TransportCredentials {
+	return grpccredentials.NewTLS(cfg)
 }
 
-// Bundle defines gRPC credential interface.
-type Bundle interface {
-	grpccredentials.Bundle
+// PerRPCCredentialsBundle defines gRPC credential interface.
+type PerRPCCredentialsBundle interface {
 	UpdateAuthToken(token string)
+	PerRPCCredentials() grpccredentials.PerRPCCredentials
 }
 
-// NewBundle constructs a new gRPC credential bundle.
-func NewBundle(cfg Config) Bundle {
-	return &bundle{
-		tc: newTransportCredential(cfg.TLSConfig),
-		rc: newPerRPCCredential(),
+func NewPerRPCCredentialBundle() PerRPCCredentialsBundle {
+	return &perRPCCredentialBundle{
+		rc: &perRPCCredential{},
 	}
 }
 
-// bundle implements "grpccredentials.Bundle" interface.
-type bundle struct {
-	tc *transportCredential
+// perRPCCredentialBundle implements `PerRPCCredentialsBundle` interface.
+type perRPCCredentialBundle struct {
 	rc *perRPCCredential
 }
 
-func (b *bundle) TransportCredentials() grpccredentials.TransportCredentials {
-	return b.tc
+func (b *perRPCCredentialBundle) UpdateAuthToken(token string) {
+	if b.rc == nil {
+		return
+	}
+	b.rc.UpdateAuthToken(token)
 }
 
-func (b *bundle) PerRPCCredentials() grpccredentials.PerRPCCredentials {
+func (b *perRPCCredentialBundle) PerRPCCredentials() grpccredentials.PerRPCCredentials {
 	return b.rc
 }
 
-func (b *bundle) NewWithMode(mode string) (grpccredentials.Bundle, error) {
-	// no-op
-	return nil, nil
-}
-
-// transportCredential implements "grpccredentials.TransportCredentials" interface.
-type transportCredential struct {
-	gtc grpccredentials.TransportCredentials
-}
-
-func newTransportCredential(cfg *tls.Config) *transportCredential {
-	return &transportCredential{
-		gtc: grpccredentials.NewTLS(cfg),
-	}
-}
-
-func (tc *transportCredential) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, grpccredentials.AuthInfo, error) {
-	return tc.gtc.ClientHandshake(ctx, authority, rawConn)
-}
-
-func (tc *transportCredential) ServerHandshake(rawConn net.Conn) (net.Conn, grpccredentials.AuthInfo, error) {
-	return tc.gtc.ServerHandshake(rawConn)
-}
-
-func (tc *transportCredential) Info() grpccredentials.ProtocolInfo {
-	return tc.gtc.Info()
-}
-
-func (tc *transportCredential) Clone() grpccredentials.TransportCredentials {
-	return &transportCredential{
-		gtc: tc.gtc.Clone(),
-	}
-}
-
-func (tc *transportCredential) OverrideServerName(serverNameOverride string) error {
-	return tc.gtc.OverrideServerName(serverNameOverride)
-}
-
-// perRPCCredential implements "grpccredentials.PerRPCCredentials" interface.
+// perRPCCredential implements `grpccredentials.PerRPCCredentials` interface.
 type perRPCCredential struct {
 	authToken   string
 	authTokenMu sync.RWMutex
 }
-
-func newPerRPCCredential() *perRPCCredential { return &perRPCCredential{} }
 
 func (rc *perRPCCredential) RequireTransportSecurity() bool { return false }
 
@@ -116,13 +74,6 @@ func (rc *perRPCCredential) GetRequestMetadata(ctx context.Context, s ...string)
 		return nil, nil
 	}
 	return map[string]string{rpctypes.TokenFieldNameGRPC: authToken}, nil
-}
-
-func (b *bundle) UpdateAuthToken(token string) {
-	if b.rc == nil {
-		return
-	}
-	b.rc.UpdateAuthToken(token)
 }
 
 func (rc *perRPCCredential) UpdateAuthToken(token string) {

--- a/client/v3/credentials/credentials_test.go
+++ b/client/v3/credentials/credentials_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestUpdateAuthToken(t *testing.T) {
-	bundle := NewBundle(Config{})
+	bundle := NewPerRPCCredentialBundle()
 	ctx := context.TODO()
 
 	metadataBeforeUpdate, _ := bundle.PerRPCCredentials().GetRequestMetadata(ctx)

--- a/client/v3/retry_interceptor_test.go
+++ b/client/v3/retry_interceptor_test.go
@@ -25,16 +25,8 @@ import (
 
 type dummyAuthTokenBundle struct{}
 
-func (d dummyAuthTokenBundle) TransportCredentials() grpccredentials.TransportCredentials {
-	return nil
-}
-
 func (d dummyAuthTokenBundle) PerRPCCredentials() grpccredentials.PerRPCCredentials {
 	return nil
-}
-
-func (d dummyAuthTokenBundle) NewWithMode(mode string) (grpccredentials.Bundle, error) {
-	return nil, nil
 }
 
 func (d dummyAuthTokenBundle) UpdateAuthToken(token string) {
@@ -42,7 +34,7 @@ func (d dummyAuthTokenBundle) UpdateAuthToken(token string) {
 
 func TestClientShouldRefreshToken(t *testing.T) {
 	type fields struct {
-		authTokenBundle credentials.Bundle
+		authTokenBundle credentials.PerRPCCredentialsBundle
 	}
 	type args struct {
 		err      error

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -797,8 +797,7 @@ func (e *Etcd) grpcGatewayDial(splitHttp bool) (grpcDial func(ctx context.Contex
 		dtls := tlscfg.Clone()
 		// trust local server
 		dtls.InsecureSkipVerify = true
-		bundle := credentials.NewBundle(credentials.Config{TLSConfig: dtls})
-		opts = append(opts, grpc.WithTransportCredentials(bundle.TransportCredentials()))
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTransportCredential(dtls)))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/server/etcdserver/api/v3rpc/grpc.go
+++ b/server/etcdserver/api/v3rpc/grpc.go
@@ -39,8 +39,7 @@ func Server(s *etcdserver.EtcdServer, tls *tls.Config, interceptor grpc.UnarySer
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.CustomCodec(&codec{}))
 	if tls != nil {
-		bundle := credentials.NewBundle(credentials.Config{TLSConfig: tls})
-		opts = append(opts, grpc.Creds(bundle.TransportCredentials()))
+		opts = append(opts, grpc.Creds(credentials.NewTransportCredential(tls)))
 	}
 	chainUnaryInterceptors := []grpc.UnaryServerInterceptor{
 		newLogUnaryInterceptor(s),


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/issues/15145

The [credentials.Bundle](https://github.com/grpc/grpc-go/blob/8f496b2a9544fdceadb26b0d45392b1022d232d9/credentials/credentials.go#L180) is an experimental API. We should try to remove the dependency on such experimental gRPC API. 

Actually transport credential and per GRPC credentials are two different things, no need to get them bind together.
