### PR TITLE
Maintain a consistent naming standard for curlv3 tests

### DIFF
--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -27,9 +27,9 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestV3CurlCipherSuitesValid(t *testing.T)    { testV3CurlCipherSuites(t, true) }
-func TestV3CurlCipherSuitesMismatch(t *testing.T) { testV3CurlCipherSuites(t, false) }
-func testV3CurlCipherSuites(t *testing.T, valid bool) {
+func TestCurlV3CipherSuitesValid(t *testing.T)    { testCurlV3CipherSuites(t, true) }
+func TestCurlV3CipherSuitesMismatch(t *testing.T) { testCurlV3CipherSuites(t, false) }
+func testCurlV3CipherSuites(t *testing.T, valid bool) {
 	cc := e2e.NewConfigClientTLS()
 	cc.ClusterSize = 1
 	cc.CipherSuites = []string{

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -29,14 +29,14 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestV3CurlAuth(t *testing.T) {
-	testCtl(t, testV3CurlAuth)
+func TestCurlV3Auth(t *testing.T) {
+	testCtl(t, testCurlV3Auth)
 }
-func TestV3CurlAuthClientTLSCertAuth(t *testing.T) {
-	testCtl(t, testV3CurlAuth, withCfg(*e2e.NewConfigClientTLSCertAuthWithNoCN()))
+func TestCurlV3AuthClientTLSCertAuth(t *testing.T) {
+	testCtl(t, testCurlV3Auth, withCfg(*e2e.NewConfigClientTLSCertAuthWithNoCN()))
 }
 
-func testV3CurlAuth(cx ctlCtx) {
+func testCurlV3Auth(cx ctlCtx) {
 	usernames := []string{"root", "nonroot", "nooption"}
 	pwds := []string{"toor", "pass", "pass"}
 	options := []*authpb.UserAddOptions{{NoPassword: false}, {NoPassword: false}, nil}
@@ -51,7 +51,7 @@ func testV3CurlAuth(cx ctlCtx) {
 			Value:    string(user),
 			Expected: expect.ExpectedResponse{Value: "revision"},
 		}); err != nil {
-			cx.t.Fatalf("testV3CurlAuth failed to add user %v (%v)", usernames[i], err)
+			cx.t.Fatalf("testCurlV3Auth failed to add user %v (%v)", usernames[i], err)
 		}
 	}
 
@@ -64,7 +64,7 @@ func testV3CurlAuth(cx ctlCtx) {
 		Value:    string(rolereq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
 	}); err != nil {
-		cx.t.Fatalf("testV3CurlAuth failed to create role (%v)", err)
+		cx.t.Fatalf("testCurlV3Auth failed to create role (%v)", err)
 	}
 
 	//grant root role
@@ -77,7 +77,7 @@ func testV3CurlAuth(cx ctlCtx) {
 			Value:    string(grantroleroot),
 			Expected: expect.ExpectedResponse{Value: "revision"},
 		}); err != nil {
-			cx.t.Fatalf("testV3CurlAuth failed to grant role (%v)", err)
+			cx.t.Fatalf("testCurlV3Auth failed to grant role (%v)", err)
 		}
 	}
 
@@ -87,7 +87,7 @@ func testV3CurlAuth(cx ctlCtx) {
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{Value: "revision"},
 	}); err != nil {
-		cx.t.Fatalf("testV3CurlAuth failed to enable auth (%v)", err)
+		cx.t.Fatalf("testCurlV3Auth failed to enable auth (%v)", err)
 	}
 
 	for i := 0; i < len(usernames); i++ {
@@ -101,7 +101,7 @@ func testV3CurlAuth(cx ctlCtx) {
 			Value:    string(putreq),
 			Expected: expect.ExpectedResponse{Value: "error"},
 		}); err != nil {
-			cx.t.Fatalf("testV3CurlAuth failed to put without token (%v)", err)
+			cx.t.Fatalf("testCurlV3Auth failed to put without token (%v)", err)
 		}
 
 		// auth request
@@ -141,7 +141,7 @@ func testV3CurlAuth(cx ctlCtx) {
 			Header:   authHeader,
 			Expected: expect.ExpectedResponse{Value: "revision"},
 		}); err != nil {
-			cx.t.Fatalf("testV3CurlAuth failed to auth put with user (%v) (%v)", usernames[i], err)
+			cx.t.Fatalf("testCurlV3Auth failed to auth put with user (%v) (%v)", usernames[i], err)
 		}
 	}
 }

