### PR TITLE
api: address golangci var-naming issues

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -47,7 +47,11 @@ var (
 	ErrGRPCMemberNotLearner       = status.Error(codes.FailedPrecondition, "etcdserver: can only promote a learner member")
 	ErrGRPCLearnerNotReady        = status.Error(codes.FailedPrecondition, "etcdserver: can only promote a learner member which is in sync with leader")
 	ErrGRPCTooManyLearners        = status.Error(codes.FailedPrecondition, "etcdserver: too many learner members in cluster")
-	ErrGRPCClusterIdMismatch      = status.Error(codes.FailedPrecondition, "etcdserver: cluster ID mismatch")
+	ErrGRPCClusterIDMismatch      = status.Error(codes.FailedPrecondition, "etcdserver: cluster ID mismatch")
+	//revive:disable:var-naming
+	// Deprecated: Please use ErrGRPCClusterIDMismatch.
+	ErrGRPCClusterIdMismatch = ErrGRPCClusterIDMismatch
+	//revive:enable:var-naming
 
 	ErrGRPCRequestTooLarge        = status.Error(codes.InvalidArgument, "etcdserver: request is too large")
 	ErrGRPCRequestTooManyRequests = status.Error(codes.ResourceExhausted, "etcdserver: too many requests")
@@ -118,7 +122,7 @@ var (
 		ErrorDesc(ErrGRPCMemberNotLearner):       ErrGRPCMemberNotLearner,
 		ErrorDesc(ErrGRPCLearnerNotReady):        ErrGRPCLearnerNotReady,
 		ErrorDesc(ErrGRPCTooManyLearners):        ErrGRPCTooManyLearners,
-		ErrorDesc(ErrGRPCClusterIdMismatch):      ErrGRPCClusterIdMismatch,
+		ErrorDesc(ErrGRPCClusterIDMismatch):      ErrGRPCClusterIDMismatch,
 
 		ErrorDesc(ErrGRPCRequestTooLarge):        ErrGRPCRequestTooLarge,
 		ErrorDesc(ErrGRPCRequestTooManyRequests): ErrGRPCRequestTooManyRequests,
@@ -206,7 +210,11 @@ var (
 	ErrInvalidAuthToken     = Error(ErrGRPCInvalidAuthToken)
 	ErrAuthOldRevision      = Error(ErrGRPCAuthOldRevision)
 	ErrInvalidAuthMgmt      = Error(ErrGRPCInvalidAuthMgmt)
-	ErrClusterIdMismatch    = Error(ErrGRPCClusterIdMismatch)
+	ErrClusterIDMismatch    = Error(ErrGRPCClusterIDMismatch)
+	//revive:disable:var-naming
+	// Deprecated: Please use ErrGRPCClusterIDMismatch.
+	ErrClusterIdMismatch = ErrClusterIDMismatch
+	//revive:enable:var-naming
 
 	ErrNoLeader                   = Error(ErrGRPCNoLeader)
 	ErrNotLeader                  = Error(ErrGRPCNotLeader)

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -150,7 +150,7 @@ func (cm *corruptionChecker) InitialCheck() error {
 					zap.Strings("remote-peer-endpoints", p.eps),
 					zap.Error(err),
 				)
-			case rpctypes.ErrClusterIdMismatch:
+			case rpctypes.ErrClusterIDMismatch:
 				cm.lg.Warn(
 					"cluster ID mismatch",
 					zap.String("local-member-id", cm.hasher.MemberId().String()),
@@ -611,7 +611,7 @@ func HashByRev(ctx context.Context, cid types.ID, cc *http.Client, url string, r
 		}
 	} else if resp.StatusCode == http.StatusPreconditionFailed {
 		if strings.Contains(string(b), rafthttp.ErrClusterIDMismatch.Error()) {
-			return nil, rpctypes.ErrClusterIdMismatch
+			return nil, rpctypes.ErrClusterIDMismatch
 		}
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -99,7 +99,7 @@ func TestInitialCheck(t *testing.T) {
 		{
 			name: "Cluster ID Mismatch does not fail CorruptionChecker.InitialCheck()",
 			hasher: fakeHasher{
-				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIdMismatch}},
+				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIDMismatch}},
 			},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "HashByRev(0)", "PeerHashByRev(0)", "MemberId()", "MemberId()"},
 		},
@@ -223,7 +223,7 @@ func TestPeriodicCheck(t *testing.T) {
 		{
 			name: "Cluster ID Mismatch does not fail CorruptionChecker.PeriodicCheck()",
 			hasher: fakeHasher{
-				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIdMismatch}},
+				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIDMismatch}},
 			},
 			expectActions: []string{"HashByRev(0)", "PeerHashByRev(0)", "ReqTimeout()", "LinearizableReadNotify()", "HashByRev(0)"},
 		},
@@ -416,7 +416,7 @@ func TestCompactHashCheck(t *testing.T) {
 			name: "Cluster ID Mismatch does not fail CorruptionChecker.CompactHashCheck()",
 			hasher: fakeHasher{
 				hashes:     []mvcc.KeyValueHash{{Revision: 1, CompactRevision: 1, Hash: 1}},
-				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIdMismatch}},
+				peerHashes: []*peerHashKVResp{{err: rpctypes.ErrClusterIDMismatch}},
 			},
 			expectActions: []string{"MemberId()", "ReqTimeout()", "Hashes()", "PeerHashByRev(1)", "MemberId()"},
 		},


### PR DESCRIPTION
Addresses the `var-naming` linter issues in `api`.

Renames the exported variables:

* `rpctypes.ErrGRPCClusterIdMismatch` -> `rpctypes.ErrGRPCClusterIDMismatch`
* `rpctypes.ErrClusterIdMismatch` -> `rpctypes.ErrClusterIDMismatch`

Should we need to deprecate rather than rename, I can add a linter exception.

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
