### PR TITLE
[WIP] Fix grpc log format

### DIFF
--- a/client/v3/logger.go
+++ b/client/v3/logger.go
@@ -33,8 +33,8 @@ func init() {
 		if err != nil {
 			panic(err)
 		}
+		grpclog.SetLoggerV2(zapgrpc.NewLogger(lg.Named("grpc")))
 		lg = lg.Named("etcd-client")
-		grpclog.SetLoggerV2(zapgrpc.NewLogger(lg))
 	}
 }
 

--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -19,9 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
-	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -227,13 +225,13 @@ func NewZapCoreLoggerBuilder(lg *zap.Logger, _ zapcore.Core, _ zapcore.WriteSync
 func (cfg *Config) SetupGlobalLoggers() {
 	lg := cfg.GetLogger()
 	if lg != nil {
+		zap.ReplaceGlobals(lg)
 		if cfg.LogLevel == "debug" {
 			grpc.EnableTracing = true
-			grpclog.SetLoggerV2(zapgrpc.NewLogger(lg))
 		} else {
-			grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, os.Stderr, os.Stderr))
+			lg = lg.WithOptions(zap.IncreaseLevel(zap.WarnLevel))
 		}
-		zap.ReplaceGlobals(lg)
+		grpclog.SetLoggerV2(zapgrpc.NewLogger(lg.Named("grpc")))
 	}
 }
 

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -190,7 +190,7 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 	}
 	defer lg.Sync()
 
-	grpclog.SetLoggerV2(zapgrpc.NewLogger(lg))
+	grpclog.SetLoggerV2(zapgrpc.NewLogger(lg.Named("grpc")))
 
 	// The proxy itself (ListenCert) can have not-empty CN.
 	// The empty CN is required for grpcProxyCert.


### PR DESCRIPTION
Before 
```
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel created
2024/02/15 18:20:58 INFO: [core] [Channel #1] original dial target is: "localhost:2379"
2024/02/15 18:20:58 INFO: [core] [Channel #1] parsed dial target is: resolver.Target{URL:url.URL{Scheme:"localhost", Opaque:"2379", User:(*url.Userinfo)(nil), Host:"", Path:"", RawPath:"", OmitHost:false, ForceQuery:false, RawQuery:"", Fragment:"", RawFragment:""}}
2024/02/15 18:20:58 INFO: [core] [Channel #1] fallback to scheme "passthrough"
2024/02/15 18:20:58 INFO: [core] [Channel #1] parsed dial target is: passthrough:///localhost:2379
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel authority set to "localhost:2379"
{"level":"info","ts":"2024-02-15T18:20:58.135268+0100","caller":"etcdmain/main.go:44","msg":"notifying init daemon"}
{"level":"info","ts":"2024-02-15T18:20:58.13538+0100","caller":"etcdmain/main.go:50","msg":"successfully notified init daemon"}
2024/02/15 18:20:58 INFO: [core] [Channel #1] Resolver state updated: {
  "Addresses": [
    {
      "Addr": "localhost:2379",
      "ServerName": "",
      "Attributes": null,
      "BalancerAttributes": null,
      "Metadata": null
    }
  ],
  "Endpoints": [
    {
      "Addresses": [
        {
          "Addr": "localhost:2379",
          "ServerName": "",
          "Attributes": null,
          "BalancerAttributes": null,
          "Metadata": null
        }
      ],
      "Attributes": null
    }
  ],
  "ServiceConfig": null,
  "Attributes": null
} (resolver returned new addresses)
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel switches to new LB policy "pick_first"
2024/02/15 18:20:58 INFO: [core] [Channel #1 SubChannel #2] Subchannel created
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel Connectivity change to CONNECTING
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel exiting idle mode
2024/02/15 18:20:58 INFO: [core] [Channel #1 SubChannel #2] Subchannel Connectivity change to CONNECTING
2024/02/15 18:20:58 INFO: [core] [Channel #1 SubChannel #2] Subchannel picks a new address "localhost:2379" to connect
2024/02/15 18:20:58 INFO: [core] [Server #3] Server created
{"level":"info","ts":"2024-02-15T18:20:58.137098+0100","caller":"v3rpc/health.go:62","msg":"grpc service status changed","service":"","status":"SERVING"}
{"level":"info","ts":"2024-02-15T18:20:58.139472+0100","caller":"embed/serve.go:188","msg":"serving client traffic insecurely; this is strongly discouraged!","traffic":"grpc+http","address":"127.0.0.1:2379"}
2024/02/15 18:20:58 INFO: [core] [Server #3 ListenSocket #5] ListenSocket created
2024/02/15 18:20:58 INFO: [core] [Channel #1 SubChannel #2] Subchannel Connectivity change to READY
2024/02/15 18:20:58 INFO: [core] [Channel #1] Channel Connectivity change to READY

```

