### PR TITLE
test: fix the flaky test case `TestMemberList`

### DIFF
--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -50,15 +50,18 @@ func TestMemberList(t *testing.T) {
 				if expectNum != gotNum {
 					t.Fatalf("number of members not equal, expect: %d, got: %d", expectNum, gotNum)
 				}
-				assert.Eventually(t, func() (done bool) {
+				assert.Eventually(t, func() bool {
+					resp, err := cc.MemberList(ctx, false)
+					if err != nil {
+						t.Logf("Failed to get member list, err: %v", err)
+						return false
+					}
 					for _, m := range resp.Members {
 						if len(m.ClientURLs) == 0 {
 							t.Logf("member is not started, memberId:%d, memberName:%s", m.ID, m.Name)
-							done = false
-							return done
+							return false
 						}
 					}
-					done = true
 					return true
 				}, time.Second*5, time.Millisecond*100)
 			})


### PR DESCRIPTION
Get memberlist immediately before each time checking the members, otherwise it always checks the member on a static list of members.

```
    member_test.go:53: 
        	Error Trace:	/__w/etcd/etcd/tests/common/member_test.go:53
        	            				/__w/etcd/etcd/tests/framework/testutils/execute.go:38
        	            				/__t/go/1.20.7/x64/src/runtime/asm_amd64.s:1598
        	Error:      	Condition never satisfied
        	Test:       	TestMemberList/PeerTLS
```

See https://github.com/etcd-io/etcd/actions/runs/6093660649/job/16533696393

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
