### PR TITLE
scripts: remove the markdown_you_pass

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -358,16 +358,6 @@ function shellws_pass {
   fi
 }
 
-function markdown_you_find_eschew_you {
-  local find_you_cmd="find . -name \\*.md ! -path '*/vendor/*' ! -path './Documentation/*' ! -path './gopath.proto/*' ! -path './release/*' -exec grep -E --color '[Yy]ou[r]?[ '\\''.,;]' {} + || true"
-  run eval "${find_you_cmd}"
-}
-
-function markdown_you_pass {
-  # TODO: ./CONTRIBUTING.md:## Get your pull request reviewed
-  generic_checker markdown_you_find_eschew_you
-}
-
 function markdown_marker_pass {
   # TODO: check other markdown files when marker handles headers with '[]'
   if tool_exists "marker" "https://crates.io/crates/marker"; then


### PR DESCRIPTION
Part of #15549 

The markdown_you_pass was introduced by https://github.com/etcd-io/etcd/pull/7416

But in the etcd-io org, I don't see any documents relative to [eschew-you](https://github.com/coreos/docs/blob/master/STYLE.md#eschew-you). 

The comment like `Get your pull request reviewed` seems reasonable.
This pr is to clean up the `markdown_you_pass`.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
