### PR TITLE
Disable following redirects when checking peer urls

### DIFF
--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -240,6 +240,9 @@ func getVersion(lg *zap.Logger, m *membership.Member, rt http.RoundTripper, time
 	cc := &http.Client{
 		Transport: rt,
 		Timeout:   timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 	var (
 		err  error


### PR DESCRIPTION
It's possible that etcd server may run into a server side request forgery situation when adding a new member. If users provide a malicious peer URL, the existing etcd members may be redirected to other unexpected internal URL when getting the new member's version.

One component of #16969
