### PR TITLE
tests/robustness: check for compaction before prevKV validation

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -16,6 +16,7 @@ package robustness
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
+	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/robustness/failpoint"
@@ -89,11 +91,18 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 		report.Report(t, panicked)
 	}()
 	report.Client = s.run(ctx, t, lg, report.Cluster)
+	compaction, err := checkForCompaction(report.Cluster)
+	if err != nil {
+		t.Fatalf("failed checking for compaction: %v", err)
+	}
 	forcestopCluster(report.Cluster)
 
 	watchProgressNotifyEnabled := report.Cluster.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
 	validateGotAtLeastOneProgressNotify(t, report.Client, s.watch.requestProgress || watchProgressNotifyEnabled)
-	validateConfig := validate.Config{ExpectRevisionUnique: s.traffic.ExpectUniqueRevision()}
+	validateConfig := validate.Config{
+		ExpectRevisionUnique: s.traffic.ExpectUniqueRevision(),
+		AssumeCompaction:     compaction,
+	}
 	report.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, report.Client)
 
 	panicked = false
@@ -157,4 +166,31 @@ func forcestopCluster(clus *e2e.EtcdProcessCluster) error {
 		member.Kill()
 	}
 	return clus.ConcurrentStop()
+}
+
+func checkForCompaction(clus *e2e.EtcdProcessCluster) (bool, error) {
+	req := e2e.CURLReq{
+		Endpoint: "/metrics",
+		Expected: expect.ExpectedResponse{
+			// Filter out the etcd_debugging_mvcc_db_compaction_keys_total
+			// metric if it has a value greater than 0 from the response returned
+			// by the /metrics endpoint.
+			Value:         `etcd_debugging_mvcc_db_compaction_keys_total\s+[1-9][0-9]*`,
+			IsRegularExpr: true,
+		},
+	}
+
+	err := e2e.CURLGet(clus, req)
+	if err == nil {
+		return true, nil
+	}
+
+	// If no match was found, compaction did not take place.
+	noCompaction := strings.Contains(err.Error(), "match not found.") ||
+		strings.Contains(err.Error(), "context deadline exceeded")
+	if noCompaction {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -49,6 +49,7 @@ func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, report
 
 type Config struct {
 	ExpectRevisionUnique bool
+	AssumeCompaction     bool
 }
 
 func mergeWatchEventHistory(reports []report.ClientReport) ([]model.PersistedEvent, error) {


### PR DESCRIPTION
Follow up from https://github.com/etcd-io/etcd/pull/17352#issuecomment-1941122809

We can check for the condition that Kubernetes checks for, i.e. prevKV can be nil iff the event is not a create a event, only if we know whether compaction has occured or not. If compaction has occured, prevKV can be nil and that is completely valid.

This commit checks if compaction took place during the test run by querying the `/metrics` endpoint. Based on if compaction occured, we now check the Kubernetes condition in the prevKV robustness test.

/assign @serathius 