### PR TITLE
Replace the deprecated `x509.ParseCRL` with `x509.ParseRevocationList`

### DIFF
--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -264,9 +264,10 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(time.Duration(selfSignedCertValidity) * 365 * (24 * time.Hour)),
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
 		ExtKeyUsage:           append([]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, additionalUsages...),
 		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
 	if info.Logger != nil {

--- a/client/pkg/transport/listener_tls.go
+++ b/client/pkg/transport/listener_tls.go
@@ -172,12 +172,12 @@ func checkCRL(crlPath string, cert []*x509.Certificate) error {
 	if err != nil {
 		return err
 	}
-	certList, err := x509.ParseCRL(crlBytes)
+	certList, err := x509.ParseRevocationList(crlBytes)
 	if err != nil {
 		return err
 	}
 	revokedSerials := make(map[string]struct{})
-	for _, rc := range certList.TBSCertList.RevokedCertificates {
+	for _, rc := range certList.RevokedCertificateEntries {
 		revokedSerials[string(rc.SerialNumber.Bytes())] = struct{}{}
 	}
 	for _, c := range cert {


### PR DESCRIPTION
Continues the work from #16860. Implements the unit tests to verify the revocation list functionality. 

Fixes #16861.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
