### PR TITLE
[3.5] Implement etcd process go fail client timeout

### DIFF
--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -138,12 +138,13 @@ type EtcdProcessCluster struct {
 }
 
 type EtcdProcessClusterConfig struct {
-	ExecPath      string
-	DataDirPath   string
-	KeepDataDir   bool
-	GoFailEnabled bool
-	PeerProxy     bool
-	EnvVars       map[string]string
+	ExecPath            string
+	DataDirPath         string
+	KeepDataDir         bool
+	GoFailEnabled       bool
+	GoFailClientTimeout time.Duration
+	PeerProxy           bool
+	EnvVars             map[string]string
 
 	ClusterSize int
 
@@ -400,21 +401,22 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfigs(tb testing.TB) []*
 		}
 
 		etcdCfgs[i] = &EtcdServerProcessConfig{
-			lg:            lg,
-			ExecPath:      cfg.ExecPath,
-			Args:          args,
-			EnvVars:       envVars,
-			TlsArgs:       cfg.TlsArgs(),
-			DataDirPath:   dataDirPath,
-			KeepDataDir:   cfg.KeepDataDir,
-			Name:          name,
-			Purl:          peerAdvertiseUrl,
-			Acurl:         curl,
-			Murl:          murl,
-			InitialToken:  cfg.InitialToken,
-			ClientHttpUrl: clientHttpUrl,
-			GoFailPort:    gofailPort,
-			Proxy:         proxyCfg,
+			lg:                  lg,
+			ExecPath:            cfg.ExecPath,
+			Args:                args,
+			EnvVars:             envVars,
+			TlsArgs:             cfg.TlsArgs(),
+			DataDirPath:         dataDirPath,
+			KeepDataDir:         cfg.KeepDataDir,
+			Name:                name,
+			Purl:                peerAdvertiseUrl,
+			Acurl:               curl,
+			Murl:                murl,
+			InitialToken:        cfg.InitialToken,
+			ClientHttpUrl:       clientHttpUrl,
+			GoFailPort:          gofailPort,
+			GoFailClientTimeout: cfg.GoFailClientTimeout,
+			Proxy:               proxyCfg,
 		}
 	}
 

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -94,10 +94,11 @@ type EtcdServerProcessConfig struct {
 	Murl          string
 	ClientHttpUrl string
 
-	InitialToken   string
-	InitialCluster string
-	GoFailPort     int
-	Proxy          *proxy.ServerConfig
+	InitialToken        string
+	InitialCluster      string
+	GoFailPort          int
+	GoFailClientTimeout time.Duration
+	Proxy               *proxy.ServerConfig
 }
 
 func NewEtcdServerProcess(cfg *EtcdServerProcessConfig) (*EtcdServerProcess, error) {
@@ -111,7 +112,10 @@ func NewEtcdServerProcess(cfg *EtcdServerProcessConfig) (*EtcdServerProcess, err
 	}
 	ep := &EtcdServerProcess{cfg: cfg, donec: make(chan struct{})}
 	if cfg.GoFailPort != 0 {
-		ep.failpoints = &BinaryFailpoints{member: ep}
+		ep.failpoints = &BinaryFailpoints{
+			member:        ep,
+			clientTimeout: cfg.GoFailClientTimeout,
+		}
 	}
 	return ep, nil
 }
@@ -258,6 +262,7 @@ func (ep *EtcdServerProcess) Etcdctl(connType ClientConnType, isAutoTLS, v2 bool
 type BinaryFailpoints struct {
 	member         EtcdProcess
 	availableCache map[string]string
+	clientTimeout  time.Duration
 }
 
 func (f *BinaryFailpoints) SetupEnv(failpoint, payload string) error {
@@ -278,6 +283,12 @@ func (f *BinaryFailpoints) SetupHTTP(ctx context.Context, failpoint, payload str
 	r, err := http.NewRequestWithContext(ctx, "PUT", failpointUrl.String(), bytes.NewBuffer([]byte(payload)))
 	if err != nil {
 		return err
+	}
+	httpClient := http.Client{
+		Timeout: 1 * time.Second,
+	}
+	if f.clientTimeout != 0 {
+		httpClient.Timeout = f.clientTimeout
 	}
 	resp, err := httpClient.Do(r)
 	if err != nil {
@@ -301,6 +312,12 @@ func (f *BinaryFailpoints) DeactivateHTTP(ctx context.Context, failpoint string)
 	if err != nil {
 		return err
 	}
+	httpClient := http.Client{
+		Timeout: 1 * time.Second,
+	}
+	if f.clientTimeout != 0 {
+		httpClient.Timeout = f.clientTimeout
+	}
 	resp, err := httpClient.Do(r)
 	if err != nil {
 		return err
@@ -310,10 +327,6 @@ func (f *BinaryFailpoints) DeactivateHTTP(ctx context.Context, failpoint string)
 		return fmt.Errorf("bad status code: %d", resp.StatusCode)
 	}
 	return nil
-}
-
-var httpClient = http.Client{
-	Timeout: 1 * time.Second,
 }
 
 func (f *BinaryFailpoints) Enabled() bool {


### PR DESCRIPTION
This PR backports EtcdProcess's GoFailClientTimeout, as requested in #17425.

Required to backport #16822.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
