### PR TITLE
*: fix staticcheck lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ verify-dep:
 # still depends on legacy {ineffassign,nakedret,unparam,...}_pass. These X_pass
 # will be removed when the golangci-lint covers all the sub modules.
 .PHONY: verify-lint
-verify-lint: verify-ineffassign
+verify-lint: verify-golangcilint
 	golangci-lint run --config tools/.golangci.yaml
 
 .PHONY: fix-lint
@@ -150,9 +150,9 @@ verify-yamllint:
 verify-govet-shadow:
 	PASSES="govet_shadow" ./scripts/test.sh
 
-.PHONY: verify-ineffassign
-verify-ineffassign:
-	PASSES="ineffassign" ./scripts/test.sh
+.PHONY: verify-golangcilint
+verify-golangcilint:
+	PASSES="golangcilint" ./scripts/test.sh
 
 YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
 

--- a/Makefile
+++ b/Makefile
@@ -85,14 +85,9 @@ fix-bom:
 verify-dep:
 	PASSES="dep" ./scripts/test.sh
 
-# TODO: https://github.com/etcd-io/etcd/issues/16610
-#
-# The golangci-lint doesn't verify sub modules. Before #16610 fixed, verify-lint
-# still depends on legacy {ineffassign,nakedret,unparam,...}_pass. These X_pass
-# will be removed when the golangci-lint covers all the sub modules.
 .PHONY: verify-lint
-verify-lint: verify-golangcilint
-	golangci-lint run --config tools/.golangci.yaml
+verify-lint:
+	PASSES="lint" ./scripts/test.sh
 
 .PHONY: fix-lint
 fix-lint:
@@ -149,10 +144,6 @@ verify-yamllint:
 .PHONY: verify-govet-shadow
 verify-govet-shadow:
 	PASSES="govet_shadow" ./scripts/test.sh
-
-.PHONY: verify-golangcilint
-verify-golangcilint:
-	PASSES="golangcilint" ./scripts/test.sh
 
 YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
 

--- a/api/v3rpc/rpctypes/metadatafields.go
+++ b/api/v3rpc/rpctypes/metadatafields.go
@@ -18,3 +18,6 @@ var (
 	TokenFieldNameGRPC    = "token"
 	TokenFieldNameSwagger = "authorization"
 )
+
+// TokenFieldNameGRPCKey is used as a key of context to store token.
+type TokenFieldNameGRPCKey struct{}

--- a/client/v3/experimental/recipes/double_barrier.go
+++ b/client/v3/experimental/recipes/double_barrier.go
@@ -71,10 +71,9 @@ func (b *DoubleBarrier) Enter() error {
 			// delete itself now, otherwise other processes may need to wait
 			// until these keys are automatically deleted when the related
 			// lease expires.
-			if err = b.myKey.Delete(); err != nil {
-				// Nothing to do here. We have to wait for the key to be
-				// deleted when the lease expires.
-			}
+			b.myKey.Delete()
+			// Nothing to do here even if we run into error.
+			// We have to wait for the key to be deleted when the lease expires.
 			return ErrTooManyClients
 		}
 

--- a/client/v3/experimental/recipes/double_barrier.go
+++ b/client/v3/experimental/recipes/double_barrier.go
@@ -71,9 +71,11 @@ func (b *DoubleBarrier) Enter() error {
 			// delete itself now, otherwise other processes may need to wait
 			// until these keys are automatically deleted when the related
 			// lease expires.
-			b.myKey.Delete()
-			// Nothing to do here even if we run into error.
-			// We have to wait for the key to be deleted when the lease expires.
+			//nolint:staticcheck // SA9003 disable empty branch checker to keep the comment for why we ignore error
+			if err = b.myKey.Delete(); err != nil {
+				// Nothing to do here. We have to wait for the key to be
+				// deleted when the lease expires.
+			}
 			return ErrTooManyClients
 		}
 

