### PR TITLE
test: remove apiPrefix and withApiPrefix

### DIFF
--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -119,9 +119,8 @@ func dialWithSchemeTest(cx ctlCtx) {
 }
 
 type ctlCtx struct {
-	t         *testing.T
-	apiPrefix string
-	cfg       e2e.EtcdProcessClusterConfig
+	t   *testing.T
+	cfg e2e.EtcdProcessClusterConfig
 
 	corruptFunc                func(string) error
 	disableStrictReconfigCheck bool
@@ -185,10 +184,6 @@ func withCorruptFunc(f func(string) error) ctlOption {
 
 func withDisableStrictReconfig() ctlOption {
 	return func(cx *ctlCtx) { cx.disableStrictReconfigCheck = true }
-}
-
-func withApiPrefix(p string) ctlOption {
-	return func(cx *ctlCtx) { cx.apiPrefix = p }
 }
 
 func withFlagByEnv() ctlOption {

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -23,24 +23,16 @@ import (
 )
 
 func TestCurlV3LeaseGrantNoTLS(t *testing.T) {
-	for _, p := range apiPrefix {
-		testCtl(t, testCurlV3LeaseGrant, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
-	}
+	testCtl(t, testCurlV3LeaseGrant, withCfg(*e2e.NewConfigNoTLS()))
 }
 func TestCurlV3LeaseRevokeNoTLS(t *testing.T) {
-	for _, p := range apiPrefix {
-		testCtl(t, testCurlV3LeaseRevoke, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
-	}
+	testCtl(t, testCurlV3LeaseRevoke, withCfg(*e2e.NewConfigNoTLS()))
 }
 func TestCurlV3LeaseLeasesNoTLS(t *testing.T) {
-	for _, p := range apiPrefix {
-		testCtl(t, testCurlV3LeaseLeases, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
-	}
+	testCtl(t, testCurlV3LeaseLeases, withCfg(*e2e.NewConfigNoTLS()))
 }
 func TestCurlV3LeaseKeepAliveNoTLS(t *testing.T) {
-	for _, p := range apiPrefix {
-		testCtl(t, testCurlV3LeaseKeepAlive, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
-	}
+	testCtl(t, testCurlV3LeaseKeepAlive, withCfg(*e2e.NewConfigNoTLS()))
 }
 
 type v3cURLTest struct {
@@ -54,22 +46,22 @@ func testCurlV3LeaseGrant(cx ctlCtx) {
 
 	tests := []v3cURLTest{
 		{
-			endpoint: "/lease/grant",
+			endpoint: "/v3/lease/grant",
 			value:    gwLeaseGrant(cx, leaseID, 0),
 			expected: gwLeaseIDExpected(leaseID),
 		},
 		{
-			endpoint: "/lease/grant",
+			endpoint: "/v3/lease/grant",
 			value:    gwLeaseGrant(cx, 0, 20),
 			expected: `"TTL":"20"`,
 		},
 		{
-			endpoint: "/kv/put",
+			endpoint: "/v3/kv/put",
 			value:    gwKVPutLease(cx, "foo", "bar", leaseID),
 			expected: `"revision":"`,
 		},
 		{
-			endpoint: "/lease/timetolive",
+			endpoint: "/v3/lease/timetolive",
 			value:    gwLeaseTTLWithKeys(cx, leaseID),
 			expected: `"grantedTTL"`,
 		},
@@ -84,12 +76,12 @@ func testCurlV3LeaseRevoke(cx ctlCtx) {
 
 	tests := []v3cURLTest{
 		{
-			endpoint: "/lease/grant",
+			endpoint: "/v3/lease/grant",
 			value:    gwLeaseGrant(cx, leaseID, 0),
 			expected: gwLeaseIDExpected(leaseID),
 		},
 		{
-			endpoint: "/lease/revoke",
+			endpoint: "/v3/lease/revoke",
 			value:    gwLeaseRevoke(cx, leaseID),
 			expected: `"revision":"`,
 		},
@@ -104,12 +96,12 @@ func testCurlV3LeaseLeases(cx ctlCtx) {
 
 	tests := []v3cURLTest{
 		{
-			endpoint: "/lease/grant",
+			endpoint: "/v3/lease/grant",
 			value:    gwLeaseGrant(cx, leaseID, 0),
 			expected: gwLeaseIDExpected(leaseID),
 		},
 		{
-			endpoint: "/lease/leases",
+			endpoint: "/v3/lease/leases",
 			value:    "{}",
 			expected: gwLeaseIDExpected(leaseID),
 		},
@@ -124,12 +116,12 @@ func testCurlV3LeaseKeepAlive(cx ctlCtx) {
 
 	tests := []v3cURLTest{
 		{
-			endpoint: "/lease/grant",
+			endpoint: "/v3/lease/grant",
 			value:    gwLeaseGrant(cx, leaseID, 0),
 			expected: gwLeaseIDExpected(leaseID),
 		},
 		{
-			endpoint: "/lease/keepalive",
+			endpoint: "/v3/lease/keepalive",
 			value:    gwLeaseKeepAlive(cx, leaseID),
 			expected: gwLeaseIDExpected(leaseID),
 		},

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"math/rand"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,17 +26,15 @@ import (
 )
 
 func TestCurlV3MaintenanceAlarmMissiongAlarm(t *testing.T) {
-	for _, p := range apiPrefix {
-		testCtl(t, testCurlV3MaintenanceAlarmMissiongAlarm, withApiPrefix(p), withCfg(*e2e.NewConfigNoTLS()))
-	}
+	testCtl(t, testCurlV3MaintenanceAlarmMissiongAlarm, withCfg(*e2e.NewConfigNoTLS()))
 }
 
 func testCurlV3MaintenanceAlarmMissiongAlarm(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
-		Endpoint: path.Join(cx.apiPrefix, "/maintenance/alarm"),
+		Endpoint: "/v3/maintenance/alarm",
 		Value:    `{"action": "ACTIVATE"}`,
 	}); err != nil {
-		cx.t.Fatalf("failed post maintenance alarm (%s) (%v)", cx.apiPrefix, err)
+		cx.t.Fatalf("failed post maintenance alarm (%v)", err)
 	}
 }
 


### PR DESCRIPTION
v2 API has already been deprecated. It doesn't make sense to maintain an apiPrefix in the test cases. So cleanup the apiPrefix.

Link to https://github.com/etcd-io/etcd/issues/16507