### PR TITLE
*: enable ubuntu-latest-8-cores runner for amd64 robustness workflow

### DIFF
--- a/.github/workflows/robustness-nightly.yaml
+++ b/.github/workflows/robustness-nightly.yaml
@@ -15,6 +15,7 @@ jobs:
       count: 80
       testTimeout: 200m
       artifactName: main
+      runs-on: "['ubuntu-latest-8-cores']"
   main-arm64:
     uses: ./.github/workflows/robustness-template.yaml
     with:
@@ -30,6 +31,7 @@ jobs:
       count: 80
       testTimeout: 200m
       artifactName: release-35
+      runs-on: "['ubuntu-latest-8-cores']"
   release-35-arm64:
     uses: ./.github/workflows/robustness-template.yaml
     with:
@@ -45,3 +47,4 @@ jobs:
       count: 80
       testTimeout: 200m
       artifactName: release-34
+      runs-on: "['ubuntu-latest-8-cores']"

--- a/.github/workflows/robustness.yaml
+++ b/.github/workflows/robustness.yaml
@@ -10,3 +10,4 @@ jobs:
       count: 12
       testTimeout: 30m
       artifactName: main
+      runs-on: "['ubuntu-latest-8-cores']"

--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -78,7 +78,7 @@ func TestRobustness(t *testing.T) {
 		clusterOfSize1Options := baseOptions
 		clusterOfSize1Options = append(clusterOfSize1Options, e2e.WithClusterSize(1))
 		// Add LazyFS only for traffic with lower QPS as it uses a lot of CPU lowering minimal QPS.
-		if enableLazyFS && tp.Profile.MinimalQPS <= 80 {
+		if enableLazyFS && tp.Profile.MinimalQPS <= 100 {
 			clusterOfSize1Options = append(clusterOfSize1Options, e2e.WithLazyFSEnabled(true))
 			name = filepath.Join(name, "LazyFS")
 		}

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -37,7 +37,7 @@ var (
 
 	LowTraffic = Profile{
 		Name:                           "LowTraffic",
-		MinimalQPS:                     80,
+		MinimalQPS:                     100,
 		MaximalQPS:                     200,
 		ClientCount:                    8,
 		MaxNonUniqueRequestConcurrency: 3,


### PR DESCRIPTION
Use ubuntu-latest-8-cores to run lazyfs for robustness CI, since the lazyfs uses more CPU resources.

REF: https://github.com/etcd-io/etcd/issues/16370

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
