### PR TITLE
[3.4] etcdserver: drain leaky goroutines before test completed

### DIFF
--- a/etcdserver/apply_auth_test.go
+++ b/etcdserver/apply_auth_test.go
@@ -48,6 +48,7 @@ func TestCheckLeasePutsKeys(t *testing.T) {
 
 	tp, _ := auth.NewTokenProvider(zaptest.NewLogger(t), tokenTypeSimple, dummyIndexWaiter, simpleTokenTTLDefault)
 	as := auth.NewAuthStore(lg, b, tp, bcrypt.MinCost)
+	defer as.AuthDisable()
 
 	aa := authApplierV3{as: as}
 	assert.NoError(t, aa.checkLeasePutsKeys(lease.NewLease(lease.LeaseID(1), 3600)), "auth is disabled, should allow puts")

--- a/etcdserver/corrupt_test.go
+++ b/etcdserver/corrupt_test.go
@@ -47,6 +47,9 @@ func TestHashKVHandler(t *testing.T) {
 		assert.NoError(t, be.Close())
 	}()
 	etcdSrv.kv = mvcc.New(zap.NewNop(), be, &lease.FakeLessor{}, nil, nil, mvcc.StoreConfig{})
+	defer func() {
+		assert.NoError(t, etcdSrv.kv.Close())
+	}()
 	ph := &hashKVHandler{
 		lg:     zap.NewNop(),
 		server: etcdSrv,

--- a/etcdserver/raft_test.go
+++ b/etcdserver/raft_test.go
@@ -197,7 +197,7 @@ func TestConfigChangeBlocksApply(t *testing.T) {
 		updateLead:       func(uint64) {},
 		updateLeadership: func(bool) {},
 	})
-	defer srv.r.Stop()
+	defer srv.r.stop()
 
 	n.readyc <- raft.Ready{
 		SoftState:        &raft.SoftState{RaftState: raft.StateFollower},

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/etcdserver/api/membership"
 	"go.etcd.io/etcd/etcdserver/api/rafthttp"
 	"go.etcd.io/etcd/etcdserver/api/snap"
@@ -967,6 +968,9 @@ func TestSnapshot(t *testing.T) {
 	defer func() {
 		os.RemoveAll(tmpPath)
 	}()
+	defer func() {
+		assert.NoError(t, be.Close())
+	}()
 
 	s := raft.NewMemoryStorage()
 	s.Append([]raftpb.Entry{{Index: 1}})
@@ -985,6 +989,9 @@ func TestSnapshot(t *testing.T) {
 		v2store: st,
 	}
 	srv.kv = mvcc.New(zap.NewExample(), be, &lease.FakeLessor{}, nil, &srv.consistIndex, mvcc.StoreConfig{})
+	defer func() {
+		assert.NoError(t, srv.kv.Close())
+	}()
 	srv.be = be
 
 	ch := make(chan struct{}, 2)


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/17317

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
