### PR TITLE
CHANGELOG Add entries for updated compaction logs

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.31 (TBD)
 
+### etcd server
+- Add [mvcc: print backend database size and size in use in compaction logs](https://github.com/etcd-io/etcd/pull/17436)
+
 ### Package `clientv3`
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17369).
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -28,6 +28,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [needlessly flocking snapshot files when deleting](https://github.com/etcd-io/etcd/pull/17206)
 - Add [digest for etcd base image](https://github.com/etcd-io/etcd/pull/17205)
 - Fix [delete inconsistencies in read buffer](https://github.com/etcd-io/etcd/pull/17230)
+- Add [mvcc: print backend database size and size in use in compaction logs](https://github.com/etcd-io/etcd/pull/17291)
 
 ### Dependencies
 - Compile binaries using [go 1.20.13](https://github.com/etcd-io/etcd/pull/17275)


### PR DESCRIPTION
Add the changelog entry for upcoming `3.4.31` release and add the missing changelog entry for `3.5.12`.

Fixes https://github.com/etcd-io/etcd/issues/17179.