### PR TITLE
Fix bootstrap

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -393,7 +393,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 	}
 
 	defer func() {
-		if err != nil {
+		if be != nil && err != nil {
 			be.Close()
 		}
 	}()

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -35,6 +35,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.etcd.io/etcd/server/v3/config"
+	"go.etcd.io/etcd/server/v3/wal/walpb"
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -485,13 +486,14 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		}
 
 		// Find a snapshot to start/restart a raft node
-		walSnaps, err := wal.ValidSnapshotEntries(cfg.Logger, cfg.WALDir())
+		var walSnaps []walpb.Snapshot
+		walSnaps, err = wal.ValidSnapshotEntries(cfg.Logger, cfg.WALDir())
 		if err != nil {
 			return nil, err
 		}
 		// snapshot files can be orphaned if etcd crashes after writing them but before writing the corresponding
 		// wal log entries
-		snapshot, err := ss.LoadNewestAvailable(walSnaps)
+		snapshot, err = ss.LoadNewestAvailable(walSnaps)
 		if err != nil && err != snap.ErrNoSnapshot {
 			return nil, err
 		}


### PR DESCRIPTION
Don't redeclare err and snapshot variable, fixing validation of consistent index and closing database on defer

`err` variable shared throughout the NewServer function and used on line
396 to defer decision whether backend should be closed when starting
the server failed.

`snapshot` variable is first defined 407, redeclared locally on line 496 and later
again used on line 625. Creation of local variable is a bug introduced
in https://github.com/etcd-io/etcd/pull/11888.

Checking `be` variable is nil is done to avoid panic from  https://github.com/etcd-io/etcd/issues/17146

```
DEFAULT 2023-12-16T11:46:09.619866958Z panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc1a07e] goroutine 1 [running]: go.etcd.io/etcd/etcdserver.NewServer.func2(0xc000452de0, 0xc000451ca0) go.etcd.io/etcd/etcdserver/server.go:345 +0x3e panic(0xed6ba0, 0xc0003261f0) /usr/local/go/src/runtime/panic.go:971 +0x499 go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00029e630, 0xc007e7c000, 0x1, 0x1) /workspace/louhi_ws/go/pkg/mod/go.uber.org/zap@v1.10.0/zapcore/entry.go:229 +0x565 go.uber.org/zap.(*Logger).Panic(0xc000114c60, 0x1097425, 0x2a, 0xc007e7c000, 0x1, 0x1) /workspace/louhi_ws/go/pkg/mod/go.uber.org/zap@v1.10.0/logger.go:225 +0x85 go.etcd.io/etcd/etcdserver.NewServer(0x7ffd9ebad365, 0x11, 0x0, 0x0, 0x0, 0x0, 0xc00016fcb0, 0x1, 0x1, 0xc00016fa70, ...) go.etcd.io/etcd/etcdserver/server.go:473 +0x3ab3 go.etcd.io/etcd/embed.StartEtcd(0xc000404000, 0xc00015a580, 0x0, 0x0) go.etcd.io/etcd/embed/etcd.go:218 +0xa38 go.etcd.io/etcd/etcdmain.startEtcd(0xc000404000, 0x106c356, 0x6, 0xc000126a01, 0x2) go.etcd.io/etcd/etcdmain/etcd.go:302 +0x32 go.etcd.io/etcd/etcdmain.startEtcdOrProxyV2() go.etcd.io/etcd/etcdmain/etcd.go:144 +0x2cba go.etcd.io/etcd/etcdmain.Main() go.etcd.io/etcd/etcdmain/main.go:46 +0x37 main.main() go.etcd.io/etcd/main.go:28 +0x25
```