### PR TITLE
Fix cluster variable in mixins

### DIFF
--- a/contrib/mixin/dashboards/variables.libsonnet
+++ b/contrib/mixin/dashboards/variables.libsonnet
@@ -9,7 +9,7 @@ function(config) {
     + var.datasource.generalOptions.withLabel('Data Source'),
 
   cluster:
-    var.query.new(config.clusterLabel)
+    var.query.new('cluster')
     + var.query.generalOptions.withLabel('cluster')
     + var.query.withDatasourceFromVariable(self.datasource)
     + { refresh: config.dashboard_var_refresh }


### PR DESCRIPTION
Fix mixin cluster parameter otherwise generated mixins looks like this:

```json
{"type":"prometheus","uid":"${datasource}"},"label":"cluster","name":"job","query":"label_values(etcd_server_has_leader{job=~\".*etcd.*\"}, job)","refresh":2,"type":"query"}]},"time":{"from":"now-15m","to":"now"},"timezone": "`}}{{ .Values.grafana.defaultDashboardsTimezone }}{{`","title":"etcd","uid":"c2f4e12cdf69feb95caa41a5a1b423d9"}`}}
```

where name is job when the variable name used in dashboard queries is cluster.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.


Issue came up here: https://github.com/prometheus-community/helm-charts/pull/3880#issuecomment-1765190231