### PR TITLE
testutils: return early instead of first breaking in LogObserver.Expe…

### DIFF
--- a/tests/framework/testutils/log_observer.go
+++ b/tests/framework/testutils/log_observer.go
@@ -79,13 +79,10 @@ func (logOb *LogObserver) ExpectFunc(ctx context.Context, filter func(string) bo
 			}
 
 			if len(res) >= count {
-				break
+				return res, nil
 			}
 		}
 
-		if len(res) >= count {
-			return res, nil
-		}
 		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
Return early instead of unnecessarily first breaking, and then returning under condition `len(res) >= count` in `LogObserver.ExpectFunc`, in `testutils` package. Control flow logic is (I think) unchanged.