### PR TITLE
[3.4] backport EtcdProcess GoFailClientTimeout

### DIFF
--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -101,12 +101,13 @@ type etcdProcessCluster struct {
 }
 
 type etcdProcessClusterConfig struct {
-	execPath      string
-	dataDirPath   string
-	keepDataDir   bool
-	goFailEnabled bool
-	peerProxy     bool
-	envVars       map[string]string
+	execPath            string
+	dataDirPath         string
+	keepDataDir         bool
+	goFailEnabled       bool
+	goFailClientTimeout time.Duration
+	peerProxy           bool
+	envVars             map[string]string
 
 	clusterSize int
 
@@ -348,20 +349,21 @@ func (cfg *etcdProcessClusterConfig) etcdServerProcessConfigs() []*etcdServerPro
 		}
 
 		etcdCfgs[i] = &etcdServerProcessConfig{
-			execPath:      cfg.execPath,
-			args:          args,
-			envVars:       envVars,
-			tlsArgs:       cfg.tlsArgs(),
-			dataDirPath:   dataDirPath,
-			keepDataDir:   cfg.keepDataDir,
-			name:          name,
-			purl:          peerAdvertiseUrl,
-			acurl:         curl,
-			murl:          murl,
-			initialToken:  cfg.initialToken,
-			clientHttpUrl: clientHttpUrl,
-			goFailPort:    gofailPort,
-			proxy:         proxyCfg,
+			execPath:            cfg.execPath,
+			args:                args,
+			envVars:             envVars,
+			tlsArgs:             cfg.tlsArgs(),
+			dataDirPath:         dataDirPath,
+			keepDataDir:         cfg.keepDataDir,
+			name:                name,
+			purl:                peerAdvertiseUrl,
+			acurl:               curl,
+			murl:                murl,
+			initialToken:        cfg.initialToken,
+			clientHttpUrl:       clientHttpUrl,
+			goFailPort:          gofailPort,
+			goFailClientTimeout: cfg.goFailClientTimeout,
+			proxy:               proxyCfg,
 		}
 	}
 


### PR DESCRIPTION
This PR backports e2e `EtcdProcess`' `GoFailClientTimeout`. Which is required to backport #16822.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
