### PR TITLE
Revert https://github.com/etcd-io/etcd/pull/17228

### DIFF
--- a/server/storage/backend/batch_tx_test.go
+++ b/server/storage/backend/batch_tx_test.go
@@ -252,53 +252,6 @@ func TestRangeAfterDeleteMatch(t *testing.T) {
 	checkForEach(t, b.BatchTx(), b.ReadTx(), nil, nil)
 }
 
-func TestRangeAfterOverwriteMatch(t *testing.T) {
-	b, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
-	defer betesting.Close(t, b)
-
-	tx := b.BatchTx()
-
-	tx.Lock()
-	tx.UnsafeCreateBucket(schema.Test)
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar2"))
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar0"))
-	tx.UnsafePut(schema.Test, []byte("foo1"), []byte("bar10"))
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar1"))
-	tx.UnsafePut(schema.Test, []byte("foo1"), []byte("bar11"))
-	tx.Unlock()
-
-	checkRangeResponseMatch(t, b.BatchTx(), b.ReadTx(), []byte("foo"), []byte("foo3"), 1)
-	checkForEach(t, b.BatchTx(), b.ReadTx(), [][]byte{[]byte("foo"), []byte("foo1")}, [][]byte{[]byte("bar1"), []byte("bar11")})
-}
-
-func TestRangeAfterOverwriteAndDeleteMatch(t *testing.T) {
-	b, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
-	defer betesting.Close(t, b)
-
-	tx := b.BatchTx()
-
-	tx.Lock()
-	tx.UnsafeCreateBucket(schema.Test)
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar2"))
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar0"))
-	tx.UnsafePut(schema.Test, []byte("foo1"), []byte("bar10"))
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar1"))
-	tx.UnsafePut(schema.Test, []byte("foo1"), []byte("bar11"))
-	tx.Unlock()
-
-	checkRangeResponseMatch(t, b.BatchTx(), b.ReadTx(), []byte("foo"), nil, 0)
-	checkForEach(t, b.BatchTx(), b.ReadTx(), [][]byte{[]byte("foo"), []byte("foo1")}, [][]byte{[]byte("bar1"), []byte("bar11")})
-
-	tx.Lock()
-	tx.UnsafePut(schema.Test, []byte("foo"), []byte("bar3"))
-	tx.UnsafeDelete(schema.Test, []byte("foo1"))
-	tx.Unlock()
-
-	checkRangeResponseMatch(t, b.BatchTx(), b.ReadTx(), []byte("foo"), nil, 0)
-	checkRangeResponseMatch(t, b.BatchTx(), b.ReadTx(), []byte("foo1"), nil, 0)
-	checkForEach(t, b.BatchTx(), b.ReadTx(), [][]byte{[]byte("foo")}, [][]byte{[]byte("bar3")})
-}
-
 func checkRangeResponseMatch(t *testing.T, tx backend.BatchTx, rtx backend.ReadTx, key, endKey []byte, limit int64) {
 	tx.Lock()
 	ks1, vs1 := tx.UnsafeRange(schema.Test, key, endKey, limit)

--- a/server/storage/backend/tx_buffer.go
+++ b/server/storage/backend/tx_buffer.go
@@ -83,7 +83,6 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 		if !ok {
 			delete(txw.buckets, k)
 			txr.buckets[k] = wb
-			wb.dedupe()
 			continue
 		}
 		if seq, ok := txw.bucket2seq[k]; ok && !seq && wb.used > 1 {
@@ -204,12 +203,10 @@ func (bb *bucketBuffer) merge(bbsrc *bucketBuffer) {
 	if bytes.Compare(bb.buf[(bb.used-bbsrc.used)-1].key, bbsrc.buf[0].key) < 0 {
 		return
 	}
-	bb.dedupe()
-}
 
-// dedupe removes duplicates, using only newest update
-func (bb *bucketBuffer) dedupe() {
 	sort.Stable(bb)
+
+	// remove duplicates, using only newest update
 	widx := 0
 	for ridx := 1; ridx < bb.used; ridx++ {
 		if !bytes.Equal(bb.buf[ridx].key, bb.buf[widx].key) {


### PR DESCRIPTION
Actually https://github.com/etcd-io/etcd/pull/17228 was fixing a non-exist issue, because there will never have duplicated keys. Please refer to
https://github.com/etcd-io/etcd/issues/17247#issuecomment-1895725142.

Let alone the PR (pull/17228) also introduces a bug (issues/17247).


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
