### PR TITLE
test: support regular expression matching on the response

### DIFF
--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -127,7 +127,7 @@ func TestEcho(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	l, eerr := ep.ExpectWithContext(ctx, "world")
+	l, eerr := ep.ExpectWithContext(ctx, ExpectedResponse{Value: "world"})
 	if eerr != nil {
 		t.Fatal(eerr)
 	}
@@ -138,7 +138,7 @@ func TestEcho(t *testing.T) {
 	if cerr := ep.Close(); cerr != nil {
 		t.Fatal(cerr)
 	}
-	if _, eerr = ep.ExpectWithContext(ctx, "..."); eerr == nil {
+	if _, eerr = ep.ExpectWithContext(ctx, ExpectedResponse{Value: "..."}); eerr == nil {
 		t.Fatalf("expected error on closed expect process")
 	}
 }
@@ -149,7 +149,7 @@ func TestLineCount(t *testing.T) {
 		t.Fatal(err)
 	}
 	wstr := "3"
-	l, eerr := ep.ExpectWithContext(context.Background(), wstr)
+	l, eerr := ep.ExpectWithContext(context.Background(), ExpectedResponse{Value: wstr})
 	if eerr != nil {
 		t.Fatal(eerr)
 	}
@@ -172,7 +172,7 @@ func TestSend(t *testing.T) {
 	if err := ep.Send("a\r"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ep.ExpectWithContext(context.Background(), "b"); err != nil {
+	if _, err := ep.ExpectWithContext(context.Background(), ExpectedResponse{Value: "b"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := ep.Stop(); err != nil {

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -25,6 +25,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
 	"go.etcd.io/etcd/server/v3/storage/mvcc/testutil"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -334,11 +335,11 @@ func TestCompactHashCheckDetectCorruptionInterrupt(t *testing.T) {
 	err = epc.Procs[slowCompactionNodeIndex].Restart(ctx)
 
 	// Wait until the node finished compaction and the leader finished compaction hash check
-	_, err = epc.Procs[slowCompactionNodeIndex].Logs().ExpectWithContext(ctx, "finished scheduled compaction")
+	_, err = epc.Procs[slowCompactionNodeIndex].Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "finished scheduled compaction"})
 	require.NoError(t, err, "can't get log indicating finished scheduled compaction")
 
 	leaderIndex := epc.WaitLeader(t)
-	_, err = epc.Procs[leaderIndex].Logs().ExpectWithContext(ctx, "finished compaction hash check")
+	_, err = epc.Procs[leaderIndex].Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "finished compaction hash check"})
 	require.NoError(t, err, "can't get log indicating finished compaction hash check")
 
 	alarmResponse, err := cc.AlarmList(ctx)

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -58,25 +59,25 @@ func authEnable(cx ctlCtx) error {
 
 func ctlV3AuthEnable(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "auth", "enable")
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, "Authentication Enabled")
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "Authentication Enabled"})
 }
 
 func ctlV3PutFailPerm(cx ctlCtx, key, val string) error {
-	return e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "put", key, val), cx.envMap, "permission denied")
+	return e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "put", key, val), cx.envMap, expect.ExpectedResponse{Value: "permission denied"})
 }
 
 func authSetupTestUser(cx ctlCtx) {
 	if err := ctlV3User(cx, []string{"add", "test-user", "--interactive=false"}, "User test-user created", []string{"pass"}); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, "Role test-role created"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3User(cx, []string{"grant-role", "test-user", "test-role"}, "Role test-role is granted to user test-user", nil); err != nil {
 		cx.t.Fatal(err)
 	}
 	cmd := append(cx.PrefixArgs(), "role", "grant-permission", "test-role", "readwrite", "foo")
-	if err := e2e.SpawnWithExpectWithEnv(cmd, cx.envMap, "Role test-role updated"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(cmd, cx.envMap, expect.ExpectedResponse{Value: "Role test-role updated"}); err != nil {
 		cx.t.Fatal(err)
 	}
 }
@@ -118,7 +119,7 @@ func authTestCertCN(cx ctlCtx) {
 	if err := ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""}); err != nil {
 		cx.t.Fatal(err)
 	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, "Role test-role created"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3User(cx, []string{"grant-role", "example.com", "test-role"}, "Role test-role is granted to user example.com", nil); err != nil {
@@ -379,7 +380,7 @@ func certCNAndUsername(cx ctlCtx, noPassword bool) {
 			cx.t.Fatal(err)
 		}
 	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role-cn"), cx.envMap, "Role test-role-cn created"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role-cn"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role-cn created"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3User(cx, []string{"grant-role", "example.com", "test-role-cn"}, "Role test-role-cn is granted to user example.com", nil); err != nil {
@@ -428,9 +429,9 @@ func authTestCertCNAndUsernameNoPassword(cx ctlCtx) {
 
 func ctlV3EndpointHealth(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "endpoint", "health")
-	lines := make([]string, cx.epc.Cfg.ClusterSize)
+	lines := make([]expect.ExpectedResponse, cx.epc.Cfg.ClusterSize)
 	for i := range lines {
-		lines[i] = "is healthy"
+		lines[i] = expect.ExpectedResponse{Value: "is healthy"}
 	}
 	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, lines...)
 }

--- a/tests/e2e/ctl_v3_defrag_test.go
+++ b/tests/e2e/ctl_v3_defrag_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"testing"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -35,16 +36,16 @@ func maintenanceInitKeys(cx ctlCtx) {
 
 func ctlV3OnlineDefrag(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "defrag")
-	lines := make([]string, cx.epc.Cfg.ClusterSize)
+	lines := make([]expect.ExpectedResponse, cx.epc.Cfg.ClusterSize)
 	for i := range lines {
-		lines[i] = "Finished defragmenting etcd member"
+		lines[i] = expect.ExpectedResponse{Value: "Finished defragmenting etcd member"}
 	}
 	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, lines...)
 }
 
 func ctlV3OfflineDefrag(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgsUtl(), "defrag", "--data-dir", cx.dataDir)
