### PR TITLE
Bootstrap from v3 store

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -305,7 +305,7 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 // ensures that it is still valid.
 func (c *RaftCluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 	// TODO: this must be switched to backend as well.
-	membersMap, removedMap := membersFromStore(c.lg, c.v2store)
+	membersMap, removedMap := c.be.MustReadMembersFromBackend()
 	id := types.ID(cc.NodeID)
 	if removedMap[id] {
 		return ErrIDRemoved

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -115,10 +115,10 @@ func CreateConfigChangeEnts(lg *zap.Logger, ids []uint64, self uint64, term, ind
 // - ConfChangeAddNode, in which case the contained ID will Be added into the set.
 // - ConfChangeRemoveNode, in which case the contained ID will Be removed from the set.
 // - ConfChangeAddLearnerNode, in which the contained ID will Be added into the set.
-func GetEffectiveNodeIDsFromWalEntries(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
+func GetEffectiveNodeIDsFromWalEntries(lg *zap.Logger, confstate *raftpb.ConfState, ents []raftpb.Entry) []uint64 {
 	ids := make(map[uint64]bool)
-	if snap != nil {
-		for _, id := range snap.Metadata.ConfState.Voters {
+	if confstate != nil {
+		for _, id := range confstate.Voters {
 			ids[id] = true
 		}
 	}


### PR DESCRIPTION
Very drafty draft for bootstraping etcd from v3 store.

Looks like there is no function in raft.MemoryStorage to start from ConsistentIndex + Confstate instead of snapshot.
So I forced it into a ApplySnapshot which I don't think it correct. Still it worked on trivial case for me locally.

I think there are still some edge cases to cover, for example:
* what happens if etcd exits before it flushes confstate and CI to db.
