### PR TITLE
*: enable markdown_marker checker

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -22,6 +22,13 @@ jobs:
         with:
           version: '3.20.3'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: |
+          set -euo pipefail
+
+          cargo install marker --version 0.9.0
       - run: |
           set -euo pipefail
 

--- a/Documentation/contributor-guide/branch_management.md
+++ b/Documentation/contributor-guide/branch_management.md
@@ -15,13 +15,13 @@ The `main` branch is our development branch. All new features land here first.
 
 To try new and experimental features, pull `main` and play with it. Note that `main` may not be stable because new features may introduce bugs.
 
-Before the release of the next stable version, feature PRs will be frozen. A [release manager](./release.md/#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
+Before the release of the next stable version, feature PRs will be frozen. A [release manager](./release.md#release-management) will be assigned to major/minor version and will lead the etcd community in test, bug-fix and documentation of the release for one to two weeks.
 
 ### Stable branches
 
 All branches with prefix `release-` are considered _stable_ branches.
 
-After every minor release ([semver.org](https://semver.org/)), we will have a new stable branch for that release, managed by a [patch release manager](./release.md/#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
+After every minor release ([semver.org](https://semver.org/)), we will have a new stable branch for that release, managed by a [patch release manager](./release.md#release-management). We will keep fixing the backwards-compatible bugs for the latest two stable releases. A _patch_ release to each supported release branch, incorporating any bug fixes, will be once every two weeks, given any patches.
 
 [main]: https://github.com/etcd-io/etcd/tree/main
 

--- a/Documentation/contributor-guide/community-membership.md
+++ b/Documentation/contributor-guide/community-membership.md
@@ -38,7 +38,7 @@ contributors to the community.
     - Filing or commenting on issues on GitHub
     - Contributing to community discussions (e.g. meetings, Slack, email discussion
       forums, Stack Overflow)
-- Subscribed to [etcd-dev@googlegroups.com]
+- Subscribed to etcd-dev@googlegroups.com
 - Have read the [contributor guide]
 - Sponsored by one active maintainer or two reviewers.
     - Sponsors must be from multiple member companies to demonstrate integration across community.
@@ -114,13 +114,13 @@ depend on to make decisions in the best interest of the project in a consistent 
 - Directly contributed to the project through implementation and / or review
 - Sponsored by two active maintainers and elected by supermajority
     - Sponsors must be from multiple member companies to demonstrate integration across community.
-- To become a maintainer send an email with your candidacy to [etcd-maintainers-private@googlegroups.com]
+- To become a maintainer send an email with your candidacy to etcd-maintainers-private@googlegroups.com
     - Ensure your sponsors are @mentioned on the email
     - Include a list of contributions representative of your work on the project.
     - Existing maintainers vote will privately and respond to the email with either acceptance or with feedback for suggested improvement.
 - With your membership approved you are expected to:
   - Open a PR and add an entry to the [MAINTAINERS] file
-  - Subscribe to [etcd-maintainers@googlegroups.com] and [etcd-maintainers-private@googlegroups.com]
+  - Subscribe to etcd-maintainers@googlegroups.com and etcd-maintainers-private@googlegroups.com
   - Request to join to [etcd-maintainer teams of etcd organization of GitHub](https://github.com/orgs/etcd-io/teams/maintainers-etcd)
   - Request to join to the private slack channel for etcd maintainers on [kubernetes slack](http://slack.kubernetes.io/)
   - Request access to etcd-development GCP project where we publish releases

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ fuzz:
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
 	verify-govet verify-license-header verify-receiver-name verify-mod-tidy verify-shellcheck \
 	verify-shellws verify-proto-annotations verify-genproto verify-yamllint \
-	verify-govet-shadow
+	verify-govet-shadow verify-markdown-marker
 fix: fix-bom fix-lint fix-yamllint
 	./scripts/fix.sh
 
@@ -136,6 +136,10 @@ verify-yamllint:
 .PHONY: verify-govet-shadow
 verify-govet-shadow:
 	PASSES="govet_shadow" ./scripts/test.sh
+
+.PHONY: verify-markdown-marker
+verify-markdown-marker:
+	PASSES="markdown_marker" ./scripts/test.sh
 
 YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -361,7 +361,7 @@ function shellws_pass {
 function markdown_marker_pass {
   # TODO: check other markdown files when marker handles headers with '[]'
   if tool_exists "marker" "https://crates.io/crates/marker"; then
-    generic_checker run marker --skip-http --root ./Documentation 2>&1
+    generic_checker run marker --skip-http --allow-absolute-paths --root "${ETCD_ROOT_DIR}" -e ./CHANGELOG -e ./etcdctl -e etcdutl -e ./tools 2>&1
   fi
 }
 

--- a/security/README.md
+++ b/security/README.md
@@ -35,7 +35,7 @@ A public disclosure date is negotiated by the etcd Product Security Committee an
 ## Security Audit
 
 A third party security audit was performed by Trail of Bits, find the full report [here](SECURITY_AUDIT.pdf).
-A third party fuzzing audit was performed by Ada Logics, find the full report [here](FUZZING_AUDIT_2022.pdf).
+A third party fuzzing audit was performed by Ada Logics, find the full report [here](FUZZING_AUDIT_2022.PDF).
 
 ## Private Distributor List
 


### PR DESCRIPTION
Part of #15549 

It's trying to re-enable the markdown_marker checker in the repo because we have the old issue https://github.com/etcd-io/etcd/issues/7123. 

However, the marker tool doesn't support the github-like relative path render. 
The `/absolute-path` is useful and easier to be maintained in the github repo than `../../`.

```markdown
This is [MAINTAINER](/MAINTAINER) file.
```


Filed to https://github.com/crawford/marker/pull/23 and hope @crawford can give some inputs.

CI Result: https://github.com/etcd-io/etcd/actions/runs/6446242086/job/17501156794?pr=16708#step:9:459

```
'markdown_marker' started at Sun Oct  8 07:23:06 UTC 2023
% 'marker' '--skip-http' '--root' './Documentation'
'markdown_marker' PASSED and completed at Sun Oct  8 07:23:06 UTC 2023
SUCCESS
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
