### PR TITLE
changelog: add 3.4 and 3.5 note about go 1.20.13

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -9,6 +9,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### etcd server
 - Fix [nil pointer panicking due to using the wrong log library](https://github.com/etcd-io/etcd/pull/17270)
 
+### Dependencies
+- Compile binaries using go [1.20.13](https://github.com/etcd-io/etcd/pull/17276).
+
 <hr>
 
 ## v3.4.29 (2024-01-09)

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 - [Add livez/readyz HTTP endpoints](https://github.com/etcd-io/etcd/pull/17039)
 
+### Dependencies
+- Compile binaries using [go 1.20.13](https://github.com/etcd-io/etcd/pull/17275)
+
 ## v3.5.11 (2023-12-07)
 
 ### etcd server


### PR DESCRIPTION
Updates 3.4 and 3.5 CHANGELOGs to add a line that the binaries are compiled with go version 1.20.13.

Related to #17269

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
