### PR TITLE
[3.5] tests: Backport recent test flake fixes

### DIFF
--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -37,8 +37,8 @@ func TestPageWriterRandom(t *testing.T) {
 	if cw.writeBytes > n {
 		t.Fatalf("wrote %d bytes to io.Writer, but only wrote %d bytes", cw.writeBytes, n)
 	}
-	if n-cw.writeBytes > pageBytes {
-		t.Fatalf("got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, pageBytes)
+	if maxPendingBytes := pageBytes + defaultBufferBytes; n-cw.writeBytes > maxPendingBytes {
+		t.Fatalf("got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, maxPendingBytes)
 	}
 	t.Logf("total writes: %d", cw.writes)
 	t.Logf("total write bytes: %d (of %d)", cw.writeBytes, n)

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -55,25 +55,25 @@ var tcs = []testCase{
 	{
 		name:          "NoTLS",
 		config:        etcdProcessClusterConfig{clusterSize: 1},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "TLS",
 		config:        etcdProcessClusterConfig{clusterSize: 1, isClientAutoTLS: true, clientTLS: clientTLS},
-		maxWatchDelay: 2 * time.Second,
+		maxWatchDelay: 3 * time.Second,
 		dbSizeBytes:   500 * Kilo,
 	},
 	{
 		name:          "SeparateHttpNoTLS",
 		config:        etcdProcessClusterConfig{clusterSize: 1, clientHttpSeparate: true},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "SeparateHttpTLS",
 		config:        etcdProcessClusterConfig{clusterSize: 1, isClientAutoTLS: true, clientTLS: clientTLS, clientHttpSeparate: true},
-		maxWatchDelay: 100 * time.Millisecond,
+		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 }


### PR DESCRIPTION
Our nightly `arm64` integration tests have been flaking recently, on the `release-3.5` branch refer: https://github.com/etcd-io/etcd/actions/workflows/tests-arm64-nightly.yaml

One of these flakes relate to `TestPageWriterRandom` https://github.com/etcd-io/etcd/actions/runs/5908988147/job/16029062404. This test was improved recently in `main` under https://github.com/etcd-io/etcd/pull/16268.

Another flake is happening on `release-3.5` for `TestWatchDelay`. This was also fixed in `main` under https://github.com/etcd-io/etcd/pull/15636.

We should consider backporting these fixes to `release-3.5`.



