### PR TITLE
test: de-flake test case TestV3WatchProgressOnMemberRestart

### DIFF
--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -968,6 +968,8 @@ func TestV3WatchProgressOnMemberRestart(t *testing.T) {
 
 	t.Log("Waiting for result")
 	select {
+	case <-progressNotifyC:
+		t.Log("Progress notification received")
 	case err := <-errC:
 		t.Fatal(err)
 	case <-doneC:


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/16416

The case may be blocked on sending progress notification, so may not be able to exit the goroutine.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
