### PR TITLE
Adding automated install of Protoc if not found on the system

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -25,8 +25,28 @@ fi
 source ./scripts/test_lib.sh
 
 if [[ $(protoc --version | cut -f2 -d' ') != "3.20.3" ]]; then
-  echo "could not find protoc 3.20.3, is it installed + in PATH?"
-  exit 255
+  echo "Could not find protoc 3.20.3, installing now..."
+
+  arch=$(go env GOARCH)
+
+  case ${arch} in
+    "amd64") file="x86_64" ;;
+    "arm64") file="aarch_64" ;;
+    *)
+      echo "Unsupported architecture: ${arch}"
+      exit 255
+      ;;
+  esac
+
+  download_url="https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-${file}.zip"
+  echo "Running on ${arch}."
+  wget ${download_url} && unzip -p protoc-3.20.3-linux-${file}.zip bin/protoc > tmpFile && mv tmpFile bin/protoc 
+  rm protoc-3.20.3-linux-${file}.zip
+  chmod +x bin/protoc
+  PATH=$PATH:$(pwd)/bin
+  export PATH
+  echo "Now running: $(protoc --version)"
+
 fi
 
 GOFAST_BIN=$(tool_get_bin github.com/gogo/protobuf/protoc-gen-gofast)


### PR DESCRIPTION
@jmhbnz and I are working on refining the test-infra prow workflow to harmonise with the legacy GitHub Actions workflow.

We noticed the [test-infra/config/jobs/etcd/etcd-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/551ef90f7a3efa1560b593bf0c6eea7290bee516/config/jobs/etcd/etcd-presubmits.yaml#L69) is using `make verify-lint` whilst the [etcd/.github/workflows/static-anaylsis.yaml](https://github.com/etcd-io/etcd/blob/db4e95cb1f8d3a8eebfb89c880d5fbd8d6165292/.github/workflows/static-analysis.yaml#L37) is using `make verify`

We want to make a change from `make verify-lint` to `make verify` within the test-infra repo 

When testing the `make verify` command in the test-infra image: `gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231122-5f461e0995-master` there was an error relating to `protoc-3.20.3` not been installed which immediately exists with code `255`

This proposed change adds the automation of installing `protoc-3.20.3` depending on the architecture of the system if its not found.

