### PR TITLE
Update 3.6 changelog to include the grpc-gateway upgrading from v1 to v2 and golang upgrading to 1.21

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -94,11 +94,12 @@ See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per 
 - Add [`etcd_debugging_server_alarms`](https://github.com/etcd-io/etcd/pull/14276).
 
 ### Go
-- Require [Go 1.20+](https://github.com/etcd-io/etcd/pull/16394).
-- Compile with [Go 1.20+](https://golang.org/doc/devel/release.html#go1.20). Please refer to [gc-guide](https://go.dev/doc/gc-guide) to configure `GOGC` and `GOMEMLIMIT` properly. 
+- Require [Go 1.21+](https://github.com/etcd-io/etcd/pull/16594).
+- Compile with [Go 1.21+](https://go.dev/doc/devel/release#go1.21.minor). Please refer to [gc-guide](https://go.dev/doc/gc-guide) to configure `GOGC` and `GOMEMLIMIT` properly. 
 
 ### Other
 
 - Use Distroless as base image to make the image less vulnerable and reduce image size.
+- [Upgrade grpc-gateway from v1 to v2](https://github.com/etcd-io/etcd/pull/16595).
 
 <hr>


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/16595 and https://github.com/etcd-io/etcd/pull/16594



Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
