### PR TITLE
No need remove duplicate keys for the Key bucket and add a verification

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -28,6 +28,23 @@ import (
 
 type BucketID int
 
+const (
+	BucketIdKey     BucketID = 1
+	BucketIdMeta    BucketID = 2
+	BucketIdLease   BucketID = 3
+	BucketIdAlarm   BucketID = 4
+	BucketIdCluster BucketID = 5
+
+	BucketIdMembers        BucketID = 10
+	BucketIdMembersRemoved BucketID = 11
+
+	BucketIdAuth      BucketID = 20
+	BucketIdAuthUsers BucketID = 21
+	BucketIdAuthRoles BucketID = 22
+
+	BucketIdTest BucketID = 100
+)
+
 type Bucket interface {
 	// ID returns a unique identifier of a bucket.
 	// The id must NOT be persisted and can be used as lightweight identificator

--- a/server/storage/schema/bucket.go
+++ b/server/storage/schema/bucket.go
@@ -40,20 +40,20 @@ var (
 )
 
 var (
-	Key     = backend.Bucket(bucket{id: 1, name: keyBucketName, safeRangeBucket: true})
-	Meta    = backend.Bucket(bucket{id: 2, name: metaBucketName, safeRangeBucket: false})
-	Lease   = backend.Bucket(bucket{id: 3, name: leaseBucketName, safeRangeBucket: false})
-	Alarm   = backend.Bucket(bucket{id: 4, name: alarmBucketName, safeRangeBucket: false})
-	Cluster = backend.Bucket(bucket{id: 5, name: clusterBucketName, safeRangeBucket: false})
+	Key     = backend.Bucket(bucket{id: backend.BucketIdKey, name: keyBucketName, safeRangeBucket: true})
+	Meta    = backend.Bucket(bucket{id: backend.BucketIdMeta, name: metaBucketName, safeRangeBucket: false})
+	Lease   = backend.Bucket(bucket{id: backend.BucketIdLease, name: leaseBucketName, safeRangeBucket: false})
+	Alarm   = backend.Bucket(bucket{id: backend.BucketIdAlarm, name: alarmBucketName, safeRangeBucket: false})
+	Cluster = backend.Bucket(bucket{id: backend.BucketIdCluster, name: clusterBucketName, safeRangeBucket: false})
 
-	Members        = backend.Bucket(bucket{id: 10, name: membersBucketName, safeRangeBucket: false})
-	MembersRemoved = backend.Bucket(bucket{id: 11, name: membersRemovedBucketName, safeRangeBucket: false})
+	Members        = backend.Bucket(bucket{id: backend.BucketIdMembers, name: membersBucketName, safeRangeBucket: false})
+	MembersRemoved = backend.Bucket(bucket{id: backend.BucketIdMembersRemoved, name: membersRemovedBucketName, safeRangeBucket: false})
 
-	Auth      = backend.Bucket(bucket{id: 20, name: authBucketName, safeRangeBucket: false})
-	AuthUsers = backend.Bucket(bucket{id: 21, name: authUsersBucketName, safeRangeBucket: false})
-	AuthRoles = backend.Bucket(bucket{id: 22, name: authRolesBucketName, safeRangeBucket: false})
+	Auth      = backend.Bucket(bucket{id: backend.BucketIdAuth, name: authBucketName, safeRangeBucket: false})
+	AuthUsers = backend.Bucket(bucket{id: backend.BucketIdAuthUsers, name: authUsersBucketName, safeRangeBucket: false})
+	AuthRoles = backend.Bucket(bucket{id: backend.BucketIdAuthRoles, name: authRolesBucketName, safeRangeBucket: false})
 
-	Test = backend.Bucket(bucket{id: 100, name: testBucketName, safeRangeBucket: false})
+	Test = backend.Bucket(bucket{id: backend.BucketIdTest, name: testBucketName, safeRangeBucket: false})
 )
 
 type bucket struct {


### PR DESCRIPTION
This PR is on top of https://github.com/etcd-io/etcd/pull/17280, which is where the first commit coming from.

So please only read the second commit. Since there will never be any duplicated keys in the bucket buffer, so there is no need to remove duplicated keys. Also added a verification to double check it. Note that it's an **invariant property** for etcd. 

Please also read https://github.com/etcd-io/etcd/issues/17247#issuecomment-1895725142 

