### PR TITLE
reproduce 16845

### DIFF
--- a/tests/e2e/http_health_check_test.go
+++ b/tests/e2e/http_health_check_test.go
@@ -210,7 +210,7 @@ func blackhole(_ context.Context, t *testing.T, clus *e2e.EtcdProcessCluster) {
 
 func triggerRaftLoopDeadLock(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessCluster) {
 	require.NoError(t, clus.Procs[0].Failpoints().SetupHTTP(ctx, "raftBeforeSave", `sleep("3s")`))
-	clus.Procs[0].Etcdctl().Put(context.Background(), "foo", "bar", config.PutOptions{})
+	clus.Procs[0].Etcdctl().Put(context.Background(), "foo", "bar", config.PutOptions{Timeout: 100 * time.Millisecond})
 }
 
 func triggerSlowBufferWriteBackWithAuth(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessCluster) {


### PR DESCRIPTION
reproduce #16845
```
make gofail-enable
make build
pushd tests/e2e && EXPECT_DEBUG=true go test -v -run TestLeaseGrantTimeToLiveExpired
```


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
