### PR TITLE
clientv3test: add comments for clientv3test

### DIFF
--- a/client/v3/ordering/util.go
+++ b/client/v3/ordering/util.go
@@ -29,7 +29,7 @@ func NewOrderViolationSwitchEndpointClosure(c *clientv3.Client) OrderViolationFu
 	violationCount := int32(0)
 	return func(_ clientv3.Op, _ clientv3.OpResponse, _ int64) error {
 		// Each request is assigned by round-robin load-balancer's picker to a different
-		// endpoints. If we cycled them 5 times (even with some level of concurrency),
+		// endpoint. If we cycled them 5 times (even with some level of concurrency),
 		// with high probability no endpoint points on a member with fresh data.
 		// TODO: Ideally we should track members (resp.opp.Header) that returned
 		// stale result and explicitly temporarily disable them in 'picker'.


### PR DESCRIPTION
Add tests for `clientv3test.TestUnresolvableOrderViolation` and `clientv3test.TestEndpointSwitchResolvesViolation`

Improve `TestEndpointSwitchResolvesViolation` with a partition resolved return no error case

Addresses https://github.com/etcd-io/etcd/issues/16865