### PR TITLE
Fix unit tests and make targets to not fail in some environments

### DIFF
--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -72,7 +72,7 @@ func TestExpectFuncTimeout(t *testing.T) {
 	}
 
 	err = ep.Close()
-	require.ErrorContains(t, err, "unexpected exit code [143] after running [/usr/bin/tail -f /dev/null]")
+	require.ErrorContains(t, err, "unexpected exit code [143]")
 	require.Equal(t, 143, ep.exitCode)
 }
 
@@ -89,7 +89,7 @@ func TestExpectFuncExitFailure(t *testing.T) {
 	_, err = ep.ExpectFunc(ctx, func(s string) bool {
 		return strings.Contains(s, "something entirely unexpected")
 	})
-	require.ErrorContains(t, err, "unexpected exit code [1] after running [/usr/bin/tail -x]")
+	require.ErrorContains(t, err, "unexpected exit code [1]")
 	require.Equal(t, 1, ep.exitCode)
 }
 
@@ -106,7 +106,7 @@ func TestExpectFuncExitFailureStop(t *testing.T) {
 	_, err = ep.ExpectFunc(ctx, func(s string) bool {
 		return strings.Contains(s, "something entirely unexpected")
 	})
-	require.ErrorContains(t, err, "unexpected exit code [1] after running [/usr/bin/tail -x]")
+	require.ErrorContains(t, err, "unexpected exit code [1]")
 	exitCode, err := ep.ExitCode()
 	require.Equal(t, 1, exitCode)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestExpectFuncExitFailureStop(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = ep.Close()
-	require.ErrorContains(t, err, "unexpected exit code [1] after running [/usr/bin/tail -x]")
+	require.ErrorContains(t, err, "unexpected exit code [1]")
 	exitCode, err = ep.ExitCode()
 	require.Equal(t, 1, exitCode)
 	require.NoError(t, err)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -103,8 +103,8 @@ function build_pass {
 function run_unit_tests {
   local pkgs="${1:-./...}"
   shift 1
-  # shellcheck disable=SC2086
-  GOLANG_TEST_SHORT=true go_test "${pkgs}" "parallel" : -short -timeout="${TIMEOUT:-3m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" "$@"
+  # shellcheck disable=SC2068 #For context see - https://github.com/etcd-io/etcd/pull/16433#issuecomment-1684312755
+  GOLANG_TEST_SHORT=true go_test "${pkgs}" "parallel" : -short -timeout="${TIMEOUT:-3m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@"
 }
 
 function unit_pass {
@@ -113,27 +113,33 @@ function unit_pass {
 
 function integration_extra {
   if [ -z "${PKG}" ] ; then
-    run_for_module "tests"  go_test "./integration/v2store/..." "keep_going" : -timeout="${TIMEOUT:-5m}" "${RUN_ARG[@]}" "${COMMON_TEST_FLAGS[@]}" "$@" || return $?
+    # shellcheck disable=SC2068
+    run_for_module "tests"  go_test "./integration/v2store/..." "keep_going" : -timeout="${TIMEOUT:-5m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@" || return $?
   else
     log_warning "integration_extra ignored when PKG is specified"
   fi
 }
 
 function integration_pass {
-  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" "${RUN_ARG[@]}" -p=2 "$@" || return $?
-  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" "${COMMON_TEST_FLAGS[@]}" -p=2 "${RUN_ARG[@]}" "$@" || return $?
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} -p=2 "$@" || return $?
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} -p=2 "$@" || return $?
   integration_extra "$@"
 }
 
 function e2e_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
-  run_for_module "tests" go_test "./e2e/..." "keep_going" : -timeout="${TIMEOUT:-30m}" "${RUN_ARG[@]}" "$@" || return $?
-  run_for_module "tests" go_test "./common/..." "keep_going" : --tags=e2e -timeout="${TIMEOUT:-30m}" "${RUN_ARG[@]}" "$@"
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./e2e/..." "keep_going" : -timeout="${TIMEOUT:-30m}" ${RUN_ARG[@]:-} "$@" || return $?
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./common/..." "keep_going" : --tags=e2e -timeout="${TIMEOUT:-30m}" ${RUN_ARG[@]:-} "$@"
 }
 
 function robustness_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
-  run_for_module "tests" go_test "./robustness" "keep_going" : -timeout="${TIMEOUT:-30m}" "${RUN_ARG[@]}" "$@"
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./robustness" "keep_going" : -timeout="${TIMEOUT:-30m}" ${RUN_ARG[@]:-} "$@"
 }
 
 function integration_e2e_pass {
@@ -164,13 +170,13 @@ function grpcproxy_pass {
 }
 
 function grpcproxy_integration_pass {
-  run_for_module "tests" go_test "./integration/..." "fail_fast" : \
-      -timeout=30m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./integration/..." "fail_fast" : -timeout=30m -tags cluster_proxy ${COMMON_TEST_FLAGS[@]:-} "$@"
 }
 
 function grpcproxy_e2e_pass {
-  run_for_module "tests" go_test "./e2e" "fail_fast" : \
-      -timeout=30m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
+  # shellcheck disable=SC2068
+  run_for_module "tests" go_test "./e2e" "fail_fast" : -timeout=30m -tags cluster_proxy ${COMMON_TEST_FLAGS[@]:-} "$@"
 }
 
 ################# COVERAGE #####################################################


### PR DESCRIPTION
Fixes for:

- Some bash versions can't take empty list variables and fail today with error like this:
```
PASSES="e2e" ./scripts/test.sh 
Running with --race=true --cpu=4
Starting at: Thu Aug 17 20:18:19 UTC 2023

'e2e' started at Thu Aug 17 20:18:19 UTC 2023
./scripts/test.sh: line 130: RUN_ARG[@]: unbound variable
make: *** [test-e2e] Error 1
```

- Unit tests which hardcode `tail` path fail with errors like this when it's present at different path:
```
--- FAIL: TestExpectFuncTimeout (0.51s)
    expect_test.go:75: 
        	Error Trace:	/home/$USER/workspace/go/src/github.com/shyamjvs/etcd/pkg/expect/expect_test.go:75
        	Error:      	Error "unexpected exit code [143] after running [/bin/tail -f /dev/null]" does not contain "unexpected exit code [143] after running [/usr/bin/tail -f /dev/null]"
        	Test:       	TestExpectFuncTimeout
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.