### PR TITLE
etcdserver/raft.go: separate raft tick and ready

### DIFF
--- a/server/etcdserver/api/v3rpc/interceptor.go
+++ b/server/etcdserver/api/v3rpc/interceptor.go
@@ -323,7 +323,7 @@ func monitorLeader(s *etcdserver.EtcdServer) *streamsMap {
 			case <-s.StoppingNotify():
 				return
 			case <-time.After(election):
-				if s.Leader() == types.ID(raft.None) {
+				if s.RaftStatus().Lead == raft.None {
 					noLeaderCnt++
 				} else {
 					noLeaderCnt = 0

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -1492,9 +1492,9 @@ func (s *EtcdServer) isLearnerReady(id uint64) error {
 		return err
 	}
 
-	rs := s.raftStatus()
+	rs := s.RaftStatus()
 
-	// leader's raftStatus.Progress is not nil
+	// leader's RaftStatus.Progress is not nil
 	if rs.Progress == nil {
 		return errors.ErrNotLeader
 	}
@@ -2451,8 +2451,8 @@ func (s *EtcdServer) IsMemberExist(id types.ID) bool {
 	return s.cluster.IsMemberExist(id)
 }
 
-// raftStatus returns the raft status of this etcd node.
-func (s *EtcdServer) raftStatus() raft.Status {
+// RaftStatus returns the raft status of this etcd node.
+func (s *EtcdServer) RaftStatus() raft.Status {
 	return s.r.Node.Status()
 }
 


### PR DESCRIPTION
Related to https://github.com/etcd-io/etcd/issues/15944. 

etcd leader should not fail to send the heartbeat if disk is blocked. 

This should be helpful to cancel watch streams when disk is stalled. Refer to https://github.com/etcd-io/etcd/issues/13527. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

TODO:

1. add verification that watch will be cancelled if disk is stalled after this patch (also with negative test case). 
2. evaluate if all the `s.Leader()` should be replaced with `r.RaftStatus.Leader`
