### PR TITLE
tests/robustness: Reduce minimal QPS to eliminate flakes

### DIFF
--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -78,7 +78,7 @@ func TestRobustness(t *testing.T) {
 		clusterOfSize1Options := baseOptions
 		clusterOfSize1Options = append(clusterOfSize1Options, e2e.WithClusterSize(1))
 		// Add LazyFS only for traffic with lower QPS as it uses a lot of CPU lowering minimal QPS.
-		if enableLazyFS && tp.Profile.MinimalQPS <= 100 {
+		if enableLazyFS && tp.Profile.MinimalQPS <= 80 {
 			clusterOfSize1Options = append(clusterOfSize1Options, e2e.WithLazyFSEnabled(true))
 			name = filepath.Join(name, "LazyFS")
 		}

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -37,7 +37,7 @@ var (
 
 	LowTraffic = Profile{
 		Name:                           "LowTraffic",
-		MinimalQPS:                     100,
+		MinimalQPS:                     80,
 		MaximalQPS:                     200,
 		ClientCount:                    8,
 		MaxNonUniqueRequestConcurrency: 3,


### PR DESCRIPTION
Fixes https://github.com/etcd-io/etcd/issues/16370

Minimal QPS observed was 88.