### PR TITLE
Added container tools to devcontainer for debugging prow jobs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		  "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		  "ghcr.io/devcontainers/features/github-cli:1": {}
+		  "ghcr.io/devcontainers/features/github-cli:1": {},
+		  "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Working with @jmhbnz to debug issues with etcd `make verify` prow job, we noticed required tools for working with prow locally are not available in the codespace `devcontainer.json` 