### PR TITLE
Replace `CreateBucket` with `CreateBucketIfNotExists`

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -112,8 +112,7 @@ func (t *batchTx) Unlock() {
 }
 
 func (t *batchTx) UnsafeCreateBucket(bucket Bucket) {
-	_, err := t.tx.CreateBucket(bucket.Name())
-	if err != nil && err != bolt.ErrBucketExists {
+	if _, err := t.tx.CreateBucketIfNotExists(bucket.Name()); err != nil {
 		t.backend.lg.Fatal(
 			"failed to create a bucket",
 			zap.Stringer("bucket-name", bucket),


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/17245

etcd creates the meta bucket twice on startup, 
- https://github.com/etcd-io/etcd/blob/4bc55e520861f6998d3e8b8b919c1b3abaeb487f/server/etcdserver/bootstrap.go#L212
- https://github.com/etcd-io/etcd/blob/4bc55e520861f6998d3e8b8b919c1b3abaeb487f/server/storage/mvcc/kvstore.go#L118

Overall, it isn't a big problem. But let's replace `CreateBucket` with `CreateBucketIfNotExists` to remove the error message, to avoid any confusion.