after
```
{"level":"info","ts":"2024-02-15T18:31:56.50259+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:429","msg":"[core] [Channel #1] Channel created"}
{"level":"info","ts":"2024-02-15T18:31:56.502641+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1724","msg":"[core] [Channel #1] original dial target is: \"localhost:2379\""}
{"level":"info","ts":"2024-02-15T18:31:56.502692+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1731","msg":"[core] [Channel #1] parsed dial target is: resolver.Target{URL:url.URL{Scheme:\"localhost\", Opaque:\"2379\", User:(*url.Userinfo)(nil), Host:\"\", Path:\"\", RawPath:\"\", OmitHost:false, ForceQuery:false, RawQuery:\"\", Fragment:\"\", RawFragment:\"\"}}"}
{"level":"info","ts":"2024-02-15T18:31:56.502704+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1745","msg":"[core] [Channel #1] fallback to scheme \"passthrough\""}
{"level":"info","ts":"2024-02-15T18:31:56.502716+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1753","msg":"[core] [Channel #1] parsed dial target is: passthrough:///localhost:2379"}
{"level":"info","ts":"2024-02-15T18:31:56.502726+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1874","msg":"[core] [Channel #1] Channel authority set to \"localhost:2379\""}
{"level":"info","ts":"2024-02-15T18:31:56.502647+0100","caller":"etcdmain/main.go:44","msg":"notifying init daemon"}
{"level":"info","ts":"2024-02-15T18:31:56.502789+0100","caller":"etcdmain/main.go:50","msg":"successfully notified init daemon"}
{"level":"info","ts":"2024-02-15T18:31:56.502869+0100","logger":"grpc","caller":"grpc@v1.61.0/resolver_wrapper.go:196","msg":"[core] [Channel #1] Resolver state updated: {\n  \"Addresses\": [\n    {\n      \"Addr\": \"localhost:2379\",\n      \"ServerName\": \"\",\n      \"Attributes\": null,\n      \"BalancerAttributes\": null,\n      \"Metadata\": null\n    }\n  ],\n  \"Endpoints\": [\n    {\n      \"Addresses\": [\n        {\n          \"Addr\": \"localhost:2379\",\n          \"ServerName\": \"\",\n          \"Attributes\": null,\n          \"BalancerAttributes\": null,\n          \"Metadata\": null\n        }\n      ],\n      \"Attributes\": null\n    }\n  ],\n  \"ServiceConfig\": null,\n  \"Attributes\": null\n} (resolver returned new addresses)"}
{"level":"info","ts":"2024-02-15T18:31:56.502895+0100","logger":"grpc","caller":"grpc@v1.61.0/balancer_wrapper.go:161","msg":"[core] [Channel #1] Channel switches to new LB policy \"pick_first\""}
{"level":"info","ts":"2024-02-15T18:31:56.503922+0100","logger":"grpc","caller":"gracefulswitch/gracefulswitch.go:164","msg":"[core] [pick-first-lb 0xc000680000] Received new config {\n  \"shuffleAddressList\": false\n}, resolver state {\n  \"Addresses\": [\n    {\n      \"Addr\": \"localhost:2379\",\n      \"ServerName\": \"\",\n      \"Attributes\": null,\n      \"BalancerAttributes\": null,\n      \"Metadata\": null\n    }\n  ],\n  \"Endpoints\": [\n    {\n      \"Addresses\": [\n        {\n          \"Addr\": \"localhost:2379\",\n          \"ServerName\": \"\",\n          \"Attributes\": null,\n          \"BalancerAttributes\": null,\n          \"Metadata\": null\n        }\n      ],\n      \"Attributes\": null\n    }\n  ],\n  \"ServiceConfig\": null,\n  \"Attributes\": null\n}"}
{"level":"info","ts":"2024-02-15T18:31:56.503953+0100","logger":"grpc","caller":"grpc@v1.61.0/balancer_wrapper.go:213","msg":"[core] [Channel #1 SubChannel #2] Subchannel created"}
{"level":"info","ts":"2024-02-15T18:31:56.503967+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:532","msg":"[core] [Channel #1] Channel Connectivity change to CONNECTING"}
{"level":"info","ts":"2024-02-15T18:31:56.503983+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:335","msg":"[core] [Channel #1] Channel exiting idle mode"}
{"level":"info","ts":"2024-02-15T18:31:56.504028+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1223","msg":"[core] [Channel #1 SubChannel #2] Subchannel Connectivity change to CONNECTING"}
{"level":"info","ts":"2024-02-15T18:31:56.504077+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1338","msg":"[core] [Channel #1 SubChannel #2] Subchannel picks a new address \"localhost:2379\" to connect"}
{"level":"info","ts":"2024-02-15T18:31:56.504092+0100","logger":"grpc","caller":"grpc@v1.61.0/server.go:681","msg":"[core] [Server #3] Server created"}
{"level":"info","ts":"2024-02-15T18:31:56.504139+0100","caller":"v3rpc/health.go:62","msg":"grpc service status changed","service":"","status":"SERVING"}
{"level":"info","ts":"2024-02-15T18:31:56.504162+0100","logger":"grpc","caller":"grpc@v1.61.0/pickfirst.go:138","msg":"[core] [pick-first-lb 0xc000680000] Received SubConn state update: 0xc0006801b0, {ConnectivityState:CONNECTING ConnectionError:<nil>}"}
{"level":"info","ts":"2024-02-15T18:31:56.505336+0100","caller":"embed/serve.go:188","msg":"serving client traffic insecurely; this is strongly discouraged!","traffic":"grpc+http","address":"127.0.0.1:2379"}
{"level":"info","ts":"2024-02-15T18:31:56.505382+0100","logger":"grpc","caller":"grpc@v1.61.0/server.go:881","msg":"[core] [Server #3 ListenSocket #5] ListenSocket created"}
{"level":"info","ts":"2024-02-15T18:31:56.505545+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:1223","msg":"[core] [Channel #1 SubChannel #2] Subchannel Connectivity change to READY"}
{"level":"info","ts":"2024-02-15T18:31:56.505583+0100","logger":"grpc","caller":"grpc@v1.61.0/pickfirst.go:138","msg":"[core] [pick-first-lb 0xc000680000] Received SubConn state update: 0xc0006801b0, {ConnectivityState:READY ConnectionError:<nil>}"}
{"level":"info","ts":"2024-02-15T18:31:56.5056+0100","logger":"grpc","caller":"grpc@v1.61.0/clientconn.go:532","msg":"[core] [Channel #1] Channel Connectivity change to READY"}
```