### PR TITLE
Reuse events used for syncing watchers

### DIFF
--- a/server/storage/mvcc/watcher_test.go
+++ b/server/storage/mvcc/watcher_test.go
@@ -320,7 +320,7 @@ func TestWatcherRequestProgress(t *testing.T) {
 	default:
 	}
 
-	s.syncWatchers()
+	s.syncWatchers([]mvccpb.Event{})
 
 	w.RequestProgress(id)
 	wrs := WatchResponse{WatchID: id, Revision: 2}
@@ -359,7 +359,7 @@ func TestWatcherRequestProgressAll(t *testing.T) {
 	default:
 	}
 
-	s.syncWatchers()
+	s.syncWatchers([]mvccpb.Event{})
 
 	w.RequestProgressAll()
 	wrs := WatchResponse{WatchID: clientv3.InvalidWatchID, Revision: 2}


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/16839
Improve etcd behavior during watch congestion by reducing the memory needed. 
Congestion causes watch requests to backup and resync loop to allocate tons of memory. This patch has shown to reduce memory needed 5-10 times.

| Reuse events | object size [KB] | etcd memory[MB] | latency 50%ile | latency 90%ile | latency 99%ile |
| ------------ | ---------------- | --------------- | -------------- | -------------- | -------------- |
| FALSE        | 5                | 111.72          | 0.1005         | 0.1543         | 0.1856         |
| TRUE         | 5                | 109.096         | 0.1012         | 0.1556         | 0.1874         |
| FALSE        | 10               | 1103.924        | 2.7177         | 7.3661         | 11.9127        |
| TRUE         | 10               | 291.184         | 2.6623         | 7.687          | 12.5456        |
| FALSE        | 100              | 5138.712        | 14.0618        | 26.2721        | 29.1691        |
| TRUE         | 100              | 641.844         | 13.9372        | 25.8267        | 28.519         |

Tested using command `go run ./tools/benchmark/main.go watch-latency --watch-per-stream 1000 --streams 1 --put-total 200 --val-size 100000`. Parameters adjusted for total object size be a 20MB. 
