### PR TITLE
Update changelog for 3.4 & 3.5

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -11,7 +11,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [Reset auth token when failing to authenticate due to auth being disabled](https://github.com/etcd-io/etcd/pull/16240)
 
 ### Dependencies
-- Compile binaries using [go 1.20.8](https://github.com/etcd-io/etcd/pull/16556).
+- Compile binaries using [go 1.20.9](https://github.com/etcd-io/etcd/pull/16729).
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -29,7 +29,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [panic in etcd validate secure endpoints](https://github.com/etcd-io/etcd/pull/16565)
 
 ### Dependencies
-- Compile binaries using [go 1.20.8](https://github.com/etcd-io/etcd/pull/16555).
+- Compile binaries using [go 1.20.9](https://github.com/etcd-io/etcd/pull/16730).
 
 <hr>
 


### PR DESCRIPTION
To log the go version 1.20.9 bump.

Closes #16712 and links to https://github.com/etcd-io/etcd/pull/16729 and https://github.com/etcd-io/etcd/pull/16730


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
