### PR TITLE
all: call Close() after reading http.Response.Body

### DIFF
--- a/contrib/lock/client/client.go
+++ b/contrib/lock/client/client.go
@@ -69,6 +69,7 @@ func write(key string, value string, version int64) error {
 	if err != nil {
 		log.Fatalf("failed to read request body: %s", err)
 	}
+	httpResp.Body.Close()
 
 	resp := new(response)
 	err = json.Unmarshal(respBytes, resp)

--- a/server/etcdserver/api/etcdhttp/peer_test.go
+++ b/server/etcdserver/api/etcdhttp/peer_test.go
@@ -103,6 +103,7 @@ func TestNewPeerHandlerOnRaftPrefix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected io.ReadAll error: %v", err)
 		}
+		resp.Body.Close()
 		if w := "test data"; string(body) != w {
 			t.Errorf("#%d: body = %s, want %s", i, body, w)
 		}


### PR DESCRIPTION
As the doc of http.Response.Body says:

// The http Client and Transport guarantee that Body is always
// non-nil, even on responses without a body or responses with
// a zero-length body. It is the caller's responsibility to
// close Body.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
