### PR TITLE
*: fix ineffassign lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,13 @@ fix-bom:
 verify-dep:
 	PASSES="dep" ./scripts/test.sh
 
+# TODO: https://github.com/etcd-io/etcd/issues/16610
+#
+# The golangci-lint doesn't verify sub modules. Before #16610 fixed, verify-lint
+# still depends on legacy {ineffassign,nakedret,unparam,...}_pass. These X_pass
+# will be removed when the golangci-lint covers all the sub modules.
 .PHONY: verify-lint
-verify-lint:
+verify-lint: verify-ineffassign
 	golangci-lint run --config tools/.golangci.yaml
 
 .PHONY: fix-lint
@@ -144,6 +149,10 @@ verify-yamllint:
 .PHONY: verify-govet-shadow
 verify-govet-shadow:
 	PASSES="govet_shadow" ./scripts/test.sh
+
+.PHONY: verify-ineffassign
+verify-ineffassign:
+	PASSES="ineffassign" ./scripts/test.sh
 
 YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -442,17 +442,8 @@ function unconvert_pass {
   run_for_modules generic_checker run_go_tool "github.com/mdempsky/unconvert" unconvert -v
 }
 
-function ineffassign_per_package {
-  # bash 3.x compatible replacement of: mapfile -t gofiles < <(go_srcs_in_module)
-  local gofiles=()
-  while IFS= read -r line; do gofiles+=("$line"); done < <(go_srcs_in_module)
-
-  # TODO: ineffassign should work with package instead of files
-  run_go_tool github.com/gordonklaus/ineffassign "${gofiles[@]}"
-}
-
 function ineffassign_pass {
-  run_for_modules generic_checker ineffassign_per_package
+  run_for_modules generic_checker run_go_tool "github.com/gordonklaus/ineffassign"
 }
 
 function nakedret_pass {

--- a/server/lease/lessor_bench_test.go
+++ b/server/lease/lessor_bench_test.go
@@ -90,7 +90,6 @@ func benchmarkLessorGrant(benchSize int, b *testing.B) {
 		b.StopTimer()
 		if tearDown != nil {
 			tearDown()
-			tearDown = nil
 		}
 		le, tearDown = setUp(b)
 		b.StartTimer()
@@ -117,7 +116,6 @@ func benchmarkLessorRevoke(benchSize int, b *testing.B) {
 		b.StopTimer()
 		if tearDown != nil {
 			tearDown()
-			tearDown = nil
 		}
 		le, tearDown = setUp(b)
 		for j := 1; j <= benchSize; j++ {
@@ -148,7 +146,6 @@ func benchmarkLessorRenew(benchSize int, b *testing.B) {
 		b.StopTimer()
 		if tearDown != nil {
 			tearDown()
-			tearDown = nil
 		}
 		le, tearDown = setUp(b)
 		for j := 1; j <= benchSize; j++ {
@@ -181,7 +178,6 @@ func benchmarkLessorFindExpired(benchSize int, b *testing.B) {
 		b.StopTimer()
 		if tearDown != nil {
 			tearDown()
-			tearDown = nil
 		}
 		le, tearDown = setUp(b)
 		for j := 1; j <= benchSize; j++ {

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -69,7 +69,7 @@ func TestCompact(t *testing.T) {
 					t.Fatalf("compactTest: Compact error (%v)", err)
 				}
 
-				get, err = cc.Get(ctx, "key", config.GetOptions{Revision: 3})
+				_, err = cc.Get(ctx, "key", config.GetOptions{Revision: 3})
 				if err != nil {
 					if !strings.Contains(err.Error(), "required revision has been compacted") {
 						t.Fatalf("compactTest: Get compact key error (%v)", err)

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -324,6 +324,7 @@ func TestCompactHashCheckDetectCorruptionInterrupt(t *testing.T) {
 
 	t.Log("compaction started...")
 	_, err = cc.Compact(ctx, 5, config.CompactOption{})
+	require.NoError(t, err)
 
 	err = epc.Procs[slowCompactionNodeIndex].Close()
 	require.NoError(t, err)
@@ -333,6 +334,7 @@ func TestCompactHashCheckDetectCorruptionInterrupt(t *testing.T) {
 
 	t.Logf("restart proc %d to interrupt its compaction...", slowCompactionNodeIndex)
 	err = epc.Procs[slowCompactionNodeIndex].Restart(ctx)
+	require.NoError(t, err)
 
 	// Wait until the node finished compaction and the leader finished compaction hash check
 	_, err = epc.Procs[slowCompactionNodeIndex].Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "finished scheduled compaction"})

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -71,6 +71,7 @@ func memberListSerializableTest(cx ctlCtx) {
 	require.NoError(cx.t, err)
 
 	resp, err = getMemberList(cx, true)
+	require.NoError(cx.t, err)
 	require.Equal(cx.t, 2, len(resp.Members))
 }
 

--- a/tests/e2e/v3_curl_cluster_test.go
+++ b/tests/e2e/v3_curl_cluster_test.go
@@ -71,6 +71,8 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 	// update member
 	cx.t.Logf("Update peerURL from %q to %q for member %q", peerURL, updatedPeerURL, newMemberIDStr)
 	newMemberID, err := strconv.ParseUint(newMemberIDStr, 10, 64)
+	require.NoError(cx.t, err)
+
 	updateMemberReq, err := json.Marshal(&pb.MemberUpdateRequest{ID: newMemberID, PeerURLs: []string{updatedPeerURL}})
 	require.NoError(cx.t, err)
 

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -510,7 +510,7 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 
 	name := fmt.Sprintf("%s-test-%d", testNameCleanRegex.ReplaceAllString(tb.Name(), ""), i)
 
-	dataDirPath := cfg.DataDirPath
+	var dataDirPath string
 	if cfg.DataDirPath == "" {
 		dataDirPath = tb.TempDir()
 	} else {

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -444,12 +444,12 @@ func TestV3AuthWatchAndTokenExpire(t *testing.T) {
 	// The first watch gets a valid auth token through watcher.newWatcherGrpcStream()
 	// We should discard the first one by waiting TTL after the first watch.
 	wChan := c.Watch(ctx, "key", clientv3.WithRev(1))
-	watchResponse := <-wChan
+	<-wChan
 
 	time.Sleep(5 * time.Second)
 
 	wChan = c.Watch(ctx, "key", clientv3.WithRev(1))
-	watchResponse = <-wChan
+	watchResponse := <-wChan
 	testutil.AssertNil(t, watchResponse.Err())
 }
 


### PR DESCRIPTION
Part of #15549

```bash
PASSES="ineffassign" ./scripts/test.sh
Running with --race
Starting at: Mon Sep 18 12:40:24 HKT 2023

'ineffassign' started at Mon Sep 18 12:40:24 HKT 2023
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd api && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd pkg && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd client/pkg && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd client/internal/v2 && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd client/v3 && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd server && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd etcdutl && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd etcdctl && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% (cd tests && '/home/fuwei/go/bin/ineffassign' './...')
% (cd tools/mod && 'go' 'install' 'github.com/gordonklaus/ineffassign')
% '/home/fuwei/go/bin/ineffassign' './...'
'ineffassign' PASSED and completed at Mon Sep 18 12:40:25 HKT 2023
SUCCESS
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
