### PR TITLE
server/storage/mvcc: deflake TestHashKVWhenCompacting

### DIFF
--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -591,18 +591,17 @@ func TestHashKVWhenCompacting(t *testing.T) {
 		defer wg.Done()
 		revHash := make(map[int64]uint32)
 		for {
-			r := <-hashCompactc
-			if revHash[r.compactRev] == 0 {
-				revHash[r.compactRev] = r.hash
-			}
-			if r.hash != revHash[r.compactRev] {
-				t.Errorf("Hashes differ (current %v) != (saved %v)", r.hash, revHash[r.compactRev])
-			}
-
 			select {
+			case r := <-hashCompactc:
+				if revHash[r.compactRev] == 0 {
+					revHash[r.compactRev] = r.hash
+				}
+
+				if r.hash != revHash[r.compactRev] {
+					t.Errorf("Hashes differ (current %v) != (saved %v)", r.hash, revHash[r.compactRev])
+				}
 			case <-donec:
 				return
-			default:
 			}
 		}
 	}()


### PR DESCRIPTION
The HashByRev-goroutines exit since receive `donec` notification. The Check-computed-hashes goroutine could not have chance to get the hash result and be stuck forever. We should add case for donec when we wait for hash result.

Closes: #16266

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
