### PR TITLE
Install gofail in module-aware mode and ignore go.mod file

### DIFF
--- a/tests/robustness/makefile.mk
+++ b/tests/robustness/makefile.mk
@@ -52,7 +52,7 @@ gofail-disable: install-gofail
 
 .PHONY: install-gofail
 install-gofail:
-	cd tools/mod; go install go.etcd.io/gofail@${GOFAIL_VERSION}
+	go install go.etcd.io/gofail@${GOFAIL_VERSION}
 
 # Build previous releases for robustness tests
 


### PR DESCRIPTION
If the arguments have version suffixes (like @latest or @v1.0.0), "go install" builds packages in module-aware mode, ignoring the go.mod file in the current directory or any parent directory, if there is one.

So there is no need to execute "`cd tools/mod`"
