### PR TITLE
server: ignore raft messages if member id mismatch

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -698,6 +698,14 @@ func (s *EtcdServer) Process(ctx context.Context, m raftpb.Message) error {
 		)
 		return httptypes.NewHTTPError(http.StatusForbidden, "cannot process message from removed member")
 	}
+	if s.MemberId() != types.ID(m.To) {
+		lg.Warn(
+			"rejected Raft message to mismatch member",
+			zap.String("local-member-id", s.MemberId().String()),
+			zap.String("mismatch-member-id", types.ID(m.To).String()),
+		)
+		return httptypes.NewHTTPError(http.StatusForbidden, "cannot process message to mismatch member")
+	}
 	if m.Type == raftpb.MsgApp {
 		s.stats.RecvAppendReq(types.ID(m.From).String(), m.Size())
 	}


### PR DESCRIPTION
Ignore Raft messages when the `To` field mismatches the local member ID. In cases where incorrect Raft messages are dispatched, potentially due to a malfunctioning switch, this proactive check prevents panics, such as "tocommit is out of range".

Fix #16220
Fix #17081

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
