### PR TITLE
tests/e2e: address golangci var-naming issues

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -43,7 +43,7 @@ func TestConnectionMultiplexing(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		serverTLS        e2e.ClientConnType
-		separateHttpPort bool
+		separateHTTPPort bool
 	}{
 		{
 			name:      "ServerTLS",
@@ -60,19 +60,19 @@ func TestConnectionMultiplexing(t *testing.T) {
 		{
 			name:             "SeparateHTTP/ServerTLS",
 			serverTLS:        e2e.ClientTLS,
-			separateHttpPort: true,
+			separateHTTPPort: true,
 		},
 		{
 			name:             "SeparateHTTP/ServerNonTLS",
 			serverTLS:        e2e.ClientNonTLS,
-			separateHttpPort: true,
+			separateHTTPPort: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			cfg := e2e.NewConfig(e2e.WithClusterSize(1))
 			cfg.Client.ConnectionType = tc.serverTLS
-			cfg.ClientHttpSeparate = tc.separateHttpPort
+			cfg.ClientHttpSeparate = tc.separateHTTPPort
 			clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
@@ -129,7 +129,7 @@ func testConnectionMultiplexing(ctx context.Context, t *testing.T, member e2e.Et
 				tname = "default"
 			}
 			t.Run(tname, func(t *testing.T) {
-				assert.NoError(t, fetchGrpcGateway(httpEndpoint, httpVersion, connType))
+				assert.NoError(t, fetchGRPCGateway(httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchMetrics(t, httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchVersion(httpEndpoint, httpVersion, connType))
 				assert.NoError(t, fetchHealth(httpEndpoint, httpVersion, connType))
@@ -139,7 +139,7 @@ func testConnectionMultiplexing(ctx context.Context, t *testing.T, member e2e.Et
 	})
 }
 
-func fetchGrpcGateway(endpoint string, httpVersion string, connType e2e.ClientConnType) error {
+func fetchGRPCGateway(endpoint string, httpVersion string, connType e2e.ClientConnType) error {
 	rangeData, err := json.Marshal(&pb.RangeRequest{
 		Key: []byte("a"),
 	})
@@ -157,10 +157,12 @@ func fetchGrpcGateway(endpoint string, httpVersion string, connType e2e.ClientCo
 func validateGrpcgatewayRangeReponse(respData []byte) error {
 	// Modified json annotation so ResponseHeader fields are stored in string.
 	type responseHeader struct {
+		//revive:disable:var-naming
 		ClusterId uint64 `json:"cluster_id,string,omitempty"`
 		MemberId  uint64 `json:"member_id,string,omitempty"`
-		Revision  int64  `json:"revision,string,omitempty"`
-		RaftTerm  uint64 `json:"raft_term,string,omitempty"`
+		//revive:enable:var-naming
+		Revision int64  `json:"revision,string,omitempty"`
+		RaftTerm uint64 `json:"raft_term,string,omitempty"`
 	}
 	type rangeResponse struct {
 		Header *responseHeader    `json:"header,omitempty"`

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -218,7 +218,7 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 		assert.NoError(t, err, "error on put")
 	}
 
-	memberID, found, err := getMemberIdByName(ctx, cc, epc.Procs[0].Config().Name)
+	memberID, found, err := getMemberIDByName(ctx, cc, epc.Procs[0].Config().Name)
 	assert.NoError(t, err, "error on member list")
 	assert.Equal(t, found, true, "member not found")
 
@@ -258,7 +258,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 		err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
 		assert.NoError(t, err, "error on put")
 	}
-	memberID, found, err := getMemberIdByName(ctx, cc, epc.Procs[0].Config().Name)
+	memberID, found, err := getMemberIDByName(ctx, cc, epc.Procs[0].Config().Name)
 	assert.NoError(t, err, "error on member list")
 	assert.Equal(t, found, true, "member not found")
 

--- a/tests/e2e/ctl_v3_auth_security_test.go
+++ b/tests/e2e/ctl_v3_auth_security_test.go
@@ -27,10 +27,10 @@ import (
 
 // TestAuth_CVE_2021_28235 verifies https://nvd.nist.gov/vuln/detail/CVE-2021-28235
 func TestAuth_CVE_2021_28235(t *testing.T) {
-	testCtl(t, authTest_CVE_2021_28235, withCfg(*e2e.NewConfigNoTLS()), withLogLevel("debug"))
+	testCtl(t, authTestCVE2021_28235, withCfg(*e2e.NewConfigNoTLS()), withLogLevel("debug"))
 }
 
-func authTest_CVE_2021_28235(cx ctlCtx) {
+func authTestCVE2021_28235(cx ctlCtx) {
 	// create root user with root role
 	rootPass := "changeme123"
 	err := ctlV3User(cx, []string{"add", "root", "--interactive=false"}, "User root created", []string{rootPass})

--- a/tests/e2e/ctl_v3_member_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_member_no_proxy_test.go
@@ -50,7 +50,7 @@ func TestMemberReplace(t *testing.T) {
 	cc, err := e2e.NewEtcdctl(epc.Cfg.Client, endpoints)
 	require.NoError(t, err)
 
-	memberID, found, err := getMemberIdByName(ctx, cc, memberName)
+	memberID, found, err := getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
 	require.Equal(t, found, true, "Member not found")
 
@@ -60,7 +60,7 @@ func TestMemberReplace(t *testing.T) {
 	t.Logf("Removing member %s", memberName)
 	_, err = cc.MemberRemove(ctx, memberID)
 	require.NoError(t, err)
-	_, found, err = getMemberIdByName(ctx, cc, memberName)
+	_, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
 	require.Equal(t, found, false, "Expected member to be removed")
 	for member.IsRunning() {
@@ -75,8 +75,8 @@ func TestMemberReplace(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Adding member %s back", memberName)
-	removedMemberPeerUrl := member.Config().PeerURL.String()
-	_, err = cc.MemberAdd(ctx, memberName, []string{removedMemberPeerUrl})
+	removedMemberPeerURL := member.Config().PeerURL.String()
+	_, err = cc.MemberAdd(ctx, memberName, []string{removedMemberPeerURL})
 	require.NoError(t, err)
 	err = patchArgs(member.Config().Args, "initial-cluster-state", "existing")
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestMemberReplace(t *testing.T) {
 	require.NoError(t, err)
 	testutils.ExecuteUntil(ctx, t, func() {
 		for {
-			_, found, err := getMemberIdByName(ctx, cc, memberName)
+			_, found, err := getMemberIDByName(ctx, cc, memberName)
 			if err != nil || !found {
 				time.Sleep(10 * time.Millisecond)
 				continue
@@ -117,7 +117,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 	cc, err := e2e.NewEtcdctl(epc.Cfg.Client, endpoints)
 	require.NoError(t, err)
 
-	memberID, found, err := getMemberIdByName(ctx, cc, memberName)
+	memberID, found, err := getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
 	require.Equal(t, true, found, "Member not found")
 
@@ -127,7 +127,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 	t.Logf("Removing member %s", memberName)
 	_, err = cc.MemberRemove(ctx, memberID)
 	require.NoError(t, err)
-	_, found, err = getMemberIdByName(ctx, cc, memberName)
+	_, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
 	require.Equal(t, false, found, "Expected member to be removed")
 	for member.IsRunning() {
@@ -142,8 +142,8 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Adding member %s back as Learner", memberName)
-	removedMemberPeerUrl := member.Config().PeerURL.String()
-	_, err = cc.MemberAddAsLearner(ctx, memberName, []string{removedMemberPeerUrl})
+	removedMemberPeerURL := member.Config().PeerURL.String()
+	_, err = cc.MemberAddAsLearner(ctx, memberName, []string{removedMemberPeerURL})
 	require.NoError(t, err)
 
 	err = patchArgs(member.Config().Args, "initial-cluster-state", "existing")
@@ -158,7 +158,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 	var learnMemberID uint64
 	testutils.ExecuteUntil(ctx, t, func() {
 		for {
-			learnMemberID, found, err = getMemberIdByName(ctx, cc, memberName)
+			learnMemberID, found, err = getMemberIDByName(ctx, cc, memberName)
 			if err != nil || !found {
 				time.Sleep(10 * time.Millisecond)
 				continue
@@ -167,7 +167,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 		}
 	})
 
-	learnMemberID, found, err = getMemberIdByName(ctx, cc, memberName)
+	learnMemberID, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
 	require.Equal(t, true, found, "Member not found")
 

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -45,15 +45,15 @@ func TestTLSClusterOf5UsingV3Discovery_3endpoints(t *testing.T) {
 	testClusterUsingV3Discovery(t, 3, 5, e2e.ClientTLS, false)
 }
 
-func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClusterSize int, clientTlsType e2e.ClientConnType, isClientAutoTls bool) {
+func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClusterSize int, clientTLSType e2e.ClientConnType, isClientAutoTLS bool) {
 	e2e.BeforeTest(t)
 
 	// step 1: start the discovery service
 	ds, err := e2e.NewEtcdProcessCluster(context.TODO(), t,
 		e2e.WithBasePort(2000),
 		e2e.WithClusterSize(discoveryClusterSize),
-		e2e.WithClientConnType(clientTlsType),
-		e2e.WithClientAutoTLS(isClientAutoTls),
+		e2e.WithClientConnType(clientTLSType),
+		e2e.WithClientAutoTLS(isClientAutoTLS),
 	)
 	if err != nil {
 		t.Fatalf("could not start discovery etcd cluster (%v)", err)
@@ -69,7 +69,7 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 	}
 
 	// step 3: start the etcd cluster
-	epc, err := bootstrapEtcdClusterUsingV3Discovery(t, ds.EndpointsGRPC(), discoveryToken, targetClusterSize, clientTlsType, isClientAutoTls)
+	epc, err := bootstrapEtcdClusterUsingV3Discovery(t, ds.EndpointsGRPC(), discoveryToken, targetClusterSize, clientTLSType, isClientAutoTLS)
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}
@@ -85,7 +85,7 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 	}
 }
 
-func bootstrapEtcdClusterUsingV3Discovery(t *testing.T, discoveryEndpoints []string, discoveryToken string, clusterSize int, clientTlsType e2e.ClientConnType, isClientAutoTls bool) (*e2e.EtcdProcessCluster, error) {
+func bootstrapEtcdClusterUsingV3Discovery(t *testing.T, discoveryEndpoints []string, discoveryToken string, clusterSize int, clientTLSType e2e.ClientConnType, isClientAutoTLS bool) (*e2e.EtcdProcessCluster, error) {
 	// cluster configuration
 	cfg := e2e.NewConfig(
 		e2e.WithBasePort(3000),
@@ -107,8 +107,8 @@ func bootstrapEtcdClusterUsingV3Discovery(t *testing.T, discoveryEndpoints []str
 	for _, ep := range epc.Procs {
 		epCfg := ep.Config()
 
-		if clientTlsType == e2e.ClientTLS {
-			if isClientAutoTls {
+		if clientTLSType == e2e.ClientTLS {
+			if isClientAutoTLS {
 				epCfg.Args = append(epCfg.Args, "--discovery-insecure-transport=false")
 				epCfg.Args = append(epCfg.Args, "--discovery-insecure-skip-tls-verify=true")
 			} else {

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -408,11 +408,11 @@ func TestEtcdHealthyWithTinySnapshotCatchupEntries(t *testing.T) {
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 	for i := 0; i < 10; i++ {
-		clientId := i
+		clientID := i
 		g.Go(func() error {
 			cc := epc.Etcdctl()
 			for j := 0; j < 100; j++ {
-				if err := cc.Put(ctx, "foo", fmt.Sprintf("bar%d", clientId), config.PutOptions{}); err != nil {
+				if err := cc.Put(ctx, "foo", fmt.Sprintf("bar%d", clientID), config.PutOptions{}); err != nil {
 					return err
 				}
 			}

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -108,7 +108,7 @@ func curl(endpoint string, method string, curlReq e2e.CURLReq, connType e2e.Clie
 	return strings.Join(lines, "\n"), nil
 }
 
-func runCommandAndReadJsonOutput(args []string) (map[string]any, error) {
+func runCommandAndReadJSONOutput(args []string) (map[string]any, error) {
 	lines, err := e2e.RunUtilCompletion(args, nil)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func runCommandAndReadJsonOutput(args []string) (map[string]any, error) {
 	return resp, nil
 }
 
-func getMemberIdByName(ctx context.Context, c *e2e.EtcdctlV3, name string) (id uint64, found bool, err error) {
+func getMemberIDByName(ctx context.Context, c *e2e.EtcdctlV3, name string) (id uint64, found bool, err error) {
 	resp, err := c.MemberList(ctx, false)
 	if err != nil {
 		return 0, false, err

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -237,7 +237,7 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 		Endpoint: "/v3/auth/user/list",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	users, ok := resp["users"]
@@ -366,7 +366,7 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 		Endpoint: "/v3/auth/role/list",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	roles, ok := resp["roles"]

--- a/tests/e2e/v3_curl_cluster_test.go
+++ b/tests/e2e/v3_curl_cluster_test.go
@@ -116,7 +116,7 @@ func mustListMembers(cx ctlCtx) []any {
 		Endpoint: "/v3/cluster/member/list",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	members, ok := resp["members"]

--- a/tests/e2e/v3_curl_kv_test.go
+++ b/tests/e2e/v3_curl_kv_test.go
@@ -185,7 +185,7 @@ func mustExecuteTxn(cx ctlCtx, reqData string) (bool, []any) {
 		Endpoint: "/v3/kv/txn",
 		Value:    reqData,
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	succeeded, ok := resp["succeeded"]

--- a/tests/e2e/v3_curl_lock_test.go
+++ b/tests/e2e/v3_curl_lock_test.go
@@ -40,7 +40,7 @@ func testCurlV3LockOperations(cx ctlCtx) {
 		Endpoint: "/v3/lock/lock",
 		Value:    string(lockReq),
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 	key, ok := resp["key"]
 	require.True(cx.t, ok)

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -48,7 +48,7 @@ func testCurlV3MaintenanceStatus(cx ctlCtx) {
 		Endpoint: "/v3/maintenance/status",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	requiredFields := []string{"version", "dbSize", "leader", "raftIndex", "raftTerm", "raftAppliedIndex", "dbSizeInUse", "storageVersion"}
@@ -88,7 +88,7 @@ func testCurlV3MaintenanceHash(cx ctlCtx) {
 		Endpoint: "/v3/maintenance/hash",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	requiredFields := []string{"header", "hash"}
@@ -109,7 +109,7 @@ func testCurlV3MaintenanceHashKV(cx ctlCtx) {
 		Endpoint: "/v3/maintenance/hashkv",
 		Value:    "{}",
 	})
-	resp, err := runCommandAndReadJsonOutput(args)
+	resp, err := runCommandAndReadJSONOutput(args)
 	require.NoError(cx.t, err)
 
 	requiredFields := []string{"header", "hash", "compact_revision", "hash_revision"}

--- a/tests/e2e/v3_lease_no_proxy_test.go
+++ b/tests/e2e/v3_lease_no_proxy_test.go
@@ -82,7 +82,7 @@ func testLeaseRevokeIssue(t *testing.T, connectToOneFollower bool) {
 
 	resp, err := client.Status(ctx, epsForNormalOperations[0])
 	require.NoError(t, err)
-	oldLeaderId := resp.Leader
+	oldLeaderID := resp.Leader
 
 	t.Log("Creating a new lease")
 	leaseRsp, err := client.Grant(ctx, 20)
@@ -118,11 +118,11 @@ func testLeaseRevokeIssue(t *testing.T, connectToOneFollower bool) {
 	require.NoError(t, err)
 
 	cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Logf("Waiting for a new leader to be elected, old leader index: %d, old leader ID: %d", leaderIdx, oldLeaderId)
+	t.Logf("Waiting for a new leader to be elected, old leader index: %d, old leader ID: %d", leaderIdx, oldLeaderID)
 	testutils.ExecuteUntil(cctx, t, func() {
 		for {
 			resp, err = client.Status(ctx, epsForNormalOperations[0])
-			if err == nil && resp.Leader != oldLeaderId {
+			if err == nil && resp.Leader != oldLeaderID {
 				t.Logf("A new leader has already been elected, new leader index: %d", resp.Leader)
 				return
 			}

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -39,11 +39,11 @@ const (
 )
 
 type testCase struct {
-	name                string
-	client              e2e.ClientConfig
-	clientHttpSerparate bool
-	maxWatchDelay       time.Duration
-	dbSizeBytes         int
+	name               string
+	client             e2e.ClientConfig
+	clientHTTPSeparate bool
+	maxWatchDelay      time.Duration
+	dbSizeBytes        int
 }
 
 const (
@@ -67,17 +67,17 @@ var tcs = []testCase{
 		dbSizeBytes:   5 * Mega,
 	},
 	{
-		name:                "SeparateHttpNoTLS",
-		clientHttpSerparate: true,
-		maxWatchDelay:       150 * time.Millisecond,
-		dbSizeBytes:         5 * Mega,
+		name:               "SeparateHTTPNoTLS",
+		clientHTTPSeparate: true,
+		maxWatchDelay:      150 * time.Millisecond,
+		dbSizeBytes:        5 * Mega,
 	},
 	{
-		name:                "SeparateHttpTLS",
-		client:              e2e.ClientConfig{ConnectionType: e2e.ClientTLS},
-		clientHttpSerparate: true,
-		maxWatchDelay:       150 * time.Millisecond,
-		dbSizeBytes:         5 * Mega,
+		name:               "SeparateHTTPTLS",
+		client:             e2e.ClientConfig{ConnectionType: e2e.ClientTLS},
+		clientHTTPSeparate: true,
+		maxWatchDelay:      150 * time.Millisecond,
+		dbSizeBytes:        5 * Mega,
 	},
 }
 
@@ -89,7 +89,7 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 		cfg.ClusterSize = 1
 		cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval = watchResponsePeriod
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHttpSerparate
+		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestWatchDelayForManualProgressNotification(t *testing.T) {
 		cfg := e2e.DefaultConfig()
 		cfg.ClusterSize = 1
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHttpSerparate
+		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestWatchDelayForEvent(t *testing.T) {
 		cfg := e2e.DefaultConfig()
 		cfg.ClusterSize = 1
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHttpSerparate
+		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)


### PR DESCRIPTION
Addresses the `var-naming` issues in `tests/e2e`.

Part of #17578

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