-	lines := []string{"finished defragmenting directory"}
+	lines := []expect.ExpectedResponse{{Value: "finished defragmenting directory"}}
 	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, lines...)
 }
 

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -160,7 +161,7 @@ func templateEndpoints(t *testing.T, pattern string, clus *e2e.EtcdProcessCluste
 
 func assertAuthority(t *testing.T, expectAuthorityPattern string, clus *e2e.EtcdProcessCluster) {
 	for i := range clus.Procs {
-		line, _ := clus.Procs[i].Logs().ExpectWithContext(context.TODO(), `http2: decoded hpack field header field ":authority"`)
+		line, _ := clus.Procs[i].Logs().ExpectWithContext(context.TODO(), expect.ExpectedResponse{Value: `http2: decoded hpack field header field ":authority"`})
 		line = strings.TrimSuffix(line, "\n")
 		line = strings.TrimSuffix(line, "\r")
 

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -178,7 +179,7 @@ func getFormatTest(cx ctlCtx) {
 			cmdArgs = append(cmdArgs, "--print-value-only")
 		}
 		cmdArgs = append(cmdArgs, "abc")
-		if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, tt.wstr); err != nil {
+		if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: tt.wstr}); err != nil {
 			cx.t.Errorf("#%d: error (%v), wanted %v", i, err, tt.wstr)
 		}
 	}
@@ -216,28 +217,28 @@ func getKeysOnlyTest(cx ctlCtx) {
 		cx.t.Fatal(err)
 	}
 	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--keys-only", "key"}...)
-	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, "key"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"}); err != nil {
 		cx.t.Fatal(err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, "key")
+	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"})
 	require.NoError(cx.t, err)
 	require.NotContains(cx.t, lines, "val", "got value but passed --keys-only")
 }
 
 func getCountOnlyTest(cx ctlCtx) {
 	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, "\"Count\" : 0"); err != nil {
+	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 0"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3Put(cx, "key", "val", ""); err != nil {
 		cx.t.Fatal(err)
 	}
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, "\"Count\" : 1"); err != nil {
+	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 1"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3Put(cx, "key1", "val", ""); err != nil {
@@ -247,14 +248,14 @@ func getCountOnlyTest(cx ctlCtx) {
 		cx.t.Fatal(err)
 	}
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, "\"Count\" : 2"); err != nil {
+	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 2"}); err != nil {
 		cx.t.Fatal(err)
 	}
 	if err := ctlV3Put(cx, "key2", "val", ""); err != nil {
 		cx.t.Fatal(err)
 	}
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, "\"Count\" : 3"); err != nil {
+	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 3"}); err != nil {
 		cx.t.Fatal(err)
 	}
 
