### PR TITLE
[3.5] feat: add wal write system call metrics observation

### DIFF
--- a/server/wal/metrics.go
+++ b/server/wal/metrics.go
@@ -28,6 +28,15 @@ var (
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 14),
 	})
 
+	walWriteSec = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd",
+		Subsystem: "disk",
+		Name:      "wal_write_duration_seconds",
+		Help:      "The latency distributions of write called by WAL.",
+
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 14),
+	})
+
 	walWriteBytes = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "etcd",
 		Subsystem: "disk",


### PR DESCRIPTION
xref. #17615 


add new metrics: _**wal_write_duration_seconds**_

**_wal_write_duration_seconds_** represent total delay of: 
> syscall.write(padding_info + record_data_with_padding)

- delay of fsync is not included in _**wal_write_duration_seconds**_
- data: the raft log to write to the WAL on disk at one single raftNode loop