### PR TITLE
Backporting commit 21bbc82710a39db30f1bf7d89ea4fa073ad26bcd into ETCD 3.5

### DIFF
--- a/server/mvcc/backend/tx_buffer.go
+++ b/server/mvcc/backend/tx_buffer.go
@@ -120,7 +120,7 @@ func newBucketBuffer() *bucketBuffer {
 func (bb *bucketBuffer) Range(key, endKey []byte, limit int64) (keys [][]byte, vals [][]byte) {
 	f := func(i int) bool { return bytes.Compare(bb.buf[i].key, key) >= 0 }
 	idx := sort.Search(bb.used, f)
-	if idx < 0 {
+	if idx < 0 || idx >= bb.used {
 		return nil, nil
 	}
 	if len(endKey) == 0 {

--- a/server/mvcc/kvstore_compaction.go
+++ b/server/mvcc/kvstore_compaction.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
 	"go.uber.org/zap"
 )
 
@@ -53,10 +54,15 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 			revToBytes(revision{main: compactMainRev}, rbytes)
 			tx.UnsafePut(metaBucketName, finishedCompactKeyName, rbytes)
 			tx.Unlock()
+			size, sizeInUse := s.b.Size(), s.b.SizeInUse()
 			s.lg.Info(
 				"finished scheduled compaction",
 				zap.Int64("compact-revision", compactMainRev),
 				zap.Duration("took", time.Since(totalStart)),
+				zap.Int64("current-db-size-bytes", size),
+				zap.String("current-db-size", humanize.Bytes(uint64(size))),
+				zap.Int64("current-db-size-in-use-bytes", sizeInUse),
+				zap.String("current-db-size-in-use", humanize.Bytes(uint64(sizeInUse))),
 			)
 			return true
 		}


### PR DESCRIPTION
**mvcc: Printing etcd backend database related metrics inside scheduleCompaction function**

To improve traceability of backend database usage, Added below parameter related to backend database usage metrics inside scheduledCompaction function.
current-db-size-bytes
current-db-size
current-db-size-in-use-bytes
current-db-size-in-use
Signed-off-by: Rahul More [rahulbapumore@gmail.com](mailto:rahulbapumore@gmail.com)