@@ -262,7 +263,7 @@ func getCountOnlyTest(cx ctlCtx) {
 	defer cancel()
 
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key3", "--prefix", "--write-out=fields"}...)
-	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, "\"Count\"")
+	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\""})
 	require.NoError(cx.t, err)
 	require.NotContains(cx.t, lines, "\"Count\" : 3")
 }
@@ -341,7 +342,7 @@ func ctlV3Put(cx ctlCtx, key, value, leaseID string, flags ...string) error {
 	if len(flags) != 0 {
 		cmdArgs = append(cmdArgs, flags...)
 	}
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, "OK")
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "OK"})
 }
 
 type kv struct {
@@ -354,25 +355,15 @@ func ctlV3Get(cx ctlCtx, args []string, kvs ...kv) error {
 	if !cx.quorum {
 		cmdArgs = append(cmdArgs, "--consistency", "s")
 	}
-	var lines []string
+	var lines []expect.ExpectedResponse
 	for _, elem := range kvs {
-		lines = append(lines, elem.key, elem.val)
+		lines = append(lines, expect.ExpectedResponse{Value: elem.key}, expect.ExpectedResponse{Value: elem.val})
 	}
 	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, lines...)
-}
-
-// ctlV3GetWithErr runs "get" command expecting no output but error
-func ctlV3GetWithErr(cx ctlCtx, args []string, errs []string) error {
-	cmdArgs := append(cx.PrefixArgs(), "get")
-	cmdArgs = append(cmdArgs, args...)
-	if !cx.quorum {
-		cmdArgs = append(cmdArgs, "--consistency", "s")
-	}
-	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, errs...)
 }
 
 func ctlV3Del(cx ctlCtx, args []string, num int) error {
 	cmdArgs := append(cx.PrefixArgs(), "del")
 	cmdArgs = append(cmdArgs, args...)
-	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, fmt.Sprintf("%d", num))
+	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf("%d", num)})
 }

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -93,7 +94,7 @@ func ctlV3LeaseKeepAlive(cx ctlCtx, leaseID string) error {
 
 func ctlV3LeaseRevoke(cx ctlCtx, leaseID string) error {
 	cmdArgs := append(cx.PrefixArgs(), "lease", "revoke", leaseID)
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s revoked", leaseID))
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf("lease %s revoked", leaseID)})
 }
 
 func ctlV3LeaseTimeToLive(cx ctlCtx, leaseID string, withKeys bool) error {
@@ -101,5 +102,5 @@ func ctlV3LeaseTimeToLive(cx ctlCtx, leaseID string, withKeys bool) error {
 	if withKeys {
 		cmdArgs = append(cmdArgs, "--keys")
 	}
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("lease %s granted with", leaseID))
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf("lease %s granted with", leaseID)})
 }

