### PR TITLE
Tweak golang version policy to avoid unsupported minor versions

### DIFF
--- a/Documentation/contributor-guide/dependency_management.md
+++ b/Documentation/contributor-guide/dependency_management.md
@@ -120,7 +120,7 @@ Suggested steps for performing a minor version upgrade for the etcd development 
 4. Run performance benchmarks locally to compare before and after.
 5. Raise a pull request for the changes, example <https://github.com/etcd-io/etcd/pull/16394>.
 
-Stable etcd release branches will be maintained to stay on the latest patch release of a supported Go version, however upgrading minor versions will be avoided unless the minor version in use is now out of support. Refer to the [Go release policy](https://go.dev/doc/devel/release).
+Stable etcd release branches will be maintained to stay on the latest patch release of a supported Go version. Upgrading minor versions will be completed before the minor version in use currently is no longer supported. Refer to the [Go release policy](https://go.dev/doc/devel/release).
 
 For an example of how to update etcd to a new patch release of Go refer to issue <https://github.com/etcd-io/etcd/issues/16343> and the linked pull requests.
 


### PR DESCRIPTION
Our recent golang update pr's got me thinking about our version policy once again.

Re-reading our current agreed policy I noticed the wording made it possible for us to have periods of time when our stable release branches could potentially be promoting an unsupported version of go.

This pull requests proposes updating our policy so that rather than waiting to upgrade until the current version is no longer supported, we should instead get started on the update a bit sooner.

---

### Example

We currently promote golang version `1.21` as the minimum version to build our stable releases. The next upgrade for these branches will be to golang `1.22`. 

| Old policy         | New policy |
|--------------|:-----:|
| Wait until golang `1.23` is released before upgrading. Meaning we could have a period of time where our stable release branches are promoting an unsupported golang version (depending on how long it takes us to get around to do the update)|  Start the update before `1.23` releases (perhaps 1-3 months out) so we can ensure no period of promoting unsupported version |


