### PR TITLE
contrib: add missing lock and mixin readme descriptions

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -2,6 +2,8 @@
 
 Scripts and files which may be useful but aren't part of the core etcd project.
 
-* [systemd](systemd) - an example unit file for deploying etcd on systemd-based distributions
+* [lock](lock) - example addressing the expired lease problem of distributed locking with etcd
+* [mixin](mixin) - customisable set of Grafana dashboard and Prometheus alerts for etcd
 * [raftexample](raftexample) - an example distributed key-value store using raft
+* [systemd](systemd) - an example unit file for deploying etcd on systemd-based distributions
 * [systemd/etcd3-multinode](systemd/etcd3-multinode) - multi-node cluster setup with systemd


### PR DESCRIPTION
Add missing lock and mixin contrib example descriptions to contrib README.
