### PR TITLE
Let dapendabot to auto-update docker for release 3.4&3.5.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    target-branch: "release-3.4"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: docker
+    directory: /
+    target-branch: "release-3.5"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Now we will automatically upgrade the docker image in the main branch, let's treat release-3.4 and release-3.5 similarly

Releated: 
- https://github.com/etcd-io/etcd/issues/17609