### PR TITLE
all: use built-in min/max

### DIFF
--- a/pkg/report/timeseries.go
+++ b/pkg/report/timeseries.go
@@ -64,9 +64,9 @@ func (sp *secondPoints) Add(ts time.Time, lat time.Duration) {
 		sp.tm[tk] = secondPoint{minLatency: lat, maxLatency: lat, totalLatency: lat, count: 1}
 	} else {
 		if lat != time.Duration(0) {
-			v.minLatency = minDuration(v.minLatency, lat)
+			v.minLatency = min(v.minLatency, lat)
 		}
-		v.maxLatency = maxDuration(v.maxLatency, lat)
+		v.maxLatency = max(v.maxLatency, lat)
 		v.totalLatency += lat
 		v.count++
 		sp.tm[tk] = v
@@ -143,18 +143,4 @@ func (t TimeSeries) String() string {
 		log.Fatal(err)
 	}
 	return fmt.Sprintf("\nSample in one second (unix latency throughput):\n%s", buf.String())
-}
-
-func minDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxDuration(a, b time.Duration) time.Duration {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -152,13 +152,6 @@ func compactKV(clients []*v3.Client) {
 	}
 }
 
-func max(n1, n2 int64) int64 {
-	if n1 > n2 {
-		return n1
-	}
-	return n2
-}
-
 func hashKV(cmd *cobra.Command, clients []*v3.Client) {
 	eps, err := cmd.Flags().GetStringSlice("endpoints")
 	if err != nil {


### PR DESCRIPTION
Since go.mod is 1.21, we can simplify code by using these built-in functions.