### PR TITLE
tests: temporary disable coverage redisign Go experiment

### DIFF
--- a/scripts/codecov_upload.sh
+++ b/scripts/codecov_upload.sh
@@ -8,7 +8,7 @@ set -o pipefail
 LOG_FILE=${1:-test-coverage.log}
 
 # We collect the coverage
-COVERDIR=covdir PASSES='build cov' ./scripts/test.sh 2>&1 | tee "${LOG_FILE}"
+GOEXPERIMENT=nocoverageredesign COVERDIR=covdir PASSES='build cov' ./scripts/test.sh 2>&1 | tee "${LOG_FILE}"
 test_success="$?"
 
 # We try to upload whatever we have:


### PR DESCRIPTION
Go v1.22 has an error generating the coverage output. Disable it temporarily so GitHub workflows can run in the meantime.

Related to #17560

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
