### PR TITLE
Avoid timing out and provide a proper error in TestCtlV3GetFormat test

### DIFF
--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -17,9 +17,11 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/pkg/v3/expect"
@@ -179,9 +181,11 @@ func getFormatTest(cx ctlCtx) {
 			cmdArgs = append(cmdArgs, "--print-value-only")
 		}
 		cmdArgs = append(cmdArgs, "abc")
-		if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: tt.wstr}); err != nil {
-			cx.t.Errorf("#%d: error (%v), wanted %v", i, err, tt.wstr)
+		lines, err := e2e.RunUtilCompletion(cmdArgs, cx.envMap)
+		if err != nil {
+			cx.t.Errorf("#%d: error (%v)", i, err)
 		}
+		assert.Contains(cx.t, strings.Join(lines, "\n"), tt.wstr)
 	}
 }
 


### PR DESCRIPTION
Failed in https://github.com/etcd-io/etcd/pull/16688 with hard to debug error.

Before:
```
/home/serathius/src/go.etcd.io/etcd/bin/etcdctl (/home/serathius/src/go.etcd.io/etcd/bin/etcdctl_--endpoints=http://localhost:20000_--dial-timeout=7s_get_--write-out=protobuf_abc) (1966803):�ك����}���Ԉ���2 
/home/serathius/src/go.etcd.io/etcd/bin/etcdctl (/home/serathius/src/go.etcd.io/etcd/bin/etcdctl_--endpoints=http://localhost:20000_--dial-timeout=7s_get_--write-out=protobuf_abc) (1966803): abc *123     testutil.go:56: ---> Test failed: test timed out after 15s
    testutil.go:57: goroutine 171 [running]:
        go.etcd.io/etcd/client/pkg/v3/testutil.FatalStack(0xc000103380, {0xc0001ea018, 0x18})
                /home/serathius/src/go.etcd.io/etcd/client/pkg/testutil/testutil.go:55 +0x4c
        go.etcd.io/etcd/tests/v3/e2e.runCtlTest(_, _, _, {0xc000103380, {{{0xf34e7e, 0x7}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...}, ...})
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:267 +0x286
        go.etcd.io/etcd/tests/v3/e2e.testCtlWithOffline(0xc000103380, 0xfaf358?, 0x0, {0x0, 0x0, 0x0?})
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:239 +0x3fd
        go.etcd.io/etcd/tests/v3/e2e.testCtl(...)
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:204
        go.etcd.io/etcd/tests/v3/e2e.TestCtlV3GetFormat(0x0?)
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_kv_test.go:38 +0x25
        testing.tRunner(0xc000103380, 0xfaec98)
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 1
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:1648 +0x3ad
        
        goroutine 1 [chan receive]:
        testing.(*T).Run(0xc0001031e0, {0xf4035b?, 0x53439c?}, 0xfaec98)
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:1649 +0x3c8
        testing.runTests.func1(0x17afa80?)
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:2054 +0x3e
        testing.tRunner(0xc0001031e0, 0xc00063fbe8)
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:1595 +0xff
        testing.runTests(0xc0000ecc80?, {0x17a4380, 0xa6, 0xa6}, {0xc0003ba9d8?, 0x0?, 0x17ad500?})
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:2052 +0x445
        testing.(*M).Run(0xc0000ecc80)
                /home/serathius/.gvm/gos/go1.21.1/src/testing/testing.go:1925 +0x636
        go.etcd.io/etcd/tests/v3/e2e.TestMain(0x4736fa?)
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/main_test.go:17 +0x25
        main.main()
                _testmain.go:379 +0x1c6
        
        goroutine 52 [select]:
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).ExpectFunc(0xc0002e63c0, {0x10b0f80, 0x17de100}, 0xc0003ced40)
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:194 +0x106
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).ExpectWithContext(0xc000170200?, {0x10b0f80?, 0x17de100?}, {{0xf3b1b8?, 0xed23433500000003?}, 0x20?})
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:243 +0xd3
        go.etcd.io/etcd/tests/v3/framework/e2e.SpawnWithExpectLines({0x10b0f80, 0x17de100}, {0xc000170200, 0x6, 0x8}, 0x5?, {0xc0003cf740, 0x1, 0xc000170200?})
                /home/serathius/src/go.etcd.io/etcd/tests/framework/e2e/util.go:73 +0x1ce
        go.etcd.io/etcd/tests/v3/framework/e2e.SpawnWithExpectsContext(...)
                /home/serathius/src/go.etcd.io/etcd/tests/framework/e2e/util.go:57
        go.etcd.io/etcd/tests/v3/framework/e2e.SpawnWithExpects({0xc000170200?, 0xf3a2e2?, 0x7?}, 0xf36402?, {0xc0003cf740?, 0x0?, 0x0?})
                /home/serathius/src/go.etcd.io/etcd/tests/framework/e2e/util.go:53 +0x45
        go.etcd.io/etcd/tests/v3/framework/e2e.SpawnWithExpectWithEnv(...)
                /home/serathius/src/go.etcd.io/etcd/tests/framework/e2e/util.go:49
        go.etcd.io/etcd/tests/v3/e2e.getFormatTest({0xc000103380, {{{0xf34e7e, 0x7}, {0x0, 0x0}, {0x0, 0x0}, 0x2710, 0x1388, 0x5, ...}, ...}, ...})
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_kv_test.go:182 +0x453
        go.etcd.io/etcd/tests/v3/e2e.runCtlTest.func2()
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:259 +0xa3
        created by go.etcd.io/etcd/tests/v3/e2e.runCtlTest in goroutine 171
                /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:257 +0x185
        
        goroutine 180 [syscall]:
        syscall.Syscall(0x42d79b?, 0xc000163aa0?, 0x4ae747?, 0x7ffff800000?)
                /home/serathius/.gvm/gos/go1.21.1/src/syscall/syscall_linux.go:69 +0x25
        syscall.read(0xc00011eb40?, {0xc0003b2000?, 0x6573646374652e01?, 0x4d2e627072657672?})
                /home/serathius/.gvm/gos/go1.21.1/src/syscall/zsyscall_linux_amd64.go:721 +0x38
        syscall.Read(...)
                /home/serathius/.gvm/gos/go1.21.1/src/syscall/syscall_unix.go:181
        internal/poll.ignoringEINTRIO(...)
                /home/serathius/.gvm/gos/go1.21.1/src/internal/poll/fd_unix.go:736
        internal/poll.(*FD).Read(0xc00011eb40, {0xc0003b2000, 0x1000, 0x1000})
                /home/serathius/.gvm/gos/go1.21.1/src/internal/poll/fd_unix.go:160 +0x2ae
        os.(*File).read(...)
                /home/serathius/.gvm/gos/go1.21.1/src/os/file_posix.go:29
        os.(*File).Read(0xc0000a2048, {0xc0003b2000?, 0x4fc33b?, 0x7bec20?})
                /home/serathius/.gvm/gos/go1.21.1/src/os/file.go:118 +0x52
        bufio.(*Reader).fill(0xc000163f50)
                /home/serathius/.gvm/gos/go1.21.1/src/bufio/bufio.go:113 +0x103
        bufio.(*Reader).ReadSlice(0xc000163f50, 0xe0?)
                /home/serathius/.gvm/gos/go1.21.1/src/bufio/bufio.go:379 +0x29
        bufio.(*Reader).collectFragments(0x4bb271?, 0x5?)
                /home/serathius/.gvm/gos/go1.21.1/src/bufio/bufio.go:454 +0x6d
        bufio.(*Reader).ReadString(0xf3a31e?, 0xc?)
                /home/serathius/.gvm/gos/go1.21.1/src/bufio/bufio.go:501 +0x1f
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).tryReadNextLine(0xc0000006c0, 0x5ac?)
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:135 +0x6d
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).read(0xc0000006c0)
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:126 +0x1a8
        created by go.etcd.io/etcd/pkg/v3/expect.NewExpectWithEnv in goroutine 179
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:87 +0x265
        
        goroutine 181 [syscall]:
        syscall.Syscall6(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
                /home/serathius/.gvm/gos/go1.21.1/src/syscall/syscall_linux.go:91 +0x30
        os.(*Process).blockUntilWaitable(0xc0003d6240)
                /home/serathius/.gvm/gos/go1.21.1/src/os/wait_waitid.go:32 +0x76
        os.(*Process).wait(0xc0003d6240)
                /home/serathius/.gvm/gos/go1.21.1/src/os/exec_unix.go:22 +0x25
        os.(*Process).Wait(...)
                /home/serathius/.gvm/gos/go1.21.1/src/os/exec.go:134
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).waitProcess(0xc0000006c0)
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:329 +0x4a
        go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).waitSaveExitErr(0xc0000006c0)
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:154 +0x5c
        created by go.etcd.io/etcd/pkg/v3/expect.NewExpectWithEnv in goroutine 179
                /home/serathius/src/go.etcd.io/etcd/pkg/expect/expect.go:88 +0x2a5
        
    testutil.go:58: test timed out after 15s
```
After
```
/home/serathius/src/go.etcd.io/etcd/bin/etcdctl (/home/serathius/src/go.etcd.io/etcd/bin/etcdctl_--endpoints=http://localhost:20000_--dial-timeout=7s_get_--write-out=protobuf_abc) (1979781): 
/home/serathius/src/go.etcd.io/etcd/bin/etcdctl (/home/serathius/src/go.etcd.io/etcd/bin/etcdctl_--endpoints=http://localhost:20000_--dial-timeout=7s_get_--write-out=protobuf_abc) (1979781):�ك����}���Ԉ���2 
/home/serathius/src/go.etcd.io/etcd/bin/etcdctl (/home/serathius/src/go.etcd.io/etcd/bin/etcdctl_--endpoints=http://localhost:20000_--dial-timeout=7s_get_--write-out=protobuf_abc) (1979781): abc *123     ctl_v3_kv_test.go:188: 
                Error Trace:    /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_kv_test.go:188
                                                        /home/serathius/src/go.etcd.io/etcd/tests/e2e/ctl_v3_test.go:259
                                                        /home/serathius/.gvm/gos/go1.21.1/src/runtime/asm_amd64.s:1650
                Error:          "\r\n\n\x18\b\xd2ك\xd2\xe2\x82\xcb\xcf}\x10\xc6\xfa\xb4Ԉ\x8d\xa1\x852\x18\x02 \x02\x12\x10\r\n\n\x03abc\x10\x02\x18\x02 \x01*\x03123 \x01" does not contain "\x17\b\x93\xe7\xf6\x93\xd4ņ\xe14\x10\xed"
                Test:           TestCtlV3GetFormat
    ctl_v3_test.go:260: ---testFunc logic DONE
```
