### PR TITLE
tests: deflake TestEtcdTLSVersion

### DIFF
--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -449,4 +449,6 @@ func TestEtcdTLSVersion(t *testing.T) {
 	assert.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines), "did not receive expected output from etcd process")
 	assert.NoError(t, proc.Stop())
 
+	proc.Wait() // ensure the port has been released
+	proc.Close()
 }


### PR DESCRIPTION
The proc.Stop just sends the SIGTERM to etcd server. The etcd server needs time to teardown. If we don't wait for it, the etcd server will hold the port and then next test case, like TestGrpcProxyAutoSync, will fail to listen on the port 20000.

```bash
file_/__w/etcd/etcd/tests/fixtures/server.crt_--peer-key-file_/__w/etcd/etcd/tests/fixtures/server.key.insecure_--cert-file_/__w/etcd/etcd/tests/fixtures/server2.crt_--key-file_/__w/etcd/etcd/tests/fixtures/server2.key.insecure_--tls-min-version_TLS1.2_--tls-max-version_TLS1.3) (32856): {"level":"info","ts":"2023-10-13T06:12:32.718845Z","caller":"embed/etcd.go:394","msg":"closing etcd server","name":"e1","data-dir":"/tmp/TestEtcdTLSVersion284993522/001","advertise-peer-urls":["https://127.0.0.1:20000"],"advertise-client-urls":["https://0.0.0.0:0"]}
2023-10-13T06:12:32.7399709Z --- PASS: TestEtcdTLSVersion (1.03s)
2023-10-13T06:12:32.7400181Z === RUN   TestGrpcProxyAutoSync
2023-10-13T06:12:32.7401203Z     logger.go:130: 2023-10-13T06:12:32.719Z	INFO	starting server...	{"name": "TestGrpcProxyAutoSync-test-0"}
2023-10-13T06:12:32.7408306Z     logger.go:130: 2023-10-13T06:12:32.719Z	INFO	spawning process	{"args": ["/__w/etcd/etcd/bin/etcd", "--name=TestGrpcProxyAutoSync-test-0", "--listen-client-urls=http://localhost:20000", "--advertise-client-urls=http://localhost:20000", "--listen-peer-urls=http://localhost:20001", "--initial-advertise-peer-urls=http://localhost:20001", "--initial-cluster-token=new", "--data-dir", "/tmp/TestGrpcProxyAutoSync1139610722/001", "--snapshot-count=10000", "--initial-cluster-token=new", "--initial-cluster=TestGrpcProxyAutoSync-test-0=http://localhost:20001", "--initial-cluster-state=new"], "working-dir": "/__w/etcd/etcd/tests/e2e", "name": "TestGrpcProxyAutoSync-test-0", "environment-variables": ["ETCD_VERIFY=all", "EXPECT_DEBUG=true", "PATH=/__t/go/1.21.3/x64/bin:/go/bin:/__t/go/1.21.3/x64/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "ETCD_UNSUPPORTED_ARCH=amd64"]}

...

2023-10-13T06:12:32.7559855Z /__w/etcd/etcd/bin/etcd (TestGrpcProxyAutoSync-test-0) (32863): {"level":"fatal","ts":"2023-10-13T06:12:32.735191Z","caller":"etcdmain/etcd.go:181","msg":"discovery failed","error":"listen tcp 127.0.0.1:20000: bind: address already in use","stacktrace":"go.etcd.io/etcd/server/v3/etcdmain.startEtcdOrProxyV2\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:181\ngo.etcd.io/etcd/server/v3/etcdmain.Main\n\tgo.etcd.io/etcd/server/v3/etcdmain/main.go:40\nmain.main\n\tgo.etcd.io/etcd/server/v3/main.go:31\nruntime.main\n\truntime/proc.go:267"}
```

REF: https://github.com/etcd-io/etcd/actions/runs/6504599468/job/17666787324?pr=16708


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
