### PR TITLE
README.md: Add documentation for new snapshot restore flags

### DIFF
--- a/etcdutl/README.md
+++ b/etcdutl/README.md
@@ -59,6 +59,10 @@ The snapshot restore options closely resemble to those used in the `etcd` comman
 
 - skip-hash-check -- Ignore snapshot integrity hash value (required if copied from data directory)
 
+- bump-revision -- How much to increase the latest revision after restore
+
+- mark-compacted -- Mark the latest revision after restore as the point of scheduled compaction (required if --bump-revision > 0, disallowed otherwise)
+
 #### Output
 
 A new etcd data directory initialized with the snapshot.


### PR DESCRIPTION
Contribfest issue: [16160](https://github.com/etcd-io/etcd/issues/16160)

the 'bump-revision' and 'mark-compated' flags were added to `snapshot restore` and required documentation.

Signed off by Stephen Pawulski spawulski@gmail.com


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
