### PR TITLE
[3.5] tests/e2e: use WaitLeader in corrupt test

### DIFF
--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -320,8 +320,10 @@ func TestCompactHashCheckDetectCorruptionInterrupt(t *testing.T) {
 	_, err = epc.Procs[slowCompactionNodeIndex].Logs().Expect("finished scheduled compaction")
 	require.NoError(t, err, "can't get log indicating finished scheduled compaction")
 
-	// Wait for compaction hash check
-	time.Sleep(checkTime * 5)
+	// Wait until the leader finished compaction hash check.
+	leaderIndex := epc.WaitLeader(t)
+	_, err = epc.Procs[leaderIndex].Logs().Expect("finished compaction hash check")
+	require.NoError(t, err, "can't get log indicating finished compaction hash check")
 
 	alarmResponse, err := cc.AlarmList()
 	require.NoError(t, err, "error on alarm list")


### PR DESCRIPTION
Now that e2e `WaitLeader` is ported into 3.5, e2e corrupt tests can replace the 5 second wait for a wait on the leader to be ready. Similar to what's on the main branch: https://github.com/etcd-io/etcd/blob/main/tests/e2e/corrupt_test.go#L344-L346

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
