### PR TITLE
[3.4] backport #12890 learner support snapshot RPC

### DIFF
--- a/etcdserver/api/v3rpc/interceptor.go
+++ b/etcdserver/api/v3rpc/interceptor.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	maxNoLeaderCnt = 3
+	snapshotMethod = "/etcdserverpb.Maintenance/Snapshot"
 )
 
 type streamsMap struct {
@@ -200,7 +201,7 @@ func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor
 			return rpctypes.ErrGRPCNotCapable
 		}
 
-		if s.IsMemberExist(s.ID()) && s.IsLearner() { // learner does not support stream RPC
+		if s.IsMemberExist(s.ID()) && s.IsLearner() && info.FullMethod != snapshotMethod { // learner does not support stream RPC except Snapshot
 			return rpctypes.ErrGPRCNotSupportedForLearner
 		}
 


### PR DESCRIPTION
etcd v3.5.0 supports saving snapshot from leaner, may I backport this to v3.4?

backport #12890 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
