### PR TITLE
changelog: Update fix for CVE-2023-47108

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,6 +4,12 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
+## v3.5.11 (tbd)
+### Dependencies
+- Fix [CVE-2023-47108](https://github.com/advisories/GHSA-8pgv-569h-w5rw) by [bumping go.opentelemetry.io/otel to 1.20.0 and go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc to 0.46.0](https://github.com/etcd-io/etcd/pull/16946).
+
+<hr>
+
 ## v3.5.10 (2023-10-27)
 
 ### etcd server


### PR DESCRIPTION
Update 3.5 changelog for fixes backported to 3.5 in [PR](https://github.com/etcd-io/etcd/pull/16946)