### PR TITLE
CHANGELOG: Add 3.5.11 note for --experimental-distributed-tracing-sampling-rate

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -5,6 +5,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 <hr>
 
 ## v3.5.11 (tbd)
+
+### etcd server
+- Fix distributed tracing by ensuring `--experimental-distributed-tracing-sampling-rate` configuration option is available to [set tracing sample rate](https://github.com/etcd-io/etcd/pull/16951).
+
 ### Dependencies
 - Compile binaries using [go 1.20.11](https://github.com/etcd-io/etcd/pull/16915)
 - Fix [CVE-2023-47108](https://github.com/advisories/GHSA-8pgv-569h-w5rw) by [bumping go.opentelemetry.io/otel to 1.20.0 and go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc to 0.46.0](https://github.com/etcd-io/etcd/pull/16946).


### PR DESCRIPTION
Update CHANGELOG to cover https://github.com/etcd-io/etcd/pull/16951.