### PR TITLE
client: Added new session option to set timeout for session creation

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -12,6 +12,7 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 ### Package `clientv3`
 
 - [Make the etcd client creation non-blocking](https://github.com/etcd-io/etcd/pull/21942): etcd no longer honors the deprecated `grpc.WithBlock` dial option. To preserve the previous blocking behavior when needed, follow the guidance in grpc-go's [anti-patterns documentation](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#especially-bad-using-deprecated-dialoptions).
+- Add a timeout for concurrent session creation.
 
 ### etcd server
 

--- a/client/v3/concurrency/session.go
+++ b/client/v3/concurrency/session.go
@@ -40,14 +40,24 @@ type Session struct {
 // NewSession gets the leased session for a client.
 func NewSession(client *v3.Client, opts ...SessionOption) (*Session, error) {
 	lg := client.GetLogger()
-	ops := &sessionOptions{ttl: defaultSessionTTL, ctx: client.Ctx()}
+	ops := &sessionOptions{
+		ttl: defaultSessionTTL,
+		ctx: client.Ctx(),
+	}
 	for _, opt := range opts {
 		opt(ops, lg)
 	}
 
+	sessionCreationCtx := ops.ctx
+	if ops.creationTimeout > 0 {
+		var creationCancel context.CancelFunc
+		sessionCreationCtx, creationCancel = context.WithTimeout(ops.ctx, ops.creationTimeout)
+		defer creationCancel()
+	}
+
 	id := ops.leaseID
 	if id == v3.NoLease {
-		resp, err := client.Grant(ops.ctx, int64(ops.ttl))
+		resp, err := client.Grant(sessionCreationCtx, int64(ops.ttl))
 		if err != nil {
 			return nil, err
 		}
@@ -115,9 +125,10 @@ func (s *Session) Close() error {
 }
 
 type sessionOptions struct {
-	ttl     int
-	leaseID v3.LeaseID
-	ctx     context.Context
+	ttl             int
+	leaseID         v3.LeaseID
+	ctx             context.Context
+	creationTimeout time.Duration
 }
 
 // SessionOption configures Session.
@@ -131,6 +142,19 @@ func WithTTL(ttl int) SessionOption {
 			so.ttl = ttl
 		} else {
 			lg.Warn("WithTTL(): TTL should be > 0, preserving current TTL", zap.Int64("current-session-ttl", int64(so.ttl)))
+		}
+	}
+}
+
+// WithCreationTimeout configures the timeout for creating a new session.
+// If timeout is <= 0, no timeout will be used, and the creating new session
+// will be blocked forever until the etcd server is reachable.
+func WithCreationTimeout(timeout time.Duration) SessionOption {
+	return func(so *sessionOptions, lg *zap.Logger) {
+		if timeout > 0 {
+			so.creationTimeout = timeout
+		} else {
+			lg.Warn("WithCreationTimeout(): timeout should be > 0, preserving current timeout", zap.Int64("current-session-timeout", int64(so.creationTimeout)))
 		}
 	}
 }

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -26,11 +26,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/connectivity"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
+	clientv3test "go.etcd.io/etcd/tests/v3/integration/clientv3"
 )
 
 func init() {
@@ -525,4 +528,88 @@ func TestConcurrentMoveLeader(t *testing.T) {
 	_, err = c.Members[0].Client.MemberRemove(t.Context(), removeID)
 	require.NoError(t, err)
 	<-done
+}
+
+// TestCreationTimeout checks that the option WithCreationTimeout
+// sets a timeout for the creation of new sessions in case the cluster
+// shuts down
+func TestCreationTimeout(t *testing.T) {
+	integration.BeforeTest(t)
+
+	// create new cluster
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	// create new client
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	// ensure the connection is established.
+	clientv3test.MustWaitPinReady(t, cli)
+
+	// terminating the cluster
+	clus.Terminate(t)
+
+	// NewSession must fail with context.DeadlineExceeded once the creation
+	// timeout elapses while the cluster is unreachable, instead of blocking
+	// forever due to gRPC's WaitForReady option.
+	_, err = concurrency.NewSession(cli, concurrency.WithCreationTimeout(3*time.Second))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// the deadline must have been caused by loss of connectivity: the
+	// underlying gRPC connection should no longer report a Ready state.
+	require.NotEqual(t, connectivity.Ready, cli.ActiveConnection().GetState())
+}
+
+// TestTimeoutDoesntAffectSubsequentConnections checks that the option WithCreationTimeout
+// is only used when Session is created
+func TestTimeoutDoesntAffectSubsequentConnections(t *testing.T) {
+	integration.BeforeTest(t)
+
+	// create new cluster
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+	clus.Members[0].KeepDataDirTerminate = true
+
+	// create new client
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	// ensure the connection is established.
+	clientv3test.MustWaitPinReady(t, cli)
+
+	s, err := concurrency.NewSession(cli, concurrency.WithCreationTimeout(1*time.Second))
+	require.NoError(t, err)
+
+	// terminating the cluster
+	clus.Members[0].Terminate(t)
+
+	errorc := make(chan error)
+	defer close(errorc)
+	go func() {
+		_, err := cli.Put(s.Ctx(), "sample_key", "sample_value", clientv3.WithLease(s.Lease()))
+		errorc <- err
+	}()
+
+	select {
+	case err := <-errorc:
+		t.Fatalf("Operation put should be blocked forever when the server is unreachable: %v", err)
+	// if Put operation is blocked beyond the timeout specified using WithCreationTimeout,
+	// that timeout is not used by the Put operation
+	case <-time.After(2 * time.Second):
+	}
+
+	// restarting and ensuring that the Put operation will eventually succeed
+	clus.Members[0].Restart(t)
+	clus.Members[0].WaitOK(t)
+	select {
+	case err := <-errorc:
+		if err != nil {
+			t.Errorf("Put failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Put function hung even after restarting cluster")
+	}
 }


### PR DESCRIPTION
When communicating via gRPC, etcd sets the gRPC option WaitForReady = true to minimize client request error responses due to transient failures. But because of this option, the creation of new sessions hang without errors when all nodes could not be contacted by the client. This new session option allows client to receive an error if the nodes cannot be contacted after the specified amount of time.

This seeks to resolve #14631 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
