### PR TITLE
Fix artifact upload github action for compatibility with v4.0

### DIFF
--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -20,7 +20,7 @@ jobs:
           set -euo pipefail
 
           GOARCH=amd64 CPU=4 make fuzz
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         if: failure()
         with:
           path: "${{env.TARGET_PATH}}/testdata/fuzz/**/*"

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -65,7 +65,7 @@ jobs:
               exit 1
               ;;
           esac
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         if: always()
         with:
           name: ${{ inputs.artifactName }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -42,7 +42,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/tests-template.yaml
+++ b/.github/workflows/tests-template.yaml
@@ -71,4 +71,5 @@ jobs:
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: always()
         with:
+          name: "${{ matrix.target }}"
           path: ./**/junit_*.xml

--- a/.github/workflows/tests-template.yaml
+++ b/.github/workflows/tests-template.yaml
@@ -68,7 +68,7 @@ jobs:
               exit 1
               ;;
           esac
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         if: always()
         with:
           name: "${{ matrix.target }}"


### PR DESCRIPTION
Recently dependabot opened https://github.com/etcd-io/etcd/pull/17140 to propose bumping for v4.0 of artifact-upload github action.

There are breaking changes in v4.0, refer:
  - Description: https://github.com/actions/upload-artifact#breaking-changes
  - Discussion: https://github.com/actions/upload-artifact/issues/472

For etcd the impact appears to be isolated to `.github/workflows/tests-template.yaml` where we just need to explicitly declare a unique `name: ` for each matrix job artifact (like we already do in `.github/workflows/robustness-template.yaml` for example). 