### PR TITLE
test: increase the timeout for the flaky test `TestCtlV3AuthCertCNWithWithConcurrentOperation`

### DIFF
--- a/tests/e2e/ctl_v3_auth_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_auth_no_proxy_test.go
@@ -136,7 +136,7 @@ func TestCtlV3AuthCertCNWithWithConcurrentOperation(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	case <-donec:
 		t.Log("All done!")
-	case <-time.After(30 * time.Second):
-		t.Fatal("Test case timeout after 20 seconds")
+	case <-time.After(40 * time.Second):
+		t.Fatal("Test case timeout after 40 seconds")
 	}
 }


### PR DESCRIPTION
Recently the e2e test is flaky. I double checked two workflow failures, and both of them were pointing to the test case `TestCtlV3AuthCertCNWithWithConcurrentOperation`.  The [creating & deleting users goroutine](https://github.com/etcd-io/etcd/blob/e3a1d7fb3c713371a6f535346d7cb695d21f9f2f/tests/e2e/ctl_v3_auth_no_proxy_test.go#L88-L104) somehow couldn't finish its task in 30 seconds, but it's very close to success (already finished about 94 out of the 100 users).  

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
