### PR TITLE
[3.5] Add govuln GitHub workflow

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -1,0 +1,19 @@
+---
+name: Go Vulnerability Checker
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: date
+      - run: |
+          set -euo pipefail
+
+          go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...


### PR DESCRIPTION
Enables `govuln` in the release-3.5 branch.

Part of #17549.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
