### PR TITLE
Fix Struct Config has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation. 

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -1122,7 +1122,7 @@ func (cfg *Config) GetDNSClusterNames() ([]string, error) {
 	return clusterStrs, multierr.Combine(cerr, httpCerr)
 }
 
-func (cfg Config) InitialClusterFromName(name string) (ret string) {
+func (cfg *Config) InitialClusterFromName(name string) (ret string) {
 	if len(cfg.AdvertisePeerUrls) == 0 {
 		return ""
 	}
@@ -1136,21 +1136,21 @@ func (cfg Config) InitialClusterFromName(name string) (ret string) {
 	return ret[1:]
 }
 
-func (cfg Config) IsNewCluster() bool { return cfg.ClusterState == ClusterStateFlagNew }
-func (cfg Config) ElectionTicks() int { return int(cfg.ElectionMs / cfg.TickMs) }
+func (cfg *Config) IsNewCluster() bool { return cfg.ClusterState == ClusterStateFlagNew }
+func (cfg *Config) ElectionTicks() int { return int(cfg.ElectionMs / cfg.TickMs) }
 
-func (cfg Config) V2DeprecationEffective() config.V2DeprecationEnum {
+func (cfg *Config) V2DeprecationEffective() config.V2DeprecationEnum {
 	if cfg.V2Deprecation == "" {
 		return config.V2_DEPR_DEFAULT
 	}
 	return cfg.V2Deprecation
 }
 
-func (cfg Config) defaultPeerHost() bool {
+func (cfg *Config) defaultPeerHost() bool {
 	return len(cfg.AdvertisePeerUrls) == 1 && cfg.AdvertisePeerUrls[0].String() == DefaultInitialAdvertisePeerURLs
 }
 
-func (cfg Config) defaultClientHost() bool {
+func (cfg *Config) defaultClientHost() bool {
 	return len(cfg.AdvertiseClientUrls) == 1 && cfg.AdvertiseClientUrls[0].String() == DefaultAdvertiseClientURLs
 }
 

--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -34,7 +34,7 @@ import (
 )
 
 // GetLogger returns the logger.
-func (cfg Config) GetLogger() *zap.Logger {
+func (cfg *Config) GetLogger() *zap.Logger {
 	cfg.loggerMu.RLock()
 	l := cfg.logger
 	cfg.loggerMu.RUnlock()


### PR DESCRIPTION
Struct Config has methods on both value and pointer receivers. Such usage is not recommended by the Go Documentation. 

In general, all methods on a given type should have either value or pointer receivers, but not a mixture of both.

https://go.dev/tour/methods/8