### PR TITLE
Increased timeout for scheduled compaction to finish

### DIFF
--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -621,7 +621,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 	select {
 	case <-donec:
 		wg.Wait()
-	case <-time.After(10 * time.Second):
+	case <-time.After(20 * time.Second):
 		testutil.FatalStack(t, "timeout")
 	}
 }


### PR DESCRIPTION
Fixes : [TestHashKVWhenCompacting](https://github.com/etcd-io/etcd/issues/16963)
