### PR TITLE
pkg/stringutil: sort 'ss' in TestUniqueStrings

### DIFF
--- a/pkg/stringutil/rand_test.go
+++ b/pkg/stringutil/rand_test.go
@@ -15,16 +15,16 @@
 package stringutil
 
 import (
-	"fmt"
+	"sort"
 	"testing"
 )
 
 func TestUniqueStrings(t *testing.T) {
 	ss := UniqueStrings(10, 50)
+	sort.Strings(ss)
 	for i := 1; i < len(ss); i++ {
 		if ss[i-1] == ss[i] {
 			t.Fatalf("ss[i-1] %q == ss[i] %q", ss[i-1], ss[i])
 		}
 	}
-	fmt.Println(ss)
 }


### PR DESCRIPTION
From the algorithm below, 'ss' should be sorted.

Also removes 'fmt.Println', because the idiomatic tests would not print.
