### PR TITLE
Exclude sleep failpoint from 1 node scenario

### DIFF
--- a/tests/robustness/failpoint/gofail.go
+++ b/tests/robustness/failpoint/gofail.go
@@ -185,6 +185,9 @@ func (f killAndGofailSleep) Name() string {
 }
 
 func (f killAndGofailSleep) Available(config e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess) bool {
+	if config.ClusterSize == 1 {
+		return false
+	}
 	memberFailpoints := member.Failpoints()
 	if memberFailpoints == nil {
 		return false
@@ -220,6 +223,9 @@ func (f gofailSleepAndDeactivate) Name() string {
 }
 
 func (f gofailSleepAndDeactivate) Available(config e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess) bool {
+	if config.ClusterSize == 1 {
+		return false
+	}
 	memberFailpoints := member.Failpoints()
 	if memberFailpoints == nil {
 		return false


### PR DESCRIPTION
When a sleep failpoint is injected into a single-node scenario, the cluster becomes unable to function during the execution of the sleep failpoint. This will lead to a decrease in qps, which may even fall below the minimum requirement if the sleep time is set to a long duration.