### PR TITLE
pkg/ioutil: make TestPageWriterRandom run the same on all platforms

### DIFF
--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -17,11 +17,13 @@ package ioutil
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPageWriterRandom(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
 	// smaller buffer for stress testing
 	defaultBufferBytes = 8 * 1024
 	pageBytes := 128


### PR DESCRIPTION
This fix came about because the test failed on alternative platforms, such as aarch64 and ppc64, but passed on x86_64. The following commit fixed the error in the test:
  fddd1add52b33649a99d7f756404924138344a10

However, the reason why this was not found on x86_64 is the incorrect use of time.random(). It has to be seeded, else it repeats the same fixed sequence. By a coincidence, x86_64 started its generator in such a way that made the test pass.

Fix: #16275
