### PR TITLE
Add Make CGO_ENABLED configurable to CHANGELOG

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -8,6 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### Package `clientv3`
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17369).
+- [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17422).
 
 ### Dependencies
 - Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17368)

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### Package `clientv3`
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17363).
 - [Ignore SetKeepAlivePeriod errors on OpenBSD](https://github.com/etcd-io/etcd/pull/17387).
+- [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17421).
 
 ### Dependencies
 - Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17362)


### PR DESCRIPTION
This PR will update the changelog with `Make CGO_ENABLED configurable` in:

- CHANGELOG-3.4.md
- CHANGELOG-3.5.md

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
