### PR TITLE
all: make regexp.Regexp variables global when not using configuration…

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -34,6 +34,8 @@ running(leaking) after all tests.
 		...
 	}
 */
+var normalizedRegexp = regexp.MustCompile(`\(0[0-9a-fx, ]*\)`)
+
 func CheckLeakedGoroutine() bool {
 	gs := interestingGoroutines()
 	if len(gs) == 0 {
@@ -41,10 +43,9 @@ func CheckLeakedGoroutine() bool {
 	}
 
 	stackCount := make(map[string]int)
-	re := regexp.MustCompile(`\(0[0-9a-fx, ]*\)`)
 	for _, g := range gs {
 		// strip out pointer arguments in first function of stack dump
-		normalized := string(re.ReplaceAll([]byte(g), []byte("(...)")))
+		normalized := string(normalizedRegexp.ReplaceAll([]byte(g), []byte("(...)")))
 		stackCount[normalized]++
 	}
 

--- a/etcdctl/ctlv3/command/util.go
+++ b/etcdctl/ctlv3/command/util.go
@@ -56,9 +56,10 @@ func addHexPrefix(s string) string {
 	return string(ns)
 }
 
+var argsRegexp = regexp.MustCompile(`"(?:[^"\\]|\\.)*"|'[^']*'|[^'"\s]\S*[^'"\s]?`)
+
 func Argify(s string) []string {
-	r := regexp.MustCompile(`"(?:[^"\\]|\\.)*"|'[^']*'|[^'"\s]\S*[^'"\s]?`)
-	args := r.FindAllString(s, -1)
+	args := argsRegexp.FindAllString(s, -1)
 	for i := range args {
 		if len(args[i]) == 0 {
 			continue


### PR DESCRIPTION
… methods

As the doc of regexp.Regex is saying:

"A Regexp is safe for concurrent use by multiple goroutines, except for configuration
methods, such as Regexp.Longest."


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
