### PR TITLE
Reproduce issues caused by conf change validation

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -303,9 +303,17 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 
 // ValidateConfigurationChange takes a proposed ConfChange and
 // ensures that it is still valid.
-func (c *RaftCluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
+func (c *RaftCluster) ValidateConfigurationChange(cc raftpb.ConfChange, shouldApplyV3 ShouldApplyV3) error {
 	// TODO: this must be switched to backend as well.
-	membersMap, removedMap := membersFromStore(c.lg, c.v2store)
+	var membersMap map[types.ID]*Member
+	var removedMap map[types.ID]bool
+
+	if shouldApplyV3 {
+		membersMap, removedMap = c.be.MustReadMembersFromBackend()
+	} else {
+		membersMap, removedMap = membersFromStore(c.lg, c.v2store)
+	}
+
 	id := types.ID(cc.NodeID)
 	if removedMap[id] {
 		return ErrIDRemoved

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -457,7 +457,7 @@ func TestClusterValidateConfigurationChangeV2(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		err := cl.ValidateConfigurationChange(tt.cc)
+		err := cl.ValidateConfigurationChange(tt.cc, false)
 		if err != tt.werr {
 			t.Errorf("#%d: validateConfigurationChange error = %v, want %v", i, err, tt.werr)
 		}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -296,10 +296,13 @@ type EtcdServer struct {
 // NewServer creates a new EtcdServer from the supplied configuration. The
 // configuration is considered static for the lifetime of the EtcdServer.
 func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
+	cfg.Logger.Info("bootstrapping...")
 	b, err := bootstrap(cfg)
 	if err != nil {
+		cfg.Logger.Error("bootstrap failed", zap.Error(err))
 		return nil, err
 	}
+	cfg.Logger.Info("bootstrap successfully")
 
 	defer func() {
 		if err != nil {
@@ -1975,7 +1978,9 @@ func removeNeedlessRangeReqs(txn *pb.TxnRequest) {
 // applyConfChange applies a ConfChange to the server. It is only
 // invoked with a ConfChange that has already passed through Raft
 func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, confState *raftpb.ConfState, shouldApplyV3 membership.ShouldApplyV3) (bool, error) {
+	lg := s.Logger()
 	if err := s.cluster.ValidateConfigurationChange(cc, shouldApplyV3); err != nil {
+		lg.Error("Validation on configuration change failed", zap.Bool("shouldApplyV3", bool(shouldApplyV3)), zap.Error(err))
 		cc.NodeID = raft.None
 		s.r.ApplyConfChange(cc)
 
@@ -1988,7 +1993,6 @@ func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, confState *raftpb.Con
 		return false, err
 	}
 
-	lg := s.Logger()
 	*confState = *s.r.ApplyConfChange(cc)
 	s.beHooks.SetConfState(confState)
 	switch cc.Type {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -1975,7 +1975,7 @@ func removeNeedlessRangeReqs(txn *pb.TxnRequest) {
 // applyConfChange applies a ConfChange to the server. It is only
 // invoked with a ConfChange that has already passed through Raft
 func (s *EtcdServer) applyConfChange(cc raftpb.ConfChange, confState *raftpb.ConfState, shouldApplyV3 membership.ShouldApplyV3) (bool, error) {
-	if err := s.cluster.ValidateConfigurationChange(cc); err != nil {
+	if err := s.cluster.ValidateConfigurationChange(cc, shouldApplyV3); err != nil {
 		cc.NodeID = raft.None
 		s.r.ApplyConfChange(cc)
 


### PR DESCRIPTION
Run `go test -run TestMemberReplace -count 10 -v -failfast `

```
    ctl_v3_member_no_proxy_test.go:61: Removing member TestMemberReplace-test-1
    logger.go:130: 2023-12-13T19:08:18.672Z	INFO	server exited	{"name": "TestMemberReplace-test-1", "code": 0, "error": "process is still running"}
    ctl_v3_member_no_proxy_test.go:74: Removing member TestMemberReplace-test-1 data
    ctl_v3_member_no_proxy_test.go:78: Adding member TestMemberReplace-test-1 back
    ctl_v3_member_no_proxy_test.go:81: 
        	Error Trace:	/Users/wachao/go/src/github.com/ahrtr/etcd/tests/e2e/ctl_v3_member_no_proxy_test.go:81
        	Error:      	Received unexpected error:
        	            	match not found.  Set EXPECT_DEBUG for more info Errs: [unexpected exit code [1] after running [/Users/wachao/go/src/github.com/ahrtr/etcd/bin/etcdctl --endpoints=http://localhost:20010,http://localhost:20000 member add TestMemberReplace-test-1 --peer-urls http://localhost:20006 -w json]], last lines:
        	            	{"level":"warn","ts":"2023-12-13T19:08:18.703571Z","logger":"etcd-client","caller":"v3@v3.6.0-alpha.0/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0x14000190780/localhost:20010","method":"/etcdserverpb.Cluster/MemberAdd","attempt":0,"error":"rpc error: code = FailedPrecondition desc = etcdserver: Peer URLs already exists"}
        	            	Error: etcdserver: Peer URLs already exists
        	Test:       	TestMemberReplace
    logger.go:130: 2023-12-13T19:08:18.711Z	INFO	closing test cluster...
```