### PR TITLE
Fix test issue in TestScheduleCompaction

### DIFF
--- a/server/storage/mvcc/kvstore_compaction_test.go
+++ b/server/storage/mvcc/kvstore_compaction_test.go
@@ -76,8 +76,8 @@ func TestScheduleCompaction(t *testing.T) {
 		tx := s.b.BatchTx()
 
 		tx.Lock()
-		ibytes := NewRevBytes()
 		for _, rev := range revs {
+			ibytes := NewRevBytes()
 			ibytes = RevToBytes(rev, ibytes)
 			tx.UnsafePut(schema.Key, ibytes, []byte("bar"))
 		}
@@ -90,6 +90,7 @@ func TestScheduleCompaction(t *testing.T) {
 
 		tx.Lock()
 		for _, rev := range tt.wrevs {
+			ibytes := NewRevBytes()
 			ibytes = RevToBytes(rev, ibytes)
 			keys, _ := tx.UnsafeRange(schema.Key, ibytes, nil, 0)
 			if len(keys) != 1 {


### PR DESCRIPTION
It always reuse the same memory space. Each next iteration will always overwrite previous data.

It took me about 2 hours to identify the root cause why there are duplicated keys in the buffer.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
