### PR TITLE
[3.5] Backport expose socket options

### DIFF
--- a/client/pkg/transport/sockopt.go
+++ b/client/pkg/transport/sockopt.go
@@ -21,12 +21,12 @@ type SocketOpts struct {
 	// in which case lock on data file could result in unexpected
 	// condition. User should take caution to protect against lock race.
 	// [1] https://man7.org/linux/man-pages/man7/socket.7.html
-	ReusePort bool
+	ReusePort bool `json:"reuse-port"`
 	// ReuseAddress enables a socket option SO_REUSEADDR which allows
 	// binding to an address in `TIME_WAIT` state. Useful to improve MTTR
 	// in cases where etcd slow to restart due to excessive `TIME_WAIT`.
 	// [1] https://man7.org/linux/man-pages/man7/socket.7.html
-	ReuseAddress bool
+	ReuseAddress bool `json:"reuse-address"`
 }
 
 func getControls(sopts *SocketOpts) Controls {

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -264,7 +264,7 @@ type Config struct {
 	GRPCKeepAliveTimeout time.Duration `json:"grpc-keepalive-timeout"`
 
 	// SocketOpts are socket options passed to listener config.
-	SocketOpts transport.SocketOpts
+	SocketOpts transport.SocketOpts `json:"socket-options"`
 
 	// PreVote is true to enable Raft Pre-Vote.
 	// If enabled, Raft runs an additional election phase
@@ -470,7 +470,10 @@ func NewConfig() *Config {
 		GRPCKeepAliveInterval: DefaultGRPCKeepAliveInterval,
 		GRPCKeepAliveTimeout:  DefaultGRPCKeepAliveTimeout,
 
-		SocketOpts: transport.SocketOpts{},
+		SocketOpts: transport.SocketOpts{
+			ReusePort:    false,
+			ReuseAddress: false,
+		},
 
 		TickMs:                     100,
 		ElectionMs:                 1000,

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -42,12 +42,13 @@ func TestConfigFileOtherFields(t *testing.T) {
 	ctls := securityConfig{TrustedCAFile: "cca", CertFile: "ccert", KeyFile: "ckey"}
 	ptls := securityConfig{TrustedCAFile: "pca", CertFile: "pcert", KeyFile: "pkey"}
 	yc := struct {
-		ClientSecurityCfgFile securityConfig `json:"client-transport-security"`
-		PeerSecurityCfgFile   securityConfig `json:"peer-transport-security"`
-		ForceNewCluster       bool           `json:"force-new-cluster"`
-		Logger                string         `json:"logger"`
-		LogOutputs            []string       `json:"log-outputs"`
-		Debug                 bool           `json:"debug"`
+		ClientSecurityCfgFile securityConfig       `json:"client-transport-security"`
+		PeerSecurityCfgFile   securityConfig       `json:"peer-transport-security"`
+		ForceNewCluster       bool                 `json:"force-new-cluster"`
+		Logger                string               `json:"logger"`
+		LogOutputs            []string             `json:"log-outputs"`
+		Debug                 bool                 `json:"debug"`
+		SocketOpts            transport.SocketOpts `json:"socket-options"`
 	}{
 		ctls,
 		ptls,
@@ -55,6 +56,9 @@ func TestConfigFileOtherFields(t *testing.T) {
 		"zap",
 		[]string{"/dev/null"},
 		false,
+		transport.SocketOpts{
+			ReusePort: true,
+		},
 	}
 
 	b, err := yaml.Marshal(&yc)
@@ -70,16 +74,18 @@ func TestConfigFileOtherFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !cfg.ForceNewCluster {
-		t.Errorf("ForceNewCluster = %v, want %v", cfg.ForceNewCluster, true)
-	}
-
 	if !ctls.equals(&cfg.ClientTLSInfo) {
 		t.Errorf("ClientTLS = %v, want %v", cfg.ClientTLSInfo, ctls)
 	}
 	if !ptls.equals(&cfg.PeerTLSInfo) {
 		t.Errorf("PeerTLS = %v, want %v", cfg.PeerTLSInfo, ptls)
 	}
+
+	assert.Equal(t, true, cfg.ForceNewCluster, "ForceNewCluster does not match")
+
+	assert.Equal(t, true, cfg.SocketOpts.ReusePort, "ReusePort does not match")
+
+	assert.Equal(t, false, cfg.SocketOpts.ReuseAddress, "ReuseAddress does not match")
 }
 
 // TestUpdateDefaultClusterFromName ensures that etcd can start with 'etcd --name=abc'.


### PR DESCRIPTION
Currently in `main` it's possible to specify `--socket-reuse-port` and `--socket-reuse-address` in the config file. However, the same cannot be done for `release-3.5`.

An added complication is that the format for specifying these in the config file differs slightly from the command line parameter. Example below:

```yaml 
socket-options:
  reuse-port: true
```

This backport addresses the immediate bug of configuration via file for these options not being possible in `release-3.5`.

In future, we should also consider aligning  the way the option name should be used in both the configuration file and the command flags.

Relates to #16399.