### PR TITLE
tests/framework: address golangci var-naming issues

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -72,7 +72,7 @@ func TestConnectionMultiplexing(t *testing.T) {
 			ctx := context.Background()
 			cfg := e2e.NewConfig(e2e.WithClusterSize(1))
 			cfg.Client.ConnectionType = tc.serverTLS
-			cfg.ClientHttpSeparate = tc.separateHTTPPort
+			cfg.ClientHTTPSeparate = tc.separateHTTPPort
 			clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
 			defer clus.Close()
@@ -146,7 +146,7 @@ func fetchGRPCGateway(endpoint string, httpVersion string, connType e2e.ClientCo
 	if err != nil {
 		return err
 	}
-	req := e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Timeout: 5, HttpVersion: httpVersion}
+	req := e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Timeout: 5, HTTPVersion: httpVersion}
 	respData, err := curl(endpoint, "POST", req, connType)
 	if err != nil {
 		return err
@@ -178,7 +178,7 @@ func fetchMetrics(t *testing.T, endpoint string, httpVersion string, connType e2
 	tmpDir := t.TempDir()
 	metricFile := filepath.Join(tmpDir, "metrics")
 
-	req := e2e.CURLReq{Endpoint: "/metrics", Timeout: 5, HttpVersion: httpVersion, OutputFile: metricFile}
+	req := e2e.CURLReq{Endpoint: "/metrics", Timeout: 5, HTTPVersion: httpVersion, OutputFile: metricFile}
 	if _, err := curl(endpoint, "GET", req, connType); err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func fetchMetrics(t *testing.T, endpoint string, httpVersion string, connType e2
 }
 
 func fetchVersion(endpoint string, httpVersion string, connType e2e.ClientConnType) error {
-	req := e2e.CURLReq{Endpoint: "/version", Timeout: 5, HttpVersion: httpVersion}
+	req := e2e.CURLReq{Endpoint: "/version", Timeout: 5, HTTPVersion: httpVersion}
 	respData, err := curl(endpoint, "GET", req, connType)
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func fetchVersion(endpoint string, httpVersion string, connType e2e.ClientConnTy
 }
 
 func fetchHealth(endpoint string, httpVersion string, connType e2e.ClientConnType) error {
-	req := e2e.CURLReq{Endpoint: "/health", Timeout: 5, HttpVersion: httpVersion}
+	req := e2e.CURLReq{Endpoint: "/health", Timeout: 5, HTTPVersion: httpVersion}
 	respData, err := curl(endpoint, "GET", req, connType)
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func fetchHealth(endpoint string, httpVersion string, connType e2e.ClientConnTyp
 }
 
 func fetchDebugVars(endpoint string, httpVersion string, connType e2e.ClientConnType) error {
-	req := e2e.CURLReq{Endpoint: "/debug/vars", Timeout: 5, HttpVersion: httpVersion}
+	req := e2e.CURLReq{Endpoint: "/debug/vars", Timeout: 5, HTTPVersion: httpVersion}
 	respData, err := curl(endpoint, "GET", req, connType)
 	if err != nil {
 		return err

--- a/tests/e2e/watch_delay_test.go
+++ b/tests/e2e/watch_delay_test.go
@@ -89,7 +89,7 @@ func TestWatchDelayForPeriodicProgressNotification(t *testing.T) {
 		cfg.ClusterSize = 1
 		cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval = watchResponsePeriod
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
+		cfg.ClientHTTPSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestWatchDelayForManualProgressNotification(t *testing.T) {
 		cfg := e2e.DefaultConfig()
 		cfg.ClusterSize = 1
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
+		cfg.ClientHTTPSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestWatchDelayForEvent(t *testing.T) {
 		cfg := e2e.DefaultConfig()
 		cfg.ClusterSize = 1
 		cfg.Client = tc.client
-		cfg.ClientHttpSeparate = tc.clientHTTPSeparate
+		cfg.ClientHTTPSeparate = tc.clientHTTPSeparate
 		t.Run(tc.name, func(t *testing.T) {
 			clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg))
 			require.NoError(t, err)

--- a/tests/framework/e2e/cluster_proxy.go
+++ b/tests/framework/e2e/cluster_proxy.go
@@ -196,7 +196,7 @@ func newProxyV2Proc(cfg *EtcdServerProcessConfig) *proxyV2Proc {
 			name:     cfg.Name,
 			lg:       cfg.lg,
 			execPath: cfg.ExecPath,
-			args:     append(args, cfg.TlsArgs...),
+			args:     append(args, cfg.TLSArgs...),
 			ep:       listenAddr,
 			donec:    make(chan struct{}),
 		},
@@ -225,16 +225,16 @@ func newProxyV3Proc(cfg *EtcdServerProcessConfig) *proxyV3Proc {
 		args = append(args, "--metrics-addr", murl)
 	}
 	tlsArgs := []string{}
-	for i := 0; i < len(cfg.TlsArgs); i++ {
-		switch cfg.TlsArgs[i] {
+	for i := 0; i < len(cfg.TLSArgs); i++ {
+		switch cfg.TLSArgs[i] {
 		case "--cert-file":
-			tlsArgs = append(tlsArgs, "--cert-file", cfg.TlsArgs[i+1])
+			tlsArgs = append(tlsArgs, "--cert-file", cfg.TLSArgs[i+1])
 			i++
 		case "--key-file":
-			tlsArgs = append(tlsArgs, "--key-file", cfg.TlsArgs[i+1])
+			tlsArgs = append(tlsArgs, "--key-file", cfg.TLSArgs[i+1])
 			i++
 		case "--trusted-ca-file":
-			tlsArgs = append(tlsArgs, "--trusted-ca-file", cfg.TlsArgs[i+1])
+			tlsArgs = append(tlsArgs, "--trusted-ca-file", cfg.TLSArgs[i+1])
 			i++
 		case "--auto-tls":
 			tlsArgs = append(tlsArgs, "--auto-tls", "--insecure-skip-tls-verify")
@@ -242,10 +242,10 @@ func newProxyV3Proc(cfg *EtcdServerProcessConfig) *proxyV3Proc {
 			i++ // skip arg
 		case "--client-cert-auth", "--peer-auto-tls":
 		default:
-			tlsArgs = append(tlsArgs, cfg.TlsArgs[i])
+			tlsArgs = append(tlsArgs, cfg.TLSArgs[i])
 		}
 	}
-	if len(cfg.TlsArgs) > 0 {
+	if len(cfg.TLSArgs) > 0 {
 		// Configure certificates for connection proxy ---> server.
 		// This certificate must NOT have CN set.
 		tlsArgs = append(tlsArgs,

--- a/tests/framework/e2e/curl.go
+++ b/tests/framework/e2e/curl.go
@@ -38,7 +38,7 @@ type CURLReq struct {
 	Header   string
 
 	Ciphers     string
-	HttpVersion string
+	HTTPVersion string
 
 	OutputFile string
 }
@@ -62,8 +62,8 @@ func CURLPrefixArgs(clientURL string, cfg ClientConfig, CN bool, method string, 
 	var (
 		cmdArgs = []string{"curl"}
 	)
-	if req.HttpVersion != "" {
-		cmdArgs = append(cmdArgs, "--http"+req.HttpVersion)
+	if req.HTTPVersion != "" {
+		cmdArgs = append(cmdArgs, "--http"+req.HTTPVersion)
 	}
 	if req.IsTLS {
 		if cfg.ConnectionType != ClientTLSAndNonTLS {

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -81,7 +81,7 @@ type EtcdServerProcessConfig struct {
 	lg       *zap.Logger
 	ExecPath string
 	Args     []string
-	TlsArgs  []string
+	TLSArgs  []string
 	EnvVars  map[string]string
 
 	Client      ClientConfig
@@ -354,12 +354,12 @@ func (f *BinaryFailpoints) SetupEnv(failpoint, payload string) error {
 
 func (f *BinaryFailpoints) SetupHTTP(ctx context.Context, failpoint, payload string) error {
 	host := fmt.Sprintf("127.0.0.1:%d", f.member.Config().GoFailPort)
-	failpointUrl := url.URL{
+	failpointURL := url.URL{
 		Scheme: "http",
 		Host:   host,
 		Path:   failpoint,
 	}
-	r, err := http.NewRequestWithContext(ctx, "PUT", failpointUrl.String(), bytes.NewBuffer([]byte(payload)))
+	r, err := http.NewRequestWithContext(ctx, "PUT", failpointURL.String(), bytes.NewBuffer([]byte(payload)))
 	if err != nil {
 		return err
 	}
@@ -382,12 +382,12 @@ func (f *BinaryFailpoints) SetupHTTP(ctx context.Context, failpoint, payload str
 
 func (f *BinaryFailpoints) DeactivateHTTP(ctx context.Context, failpoint string) error {
 	host := fmt.Sprintf("127.0.0.1:%d", f.member.Config().GoFailPort)
-	failpointUrl := url.URL{
+	failpointURL := url.URL{
 		Scheme: "http",
 		Host:   host,
 		Path:   failpoint,
 	}
-	r, err := http.NewRequestWithContext(ctx, "DELETE", failpointUrl.String(), nil)
+	r, err := http.NewRequestWithContext(ctx, "DELETE", failpointURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -439,11 +439,11 @@ func failpoints(member EtcdProcess) (map[string]string, error) {
 
 func fetchFailpointsBody(member EtcdProcess) (io.ReadCloser, error) {
 	address := fmt.Sprintf("127.0.0.1:%d", member.Config().GoFailPort)
-	failpointUrl := url.URL{
+	failpointURL := url.URL{
 		Scheme: "http",
 		Host:   address,
 	}
-	resp, err := http.Get(failpointUrl.String())
+	resp, err := http.Get(failpointURL.String())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -148,7 +148,7 @@ func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) 
 		_, err = cmd.ExpectWithContext(ctx, expect.ExpectedResponse{Value: "Count"})
 		return &resp, err
 	}
-	err := ctl.spawnJsonCmd(ctx, &resp, args...)
+	err := ctl.spawnJSONCmd(ctx, &resp, args...)
 	return &resp, err
 }
 
@@ -177,7 +177,7 @@ func (ctl *EtcdctlV3) Delete(ctx context.Context, key string, o config.DeleteOpt
 		args = append(args, "--from-key")
 	}
 	var resp clientv3.DeleteResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, args...)
+	err := ctl.spawnJSONCmd(ctx, &resp, args...)
 	return &resp, err
 }
 
@@ -284,31 +284,31 @@ func (ctl *EtcdctlV3) MemberList(ctx context.Context, serializable bool) (*clien
 	if serializable {
 		args = append(args, "--consistency", "s")
 	}
-	err := ctl.spawnJsonCmd(ctx, &resp, args...)
+	err := ctl.spawnJSONCmd(ctx, &resp, args...)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) MemberAdd(ctx context.Context, name string, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
 	var resp clientv3.MemberAddResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "member", "add", name, "--peer-urls", strings.Join(peerAddrs, ","))
+	err := ctl.spawnJSONCmd(ctx, &resp, "member", "add", name, "--peer-urls", strings.Join(peerAddrs, ","))
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) MemberAddAsLearner(ctx context.Context, name string, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
 	var resp clientv3.MemberAddResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "member", "add", name, "--learner", "--peer-urls", strings.Join(peerAddrs, ","))
+	err := ctl.spawnJSONCmd(ctx, &resp, "member", "add", name, "--learner", "--peer-urls", strings.Join(peerAddrs, ","))
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
 	var resp clientv3.MemberRemoveResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "member", "remove", fmt.Sprintf("%x", id))
+	err := ctl.spawnJSONCmd(ctx, &resp, "member", "remove", fmt.Sprintf("%x", id))
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
 	var resp clientv3.MemberPromoteResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "member", "promote", fmt.Sprintf("%x", id))
+	err := ctl.spawnJSONCmd(ctx, &resp, "member", "promote", fmt.Sprintf("%x", id))
 	return &resp, err
 }
 
@@ -361,7 +361,7 @@ func (ctl *EtcdctlV3) Status(ctx context.Context) ([]*clientv3.StatusResponse, e
 		Endpoint string
 		Status   *clientv3.StatusResponse
 	}
-	err := ctl.spawnJsonCmd(ctx, &epStatus, "endpoint", "status")
+	err := ctl.spawnJSONCmd(ctx, &epStatus, "endpoint", "status")
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (ctl *EtcdctlV3) HashKV(ctx context.Context, rev int64) ([]*clientv3.HashKV
 		Endpoint string
 		HashKV   *clientv3.HashKVResponse
 	}
-	err := ctl.spawnJsonCmd(ctx, &epHashKVs, "endpoint", "hashkv", "--rev", fmt.Sprint(rev))
+	err := ctl.spawnJSONCmd(ctx, &epHashKVs, "endpoint", "hashkv", "--rev", fmt.Sprint(rev))
 	if err != nil {
 		return nil, err
 	}
@@ -483,13 +483,13 @@ func (ctl *EtcdctlV3) KeepAliveOnce(ctx context.Context, id clientv3.LeaseID) (*
 
 func (ctl *EtcdctlV3) Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error) {
 	var resp clientv3.LeaseRevokeResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "lease", "revoke", strconv.FormatInt(int64(id), 16))
+	err := ctl.spawnJSONCmd(ctx, &resp, "lease", "revoke", strconv.FormatInt(int64(id), 16))
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) AlarmList(ctx context.Context) (*clientv3.AlarmResponse, error) {
 	var resp clientv3.AlarmResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "alarm", "list")
+	err := ctl.spawnJSONCmd(ctx, &resp, "alarm", "list")
 	return &resp, err
 }
 
@@ -536,7 +536,7 @@ func (ctl *EtcdctlV3) AuthDisable(ctx context.Context) error {
 
 func (ctl *EtcdctlV3) AuthStatus(ctx context.Context) (*clientv3.AuthStatusResponse, error) {
 	var resp clientv3.AuthStatusResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "auth", "status")
+	err := ctl.spawnJSONCmd(ctx, &resp, "auth", "status")
 	return &resp, err
 }
 
@@ -581,19 +581,19 @@ func (ctl *EtcdctlV3) UserAdd(ctx context.Context, name, password string, opts c
 
 func (ctl *EtcdctlV3) UserGet(ctx context.Context, name string) (*clientv3.AuthUserGetResponse, error) {
 	var resp clientv3.AuthUserGetResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "user", "get", name)
+	err := ctl.spawnJSONCmd(ctx, &resp, "user", "get", name)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) UserList(ctx context.Context) (*clientv3.AuthUserListResponse, error) {
 	var resp clientv3.AuthUserListResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "user", "list")
+	err := ctl.spawnJSONCmd(ctx, &resp, "user", "list")
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) UserDelete(ctx context.Context, name string) (*clientv3.AuthUserDeleteResponse, error) {
 	var resp clientv3.AuthUserDeleteResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "user", "delete", name)
+	err := ctl.spawnJSONCmd(ctx, &resp, "user", "delete", name)
 	return &resp, err
 }
 
@@ -616,54 +616,54 @@ func (ctl *EtcdctlV3) UserChangePass(ctx context.Context, user, newPass string) 
 
 func (ctl *EtcdctlV3) UserGrantRole(ctx context.Context, user string, role string) (*clientv3.AuthUserGrantRoleResponse, error) {
 	var resp clientv3.AuthUserGrantRoleResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "user", "grant-role", user, role)
+	err := ctl.spawnJSONCmd(ctx, &resp, "user", "grant-role", user, role)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) UserRevokeRole(ctx context.Context, user string, role string) (*clientv3.AuthUserRevokeRoleResponse, error) {
 	var resp clientv3.AuthUserRevokeRoleResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "user", "revoke-role", user, role)
+	err := ctl.spawnJSONCmd(ctx, &resp, "user", "revoke-role", user, role)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleAdd(ctx context.Context, name string) (*clientv3.AuthRoleAddResponse, error) {
 	var resp clientv3.AuthRoleAddResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "add", name)
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "add", name)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleGrantPermission(ctx context.Context, name string, key, rangeEnd string, permType clientv3.PermissionType) (*clientv3.AuthRoleGrantPermissionResponse, error) {
 	permissionType := authpb.Permission_Type_name[int32(permType)]
 	var resp clientv3.AuthRoleGrantPermissionResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "grant-permission", name, permissionType, key, rangeEnd)
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "grant-permission", name, permissionType, key, rangeEnd)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleGet(ctx context.Context, role string) (*clientv3.AuthRoleGetResponse, error) {
 	var resp clientv3.AuthRoleGetResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "get", role)
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "get", role)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleList(ctx context.Context) (*clientv3.AuthRoleListResponse, error) {
 	var resp clientv3.AuthRoleListResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "list")
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "list")
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleRevokePermission(ctx context.Context, role string, key, rangeEnd string) (*clientv3.AuthRoleRevokePermissionResponse, error) {
 	var resp clientv3.AuthRoleRevokePermissionResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "revoke-permission", role, key, rangeEnd)
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "revoke-permission", role, key, rangeEnd)
 	return &resp, err
 }
 
 func (ctl *EtcdctlV3) RoleDelete(ctx context.Context, role string) (*clientv3.AuthRoleDeleteResponse, error) {
 	var resp clientv3.AuthRoleDeleteResponse
-	err := ctl.spawnJsonCmd(ctx, &resp, "role", "delete", role)
+	err := ctl.spawnJSONCmd(ctx, &resp, "role", "delete", role)
 	return &resp, err
 }
 
-func (ctl *EtcdctlV3) spawnJsonCmd(ctx context.Context, output any, args ...string) error {
+func (ctl *EtcdctlV3) spawnJSONCmd(ctx context.Context, output any, args ...string) error {
 	args = append(args, "-w", "json")
 	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), nil)
 	if err != nil {

--- a/tests/framework/integration/cluster_direct.go
+++ b/tests/framework/integration/cluster_direct.go
@@ -25,8 +25,8 @@ import (
 
 const ThroughProxy = false
 
-func ToGRPC(c *clientv3.Client) GrpcAPI {
-	return GrpcAPI{
+func ToGRPC(c *clientv3.Client) GRPCAPI {
+	return GRPCAPI{
 		pb.NewClusterClient(c.ActiveConnection()),
 		pb.NewKVClient(c.ActiveConnection()),
 		pb.NewLeaseClient(c.ActiveConnection()),

--- a/tests/framework/integration/cluster_proxy.go
+++ b/tests/framework/integration/cluster_proxy.go
@@ -38,13 +38,13 @@ const proxyNamespace = "proxy-namespace"
 type grpcClientProxy struct {
 	ctx       context.Context
 	ctxCancel func()
-	grpc      GrpcAPI
+	grpc      GRPCAPI
 	wdonec    <-chan struct{}
 	kvdonec   <-chan struct{}
 	lpdonec   <-chan struct{}
 }
 
-func ToGRPC(c *clientv3.Client) GrpcAPI {
+func ToGRPC(c *clientv3.Client) GRPCAPI {
 	pmu.Lock()
 	defer pmu.Unlock()
 
@@ -73,7 +73,7 @@ func ToGRPC(c *clientv3.Client) GrpcAPI {
 	lockp := grpcproxy.NewLockProxy(c)
 	electp := grpcproxy.NewElectionProxy(c)
 
-	grpc := GrpcAPI{
+	grpc := GRPCAPI{
 		adapter.ClusterServerToClusterClient(clp),
 		adapter.KvServerToKvClient(kvp),
 		adapter.LeaseServerToLeaseClient(lp),

--- a/tests/framework/integration/testing.go
+++ b/tests/framework/integration/testing.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	grpc_logsettable "github.com/grpc-ecosystem/go-grpc-middleware/logging/settable"
+	grpclogsettable "github.com/grpc-ecosystem/go-grpc-middleware/logging/settable"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zapgrpc"
@@ -31,11 +31,11 @@ import (
 	gofail "go.etcd.io/gofail/runtime"
 )
 
-var grpc_logger grpc_logsettable.SettableLoggerV2
+var grpcLogger grpclogsettable.SettableLoggerV2
 var insideTestContext bool
 
 func init() {
-	grpc_logger = grpc_logsettable.ReplaceGrpcLoggerV2()
+	grpcLogger = grpclogsettable.ReplaceGrpcLoggerV2()
 }
 
 type testOptions struct {
@@ -118,13 +118,13 @@ func BeforeTest(t testutil.TB, opts ...TestOption) {
 
 	// Registering cleanup early, such it will get executed even if the helper fails.
 	t.Cleanup(func() {
-		grpc_logger.Reset()
+		grpcLogger.Reset()
 		insideTestContext = previousInsideTestContext
 		os.Chdir(previousWD)
 		revertFunc()
 	})
 
-	grpc_logger.Set(zapgrpc.NewLogger(zaptest.NewLogger(t).Named("grpc")))
+	grpcLogger.Set(zapgrpc.NewLogger(zaptest.NewLogger(t).Named("grpc")))
 	insideTestContext = true
 
 	os.Chdir(t.TempDir())

--- a/tests/integration/grpc_test.go
+++ b/tests/integration/grpc_test.go
@@ -149,7 +149,7 @@ func templateEndpoints(t *testing.T, pattern string, clus *integration.Cluster) 
 	var endpoints []string
 	for _, m := range clus.Members {
 		ent := pattern
-		ent = strings.ReplaceAll(ent, "${MEMBER_PORT}", m.GrpcPortNumber())
+		ent = strings.ReplaceAll(ent, "${MEMBER_PORT}", m.GRPCPortNumber())
 		ent = strings.ReplaceAll(ent, "${MEMBER_NAME}", m.Name)
 		endpoints = append(endpoints, ent)
 	}
@@ -159,7 +159,7 @@ func templateEndpoints(t *testing.T, pattern string, clus *integration.Cluster) 
 func templateAuthority(t *testing.T, pattern string, m *integration.Member) string {
 	t.Helper()
 	authority := pattern
-	authority = strings.ReplaceAll(authority, "${MEMBER_PORT}", m.GrpcPortNumber())
+	authority = strings.ReplaceAll(authority, "${MEMBER_PORT}", m.GRPCPortNumber())
 	authority = strings.ReplaceAll(authority, "${MEMBER_NAME}", m.Name)
 	return authority
 }


### PR DESCRIPTION
Addresses the `var-naming` issues in `tests/framework`.

There are some exported variables that were renamed, but as they're in the tests directory, I didn't think they would need to be deprecated rather than just renamed.

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
