### PR TITLE
Validate watch even if event history cannot be created

### DIFF
--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -38,7 +38,8 @@ func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, report
 	// TODO: Don't use watch events to get event history.
 	eventHistory, err := mergeWatchEventHistory(reports)
 	if err != nil {
-		t.Errorf("Failed merging watch history to create event history, skipping further validation, err: %s", err)
+		t.Errorf("Failed merging watch history to create event history, err: %s", err)
+		validateWatch(t, lg, cfg, reports, nil)
 		return visualize
 	}
 	validateWatch(t, lg, cfg, reports, eventHistory)

--- a/tests/robustness/validate/watch.go
+++ b/tests/robustness/validate/watch.go
@@ -31,8 +31,10 @@ func validateWatch(t *testing.T, lg *zap.Logger, cfg Config, reports []report.Cl
 		validateUnique(t, cfg.ExpectRevisionUnique, r)
 		validateAtomic(t, r)
 		validateBookmarkable(t, r)
-		validateReliable(t, eventHistory, r)
-		validateResumable(t, eventHistory, r)
+		if eventHistory != nil {
+			validateReliable(t, eventHistory, r)
+			validateResumable(t, eventHistory, r)
+		}
 	}
 }
 


### PR DESCRIPTION
Creation of event history requires each client to return consistent events. If clients observed inconsistent view of some revision, merging will fail and return diff between two clients. This however doesn't provide hint on what kind of issue happend.

This PR helps cases where there is an error with single watch stream (like event duplication) by running normal watch validation even without full event history.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Before:
```
    logger.go:130: 2024-01-16T15:53:49.847+0100 INFO    Validating watch
    validate.go:43: Failed merging watch history to create event history, skipping further validation, err: events between clients 11 and 8 don't match, revision: 872, diff:   []model.WatchEvent{
        +       {
        +               Event: model.Event{
        +                       Type:  "put-operation",
        +                       Key:   "/registry/pods/default/AOn4c",
        +                       Value: model.ValueOrHash{Value: "1018"},
        +               },
        +               Revision: 872,
        +       },
                {Event: {Type: "put-operation", Key: "/registry/pods/default/AOn4c", Value: {Value: "1018"}}, Revision: 872},
          }
```
After:
```
    logger.go:130: 2024-01-16T15:53:49.847+0100 INFO    Validating watch
    watch.go:86: Broke watch guarantee: Unique - an event will never appear on a watch twice, key: "/registry/pods/default/AOn4c", revision: 872, client: 8
    validate.go:43: Failed merging watch history to create event history, err: events between clients 11 and 8 don't match, revision: 872, diff:   []model.WatchEvent{
        +       {
        +               Event: model.Event{
        +                       Type:  "put-operation",
        +                       Key:   "/registry/pods/default/AOn4c",
        +                       Value: model.ValueOrHash{Value: "1018"},
        +               },
        +               Revision: 872,
        +       },
                {Event: {Type: "put-operation", Key: "/registry/pods/default/AOn4c", Value: {Value: "1018"}}, Revision: 872},
          }
```