### PR TITLE
Add digest for base image and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
       interval: weekly
     allow:
       - dependency-type: all
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=amd64
-FROM --platform=linux/${ARCH} gcr.io/distroless/static-debian12
+FROM --platform=linux/${ARCH} gcr.io/distroless/static-debian12@sha256:4a2c1a51ae5e10ec4758a0f981be3ce5d6ac55445828463fce8dff3a355e0b75
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
This should not change the current behavior, but will cause dependabot to update the digest of the latest base image weekly. 

Related: https://github.com/etcd-io/etcd/issues/16987

Signed-off-by: Wes Panther <wpanther@google.com>
