### PR TITLE
[3.5] mvcc: Printing etcd backend database related metrics inside scheduleCompaction function

### DIFF
--- a/server/mvcc/kvstore_compaction.go
+++ b/server/mvcc/kvstore_compaction.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/server/v3/mvcc/buckets"
+	humanize "github.com/dustin/go-humanize"
 	"go.uber.org/zap"
 )
 
@@ -63,11 +64,16 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 			tx.UnsafePut(buckets.Meta, finishedCompactKeyName, rbytes)
 			tx.Unlock()
 			hash := h.Hash()
+			size, sizeInUse := s.b.Size(), s.b.SizeInUse()
 			s.lg.Info(
 				"finished scheduled compaction",
 				zap.Int64("compact-revision", compactMainRev),
 				zap.Duration("took", time.Since(totalStart)),
 				zap.Uint32("hash", hash.Hash),
+				zap.Int64("current-db-size-bytes", size),
+				zap.String("current-db-size", humanize.Bytes(uint64(size))),
+				zap.Int64("current-db-size-in-use-bytes", sizeInUse),
+				zap.String("current-db-size-in-use", humanize.Bytes(uint64(sizeInUse))),
 			)
 			return hash, nil
 		}


### PR DESCRIPTION


Backporting commit 21bbc82 in etcd 3.5
To improve traceability of backend database usage, Added below parameter related to backend database usage metrics inside scheduledCompaction function.
current-db-size-bytes
current-db-size
current-db-size-in-use-bytes
current-db-size-in-use


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
