### PR TITLE
osutil: remove unused Unsetenv function

### DIFF
--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -15,27 +15,7 @@
 // Package osutil implements operating system-related utility functions.
 package osutil
 
-import (
-	"os"
-	"strings"
-)
-
 var (
 	// support to override setting SIG_DFL so tests don't terminate early
 	setDflSignal = dflSignal
 )
-
-func Unsetenv(key string) error {
-	envs := os.Environ()
-	os.Clearenv()
-	for _, e := range envs {
-		strs := strings.SplitN(e, "=", 2)
-		if strs[0] == key {
-			continue
-		}
-		if err := os.Setenv(strs[0], strs[1]); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -17,7 +17,6 @@ package osutil
 import (
 	"os"
 	"os/signal"
-	"reflect"
 	"syscall"
 	"testing"
 	"time"
@@ -26,30 +25,6 @@ import (
 )
 
 func init() { setDflSignal = func(syscall.Signal) {} }
-
-func TestUnsetenv(t *testing.T) {
-	tests := []string{
-		"data",
-		"space data",
-		"equal=data",
-	}
-	for i, tt := range tests {
-		key := "ETCD_UNSETENV_TEST"
-		if os.Getenv(key) != "" {
-			t.Fatalf("#%d: cannot get empty %s", i, key)
-		}
-		env := os.Environ()
-		if err := os.Setenv(key, tt); err != nil {
-			t.Fatalf("#%d: cannot set %s: %v", i, key, err)
-		}
-		if err := Unsetenv(key); err != nil {
-			t.Errorf("#%d: unsetenv %s error: %v", i, key, err)
-		}
-		if g := os.Environ(); !reflect.DeepEqual(g, env) {
-			t.Errorf("#%d: env = %+v, want %+v", i, g, env)
-		}
-	}
-}
 
 func waitSig(t *testing.T, c <-chan os.Signal, sig os.Signal) {
 	select {


### PR DESCRIPTION
The osutil.Unsetenv function is not used. Today, os.Unsetenv exists in the standard library, and is already used elsewhere in etcd. Removing this function could break things that may be importing this package. According to pkg.go.dev, it seems like the only thing is etcd forks, so it may be worth getting rid of this code. See:

https://pkg.go.dev/github.com/coreos/etcd/pkg/osutil?tab=importedby

Signed-off-by: Evan Jones <ej@evanjones.ca>