### PR TITLE
fix test script and lint

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -652,7 +652,7 @@ function run_pass {
   local pass="${1}"
   shift 1
   log_callout -e "\\n'${pass}' started at $(date)"
-  if "${pass}_pass" "${@}" ; then
+  if "${pass}_pass" "$@" ; then
     log_success "'${pass}' PASSED and completed at $(date)"
     return 0
   else

--- a/server/etcdserver/api/v3discovery/discovery_test.go
+++ b/server/etcdserver/api/v3discovery/discovery_test.go
@@ -248,8 +248,8 @@ func (fkv *fakeKVForCheckCluster) Get(ctx context.Context, key string, opts ...c
 				},
 			},
 		}, nil
-
-	} else if key == clusterMembersKey {
+	}
+	if key == clusterMembersKey {
 		if fkv.getMembersRetries > 0 {
 			fkv.getMembersRetries--
 			// discovery client should retry on error.
@@ -263,10 +263,9 @@ func (fkv *fakeKVForCheckCluster) Get(ctx context.Context, key string, opts ...c
 			},
 			Kvs: kvs,
 		}, nil
-	} else {
-		fkv.t.Errorf("unexpected key: %s", key)
-		return nil, fmt.Errorf("unexpected key: %s", key)
 	}
+	fkv.t.Errorf("unexpected key: %s", key)
+	return nil, fmt.Errorf("unexpected key: %s", key)
 }
 
 func TestCheckCluster(t *testing.T) {


### PR DESCRIPTION
Fixes typo in `test.sh` script and `golangci-lint` failure.