### PR TITLE
[3.4] backport client: call .Endpoints() in dial() in client/v3/client.go instead of accessing cfg.Endpoints directly

### DIFF
--- a/clientv3/client.go
+++ b/clientv3/client.go
@@ -56,7 +56,9 @@ type Client struct {
 	cfg      Config
 	creds    grpccredentials.TransportCredentials
 	resolver *resolver.EtcdManualResolver
-	mu       *sync.RWMutex
+
+	epMu      *sync.RWMutex
+	endpoints []string
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -140,18 +142,18 @@ func (c *Client) Ctx() context.Context { return c.ctx }
 // Endpoints lists the registered endpoints for the client.
 func (c *Client) Endpoints() []string {
 	// copy the slice; protect original endpoints from being changed
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	eps := make([]string, len(c.cfg.Endpoints))
-	copy(eps, c.cfg.Endpoints)
+	c.epMu.RLock()
+	defer c.epMu.RUnlock()
+	eps := make([]string, len(c.endpoints))
+	copy(eps, c.endpoints)
 	return eps
 }
 
 // SetEndpoints updates client's endpoints.
 func (c *Client) SetEndpoints(eps ...string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cfg.Endpoints = eps
+	c.epMu.Lock()
+	defer c.epMu.Unlock()
+	c.endpoints = eps
 
 	c.resolver.SetEndpoints(eps)
 }
@@ -279,7 +281,7 @@ func (c *Client) dial(creds grpccredentials.TransportCredentials, dopts ...grpc.
 		defer cancel() // TODO: Is this right for cases where grpc.WithBlock() is not set on the dial options?
 	}
 
-	initialEndpoints := strings.Join(c.cfg.Endpoints, ";")
+	initialEndpoints := strings.Join(c.Endpoints(), ";")
 	target := fmt.Sprintf("%s://%p/#initially=[%s]", resolver.Schema, c, initialEndpoints)
 	conn, err := grpc.DialContext(dctx, target, opts...)
 	if err != nil {
@@ -327,7 +329,7 @@ func newClient(cfg *Config) (*Client, error) {
 		creds:    creds,
 		ctx:      ctx,
 		cancel:   cancel,
-		mu:       new(sync.RWMutex),
+		epMu:     new(sync.RWMutex),
 		callOpts: defaultCallOpts,
 		lgMu:     new(sync.RWMutex),
 	}
@@ -369,6 +371,7 @@ func newClient(cfg *Config) (*Client, error) {
 	if len(cfg.Endpoints) < 1 {
 		return nil, fmt.Errorf("at least one Endpoint must is required in client config")
 	}
+	client.SetEndpoints(cfg.Endpoints...)
 
 	// Use a provided endpoint target so that for https:// without any tls config given, then
 	// grpc will assume the certificate server name is the endpoint host.

--- a/clientv3/client_test.go
+++ b/clientv3/client_test.go
@@ -237,14 +237,12 @@ func TestClientRejectOldCluster(t *testing.T) {
 				endpointToVersion[tt.endpoints[j]] = tt.versions[j]
 			}
 			c := &Client{
-				ctx: context.Background(),
-				cfg: Config{
-					Endpoints: tt.endpoints,
-				},
+				ctx:       context.Background(),
+				endpoints: tt.endpoints,
+				epMu:      new(sync.RWMutex),
 				Maintenance: &mockMaintenance{
 					Version: endpointToVersion,
 				},
-				mu: new(sync.RWMutex),
 			}
 
 			if err := c.checkVersion(); err != tt.expectedError {


### PR DESCRIPTION
Breakdown of https://github.com/etcd-io/etcd/pull/16827 for https://github.com/etcd-io/etcd/issues/16740

Backports
- https://github.com/etcd-io/etcd/pull/13203


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
