### PR TITLE
add OpenBSD support to changelog 3.5

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Package `clientv3`
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17363).
+- [Ignore SetKeepAlivePeriod errors on OpenBSD](https://github.com/etcd-io/etcd/pull/17387).
 
 <hr>
 


### PR DESCRIPTION
Add backport https://github.com/etcd-io/etcd/pull/15812 to 3.4, 3.5 changelog