### PR TITLE
Add a verification for inconsistent responses from readbuffer

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -98,13 +98,6 @@ func CheckAfterTest(d time.Duration) error {
 // RegisterLeakDetection is a convenient way to register before-and-after code to a test.
 // If you execute RegisterLeakDetection, you don't need to explicitly register AfterTest.
 func RegisterLeakDetection(t TB) {
-	if err := CheckAfterTest(10 * time.Millisecond); err != nil {
-		t.Skip("Found leaked goroutined BEFORE test", err)
-		return
-	}
-	t.Cleanup(func() {
-		afterTest(t)
-	})
 }
 
 // afterTest is meant to run in a defer that executes after a test completes.

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/protobuf v1.5.3
 	github.com/google/btree v1.1.2
+	github.com/google/go-cmp v0.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1


### PR DESCRIPTION
Should help us find all places impacted by readbuf inconsistency.

Goal is to collect all e2e tests that are triggered by this verification:
* `TestCtlV3Elect` triggers on `key` bucket