### PR TITLE
[3.4][3.5] Changelog: Add CVE-2024-24786 remediation

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -14,7 +14,6 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Add [client backoff and retry config options](https://github.com/etcd-io/etcd/pull/17369).
 
 ### Dependencies
-- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17368).
 - Upgrade [bbolt to 1.3.9](https://github.com/etcd-io/etcd/pull/17484).
 - Compile binaries using [go 1.21.8](https://github.com/etcd-io/etcd/pull/17538).
 

--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -16,6 +16,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### Dependencies
 - Upgrade [bbolt to 1.3.9](https://github.com/etcd-io/etcd/pull/17484).
 - Compile binaries using [go 1.21.8](https://github.com/etcd-io/etcd/pull/17538).
+- Upgrade [google.golang.org/protobuf to v1.33.0 to address CVE-2024-24786](https://github.com/etcd-io/etcd/pull/17554).
 
 ### Others
 - [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17422).

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -23,6 +23,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### Dependencies
 - Upgrade [bbolt to v1.3.9](https://github.com/etcd-io/etcd/pull/17483).
 - Compile binaries using [go 1.21.8](https://github.com/etcd-io/etcd/pull/17537).
+- Upgrade [google.golang.org/protobuf to v1.33.0 to address CVE-2024-24786](https://github.com/etcd-io/etcd/pull/17553).
 
 ### Others
 - [Make CGO_ENABLED configurable](https://github.com/etcd-io/etcd/pull/17421).

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -21,7 +21,6 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
   - `--permit-without-stream`
 
 ### Dependencies
-- Compile binaries using [go 1.21.6](https://github.com/etcd-io/etcd/pull/17362).
 - Upgrade [bbolt to v1.3.9](https://github.com/etcd-io/etcd/pull/17483).
 - Compile binaries using [go 1.21.8](https://github.com/etcd-io/etcd/pull/17537).
 


### PR DESCRIPTION
* Add a line in 3.4 and 3.5 changelogs regarding updating google.golang.org/protobuf to v1.33.0 to address CVE-2024-24786. 
* Remove a duplicated line from compiling binaries with Go 1.21.6 (the most recent compilation is with 1.21.8).

Fixes: #17551 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
