### PR TITLE
[3.5] Backport redirecting cmux test metrics data into file to reduce output

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -137,7 +139,7 @@ func testConnectionMultiplexing(ctx context.Context, t *testing.T, member etcdPr
 			}
 			t.Run(tname, func(t *testing.T) {
 				assert.NoError(t, fetchGrpcGateway(httpEndpoint, httpVersion, connType))
-				assert.NoError(t, fetchMetrics(httpEndpoint, httpVersion, connType))
+				assert.NoError(t, fetchMetrics(t, httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchVersion(httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchHealth(httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchDebugVars(httpEndpoint, httpVersion, connType))
@@ -187,12 +189,21 @@ func validateGrpcgatewayRangeReponse(respData []byte) error {
 	return json.Unmarshal(respData, &resp)
 }
 
-func fetchMetrics(endpoint string, httpVersion string, connType clientConnType) error {
-	req := cURLReq{endpoint: "/metrics", timeout: 5, httpVersion: httpVersion}
-	respData, err := curl(endpoint, "GET", req, connType)
-	if err != nil {
+func fetchMetrics(t *testing.T, endpoint string, httpVersion string, connType clientConnType) error {
+	tmpDir := t.TempDir()
+	metricFile := filepath.Join(tmpDir, "metrics")
+
+	req := cURLReq{endpoint: "/metrics", timeout: 5, httpVersion: httpVersion, OutputFile: metricFile}
+	if _, err := curl(endpoint, "GET", req, connType); err != nil {
 		return err
 	}
+
+	rawData, err := os.ReadFile(metricFile)
+	if err != nil {
+		return fmt.Errorf("failed to read the metric: %w", err)
+	}
+	respData := string(rawData)
+
 	var parser expfmt.TextParser
 	_, err = parser.TextToMetricFamilies(strings.NewReader(strings.ReplaceAll(respData, "\r\n", "\n")))
 	return err

--- a/tests/e2e/v2_curl_test.go
+++ b/tests/e2e/v2_curl_test.go
@@ -131,6 +131,8 @@ type cURLReq struct {
 
 	ciphers     string
 	httpVersion string
+
+	OutputFile string
 }
 
 // cURLPrefixArgsCluster builds the beginning of a curl command for a given key
@@ -183,6 +185,10 @@ func cURLPrefixArgs(clientURL string, connType clientConnType, CN bool, method s
 
 	if req.ciphers != "" {
 		cmdArgs = append(cmdArgs, "--ciphers", req.ciphers)
+	}
+
+	if req.OutputFile != "" {
+		cmdArgs = append(cmdArgs, "--output", req.OutputFile)
 	}
 
 	switch method {


### PR DESCRIPTION
Our `arm64` e2e nightly tests have failed for six days in a row for the `release-3.5` branch, so I am looking into that, refer: https://github.com/etcd-io/etcd/actions/workflows/e2e-arm64-nightly.yaml  

While investigating I noticed we haven't backported the great work @fuweid did in https://github.com/etcd-io/etcd/pull/16439 so in 3.5 the logs are still full of spam and have to be downloaded to see issues.

Let's backport the metrics redirection to make life easier.