### PR TITLE
.github: ensure there is no change after make-fix

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -30,3 +30,13 @@ jobs:
           set -euo pipefail
 
           make fix
+
+          DIFF=$(git status --porcelain)
+
+          if [ -n "$DIFF" ]; then
+            echo "These files were modified:"
+            echo
+            echo "$DIFF"
+            echo
+            exit 1
+          fi

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -23,7 +23,7 @@ linters:
     - staticcheck
     - stylecheck
     - unused
-    - unconvert  # Remove unnecessary type conversions
+    - unconvert # Remove unnecessary type conversions
 linters-settings: # please keep this alphabetized
   goimports:
     local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.


### PR DESCRIPTION
The yamllint is different from yamlfmt. We disable the yamlint on comment.
This patch is to check the diff after make-fix. Maybe we can consider to use `yamlfmt -lint` instead of yamllint

REF: https://github.com/etcd-io/etcd/pull/16269#discussion_r1341239430

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