--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -198,12 +198,12 @@ func NewLeaseFromLeaseClient(remote pb.LeaseClient, c *Client, keepAliveTimeout 
 		keepAlives:            make(map[LeaseID]*keepAlive),
 		remote:                remote,
 		firstKeepAliveTimeout: keepAliveTimeout,
-		lg:                    c.lg,
 	}
 	if l.firstKeepAliveTimeout == time.Second {
 		l.firstKeepAliveTimeout = defaultTTL
 	}
 	if c != nil {
+		l.lg = c.lg
 		l.callOpts = c.callOpts
 	}
 	reqLeaderCtx := WithRequireLeader(context.Background())

--- a/client/v3/maintenance.go
+++ b/client/v3/maintenance.go
@@ -133,7 +133,6 @@ func NewMaintenance(c *Client) Maintenance {
 
 func NewMaintenanceFromMaintenanceClient(remote pb.MaintenanceClient, c *Client) Maintenance {
 	api := &maintenance{
-		lg: c.lg,
 		dial: func(string) (pb.MaintenanceClient, func(), error) {
 			return remote, func() {}, nil
 		},
@@ -141,6 +140,7 @@ func NewMaintenanceFromMaintenanceClient(remote pb.MaintenanceClient, c *Client)
 	}
 	if c != nil {
 		api.callOpts = c.callOpts
+		api.lg = c.lg
 	}
 	return api
 }

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -25,10 +25,11 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	TraceKey     = "trace"
-	StartTimeKey = "startTime"
-)
+// TraceKey is used as a key of context for Trace.
+type TraceKey struct{}
+
+// StartTimeKey is used as a key of context for start time of operation.
+type StartTimeKey struct{}
 
 // Field is a kv pair to record additional details of the trace.
 type Field struct {
@@ -81,7 +82,7 @@ func TODO() *Trace {
 }
 
 func Get(ctx context.Context) *Trace {
-	if trace, ok := ctx.Value(TraceKey).(*Trace); ok && trace != nil {
+	if trace, ok := ctx.Value(TraceKey{}).(*Trace); ok && trace != nil {
 		return trace
 	}
 	return TODO()

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -40,7 +40,7 @@ func TestGet(t *testing.T) {
 		},
 		{
 			name:        "When the context has trace",
-			inputCtx:    context.WithValue(context.Background(), TraceKey, traceForTest),
+			inputCtx:    context.WithValue(context.Background(), TraceKey{}, traceForTest),
 			outputTrace: traceForTest,
 		},
 	}
@@ -51,7 +51,7 @@ func TestGet(t *testing.T) {
 			if trace == nil {
 				t.Errorf("Expected %v; Got nil", tt.outputTrace)
 			}
-			if trace.operation != tt.outputTrace.operation {
+			if tt.outputTrace == nil || trace.operation != tt.outputTrace.operation {
 				t.Errorf("Expected %v; Got %v", tt.outputTrace, trace)
 			}
 		})

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -425,20 +425,15 @@ function unparam_pass {
   run_for_modules generic_checker run_go_tool "mvdan.cc/unparam"
 }
 
-function staticcheck_pass {
+function golangcilint_pass {
   local tmp_lintyaml
-  tmp_lintyaml=$(mktemp -t 'tmp_golangcilint_staticcheckXXX.yaml')
+  tmp_lintyaml=$(mktemp -t 'tmp_golangcilint_XXX.yaml')
 
   # shellcheck disable=SC2064
   trap "rm ${tmp_lintyaml}; trap - RETURN" RETURN
 
-  # TODO: The golangci-lint commandline doesn't support listener-settings. And
-  # staticcheck command[1] not just verifies the staticcheck, but also includes
-  # stylecheck and unused. So copy the tools/.golangci.yaml and just run the
-  # staticcheck rule. It should be removed when closes #16610
-  #
-  # REF:
-  # [1] https://github.com/dominikh/go-tools/blob/v0.4.5/cmd/staticcheck/staticcheck.go#L29
+  # TODO: Copy the tools/.golangci.yaml and run the linters for which we have
+  # already fixed. It should be removed when closes #16610.
   cat > "${tmp_lintyaml}" <<EOF
 ---
 run:
@@ -453,7 +448,13 @@ issues:
       linters: [ineffassign]
 linters:
   disable-all: true
-  enable:
+  enable: # please keep this alphabetized
+    # Don't use soon to deprecated[1] linters that lead to false
+    # https://github.com/golangci/golangci-lint/issues/1841
+    # - deadcode
+    # - structcheck
+    # - varcheck
+    - ineffassign
     - staticcheck
 linters-settings:
   staticcheck:
@@ -474,10 +475,6 @@ function revive_pass {
 function unconvert_pass {
   # TODO: pb package should be filtered out.
   run_for_modules generic_checker run_go_tool "github.com/mdempsky/unconvert" unconvert -v
-}
-
-function ineffassign_pass {
-  run_for_modules generic_checker run_go_tool "github.com/gordonklaus/ineffassign"
 }
 
 function nakedret_pass {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -425,46 +425,8 @@ function unparam_pass {
   run_for_modules generic_checker run_go_tool "mvdan.cc/unparam"
 }
 
-function golangcilint_pass {
-  local tmp_lintyaml
-  tmp_lintyaml=$(mktemp -t 'tmp_golangcilint_XXX.yaml')
-
-  # shellcheck disable=SC2064
-  trap "rm ${tmp_lintyaml}; trap - RETURN" RETURN
-
-  # TODO: Copy the tools/.golangci.yaml and run the linters for which we have
-  # already fixed. It should be removed when closes #16610.
-  cat > "${tmp_lintyaml}" <<EOF
----
-run:
-  timeout: 30m
-  skip-files: [^zz_generated.*]
-issues:
-  max-same-issues: 0
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # exclude ineffassing linter for generated files for conversion
-    - path: conversion\.go
-      linters: [ineffassign]
-linters:
-  disable-all: true
-  enable: # please keep this alphabetized
-    # Don't use soon to deprecated[1] linters that lead to false
-    # https://github.com/golangci/golangci-lint/issues/1841
-    # - deadcode
-    # - structcheck
-    # - varcheck
-    - ineffassign
-    - staticcheck
-linters-settings:
-  staticcheck:
-    checks:
-      - all
-      - -SA1019 # TODO(fix) Using a deprecated function, variable, constant or field
-      - -SA2002 # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn't allowed
-EOF
-
-  run_for_modules generic_checker run golangci-lint run --config "${tmp_lintyaml}"
+function lint_pass {
+  run_for_modules generic_checker run golangci-lint run --config "${ETCD_ROOT_DIR}/tools/.golangci.yaml"
 }
 
 function revive_pass {

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -1173,10 +1173,10 @@ func testAuthInfoFromCtxWithRoot(t *testing.T, opts string) {
 
 	ai, aerr := as.AuthInfoFromCtx(ctx)
 	if aerr != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if ai == nil {
-		t.Error("expected non-nil *AuthInfo")
+		t.Fatal("expected non-nil *AuthInfo")
 	}
 	if ai.Username != "root" {
 		t.Errorf("expected user name 'root', got %+v", ai)

--- a/server/etcdserver/txn/txn.go
+++ b/server/etcdserver/txn/txn.go
@@ -40,7 +40,7 @@ func Put(ctx context.Context, lg *zap.Logger, lessor lease.Lessor, kv mvcc.KV, p
 			traceutil.Field{Key: "key", Value: string(p.Key)},
 			traceutil.Field{Key: "req_size", Value: p.Size()},
 		)
-		ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 	}
 	leaseID := lease.LeaseID(p.Lease)
 	if leaseID != lease.NoLease {
@@ -102,7 +102,7 @@ func DeleteRange(ctx context.Context, lg *zap.Logger, kv mvcc.KV, dr *pb.DeleteR
 			traceutil.Field{Key: "key", Value: string(dr.Key)},
 			traceutil.Field{Key: "range_end", Value: string(dr.RangeEnd)},
 		)
-		ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 	}
 	txnWrite := kv.Write(trace)
 	defer txnWrite.End()
@@ -136,7 +136,7 @@ func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) 
 	trace = traceutil.Get(ctx)
 	if trace.IsEmpty() {
 		trace = traceutil.New("range", lg)
-		ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 	}
 	txnRead := kv.Read(mvcc.ConcurrentReadTxMode, trace)
 	defer txnRead.End()
@@ -248,7 +248,7 @@ func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWit
 	trace := traceutil.Get(ctx)
 	if trace.IsEmpty() {
 		trace = traceutil.New("transaction", lg)
-		ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 	}
 	isWrite := !IsTxnReadonly(rt)
 	// When the transaction contains write operations, we use ReadTx instead of

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -105,7 +105,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		traceutil.Field{Key: "range_begin", Value: string(r.Key)},
 		traceutil.Field{Key: "range_end", Value: string(r.RangeEnd)},
 	)
-	ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+	ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 
 	var resp *pb.RangeResponse
 	var err error
@@ -140,7 +140,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 }
 
 func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
-	ctx = context.WithValue(ctx, traceutil.StartTimeKey, time.Now())
+	ctx = context.WithValue(ctx, traceutil.StartTimeKey{}, time.Now())
 	resp, err := s.raftRequest(ctx, pb.InternalRaftRequest{Put: r})
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 			s.Logger(),
 			traceutil.Field{Key: "read_only", Value: true},
 		)
-		ctx = context.WithValue(ctx, traceutil.TraceKey, trace)
+		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
 		if !txn.IsTxnSerializable(r) {
 			err := s.linearizableReadNotify(ctx)
 			trace.Step("agreement among raft nodes before linearized reading")
@@ -190,7 +190,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		return resp, err
 	}
 
-	ctx = context.WithValue(ctx, traceutil.StartTimeKey, time.Now())
+	ctx = context.WithValue(ctx, traceutil.StartTimeKey{}, time.Now())
 	resp, err := s.raftRequest(ctx, pb.InternalRaftRequest{Txn: r})
 	if err != nil {
 		return nil, err
@@ -671,7 +671,7 @@ func (s *EtcdServer) raftRequestOnce(ctx context.Context, r pb.InternalRaftReque
 	if result.Err != nil {
 		return nil, result.Err
 	}
-	if startTime, ok := ctx.Value(traceutil.StartTimeKey).(time.Time); ok && result.Trace != nil {
+	if startTime, ok := ctx.Value(traceutil.StartTimeKey{}).(time.Time); ok && result.Trace != nil {
 		applyStart := result.Trace.GetStartTime()
 		// The trace object is created in toApply. Here reset the start time to trace
 		// the raft request time by the difference between the request start time

--- a/server/proxy/grpcproxy/util.go
+++ b/server/proxy/grpcproxy/util.go
@@ -37,7 +37,7 @@ func getAuthTokenFromClient(ctx context.Context) string {
 func withClientAuthToken(ctx, ctxWithToken context.Context) context.Context {
 	token := getAuthTokenFromClient(ctxWithToken)
 	if token != "" {
-		ctx = context.WithValue(ctx, rpctypes.TokenFieldNameGRPC, token)
+		ctx = context.WithValue(ctx, rpctypes.TokenFieldNameGRPCKey{}, token)
 	}
 	return ctx
 }
@@ -66,7 +66,7 @@ func AuthUnaryClientInterceptor(ctx context.Context, method string, req, reply a
 }
 
 func AuthStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-	tokenif := ctx.Value(rpctypes.TokenFieldNameGRPC)
+	tokenif := ctx.Value(rpctypes.TokenFieldNameGRPCKey{})
 	if tokenif != nil {
 		tokenCred := &proxyTokenCredential{tokenif.(string)}
 		opts = append(opts, grpc.PerRPCCredentials(tokenCred))

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -189,10 +189,12 @@ func (ep *EtcdServerProcess) Restart(ctx context.Context) error {
 }
 
 func (ep *EtcdServerProcess) Stop() (err error) {
-	ep.cfg.lg.Info("stopping server...", zap.String("name", ep.cfg.Name))
 	if ep == nil || ep.proc == nil {
 		return nil
 	}
+
+	ep.cfg.lg.Info("stopping server...", zap.String("name", ep.cfg.Name))
+
 	defer func() {
 		ep.proc = nil
 	}()

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -693,7 +693,7 @@ func TestLeasingTxnOwnerGet(t *testing.T) {
 		k := fmt.Sprintf("k-%d", i)
 		rr := tresp.Responses[i].GetResponseRange()
 		if rr == nil {
-			t.Errorf("expected get response, got %+v", tresp.Responses[i])
+			t.Fatalf("expected get response, got %+v", tresp.Responses[i])
 		}
 		if string(rr.Kvs[0].Key) != k || string(rr.Kvs[0].Value) != k+k {
 			t.Errorf(`expected key for %q, got %+v`, k, rr.Kvs)

--- a/tests/integration/lazy_cluster.go
+++ b/tests/integration/lazy_cluster.go
@@ -89,7 +89,10 @@ func (lc *lazyCluster) mustLazyInit() {
 }
 
 func (lc *lazyCluster) Terminate() {
-	lc.tb.Logf("Terminating...")
+	if lc != nil && lc.tb != nil {
+		lc.tb.Logf("Terminating...")
+	}
+
 	if lc != nil && lc.cluster != nil {
 		lc.cluster.Terminate(nil)
 		lc.cluster = nil

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -169,7 +169,6 @@ func loadKeyValueOperations(path string) (operations []porcupine.Operation, err 
 func persistWatchOperations(t *testing.T, lg *zap.Logger, path string, responses []model.WatchOperation) {
 	lg.Info("Saving watch operations", zap.String("path", path))
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
-	defer file.Close()
 	if err != nil {
 		t.Errorf("Failed to save watch operations: %v", err)
 		return

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -17,13 +17,13 @@ linters:
     # - deadcode
     # - structcheck
     # - varcheck
-    - goimports
+    # - goimports  # TODO: enable by #16610
     - ineffassign
-    - revive
+    # - revive     # TODO: enable by #16610
     - staticcheck
-    - stylecheck
-    - unused
-    - unconvert # Remove unnecessary type conversions
+    # - stylecheck # TODO: enable by #16610
+    # - unused     # TODO: enable by #16610
+    # - unconvert  # Remove unnecessary type conversions TODO: enable by #16610
 linters-settings: # please keep this alphabetized
   goimports:
     local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/addlicense v1.1.1
 	github.com/google/yamlfmt v0.10.0
-	github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0
 	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f
 	github.com/mgechev/revive v1.3.3

--- a/tools/mod/go.sum
+++ b/tools/mod/go.sum
@@ -84,8 +84,6 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/yamlfmt v0.10.0 h1:0eR+Z3ZhkJ4uYIpEU/BcxpnqtkNDq8eCxon/Sj0YeRc=
 github.com/google/yamlfmt v0.10.0/go.mod h1:jW0ice5/S1EBCHhIV9rkGVfUjyCXD1cTlddkKwI8TKo=
-github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8 h1:PVRE9d4AQKmbelZ7emNig1+NT27DUmKZn5qXxfio54U=
-github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8/go.mod h1:Qcp2HIAYhR7mNUVSIxZww3Guk4it82ghYcEXIAk+QT0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -184,7 +182,6 @@ github.com/weppos/publicsuffix-go v0.15.1-0.20220329081811-9a40b608a236 h1:vMJBP
 github.com/weppos/publicsuffix-go v0.15.1-0.20220329081811-9a40b608a236/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
 github.com/zmap/zcertificate v0.0.0-20180516150559-0e3d58b1bac4/go.mod h1:5iU54tB79AMBcySS0R2XIyZBAVmeHranShAFELYx7is=
@@ -211,7 +208,6 @@ golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
@@ -222,7 +218,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
@@ -242,9 +237,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -272,7 +265,6 @@ golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
 golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=

--- a/tools/mod/tools.go
+++ b/tools/mod/tools.go
@@ -29,7 +29,6 @@ import (
 	_ "github.com/coreos/license-bill-of-materials"
 	_ "github.com/google/addlicense"
 	_ "github.com/google/yamlfmt/cmd/yamlfmt"
-	_ "github.com/gordonklaus/ineffassign"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
 	_ "github.com/mdempsky/unconvert"


### PR DESCRIPTION
Changed TraceKey/StartTimeKey/TokenFieldNameGRPCKey to struct{} to follow the correct usage of context. Similar patch to #8901.


~~And this patch also copies the tools/.golangci.yaml and run the linters for which we have already fixed. 
The temp .golangci.yaml will be removed when we fixes all the linters' issues.~~

Added `lint_pass` in scripts/test.sh to run the golangci linters for each modules. And disable no working linters in the global golangci.yaml and enable them by #16610.

Part of #16610

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
