### PR TITLE
Add example config for TLS protocol version

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -145,3 +145,7 @@ cipher-suites: [
   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
   TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 ]
+
+# Limit etcd to specific TLS protocol versions 
+tls-min-version: 'TLS1.2'
+tls-max-version: 'TLS1.3'


### PR DESCRIPTION
As discussed recently in #13506  it would be good if an example of the TLS protocol configuration was included in the sample etcd conf file 