### PR TITLE
readme: fix slack link for sig-etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Now it's time to dig into the full etcd API and other guides.
 ## Contact
 
 * Email: [etcd-dev](https://groups.google.com/g/etcd-dev)
-* Slack: [#etcd](https://kubernetes.slack.com/messages/C3HD8ARJ5/details/) channel on Kubernetes ([get an invite](http://slack.kubernetes.io/))
+* Slack: [#sig-etcd](https://kubernetes.slack.com/archives/C3HD8ARJ5) channel on Kubernetes ([get an invite](http://slack.kubernetes.io/))
 * [Community meetings](#community-meetings)
 
 ### Community meetings

--- a/security/security-release-process.md
+++ b/security/security-release-process.md
@@ -104,7 +104,7 @@ With the Fix Development underway, the PSC needs to come up with an overall comm
 - The PSC will announce the new releases, the CVE number, severity, and impact, and the location of the binaries to get wide distribution and user action. As much as possible this announcement should be actionable, and include any mitigating steps users can take prior to upgrading to a fixed version. The recommended target time is 4pm UTC on a non-Friday weekday. This means the announcement will be seen morning Pacific, early evening Europe, and late evening Asia. The announcement will be sent via the following channels:
   - etcd-dev@googlegroups.com
   - [Kubernetes announcement slack channel](https://kubernetes.slack.com/messages/C9T0QMNG4)
-  - [etcd slack channel](https://kubernetes.slack.com/messages/C3HD8ARJ5)
+  - [sig-etcd slack channel](https://kubernetes.slack.com/archives/C3HD8ARJ5)
 
 ## Retrospective
 


### PR DESCRIPTION
This pr fixes the slack link for sig-etcd in readme.md. More details here: https://github.com/kubernetes/community/issues/7616