### PR TITLE
[3.4] etcd: upgrade go version to 1.20.9 in Makefile & scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker-remove:
 
 
 
-GO_VERSION ?= 1.20.8
+GO_VERSION ?= 1.20.9
 ETCD_VERSION ?= $(shell git rev-parse --short HEAD || echo "GitNotFound")
 
 TEST_SUFFIX = $(shell date +%s | base64 | head -c 15)

--- a/functional/scripts/docker-local-agent.sh
+++ b/functional/scripts/docker-local-agent.sh
@@ -13,7 +13,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-agent.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.20.8
+  GO_VERSION=1.20.9
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 

--- a/functional/scripts/docker-local-tester.sh
+++ b/functional/scripts/docker-local-tester.sh
@@ -6,7 +6,7 @@ if ! [[ "${0}" =~ "scripts/docker-local-tester.sh" ]]; then
 fi
 
 if [[ -z "${GO_VERSION}" ]]; then
-  GO_VERSION=1.20.8
+  GO_VERSION=1.20.9
 fi
 echo "Running with GO_VERSION:" ${GO_VERSION}
 


### PR DESCRIPTION
Following up on #16729.

Could be a good idea to fetch the go version from .go-version like it is done in the main branch to simplify go version bumps on 3.4 in the future.