### PR TITLE
[3.5] Backport adding digest for etcd base image

### DIFF
--- a/Dockerfile-release.amd64
+++ b/Dockerfile-release.amd64
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 gcr.io/distroless/static-debian11
+FROM --platform=linux/amd64 gcr.io/distroless/static-debian11@sha256:9be3fcc6abeaf985b5ecce59451acbcbb15e7be39472320c538d0d55a0834edc
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.arm64
+++ b/Dockerfile-release.arm64
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 gcr.io/distroless/static-debian11
+FROM --platform=linux/arm64 gcr.io/distroless/static-debian11@sha256:9be3fcc6abeaf985b5ecce59451acbcbb15e7be39472320c538d0d55a0834edc
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.ppc64le
+++ b/Dockerfile-release.ppc64le
@@ -1,4 +1,4 @@
-FROM --platform=linux/ppc64le gcr.io/distroless/static-debian11
+FROM --platform=linux/ppc64le gcr.io/distroless/static-debian11@sha256:9be3fcc6abeaf985b5ecce59451acbcbb15e7be39472320c538d0d55a0834edc
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/

--- a/Dockerfile-release.s390x
+++ b/Dockerfile-release.s390x
@@ -1,4 +1,4 @@
-FROM --platform=linux/s390x gcr.io/distroless/static-debian11
+FROM --platform=linux/s390x gcr.io/distroless/static-debian11@sha256:9be3fcc6abeaf985b5ecce59451acbcbb15e7be39472320c538d0d55a0834edc
 
 ADD etcd /usr/local/bin/
 ADD etcdctl /usr/local/bin/


### PR DESCRIPTION
This pull request proposes backporting https://github.com/etcd-io/etcd/pull/17122 to `release-3.5`.

Currently etcd official release image builds are not reproducible as we currently use the mutable `latest` tag for our distroless base image. With this backport they would become reproducible through a switch to immutable digests.

It needs to be called out there is a tradeoff that before each release we would ideally consider updating to the latest upstream image sha to ensure our reproducible builds are using the most current base image.  For `main` we have dependabot keeping on top of this.  For release branches I don't believe dependabot can be configured to analyse non default branch so we would need to do it manually.

Relates to https://github.com/etcd-io/etcd/issues/16987.