--- a/tests/e2e/ctl_v3_lock_test.go
+++ b/tests/e2e/ctl_v3_lock_test.go
@@ -114,16 +114,16 @@ func testLock(cx ctlCtx) {
 func testLockWithCmd(cx ctlCtx) {
 	// exec command with zero exit code
 	echoCmd := []string{"echo"}
-	if err := ctlV3LockWithCmd(cx, echoCmd, ""); err != nil {
+	if err := ctlV3LockWithCmd(cx, echoCmd, expect.ExpectedResponse{Value: ""}); err != nil {
 		cx.t.Fatal(err)
 	}
 
 	// exec command with non-zero exit code
 	code := 3
 	awkCmd := []string{"awk", fmt.Sprintf("BEGIN{exit %d}", code)}
-	expect := fmt.Sprintf("Error: exit status %d", code)
+	expect := expect.ExpectedResponse{Value: fmt.Sprintf("Error: exit status %d", code)}
 	err := ctlV3LockWithCmd(cx, awkCmd, expect)
-	require.ErrorContains(cx.t, err, expect)
+	require.ErrorContains(cx.t, err, expect.Value)
 }
 
 // ctlV3Lock creates a lock process with a channel listening for when it acquires the lock.
@@ -149,7 +149,7 @@ func ctlV3Lock(cx ctlCtx, name string) (*expect.ExpectProcess, <-chan string, er
 }
 
 // ctlV3LockWithCmd creates a lock process to exec command.
-func ctlV3LockWithCmd(cx ctlCtx, execCmd []string, as ...string) error {
+func ctlV3LockWithCmd(cx ctlCtx, execCmd []string, as ...expect.ExpectedResponse) error {
 	// use command as lock name
 	cmdArgs := append(cx.PrefixArgs(), "lock", execCmd[0])
 	cmdArgs = append(cmdArgs, execCmd...)

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -75,9 +76,9 @@ func memberListSerializableTest(cx ctlCtx) {
 
 func ctlV3MemberList(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "member", "list")
-	lines := make([]string, cx.cfg.ClusterSize)
+	lines := make([]expect.ExpectedResponse, cx.cfg.ClusterSize)
 	for i := range lines {
-		lines[i] = "started"
+		lines[i] = expect.ExpectedResponse{Value: "started"}
 	}
 	return e2e.SpawnWithExpects(cmdArgs, cx.envMap, lines...)
 }
@@ -162,7 +163,7 @@ func memberListWithHexTest(cx ctlCtx) {
 
 func ctlV3MemberRemove(cx ctlCtx, ep, memberID, clusterID string) error {
 	cmdArgs := append(cx.prefixArgs([]string{ep}), "member", "remove", memberID)
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf("%s removed from cluster %s", memberID, clusterID))
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf("%s removed from cluster %s", memberID, clusterID)})
 }
 
 func memberAddTest(cx ctlCtx) {
@@ -186,7 +187,7 @@ func ctlV3MemberAdd(cx ctlCtx, peerURL string, isLearner bool) error {
 		cmdArgs = append(cmdArgs, "--learner")
 		asLearner = " as learner "
 	}
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, fmt.Sprintf(" added%sto cluster ", asLearner))
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf(" added%sto cluster ", asLearner)})
 }
 
 func memberUpdateTest(cx ctlCtx) {
@@ -204,5 +205,5 @@ func memberUpdateTest(cx ctlCtx) {
 
 func ctlV3MemberUpdate(cx ctlCtx, memberID, peerURL string) error {
 	cmdArgs := append(cx.PrefixArgs(), "member", "update", memberID, fmt.Sprintf("--peer-urls=%s", peerURL))
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, " updated in cluster ")
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: " updated in cluster "})
 }

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -26,6 +26,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -135,7 +136,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 	for i, tc := range tests {
 		prefix := cx.prefixArgs(tc.eps)
 		cmdArgs := append(prefix, "move-leader", types.ID(transferee).String())
-		err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, tc.expect)
+		err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: tc.expect})
 		if tc.expectErr {
 			require.ErrorContains(t, err, tc.expect)
 		} else {

--- a/tests/e2e/ctl_v3_role_test.go
+++ b/tests/e2e/ctl_v3_role_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -55,7 +56,7 @@ func ctlV3Role(cx ctlCtx, args []string, expStr string) error {
 	cmdArgs := append(cx.PrefixArgs(), "role")
 	cmdArgs = append(cmdArgs, args...)
 
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expStr)
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: expStr})
 }
 
 func ctlV3RoleGrantPermission(cx ctlCtx, rolename string, perm grantingPerm) error {

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -26,6 +26,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/pkg/v3/flags"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -88,7 +89,7 @@ func versionTest(cx ctlCtx) {
 func clusterVersionTest(cx ctlCtx, expected string) {
 	var err error
 	for i := 0; i < 35; i++ {
-		if err = e2e.CURLGet(cx.epc, e2e.CURLReq{Endpoint: "/version", Expected: expected}); err != nil {
+		if err = e2e.CURLGet(cx.epc, e2e.CURLReq{Endpoint: "/version", Expected: expect.ExpectedResponse{Value: expected}}); err != nil {
 			cx.t.Logf("#%d: v3 is not ready yet (%v)", i, err)
 			time.Sleep(200 * time.Millisecond)
 			continue
@@ -102,7 +103,7 @@ func clusterVersionTest(cx ctlCtx, expected string) {
 
 func ctlV3Version(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "version")
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, version.Version)
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: version.Version})
 }
 
 // TestCtlV3DialWithHTTPScheme ensures that client handles Endpoints with HTTPS scheme.
@@ -112,7 +113,7 @@ func TestCtlV3DialWithHTTPScheme(t *testing.T) {
 
 func dialWithSchemeTest(cx ctlCtx) {
 	cmdArgs := append(cx.prefixArgs(cx.epc.EndpointsGRPC()), "put", "foo", "bar")
-	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, "OK"); err != nil {
+	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "OK"}); err != nil {
 		cx.t.Fatal(err)
 	}
 }

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -26,6 +26,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/v2"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -73,10 +74,10 @@ func testClusterUsingDiscovery(t *testing.T, size int, peerTLS bool) {
 	defer c.Close()
 
 	kubectl := []string{e2e.BinPath.Etcdctl, "--endpoints", strings.Join(c.EndpointsGRPC(), ",")}
-	if err := e2e.SpawnWithExpect(append(kubectl, "put", "key", "value"), "OK"); err != nil {
+	if err := e2e.SpawnWithExpect(append(kubectl, "put", "key", "value"), expect.ExpectedResponse{Value: "OK"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := e2e.SpawnWithExpect(append(kubectl, "get", "key"), "value"); err != nil {
+	if err := e2e.SpawnWithExpect(append(kubectl, "get", "key"), expect.ExpectedResponse{Value: "value"}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -76,10 +77,10 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 
 	// step 4: sanity test on the etcd cluster
 	etcdctl := []string{e2e.BinPath.Etcdctl, "--endpoints", strings.Join(epc.EndpointsGRPC(), ",")}
-	if err := e2e.SpawnWithExpect(append(etcdctl, "put", "key", "value"), "OK"); err != nil {
+	if err := e2e.SpawnWithExpect(append(etcdctl, "put", "key", "value"), expect.ExpectedResponse{Value: "OK"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := e2e.SpawnWithExpect(append(etcdctl, "get", "key"), "value"); err != nil {
+	if err := e2e.SpawnWithExpect(append(etcdctl, "get", "key"), expect.ExpectedResponse{Value: "value"}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -296,7 +296,7 @@ func TestGrpcproxyAndCommonName(t *testing.T) {
 		"--cacert", e2e.CaPath,
 	}
 
-	err := e2e.SpawnWithExpect(argsWithNonEmptyCN, "cert has non empty Common Name")
+	err := e2e.SpawnWithExpect(argsWithNonEmptyCN, expect.ExpectedResponse{Value: "cert has non empty Common Name"})
 	require.ErrorContains(t, err, "cert has non empty Common Name")
 
 	p, err := e2e.SpawnCmd(argsWithEmptyCN, nil)

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -97,7 +98,7 @@ func TestReleaseUpgrade(t *testing.T) {
 	// new cluster version needs more time to upgrade
 	ver := version.Cluster(version.Version)
 	for i := 0; i < 7; i++ {
-		if err = e2e.CURLGet(epc, e2e.CURLReq{Endpoint: "/version", Expected: `"etcdcluster":"` + ver}); err != nil {
+		if err = e2e.CURLGet(epc, e2e.CURLReq{Endpoint: "/version", Expected: expect.ExpectedResponse{Value: `"etcdcluster":"` + ver}}); err != nil {
 			t.Logf("#%d: %v is not ready yet (%v)", i, ver, err)
 			time.Sleep(time.Second)
 			continue

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -42,7 +42,7 @@ func TestGateway(t *testing.T) {
 		p.Close()
 	}()
 
-	err = e2e.SpawnWithExpect([]string{e2e.BinPath.Etcdctl, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, "OK\r\n")
+	err = e2e.SpawnWithExpect([]string{e2e.BinPath.Etcdctl, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, expect.ExpectedResponse{Value: "OK\r\n"})
 	if err != nil {
 		t.Errorf("failed to finish put request through gateway: %v", err)
 	}

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -63,7 +64,7 @@ func metricsTest(cx ctlCtx) {
 		if err := ctlV3Watch(cx, []string{"k", "--rev", "1"}, []kvExec{{key: "k", val: "v"}}...); err != nil {
 			cx.t.Fatal(err)
 		}
-		if err := e2e.CURLGet(cx.epc, e2e.CURLReq{Endpoint: test.endpoint, Expected: test.expected}); err != nil {
+		if err := e2e.CURLGet(cx.epc, e2e.CURLReq{Endpoint: test.endpoint, Expected: expect.ExpectedResponse{Value: test.expected}}); err != nil {
 			cx.t.Fatalf("failed get with curl (%v)", err)
 		}
 	}

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -29,6 +29,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/schema"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -139,7 +140,7 @@ func TestEtctlutlMigrate(t *testing.T) {
 
 			t.Log("Write keys to ensure wal snapshot is created and all v3.5 fields are set...")
 			for i := 0; i < 10; i++ {
-				if err = e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), "OK"); err != nil {
+				if err = e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), expect.ExpectedResponse{Value: "OK"}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -155,7 +156,7 @@ func TestEtctlutlMigrate(t *testing.T) {
 			if tc.force {
 				args = append(args, "--force")
 			}
-			err = e2e.SpawnWithExpect(args, tc.expectLogsSubString)
+			err = e2e.SpawnWithExpect(args, expect.ExpectedResponse{Value: tc.expectLogsSubString})
 			if err != nil {
 				if tc.expectLogsSubString != "" {
 					require.ErrorContains(t, err, tc.expectLogsSubString)

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
@@ -58,7 +59,7 @@ func createV2store(t testing.TB, dataDirPath string) string {
 	for i := 0; i < 10; i++ {
 		if err := e2e.CURLPut(epc, e2e.CURLReq{
 			Endpoint: "/v2/keys/foo", Value: "bar" + fmt.Sprint(i),
-			Expected: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)}); err != nil {
+			Expected: expect.ExpectedResponse{Value: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)}}); err != nil {
 			t.Fatalf("failed put with curl (%v)", err)
 		}
 	}

--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -49,7 +50,7 @@ func testV3CurlCipherSuites(t *testing.T, valid bool) {
 func cipherSuiteTestValid(cx ctlCtx) {
 	if err := e2e.CURLGet(cx.epc, e2e.CURLReq{
 		Endpoint: "/metrics",
-		Expected: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version),
+		Expected: expect.ExpectedResponse{Value: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
 		Ciphers:  "ECDHE-RSA-AES128-GCM-SHA256", // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 	}); err != nil {
 		require.ErrorContains(cx.t, err, fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version))
@@ -59,7 +60,7 @@ func cipherSuiteTestValid(cx ctlCtx) {
 func cipherSuiteTestMismatch(cx ctlCtx) {
 	err := e2e.CURLGet(cx.epc, e2e.CURLReq{
 		Endpoint: "/metrics",
-		Expected: "failed setting cipher list",
+		Expected: expect.ExpectedResponse{Value: "failed setting cipher list"},
 		Ciphers:  "ECDHE-RSA-DES-CBC3-SHA", // TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
 	})
 	require.ErrorContains(cx.t, err, "curl: (59) failed setting cipher list")

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -29,6 +29,7 @@ import (
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -166,7 +167,7 @@ func submitConcurrentWatch(cx ctlCtx, number int, wgDone *sync.WaitGroup, closeC
 
 		// make sure that watch request has been created
 		expectedLine := `"created":true}}`
-		_, lerr := proc.ExpectWithContext(context.TODO(), expectedLine)
+		_, lerr := proc.ExpectWithContext(context.TODO(), expect.ExpectedResponse{Value: expectedLine})
 		if lerr != nil {
 			return fmt.Errorf("%v %v (expected %q). Try EXPECT_DEBUG=TRUE", args, lerr, expectedLine)
 		}
@@ -213,7 +214,7 @@ func submitRangeAfterConcurrentWatch(cx ctlCtx, expectedValue string) {
 	}
 
 	cx.t.Log("Submitting range request...")
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Expected: expectedValue, Timeout: 5}); err != nil {
+	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Expected: expect.ExpectedResponse{Value: expectedValue}, Timeout: 5}); err != nil {
 		require.ErrorContains(cx.t, err, expectedValue)
 	}
 	cx.t.Log("range request done")

--- a/tests/framework/e2e/curl.go
+++ b/tests/framework/e2e/curl.go
@@ -20,6 +20,8 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+
+	"go.etcd.io/etcd/pkg/v3/expect"
 )
 
 type CURLReq struct {
@@ -32,7 +34,7 @@ type CURLReq struct {
 	Endpoint string
 
 	Value    string
-	Expected string
+	Expected expect.ExpectedResponse
 	Header   string
 
 	Ciphers     string

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -62,7 +62,7 @@ type EtcdProcess interface {
 }
 
 type LogsExpect interface {
-	ExpectWithContext(context.Context, string) (string, error)
+	ExpectWithContext(context.Context, expect.ExpectedResponse) (string, error)
 	Lines() []string
 	LineCount() int
 }
@@ -313,7 +313,7 @@ func AssertProcessLogs(t *testing.T, ep EtcdProcess, expectLog string) {
 	var err error
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_, err = ep.Logs().ExpectWithContext(ctx, expectLog)
+	_, err = ep.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: expectLog})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/framework/e2e/lazyfs.go
+++ b/tests/framework/e2e/lazyfs.go
@@ -65,7 +65,7 @@ func (fs *LazyFS) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	_, err = fs.ep.ExpectWithContext(ctx, "waiting for fault commands")
+	_, err = fs.ep.ExpectWithContext(ctx, expect.ExpectedResponse{Value: "waiting for fault commands"})
 	return err
 }
 
@@ -109,6 +109,6 @@ func (fs *LazyFS) ClearCache(ctx context.Context) error {
 	}
 	// TODO: Wait for response on socket instead of reading logs to get command completion.
 	// Set `fifo_path_completed` config for LazyFS to create separate socket to write when it has completed command.
-	_, err = fs.ep.ExpectWithContext(ctx, "cache is cleared")
+	_, err = fs.ep.ExpectWithContext(ctx, expect.ExpectedResponse{Value: "cache is cleared"})
 	return err
 }

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -41,24 +41,24 @@ func WaitReadyExpectProc(ctx context.Context, exproc *expect.ExpectProcess, read
 	return err
 }
 
-func SpawnWithExpect(args []string, expected string) error {
-	return SpawnWithExpects(args, nil, []string{expected}...)
+func SpawnWithExpect(args []string, expected expect.ExpectedResponse) error {
+	return SpawnWithExpects(args, nil, []expect.ExpectedResponse{expected}...)
 }
 
-func SpawnWithExpectWithEnv(args []string, envVars map[string]string, expected string) error {
-	return SpawnWithExpects(args, envVars, []string{expected}...)
+func SpawnWithExpectWithEnv(args []string, envVars map[string]string, expected expect.ExpectedResponse) error {
+	return SpawnWithExpects(args, envVars, []expect.ExpectedResponse{expected}...)
 }
 
-func SpawnWithExpects(args []string, envVars map[string]string, xs ...string) error {
+func SpawnWithExpects(args []string, envVars map[string]string, xs ...expect.ExpectedResponse) error {
 	return SpawnWithExpectsContext(context.TODO(), args, envVars, xs...)
 }
 
-func SpawnWithExpectsContext(ctx context.Context, args []string, envVars map[string]string, xs ...string) error {
+func SpawnWithExpectsContext(ctx context.Context, args []string, envVars map[string]string, xs ...expect.ExpectedResponse) error {
 	_, err := SpawnWithExpectLines(ctx, args, envVars, xs...)
 	return err
 }
 
-func SpawnWithExpectLines(ctx context.Context, args []string, envVars map[string]string, xs ...string) ([]string, error) {
+func SpawnWithExpectLines(ctx context.Context, args []string, envVars map[string]string, xs ...expect.ExpectedResponse) ([]string, error) {
 	proc, err := SpawnCmd(args, envVars)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func SpawnWithExpectLines(ctx context.Context, args []string, envVars map[string
 		l, lerr := proc.ExpectWithContext(ctx, txt)
 		if lerr != nil {
 			proc.Close()
-			return nil, fmt.Errorf("%v %v (expected %q, got %q). Try EXPECT_DEBUG=TRUE", args, lerr, txt, lines)
+			return nil, fmt.Errorf("%v %v (expected %q, got %q). Try EXPECT_DEBUG=TRUE", args, lerr, txt.Value, lines)
 		}
 		lines = append(lines, l)
 	}


### PR DESCRIPTION
Currently we only support exact string match on the response (e.g. curl response, and process output). But in some cases, the response may not be a fixed string. One example is discussed in https://github.com/etcd-io/etcd/pull/16454, there may be random spaces in the grpc-gateway v2 response.

So we need to support match the response based on a regular expression.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
