### PR TITLE
transport: separate implied client certificate usage with trusted ca

### DIFF
--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -511,7 +511,7 @@ func (info TLSInfo) ServerConfig() (*tls.Config, error) {
 	}
 
 	cfg.ClientAuth = tls.NoClientCert
-	if info.TrustedCAFile != "" || info.ClientCertAuth {
+	if info.ClientCertAuth {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -276,6 +276,7 @@ func testNewListenerTLSInfoClientCheck(t *testing.T, skipClientSANVerify, goodCl
 
 	tlsInfo.SkipClientSANVerify = skipClientSANVerify
 	tlsInfo.TrustedCAFile = clientTLSInfo.CertFile
+	tlsInfo.ClientCertAuth = true
 
 	rootCAs := x509.NewCertPool()
 	loaded, err := os.ReadFile(tlsInfo.CertFile)


### PR DESCRIPTION
The `--trusted-ca-file` flag currently implies using client certificates. However, this is undocumented behavior and adding a CA may has led to some users unexpectedly having client cert auth enabled.

This pr revives https://github.com/etcd-io/etcd/pull/11703 to make `--client-cert-auth` a more explicit boolean flag and is intended to address https://github.com/etcd-io/etcd/issues/11124.

An alternative approach would be to update our documentation to make it clear the two flags are actually coupled.

