### PR TITLE
Adopt kubernetes issue priorities

### DIFF
--- a/Documentation/contributor-guide/roadmap.md
+++ b/Documentation/contributor-guide/roadmap.md
@@ -6,10 +6,7 @@ Proposed milestones is what we think we can deliver with people we have. If we h
 stuff, we could pick up more items from backlog. Note that etcd will continue to mainly focus on technical debt over
 the next few major or minor releases.
 
-Each item has an assigned priority:
-- P0 - Critical for the current milestone, and blocks the release.
-- P1 - Important for the current milestone, and critical for the next milestone.
-- P2 - Nice to have, can be always skipped and should not block anything.
+Each item has an assigned priority. Refer to [priority definitions](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/triage_issues.md#step-5---prioritise-the-issue).
 
 ## v3.6.0
 
@@ -17,16 +14,16 @@ For a full list of tasks in `v3.6.0`, please see [milestone etcd-v3.6](https://g
 
 | Title                                                                                                              | Priority | Status      | Note                                                                                                         |
 |--------------------------------------------------------------------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------|
-| [Support downgrade](https://github.com/etcd-io/etcd/issues/11716)                                                  | P0       | In progress | etcd will support downgrade starting from 3.6.0. But it will also support offline downgrade from 3.5 to 3.4. |
-| [StoreV2 deprecation](https://github.com/etcd-io/etcd/issues/12913)                                                | P0       | In progress | This task will be covered in both 3.6 and 3.7.                                                               |
-| [Release raft 3.6.0](https://github.com/etcd-io/raft/issues/89)                                                    | P0       | Not started | etcd 3.6.0 will depends on raft 3.6.0                                                                        |
-| [Release bbolt 1.4.0](https://github.com/etcd-io/bbolt/issues/553)                                                 | P0       | Not started | etcd 3.6.0 will depends on bbolt 1.4.0                                                                       |
-| [Support /livez and /readyz endpoints](https://github.com/etcd-io/etcd/issues/16007)                               | P1       | In progress | It provides clearer APIs, and can also workaround the stalled writes issue                                   |
-| [Bump gRPC](https://github.com/etcd-io/etcd/issues/16290)                                                          | P1       | Completed   | It isn't guaranteed to be resolved in 3.6, and might be postponed to 3.7 depending on the effort and risk.   |
-| [Deprecate grpc-gateway or bump it](https://github.com/etcd-io/etcd/issues/14499)                                  | P1       | Completed   | It isn't guaranteed to be resolved in 3.6, and might be postponed to 3.7 depending on the effort and risk.   |
-| [bbolt: Add logger into bbolt](https://github.com/etcd-io/bbolt/issues/509)                                        | P1       | In progress | It's important to diagnose bbolt issues                                                                      |
-| [bbolt: Add surgery commands](https://github.com/etcd-io/bbolt/issues/370)                                         | P1       | Completed   | Surgery commands are important for fixing corrupted db files                                                 |
-| [Evaluate and (Gradulate or deprecate/remove) experimental features](https://github.com/etcd-io/etcd/issues/16292) | P2       | Not started | This task will be covered in both 3.6 and 3.7.                                                               |
+| [Support downgrade](https://github.com/etcd-io/etcd/issues/11716)                                                  | priority/important-soon | In progress | etcd will support downgrade starting from 3.6.0. But it will also support offline downgrade from 3.5 to 3.4. |
+| [StoreV2 deprecation](https://github.com/etcd-io/etcd/issues/12913)                                                | priority/important-soon | In progress | This task will be covered in both 3.6 and 3.7.                                                               |
+| [Release raft 3.6.0](https://github.com/etcd-io/raft/issues/89)                                                    | priority/important-soon | Not started | etcd 3.6.0 will depends on raft 3.6.0                                                                        |
+| [Release bbolt 1.4.0](https://github.com/etcd-io/bbolt/issues/553)                                                 | priority/important-soon | Not started | etcd 3.6.0 will depends on bbolt 1.4.0                                                                       |
+| [Support /livez and /readyz endpoints](https://github.com/etcd-io/etcd/issues/16007)                               | priority/important-longterm | In progress | It provides clearer APIs, and can also workaround the stalled writes issue                                   |
+| [Bump gRPC](https://github.com/etcd-io/etcd/issues/16290)                                                          | priority/important-longterm | Completed   | It isn't guaranteed to be resolved in 3.6, and might be postponed to 3.7 depending on the effort and risk.   |
+| [Deprecate grpc-gateway or bump it](https://github.com/etcd-io/etcd/issues/14499)                                  | priority/important-longterm | Completed   | It isn't guaranteed to be resolved in 3.6, and might be postponed to 3.7 depending on the effort and risk.   |
+| [bbolt: Add logger into bbolt](https://github.com/etcd-io/bbolt/issues/509)                                        | priority/important-longterm | Completed   | It's important to diagnose bbolt issues                                                                      |
+| [bbolt: Add surgery commands](https://github.com/etcd-io/bbolt/issues/370)                                         | priority/important-longterm | Completed   | Surgery commands are important for fixing corrupted db files                                                 |
+| [Evaluate and (Gradulate or deprecate/remove) experimental features](https://github.com/etcd-io/etcd/issues/16292) | priority/backlog | Not started | This task will be covered in both 3.6 and 3.7.                                                               |
 
 ## v3.7.0
 

--- a/Documentation/contributor-guide/triage_issues.md
+++ b/Documentation/contributor-guide/triage_issues.md
@@ -129,7 +129,17 @@ Below is a brief summary of the area labels in active use by the etcd project al
 
 ## Step 5 - Prioritise the issue
 
-Placeholder.
+If an issue lacks a priority label it has not been formally prioritized yet.
+
+Adding a `priority` label helps the etcd project understand what is important and should be worked on now, and conversely what is not as important and is on the project backlog.
+
+|Priority label|What it means|Examples|
+|---|---|---|
+| `priority/critical-urgent` | Maintainers are responsible for making sure that these issues (in their area) are being actively worked on—i.e., drop what you're doing. Stuff is burning. These should be fixed before the next release. | user-visible critical bugs in core features <br> broken builds on tier1 supported platforms <br> tests and critical security issues |
+| `priority/important-soon` | Must be staffed and worked on either currently or very soon—ideally in time for the next release. | |
+| `priority/important-longterm` | Important over the long term, but may not be currently staffed and/or may require multiple releases to complete. | |
+| `priority/backlog`  | General agreement that this is a nice-to-have, but no one's available to work on it anytime soon. Community contributions would be most welcome in the meantime, though it might take a while to get them reviewed if reviewers are fully occupied with higher-priority issues—for example, immediately before a release.| |
+| `priority/awaiting-more-evidence` | Possibly useful, but not yet enough support to actually get it done. | Mostly placeholders for potentially good ideas, so that they don't get completely forgotten, and can be referenced or deduped every time they come up |
 
 ## Step 6 - Support new contributors
 


### PR DESCRIPTION
One of the last remaining steps of https://github.com/etcd-io/etcd/issues/15773 and https://github.com/etcd-io/etcd/issues/13611 is refreshing how we prioritize issues for etcd.

Currently the only issue label we have is `priority/important` which means we have no way of distinguishing issue criticality or equally importantly which issues are truly backlog and should not be worked on right now. We have attempted to create priorities in our roadmap however they are bespoke, lack description and don't exist as project issue labels.


This pull request:
1. Proposes we adopt the Kubernetes project issue priorities defined here: https://www.kubernetes.dev/docs/guide/issue-triage/#step-three-define-priority
2. Updates our `roadmap.md` to use the new priorities.

I think it makes sense for etcd to re-use the priorities defined by the Kubernetes project given our recent change to establish the etcd Kubernetes special interest group and our alignment to Kubernetes in many other areas.

Having this pull request merged would empower etcd community members with triage permissions (members + reviewers) with instructions for prioritizing issues which will allow us to more actively make it clear what is important and perhaps more crucially what is on backlog and should not be worked on currently.

---

Note: If this proposal is accepted, the following actions would be required from a maintainer:

1 - Create new labels `priority/critical-urgent`, `priority/important-longterm`, `priority/backlog`, `priority/awaiting-more-evidence` following [github docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label).

2 - Edit the existing `priority/important` label name to `priority/important-soon` following [github docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#editing-a-label).

Fixes https://github.com/etcd-io/etcd/issues/13611 https://github.com/etcd-io/etcd/issues/15773

cc @etcd-io/maintainers-etcd 