### PR TITLE
Backport 16822 changes and dependencies

### DIFF
--- a/tests/framework/config/client.go
+++ b/tests/framework/config/client.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// ClientOption configures the client with additional parameter.
+// For example, if Auth is enabled, the common test cases just need to
+// use `WithAuth` to return a ClientOption. Note that the common `WithAuth`
+// function calls `e2e.WithAuth` or `integration.WithAuth`, depending on the
+// build tag (either "e2e" or "integration").
+type ClientOption func(any)
+
+type GetOptions struct {
+	Revision     int
+	End          string
+	CountOnly    bool
+	Serializable bool
+	Prefix       bool
+	FromKey      bool
+	Limit        int
+	Order        clientv3.SortOrder
+	SortBy       clientv3.SortTarget
+	Timeout      time.Duration
+}

--- a/tests/framework/config/cluster.go
+++ b/tests/framework/config/cluster.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"time"
+)
+
+const (
+	TickDuration = 10 * time.Millisecond
+)

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/pkg/v3/proxy"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.uber.org/zap"
 )
 
@@ -46,6 +47,7 @@ type EtcdProcess interface {
 	EndpointsGRPC() []string
 	EndpointsHTTP() []string
 	EndpointsMetrics() []string
+	Etcdctl(opts ...config.ClientOption) *EtcdctlV3
 
 	Start() error
 	Restart() error
@@ -80,6 +82,7 @@ type EtcdServerProcessConfig struct {
 	Args     []string
 	TlsArgs  []string
 	EnvVars  map[string]string
+	Client   ClientConfig
 
 	DataDirPath string
 	KeepDataDir bool
@@ -124,6 +127,14 @@ func (ep *EtcdServerProcess) EndpointsHTTP() []string {
 	return []string{ep.cfg.ClientHttpUrl}
 }
 func (ep *EtcdServerProcess) EndpointsMetrics() []string { return []string{ep.cfg.Murl} }
+
+func (ep *EtcdServerProcess) Etcdctl(opts ...config.ClientOption) *EtcdctlV3 {
+	etcdctl, err := NewEtcdctl(ep.Config().Client, ep.EndpointsGRPC(), opts...)
+	if err != nil {
+		panic(err)
+	}
+	return etcdctl
+}
 
 func (ep *EtcdServerProcess) Start() error {
 	if ep.proc != nil {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -1,0 +1,190 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/pkg/v3/expect"
+	"go.etcd.io/etcd/tests/v3/framework/config"
+)
+
+type EtcdctlV3 struct {
+	cfg        ClientConfig
+	endpoints  []string
+	authConfig clientv3.AuthConfig
+}
+
+func NewEtcdctl(cfg ClientConfig, endpoints []string, opts ...config.ClientOption) (*EtcdctlV3, error) {
+	ctl := &EtcdctlV3{
+		cfg:       cfg,
+		endpoints: endpoints,
+	}
+
+	for _, opt := range opts {
+		opt(ctl)
+	}
+
+	if !ctl.authConfig.Empty() {
+		client, err := clientv3.New(clientv3.Config{
+			Endpoints:   ctl.endpoints,
+			DialTimeout: 5 * time.Second,
+			DialOptions: []grpc.DialOption{grpc.WithBlock()},
+			Username:    ctl.authConfig.Username,
+			Password:    ctl.authConfig.Password,
+		})
+		if err != nil {
+			return nil, err
+		}
+		client.Close()
+	}
+
+	return ctl, nil
+}
+
+func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) (*clientv3.GetResponse, error) {
+	resp := clientv3.GetResponse{}
+	var args []string
+	if o.Timeout != 0 {
+		args = append(args, fmt.Sprintf("--command-timeout=%s", o.Timeout))
+	}
+	if o.Serializable {
+		args = append(args, "--consistency", "s")
+	}
+	args = append(args, "get", key, "-w", "json")
+	if o.End != "" {
+		args = append(args, o.End)
+	}
+	if o.Revision != 0 {
+		args = append(args, fmt.Sprintf("--rev=%d", o.Revision))
+	}
+	if o.Prefix {
+		args = append(args, "--prefix")
+	}
+	if o.Limit != 0 {
+		args = append(args, fmt.Sprintf("--limit=%d", o.Limit))
+	}
+	if o.FromKey {
+		args = append(args, "--from-key")
+	}
+	if o.CountOnly {
+		args = append(args, "-w", "fields", "--count-only")
+	} else {
+		args = append(args, "-w", "json")
+	}
+	switch o.SortBy {
+	case clientv3.SortByCreateRevision:
+		args = append(args, "--sort-by=CREATE")
+	case clientv3.SortByModRevision:
+		args = append(args, "--sort-by=MODIFY")
+	case clientv3.SortByValue:
+		args = append(args, "--sort-by=VALUE")
+	case clientv3.SortByVersion:
+		args = append(args, "--sort-by=VERSION")
+	case clientv3.SortByKey:
+		// nothing
+	default:
+		return nil, fmt.Errorf("bad sort target %v", o.SortBy)
+	}
+	switch o.Order {
+	case clientv3.SortAscend:
+		args = append(args, "--order=ASCEND")
+	case clientv3.SortDescend:
+		args = append(args, "--order=DESCEND")
+	case clientv3.SortNone:
+		// nothing
+	default:
+		return nil, fmt.Errorf("bad sort order %v", o.Order)
+	}
+	if o.CountOnly {
+		cmd, err := SpawnCmd(ctl.cmdArgs(args...), nil)
+		if err != nil {
+			return nil, err
+		}
+		defer cmd.Close()
+		_, err = cmd.ExpectWithContext(ctx, expect.ExpectedResponse{Value: "Count"})
+		return &resp, err
+	}
+	err := ctl.spawnJsonCmd(ctx, &resp, args...)
+	return &resp, err
+}
+
+func (ctl *EtcdctlV3) Status(ctx context.Context) ([]*clientv3.StatusResponse, error) {
+	var epStatus []*struct {
+		Endpoint string
+		Status   *clientv3.StatusResponse
+	}
+	err := ctl.spawnJsonCmd(ctx, &epStatus, "endpoint", "status")
+	if err != nil {
+		return nil, err
+	}
+	resp := make([]*clientv3.StatusResponse, len(epStatus))
+	for i, e := range epStatus {
+		resp[i] = e.Status
+	}
+	return resp, err
+}
+
+func (ctl *EtcdctlV3) cmdArgs(args ...string) []string {
+	cmdArgs := []string{BinPath.Etcdctl}
+	for k, v := range ctl.flags() {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--%s=%s", k, v))
+	}
+	return append(cmdArgs, args...)
+}
+
+func (ctl *EtcdctlV3) flags() map[string]string {
+	fmap := make(map[string]string)
+	if ctl.cfg.ConnectionType == ClientTLS {
+		if ctl.cfg.AutoTLS {
+			fmap["insecure-transport"] = "false"
+			fmap["insecure-skip-tls-verify"] = "true"
+		} else if ctl.cfg.RevokeCerts {
+			fmap["cacert"] = CaPath
+			fmap["cert"] = RevokedCertPath
+			fmap["key"] = RevokedPrivateKeyPath
+		} else {
+			fmap["cacert"] = CaPath
+			fmap["cert"] = CertPath
+			fmap["key"] = PrivateKeyPath
+		}
+	}
+	fmap["endpoints"] = strings.Join(ctl.endpoints, ",")
+	if !ctl.authConfig.Empty() {
+		fmap["user"] = ctl.authConfig.Username + ":" + ctl.authConfig.Password
+	}
+	return fmap
+}
+
+func (ctl *EtcdctlV3) spawnJsonCmd(ctx context.Context, output any, args ...string) error {
+	args = append(args, "-w", "json")
+	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
+	if err != nil {
+		return err
+	}
+	defer cmd.Close()
+	line, err := cmd.ExpectWithContext(ctx, expect.ExpectedResponse{Value: "header"})
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(line), output)
+}


### PR DESCRIPTION
This PR contains changes for backporting #16822 dependencies only. 
Please refer to PR #17196 for backporting changes related to #16822. 

With these changes "make test-unit" gives the following errors which would need additional changes-

```
stderr: # go.etcd.io/etcd/tests/v3/framework/e2e
stderr: framework/e2e/etcdctl.go:34:22: undefined: clientv3.AuthConfig
stderr: framework/e2e/etcdctl.go:124:16: cmd.ExpectWithContext undefined (type *expect.ExpectProcess has no field or method ExpectWithContext)
stderr: framework/e2e/etcdctl.go:124:46: undefined: expect.ExpectedResponse
stderr: framework/e2e/etcdctl.go:148:30: BinPath.Etcdctl undefined (type string has no field or method Etcdctl)
stderr: framework/e2e/etcdctl.go:185:19: cmd.ExpectWithContext undefined (type *expect.ExpectProcess has no field or method ExpectWithContext)
stderr: framework/e2e/etcdctl.go:185:49: undefined: expect.ExpectedResponse 
```

All backporting changes in this PR have been confined to the tests/framework however, the below error related to clientv3.AuthConfig and cmd.ExpectWithContext would require changes outside the test framework like-
client/v3/config.go
pkg/expect/expect.go

This PR is to get feedback if making changes outside the test\framework for backporting should be feasible or alternatively, re-write\modify tests/e2e/v3_lease_no_proxy_test.go in v3.5 to use available v3.5 interface wherever feasible specially related to EtcdctlV3 and NewEtcdctl.