### PR TITLE
Dynamically generate flags passed to etcd binary

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -70,8 +70,10 @@ func TestConnectionMultiplexing(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			cfg := e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: tc.serverTLS}, ClientHttpSeparate: tc.separateHttpPort}
-			clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&cfg))
+			cfg := e2e.NewConfig(e2e.WithClusterSize(1))
+			cfg.Client.ConnectionType = tc.serverTLS
+			cfg.ClientHttpSeparate = tc.separateHttpPort
+			clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
 

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -39,10 +39,11 @@ const (
 )
 
 type testCase struct {
-	name          string
-	config        e2e.EtcdProcessClusterConfig
-	maxWatchDelay time.Duration
-	dbSizeBytes   int
+	name                string
+	client              e2e.ClientConfig
+	clientHttpSerparate bool
+	maxWatchDelay       time.Duration
+	dbSizeBytes         int
 }
 
 const (
@@ -56,27 +57,27 @@ const (
 var tcs = []testCase{
 	{
 		name:          "NoTLS",
-		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1},
 		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "TLS",
-		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: e2e.ClientTLS}},
+		client:        e2e.ClientConfig{ConnectionType: e2e.ClientTLS},
 		maxWatchDelay: 150 * time.Millisecond,
 		dbSizeBytes:   5 * Mega,
 	},
 	{
-		name:          "SeparateHttpNoTLS",
-		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, ClientHttpSeparate: true},
-		maxWatchDelay: 150 * time.Millisecond,
-		dbSizeBytes:   5 * Mega,
+		name:                "SeparateHttpNoTLS",
+		clientHttpSerparate: true,
+		maxWatchDelay:       150 * time.Millisecond,
+		dbSizeBytes:         5 * Mega,
 	},
 	{
-		name:          "SeparateHttpTLS",
-		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: e2e.ClientTLS}, ClientHttpSeparate: true},
-		maxWatchDelay: 150 * time.Millisecond,
-		dbSizeBytes:   5 * Mega,
+		name:                "SeparateHttpTLS",
+		client:              e2e.ClientConfig{ConnectionType: e2e.ClientTLS},
+		clientHttpSerparate: true,
+		maxWatchDelay:       150 * time.Millisecond,
+		dbSizeBytes:         5 * Mega,
 	},
 }
 
@@ -84,12 +85,16 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 	e2e.BeforeTest(t)
 	for _, tc := range tcs {
 		tc := tc
-		tc.config.ServerConfig.ExperimentalWatchProgressNotifyInterval = watchResponsePeriod
+		cfg := e2e.DefaultConfig()
+		cfg.ClusterSize = 1
+		cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval = watchResponsePeriod
+		cfg.Client = tc.client
+		cfg.ClientHttpSeparate = tc.clientHttpSerparate
 		t.Run(tc.name, func(t *testing.T) {
-			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(&tc.config))
+			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus.EndpointsGRPC(), tc.config.Client)
+			c := newClient(t, clus.EndpointsGRPC(), tc.client)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, tc.dbSizeBytes))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)
@@ -105,11 +110,16 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 func TestWatchDelayForManualProgressNotification(t *testing.T) {
 	e2e.BeforeTest(t)
 	for _, tc := range tcs {
+		tc := tc
+		cfg := e2e.DefaultConfig()
+		cfg.ClusterSize = 1
+		cfg.Client = tc.client
+		cfg.ClientHttpSeparate = tc.clientHttpSerparate
 		t.Run(tc.name, func(t *testing.T) {
-			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(&tc.config))
+			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus.EndpointsGRPC(), tc.config.Client)
+			c := newClient(t, clus.EndpointsGRPC(), tc.client)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, tc.dbSizeBytes))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)
@@ -137,11 +147,16 @@ func TestWatchDelayForManualProgressNotification(t *testing.T) {
 func TestWatchDelayForEvent(t *testing.T) {
 	e2e.BeforeTest(t)
 	for _, tc := range tcs {
+		tc := tc
+		cfg := e2e.DefaultConfig()
+		cfg.ClusterSize = 1
+		cfg.Client = tc.client
+		cfg.ClientHttpSeparate = tc.clientHttpSerparate
 		t.Run(tc.name, func(t *testing.T) {
-			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(&tc.config))
+			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
-			c := newClient(t, clus.EndpointsGRPC(), tc.config.Client)
+			c := newClient(t, clus.EndpointsGRPC(), tc.client)
 			require.NoError(t, fillEtcdWithData(context.Background(), c, tc.dbSizeBytes))
 
 			ctx, cancel := context.WithTimeout(context.Background(), watchTestDuration)

--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -57,7 +57,7 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			name:   "CorruptCheck",
 			config: NewConfig(WithInitialCorruptCheck(true)),
 			expectArgsContain: []string{
-				"--experimental-initial-corrupt-check",
+				"--experimental-initial-corrupt-check=true",
 			},
 		},
 		{


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/16673 to randomize etcd configuration we need to expand coverage of flags that can be provided in e2e tests. Instead of manually transforming embed.Config struct fields, we can use flagset to automatically generate flags.