--- a/tests/e2e/v3_curl_kv_test.go
+++ b/tests/e2e/v3_curl_kv_test.go
@@ -161,7 +161,7 @@ func testCurlV3KVTxn(cx ctlCtx) {
 		Value:    string(jsonDat),
 		Expected: expect.ExpectedResponse{Value: expected},
 	})
-	require.NoErrorf(cx.t, err, "testV3CurlTxn failed")
+	require.NoErrorf(cx.t, err, "testCurlV3Txn failed")
 
 	// was crashing etcd server
 	malformed := `{"compare":[{"result":0,"target":1,"key":"Zm9v","TargetUnion":null}],"success":[{"Request":{"RequestPut":{"key":"Zm9v","value":"YmFy"}}}]}`
@@ -170,7 +170,7 @@ func testCurlV3KVTxn(cx ctlCtx) {
 		Value:    malformed,
 		Expected: expect.ExpectedResponse{Value: "error"},
 	})
-	require.NoErrorf(cx.t, err, "testV3CurlTxn with malformed request failed")
+	require.NoErrorf(cx.t, err, "testCurlV3Txn with malformed request failed")
 }
 
 func testCurlV3KVCompact(cx ctlCtx) {

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -22,24 +22,24 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestV3CurlLeaseGrantNoTLS(t *testing.T) {
+func TestCurlV3LeaseGrantNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseGrant, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3LeaseGrant, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
-func TestV3CurlLeaseRevokeNoTLS(t *testing.T) {
+func TestCurlV3LeaseRevokeNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseRevoke, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3LeaseRevoke, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
-func TestV3CurlLeaseLeasesNoTLS(t *testing.T) {
+func TestCurlV3LeaseLeasesNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseLeases, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3LeaseLeases, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
-func TestV3CurlLeaseKeepAliveNoTLS(t *testing.T) {
+func TestCurlV3LeaseKeepAliveNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlLeaseKeepAlive, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3LeaseKeepAlive, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
 
@@ -49,7 +49,7 @@ type v3cURLTest struct {
 	expected string
 }
 
-func testV3CurlLeaseGrant(cx ctlCtx) {
+func testCurlV3LeaseGrant(cx ctlCtx) {
 	leaseID := e2e.RandomLeaseID()
 
 	tests := []v3cURLTest{
@@ -75,11 +75,11 @@ func testV3CurlLeaseGrant(cx ctlCtx) {
 		},
 	}
 	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testV3CurlLeaseGrant: %v", err)
+		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
 	}
 }
 
-func testV3CurlLeaseRevoke(cx ctlCtx) {
+func testCurlV3LeaseRevoke(cx ctlCtx) {
 	leaseID := e2e.RandomLeaseID()
 
 	tests := []v3cURLTest{
@@ -95,11 +95,11 @@ func testV3CurlLeaseRevoke(cx ctlCtx) {
 		},
 	}
 	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testV3CurlLeaseRevoke: %v", err)
+		cx.t.Fatalf("testCurlV3LeaseRevoke: %v", err)
 	}
 }
 
-func testV3CurlLeaseLeases(cx ctlCtx) {
+func testCurlV3LeaseLeases(cx ctlCtx) {
 	leaseID := e2e.RandomLeaseID()
 
 	tests := []v3cURLTest{
@@ -115,11 +115,11 @@ func testV3CurlLeaseLeases(cx ctlCtx) {
 		},
 	}
 	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testV3CurlLeaseGrant: %v", err)
+		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
 	}
 }
 
-func testV3CurlLeaseKeepAlive(cx ctlCtx) {
+func testCurlV3LeaseKeepAlive(cx ctlCtx) {
 	leaseID := e2e.RandomLeaseID()
 
 	tests := []v3cURLTest{
@@ -135,7 +135,7 @@ func testV3CurlLeaseKeepAlive(cx ctlCtx) {
 		},
 	}
 	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testV3CurlLeaseGrant: %v", err)
+		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
 	}
 }
 

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -26,13 +26,13 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestV3CurlMaintenanceAlarmMissiongAlarm(t *testing.T) {
+func TestCurlV3MaintenanceAlarmMissiongAlarm(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlMaintenanceAlarmMissiongAlarm, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3MaintenanceAlarmMissiongAlarm, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
 
-func testV3CurlMaintenanceAlarmMissiongAlarm(cx ctlCtx) {
+func testCurlV3MaintenanceAlarmMissiongAlarm(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: path.Join(cx.apiPrefix, "/maintenance/alarm"),
 		Value:    `{"action": "ACTIVATE"}`,
@@ -41,11 +41,11 @@ func testV3CurlMaintenanceAlarmMissiongAlarm(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceStatus(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceStatus, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceStatus(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceStatus, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceStatus(cx ctlCtx) {
+func testCurlV3MaintenanceStatus(cx ctlCtx) {
 	clus := cx.epc
 	args := e2e.CURLPrefixArgsCluster(clus.Cfg, clus.Procs[rand.Intn(clus.Cfg.ClusterSize)], "POST", e2e.CURLReq{
 		Endpoint: "/v3/maintenance/status",
@@ -65,11 +65,11 @@ func testV3CurlMaintenanceStatus(cx ctlCtx) {
 	require.Equal(cx.t, version.Version, actualVersion)
 }
 
-func TestV3CurlMaintenanceDefragment(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceDefragment, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceDefragment(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceDefragment, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceDefragment(cx ctlCtx) {
+func testCurlV3MaintenanceDefragment(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/defragment",
 		Value:    "{}",
@@ -81,11 +81,11 @@ func testV3CurlMaintenanceDefragment(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceHash(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceHash, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceHash(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceHash, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceHash(cx ctlCtx) {
+func testCurlV3MaintenanceHash(cx ctlCtx) {
 	clus := cx.epc
 	args := e2e.CURLPrefixArgsCluster(clus.Cfg, clus.Procs[rand.Intn(clus.Cfg.ClusterSize)], "POST", e2e.CURLReq{
 		Endpoint: "/v3/maintenance/hash",
@@ -102,11 +102,11 @@ func testV3CurlMaintenanceHash(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceHashKV(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceHashKV, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceHashKV(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceHashKV, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceHashKV(cx ctlCtx) {
+func testCurlV3MaintenanceHashKV(cx ctlCtx) {
 	clus := cx.epc
 	args := e2e.CURLPrefixArgsCluster(clus.Cfg, clus.Procs[rand.Intn(clus.Cfg.ClusterSize)], "POST", e2e.CURLReq{
 		Endpoint: "/v3/maintenance/hashkv",
@@ -123,11 +123,11 @@ func testV3CurlMaintenanceHashKV(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceSnapshot(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceSnapshot, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceSnapshot(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceSnapshot, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceSnapshot(cx ctlCtx) {
+func testCurlV3MaintenanceSnapshot(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/snapshot",
 		Value:    "{}",
@@ -139,11 +139,11 @@ func testV3CurlMaintenanceSnapshot(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceMoveleader(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceMoveleader, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceMoveleader(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceMoveleader, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceMoveleader(cx ctlCtx) {
+func testCurlV3MaintenanceMoveleader(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/transfer-leadership",
 		Value:    `{"targetID": 123}`,
@@ -155,11 +155,11 @@ func testV3CurlMaintenanceMoveleader(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlMaintenanceDowngrade(t *testing.T) {
-	testCtl(t, testV3CurlMaintenanceDowngrade, withCfg(*e2e.NewConfigNoTLS()))
+func TestCurlV3MaintenanceDowngrade(t *testing.T) {
+	testCtl(t, testCurlV3MaintenanceDowngrade, withCfg(*e2e.NewConfigNoTLS()))
 }
 
-func testV3CurlMaintenanceDowngrade(cx ctlCtx) {
+func testCurlV3MaintenanceDowngrade(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/downgrade",
 		Value:    `{"action": 0, "version": "3.0"}`,

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -34,50 +34,50 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-// TestV3Curl_MaxStreams_BelowLimit_NoTLS_Small tests no TLS
-func TestV3Curl_MaxStreams_BelowLimit_NoTLS_Small(t *testing.T) {
-	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(3))
+// TestCurlV3_MaxStreams_BelowLimit_NoTLS_Small tests no TLS
+func TestCurlV3_MaxStreams_BelowLimit_NoTLS_Small(t *testing.T) {
+	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(3))
 }
 
-func TestV3Curl_MaxStreams_BelowLimit_NoTLS_Medium(t *testing.T) {
-	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
+func TestCurlV3_MaxStreams_BelowLimit_NoTLS_Medium(t *testing.T) {
+	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
 }
 
-func TestV3Curl_MaxStreamsNoTLS_BelowLimit_Large(t *testing.T) {
+func TestCurlV3_MaxStreamsNoTLS_BelowLimit_Large(t *testing.T) {
 	f, err := setRLimit(10240)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f()
-	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(1000), withTestTimeout(200*time.Second))
+	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(1000), withTestTimeout(200*time.Second))
 }
 
-func TestV3Curl_MaxStreams_ReachLimit_NoTLS_Small(t *testing.T) {
-	testV3CurlMaxStream(t, true, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(3))
+func TestCurlV3_MaxStreams_ReachLimit_NoTLS_Small(t *testing.T) {
+	testCurlV3MaxStream(t, true, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(3))
 }
 
-func TestV3Curl_MaxStreams_ReachLimit_NoTLS_Medium(t *testing.T) {
-	testV3CurlMaxStream(t, true, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
+func TestCurlV3_MaxStreams_ReachLimit_NoTLS_Medium(t *testing.T) {
+	testCurlV3MaxStream(t, true, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
 }
 
-// TestV3Curl_MaxStreams_BelowLimit_TLS_Small tests with TLS
-func TestV3Curl_MaxStreams_BelowLimit_TLS_Small(t *testing.T) {
-	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(3))
+// TestCurlV3_MaxStreams_BelowLimit_TLS_Small tests with TLS
+func TestCurlV3_MaxStreams_BelowLimit_TLS_Small(t *testing.T) {
+	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(3))
 }
 
-func TestV3Curl_MaxStreams_BelowLimit_TLS_Medium(t *testing.T) {
-	testV3CurlMaxStream(t, false, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
+func TestCurlV3_MaxStreams_BelowLimit_TLS_Medium(t *testing.T) {
+	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
 }
 
-func TestV3Curl_MaxStreams_ReachLimit_TLS_Small(t *testing.T) {
-	testV3CurlMaxStream(t, true, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(3))
+func TestCurlV3_MaxStreams_ReachLimit_TLS_Small(t *testing.T) {
+	testCurlV3MaxStream(t, true, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(3))
 }
 
-func TestV3Curl_MaxStreams_ReachLimit_TLS_Medium(t *testing.T) {
-	testV3CurlMaxStream(t, true, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
+func TestCurlV3_MaxStreams_ReachLimit_TLS_Medium(t *testing.T) {
+	testCurlV3MaxStream(t, true, withCfg(*e2e.NewConfigTLS()), withMaxConcurrentStreams(100), withTestTimeout(20*time.Second))
 }
 
-func testV3CurlMaxStream(t *testing.T, reachLimit bool, opts ...ctlOption) {
+func testCurlV3MaxStream(t *testing.T, reachLimit bool, opts ...ctlOption) {
 	e2e.BeforeTest(t)
 
 	// Step 1: generate configuration for creating cluster
@@ -138,7 +138,7 @@ func testV3CurlMaxStream(t *testing.T, reachLimit bool, opts ...ctlOption) {
 		t.Log("All watch goroutines exited.")
 	}
 
-	t.Log("testV3CurlMaxStream done!")
+	t.Log("testCurlV3MaxStream done!")
 }
 
 func submitConcurrentWatch(cx ctlCtx, number int, wgDone *sync.WaitGroup, closeCh chan struct{}) {
@@ -195,7 +195,7 @@ func submitConcurrentWatch(cx ctlCtx, number int, wgDone *sync.WaitGroup, closeC
 				defer wgDone.Done()
 
 				if err := createWatchConnection(); err != nil {
-					cx.t.Fatalf("testV3CurlMaxStream watch failed: %d, error: %v", i, err)
+					cx.t.Fatalf("testCurlV3MaxStream watch failed: %d, error: %v", i, err)
 				}
 			}(i)
 		}

--- a/tests/e2e/v3_curl_test.go
+++ b/tests/e2e/v3_curl_test.go
@@ -34,13 +34,13 @@ import (
 
 var apiPrefix = []string{"/v3"}
 
-func TestV3CurlWatch(t *testing.T) {
+func TestCurlV3Watch(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlWatch, withApiPrefix(p))
+		testCtl(t, testCurlV3Watch, withApiPrefix(p))
 	}
 }
 
-func testV3CurlWatch(cx ctlCtx) {
+func testCurlV3Watch(cx ctlCtx) {
 	// store "bar" into "foo"
 	putreq, err := json.Marshal(&pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	if err != nil {
@@ -59,20 +59,20 @@ func testV3CurlWatch(cx ctlCtx) {
 	p := cx.apiPrefix
 
 	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: path.Join(p, "/kv/put"), Value: string(putreq), Expected: expect.ExpectedResponse{Value: "revision"}}); err != nil {
-		cx.t.Fatalf("failed testV3CurlWatch put with curl using prefix (%s) (%v)", p, err)
+		cx.t.Fatalf("failed testCurlV3Watch put with curl using prefix (%s) (%v)", p, err)
 	}
 	// expects "bar", timeout after 2 seconds since stream waits forever
 	err = e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: path.Join(p, "/watch"), Value: wstr, Expected: expect.ExpectedResponse{Value: `"YmFy"`}, Timeout: 2})
 	require.ErrorContains(cx.t, err, "unexpected exit code")
 }
 
-func TestV3CurlCampaignNoTLS(t *testing.T) {
+func TestCurlV3CampaignNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlCampaign, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3Campaign, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
 
-func testV3CurlCampaign(cx ctlCtx) {
+func testCurlV3Campaign(cx ctlCtx) {
 	cdata, err := json.Marshal(&epb.CampaignRequest{
 		Name:  []byte("/election-prefix"),
 		Value: []byte("v1"),
@@ -128,13 +128,13 @@ func testV3CurlCampaign(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlProclaimMissiongLeaderKeyNoTLS(t *testing.T) {
+func TestCurlV3ProclaimMissiongLeaderKeyNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlProclaimMissiongLeaderKey, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3ProclaimMissiongLeaderKey, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
 
-func testV3CurlProclaimMissiongLeaderKey(cx ctlCtx) {
+func testCurlV3ProclaimMissiongLeaderKey(cx ctlCtx) {
 	pdata, err := json.Marshal(&epb.ProclaimRequest{Value: []byte("v2")})
 	if err != nil {
 		cx.t.Fatal(err)
@@ -148,13 +148,13 @@ func testV3CurlProclaimMissiongLeaderKey(cx ctlCtx) {
 	}
 }
 
-func TestV3CurlResignMissiongLeaderKeyNoTLS(t *testing.T) {
+func TestCurlV3ResignMissiongLeaderKeyNoTLS(t *testing.T) {
 	for _, p := range apiPrefix {
-		testCtl(t, testV3CurlResignMissiongLeaderKey, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
+		testCtl(t, testCurlV3ResignMissiongLeaderKey, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
 	}
 }
 
-func testV3CurlResignMissiongLeaderKey(cx ctlCtx) {
+func testCurlV3ResignMissiongLeaderKey(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: path.Join(cx.apiPrefix, "/election/resign"),
 		Value:    `{}`,


### PR DESCRIPTION
As discussed in https://github.com/etcd-io/etcd/pull/16511#issuecomment-1702499475 we proposed a new naming standard for our v3 RESTful tests.

This is a quick maintenance pr to apply that new standard to the rest of the test cases so we don't have any inconsistency.

```bash
 james  ~  D  etcd   maintain-testc.. 
 ➜ grep -Riol  TestV3Curl | xargs sed -i 's/TestV3Curl/TestCurlV3/g'

 james  ~  D  etcd   maintain-testc.. 
 ➜ grep -Riol  testV3Curl | xargs sed -i 's/testV3Curl/testCurlV3/g'

 james  ~  D  etcd   maintain-testc.. 
 ➜ grep -Riol  TestV3Curl | wc -l
 0
```