### PR TITLE
Streamline test commands between branches

### DIFF
--- a/.github/workflows/e2e-arm64-nightly.yaml
+++ b/.github/workflows/e2e-arm64-nightly.yaml
@@ -11,9 +11,7 @@ jobs:
     uses: ./.github/workflows/e2e-arm64-template.yaml
     with:
       etcdBranch: main
-      e2eTestCmd: make test-e2e-release
   release-35-arm64:
     uses: ./.github/workflows/e2e-arm64-template.yaml
     with:
       etcdBranch: release-3.5
-      e2eTestCmd: PASSES='build release e2e' COVER='false' ./test.sh

--- a/.github/workflows/e2e-arm64-template.yaml
+++ b/.github/workflows/e2e-arm64-template.yaml
@@ -6,9 +6,6 @@ on:
       etcdBranch:
         required: true
         type: string
-      e2eTestCmd:
-        required: false
-        type: string
 permissions: read-all
 jobs:
   test:
@@ -44,7 +41,7 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-arm64-e2e)
-              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true ${{ inputs.e2eTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/tests-arm64-nightly.yaml
+++ b/.github/workflows/tests-arm64-nightly.yaml
@@ -11,12 +11,8 @@ jobs:
     uses: ./.github/workflows/tests-arm64-template.yaml
     with:
       etcdBranch: main
-      integrationTestCmd: make test-integration
-      unitTestCmd: GO_TEST_FLAGS='-p=2' make test-unit
   release-35-arm64:
     uses: ./.github/workflows/tests-arm64-template.yaml
     with:
       etcdBranch: release-3.5
-      integrationTestCmd: PASSES='integration' ./test.sh
-      unitTestCmd: PASSES='unit' CPU='4' ./test.sh -p=2
       gofailMake: "no"

--- a/.github/workflows/tests-arm64-template.yaml
+++ b/.github/workflows/tests-arm64-template.yaml
@@ -6,12 +6,6 @@ on:
       etcdBranch:
         required: true
         type: string
-      integrationTestCmd:
-        required: true
-        type: string
-      unitTestCmd:
-        required: true
-        type: string
       gofailMake:
         required: false
         type: string
@@ -57,18 +51,18 @@ jobs:
           case "${TARGET}" in
             linux-arm64-integration-1-cpu)
               if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
-              GOOS=linux GOARCH=arm64 CPU=1 ${{ inputs.integrationTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=1 make test-integration
               ;;
             linux-arm64-integration-2-cpu)
               if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
-              GOOS=linux GOARCH=arm64 CPU=2 ${{ inputs.integrationTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=2 make test-integration
               ;;
             linux-arm64-integration-4-cpu)
               if [ "${{ inputs.gofailMake }}" == "yes" ]; then make gofail-enable; fi
-              GOOS=linux GOARCH=arm64 CPU=4 ${{ inputs.integrationTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=4 make test-integration
               ;;
             linux-arm64-unit-4-cpu)
-              GOOS=linux GOARCH=arm64 CPU=4 ${{ inputs.unitTestCmd }}
+              GOOS=linux GOARCH=arm64 CPU=4 GO_TEST_FLAGS='-p=2' make test-unit
               ;;
             *)
               echo "Failed to find target"


### PR DESCRIPTION
Now that a minimal backport of command test command makefile recipes has been backported to `release-3.5` in https://github.com/etcd-io/etcd/pull/16340 we can go ahead with simplifying how test commands are managed in `main`.

We can further simplify some of the template files once all etcd test workflows adopt containers in https://github.com/etcd-io/etcd/issues/15956.

Progress towards https://github.com/etcd-io/etcd/issues/16176.