### PR TITLE
Replace the deprecated `x509.ParseCRL` with `x509.ParseRevocationList`

### DIFF
--- a/client/pkg/transport/listener_tls.go
+++ b/client/pkg/transport/listener_tls.go
@@ -172,12 +172,12 @@ func checkCRL(crlPath string, cert []*x509.Certificate) error {
 	if err != nil {
 		return err
 	}
-	certList, err := x509.ParseCRL(crlBytes)
+	certList, err := x509.ParseRevocationList(crlBytes)
 	if err != nil {
 		return err
 	}
 	revokedSerials := make(map[string]struct{})
-	for _, rc := range certList.TBSCertList.RevokedCertificates {
+	for _, rc := range certList.RevokedCertificateEntries {
 		revokedSerials[string(rc.SerialNumber.Bytes())] = struct{}{}
 	}
 	for _, c := range cert {


### PR DESCRIPTION
Refer to https://github.com/golang/go/issues/50674

We need to add a unit test to verify the CRL functionality.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
