### PR TITLE
Return to default write scheduler since golang.org/x/net@v0.11.0 started using round robin

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -262,8 +262,6 @@ func configureHttpServer(srv *http.Server, cfg config.ServerConfig) error {
 	// todo (ahrtr): should we support configuring other parameters in the future as well?
 	return http2.ConfigureServer(srv, &http2.Server{
 		MaxConcurrentStreams: cfg.MaxConcurrentStreams,
-		// Override to avoid using priority scheduler which is affected by https://github.com/golang/go/issues/58804.
-		NewWriteScheduler: http2.NewRandomWriteScheduler,
 	})
 }
 

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -63,8 +63,8 @@ var tcs = []testCase{
 	{
 		name:          "TLS",
 		config:        e2e.EtcdProcessClusterConfig{ClusterSize: 1, Client: e2e.ClientConfig{ConnectionType: e2e.ClientTLS}},
-		maxWatchDelay: 3 * time.Second,
-		dbSizeBytes:   500 * Kilo,
+		maxWatchDelay: 150 * time.Millisecond,
+		dbSizeBytes:   5 * Mega,
 	},
 	{
 		name:          "SeparateHttpNoTLS",


### PR DESCRIPTION
Introduction of round robin https://github.com/golang/net/commit/120fc906b30bade8c220769da77801566d7f4ec8 Added in v0.10.0 https://github.com/golang/net/compare/v0.10.0...v0.11.0

Fixes https://github.com/etcd-io/etcd/issues/15402 on main branch

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
