### PR TITLE
flaky: increase wait timeout in TestRevisionPause to solve flakiness issue

### DIFF
--- a/server/etcdserver/api/v3compactor/revision_test.go
+++ b/server/etcdserver/api/v3compactor/revision_test.go
@@ -72,7 +72,7 @@ func TestRevision(t *testing.T) {
 func TestRevisionPause(t *testing.T) {
 	fc := clockwork.NewFakeClock()
 	rg := &fakeRevGetter{testutil.NewRecorderStream(), 99} // will be 100
-	compactable := &fakeCompactable{testutil.NewRecorderStream()}
+	compactable := &fakeCompactable{testutil.NewRecorderStreamWithWaitTimout(10 * time.Second)}
 	tb := newRevision(zaptest.NewLogger(t), fc, 10, rg, compactable)
 
 	tb.Run()


### PR DESCRIPTION
fix flaky related to issue https://github.com/etcd-io/etcd/issues/17548
increased Recorder wait timeout in TestRevisionPause.go to be 10s to eliminate flakiness
