### PR TITLE
fix:Ensure that go version is only defined in one file for release-3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.20.8
+GO_VERSION ?= $(shell cat .go-version)
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)


### PR DESCRIPTION
Ensure that we can update the Golang patch version for release-3.5 by only updating a single file.
#16560 