### PR TITLE
Remove workflow telemetry github action

### DIFF
--- a/.github/workflows/e2e-arm64.yaml
+++ b/.github/workflows/e2e-arm64.yaml
@@ -13,8 +13,6 @@ jobs:
         target:
           - linux-arm64-e2e
     steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -27,8 +27,6 @@ jobs:
     timeout-minutes: 210
     runs-on: ${{ fromJson(inputs.runs-on) }}
     steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests-template.yaml
+++ b/.github/workflows/tests-template.yaml
@@ -26,8 +26,6 @@ jobs:
           - linux-${{ inputs.arch }}-unit-4-cpu
           - linux-386-unit-1-cpu
     steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Recently in https://github.com/etcd-io/etcd/issues/17045 we introduced a new github action to etcd testing workflows that run on `arm64` so that we could tune the memory requests of those workflows in an evidence based way.

We have now completed that tuning, with workflows being reduced from `32GB` ram to `8GB` ram which also includes plenty of headroom based on current utilisation where workflows generally all sit below `5GB`:

![image](https://github.com/etcd-io/etcd/assets/39425256/826c99b7-48a2-4801-8d84-2ef66ebaf50e)


With the tuning complete I propose we turn off collecting the detailed performance telemetry for every workflow as it creates quite noisy summaries and some error annotations on our workflows, for example: https://github.com/etcd-io/etcd/actions/runs/7231109865.   

We can always turn it back on sometime in future if performance profiling is required again.