### PR TITLE
 [3.4] Backport Makefile recipes for common test commands

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,19 +38,19 @@ jobs:
             GOARCH=amd64 PASSES='fmt bom dep' ./test
             ;;
           linux-amd64-integration-1-cpu)
-            GOARCH=amd64 CPU=1 PASSES='integration' RACE='false' ./test
+            GOARCH=amd64 CPU=1 RACE='false' make test-integration
             ;;
           linux-amd64-integration-2-cpu)
-            GOARCH=amd64 CPU=2 PASSES='integration' RACE='false' ./test
+            GOARCH=amd64 CPU=2 RACE='false' make test-integration
             ;;
           linux-amd64-integration-4-cpu)
-            GOARCH=amd64 CPU=4 PASSES='integration' RACE='false' ./test
+            GOARCH=amd64 CPU=4 RACE='false' make test-integration
             ;;
           linux-amd64-functional)
             ./build && GOARCH=amd64 PASSES='functional' ./test
             ;;
           linux-amd64-unit-4-cpu-race)
-            GOARCH=amd64 PASSES='unit' RACE='true' CPU='4' ./test -p=2
+            GOARCH=amd64 RACE='true' CPU='4' GO_TEST_FLAGS='-p=2' make test-unit
             ;;
           all-build)
             GOARCH=amd64 PASSES='build' ./test
@@ -66,10 +66,10 @@ jobs:
             PASSES='build grpcproxy' CPU='4' RACE='true' ./test
             ;;
           linux-amd64-e2e)
-            GOARCH=amd64 PASSES='build release e2e' ./test
+            GOARCH=amd64 make test-e2e-release
             ;;
           linux-386-unit)
-            GOARCH=386 PASSES='unit' ./test
+            GOARCH=386 make test-unit
             ;;
           *)
             echo "Failed to find target"

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,22 @@ test:
 	$(TEST_OPTS) ./test 2>&1 | tee test-$(TEST_SUFFIX).log
 	! egrep "(--- FAIL:|DATA RACE|panic: test timed out|appears to have leaked)" -B50 -A10 test-$(TEST_SUFFIX).log
 
+.PHONY: test-unit
+test-unit:
+	PASSES="unit" ./test $(GO_TEST_FLAGS)
+
+.PHONY: test-integration
+test-integration:
+	PASSES="integration" ./test $(GO_TEST_FLAGS)
+
+.PHONY: test-e2e
+test-e2e:
+	PASSES="build e2e" ./test $(GO_TEST_FLAGS)
+
+.PHONY: test-e2e-release
+test-e2e-release:
+	PASSES="build release e2e" ./test $(GO_TEST_FLAGS)
+
 docker-test:
 	$(info GO_VERSION: $(GO_VERSION))
 	$(info ETCD_VERSION: $(ETCD_VERSION))


### PR DESCRIPTION
This pull request is a minimal backport to ensure the Makefile recipes (mainly `test-unit`, `test-integration` and `test-e2e-release`) used heavily in later release branches are also present in `release-3.4` branch.

This pull request completes our streamline test commands issue.  After this is merged all three active branches will be using the same Makefile recipes for our common test commands. This gives us a common way of abstracting away any minor differences in actual command executed between branches.

Fixes #16176
