### PR TITLE
Skip ci of govuln for md/svg/png.

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -1,6 +1,16 @@
 ---
 name: Go Vulnerability Checker
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.svg'
+      - '**.png'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.svg'
+      - '**.png'
 permissions: read-all
 jobs:
   test:


### PR DESCRIPTION
Skip CI govuln for markdown & svg & png, avoid PRs like  https://github.com/etcd-io/etcd/pull/17544 and  https://github.com/etcd-io/etcd/pull/17542 being interfered by red CI.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
