### PR TITLE
Increased timeout to fix TestHashKVWhenCompacting test

### DIFF
--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -636,7 +636,7 @@ func TestHashKVWhenCompacting(t *testing.T) {
 
 	select {
 	case <-donec:
-	case <-time.After(10 * time.Second):
+	case <-time.After(20 * time.Second):
 		close(stopc)
 		wg.Wait()
 		testutil.FatalStack(t, "timeout")


### PR DESCRIPTION
Fixes : #16963


In test case ```TestHashKVWhenCompacting```, compactions are not finished in 10 secs so increased timeout to 20 secs to accomodate same.