### PR TITLE
test: fix the TestCtlV3ConsistentMemberList: set the wait-cluster-ready-timeout as 1ns

### DIFF
--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -69,7 +69,7 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 
 	epc, err := e2e.NewEtcdProcessCluster(ctx, t,
 		e2e.WithClusterSize(1),
-		e2e.WithWaitClusterReadyTimeout(0),
+		e2e.WithWaitClusterReadyTimeout(1*time.Nanosecond),
 		e2e.WithEnvVars(map[string]string{"GOFAIL_FAILPOINTS": `beforeApplyOneConfChange=sleep("2s")`}),
 	)
 	require.NoError(t, err, "failed to start etcd cluster: %v", err)


### PR DESCRIPTION
FIx https://github.com/etcd-io/etcd/pull/16658#discussion_r1341959776

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
