### PR TITLE
flaky: fix jwt test with increasing ttl

### DIFF
--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -115,7 +115,7 @@ func NewConfigJWT() *EtcdProcessClusterConfig {
 	return NewConfig(
 		WithClusterSize(1),
 		WithAuthTokenOpts("jwt,pub-key="+path.Join(FixturesDir, "server.crt")+
-			",priv-key="+path.Join(FixturesDir, "server.key.insecure")+",sign-method=RS256,ttl=1s"),
+			",priv-key="+path.Join(FixturesDir, "server.key.insecure")+",sign-method=RS256,ttl=5s"),
 	)
 }
 


### PR DESCRIPTION
Increasing the `ttl` to 5 second to fix flaky issue related to https://github.com/etcd-io/etcd/issues/17556.

Flaking test: `TestCtlV3AuthAndWatchJWT`.
