### PR TITLE
test: simply the expected output for some curl test cases

### DIFF
--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -121,7 +121,7 @@ func testCurlV3Auth(cx ctlCtx) {
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/kv/put",
 			Value:    string(putreq),
-			Expected: expect.ExpectedResponse{Value: "error"},
+			Expected: expect.ExpectedResponse{Value: "etcdserver: user name is empty"},
 		}); err != nil {
 			cx.t.Fatalf("testCurlV3Auth failed to put without token (%v)", err)
 		}

--- a/tests/e2e/v3_curl_election_test.go
+++ b/tests/e2e/v3_curl_election_test.go
@@ -124,7 +124,7 @@ func testCurlV3ProclaimMissiongLeaderKey(cx ctlCtx) {
 	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/election/proclaim",
 		Value:    string(pdata),
-		Expected: expect.ExpectedResponse{Value: `{"error":"\"leader\" field must be provided","code":2,"message":"\"leader\" field must be provided"}`},
+		Expected: expect.ExpectedResponse{Value: `"message":"\"leader\" field must be provided"`},
 	}); err != nil {
 		cx.t.Fatalf("failed post proclaim request (%v)", err)
 	}
@@ -138,7 +138,7 @@ func testCurlV3ResignMissiongLeaderKey(cx ctlCtx) {
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/election/resign",
 		Value:    `{}`,
-		Expected: expect.ExpectedResponse{Value: `{"error":"\"leader\" field must be provided","code":2,"message":"\"leader\" field must be provided"}`},
+		Expected: expect.ExpectedResponse{Value: `"message":"\"leader\" field must be provided"`},
 	}); err != nil {
 		cx.t.Fatalf("failed post resign request (%v)", err)
 	}


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/16454

Random spaces may be inserted between fields in a marshalled json response in grpc-gateway v2, so simply the expected output to make it work for both v1 and v2.