### PR TITLE
[3.4] Backport clientv3:get AuthToken gracefully without dialing gRPC with balancer API to get extra connection

### DIFF
--- a/clientv3/credentials/credentials.go
+++ b/clientv3/credentials/credentials.go
@@ -156,6 +156,9 @@ func (rc *perRPCCredential) GetRequestMetadata(ctx context.Context, s ...string)
 	rc.authTokenMu.RLock()
 	authToken := rc.authToken
 	rc.authTokenMu.RUnlock()
+	if authToken == "" {
+		return nil, nil
+	}
 	return map[string]string{rpctypes.TokenFieldNameGRPC: authToken}, nil
 }
 

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -703,13 +703,16 @@ func (s *EtcdServer) processInternalRaftRequestOnce(ctx context.Context, r pb.In
 		ID: s.reqIDGen.Next(),
 	}
 
-	authInfo, err := s.AuthInfoFromCtx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if authInfo != nil {
-		r.Header.Username = authInfo.Username
-		r.Header.AuthRevision = authInfo.Revision
+	// check authinfo if it is not InternalAuthenticateRequest
+	if r.Authenticate == nil {
+		authInfo, err := s.AuthInfoFromCtx(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if authInfo != nil {
+			r.Header.Username = authInfo.Username
+			r.Header.AuthRevision = authInfo.Revision
+		}
 	}
 
 	data, err := r.Marshal()


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/16740

Backport https://github.com/etcd-io/etcd/pull/12165 to release-3.4 as the first step to remove etcd dependence on gRPC old balancer API. 

https://github.com/etcd-io/etcd/pull/16800 should be merged first and this PR will be rebased on top of that. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
