### PR TITLE
Run integration, e2e & grpcproxy tests in container.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,6 +5,11 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: golang:1.20-bullseye
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: true
       matrix:
@@ -13,6 +18,8 @@ jobs:
           - linux-386-e2e
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      # https://github.com/actions/checkout/issues/1169
+      - run: git config --system --add safe.directory '*'
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -5,6 +5,10 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: golang:1.20-bullseye
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: true
       matrix:
@@ -13,6 +17,8 @@ jobs:
           - linux-amd64-grpcproxy-e2e
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      # https://github.com/actions/checkout/issues/1169
+      - run: git config --system --add safe.directory '*'
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,10 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: golang:1.20-bullseye
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +20,8 @@ jobs:
           - linux-386-unit-1-cpu
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      # https://github.com/actions/checkout/issues/1169
+      - run: git config --system --add safe.directory '*'
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0


### PR DESCRIPTION
Recent pull request https://github.com/etcd-io/etcd/pull/15927 introduced running our `arm64` ci jobs in containers to prevent leaking test processes causing issues on our self hosted runners.

The github runners we use for non arm64 ci jobs do not have the cleanup issue as our self hosted runners do, so it isn't absolutely necessary to migrate all workflows into containers. However we should consider doing it on the basis that we have one unified way to run etcd testing workflows.

Fixes: https://github.com/etcd-io/etcd/issues/15956