### PR TITLE
Extract membership applier

### DIFF
--- a/server/etcdserver/apply/apply.go
+++ b/server/etcdserver/apply/apply.go
@@ -62,13 +62,13 @@ type Result struct {
 	Trace *traceutil.Trace
 }
 
-type applyFunc func(ctx context.Context, r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result
+type applyFunc func(ctx context.Context, r *pb.InternalRaftRequest) *Result
 
 // applierV3 is the interface for processing V3 raft messages
 type applierV3 interface {
 	// Apply executes the generic portion of application logic for the current applier, but
 	// delegates the actual execution to the applyFunc method.
-	Apply(ctx context.Context, r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result
+	Apply(ctx context.Context, r *pb.InternalRaftRequest, applyFunc applyFunc) *Result
 
 	Put(ctx context.Context, p *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error)
 	Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeResponse, *traceutil.Trace, error)
@@ -146,8 +146,8 @@ func newApplierV3Backend(
 		txnModeWriteWithSharedBuffer: txnModeWriteWithSharedBuffer}
 }
 
-func (a *applierV3backend) Apply(ctx context.Context, r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
-	return applyFunc(ctx, r, shouldApplyV3)
+func (a *applierV3backend) Apply(ctx context.Context, r *pb.InternalRaftRequest, applyFunc applyFunc) *Result {
+	return applyFunc(ctx, r)
 }
 
 func (a *applierV3backend) Put(ctx context.Context, p *pb.PutRequest) (resp *pb.PutResponse, trace *traceutil.Trace, err error) {

--- a/server/etcdserver/apply/apply_auth.go
+++ b/server/etcdserver/apply/apply_auth.go
@@ -21,7 +21,6 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/auth"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	"go.etcd.io/etcd/server/v3/lease"
 )
@@ -42,7 +41,7 @@ func newAuthApplierV3(as auth.AuthStore, base applierV3, lessor lease.Lessor) *a
 	return &authApplierV3{applierV3: base, as: as, lessor: lessor}
 }
 
-func (aa *authApplierV3) Apply(ctx context.Context, r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
+func (aa *authApplierV3) Apply(ctx context.Context, r *pb.InternalRaftRequest, applyFunc applyFunc) *Result {
 	aa.mu.Lock()
 	defer aa.mu.Unlock()
 	if r.Header != nil {
@@ -58,7 +57,7 @@ func (aa *authApplierV3) Apply(ctx context.Context, r *pb.InternalRaftRequest, s
 			return &Result{Err: err}
 		}
 	}
-	ret := aa.applierV3.Apply(ctx, r, shouldApplyV3, applyFunc)
+	ret := aa.applierV3.Apply(ctx, r, applyFunc)
 	aa.authInfo.Username = ""
 	aa.authInfo.Revision = 0
 	return ret

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -44,7 +44,7 @@ func dummyIndexWaiter(_ uint64) <-chan struct{} {
 	return ch
 }
 
-func dummyApplyFunc(_ context.Context, _ *pb.InternalRaftRequest, _ membership.ShouldApplyV3) *Result {
+func dummyApplyFunc(_ context.Context, _ *pb.InternalRaftRequest) *Result {
 	return &Result{}
 }
 
@@ -215,7 +215,7 @@ func TestAuthApplierV3_Apply(t *testing.T) {
 	defer cancel()
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			result := authApplier.Apply(ctx, tc.request, false, dummyApplyFunc)
+			result := authApplier.Apply(ctx, tc.request, dummyApplyFunc)
 			require.Equalf(t, result, tc.expectResult, "Apply: got %v, expect: %v", result, tc.expectResult)
 		})
 	}
@@ -386,7 +386,7 @@ func TestAuthApplierV3_AdminPermission(t *testing.T) {
 			if tc.adminPermissionNeeded {
 				tc.request.Header = &pb.RequestHeader{Username: userReadOnly}
 			}
-			result := authApplier.Apply(ctx, tc.request, false, dummyApplyFunc)
+			result := authApplier.Apply(ctx, tc.request, dummyApplyFunc)
 			require.Equal(t, result.Err == auth.ErrPermissionDenied, tc.adminPermissionNeeded,
 				"Admin permission needed: got %v, expect: %v", result.Err == auth.ErrPermissionDenied, tc.adminPermissionNeeded)
 		})

--- a/server/etcdserver/apply/uber_applier.go
+++ b/server/etcdserver/apply/uber_applier.go
@@ -32,7 +32,7 @@ import (
 )
 
 type UberApplier interface {
-	Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result
+	Apply(r *pb.InternalRaftRequest) *Result
 }
 
 type uberApplier struct {
@@ -108,18 +108,18 @@ func (a *uberApplier) restoreAlarms() {
 	}
 }
 
-func (a *uberApplier) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result {
+func (a *uberApplier) Apply(r *pb.InternalRaftRequest) *Result {
 	// We first execute chain of Apply() calls down the hierarchy:
 	// (i.e. CorruptApplier -> CappedApplier -> Auth -> Quota -> Backend),
 	// then dispatch() unpacks the request to a specific method (like Put),
 	// that gets executed down the hierarchy again:
 	// i.e. CorruptApplier.Put(CappedApplier.Put(...(BackendApplier.Put(...)))).
-	return a.applyV3.Apply(context.TODO(), r, shouldApplyV3, a.dispatch)
+	return a.applyV3.Apply(context.TODO(), r, a.dispatch)
 }
 
 // dispatch translates the request (r) into appropriate call (like Put) on
 // the underlying applyV3 object.
-func (a *uberApplier) dispatch(ctx context.Context, r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result {
+func (a *uberApplier) dispatch(ctx context.Context, r *pb.InternalRaftRequest) *Result {
 	op := "unknown"
 	ar := &Result{}
 	defer func(start time.Time) {
@@ -130,10 +130,6 @@ func (a *uberApplier) dispatch(ctx context.Context, r *pb.InternalRaftRequest, s
 			txn.WarnOfFailedRequest(a.lg, start, &pb.InternalRaftStringer{Request: r}, ar.Resp, ar.Err)
 		}
 	}(time.Now())
-
-	if !shouldApplyV3 {
-		return nil
-	}
 
 	switch {
 	case r.Range != nil:

--- a/server/etcdserver/apply/uber_applier.go
+++ b/server/etcdserver/apply/uber_applier.go
@@ -131,21 +131,6 @@ func (a *uberApplier) dispatch(ctx context.Context, r *pb.InternalRaftRequest, s
 		}
 	}(time.Now())
 
-	switch {
-	case r.ClusterVersionSet != nil: // Implemented in 3.5.x
-		op = "ClusterVersionSet"
-		a.applyV3.ClusterVersionSet(r.ClusterVersionSet, shouldApplyV3)
-		return ar
-	case r.ClusterMemberAttrSet != nil:
-		op = "ClusterMemberAttrSet" // Implemented in 3.5.x
-		a.applyV3.ClusterMemberAttrSet(r.ClusterMemberAttrSet, shouldApplyV3)
-		return ar
-	case r.DowngradeInfoSet != nil:
-		op = "DowngradeInfoSet" // Implemented in 3.5.x
-		a.applyV3.DowngradeInfoSet(r.DowngradeInfoSet, shouldApplyV3)
-		return ar
-	}
-
 	if !shouldApplyV3 {
 		return nil
 	}

--- a/server/etcdserver/apply/uber_applier_test.go
+++ b/server/etcdserver/apply/uber_applier_test.go
@@ -128,13 +128,13 @@ func TestUberApplier_Alarm_Corrupt(t *testing.T) {
 			MemberID: memberId,
 			Alarm:    pb.AlarmType_CORRUPT,
 		},
-	}, true)
+	})
 	require.NotNil(t, result)
 	require.Nil(t, result.Err)
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			result = ua.Apply(tc.request, true)
+			result = ua.Apply(tc.request)
 			require.NotNil(t, result)
 			require.Equalf(t, tc.expectError, result.Err, "Apply: got %v, expect: %v", result.Err, tc.expectError)
 		})
