### PR TITLE
[3.4]Add a unit tests and missing flags in etcd help.

### DIFF
--- a/etcdmain/config_test.go
+++ b/etcdmain/config_test.go
@@ -15,6 +15,7 @@
 package etcdmain
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -24,6 +25,7 @@ import (
 	"testing"
 
 	"go.etcd.io/etcd/embed"
+	"go.etcd.io/etcd/pkg/flags"
 	"sigs.k8s.io/yaml"
 )
 
@@ -494,6 +496,21 @@ func TestConfigFileElectionTimeout(t *testing.T) {
 			t.Errorf("%d: Wrong err = %v", i, err)
 		}
 	}
+}
+
+func TestFlagsPresentInHelp(t *testing.T) {
+	cfg := newConfig()
+	cfg.cf.flagSet.VisitAll(func(f *flag.Flag) {
+		if _, ok := f.Value.(*flags.IgnoredFlag); ok {
+			// Ignored flags do not need to be in the help
+			return
+		}
+
+		flagText := fmt.Sprintf("--%s", f.Name)
+		if !strings.Contains(flagsline, flagText) && !strings.Contains(usageline, flagText) {
+			t.Errorf("Neither flagsline nor usageline in help.go contains flag named %s", flagText)
+		}
+	})
 }
 
 func mustCreateCfgFile(t *testing.T, b []byte) *os.File {

--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -85,6 +85,8 @@ Member:
     Minimum duration interval that a client should wait before pinging server.
   --grpc-keepalive-interval '2h'
     Frequency duration of server-to-client ping to check if a connection is alive (0 to disable).
+  --enable-grpc-gateway
+    Enable GRPC gateway.
   --grpc-keepalive-timeout '20s'
     Additional duration of wait before closing a non-responsive connection (0 to disable).
 
@@ -229,6 +231,8 @@ Experimental feature:
 Unsafe feature:
   --force-new-cluster 'false'
     Force to create a new one-member cluster.
+  --unsafe-no-fsync 'false'
+    Disables fsync, unsafe, will cause data loss.
 
 CAUTIOUS with unsafe flag! It may break the guarantees given by the consensus protocol!
 


### PR DESCRIPTION

Fixes : https://github.com/etcd-io/etcd/issues/16034 for `etcd v3.5`
Backport: https://github.com/etcd-io/etcd/pull/16465
