### PR TITLE
[release-3.4] Check if be is nil to avoid panic when be is overriden with nil

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -341,7 +341,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 	be := openBackend(cfg)
 
 	defer func() {
-		if err != nil {
+		if be != nil && err != nil {
 			be.Close()
 		}
 	}()


### PR DESCRIPTION
Backporting one of the commits from https://github.com/etcd-io/etcd/pull/17151

Checking `be` variable is nil is done to avoid panic from  https://github.com/etcd-io/etcd/issues/17146

```
DEFAULT 2023-12-16T11:46:09.619866958Z panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc1a07e] goroutine 1 [running]: go.etcd.io/etcd/etcdserver.NewServer.func2(0xc000452de0, 0xc000451ca0) go.etcd.io/etcd/etcdserver/server.go:345 +0x3e panic(0xed6ba0, 0xc0003261f0) /usr/local/go/src/runtime/panic.go:971 +0x499 go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00029e630, 0xc007e7c000, 0x1, 0x1) /workspace/louhi_ws/go/pkg/mod/go.uber.org/zap@v1.10.0/zapcore/entry.go:229 +0x565 go.uber.org/zap.(*Logger).Panic(0xc000114c60, 0x1097425, 0x2a, 0xc007e7c000, 0x1, 0x1) /workspace/louhi_ws/go/pkg/mod/go.uber.org/zap@v1.10.0/logger.go:225 +0x85 go.etcd.io/etcd/etcdserver.NewServer(0x7ffd9ebad365, 0x11, 0x0, 0x0, 0x0, 0x0, 0xc00016fcb0, 0x1, 0x1, 0xc00016fa70, ...) go.etcd.io/etcd/etcdserver/server.go:473 +0x3ab3 go.etcd.io/etcd/embed.StartEtcd(0xc000404000, 0xc00015a580, 0x0, 0x0) go.etcd.io/etcd/embed/etcd.go:218 +0xa38 go.etcd.io/etcd/etcdmain.startEtcd(0xc000404000, 0x106c356, 0x6, 0xc000126a01, 0x2) go.etcd.io/etcd/etcdmain/etcd.go:302 +0x32 go.etcd.io/etcd/etcdmain.startEtcdOrProxyV2() go.etcd.io/etcd/etcdmain/etcd.go:144 +0x2cba go.etcd.io/etcd/etcdmain.Main() go.etcd.io/etcd/etcdmain/main.go:46 +0x37 main.main() go.etcd.io/etcd/main.go:28 +0x25
```