### PR TITLE
Add range response KV length as a metric

### DIFF
--- a/server/etcdserver/metrics.go
+++ b/server/etcdserver/metrics.go
@@ -118,6 +118,12 @@ var (
 		Name:      "lease_expired_total",
 		Help:      "The total number of expired leases.",
 	})
+	rangeResponseKvCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "range_response_kv_count",
+		Help:      "The number of KVs returned by range calls.",
+	}, []string{"range_begin"})
 
 	currentVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "etcd",
@@ -168,6 +174,7 @@ func init() {
 	prometheus.MustRegister(slowReadIndex)
 	prometheus.MustRegister(readIndexFailed)
 	prometheus.MustRegister(leaseExpired)
+	prometheus.MustRegister(rangeResponseKvCount)
 	prometheus.MustRegister(currentVersion)
 	prometheus.MustRegister(currentGoVersion)
 	prometheus.MustRegister(serverID)

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -136,6 +136,9 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		err = serr
 		return nil, err
 	}
+
+	rangeResponseKvCount.WithLabelValues(string(r.Key)).Observe(float64(len(resp.Kvs)))
+
 	return resp, err
 }
 


### PR DESCRIPTION
This adds a metric to allow us to alert on large range responses described in #14809.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
