### PR TITLE
[3.5] Backport ignore SetKeepAlivePeriod errors on OpenBSD

### DIFF
--- a/client/pkg/transport/keepalive_listener.go
+++ b/client/pkg/transport/keepalive_listener.go
@@ -87,11 +87,6 @@ func (l *keepAliveConn) SetKeepAlive(doKeepAlive bool) error {
 	return l.TCPConn.SetKeepAlive(doKeepAlive)
 }
 
-// SetKeepAlivePeriod sets keepalive period
-func (l *keepAliveConn) SetKeepAlivePeriod(d time.Duration) error {
-	return l.TCPConn.SetKeepAlivePeriod(d)
-}
-
 // A tlsKeepaliveListener implements a network listener (net.Listener) for TLS connections.
 type tlsKeepaliveListener struct {
 	net.Listener

--- a/client/pkg/transport/keepalive_listener_openbsd.go
+++ b/client/pkg/transport/keepalive_listener_openbsd.go
@@ -1,0 +1,26 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build openbsd
+
+package transport
+
+import "time"
+
+// SetKeepAlivePeriod sets keepalive period
+func (l *keepAliveConn) SetKeepAlivePeriod(d time.Duration) error {
+	// OpenBSD has no user-settable per-socket TCP keepalive options.
+	// Refer to https://github.com/etcd-io/etcd/issues/15811.
+	return nil
+}

--- a/client/pkg/transport/keepalive_listener_unix.go
+++ b/client/pkg/transport/keepalive_listener_unix.go
@@ -1,0 +1,24 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !openbsd
+
+package transport
+
+import "time"
+
+// SetKeepAlivePeriod sets keepalive period
+func (l *keepAliveConn) SetKeepAlivePeriod(d time.Duration) error {
+	return l.TCPConn.SetKeepAlivePeriod(d)
+}


### PR DESCRIPTION
This is a backport of https://github.com/etcd-io/etcd/pull/15812

cc @ahrtr