### PR TITLE
[3.5] etcdserver: drain leaky goroutines before test completed

### DIFF
--- a/server/etcdserver/apply_auth_test.go
+++ b/server/etcdserver/apply_auth_test.go
@@ -50,6 +50,7 @@ func TestCheckLeasePutsKeys(t *testing.T) {
 
 	tp, _ := auth.NewTokenProvider(zaptest.NewLogger(t), tokenTypeSimple, dummyIndexWaiter, simpleTokenTTLDefault)
 	as := auth.NewAuthStore(lg, b, tp, bcrypt.MinCost)
+	defer as.AuthDisable()
 
 	aa := authApplierV3{as: as}
 	assert.NoError(t, aa.checkLeasePutsKeys(lease.NewLease(lease.LeaseID(1), 3600)), "auth is disabled, should allow puts")

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -421,6 +421,9 @@ func TestHashKVHandler(t *testing.T) {
 	be, _ := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, be)
 	etcdSrv.kv = mvcc.New(zap.NewNop(), be, &lease.FakeLessor{}, mvcc.StoreConfig{})
+	defer func() {
+		assert.NoError(t, etcdSrv.kv.Close())
+	}()
 	ph := &hashKVHandler{
 		lg:     zap.NewNop(),
 		server: etcdSrv,

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -198,7 +198,7 @@ func TestConfigChangeBlocksApply(t *testing.T) {
 		updateLead:       func(uint64) {},
 		updateLeadership: func(bool) {},
 	})
-	defer srv.r.Stop()
+	defer srv.r.stop()
 
 	n.readyc <- raft.Ready{
 		SoftState:        &raft.SoftState{RaftState: raft.StateFollower},

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -663,6 +663,7 @@ func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 		consistIndex: ci,
 		beHooks:      &backendHooks{lg: lg, indexer: ci},
 	}
+	defer srv.r.Stop()
 
 	// create EntryConfChange entry
 	now := time.Now()
@@ -1013,6 +1014,7 @@ func TestSyncTrigger(t *testing.T) {
 // TestSnapshot as snapshot should snapshot the store and cut the persistent
 func TestSnapshot(t *testing.T) {
 	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
 
 	s := raft.NewMemoryStorage()
 	s.Append([]raftpb.Entry{{Index: 1}})
@@ -1032,6 +1034,11 @@ func TestSnapshot(t *testing.T) {
 		consistIndex: cindex.NewConsistentIndex(be),
 	}
 	srv.kv = mvcc.New(zap.NewExample(), be, &lease.FakeLessor{}, mvcc.StoreConfig{})
+
+	defer func() {
+		assert.NoError(t, srv.kv.Close())
+	}()
+
 	srv.be = be
 
 	ch := make(chan struct{}, 2)
@@ -1602,6 +1609,7 @@ func TestPublishV3(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	lg := zaptest.NewLogger(t)
 	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
 	srv := &EtcdServer{
 		lgMu:       new(sync.RWMutex),
 		lg:         lg,
@@ -1672,6 +1680,7 @@ func TestPublishV3Retry(t *testing.T) {
 
 	lg := zaptest.NewLogger(t)
 	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
 	srv := &EtcdServer{
 		lgMu:       new(sync.RWMutex),
 		lg:         lg,


### PR DESCRIPTION
Part of #17317

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