@@ -227,13 +227,13 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 			MemberID: memberId,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, true)
+	})
 	require.NotNil(t, result)
 	require.Nil(t, result.Err)
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			result = ua.Apply(tc.request, true)
+			result = ua.Apply(tc.request)
 			require.NotNil(t, result)
 			require.Equalf(t, tc.expectError, result.Err, "Apply: got %v, expect: %v", result.Err, tc.expectError)
 		})
@@ -250,11 +250,11 @@ func TestUberApplier_Alarm_Deactivate(t *testing.T) {
 			MemberID: memberId,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, true)
+	})
 	require.NotNil(t, result)
 	require.Nil(t, result.Err)
 
-	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}, true)
+	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}})
 	require.NotNil(t, result)
 	require.Equalf(t, errors.ErrNoSpace, result.Err, "Apply: got %v, expect: %v", result.Err, errors.ErrNoSpace)
 
@@ -265,11 +265,11 @@ func TestUberApplier_Alarm_Deactivate(t *testing.T) {
 			MemberID: memberId,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, true)
+	})
 	require.NotNil(t, result)
 	require.Nil(t, result.Err)
 
-	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}, true)
+	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}})
 	require.NotNil(t, result)
 	require.Nil(t, result.Err)
 }

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -1913,7 +1913,10 @@ func (s *EtcdServer) applyEntryNormal(e *raftpb.Entry, shouldApplyV3 membership.
 
 func (s *EtcdServer) applyInternalRaftRequest(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *apply.Result {
 	if r.ClusterVersionSet == nil && r.ClusterMemberAttrSet == nil && r.DowngradeInfoSet == nil {
-		return s.uberApply.Apply(r, shouldApplyV3)
+		if !shouldApplyV3 {
+			return nil
+		}
+		return s.uberApply.Apply(r)
 	}
 	membershipApplier := apply.NewApplierMembership(s.lg, s.cluster, s)
 	op := "unknown"

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -60,6 +60,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/apply"
 	"go.etcd.io/etcd/server/v3/etcdserver/cindex"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
+	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	serverversion "go.etcd.io/etcd/server/v3/etcdserver/version"
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/lease/leasehttp"
@@ -1874,7 +1875,7 @@ func (s *EtcdServer) applyEntryNormal(e *raftpb.Entry, shouldApplyV3 membership.
 		if !needResult && raftReq.Txn != nil {
 			removeNeedlessRangeReqs(raftReq.Txn)
 		}
-		ar = s.uberApply.Apply(&raftReq, shouldApplyV3)
+		ar = s.applyInternalRaftRequest(&raftReq, shouldApplyV3)
 	}
 
 	// do not re-toApply applied entries.
@@ -1908,6 +1909,34 @@ func (s *EtcdServer) applyEntryNormal(e *raftpb.Entry, shouldApplyV3 membership.
 		s.raftRequest(s.ctx, pb.InternalRaftRequest{Alarm: a})
 		s.w.Trigger(id, ar)
 	})
+}
+
+func (s *EtcdServer) applyInternalRaftRequest(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *apply.Result {
+	if r.ClusterVersionSet == nil && r.ClusterMemberAttrSet == nil && r.DowngradeInfoSet == nil {
+		return s.uberApply.Apply(r, shouldApplyV3)
+	}
+	membershipApplier := apply.NewApplierMembership(s.lg, s.cluster, s)
+	op := "unknown"
+	defer func(start time.Time) {
+		txn.ApplySecObserve("v3", op, true, time.Since(start))
+		txn.WarnOfExpensiveRequest(s.lg, s.Cfg.WarningApplyDuration, start, &pb.InternalRaftStringer{Request: r}, nil, nil)
+	}(time.Now())
+	switch {
+	case r.ClusterVersionSet != nil:
+		op = "ClusterVersionSet" // Implemented in 3.5.x
+		membershipApplier.ClusterVersionSet(r.ClusterVersionSet, shouldApplyV3)
+		return &apply.Result{}
+	case r.ClusterMemberAttrSet != nil:
+		op = "ClusterMemberAttrSet" // Implemented in 3.5.x
+		membershipApplier.ClusterMemberAttrSet(r.ClusterMemberAttrSet, shouldApplyV3)
+	case r.DowngradeInfoSet != nil:
+		op = "DowngradeInfoSet" // Implemented in 3.5.x
+		membershipApplier.DowngradeInfoSet(r.DowngradeInfoSet, shouldApplyV3)
+	default:
+		s.lg.Panic("not implemented apply", zap.Stringer("raft-request", r))
+		return nil
+	}
+	return &apply.Result{}
 }
 
 func noSideEffect(r *pb.InternalRaftRequest) bool {

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -142,7 +142,7 @@ func TestApplyRepeat(t *testing.T) {
 
 type uberApplierMock struct{}
 
-func (uberApplierMock) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *apply2.Result {
+func (uberApplierMock) Apply(r *pb.InternalRaftRequest) *apply2.Result {
 	return &apply2.Result{}
 }
 


### PR DESCRIPTION
Cluster membership changes can be done via both `EntryNormal` (setting attribute on member) and `EntryConfChange` (adding member). This made it natural to keep them in separate code paths, but it resulted that changes to membership.Cluster can go through totally separate paths
* applyEntryNormal -> uberApplier -> corruptApplier -> authApplier ->  backendApplier -> membership.Cluster
* applyConfChange -> membership.Cluster

This has lead to very weird `shouldApplyV3` logic required to handle v2 and v3 synchronization.

My proposal would be to move the membershipChanges from `applyEntryNormal` and keep them next to `applyConfChange`. The long term goal would be to change `membership.Cluster` into a `membership.Applier`, that would be a single state machine handling all changes to cluster members.

 This PR makes the first step and illustrates how much `shouldApplyV3` is passed through the `v3applier` stack needelesly. 
