### PR TITLE
tests/robustness: fix out of index panic in model replay

### DIFF
--- a/tests/robustness/model/replay.go
+++ b/tests/robustness/model/replay.go
@@ -73,7 +73,7 @@ func (r *EtcdReplay) next() (request EtcdRequest, revision int64, index int) {
 	revision = r.eventHistory[r.eventHistoryIndex].Revision
 	index = r.eventHistoryIndex
 	operations := []EtcdOperation{}
-	for r.eventHistory[index].Revision == revision {
+	for index < len(r.eventHistory) && r.eventHistory[index].Revision == revision {
 		event := r.eventHistory[index]
 		switch event.Type {
 		case PutOperation:


### PR DESCRIPTION
Encountered this while addressing comments in https://github.com/etcd-io/etcd/pull/17352

Panic encountered:
```
--- FAIL: TestRobustnessExploratory (5.57s)
    --- FAIL: TestRobustnessExploratory/Kubernetes/LowTraffic/ClusterOfSize1 (5.55s)
panic: runtime error: index out of range [184] with length 184 [recovered]
	panic: runtime error: index out of range [184] with length 184

goroutine 162 [running]:
testing.tRunner.func1.2({0x1a829c0, 0xc0001b5320})
	/usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x1a829c0?, 0xc0001b5320?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
go.etcd.io/etcd/tests/v3/robustness/model.(*EtcdReplay).next(0xc0000c4d30)
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/model/replay.go:76 +0x585
go.etcd.io/etcd/tests/v3/robustness/model.(*EtcdReplay).StateForRevision(0xc0002aad30, 0xb9)
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/model/replay.go:52 +0x1c5
go.etcd.io/etcd/tests/v3/robustness/validate.validatePrevKV(0xc000500820, {0x2, {0x23758c0, 0x0, 0x0}, {0xc00049c340, 0x1, 0x1}}, {0xc00043e000, 0xb8, ...})
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/validate/watch.go:158 +0x2cf
go.etcd.io/etcd/tests/v3/robustness/validate.validateWatch(0xa?, 0x1f3?, {0x19?}, {0xc0005fa380, 0xa, 0xb27b95a0?}, {0xc00043e000, 0xb8, 0x110}, 0x1)
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/validate/watch.go:39 +0x2fd
go.etcd.io/etcd/tests/v3/robustness/validate.ValidateAndReturnVisualize(0xc000500820, 0xc0005fa380?, {0x0?}, {0xc0005fa380, 0xa, 0x10}, 0x0?)
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/validate/validate.go:45 +0x205
go.etcd.io/etcd/tests/v3/robustness.testRobustness({_, _}, _, _, {{0xc0000482d0, 0x24}, {0x1c6d200, 0x2328e40}, {{{0x1afe9b2, 0x7}, ...}, ...}, ...})
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/main_test.go:97 +0x36b
go.etcd.io/etcd/tests/v3/robustness.TestRobustnessExploratory.func1(0xc000500820?)
	/Users/mjivrajani/gocode/src/github.com/MadhavJivrajani/etcd/tests/robustness/main_test.go:49 +0xb2
testing.tRunner(0xc000500820, 0xc0003ac610)
	/usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 128
	/usr/local/go/src/testing/testing.go:1648 +0x3ad

```

/assign @serathius 