### PR TITLE
Limit a timeout in testing robustness validation

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -94,7 +94,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 	watchProgressNotifyEnabled := report.Cluster.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
 	validateGotAtLeastOneProgressNotify(t, report.Client, s.watch.requestProgress || watchProgressNotifyEnabled)
 	validateConfig := validate.Config{ExpectRevisionUnique: s.traffic.ExpectUniqueRevision()}
-	report.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, report.Client)
+	report.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, report.Client, 5*time.Minute)
 
 	panicked = false
 }

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -28,17 +28,17 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/model"
 )
 
-func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []porcupine.Operation) (result porcupine.CheckResult, visualize func(basepath string) error) {
-	const timeout = 5 * time.Minute
+func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []porcupine.Operation, timeout time.Duration) (result porcupine.CheckResult, visualize func(basepath string) error) {
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
+	start := time.Now()
 	result, info := porcupine.CheckOperationsVerbose(model.NonDeterministicModel, operations, timeout)
 	switch result {
 	case porcupine.Illegal:
-		lg.Error("Linearization failed")
+		lg.Error("Linearization failed", zap.Duration("duration", time.Since(start)))
 	case porcupine.Unknown:
-		lg.Error("Linearization has timed out")
+		lg.Error("Linearization has timed out", zap.Duration("duration", time.Since(start)))
 	case porcupine.Ok:
-		lg.Info("Linearization success")
+		lg.Info("Linearization success", zap.Duration("duration", time.Since(start)))
 	default:
 		panic(fmt.Sprintf("Unknown Linearization result %s", result))
 	}

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/anishathalye/porcupine"
 	"github.com/google/go-cmp/cmp"
@@ -28,9 +29,9 @@ import (
 )
 
 // ValidateAndReturnVisualize returns visualize as porcupine.linearizationInfo used to generate visualization is private.
-func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, reports []report.ClientReport) (visualize func(basepath string) error) {
+func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, reports []report.ClientReport, timeout time.Duration) (visualize func(basepath string) error) {
 	patchedOperations := patchedOperationHistory(reports)
-	linearizable, visualize := validateLinearizableOperationsAndVisualize(lg, patchedOperations)
+	linearizable, visualize := validateLinearizableOperationsAndVisualize(lg, patchedOperations, timeout)
 	if linearizable != porcupine.Ok {
 		t.Error("Failed linearization, skipping further validation")
 		return visualize

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
@@ -37,7 +38,7 @@ func TestValidate(t *testing.T) {
 			path := filepath.Join(testdataPath, file.Name())
 			reports, err := report.LoadClientReports(path)
 			assert.NoError(t, err)
-			visualize := ValidateAndReturnVisualize(t, zaptest.NewLogger(t), Config{}, reports)
+			visualize := ValidateAndReturnVisualize(t, zaptest.NewLogger(t), Config{}, reports, 5*time.Minute)
 
 			if t.Failed() {
 				err := visualize(filepath.Join(path, "history.html"))


### PR DESCRIPTION
As part of https://github.com/etcd-io/etcd/issues/15598 I was working on re-implementing the history patching to avoid too much space explosion. One thing I noticed that it's not easy to reproduce linearization timeout if patching is totally disabled.

To ensure that patching is working and helping reduce the runtime, I have generated and added a case to `TestValidation` that is expected to run over 5 minutes without any patching

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
