### PR TITLE
Refactor v2 deprecation tests to allow different cluster config

### DIFF
--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -38,73 +38,54 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func createV2store(t testing.TB, dataDirPath string) string {
-	t.Log("Creating not-yet v2-deprecated etcd")
-
-	cfg := e2e.ConfigStandalone(*e2e.NewConfig(
-		e2e.WithVersion(e2e.LastVersion),
-		e2e.WithEnableV2(true),
-		e2e.WithDataDirPath(dataDirPath),
-		e2e.WithSnapshotCount(5),
-	))
-	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, e2e.WithConfig(cfg))
-	assert.NoError(t, err)
-	memberDataDir := epc.Procs[0].Config().DataDirPath
-
-	defer func() {
-		assert.NoError(t, epc.Stop())
-	}()
-
-	// We need to exceed 'SnapshotCount' such that v2 snapshot is dumped.
-	for i := 0; i < 10; i++ {
+func writeCustomV2Data(t testing.TB, epc *e2e.EtcdProcessCluster, count int) {
+	for i := 0; i < count; i++ {
 		if err := e2e.CURLPut(epc, e2e.CURLReq{
 			Endpoint: "/v2/keys/foo", Value: "bar" + fmt.Sprint(i),
 			Expected: expect.ExpectedResponse{Value: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)}}); err != nil {
 			t.Fatalf("failed put with curl (%v)", err)
 		}
 	}
-	return memberDataDir
 }
 
-func assertVerifyCannotStartV2deprecationWriteOnly(t testing.TB, dataDirPath string) {
-	t.Log("Verify its infeasible to start etcd with --v2-deprecation=write-only mode")
-	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--v2-deprecation=write-only", "--data-dir=" + dataDirPath}, nil)
-	assert.NoError(t, err)
-
-	_, err = proc.Expect("detected disallowed custom content in v2store for stage --v2-deprecation=write-only")
-	assert.NoError(t, err)
-}
-
-func assertVerifyCannotStartV2deprecationNotYet(t testing.TB, dataDirPath string) {
+func TestV2DeprecationNotYet(t *testing.T) {
+	e2e.BeforeTest(t)
 	t.Log("Verify its infeasible to start etcd with --v2-deprecation=not-yet mode")
-	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--v2-deprecation=not-yet", "--data-dir=" + dataDirPath}, nil)
+	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--v2-deprecation=not-yet"}, nil)
 	assert.NoError(t, err)
 
 	_, err = proc.Expect(`invalid value "not-yet" for flag -v2-deprecation: invalid value "not-yet"`)
 	assert.NoError(t, err)
 }
 
-func TestV2DeprecationFlags(t *testing.T) {
+func TestV2DeprecationWriteOnlySnapshot(t *testing.T) {
 	e2e.BeforeTest(t)
 	dataDirPath := t.TempDir()
 
 	if !fileutil.Exist(e2e.BinPath.EtcdLastRelease) {
 		t.Skipf("%q does not exist", e2e.BinPath.EtcdLastRelease)
 	}
+	cfg := e2e.ConfigStandalone(*e2e.NewConfig(
+		e2e.WithVersion(e2e.LastVersion),
+		e2e.WithEnableV2(true),
+		e2e.WithDataDirPath(dataDirPath),
+		e2e.WithSnapshotCount(10),
+	))
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, e2e.WithConfig(cfg))
+	assert.NoError(t, err)
+	memberDataDir := epc.Procs[0].Config().DataDirPath
 
-	var memberDataDir string
-	t.Run("create-storev2-data", func(t *testing.T) {
-		memberDataDir = createV2store(t, dataDirPath)
-	})
+	// We need to exceed 'SnapshotCount' such that v2 snapshot is dumped.
+	writeCustomV2Data(t, epc, 10)
 
-	t.Run("--v2-deprecation=not-yet fails", func(t *testing.T) {
-		assertVerifyCannotStartV2deprecationNotYet(t, memberDataDir)
-	})
+	assert.NoError(t, epc.Stop())
 
-	t.Run("--v2-deprecation=write-only fails", func(t *testing.T) {
-		assertVerifyCannotStartV2deprecationWriteOnly(t, memberDataDir)
-	})
+	t.Log("Verify its infeasible to start etcd with --v2-deprecation=write-only mode")
+	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--v2-deprecation=write-only", "--data-dir=" + memberDataDir}, nil)
+	assert.NoError(t, err)
 
+	_, err = proc.Expect("detected disallowed custom content in v2store for stage --v2-deprecation=write-only")
+	assert.NoError(t, err)
 }
 
 func TestV2DeprecationSnapshotMatches(t *testing.T) {


### PR DESCRIPTION
Split from https://github.com/etcd-io/etcd/pull/16989