### PR TITLE
Investigate arm64 robustness performance

### DIFF
--- a/.github/workflows/robustness-nightly.yaml
+++ b/.github/workflows/robustness-nightly.yaml
@@ -29,7 +29,7 @@ jobs:
       count: 150
       testTimeout: 200m
       artifactName: main-arm64
-      runs-on: "['actuated-arm64-8cpu-8gb']"
+      runs-on: "['actuated-arm64-12cpu-8gb']"
       scenario: TestRobustnessExploratory
       lazyfsEnabled: false
   release-35:
@@ -49,7 +49,7 @@ jobs:
       count: 150
       testTimeout: 200m
       artifactName: release-35-arm64
-      runs-on: "['actuated-arm64-8cpu-8gb']"
+      runs-on: "['actuated-arm64-12cpu-8gb']"
       scenario: TestRobustnessExploratory
       lazyfsEnabled: false
   release-34:

--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -39,6 +39,15 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ steps.goversion.outputs.goversion }}
+
+      # Temporary monitoring to compare amd64 and arm64 runner performance
+      # Refer: https://actuated.dev/blog/right-sizing-vms-github-actions
+      - uses: alexellis/setup-arkade@master
+      - name: Install vmmeter
+        run: |
+          sudo -E arkade oci install ghcr.io/openfaasltd/vmmeter:latest --path /usr/local/bin/
+      - uses: self-actuated/vmmeter-action@master
+
       - name: install-lazyfs
         if: ${{ inputs.lazyfsEnabled }}
         run: |

--- a/.github/workflows/robustness.yaml
+++ b/.github/workflows/robustness.yaml
@@ -20,6 +20,6 @@ jobs:
       count: 12
       testTimeout: 30m
       artifactName: main-arm64
-      runs-on: "['actuated-arm64-8cpu-8gb']"
+      runs-on: "['actuated-arm64-12cpu-8gb']"
       scenario: TestRobustness
       lazyfsEnabled: false


### PR DESCRIPTION
In October last year we switched from self managed arm64 CI infrastructure from Equinix Metal to managed arm64 runners provided via the CNCF and actuated.dev.

Since then we have completed some right sizing for memory requirements for all our `arm64` workflows, however we are still hitting some teething issues with CPU performance. Notably for robustness testing.

Performance issues were tracked in:
- https://github.com/etcd-io/etcd/issues/17246
- https://github.com/etcd-io/etcd/issues/17593

One mitigation to improve CPU performance was to disable lazyfs for `arm64` which was completed in https://github.com/etcd-io/etcd/pull/17323. 

Even with lazyfs disabled we are still seeing failures, recent examples are:

1. https://github.com/etcd-io/etcd/actions/runs/8324216324/job/22775349104

```bash
2024-03-18T10:49:54.6347546Z     logger.go:130: 2024-03-18T10:44:54.551Z	INFO	Validating linearizable operations	{"timeout": "5m0s"}
2024-03-18T10:49:54.6353444Z     logger.go:130: 2024-03-18T10:49:54.605Z	ERROR	Linearization has timed out
```

2. https://github.com/etcd-io/etcd/actions/runs/8262348764/job/22601494073

```bash
2024-03-13T10:47:07.8149258Z     logger.go:130: 2024-03-13T10:47:07.791Z	INFO	Average traffic	{"qps": 98.21620104737428}
2024-03-13T10:47:07.8150704Z     traffic.go:105: Requiring minimal 100.000000 qps for test results to be reliable, got 98.216201 qps
```

The above failures indicate CPU and/or disk IOPS performance bottlnecks, so this pull request increases robustness cpu cores from 8 to 12 and also enables vmmeter so we can more closely introspect the performance of the `arm64` runners versus standard github `amd64` runners.


cc @serathius, @alexellis 

