### PR TITLE
CHANGELOG-3.5.md: Upgrade gRPC to 1.58.3

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -30,6 +30,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Dependencies
 - Compile binaries using [go 1.20.10](https://github.com/etcd-io/etcd/pull/16745).
+- Upgrade gRPC to 1.58.3 in https://github.com/etcd-io/etcd/pull/16625, https://github.com/etcd-io/etcd/pull/16781 and https://github.com/etcd-io/etcd/pull/16790. Note that gRPC server will reject requests with connection header (refer to https://github.com/grpc/grpc-go/pull/4803).
 
 <hr>
 


### PR DESCRIPTION
Ref: https://github.com/etcd-io/etcd/pull/16790

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
