### PR TITLE
Handle ErrCompacted errors for Compact in raftexample

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -392,10 +392,13 @@ func (rc *raftNode) maybeTriggerSnapshot(applyDoneC <-chan struct{}) {
 		compactIndex = rc.appliedIndex - snapshotCatchUpEntriesN
 	}
 	if err := rc.raftStorage.Compact(compactIndex); err != nil {
-		panic(err)
+		if err != raft.ErrCompacted {
+			panic(err)
+		}
+	} else {
+		log.Printf("compacted log at index %d", compactIndex)
 	}
 
-	log.Printf("compacted log at index %d", compactIndex)
 	rc.snapshotIndex = rc.appliedIndex
 }
 


### PR DESCRIPTION
When I adjust the value of `defaultSnapshotCount` to be smaller than `snapshotCatchUpEntriesN` in raftexample, because the `compactIndex` cannot be updated, a panic will occur when the snapshot is triggered for the second time, and the error is "panic: requested index is unavailable due to compaction".

This PR adds ErrCompacted error handling for Compact  (keep consistent with etcd server).