### PR TITLE
[3.5] Backport removing obsolete http 1.0 version for cmux tests

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -132,7 +132,7 @@ func testConnectionMultiplexing(ctx context.Context, t *testing.T, member etcdPr
 		assert.NoError(t, err)
 	})
 	t.Run("curl", func(t *testing.T) {
-		for _, httpVersion := range []string{"2", "1.1", "1.0", ""} {
+		for _, httpVersion := range []string{"2", "1.1", ""} {
 			tname := "http" + httpVersion
 			if httpVersion == "" {
 				tname = "default"


### PR DESCRIPTION
Our nightly `arm64` e2e tests have been failing this week ever since we adopted Debian 12 in https://github.com/etcd-io/etcd/pull/16516.

As mentioned in https://github.com/etcd-io/etcd/pull/16513#issuecomment-1702385175 http 1.0 is no longer supported in Debian 12.  We've removed this version from `TestConnectionMultiplexing` already in `main`.

This pull request backports the change to `release-3.5` so our nightly `arm64` e2e tests that run in a Debian 12 container on our self hosted runners will return to green.