### PR TITLE
Continue on e2e failure

### DIFF
--- a/.github/workflows/e2e-arm64-template.yaml
+++ b/.github/workflows/e2e-arm64-template.yaml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target:
           - linux-arm64-e2e

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,7 +11,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target:
           - linux-amd64-e2e

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -10,7 +10,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         target:
           - linux-amd64-grpcproxy-integration


### PR DESCRIPTION
E2e tests has been flaky, with failfast and 2 scenarios tests are twice as fragile. Any early failure of one of the scenarios cases second to be canceled. Retryign always require running both scenarios.

Intead let's just wait as in other tests allowing us to retry just the scenario that failed

