### PR TITLE
testutil: allow goroutines started by pprof for CPU profiling

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -148,7 +148,8 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
 			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") ||
 			strings.Contains(stack, "net.(*netFD).Close(") ||
-			strings.Contains(stack, "testing.(*T).Run") {
+			strings.Contains(stack, "testing.(*T).Run") ||
+			strings.Contains(stack, "pprof.StartCPUProfile") {
 			continue
 		}
 		gs = append(gs, stack)


### PR DESCRIPTION
While debugging something as part of https://github.com/etcd-io/etcd/pull/17352, I switched on CPU profiling and got the following error:
```
=== RUN   TestRobustnessExploratory
    leak.go:102: Found leaked goroutined BEFORE test appears to have leaked :
        time.Sleep(0x5f5e100)
        	/usr/local/go/src/runtime/time.go:195 +0x125
        runtime/pprof.profileWriter({0x1c65760?, 0xc000604358?})
        	/usr/local/go/src/runtime/pprof/pprof.go:809 +0x4a
        created by runtime/pprof.StartCPUProfile in goroutine 1
        	/usr/local/go/src/runtime/pprof/pprof.go:794 +0x13f
--- SKIP: TestRobustnessExploratory (0.05s)
=== RUN   TestRobustnessRegression
    leak.go:102: Found leaked goroutined BEFORE test appears to have leaked :
        time.Sleep(0x5f5e100)
        	/usr/local/go/src/runtime/time.go:195 +0x125
        runtime/pprof.profileWriter({0x1c65760?, 0xc000604358?})
        	/usr/local/go/src/runtime/pprof/pprof.go:809 +0x4a
        created by runtime/pprof.StartCPUProfile in goroutine 1
        	/usr/local/go/src/runtime/pprof/pprof.go:794 +0x13f
--- SKIP: TestRobustnessRegression (0.05s)
PASS
ok  	go.etcd.io/etcd/tests/v3/robustness	0.228s
```

This commit exempts goroutines in the leak detector that are started by pprof for CPU profiling.

Interestingly, this error does not creep up when I switch on other types of profiling (mutex, block, heap etc).

/assign @serathius 