### PR TITLE
Update to generate v2 snapshot from v3 state

### DIFF
--- a/server/etcdserver/snapshot_merge.go
+++ b/server/etcdserver/snapshot_merge.go
@@ -31,11 +31,7 @@ import (
 func (s *EtcdServer) createMergedSnapshotMessage(m raftpb.Message, snapt, snapi uint64, confState raftpb.ConfState) snap.Message {
 	lg := s.Logger()
 	// get a snapshot of v2 store as []byte
-	clone := s.v2store.Clone()
-	d, err := clone.SaveNoCopy()
-	if err != nil {
-		lg.Panic("failed to save v2 store data", zap.Error(err))
-	}
+	d := GetMembershipInfoInV2Format(lg, s.cluster)
 
 	// commit kv to write metadata(for example: consistent index).
 	s.KV().Commit()


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
Related to https://github.com/etcd-io/etcd/issues/12913

e2e test is TestDowngradeUpgradeClusterOf3WithSnapshot