### PR TITLE
Fix RaftCluster boostrap being based on v3 store while apply is based on v2 store.

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -260,12 +260,12 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 	c.Lock()
 	defer c.Unlock()
 
-	if c.be != nil {
-		c.version = c.be.ClusterVersionFromBackend()
-		c.members, c.removed = c.be.MustReadMembersFromBackend()
-	} else {
+	if c.v2store != nil {
 		c.version = clusterVersionFromStore(c.lg, c.v2store)
 		c.members, c.removed = membersFromStore(c.lg, c.v2store)
+	} else {
+		c.version = c.be.ClusterVersionFromBackend()
+		c.members, c.removed = c.be.MustReadMembersFromBackend()
 	}
 	c.buildMembershipMetric()
 


### PR DESCRIPTION
Migration off v2 store was unfinished during v3.5 development https://github.com/etcd-io/etcd/pull/12914 leaving RaftCluster broken, half migrated. This was found in v3.5 and fixed in https://github.com/etcd-io/etcd/pull/13348, however this is was not patched on main branch.

This PR makes v3.6 RaftCluster consistent with v3.5 so we can cleanly migrate off v2 store.
