### PR TITLE
Enable org members to approve workflows for backports

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -8,6 +8,8 @@ on:
       - synchronize
     branches:
       - main
+      - release-3.5
+      - release-3.4
 
 jobs:
   approve:


### PR DESCRIPTION
Earlier today I `/ok-to-test` approved https://github.com/etcd-io/etcd/pull/17190 and https://github.com/etcd-io/etcd/pull/17189.

These are both backport prs to our stable release branches.

After adding the comment k8s ci bot happily added the correct `ok-to-test` label, however our github workflows didn't actually approve and run, meaning they are still waiting on a maintainer.

Investigating it looks like we are just missing `release-3.4` and `release-3.5` branches in the `gh-workflow-approve.yaml` workflow to fix this so org members can help take the load off maintainers when managing backports.