### PR TITLE
mvcc: Printing etcd backend database related metrics inside scheduleCompaction function

### DIFF
--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/server/v3/storage/schema"
@@ -66,11 +67,16 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 			tx.Unlock()
 			// gofail: var compactAfterSetFinishedCompact struct{}
 			hash := h.Hash()
+			size, sizeInUse := s.b.Size(), s.b.SizeInUse()
 			s.lg.Info(
 				"finished scheduled compaction",
 				zap.Int64("compact-revision", compactMainRev),
 				zap.Duration("took", time.Since(totalStart)),
 				zap.Uint32("hash", hash.Hash),
+				zap.Int64("current-db-size-bytes", size),
+				zap.String("current-db-size", humanize.Bytes(uint64(size))),
+				zap.Int64("current-db-size-in-use-bytes", sizeInUse),
+				zap.String("current-db-size-in-use", humanize.Bytes(uint64(sizeInUse))),
 			)
 			return hash, nil
 		}


### PR DESCRIPTION

To improve traceability of backend database usage, Added below parameter related to backend database usage metrics inside scheduledCompaction function.
current-db-size-bytes
current-db-size
current-db-size-in-use-bytes
current-db-size-in-use
Signed-off-by: Rahul More <rahulbapumore@gmail.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
