### PR TITLE
changelog: Update changelog for 3.5.11 to include url redirect fix

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### etcd server
 - Fix distributed tracing by ensuring `--experimental-distributed-tracing-sampling-rate` configuration option is available to [set tracing sample rate](https://github.com/etcd-io/etcd/pull/16951).
+- Fix [url redirects while checking peer urls during new member addition](https://github.com/etcd-io/etcd/pull/16986)
 
 ### Dependencies
 - Compile binaries using [go 1.20.11](https://github.com/etcd-io/etcd/pull/16915)


### PR DESCRIPTION
Updates changelog for 3.5 to include https://github.com/etcd-io/etcd/pull/16986
