### PR TITLE
pkg: address golangci var-naming issues

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -32,7 +32,7 @@ import (
 	"github.com/creack/pty"
 )
 
-const DEBUG_LINES_TAIL = 40
+const debugLinesTail = 40
 
 var (
 	ErrProcessRunning = fmt.Errorf("process is still running")
@@ -218,7 +218,7 @@ func (ep *ExpectProcess) ExpectFunc(ctx context.Context, f func(string) bool) (s
 		}
 	}
 
-	lastLinesIndex := len(ep.lines) - DEBUG_LINES_TAIL
+	lastLinesIndex := len(ep.lines) - debugLinesTail
 	if lastLinesIndex < 0 {
 		lastLinesIndex = 0
 	}

--- a/pkg/grpctesting/recorder.go
+++ b/pkg/grpctesting/recorder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc_testing
+package grpctesting
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-type GrpcRecorder struct {
+type GRPCRecorder struct {
 	mux      sync.RWMutex
 	requests []RequestInfo
 }
@@ -32,7 +32,7 @@ type RequestInfo struct {
 	Authority  string
 }
 
-func (ri *GrpcRecorder) UnaryInterceptor() grpc.UnaryServerInterceptor {
+func (ri *GRPCRecorder) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		ri.record(toRequestInfo(ctx, info))
 		resp, err := handler(ctx, req)
@@ -40,7 +40,7 @@ func (ri *GrpcRecorder) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-func (ri *GrpcRecorder) RecordedRequests() []RequestInfo {
+func (ri *GRPCRecorder) RecordedRequests() []RequestInfo {
 	ri.mux.RLock()
 	defer ri.mux.RUnlock()
 	reqs := make([]RequestInfo, len(ri.requests))
@@ -62,7 +62,7 @@ func toRequestInfo(ctx context.Context, info *grpc.UnaryServerInfo) RequestInfo 
 	return req
 }
 
-func (ri *GrpcRecorder) record(r RequestInfo) {
+func (ri *GRPCRecorder) record(r RequestInfo) {
 	ri.mux.Lock()
 	defer ri.mux.Unlock()
 	ri.requests = append(ri.requests, r)

--- a/pkg/grpctesting/stub_server.go
+++ b/pkg/grpctesting/stub_server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc_testing
+package grpctesting
 
 import (
 	"context"

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -50,7 +50,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/pkg/v3/grpc_testing"
+	"go.etcd.io/etcd/pkg/v3/grpctesting"
 	"go.etcd.io/etcd/server/v3/config"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver"
@@ -582,7 +582,7 @@ type Member struct {
 	IsLearner bool
 	Closed    bool
 
-	GrpcServerRecorder *grpc_testing.GrpcRecorder
+	GrpcServerRecorder *grpctesting.GRPCRecorder
 
 	LogObserver *testutils.LogObserver
 }
@@ -734,7 +734,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 		m.ExperimentalMaxLearners = mcfg.ExperimentalMaxLearners
 	}
 	m.V2Deprecation = config.V2_DEPR_DEFAULT
-	m.GrpcServerRecorder = &grpc_testing.GrpcRecorder{}
+	m.GrpcServerRecorder = &grpctesting.GRPCRecorder{}
 
 	m.Logger, m.LogObserver = memberLogger(t, mcfg.Name)
 
@@ -1118,7 +1118,7 @@ func (m *Member) Launch() error {
 	return nil
 }
 
-func (m *Member) RecordedRequests() []grpc_testing.RequestInfo {
+func (m *Member) RecordedRequests() []grpctesting.RequestInfo {
 	return m.GrpcServerRecorder.RecordedRequests()
 }
 

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -28,7 +28,7 @@ import (
 
 	"go.etcd.io/etcd/client/v3/naming/endpoints"
 	"go.etcd.io/etcd/client/v3/naming/resolver"
-	"go.etcd.io/etcd/pkg/v3/grpc_testing"
+	"go.etcd.io/etcd/pkg/v3/grpctesting"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
@@ -36,13 +36,13 @@ func testEtcdGrpcResolver(t *testing.T, lbPolicy string) {
 
 	// Setup two new dummy stub servers
 	payloadBody := []byte{'1'}
-	s1 := grpc_testing.NewDummyStubServer(payloadBody)
+	s1 := grpctesting.NewDummyStubServer(payloadBody)
 	if err := s1.Start(nil); err != nil {
 		t.Fatal("failed to start dummy grpc server (s1)", err)
 	}
 	defer s1.Stop()
 
-	s2 := grpc_testing.NewDummyStubServer(payloadBody)
+	s2 := grpctesting.NewDummyStubServer(payloadBody)
 	if err := s2.Start(nil); err != nil {
 		t.Fatal("failed to start dummy grpc server (s2)", err)
 	}
@@ -153,13 +153,13 @@ func TestEtcdEndpointManager(t *testing.T) {
 	integration2.BeforeTest(t)
 
 	s1PayloadBody := []byte{'1'}
-	s1 := grpc_testing.NewDummyStubServer(s1PayloadBody)
+	s1 := grpctesting.NewDummyStubServer(s1PayloadBody)
 	err := s1.Start(nil)
 	assert.NoError(t, err)
 	defer s1.Stop()
 
 	s2PayloadBody := []byte{'2'}
-	s2 := grpc_testing.NewDummyStubServer(s2PayloadBody)
+	s2 := grpctesting.NewDummyStubServer(s2PayloadBody)
 	err = s2.Start(nil)
 	assert.NoError(t, err)
 	defer s2.Stop()


### PR DESCRIPTION
Addresses the `var-naming` issues in `pkg`.

* Renames the `grpc_testing` module to `grpctesting`
* Renames the exported `GrpcRecorder` struct to `GRPCRecorder`

Part of #17578

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
