### PR TITLE
Automate installation of yamllint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ fuzz:
 # Static analysis
 
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
-	verify-govet verify-license-header verify-receiver-name verify-mod-tidy verify-shellcheck \
+	verify-govet verify-license-header verify-receiver-name verify-mod-tidy \
 	verify-shellws verify-proto-annotations verify-genproto verify-yamllint \
 	verify-govet-shadow verify-markdown-marker
 fix: fix-bom fix-lint fix-yamllint
@@ -131,7 +131,15 @@ verify-genproto:
 
 .PHONY: verify-yamllint
 verify-yamllint:
+ifeq (, $(shell which yamllint))
+	@echo "Installing yamllint..."
+	python3 -m venv bin/python
+	bin/python/bin/python3 -m pip install yamllint
+	./bin/python/bin/yamllint --config-file tools/.yamllint .
+else
+	@echo "yamllint already installed..."
 	yamllint --config-file tools/.yamllint .
+endif
 
 .PHONY: verify-govet-shadow
 verify-govet-shadow:
@@ -154,7 +162,6 @@ endif
 
 GOLANGCI_LINT_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} github.com/golangci/golangci-lint)
 .PHONY: install-golangci-lint
-
 install-golangci-lint:
 ifeq (, $(shell which golangci-lint))
 	$(shell curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION))
@@ -162,7 +169,6 @@ endif
 
 .PHONY: install-lazyfs
 install-lazyfs: bin/lazyfs
-
 bin/lazyfs:
 	rm /tmp/lazyfs -rf
 	git clone --depth 1 --branch 0.2.0 https://github.com/dsrhaslab/lazyfs /tmp/lazyfs

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -40,6 +40,7 @@ if [[ $(protoc --version | cut -f2 -d' ') != "3.20.3" ]]; then
 
   download_url="https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-${file}.zip"
   echo "Running on ${arch}."
+  mkdir -p bin
   wget ${download_url} && unzip -p protoc-3.20.3-linux-${file}.zip bin/protoc > tmpFile && mv tmpFile bin/protoc 
   rm protoc-3.20.3-linux-${file}.zip
   chmod +x bin/protoc


### PR DESCRIPTION
@jmhbnz and I are working on refining the test-infra prow workflow to harmonise with the legacy GitHub Actions workflow.

We noticed the [test-infra/config/jobs/etcd/etcd-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/551ef90f7a3efa1560b593bf0c6eea7290bee516/config/jobs/etcd/etcd-presubmits.yaml#L69) is using `make verify-lint` whilst the [etcd/.github/workflows/static-anaylsis.yaml](https://github.com/etcd-io/etcd/blob/db4e95cb1f8d3a8eebfb89c880d5fbd8d6165292/.github/workflows/static-analysis.yaml#L37) is using `make verify`

We want to make a change from `make verify-lint` to `make verify` within the test-infra repo

When testing the `make verify` command in the test-infra image: `gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-master` there was an error relating to yamllint not being installed

This proposed change adds the automation of installing yamllint from pip which is the standard method of installing yamllint. 

Note: We also noticed a duplicate spellcheck command which has been removed.

Added a second commit to fix a minor bug with the previous protoc automation where `bin` directory may not yet exist. 