### PR TITLE
Use crypto/rand.Read instead of deprecated math/rand.Read

### DIFF
--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -16,11 +16,11 @@ package wal
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"


### PR DESCRIPTION
We recently updated to golang 1.20.  This golang release deprecated `math/rand.Seed` (which in most cases can now be removed) and `math/rand.Read` in favor of `crypto/rand.Read`, refer: https://go.dev/doc/go1.20

In #16447 we removed instances of `math/rand.Seed`.

After scanning through the codebase this pull request updates the one instance I could find of us using `math/rand.Read` and replaces it with `crypto/rand.Read`.