### PR TITLE
 Use latest golang image to avoid confusing it's version with go-version

### DIFF
--- a/.github/workflows/e2e-arm64-template.yaml
+++ b/.github/workflows/e2e-arm64-template.yaml
@@ -12,7 +12,8 @@ jobs:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
     runs-on: [self-hosted, Linux, ARM64]
-    container: golang:1.20-bullseye
+    container:
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
     defaults:
       run:
         shell: bash

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20-bullseye
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
     defaults:
       run:
         shell: bash

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -5,7 +5,8 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: golang:1.20-bullseye
+    container:
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
     defaults:
       run:
         shell: bash

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 210
     runs-on: ${{ fromJson(inputs.runs-on) }}
     container:
-      image: golang:1.20-bullseye
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
       # Required for mounting fuse lazyfs
       options: --privileged
     defaults:

--- a/.github/workflows/tests-arm64-template.yaml
+++ b/.github/workflows/tests-arm64-template.yaml
@@ -17,7 +17,8 @@ jobs:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'etcd-io/etcd'
     runs-on: [self-hosted, Linux, ARM64]
-    container: golang:1.20-bullseye
+    container:
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,8 @@ permissions: read-all
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: golang:1.20-bullseye
+    container:
+      image: golang:bullseye@sha256:02f350d8452d3f9693a450586659ecdc6e40e9be8f8dfc6d402300d87223fdfa
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Go version from docker image is not used as
https://github.com/actions/setup-go download its own Go binary.


cc @ahrtr @jmhbnz 