### PR TITLE
etcd-io tests: trial arm64 on every pr with a small robustness workflow

### DIFF
--- a/.github/workflows/robustness.yaml
+++ b/.github/workflows/robustness.yaml
@@ -11,3 +11,11 @@ jobs:
       testTimeout: 30m
       artifactName: main
       runs-on: "['ubuntu-latest-8-cores']"
+  main-arm64:
+    uses: ./.github/workflows/robustness-template.yaml
+    with:
+      etcdBranch: main
+      count: 12
+      testTimeout: 30m
+      artifactName: main-arm64
+      runs-on: "['actuated-arm64-8cpu-32gb']"


### PR DESCRIPTION
Trial running a small robustness workflow for arm64 on every pull request KubeconNA 2023 Contribfest issue #16863


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
