### PR TITLE
Update changelogs to cover the bumping bbolt to v1.3.9 for both 3.4.31 and 3.5.13

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -14,7 +14,8 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17369).
 
 ### Dependencies
-- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17368)
+- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17368).
+- Upgrade [bbolt to 1.3.9](https://github.com/etcd-io/etcd/pull/17484).
 
 ### Others
 - [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17422).

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -21,7 +21,8 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
   - `--permit-without-stream`
 
 ### Dependencies
-- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17362)
+- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17362).
+- Upgrade [bbolt to v1.3.9](https://github.com/etcd-io/etcd/pull/17483).
 
 ### Others
 - [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17421).


### PR DESCRIPTION

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
