### PR TITLE
Fix golangci revive error-strings issues

### DIFF
--- a/client/internal/v2/client_test.go
+++ b/client/internal/v2/client_test.go
@@ -318,7 +318,7 @@ func TestSimpleHTTPClientDoHeaderTimeout(t *testing.T) {
 }
 
 func TestHTTPClusterClientDo(t *testing.T) {
-	fakeErr := errors.New("fake!")
+	fakeErr := errors.New("fake")
 	fakeURL := url.URL{}
 	tests := []struct {
 		client *httpClusterClient
@@ -583,11 +583,11 @@ func TestRedirectFollowingHTTPClient(t *testing.T) {
 			client: &multiStaticHTTPClient{
 				responses: []staticHTTPResponse{
 					{
-						err: errors.New("fail!"),
+						err: errors.New("fail"),
 					},
 				},
 			},
-			wantErr: errors.New("fail!"),
+			wantErr: errors.New("fail"),
 		},
 
 		// no need to follow redirect if none given
@@ -723,7 +723,9 @@ func TestRedirectFollowingHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			//revive:disable:error-strings
 			wantErr: errors.New("location header not valid URL: :"),
+			//revive:enable:error-strings
 		},
 
 		// fail if redirects checked way too many times
@@ -830,7 +832,7 @@ func TestHTTPClusterClientSync(t *testing.T) {
 
 func TestHTTPClusterClientSyncFail(t *testing.T) {
 	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
-		{err: errors.New("fail!")},
+		{err: errors.New("fail")},
 	})
 
 	hc := &httpClusterClient{
@@ -886,7 +888,7 @@ func TestHTTPClusterClientAutoSyncCancelContext(t *testing.T) {
 
 func TestHTTPClusterClientAutoSyncFail(t *testing.T) {
 	cf := newStaticHTTPClientFactory([]staticHTTPResponse{
-		{err: errors.New("fail!")},
+		{err: errors.New("fail")},
 	})
 
 	hc := &httpClusterClient{

--- a/client/internal/v2/keys_test.go
+++ b/client/internal/v2/keys_test.go
@@ -892,7 +892,7 @@ func TestHTTPWatcherNextFail(t *testing.T) {
 	tests := []httpClient{
 		// generic HTTP client failure
 		&staticHTTPClient{
-			err: errors.New("fail!"),
+			err: errors.New("fail"),
 		},
 
 		// unusable status code
@@ -994,7 +994,7 @@ func TestHTTPKeysAPIWatcherAction(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		testError := errors.New("fail!")
+		testError := errors.New("fail")
 		kAPI := &httpKeysAPI{
 			client: &staticHTTPClient{err: testError},
 		}
@@ -1080,7 +1080,7 @@ func TestHTTPKeysAPISetError(t *testing.T) {
 	tests := []httpClient{
 		// generic HTTP client failure
 		&staticHTTPClient{
-			err: errors.New("fail!"),
+			err: errors.New("fail"),
 		},
 
 		// unusable status code
@@ -1191,7 +1191,7 @@ func TestHTTPKeysAPIGetError(t *testing.T) {
 	tests := []httpClient{
 		// generic HTTP client failure
 		&staticHTTPClient{
-			err: errors.New("fail!"),
+			err: errors.New("fail"),
 		},
 
 		// unusable status code
@@ -1310,7 +1310,7 @@ func TestHTTPKeysAPIDeleteError(t *testing.T) {
 	tests := []httpClient{
 		// generic HTTP client failure
 		&staticHTTPClient{
-			err: errors.New("fail!"),
+			err: errors.New("fail"),
 		},
 
 		// unusable status code

--- a/client/internal/v2/members_test.go
+++ b/client/internal/v2/members_test.go
@@ -371,7 +371,7 @@ func TestHTTPMembersAPIAddError(t *testing.T) {
 		// generic httpClient failure
 		{
 			peerURL: okPeer,
-			client:  &staticHTTPClient{err: errors.New("fail!")},
+			client:  &staticHTTPClient{err: errors.New("fail")},
 		},
 
 		// unrecognized HTTP status code
@@ -456,7 +456,7 @@ func TestHTTPMembersAPIRemoveFail(t *testing.T) {
 	tests := []httpClient{
 		// generic error
 		&staticHTTPClient{
-			err: errors.New("fail!"),
+			err: errors.New("fail"),
 		},
 
 		// unexpected HTTP status code
@@ -509,7 +509,7 @@ func TestHTTPMembersAPIListSuccess(t *testing.T) {
 func TestHTTPMembersAPIListError(t *testing.T) {
 	tests := []httpClient{
 		// generic httpClient failure
-		&staticHTTPClient{err: errors.New("fail!")},
+		&staticHTTPClient{err: errors.New("fail")},
 
 		// unrecognized HTTP status code
 		&staticHTTPClient{
@@ -569,7 +569,7 @@ func TestHTTPMembersAPILeaderSuccess(t *testing.T) {
 func TestHTTPMembersAPILeaderError(t *testing.T) {
 	tests := []httpClient{
 		// generic httpClient failure
-		&staticHTTPClient{err: errors.New("fail!")},
+		&staticHTTPClient{err: errors.New("fail")},
 
 		// unrecognized HTTP status code
 		&staticHTTPClient{

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -83,9 +83,10 @@ linters-settings: # please keep this alphabetized
       - name: context-keys-type
         severity: error
         disabled: false
-      # TODO: enable the following rules
       - name: error-strings
-        disabled: true
+        severity: error
+        disabled: false
+      # TODO: enable the following rules
       - name: var-naming
         disabled: true
       - name: exported


### PR DESCRIPTION
I was looking at the disabled linter rules and addressed the `error-strings` warnings. The only offending files are in the deprecated v2 client test code.

After speaking with @jmhbnz, he told me that @fuweid was working recently with the linter rules. So, it would be great if you could take a look at this.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
