### PR TITLE
tests: add integration test for retry loop in keepAliveOnce

### DIFF
--- a/tests/integration/clientv3/lease/lease_test.go
+++ b/tests/integration/clientv3/lease/lease_test.go
@@ -117,6 +117,21 @@ func TestLeaseKeepAliveOnce(t *testing.T) {
 	if err != rpctypes.ErrLeaseNotFound {
 		t.Errorf("expected %v, got %v", rpctypes.ErrLeaseNotFound, err)
 	}
+
+	clus.Members[1].Stop(t)
+	clus.Members[2].Stop(t)
+
+	// wait for election timeout, then member[0] will not have a leader.
+	var (
+		electionTicks = 10
+		tickDuration  = 10 * time.Millisecond
+	)
+	time.Sleep(time.Duration(3*electionTicks) * tickDuration)
+
+	_, err = lapi.KeepAliveOnce(context.Background(), resp.ID)
+	if err != rpctypes.ErrNoLeader {
+		t.Errorf("expected %v, got %v", rpctypes.ErrNoLeader, err)
+	}
 }
 
 func TestLeaseKeepAlive(t *testing.T) {


### PR DESCRIPTION
fixes #16869

The retry scenarion for lease keepAliveOnce function was missing integration test coverage. This commit checks for ErrNoLeader
