### PR TITLE
Use any instead of interface{}

### DIFF
--- a/client/internal/v2/client.go
+++ b/client/internal/v2/client.go
@@ -41,7 +41,7 @@ var (
 
 	// oneShotCtxValue is set on a context using WithValue(&oneShotValue) so
 	// that Do() will not retry a request
-	oneShotCtxValue interface{}
+	oneShotCtxValue any
 )
 
 var DefaultRequestTimeout = 5 * time.Second

--- a/client/internal/v2/client_test.go
+++ b/client/internal/v2/client_test.go
@@ -496,8 +496,8 @@ func (f fakeCancelContext) Done() <-chan struct{} {
 	d <- struct{}{}
 	return d
 }
-func (f fakeCancelContext) Err() error                        { return errFakeCancelContext }
-func (f fakeCancelContext) Value(key interface{}) interface{} { return 1 }
+func (f fakeCancelContext) Err() error        { return errFakeCancelContext }
+func (f fakeCancelContext) Value(key any) any { return 1 }
 
 func withTimeout(parent context.Context, timeout time.Duration) (
 	ctx context.Context,

--- a/client/pkg/testutil/assert.go
+++ b/client/pkg/testutil/assert.go
@@ -21,20 +21,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func copyToInterface(msg ...string) []interface{} {
-	newMsg := make([]interface{}, len(msg))
+func copyToInterface(msg ...string) []any {
+	newMsg := make([]any, len(msg))
 	for i, v := range msg {
 		newMsg[i] = v
 	}
 	return newMsg
 }
 
-func AssertNil(t *testing.T, v interface{}) {
+func AssertNil(t *testing.T, v any) {
 	t.Helper()
 	assert.Nil(t, v)
 }
 
-func AssertNotNil(t *testing.T, v interface{}) {
+func AssertNotNil(t *testing.T, v any) {
 	t.Helper()
 	if v == nil {
 		t.Fatalf("expected non-nil, got %+v", v)
@@ -53,7 +53,7 @@ func AssertFalse(t *testing.T, v bool, msg ...string) {
 	assert.Equal(t, false, v, newMsg)
 }
 
-func isNil(v interface{}) bool {
+func isNil(v any) bool {
 	if v == nil {
 		return true
 	}

--- a/client/pkg/testutil/recorder.go
+++ b/client/pkg/testutil/recorder.go
@@ -23,7 +23,7 @@ import (
 
 type Action struct {
 	Name   string
-	Params []interface{}
+	Params []any
 }
 
 type Recorder interface {

--- a/client/pkg/testutil/testingtb.go
+++ b/client/pkg/testutil/testingtb.go
@@ -23,18 +23,18 @@ import (
 // We cannot implement testing.TB due to protection, so we expose this simplified interface.
 type TB interface {
 	Cleanup(func())
-	Error(args ...interface{})
-	Errorf(format string, args ...interface{})
+	Error(args ...any)
+	Errorf(format string, args ...any)
 	Fail()
 	FailNow()
 	Failed() bool
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
 	Name() string
 	TempDir() string
 	Helper()
-	Skip(args ...interface{})
+	Skip(args ...any)
 }
 
 // NewTestingTBProthesis creates a fake variant of testing.TB implementation.
@@ -59,20 +59,20 @@ func (t *testingTBProthesis) Helper() {
 	// Ignored
 }
 
-func (t *testingTBProthesis) Skip(args ...interface{}) {
-	t.Log(append([]interface{}{"Skipping due to: "}, args...))
+func (t *testingTBProthesis) Skip(args ...any) {
+	t.Log(append([]any{"Skipping due to: "}, args...))
 }
 
 func (t *testingTBProthesis) Cleanup(f func()) {
 	t.cleanups = append(t.cleanups, f)
 }
 
-func (t *testingTBProthesis) Error(args ...interface{}) {
+func (t *testingTBProthesis) Error(args ...any) {
 	log.Println(args...)
 	t.Fail()
 }
 
-func (t *testingTBProthesis) Errorf(format string, args ...interface{}) {
+func (t *testingTBProthesis) Errorf(format string, args ...any) {
 	log.Printf(format, args...)
 	t.Fail()
 }
@@ -90,19 +90,19 @@ func (t *testingTBProthesis) Failed() bool {
 	return t.failed
 }
 
-func (t *testingTBProthesis) Fatal(args ...interface{}) {
+func (t *testingTBProthesis) Fatal(args ...any) {
 	log.Fatalln(args...)
 }
 
-func (t *testingTBProthesis) Fatalf(format string, args ...interface{}) {
+func (t *testingTBProthesis) Fatalf(format string, args ...any) {
 	log.Fatalf(format, args...)
 }
 
-func (t *testingTBProthesis) Logf(format string, args ...interface{}) {
+func (t *testingTBProthesis) Logf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (t *testingTBProthesis) Log(args ...interface{}) {
+func (t *testingTBProthesis) Log(args ...any) {
 	log.Println(args...)
 }
 

--- a/client/pkg/verify/verify.go
+++ b/client/pkg/verify/verify.go
@@ -73,7 +73,7 @@ func Verify(f func()) {
 }
 
 // Assert will panic with a given formatted message if the given condition is false.
-func Assert(condition bool, msg string, v ...interface{}) {
+func Assert(condition bool, msg string, v ...any) {
 	if !condition {
 		panic(fmt.Sprintf("assertion failed: "+msg, v...))
 	}

--- a/client/v3/compare.go
+++ b/client/v3/compare.go
@@ -30,7 +30,7 @@ const (
 
 type Cmp pb.Compare
 
-func Compare(cmp Cmp, result string, v interface{}) Cmp {
+func Compare(cmp Cmp, result string, v any) Cmp {
 	var r pb.Compare_CompareResult
 
 	switch result {
@@ -120,7 +120,7 @@ func (cmp Cmp) WithPrefix() Cmp {
 }
 
 // mustInt64 panics if val isn't an int or int64. It returns an int64 otherwise.
-func mustInt64(val interface{}) int64 {
+func mustInt64(val any) int64 {
 	if v, ok := val.(int64); ok {
 		return v
 	}
@@ -132,7 +132,7 @@ func mustInt64(val interface{}) int64 {
 
 // mustInt64orLeaseID panics if val isn't a LeaseID, int or int64. It returns an
 // int64 otherwise.
-func mustInt64orLeaseID(val interface{}) int64 {
+func mustInt64orLeaseID(val any) int64 {
 	if v, ok := val.(LeaseID); ok {
 		return int64(v)
 	}

--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -32,7 +32,7 @@ type Endpoint struct {
 	// Metadata is the information associated with Addr, which may be used
 	// to make load balancing decision.
 	// Since etcd 3.1
-	Metadata interface{}
+	Metadata any
 }
 
 type Operation uint8

--- a/client/v3/naming/endpoints/internal/update.go
+++ b/client/v3/naming/endpoints/internal/update.go
@@ -48,5 +48,5 @@ type Update struct {
 	// Metadata is the updated metadata. It is nil if there is no metadata update.
 	// Metadata is not required for a custom naming implementation.
 	// Since etcd 3.1.
-	Metadata interface{}
+	Metadata any
 }

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -92,7 +92,7 @@ func NewPrinter(printerType string, isHex bool) printer {
 
 type printerRPC struct {
 	printer
-	p func(interface{})
+	p func(any)
 }
 
 func (p *printerRPC) Del(r v3.DeleteResponse)  { p.p((*pb.DeleteRangeResponse)(&r)) }
@@ -159,7 +159,7 @@ func (p *printerRPC) AuthStatus(r v3.AuthStatusResponse) {
 type printerUnsupported struct{ printerRPC }
 
 func newPrinterUnsupported(n string) printer {
-	f := func(interface{}) {
+	f := func(any) {
 		cobrautl.ExitWithError(cobrautl.ExitBadFeature, errors.New(n+" not supported as output format"))
 	}
 	return &printerUnsupported{printerRPC{nil, f}}

--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -48,7 +48,7 @@ func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse) {
 	}
 }
 
-func printJSON(v interface{}) {
+func printJSON(v any) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/etcdctl/ctlv3/command/printer_protobuf.go
+++ b/etcdctl/ctlv3/command/printer_protobuf.go
@@ -51,7 +51,7 @@ func (p *pbPrinter) Watch(r v3.WatchResponse) {
 	printPB(&wr)
 }
 
-func printPB(v interface{}) {
+func printPB(v any) {
 	m, ok := v.(pbMarshal)
 	if !ok {
 		cobrautl.ExitWithError(cobrautl.ExitBadFeature, fmt.Errorf("marshal unsupported for type %T (%v)", v, v))

--- a/etcdutl/etcdutl/printer.go
+++ b/etcdutl/etcdutl/printer.go
@@ -52,13 +52,13 @@ func NewPrinter(printerType string) printer {
 
 type printerRPC struct {
 	printer
-	p func(interface{})
+	p func(any)
 }
 
 type printerUnsupported struct{ printerRPC }
 
 func newPrinterUnsupported(n string) printer {
-	f := func(interface{}) {
+	f := func(any) {
 		cobrautl.ExitWithError(cobrautl.ExitBadFeature, errors.New(n+" not supported as output format"))
 	}
 	return &printerUnsupported{printerRPC{nil, f}}

--- a/etcdutl/etcdutl/printer_json.go
+++ b/etcdutl/etcdutl/printer_json.go
@@ -35,7 +35,7 @@ func newJSONPrinter() printer {
 func (p *jsonPrinter) DBStatus(r snapshot.Status) { printJSON(r) }
 
 // !!! Share ??
-func printJSON(v interface{}) {
+func printJSON(v any) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/etcdutl/etcdutl/printer_protobuf.go
+++ b/etcdutl/etcdutl/printer_protobuf.go
@@ -33,7 +33,7 @@ func newPBPrinter() printer {
 	}
 }
 
-func printPB(v interface{}) {
+func printPB(v any) {
 	m, ok := v.(pbMarshal)
 	if !ok {
 		cobrautl.ExitWithError(cobrautl.ExitBadFeature, fmt.Errorf("marshal unsupported for type %T (%v)", v, v))

--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -176,7 +176,7 @@ func (x *intervalNode) visit(iv *Interval, sentinel *intervalNode, nv nodeVisito
 // IntervalValue represents a range tree node that contains a range and a value.
 type IntervalValue struct {
 	Ivl Interval
-	Val interface{}
+	Val any
 }
 
 // IntervalTree represents a (mostly) textbook implementation of the
@@ -184,7 +184,7 @@ type IntervalValue struct {
 // and chapter 14.3 interval tree with search supporting "stabbing queries".
 type IntervalTree interface {
 	// Insert adds a node with the given interval into the tree.
-	Insert(ivl Interval, val interface{})
+	Insert(ivl Interval, val any)
 	// Delete removes the node with the given interval from the tree, returning
 	// true if a node is in fact removed.
 	Delete(ivl Interval) bool
@@ -423,7 +423,7 @@ func (ivt *intervalTree) deleteFixup(x *intervalNode) {
 	}
 }
 
-func (ivt *intervalTree) createIntervalNode(ivl Interval, val interface{}) *intervalNode {
+func (ivt *intervalTree) createIntervalNode(ivl Interval, val any) *intervalNode {
 	return &intervalNode{
 		iv:     IntervalValue{ivl, val},
 		max:    ivl.End,
@@ -466,7 +466,7 @@ func (ivt *intervalTree) createIntervalNode(ivl Interval, val interface{}) *inte
 //	 RB-INSERT-FIXUP(T, z)
 
 // Insert adds a node with the given interval into the tree.
-func (ivt *intervalTree) Insert(ivl Interval, val interface{}) {
+func (ivt *intervalTree) Insert(ivl Interval, val any) {
 	y := ivt.sentinel
 	z := ivt.createIntervalNode(ivl, val)
 	x := ivt.root

--- a/pkg/grpc_testing/recorder.go
+++ b/pkg/grpc_testing/recorder.go
@@ -33,7 +33,7 @@ type RequestInfo struct {
 }
 
 func (ri *GrpcRecorder) UnaryInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		ri.record(toRequestInfo(ctx, info))
 		resp, err := handler(ctx, req)
 		return resp, err

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -33,7 +33,7 @@ const (
 // Field is a kv pair to record additional details of the trace.
 type Field struct {
 	Key   string
-	Value interface{}
+	Value any
 }
 
 func (f *Field) format() string {

--- a/server/auth/jwt.go
+++ b/server/auth/jwt.go
@@ -29,7 +29,7 @@ import (
 type tokenJWT struct {
 	lg         *zap.Logger
 	signMethod jwt.SigningMethod
-	key        interface{}
+	key        any
 	ttl        time.Duration
 	verifyOnly bool
 }
@@ -46,7 +46,7 @@ func (t *tokenJWT) info(ctx context.Context, token string, rev uint64) (*AuthInf
 		revision float64
 	)
 
-	parsed, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+	parsed, err := jwt.Parse(token, func(token *jwt.Token) (any, error) {
 		if token.Method.Alg() != t.signMethod.Alg() {
 			return nil, errors.New("invalid signing method")
 		}

--- a/server/auth/options.go
+++ b/server/auth/options.go
@@ -96,7 +96,7 @@ func (opts *jwtOptions) Parse(optMap map[string]string) error {
 }
 
 // Key will parse and return the appropriately typed key for the selected signature method
-func (opts *jwtOptions) Key() (interface{}, error) {
+func (opts *jwtOptions) Key() (any, error) {
 	switch opts.SignMethod.(type) {
 	case *jwt.SigningMethodRSA, *jwt.SigningMethodRSAPSS:
 		return opts.rsaKey()
@@ -111,14 +111,14 @@ func (opts *jwtOptions) Key() (interface{}, error) {
 	}
 }
 
-func (opts *jwtOptions) hmacKey() (interface{}, error) {
+func (opts *jwtOptions) hmacKey() (any, error) {
 	if len(opts.PrivateKey) == 0 {
 		return nil, ErrMissingKey
 	}
 	return opts.PrivateKey, nil
 }
 
-func (opts *jwtOptions) rsaKey() (interface{}, error) {
+func (opts *jwtOptions) rsaKey() (any, error) {
 	var (
 		priv *rsa.PrivateKey
 		pub  *rsa.PublicKey
@@ -156,7 +156,7 @@ func (opts *jwtOptions) rsaKey() (interface{}, error) {
 	return priv, nil
 }
 
-func (opts *jwtOptions) ecKey() (interface{}, error) {
+func (opts *jwtOptions) ecKey() (any, error) {
 	var (
 		priv *ecdsa.PrivateKey
 		pub  *ecdsa.PublicKey
@@ -194,7 +194,7 @@ func (opts *jwtOptions) ecKey() (interface{}, error) {
 	return priv, nil
 }
 
-func (opts *jwtOptions) edKey() (interface{}, error) {
+func (opts *jwtOptions) edKey() (any, error) {
 	var (
 		priv ed25519.PrivateKey
 		pub  ed25519.PublicKey

--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -336,11 +336,11 @@ type wsProxyZapLogger struct {
 	*zap.Logger
 }
 
-func (w wsProxyZapLogger) Warnln(i ...interface{}) {
+func (w wsProxyZapLogger) Warnln(i ...any) {
 	w.Warn(fmt.Sprint(i...))
 }
 
-func (w wsProxyZapLogger) Debugln(i ...interface{}) {
+func (w wsProxyZapLogger) Debugln(i ...any) {
 	w.Debug(fmt.Sprint(i...))
 }
 

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -448,7 +448,7 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 	electionp := grpcproxy.NewElectionProxy(client)
 	lockp := grpcproxy.NewLockProxy(client)
 
-	alwaysLoggingDeciderServer := func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }
+	alwaysLoggingDeciderServer := func(ctx context.Context, fullMethodName string, servingObject any) bool { return true }
 
 	grpcChainStreamList := []grpc.StreamServerInterceptor{
 		grpc_prometheus.StreamServerInterceptor,

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -523,7 +523,7 @@ func TestClusterAddMember(t *testing.T) {
 	wactions := []testutil.Action{
 		{
 			Name: "Create",
-			Params: []interface{}{
+			Params: []any{
 				path.Join(StoreMembersPrefix, "1", "raftAttributes"),
 				false,
 				`{"peerURLs":null}`,
@@ -546,7 +546,7 @@ func TestClusterAddMemberAsLearner(t *testing.T) {
 	wactions := []testutil.Action{
 		{
 			Name: "Create",
-			Params: []interface{}{
+			Params: []any{
 				path.Join(StoreMembersPrefix, "1", "raftAttributes"),
 				false,
 				`{"peerURLs":null,"isLearner":true}`,
@@ -587,8 +587,8 @@ func TestClusterRemoveMember(t *testing.T) {
 	c.RemoveMember(1, true)
 
 	wactions := []testutil.Action{
-		{Name: "Delete", Params: []interface{}{MemberStoreKey(1), true, true}},
-		{Name: "Create", Params: []interface{}{RemovedMemberStoreKey(1), false, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent}}},
+		{Name: "Delete", Params: []any{MemberStoreKey(1), true, true}},
+		{Name: "Create", Params: []any{RemovedMemberStoreKey(1), false, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent}}},
 	}
 	if !reflect.DeepEqual(st.Action(), wactions) {
 		t.Errorf("actions = %v, want %v", st.Action(), wactions)

--- a/server/etcdserver/api/rafthttp/pipeline_test.go
+++ b/server/etcdserver/api/rafthttp/pipeline_test.go
@@ -276,7 +276,7 @@ func (t *respRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.rec != nil {
-		t.rec.Record(testutil.Action{Name: "req", Params: []interface{}{req}})
+		t.rec.Record(testutil.Action{Name: "req", Params: []any{req}})
 	}
 	return &http.Response{StatusCode: t.code, Header: t.header, Body: &nopReadCloser{}}, t.err
 }
@@ -287,7 +287,7 @@ type roundTripperRecorder struct {
 
 func (t *roundTripperRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.rec != nil {
-		t.rec.Record(testutil.Action{Name: "req", Params: []interface{}{req}})
+		t.rec.Record(testutil.Action{Name: "req", Params: []any{req}})
 	}
 	return &http.Response{StatusCode: http.StatusNoContent, Body: &nopReadCloser{}}, nil
 }

--- a/server/etcdserver/api/v2store/store_bench_test.go
+++ b/server/etcdserver/api/v2store/store_bench_test.go
@@ -174,7 +174,7 @@ func BenchmarkWatchOneKey(b *testing.B) {
 	}
 }
 
-func benchStoreSet(b *testing.B, valueSize int, process func(interface{}) ([]byte, error)) {
+func benchStoreSet(b *testing.B, valueSize int, process func(any) ([]byte, error)) {
 	s := newStore()
 	b.StopTimer()
 	kvs, size := generateNRandomKV(b.N, valueSize)

--- a/server/etcdserver/api/v2store/ttl_key_heap.go
+++ b/server/etcdserver/api/v2store/ttl_key_heap.go
@@ -45,13 +45,13 @@ func (h ttlKeyHeap) Swap(i, j int) {
 	h.keyMap[h.array[j]] = j
 }
 
-func (h *ttlKeyHeap) Push(x interface{}) {
+func (h *ttlKeyHeap) Push(x any) {
 	n, _ := x.(*node)
 	h.keyMap[n] = len(h.array)
 	h.array = append(h.array, n)
 }
 
-func (h *ttlKeyHeap) Pop() interface{} {
+func (h *ttlKeyHeap) Pop() any {
 	old := h.array
 	n := len(old)
 	x := old[n-1]
@@ -77,7 +77,7 @@ func (h *ttlKeyHeap) pop() *node {
 	return n
 }
 
-func (h *ttlKeyHeap) push(x interface{}) {
+func (h *ttlKeyHeap) push(x any) {
 	heap.Push(h, x)
 }
 

--- a/server/etcdserver/api/v3compactor/compactor_test.go
+++ b/server/etcdserver/api/v3compactor/compactor_test.go
@@ -27,7 +27,7 @@ type fakeCompactable struct {
 }
 
 func (fc *fakeCompactable) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
-	fc.Record(testutil.Action{Name: "c", Params: []interface{}{r}})
+	fc.Record(testutil.Action{Name: "c", Params: []any{r}})
 	return &pb.CompactionResponse{}, nil
 }
 

--- a/server/etcdserver/api/v3rpc/codec.go
+++ b/server/etcdserver/api/v3rpc/codec.go
@@ -18,13 +18,13 @@ import "github.com/golang/protobuf/proto"
 
 type codec struct{}
 
-func (c *codec) Marshal(v interface{}) ([]byte, error) {
+func (c *codec) Marshal(v any) ([]byte, error) {
 	b, err := proto.Marshal(v.(proto.Message))
 	sentBytes.Add(float64(len(b)))
 	return b, err
 }
 
-func (c *codec) Unmarshal(data []byte, v interface{}) error {
+func (c *codec) Unmarshal(data []byte, v any) error {
 	receivedBytes.Add(float64(len(data)))
 	return proto.Unmarshal(data, v.(proto.Message))
 }

--- a/server/etcdserver/api/v3rpc/interceptor.go
+++ b/server/etcdserver/api/v3rpc/interceptor.go
@@ -45,7 +45,7 @@ type streamsMap struct {
 }
 
 func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if !api.IsCapabilityEnabled(api.V3rpcCapability) {
 			return nil, rpctypes.ErrGRPCNotCapable
 		}
@@ -77,7 +77,7 @@ func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 }
 
 func newLogUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		startTime := time.Now()
 		resp, err := handler(ctx, req)
 		lg := s.Logger()
@@ -88,7 +88,7 @@ func newLogUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerIntercepto
 	}
 }
 
-func logUnaryRequestStats(ctx context.Context, lg *zap.Logger, warnLatency time.Duration, info *grpc.UnaryServerInfo, startTime time.Time, req interface{}, resp interface{}) {
+func logUnaryRequestStats(ctx context.Context, lg *zap.Logger, warnLatency time.Duration, info *grpc.UnaryServerInfo, startTime time.Time, req any, resp any) {
 	duration := time.Since(startTime)
 	var enabledDebugLevel, expensiveRequest bool
 	if lg.Core().Enabled(zap.DebugLevel) {
@@ -214,7 +214,7 @@ func logExpensiveRequestStats(lg *zap.Logger, startTime time.Time, duration time
 func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor {
 	smap := monitorLeader(s)
 
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !api.IsCapabilityEnabled(api.V3rpcCapability) {
 			return rpctypes.ErrGRPCNotCapable
 		}

--- a/server/etcdserver/api/v3rpc/quota.go
+++ b/server/etcdserver/api/v3rpc/quota.go
@@ -37,7 +37,7 @@ type quotaAlarmer struct {
 
 // check whether request satisfies the quota. If there is not enough space,
 // ignore request and raise the free space alarm.
-func (qa *quotaAlarmer) check(ctx context.Context, r interface{}) error {
+func (qa *quotaAlarmer) check(ctx context.Context, r any) error {
 	if qa.q.Available(r) {
 		return nil
 	}

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -138,7 +138,7 @@ func isClientCtxErr(ctxErr error, err error) bool {
 }
 
 // in v3.4, learner is allowed to serve serializable read and endpoint status
-func isRPCSupportedForLearner(req interface{}) bool {
+func isRPCSupportedForLearner(req any) bool {
 	switch r := req.(type) {
 	case *pb.StatusRequest:
 		return true

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -53,7 +53,7 @@ var (
 )
 
 func init() {
-	expvar.Publish("raft.status", expvar.Func(func() interface{} {
+	expvar.Publish("raft.status", expvar.Func(func() any {
 		raftStatusMu.Lock()
 		defer raftStatusMu.Unlock()
 		if raftStatus == nil {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -122,7 +122,7 @@ func init() {
 	expvar.Publish(
 		"file_descriptor_limit",
 		expvar.Func(
-			func() interface{} {
+			func() any {
 				n, _ := runtime.FDLimit()
 				return n
 			},

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -83,7 +83,7 @@ func TestDoLocalAction(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Get",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -93,7 +93,7 @@ func TestDoLocalAction(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Get",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -143,7 +143,7 @@ func TestDoBadLocalAction(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Get",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -152,7 +152,7 @@ func TestDoBadLocalAction(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Get",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -261,7 +261,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Create",
-					Params: []interface{}{"", false, "", true, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", false, "", true, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -272,7 +272,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Create",
-					Params: []interface{}{"", false, "", true, v2store.TTLOptionSet{ExpireTime: time.Unix(0, 1337)}},
+					Params: []any{"", false, "", true, v2store.TTLOptionSet{ExpireTime: time.Unix(0, 1337)}},
 				},
 			},
 		},
@@ -283,7 +283,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Create",
-					Params: []interface{}{"", true, "", true, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", true, "", true, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -294,7 +294,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Set",
-					Params: []interface{}{"", false, "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", false, "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -305,7 +305,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Set",
-					Params: []interface{}{"", true, "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", true, "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -316,7 +316,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Update",
-					Params: []interface{}{"", "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -327,7 +327,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Create",
-					Params: []interface{}{"", false, "", false, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", false, "", false, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -338,7 +338,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndSwap",
-					Params: []interface{}{"", "", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", "", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -349,7 +349,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Create",
-					Params: []interface{}{"", false, "", false, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", false, "", false, v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -360,7 +360,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndSwap",
-					Params: []interface{}{"", "", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", "", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -371,7 +371,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndSwap",
-					Params: []interface{}{"", "bar", uint64(0), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", "bar", uint64(0), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -382,7 +382,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndSwap",
-					Params: []interface{}{"", "bar", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
+					Params: []any{"", "bar", uint64(1), "", v2store.TTLOptionSet{ExpireTime: time.Time{}}},
 				},
 			},
 		},
@@ -393,7 +393,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Delete",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -404,7 +404,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndDelete",
-					Params: []interface{}{"", "", uint64(1)},
+					Params: []any{"", "", uint64(1)},
 				},
 			},
 		},
@@ -415,7 +415,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndDelete",
-					Params: []interface{}{"", "bar", uint64(0)},
+					Params: []any{"", "bar", uint64(0)},
 				},
 			},
 		},
@@ -426,7 +426,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "CompareAndDelete",
-					Params: []interface{}{"", "bar", uint64(5)},
+					Params: []any{"", "bar", uint64(5)},
 				},
 			},
 		},
@@ -437,7 +437,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "Get",
-					Params: []interface{}{"", false, false},
+					Params: []any{"", false, false},
 				},
 			},
 		},
@@ -448,7 +448,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "DeleteExpiredKeys",
-					Params: []interface{}{time.Unix(0, 0)},
+					Params: []any{time.Unix(0, 0)},
 				},
 			},
 		},
@@ -458,7 +458,7 @@ func TestApplyRequest(t *testing.T) {
 			[]testutil.Action{
 				{
 					Name:   "DeleteExpiredKeys",
-					Params: []interface{}{time.Unix(0, 12345)},
+					Params: []any{time.Unix(0, 12345)},
 				},
 			},
 		},
@@ -592,7 +592,7 @@ func TestApplyConfChangeError(t *testing.T) {
 		w := []testutil.Action{
 			{
 				Name:   "ApplyConfChange",
-				Params: []interface{}{cc},
+				Params: []any{cc},
 			},
 		}
 		if g, _ := n.Wait(1); !reflect.DeepEqual(g, w) {
@@ -1479,7 +1479,7 @@ func TestUpdateMember(t *testing.T) {
 
 func TestPublishV3(t *testing.T) {
 	n := newNodeRecorder()
-	ch := make(chan interface{}, 1)
+	ch := make(chan any, 1)
 	// simulate that request has gone through consensus
 	ch <- &apply2.Result{}
 	w := wait.NewWithResponse(ch)
@@ -1600,7 +1600,7 @@ func TestPublishV3Retry(t *testing.T) {
 
 func TestUpdateVersion(t *testing.T) {
 	n := newNodeRecorder()
-	ch := make(chan interface{}, 1)
+	ch := make(chan any, 1)
 	// simulate that request has gone through consensus
 	ch <- Response{}
 	w := wait.NewWithResponse(ch)
@@ -1647,7 +1647,7 @@ func TestUpdateVersion(t *testing.T) {
 
 func TestUpdateVersionV3(t *testing.T) {
 	n := newNodeRecorder()
-	ch := make(chan interface{}, 1)
+	ch := make(chan any, 1)
 	// simulate that request has gone through consensus
 	ch <- &apply2.Result{}
 	w := wait.NewWithResponse(ch)
@@ -1766,7 +1766,7 @@ func (n *nodeRecorder) Campaign(ctx context.Context) error {
 	return nil
 }
 func (n *nodeRecorder) Propose(ctx context.Context, data []byte) error {
-	n.Record(testutil.Action{Name: "Propose", Params: []interface{}{data}})
+	n.Record(testutil.Action{Name: "Propose", Params: []any{data}})
 	return nil
 }
 func (n *nodeRecorder) ProposeConfChange(ctx context.Context, conf raftpb.ConfChangeI) error {
@@ -1783,7 +1783,7 @@ func (n *nodeRecorder) TransferLeadership(ctx context.Context, lead, transferee 
 func (n *nodeRecorder) ReadIndex(ctx context.Context, rctx []byte) error                { return nil }
 func (n *nodeRecorder) Advance()                                                        {}
 func (n *nodeRecorder) ApplyConfChange(conf raftpb.ConfChangeI) *raftpb.ConfState {
-	n.Record(testutil.Action{Name: "ApplyConfChange", Params: []interface{}{conf}})
+	n.Record(testutil.Action{Name: "ApplyConfChange", Params: []any{conf}})
 	return &raftpb.ConfState{}
 }
 

--- a/server/etcdserver/version/downgrade_test.go
+++ b/server/etcdserver/version/downgrade_test.go
@@ -80,7 +80,7 @@ func TestMustDetectDowngrade(t *testing.T) {
 	}
 }
 
-func tryMustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) (err interface{}) {
+func tryMustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) (err any) {
 	defer func() {
 		err = recover()
 	}()

--- a/server/etcdserver/zap_raft.go
+++ b/server/etcdserver/zap_raft.go
@@ -54,50 +54,50 @@ type zapRaftLogger struct {
 	sugar *zap.SugaredLogger
 }
 
-func (zl *zapRaftLogger) Debug(args ...interface{}) {
+func (zl *zapRaftLogger) Debug(args ...any) {
 	zl.sugar.Debug(args...)
 }
 
-func (zl *zapRaftLogger) Debugf(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Debugf(format string, args ...any) {
 	zl.sugar.Debugf(format, args...)
 }
 
-func (zl *zapRaftLogger) Error(args ...interface{}) {
+func (zl *zapRaftLogger) Error(args ...any) {
 	zl.sugar.Error(args...)
 }
 
-func (zl *zapRaftLogger) Errorf(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Errorf(format string, args ...any) {
 	zl.sugar.Errorf(format, args...)
 }
 
-func (zl *zapRaftLogger) Info(args ...interface{}) {
+func (zl *zapRaftLogger) Info(args ...any) {
 	zl.sugar.Info(args...)
 }
 
-func (zl *zapRaftLogger) Infof(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Infof(format string, args ...any) {
 	zl.sugar.Infof(format, args...)
 }
 
-func (zl *zapRaftLogger) Warning(args ...interface{}) {
+func (zl *zapRaftLogger) Warning(args ...any) {
 	zl.sugar.Warn(args...)
 }
 
-func (zl *zapRaftLogger) Warningf(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Warningf(format string, args ...any) {
 	zl.sugar.Warnf(format, args...)
 }
 
-func (zl *zapRaftLogger) Fatal(args ...interface{}) {
+func (zl *zapRaftLogger) Fatal(args ...any) {
 	zl.sugar.Fatal(args...)
 }
 
-func (zl *zapRaftLogger) Fatalf(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Fatalf(format string, args ...any) {
 	zl.sugar.Fatalf(format, args...)
 }
 
-func (zl *zapRaftLogger) Panic(args ...interface{}) {
+func (zl *zapRaftLogger) Panic(args ...any) {
 	zl.sugar.Panic(args...)
 }
 
-func (zl *zapRaftLogger) Panicf(format string, args ...interface{}) {
+func (zl *zapRaftLogger) Panicf(format string, args ...any) {
 	zl.sugar.Panicf(format, args...)
 }

--- a/server/lease/lease_queue.go
+++ b/server/lease/lease_queue.go
@@ -42,14 +42,14 @@ func (pq LeaseQueue) Swap(i, j int) {
 	pq[j].index = j
 }
 
-func (pq *LeaseQueue) Push(x interface{}) {
+func (pq *LeaseQueue) Push(x any) {
 	n := len(*pq)
 	item := x.(*LeaseWithTime)
 	item.index = n
 	*pq = append(*pq, item)
 }
 
-func (pq *LeaseQueue) Pop() interface{} {
+func (pq *LeaseQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]

--- a/server/mock/mockstore/store_recorder.go
+++ b/server/mock/mockstore/store_recorder.go
@@ -50,49 +50,49 @@ func (s *storeRecorder) Index() uint64 { return 0 }
 func (s *storeRecorder) Get(path string, recursive, sorted bool) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "Get",
-		Params: []interface{}{path, recursive, sorted},
+		Params: []any{path, recursive, sorted},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) Set(path string, dir bool, val string, expireOpts v2store.TTLOptionSet) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "Set",
-		Params: []interface{}{path, dir, val, expireOpts},
+		Params: []any{path, dir, val, expireOpts},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) Update(path, val string, expireOpts v2store.TTLOptionSet) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "Update",
-		Params: []interface{}{path, val, expireOpts},
+		Params: []any{path, val, expireOpts},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) Create(path string, dir bool, val string, uniq bool, expireOpts v2store.TTLOptionSet) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "Create",
-		Params: []interface{}{path, dir, val, uniq, expireOpts},
+		Params: []any{path, dir, val, uniq, expireOpts},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) CompareAndSwap(path, prevVal string, prevIdx uint64, val string, expireOpts v2store.TTLOptionSet) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "CompareAndSwap",
-		Params: []interface{}{path, prevVal, prevIdx, val, expireOpts},
+		Params: []any{path, prevVal, prevIdx, val, expireOpts},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) Delete(path string, dir, recursive bool) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "Delete",
-		Params: []interface{}{path, dir, recursive},
+		Params: []any{path, dir, recursive},
 	})
 	return &v2store.Event{}, nil
 }
 func (s *storeRecorder) CompareAndDelete(path, prevVal string, prevIdx uint64) (*v2store.Event, error) {
 	s.Record(testutil.Action{
 		Name:   "CompareAndDelete",
-		Params: []interface{}{path, prevVal, prevIdx},
+		Params: []any{path, prevVal, prevIdx},
 	})
 	return &v2store.Event{}, nil
 }
@@ -123,7 +123,7 @@ func (s *storeRecorder) JsonStats() []byte { return nil }
 func (s *storeRecorder) DeleteExpiredKeys(cutoff time.Time) {
 	s.Record(testutil.Action{
 		Name:   "DeleteExpiredKeys",
-		Params: []interface{}{cutoff},
+		Params: []any{cutoff},
 	})
 }
 

--- a/server/mock/mockwait/wait_recorder.go
+++ b/server/mock/mockwait/wait_recorder.go
@@ -34,11 +34,11 @@ func NewRecorder() *WaitRecorder {
 }
 func NewNop() wait.Wait { return NewRecorder() }
 
-func (w *waitRecorder) Register(id uint64) <-chan interface{} {
+func (w *waitRecorder) Register(id uint64) <-chan any {
 	w.Record(testutil.Action{Name: "Register"})
 	return nil
 }
-func (w *waitRecorder) Trigger(id uint64, x interface{}) {
+func (w *waitRecorder) Trigger(id uint64, x any) {
 	w.Record(testutil.Action{Name: "Trigger"})
 }
 

--- a/server/proxy/grpcproxy/adapter/chan_stream.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream.go
@@ -96,15 +96,15 @@ func (cs *chanClientStream) CloseSend() error {
 
 // chanStream implements grpc.Stream using channels
 type chanStream struct {
-	recvc  <-chan interface{}
-	sendc  chan<- interface{}
+	recvc  <-chan any
+	sendc  chan<- any
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 func (s *chanStream) Context() context.Context { return s.ctx }
 
-func (s *chanStream) SendMsg(m interface{}) error {
+func (s *chanStream) SendMsg(m any) error {
 	select {
 	case s.sendc <- m:
 		if err, ok := m.(error); ok {
@@ -116,8 +116,8 @@ func (s *chanStream) SendMsg(m interface{}) error {
 	return s.ctx.Err()
 }
 
-func (s *chanStream) RecvMsg(m interface{}) error {
-	v := m.(*interface{})
+func (s *chanStream) RecvMsg(m any) error {
+	v := m.(*any)
 	for {
 		select {
 		case msg, ok := <-s.recvc:
@@ -141,7 +141,7 @@ func (s *chanStream) RecvMsg(m interface{}) error {
 
 func newPipeStream(ctx context.Context, ssHandler func(chanServerStream) error) chanClientStream {
 	// ch1 is buffered so server can send error on close
-	ch1, ch2 := make(chan interface{}, 1), make(chan interface{})
+	ch1, ch2 := make(chan any, 1), make(chan any)
 	headerc, trailerc := make(chan metadata.MD, 1), make(chan metadata.MD, 1)
 
 	cctx, ccancel := context.WithCancel(ctx)

--- a/server/proxy/grpcproxy/adapter/election_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/election_client_adapter.go
@@ -61,7 +61,7 @@ func (s *es2ecClientStream) Send(rr *v3electionpb.LeaderRequest) error {
 	return s.SendMsg(rr)
 }
 func (s *es2ecClientStream) Recv() (*v3electionpb.LeaderResponse, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *es2ecServerStream) Send(rr *v3electionpb.LeaderResponse) error {
 	return s.SendMsg(rr)
 }
 func (s *es2ecServerStream) Recv() (*v3electionpb.LeaderRequest, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}

--- a/server/proxy/grpcproxy/adapter/lease_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/lease_client_adapter.go
@@ -63,7 +63,7 @@ func (s *ls2lcClientStream) Send(rr *pb.LeaseKeepAliveRequest) error {
 	return s.SendMsg(rr)
 }
 func (s *ls2lcClientStream) Recv() (*pb.LeaseKeepAliveResponse, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *ls2lcServerStream) Send(rr *pb.LeaseKeepAliveResponse) error {
 	return s.SendMsg(rr)
 }
 func (s *ls2lcServerStream) Recv() (*pb.LeaseKeepAliveRequest, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}

--- a/server/proxy/grpcproxy/adapter/maintenance_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/maintenance_client_adapter.go
@@ -73,7 +73,7 @@ func (s *ss2scClientStream) Send(rr *pb.SnapshotRequest) error {
 	return s.SendMsg(rr)
 }
 func (s *ss2scClientStream) Recv() (*pb.SnapshotResponse, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *ss2scServerStream) Send(rr *pb.SnapshotResponse) error {
 	return s.SendMsg(rr)
 }
 func (s *ss2scServerStream) Recv() (*pb.SnapshotRequest, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}

--- a/server/proxy/grpcproxy/adapter/watch_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/watch_client_adapter.go
@@ -48,7 +48,7 @@ func (s *ws2wcClientStream) Send(wr *pb.WatchRequest) error {
 	return s.SendMsg(wr)
 }
 func (s *ws2wcClientStream) Recv() (*pb.WatchResponse, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (s *ws2wcServerStream) Send(wr *pb.WatchResponse) error {
 	return s.SendMsg(wr)
 }
 func (s *ws2wcServerStream) Recv() (*pb.WatchRequest, error) {
-	var v interface{}
+	var v any
 	if err := s.RecvMsg(&v); err != nil {
 		return nil, err
 	}

--- a/server/proxy/grpcproxy/util.go
+++ b/server/proxy/grpcproxy/util.go
@@ -56,7 +56,7 @@ func (cred *proxyTokenCredential) GetRequestMetadata(ctx context.Context, s ...s
 	}, nil
 }
 
-func AuthUnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func AuthUnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	token := getAuthTokenFromClient(ctx)
 	if token != "" {
 		tokenCred := &proxyTokenCredential{token}

--- a/server/storage/backend/verify_test.go
+++ b/server/storage/backend/verify_test.go
@@ -91,7 +91,7 @@ func TestLockVerify(t *testing.T) {
 	}
 }
 
-func handlePanic(f func()) (result interface{}) {
+func handlePanic(f func()) (result any) {
 	defer func() {
 		result = recover()
 	}()

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -151,12 +151,12 @@ func TestStorePut(t *testing.T) {
 		}
 
 		wact := []testutil.Action{
-			{Name: "seqput", Params: []interface{}{schema.Key, tt.wkey, data}},
+			{Name: "seqput", Params: []any{schema.Key, tt.wkey, data}},
 		}
 
 		if tt.rr != nil {
 			wact = []testutil.Action{
-				{Name: "seqput", Params: []interface{}{schema.Key, tt.wkey, data}},
+				{Name: "seqput", Params: []any{schema.Key, tt.wkey, data}},
 			}
 		}
 
@@ -164,8 +164,8 @@ func TestStorePut(t *testing.T) {
 			t.Errorf("#%d: tx action = %+v, want %+v", i, g, wact)
 		}
 		wact = []testutil.Action{
-			{Name: "get", Params: []interface{}{[]byte("foo"), tt.wputrev.main}},
-			{Name: "put", Params: []interface{}{[]byte("foo"), tt.wputrev}},
+			{Name: "get", Params: []any{[]byte("foo"), tt.wputrev.main}},
+			{Name: "put", Params: []any{[]byte("foo"), tt.wputrev}},
 		}
 		if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: index action = %+v, want %+v", i, g, wact)
@@ -232,13 +232,13 @@ func TestStoreRange(t *testing.T) {
 		wstart := newRevBytes()
 		revToBytes(tt.idxr.revs[0], wstart)
 		wact := []testutil.Action{
-			{Name: "range", Params: []interface{}{schema.Key, wstart, []byte(nil), int64(0)}},
+			{Name: "range", Params: []any{schema.Key, wstart, []byte(nil), int64(0)}},
 		}
 		if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: tx action = %+v, want %+v", i, g, wact)
 		}
 		wact = []testutil.Action{
-			{Name: "range", Params: []interface{}{[]byte("foo"), []byte("goo"), wrev}},
+			{Name: "range", Params: []any{[]byte("foo"), []byte("goo"), wrev}},
 		}
 		if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: index action = %+v, want %+v", i, g, wact)
@@ -308,14 +308,14 @@ func TestStoreDeleteRange(t *testing.T) {
 			t.Errorf("#%d: marshal err = %v, want nil", i, err)
 		}
 		wact := []testutil.Action{
-			{Name: "seqput", Params: []interface{}{schema.Key, tt.wkey, data}},
+			{Name: "seqput", Params: []any{schema.Key, tt.wkey, data}},
 		}
 		if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: tx action = %+v, want %+v", i, g, wact)
 		}
 		wact = []testutil.Action{
-			{Name: "range", Params: []interface{}{[]byte("foo"), []byte("goo"), tt.wrrev}},
-			{Name: "tombstone", Params: []interface{}{[]byte("foo"), tt.wdelrev}},
+			{Name: "range", Params: []any{[]byte("foo"), []byte("goo"), tt.wrrev}},
+			{Name: "tombstone", Params: []any{[]byte("foo"), tt.wdelrev}},
 		}
 		if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 			t.Errorf("#%d: index action = %+v, want %+v", i, g, wact)
@@ -351,18 +351,18 @@ func TestStoreCompact(t *testing.T) {
 	end := make([]byte, 8)
 	binary.BigEndian.PutUint64(end, uint64(4))
 	wact := []testutil.Action{
-		{Name: "range", Params: []interface{}{schema.Meta, schema.ScheduledCompactKeyName, []uint8(nil), int64(0)}},
-		{Name: "range", Params: []interface{}{schema.Meta, schema.FinishedCompactKeyName, []uint8(nil), int64(0)}},
-		{Name: "put", Params: []interface{}{schema.Meta, schema.ScheduledCompactKeyName, newTestRevBytes(revision{3, 0})}},
-		{Name: "range", Params: []interface{}{schema.Key, make([]byte, 17), end, int64(10000)}},
-		{Name: "delete", Params: []interface{}{schema.Key, key2}},
-		{Name: "put", Params: []interface{}{schema.Meta, schema.FinishedCompactKeyName, newTestRevBytes(revision{3, 0})}},
+		{Name: "range", Params: []any{schema.Meta, schema.ScheduledCompactKeyName, []uint8(nil), int64(0)}},
+		{Name: "range", Params: []any{schema.Meta, schema.FinishedCompactKeyName, []uint8(nil), int64(0)}},
+		{Name: "put", Params: []any{schema.Meta, schema.ScheduledCompactKeyName, newTestRevBytes(revision{3, 0})}},
+		{Name: "range", Params: []any{schema.Key, make([]byte, 17), end, int64(10000)}},
+		{Name: "delete", Params: []any{schema.Key, key2}},
+		{Name: "put", Params: []any{schema.Meta, schema.FinishedCompactKeyName, newTestRevBytes(revision{3, 0})}},
 	}
 	if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("tx actions = %+v, want %+v", g, wact)
 	}
 	wact = []testutil.Action{
-		{Name: "compact", Params: []interface{}{int64(3)}},
+		{Name: "compact", Params: []any{int64(3)}},
 	}
 	if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("index action = %+v, want %+v", g, wact)
@@ -411,9 +411,9 @@ func TestStoreRestore(t *testing.T) {
 		t.Errorf("current rev = %v, want 5", s.currentRev)
 	}
 	wact := []testutil.Action{
-		{Name: "range", Params: []interface{}{schema.Meta, schema.FinishedCompactKeyName, []byte(nil), int64(0)}},
-		{Name: "range", Params: []interface{}{schema.Meta, schema.ScheduledCompactKeyName, []byte(nil), int64(0)}},
-		{Name: "range", Params: []interface{}{schema.Key, newTestRevBytes(revision{1, 0}), newTestRevBytes(revision{math.MaxInt64, math.MaxInt64}), int64(restoreChunkKeys)}},
+		{Name: "range", Params: []any{schema.Meta, schema.FinishedCompactKeyName, []byte(nil), int64(0)}},
+		{Name: "range", Params: []any{schema.Meta, schema.ScheduledCompactKeyName, []byte(nil), int64(0)}},
+		{Name: "range", Params: []any{schema.Key, newTestRevBytes(revision{1, 0}), newTestRevBytes(revision{math.MaxInt64, math.MaxInt64}), int64(restoreChunkKeys)}},
 	}
 	if g := b.tx.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("tx actions = %+v, want %+v", g, wact)
@@ -425,8 +425,8 @@ func TestStoreRestore(t *testing.T) {
 	}
 	ki := &keyIndex{key: []byte("foo"), modified: revision{5, 0}, generations: gens}
 	wact = []testutil.Action{
-		{Name: "keyIndex", Params: []interface{}{ki}},
-		{Name: "insert", Params: []interface{}{ki}},
+		{Name: "keyIndex", Params: []any{ki}},
+		{Name: "insert", Params: []any{ki}},
 	}
 	if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("index action = %+v, want %+v", g, wact)
@@ -950,18 +950,18 @@ func (b *fakeBatchTx) RUnlock()                                 {}
 func (b *fakeBatchTx) UnsafeCreateBucket(bucket backend.Bucket) {}
 func (b *fakeBatchTx) UnsafeDeleteBucket(bucket backend.Bucket) {}
 func (b *fakeBatchTx) UnsafePut(bucket backend.Bucket, key []byte, value []byte) {
-	b.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{bucket, key, value}})
+	b.Recorder.Record(testutil.Action{Name: "put", Params: []any{bucket, key, value}})
 }
 func (b *fakeBatchTx) UnsafeSeqPut(bucket backend.Bucket, key []byte, value []byte) {
-	b.Recorder.Record(testutil.Action{Name: "seqput", Params: []interface{}{bucket, key, value}})
+	b.Recorder.Record(testutil.Action{Name: "seqput", Params: []any{bucket, key, value}})
 }
 func (b *fakeBatchTx) UnsafeRange(bucket backend.Bucket, key, endKey []byte, limit int64) (keys [][]byte, vals [][]byte) {
-	b.Recorder.Record(testutil.Action{Name: "range", Params: []interface{}{bucket, key, endKey, limit}})
+	b.Recorder.Record(testutil.Action{Name: "range", Params: []any{bucket, key, endKey, limit}})
 	r := <-b.rangeRespc
 	return r.keys, r.vals
 }
 func (b *fakeBatchTx) UnsafeDelete(bucket backend.Bucket, key []byte) {
-	b.Recorder.Record(testutil.Action{Name: "delete", Params: []interface{}{bucket, key}})
+	b.Recorder.Record(testutil.Action{Name: "delete", Params: []any{bucket, key}})
 }
 func (b *fakeBatchTx) UnsafeForEach(bucket backend.Bucket, visitor func(k, v []byte) error) error {
 	return nil
@@ -1024,43 +1024,43 @@ func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
 }
 
 func (i *fakeIndex) Get(key []byte, atRev int64) (rev, created revision, ver int64, err error) {
-	i.Recorder.Record(testutil.Action{Name: "get", Params: []interface{}{key, atRev}})
+	i.Recorder.Record(testutil.Action{Name: "get", Params: []any{key, atRev}})
 	r := <-i.indexGetRespc
 	return r.rev, r.created, r.ver, r.err
 }
 func (i *fakeIndex) Range(key, end []byte, atRev int64) ([][]byte, []revision) {
-	i.Recorder.Record(testutil.Action{Name: "range", Params: []interface{}{key, end, atRev}})
+	i.Recorder.Record(testutil.Action{Name: "range", Params: []any{key, end, atRev}})
 	r := <-i.indexRangeRespc
 	return r.keys, r.revs
 }
 func (i *fakeIndex) Put(key []byte, rev revision) {
-	i.Recorder.Record(testutil.Action{Name: "put", Params: []interface{}{key, rev}})
+	i.Recorder.Record(testutil.Action{Name: "put", Params: []any{key, rev}})
 }
 func (i *fakeIndex) Tombstone(key []byte, rev revision) error {
-	i.Recorder.Record(testutil.Action{Name: "tombstone", Params: []interface{}{key, rev}})
+	i.Recorder.Record(testutil.Action{Name: "tombstone", Params: []any{key, rev}})
 	return nil
 }
 func (i *fakeIndex) RangeSince(key, end []byte, rev int64) []revision {
-	i.Recorder.Record(testutil.Action{Name: "rangeEvents", Params: []interface{}{key, end, rev}})
+	i.Recorder.Record(testutil.Action{Name: "rangeEvents", Params: []any{key, end, rev}})
 	r := <-i.indexRangeEventsRespc
 	return r.revs
 }
 func (i *fakeIndex) Compact(rev int64) map[revision]struct{} {
-	i.Recorder.Record(testutil.Action{Name: "compact", Params: []interface{}{rev}})
+	i.Recorder.Record(testutil.Action{Name: "compact", Params: []any{rev}})
 	return <-i.indexCompactRespc
 }
 func (i *fakeIndex) Keep(rev int64) map[revision]struct{} {
-	i.Recorder.Record(testutil.Action{Name: "keep", Params: []interface{}{rev}})
+	i.Recorder.Record(testutil.Action{Name: "keep", Params: []any{rev}})
 	return <-i.indexCompactRespc
 }
 func (i *fakeIndex) Equal(b index) bool { return false }
 
 func (i *fakeIndex) Insert(ki *keyIndex) {
-	i.Recorder.Record(testutil.Action{Name: "insert", Params: []interface{}{ki}})
+	i.Recorder.Record(testutil.Action{Name: "insert", Params: []any{ki}})
 }
 
 func (i *fakeIndex) KeyIndex(ki *keyIndex) *keyIndex {
-	i.Recorder.Record(testutil.Action{Name: "keyIndex", Params: []interface{}{ki}})
+	i.Recorder.Record(testutil.Action{Name: "keyIndex", Params: []any{ki}})
 	return nil
 }
 

--- a/server/storage/quota.go
+++ b/server/storage/quota.go
@@ -38,18 +38,18 @@ const (
 // too few resources available within the quota to apply the request.
 type Quota interface {
 	// Available judges whether the given request fits within the quota.
-	Available(req interface{}) bool
+	Available(req any) bool
 	// Cost computes the charge against the quota for a given request.
-	Cost(req interface{}) int
+	Cost(req any) int
 	// Remaining is the amount of charge left for the quota.
 	Remaining() int64
 }
 
 type passthroughQuota struct{}
 
-func (*passthroughQuota) Available(interface{}) bool { return true }
-func (*passthroughQuota) Cost(interface{}) int       { return 0 }
-func (*passthroughQuota) Remaining() int64           { return 1 }
+func (*passthroughQuota) Available(any) bool { return true }
+func (*passthroughQuota) Cost(any) int       { return 0 }
+func (*passthroughQuota) Remaining() int64   { return 1 }
 
 type BackendQuota struct {
 	be              backend.Backend
@@ -123,7 +123,7 @@ func NewBackendQuota(lg *zap.Logger, quotaBackendBytesCfg int64, be backend.Back
 	return &BackendQuota{be, quotaBackendBytesCfg}
 }
 
-func (b *BackendQuota) Available(v interface{}) bool {
+func (b *BackendQuota) Available(v any) bool {
 	cost := b.Cost(v)
 	// if there are no mutating requests, it's safe to pass through
 	if cost == 0 {
@@ -133,7 +133,7 @@ func (b *BackendQuota) Available(v interface{}) bool {
 	return b.be.Size()+int64(cost) < b.maxBackendBytes
 }
 
-func (b *BackendQuota) Cost(v interface{}) int {
+func (b *BackendQuota) Cost(v any) int {
 	switch r := v.(type) {
 	case *pb.PutRequest:
 		return costPut(r)

--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -216,6 +216,6 @@ func fetchDebugVars(endpoint string, httpVersion string, connType e2e.ClientConn
 	if err != nil {
 		return err
 	}
-	var resp map[string]interface{}
+	var resp map[string]any
 	return json.Unmarshal([]byte(respData), &resp)
 }

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -110,13 +110,13 @@ func curl(endpoint string, method string, curlReq e2e.CURLReq, connType e2e.Clie
 	return strings.Join(lines, "\n"), nil
 }
 
-func runCommandAndReadJsonOutput(args []string) (map[string]interface{}, error) {
+func runCommandAndReadJsonOutput(args []string) (map[string]any, error) {
 	lines, err := e2e.RunUtilCompletion(args, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	err = json.Unmarshal([]byte(strings.Join(lines, "\n")), &resp)
 	if err != nil {
 		return nil, err

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -147,7 +147,7 @@ func testCurlV3Auth(cx ctlCtx) {
 		cURLRes, err := proc.ExpectFunc(context.Background(), lineFunc)
 		testutil.AssertNil(cx.t, err)
 
-		authRes := make(map[string]interface{})
+		authRes := make(map[string]any)
 		testutil.AssertNil(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
 
 		token, ok := authRes[rpctypes.TokenFieldNameGRPC].(string)
@@ -241,7 +241,7 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 
 	users, ok := resp["users"]
 	require.True(cx.t, ok)
-	userSlice := users.([]interface{})
+	userSlice := users.([]any)
 	require.Equal(cx.t, 2, len(userSlice))
 	require.Equal(cx.t, "user1", userSlice[0])
 	require.Equal(cx.t, "user3", userSlice[1])
@@ -370,7 +370,7 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 
 	roles, ok := resp["roles"]
 	require.True(cx.t, ok)
-	roleSlice := roles.([]interface{})
+	roleSlice := roles.([]any)
 	require.Equal(cx.t, 2, len(roleSlice))
 	require.Equal(cx.t, "role1", roleSlice[0])
 	require.Equal(cx.t, "role3", roleSlice[1])

--- a/tests/e2e/v3_curl_cluster_test.go
+++ b/tests/e2e/v3_curl_cluster_test.go
@@ -58,9 +58,9 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 
 	var newMemberIDStr string
 	for _, m := range members {
-		mObj := m.(map[string]interface{})
+		mObj := m.(map[string]any)
 		pURLs, _ := mObj["peerURLs"]
-		pURL := pURLs.([]interface{})[0].(string)
+		pURL := pURLs.([]any)[0].(string)
 		if pURL == peerURL {
 			newMemberIDStr = mObj["ID"].(string)
 			break
@@ -108,7 +108,7 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 	require.Equal(cx.t, 1, len(members))
 }
 
-func mustListMembers(cx ctlCtx) []interface{} {
+func mustListMembers(cx ctlCtx) []any {
 	clus := cx.epc
 	args := e2e.CURLPrefixArgsCluster(clus.Cfg, clus.Procs[0], "POST", e2e.CURLReq{
 		Endpoint: "/v3/cluster/member/list",
@@ -119,5 +119,5 @@ func mustListMembers(cx ctlCtx) []interface{} {
 
 	members, ok := resp["members"]
 	require.True(cx.t, ok)
-	return members.([]interface{})
+	return members.([]any)
 }

--- a/tests/e2e/v3_curl_kv_test.go
+++ b/tests/e2e/v3_curl_kv_test.go
@@ -158,7 +158,7 @@ func testCurlV3KVTxn(cx ctlCtx) {
 	succeeded, responses := mustExecuteTxn(cx, string(jsonDat))
 	require.True(cx.t, succeeded)
 	require.Equal(cx.t, 1, len(responses))
-	putResponse := responses[0].(map[string]interface{})
+	putResponse := responses[0].(map[string]any)
 	_, ok := putResponse["response_put"]
 	require.True(cx.t, ok)
 
@@ -172,7 +172,7 @@ func testCurlV3KVTxn(cx ctlCtx) {
 	require.NoErrorf(cx.t, err, "testCurlV3Txn with malformed request failed")
 }
 
-func mustExecuteTxn(cx ctlCtx, reqData string) (bool, []interface{}) {
+func mustExecuteTxn(cx ctlCtx, reqData string) (bool, []any) {
 	clus := cx.epc
 	args := e2e.CURLPrefixArgsCluster(clus.Cfg, clus.Procs[0], "POST", e2e.CURLReq{
 		Endpoint: "/v3/kv/txn",
@@ -187,7 +187,7 @@ func mustExecuteTxn(cx ctlCtx, reqData string) (bool, []interface{}) {
 	responses, ok := resp["responses"]
 	require.True(cx.t, ok)
 
-	return succeeded.(bool), responses.([]interface{})
+	return succeeded.(bool), responses.([]any)
 }
 
 func testCurlV3KVCompact(cx ctlCtx) {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -660,7 +660,7 @@ func (ctl *EtcdctlV3) RoleDelete(ctx context.Context, role string) (*clientv3.Au
 	return &resp, err
 }
 
-func (ctl *EtcdctlV3) spawnJsonCmd(ctx context.Context, output interface{}, args ...string) error {
+func (ctl *EtcdctlV3) spawnJsonCmd(ctx context.Context, output any, args ...string) error {
 	args = append(args, "-w", "json")
 	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
 	if err != nil {

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -108,7 +108,7 @@ func RandomLeaseID() int64 {
 	return rand.New(rand.NewSource(time.Now().UnixNano())).Int63()
 }
 
-func DataMarshal(data interface{}) (d string, e error) {
+func DataMarshal(data any) (d string, e error) {
 	m, err := json.Marshal(data)
 	if err != nil {
 		return "", err

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -480,7 +480,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 	}
 	defer c.Close()
 
-	watchStartCh, watchEndCh := make(chan interface{}), make(chan interface{})
+	watchStartCh, watchEndCh := make(chan any), make(chan any)
 
 	go func() {
 		wChan := c.Watch(ctx, "k1", clientv3.WithRev(1))

--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -38,14 +38,14 @@ import (
 //     to provide a full response. For example stale reads as model doesn't store
 //     whole change history as real etcd does.
 var DeterministicModel = porcupine.Model{
-	Init: func() interface{} {
+	Init: func() any {
 		data, err := json.Marshal(freshEtcdState())
 		if err != nil {
 			panic(err)
 		}
 		return string(data)
 	},
-	Step: func(st interface{}, in interface{}, out interface{}) (bool, interface{}) {
+	Step: func(st any, in any, out any) (bool, any) {
 		var s EtcdState
 		err := json.Unmarshal([]byte(st.(string)), &s)
 		if err != nil {
@@ -58,7 +58,7 @@ var DeterministicModel = porcupine.Model{
 		}
 		return ok, string(data)
 	},
-	DescribeOperation: func(in, out interface{}) string {
+	DescribeOperation: func(in, out any) string {
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), MaybeEtcdResponse{EtcdResponse: out.(EtcdResponse)}))
 	},
 }

--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -27,14 +27,14 @@ import (
 // considers both cases. This is represented as multiple equally possible deterministic states.
 // Failed requests fork the possible states, while successful requests merge and filter them.
 var NonDeterministicModel = porcupine.Model{
-	Init: func() interface{} {
+	Init: func() any {
 		data, err := json.Marshal(nonDeterministicState{freshEtcdState()})
 		if err != nil {
 			panic(err)
 		}
 		return string(data)
 	},
-	Step: func(st interface{}, in interface{}, out interface{}) (bool, interface{}) {
+	Step: func(st any, in any, out any) (bool, any) {
 		var states nonDeterministicState
 		err := json.Unmarshal([]byte(st.(string)), &states)
 		if err != nil {
@@ -47,7 +47,7 @@ var NonDeterministicModel = porcupine.Model{
 		}
 		return ok, string(data)
 	},
-	DescribeOperation: func(in, out interface{}) string {
+	DescribeOperation: func(in, out any) string {
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), out.(MaybeEtcdResponse)))
 	},
 }

--- a/tests/robustness/validate/watch.go
+++ b/tests/robustness/validate/watch.go
@@ -74,12 +74,12 @@ func validateOrdered(t *testing.T, report report.ClientReport) {
 }
 
 func validateUnique(t *testing.T, expectUniqueRevision bool, report report.ClientReport) {
-	uniqueOperations := map[interface{}]struct{}{}
+	uniqueOperations := map[any]struct{}{}
 
 	for _, op := range report.Watch {
 		for _, resp := range op.Responses {
 			for _, event := range resp.Events {
-				var key interface{}
+				var key any
 				if expectUniqueRevision {
 					key = event.Revision
 				} else {


### PR DESCRIPTION
The go.mod has been upgrade to go 1.21, we can use `any` instead of `interface{}`.