### PR TITLE
Fix memberList may return incorrect intermediate results right after bootstrap

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,7 @@ jobs:
           echo "${TARGET}"
           case "${TARGET}" in
             linux-amd64-e2e)
+              make gofail-enable
               VERBOSE=1 GOOS=linux GOARCH=amd64 CPU=4 EXPECT_DEBUG=true make test-e2e-release
               ;;
             linux-386-e2e)

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -468,6 +468,9 @@ func TestClusterGenID(t *testing.T) {
 		newTestMember(2, nil, "", nil),
 	})
 
+	be := newMembershipBackend()
+	cs.SetBackend(be)
+
 	cs.genID()
 	if cs.ID() == 0 {
 		t.Fatalf("cluster.ID = %v, want not 0", cs.ID())

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -1827,6 +1827,8 @@ func (s *EtcdServer) apply(
 			s.setTerm(e.Term)
 
 		case raftpb.EntryConfChange:
+			// gofail: var beforeApplyOneConfChange struct{}
+
 			// We need to toApply all WAL entries on top of v2store
 			// and only 'unapplied' (e.Index>backend.ConsistentIndex) on the backend.
 			shouldApplyV3 := membership.ApplyV2storeOnly

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -55,6 +55,7 @@ import (
 	"go.etcd.io/etcd/server/v3/mock/mockstore"
 	"go.etcd.io/etcd/server/v3/mock/mockwait"
 	serverstorage "go.etcd.io/etcd/server/v3/storage"
+	"go.etcd.io/etcd/server/v3/storage/backend"
 	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 	"go.etcd.io/etcd/server/v3/storage/schema"
@@ -181,6 +182,7 @@ func TestDoBadLocalAction(t *testing.T) {
 
 // TestApplyRepeat tests that server handles repeat raft messages gracefully
 func TestApplyRepeat(t *testing.T) {
+	lg := zaptest.NewLogger(t)
 	n := newNodeConfChangeCommitterStream()
 	n.readyc <- raft.Ready{
 		SoftState: &raft.SoftState{RaftState: raft.StateLeader},
@@ -188,6 +190,9 @@ func TestApplyRepeat(t *testing.T) {
 	cl := newTestCluster(t, nil)
 	st := v2store.New()
 	cl.SetStore(v2store.New())
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
+
 	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          zaptest.NewLogger(t),
@@ -490,7 +495,9 @@ func TestApplyRequest(t *testing.T) {
 }
 
 func TestApplyRequestOnAdminMemberAttributes(t *testing.T) {
-	cl := newTestCluster(t, []*membership.Member{{ID: 1}})
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+	cl := newTestClusterWithBackend(t, []*membership.Member{{ID: 1}}, be)
 	srv := &EtcdServer{
 		lgMu:    new(sync.RWMutex),
 		lg:      zaptest.NewLogger(t),
@@ -513,8 +520,14 @@ func TestApplyRequestOnAdminMemberAttributes(t *testing.T) {
 }
 
 func TestApplyConfChangeError(t *testing.T) {
-	cl := membership.NewCluster(zaptest.NewLogger(t))
+	lg := zaptest.NewLogger(t)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+
+	cl := membership.NewCluster(lg)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
 	cl.SetStore(v2store.New())
+
 	for i := 1; i <= 4; i++ {
 		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
@@ -601,8 +614,14 @@ func TestApplyConfChangeError(t *testing.T) {
 }
 
 func TestApplyConfChangeShouldStop(t *testing.T) {
-	cl := membership.NewCluster(zaptest.NewLogger(t))
+	lg := zaptest.NewLogger(t)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+
+	cl := membership.NewCluster(lg)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
 	cl.SetStore(v2store.New())
+
 	for i := 1; i <= 3; i++ {
 		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
@@ -611,7 +630,6 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 		Node:      newNodeNop(),
 		transport: newNopTransporter(),
 	})
-	lg := zaptest.NewLogger(t)
 	srv := &EtcdServer{
 		lgMu:     new(sync.RWMutex),
 		lg:       lg,
@@ -648,13 +666,15 @@ func TestApplyConfChangeShouldStop(t *testing.T) {
 // where consistIndex equals to applied index.
 func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 	lg := zaptest.NewLogger(t)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
 
 	cl := membership.NewCluster(zaptest.NewLogger(t))
 	cl.SetStore(v2store.New())
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
+
 	cl.AddMember(&membership.Member{ID: types.ID(1)}, true)
 
-	be, _ := betesting.NewDefaultTmpBackend(t)
-	defer betesting.Close(t, be)
 	schema.CreateMetaBucket(be.BatchTx())
 
 	ci := cindex.NewConsistentIndex(be)
@@ -732,6 +752,9 @@ func TestApplyMultiConfChangeShouldStop(t *testing.T) {
 	lg := zaptest.NewLogger(t)
 	cl := membership.NewCluster(lg)
 	cl.SetStore(v2store.New())
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
+
 	for i := 1; i <= 5; i++ {
 		cl.AddMember(&membership.Member{ID: types.ID(i)}, true)
 	}
@@ -1248,6 +1271,8 @@ func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
 	st := v2store.New()
 	cl := membership.NewCluster(lg)
 	cl.SetStore(st)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
 
 	testdir := t.TempDir()
 	if err := os.MkdirAll(testdir+"/member/snap", 0755); err != nil {
@@ -1264,7 +1289,6 @@ func TestConcurrentApplyAndSnapshotV3(t *testing.T) {
 		storage:     mockstorage.NewStorageRecorder(testdir),
 		raftStorage: rs,
 	})
-	be, _ := betesting.NewDefaultTmpBackend(t)
 	ci := cindex.NewConsistentIndex(be)
 	s := &EtcdServer{
 		lgMu:         new(sync.RWMutex),
@@ -1345,6 +1369,10 @@ func TestAddMember(t *testing.T) {
 	cl := newTestCluster(t, nil)
 	st := v2store.New()
 	cl.SetStore(st)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
+
 	r := newRaftNode(raftNodeConfig{
 		lg:          lg,
 		Node:        n,
@@ -1391,6 +1419,9 @@ func TestRemoveMember(t *testing.T) {
 	cl := newTestCluster(t, nil)
 	st := v2store.New()
 	cl.SetStore(v2store.New())
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
+
 	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          lg,
@@ -1430,6 +1461,8 @@ func TestRemoveMember(t *testing.T) {
 // TestUpdateMember tests RemoveMember can propose and perform node update.
 func TestUpdateMember(t *testing.T) {
 	lg := zaptest.NewLogger(t)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
 	n := newNodeConfChangeCommitterRecorder()
 	n.readyc <- raft.Ready{
 		SoftState: &raft.SoftState{RaftState: raft.StateLeader},
@@ -1437,6 +1470,7 @@ func TestUpdateMember(t *testing.T) {
 	cl := newTestCluster(t, nil)
 	st := v2store.New()
 	cl.SetStore(st)
+	cl.SetBackend(schema.NewMembershipBackend(lg, be))
 	cl.AddMember(&membership.Member{ID: 1234}, true)
 	r := newRaftNode(raftNodeConfig{
 		lg:          lg,
@@ -1897,6 +1931,16 @@ func (n *nodeCommitter) Propose(ctx context.Context, data []byte) error {
 
 func newTestCluster(t testing.TB, membs []*membership.Member) *membership.RaftCluster {
 	c := membership.NewCluster(zaptest.NewLogger(t))
+	for _, m := range membs {
+		c.AddMember(m, true)
+	}
+	return c
+}
+
+func newTestClusterWithBackend(t testing.TB, membs []*membership.Member, be backend.Backend) *membership.RaftCluster {
+	lg := zaptest.NewLogger(t)
+	c := membership.NewCluster(lg)
+	c.SetBackend(schema.NewMembershipBackend(lg, be))
 	for _, m := range membs {
 		c.AddMember(m, true)
 	}

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -193,6 +193,8 @@ type EtcdProcessClusterConfig struct {
 	ExperimentalWarningUnaryRequestDuration time.Duration
 	PeerProxy                               bool
 	WatchProcessNotifyInterval              time.Duration
+
+	WaitClusterReadyTimeout time.Duration
 }
 
 func DefaultConfig() *EtcdProcessClusterConfig {
@@ -369,6 +371,14 @@ func WithCompactionSleepInterval(time time.Duration) EPClusterOption {
 
 func WithWatchProcessNotifyInterval(interval time.Duration) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.WatchProcessNotifyInterval = interval }
+}
+
+func WithWaitClusterReadyTimeout(readyTimeout time.Duration) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.WaitClusterReadyTimeout = readyTimeout }
+}
+
+func WithEnvVars(ev map[string]string) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.EnvVars = ev }
 }
 
 func WithPeerProxy(enabled bool) EPClusterOption {
@@ -609,6 +619,9 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 	}
 	if cfg.WatchProcessNotifyInterval != 0 {
 		args = append(args, "--experimental-watch-progress-notify-interval", cfg.WatchProcessNotifyInterval.String())
+	}
+	if cfg.WaitClusterReadyTimeout != 0 {
+		args = append(args, "--experimental-wait-cluster-ready-timeout", cfg.WaitClusterReadyTimeout.String())
 	}
 	if cfg.SnapshotCatchUpEntries != etcdserver.DefaultSnapshotCatchUpEntries {
 		if cfg.Version == CurrentVersion || (cfg.Version == MinorityLastVersion && i <= cfg.ClusterSize/2) || (cfg.Version == QuorumLastVersion && i > cfg.ClusterSize/2) {


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

The first commit added a test case, basically which always fails,

```
2023-09-27T16:26:55.3567789Z     ctl_v3_member_test.go:128: 
2023-09-27T16:26:55.3568428Z         	Error Trace:	/__w/etcd/etcd/tests/e2e/ctl_v3_member_test.go:128
2023-09-27T16:26:56.3453793Z         	            				/__t/go/1.21.1/x64/src/runtime/asm_amd64.s:1650
2023-09-27T16:26:56.3455109Z         	Error:      	Not equal: 
2023-09-27T16:26:56.3456321Z         	            	expected: 1
2023-09-27T16:26:56.3457394Z         	            	actual  : 2
```

After applying the patch in the second commit, then the issue is resolved.

The third commit is fixing the broken unit test in server_test.go, and is coming from @geetasg 's PR https://github.com/etcd-io/etcd/pull/16084. I already set the author as @geetasg