### PR TITLE
Reuse embed.Config in e2e cluster config

### DIFF
--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -40,7 +40,7 @@ func TestEtcdCorruptHash(t *testing.T) {
 	cfg := e2e.NewConfigNoTLS()
 
 	// trigger snapshot so that restart member can load peers from disk
-	cfg.SnapshotCount = 3
+	cfg.ServerConfig.SnapshotCount = 3
 
 	testCtl(t, corruptTest, withQuorum(),
 		withCfg(*cfg),

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -190,13 +190,13 @@ func withFlagByEnv() ctlOption {
 // may be overwritten by `withCfg`.
 func withMaxConcurrentStreams(streams uint32) ctlOption {
 	return func(cx *ctlCtx) {
-		cx.cfg.MaxConcurrentStreams = streams
+		cx.cfg.ServerConfig.MaxConcurrentStreams = streams
 	}
 }
 
 func withLogLevel(logLevel string) ctlOption {
 	return func(cx *ctlCtx) {
-		cx.cfg.LogLevel = logLevel
+		cx.cfg.ServerConfig.LogLevel = logLevel
 	}
 }
 
@@ -221,9 +221,9 @@ func testCtlWithOffline(t *testing.T, testFunc func(ctlCtx), testOfflineFunc fun
 	if !ret.quorum {
 		ret.cfg = *e2e.ConfigStandalone(ret.cfg)
 	}
-	ret.cfg.StrictReconfigCheck = !ret.disableStrictReconfigCheck
+	ret.cfg.ServerConfig.StrictReconfigCheck = !ret.disableStrictReconfigCheck
 	if ret.initialCorruptCheck {
-		ret.cfg.InitialCorruptCheck = ret.initialCorruptCheck
+		ret.cfg.ServerConfig.ExperimentalInitialCorruptCheck = ret.initialCorruptCheck
 	}
 	if testOfflineFunc != nil {
 		ret.cfg.KeepDataDir = true

--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -90,7 +90,7 @@ func mixVersionsSnapshotTestByAddingMember(t *testing.T, clusterVersion, newInst
 	// start a new etcd instance, which will receive a snapshot from the leader.
 	newCfg := *epc.Cfg
 	newCfg.Version = newInstanceVersion
-	newCfg.SnapshotCatchUpEntries = 10
+	newCfg.ServerConfig.SnapshotCatchUpEntries = 10
 	t.Log("Starting a new etcd instance")
 	_, err = epc.StartNewProc(context.TODO(), &newCfg, t, false /* addAsLearner */)
 	require.NoError(t, err, "failed to start the new etcd instance: %v", err)

--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -32,7 +32,7 @@ func TestCurlV3CipherSuitesMismatch(t *testing.T) { testCurlV3CipherSuites(t, fa
 func testCurlV3CipherSuites(t *testing.T, valid bool) {
 	cc := e2e.NewConfigClientTLS()
 	cc.ClusterSize = 1
-	cc.CipherSuites = []string{
+	cc.ServerConfig.CipherSuites = []string{
 		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -102,15 +102,15 @@ func testCurlV3MaxStream(t *testing.T, reachLimit bool, opts ...ctlOption) {
 	//	(a) generate ${concurrentNumber} concurrent watch streams;
 	//	(b) submit a range request.
 	var wg sync.WaitGroup
-	concurrentNumber := cx.cfg.MaxConcurrentStreams - 1
+	concurrentNumber := cx.cfg.ServerConfig.MaxConcurrentStreams - 1
 	expectedResponse := `"revision":"`
 	if reachLimit {
-		concurrentNumber = cx.cfg.MaxConcurrentStreams
+		concurrentNumber = cx.cfg.ServerConfig.MaxConcurrentStreams
 		expectedResponse = "Operation timed out"
 	}
 	wg.Add(int(concurrentNumber))
 	t.Logf("Running the test, MaxConcurrentStreams: %d, concurrentNumber: %d, expected range's response: %s\n",
-		cx.cfg.MaxConcurrentStreams, concurrentNumber, expectedResponse)
+		cx.cfg.ServerConfig.MaxConcurrentStreams, concurrentNumber, expectedResponse)
 
 	closeServerCh := make(chan struct{})
 	submitConcurrentWatch(cx, int(concurrentNumber), &wg, closeServerCh)

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -84,7 +84,7 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 	e2e.BeforeTest(t)
 	for _, tc := range tcs {
 		tc := tc
-		tc.config.WatchProcessNotifyInterval = watchResponsePeriod
+		tc.config.ServerConfig.ExperimentalWatchProgressNotifyInterval = watchResponsePeriod
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(&tc.config))
 			require.NoError(t, err)

--- a/tests/robustness/failpoints.go
+++ b/tests/robustness/failpoints.go
@@ -369,7 +369,7 @@ func (t triggerCompact) Trigger(ctx context.Context, _ *testing.T, member e2e.Et
 		}
 
 		rev = resp.Header.Revision
-		if !t.multiBatchCompaction || rev > int64(clus.Cfg.CompactionBatchLimit) {
+		if !t.multiBatchCompaction || rev > int64(clus.Cfg.ServerConfig.ExperimentalCompactionBatchLimit) {
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -408,7 +408,7 @@ func (tb triggerBlackhole) Trigger(ctx context.Context, t *testing.T, member e2e
 }
 
 func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, process e2e.EtcdProcess) bool {
-	if tb.waitTillSnapshot && config.SnapshotCatchUpEntries > 100 {
+	if tb.waitTillSnapshot && config.ServerConfig.SnapshotCatchUpEntries > 100 {
 		return false
 	}
 	return config.ClusterSize > 1 && process.PeerProxy() != nil
@@ -483,7 +483,7 @@ func waitTillSnapshot(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessCl
 		// Blackholed member has to be sufficiently behind to trigger snapshot transfer.
 		// Need to make sure leader compacted latest revBlackholedMem inside EtcdServer.snapshot.
 		// That's why we wait for clus.Cfg.SnapshotCount (to trigger snapshot) + clus.Cfg.SnapshotCatchUpEntries (EtcdServer.snapshot compaction offset)
-		if clusterRevision-blackholedMemberRevision > int64(clus.Cfg.SnapshotCount+clus.Cfg.SnapshotCatchUpEntries) {
+		if clusterRevision-blackholedMemberRevision > int64(clus.Cfg.ServerConfig.SnapshotCount+clus.Cfg.ServerConfig.SnapshotCatchUpEntries) {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/tests/robustness/linearizability_test.go
+++ b/tests/robustness/linearizability_test.go
@@ -204,7 +204,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 	report.Client = s.run(ctx, t, lg, report.Cluster)
 	forcestopCluster(report.Cluster)
 
-	watchProgressNotifyEnabled := report.Cluster.Cfg.WatchProcessNotifyInterval != 0
+	watchProgressNotifyEnabled := report.Cluster.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
 	validateGotAtLeastOneProgressNotify(t, report.Client, s.watch.requestProgress || watchProgressNotifyEnabled)
 	validateConfig := validate.Config{ExpectRevisionUnique: s.traffic.ExpectUniqueRevision()}
 	report.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, report.Client)


### PR DESCRIPTION
Refactor in preparation for randomizing configuration in robustness tests for https://github.com/etcd-io/etcd/issues/16673