### PR TITLE
etcdserver: remove redundant `len` check in health check

### DIFF
--- a/server/etcdserver/api/etcdhttp/health.go
+++ b/server/etcdserver/api/etcdhttp/health.go
@@ -143,27 +143,25 @@ func getSerializableFlag(r *http.Request) bool {
 
 func checkAlarms(lg *zap.Logger, srv ServerHealth, excludedAlarms AlarmSet) Health {
 	h := Health{Health: "true"}
-	as := srv.Alarms()
-	if len(as) > 0 {
-		for _, v := range as {
-			alarmName := v.Alarm.String()
-			if _, found := excludedAlarms[alarmName]; found {
-				lg.Debug("/health excluded alarm", zap.String("alarm", v.String()))
-				continue
-			}
 
-			h.Health = "false"
-			switch v.Alarm {
-			case pb.AlarmType_NOSPACE:
-				h.Reason = "ALARM NOSPACE"
-			case pb.AlarmType_CORRUPT:
-				h.Reason = "ALARM CORRUPT"
-			default:
-				h.Reason = "ALARM UNKNOWN"
-			}
-			lg.Warn("serving /health false due to an alarm", zap.String("alarm", v.String()))
-			return h
+	for _, v := range srv.Alarms() {
+		alarmName := v.Alarm.String()
+		if _, found := excludedAlarms[alarmName]; found {
+			lg.Debug("/health excluded alarm", zap.String("alarm", v.String()))
+			continue
 		}
+
+		h.Health = "false"
+		switch v.Alarm {
+		case pb.AlarmType_NOSPACE:
+			h.Reason = "ALARM NOSPACE"
+		case pb.AlarmType_CORRUPT:
+			h.Reason = "ALARM CORRUPT"
+		default:
+			h.Reason = "ALARM UNKNOWN"
+		}
+		lg.Warn("serving /health false due to an alarm", zap.String("alarm", v.String()))
+		return h
 	}
 
 	return h


### PR DESCRIPTION
From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."

`len` returns 0 if the slice or map is `nil` (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` around a loop is unnecessary.