### PR TITLE
tests/framework: address golangci var-naming issues [remove (*Member) GRPCURL()]

### DIFF
--- a/tests/integration/clientv3/connectivity/black_hole_test.go
+++ b/tests/integration/clientv3/connectivity/black_hole_test.go
@@ -42,7 +42,7 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL}
 
 	ccfg := clientv3.Config{
 		Endpoints:            []string{eps[0]},
@@ -174,7 +174,7 @@ func testBalancerUnderBlackholeNoKeepAlive(t *testing.T, op func(*clientv3.Clien
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL}
 
 	ccfg := clientv3.Config{
 		Endpoints:   []string{eps[0]},

--- a/tests/integration/clientv3/connectivity/dial_test.go
+++ b/tests/integration/clientv3/connectivity/dial_test.go
@@ -59,7 +59,7 @@ func TestDialTLSExpired(t *testing.T) {
 	}
 	// expect remote errors "tls: bad certificate"
 	_, err = integration2.NewClient(t, clientv3.Config{
-		Endpoints:   []string{clus.Members[0].GRPCURL()},
+		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 3 * time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tls,
@@ -77,7 +77,7 @@ func TestDialTLSNoConfig(t *testing.T) {
 	defer clus.Terminate(t)
 	// expect "signed by unknown authority"
 	c, err := integration2.NewClient(t, clientv3.Config{
-		Endpoints:   []string{clus.Members[0].GRPCURL()},
+		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
@@ -110,7 +110,7 @@ func testDialSetEndpoints(t *testing.T, setBefore bool) {
 	// get endpoint list
 	eps := make([]string, 3)
 	for i := range eps {
-		eps[i] = clus.Members[i].GRPCURL()
+		eps[i] = clus.Members[i].GRPCURL
 	}
 	toKill := rand.Intn(len(eps))
 
@@ -151,7 +151,7 @@ func TestSwitchSetEndpoints(t *testing.T) {
 	defer clus.Terminate(t)
 
 	// get non partitioned members endpoints
-	eps := []string{clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	cli := clus.Client(0)
 	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
@@ -172,7 +172,7 @@ func TestRejectOldCluster(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cfg := clientv3.Config{
-		Endpoints:        []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL()},
+		Endpoints:        []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL},
 		DialTimeout:      5 * time.Second,
 		DialOptions:      []grpc.DialOption{grpc.WithBlock()},
 		RejectOldCluster: true,
@@ -214,7 +214,7 @@ func TestSetEndpointAndPut(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 2})
 	defer clus.Terminate(t)
 
-	clus.Client(1).SetEndpoints(clus.Members[0].GRPCURL())
+	clus.Client(1).SetEndpoints(clus.Members[0].GRPCURL)
 	_, err := clus.Client(1).Put(context.TODO(), "foo", "bar")
 	if err != nil && !strings.Contains(err.Error(), "closing") {
 		t.Fatal(err)

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -115,7 +115,7 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	// expect pin eps[0]
 	ccfg := clientv3.Config{
@@ -169,7 +169,7 @@ func TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection(t *testing.T
 		Size: 3,
 	})
 	defer clus.Terminate(t)
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	lead := clus.WaitLeader(t)
 
@@ -224,7 +224,7 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	target := clus.WaitLeader(t)
 	if !isolateLeader {
@@ -284,7 +284,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 	defer clus.Terminate(t)
 	leaderIndex := clus.WaitLeader(t)
 	// get a follower endpoint
-	eps := []string{clus.Members[(leaderIndex+1)%3].GRPCURL()}
+	eps := []string{clus.Members[(leaderIndex+1)%3].GRPCURL}
 	ccfg := clientv3.Config{
 		Endpoints:   eps,
 		DialTimeout: 10 * time.Second,
@@ -302,7 +302,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 	// add other endpoints for later endpoint switch
 	cli.SetEndpoints(eps...)
 	time.Sleep(time.Second * 2)
-	conn, err := cli.Dial(clus.Members[(leaderIndex+1)%3].GRPCURL())
+	conn, err := cli.Dial(clus.Members[(leaderIndex+1)%3].GRPCURL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/clientv3/connectivity/server_shutdown_test.go
+++ b/tests/integration/clientv3/connectivity/server_shutdown_test.go
@@ -38,7 +38,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	lead := clus.WaitLeader(t)
 
@@ -149,7 +149,7 @@ func testBalancerUnderServerShutdownMutable(t *testing.T, op func(*clientv3.Clie
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	// pin eps[0]
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[0]}})
@@ -206,7 +206,7 @@ func testBalancerUnderServerShutdownImmutable(t *testing.T, op func(*clientv3.Cl
 	})
 	defer clus.Terminate(t)
 
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL(), clus.Members[2].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL, clus.Members[2].GRPCURL}
 
 	// pin eps[0]
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[0]}})
@@ -283,9 +283,9 @@ func testBalancerUnderServerStopInflightRangeOnRestart(t *testing.T, linearizabl
 
 	clus := integration2.NewCluster(t, cfg)
 	defer clus.Terminate(t)
-	eps := []string{clus.Members[0].GRPCURL(), clus.Members[1].GRPCURL()}
+	eps := []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL}
 	if linearizable {
-		eps = append(eps, clus.Members[2].GRPCURL())
+		eps = append(eps, clus.Members[2].GRPCURL)
 	}
 
 	lead := clus.WaitLeader(t)

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -797,7 +797,7 @@ func TestKVForLearner(t *testing.T) {
 	// 1. clus.Members[3] is the newly added learner member, which was appended to clus.Members
 	// 2. we are using member's grpcAddr instead of clientURLs as the endpoint for clientv3.Config,
 	// because the implementation of integration test has diverged from embed/etcd.go.
-	learnerEp := clus.Members[3].GRPCURL()
+	learnerEp := clus.Members[3].GRPCURL
 	cfg := clientv3.Config{
 		Endpoints:   []string{learnerEp},
 		DialTimeout: 5 * time.Second,
@@ -870,7 +870,7 @@ func TestBalancerSupportLearner(t *testing.T) {
 	}
 
 	// clus.Members[3] is the newly added learner member, which was appended to clus.Members
-	learnerEp := clus.Members[3].GRPCURL()
+	learnerEp := clus.Members[3].GRPCURL
 	cfg := clientv3.Config{
 		Endpoints:   []string{learnerEp},
 		DialTimeout: 5 * time.Second,
@@ -890,7 +890,7 @@ func TestBalancerSupportLearner(t *testing.T) {
 	}
 	t.Logf("Expected: Read from learner error: %v", err)
 
-	eps := []string{learnerEp, clus.Members[0].GRPCURL()}
+	eps := []string{learnerEp, clus.Members[0].GRPCURL}
 	cli.SetEndpoints(eps...)
 	if _, err := cli.Get(context.Background(), "foo"); err != nil {
 		t.Errorf("expect no error (balancer should retry when request to learner fails), got error: %v", err)

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -60,7 +60,7 @@ func TestMaintenanceHashKV(t *testing.T) {
 		if _, err := cli.Get(context.TODO(), "foo"); err != nil {
 			t.Fatal(err)
 		}
-		hresp, err := cli.HashKV(context.Background(), clus.Members[i].GRPCURL(), 0)
+		hresp, err := cli.HashKV(context.Background(), clus.Members[i].GRPCURL, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func TestCompactionHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL()}, 1000)
+	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL}, 1000)
 }
 
 type hashTestCase struct {
@@ -406,7 +406,7 @@ func TestMaintenanceStatus(t *testing.T) {
 
 	eps := make([]string, 3)
 	for i := 0; i < 3; i++ {
-		eps[i] = clus.Members[i].GRPCURL()
+		eps[i] = clus.Members[i].GRPCURL
 	}
 
 	t.Logf("Creating client...")

--- a/tests/integration/clientv3/metrics_test.go
+++ b/tests/integration/clientv3/metrics_test.go
@@ -73,7 +73,7 @@ func TestV3ClientMetrics(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cfg := clientv3.Config{
-		Endpoints: []string{clus.Members[0].GRPCURL()},
+		Endpoints: []string{clus.Members[0].GRPCURL},
 		DialOptions: []grpc.DialOption{
 			grpc.WithUnaryInterceptor(grpcprom.UnaryClientInterceptor),
 			grpc.WithStreamInterceptor(grpcprom.StreamClientInterceptor),

--- a/tests/integration/clientv3/ordering_kv_test.go
+++ b/tests/integration/clientv3/ordering_kv_test.go
@@ -36,9 +36,9 @@ func TestDetectKvOrderViolation(t *testing.T) {
 
 	cfg := clientv3.Config{
 		Endpoints: []string{
-			clus.Members[0].GRPCURL(),
-			clus.Members[1].GRPCURL(),
-			clus.Members[2].GRPCURL(),
+			clus.Members[0].GRPCURL,
+			clus.Members[1].GRPCURL,
+			clus.Members[2].GRPCURL,
 		},
 	}
 	cli, err := integration2.NewClient(t, cfg)
@@ -83,7 +83,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 	clus.Members[1].Stop(t)
 	assert.NoError(t, clus.Members[2].Restart(t))
 	// force OrderingKv to query the third member
-	cli.SetEndpoints(clus.Members[2].GRPCURL())
+	cli.SetEndpoints(clus.Members[2].GRPCURL)
 	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed
 
 	t.Logf("Quering m2 after restart")
@@ -103,9 +103,9 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 
 	cfg := clientv3.Config{
 		Endpoints: []string{
-			clus.Members[0].GRPCURL(),
-			clus.Members[1].GRPCURL(),
-			clus.Members[2].GRPCURL(),
+			clus.Members[0].GRPCURL,
+			clus.Members[1].GRPCURL,
+			clus.Members[2].GRPCURL,
 		},
 	}
 	cli, err := integration2.NewClient(t, cfg)
@@ -152,7 +152,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	clus.Members[1].Stop(t)
 	assert.NoError(t, clus.Members[2].Restart(t))
 	// force OrderingKv to query the third member
-	cli.SetEndpoints(clus.Members[2].GRPCURL())
+	cli.SetEndpoints(clus.Members[2].GRPCURL)
 	time.Sleep(2 * time.Second) // FIXME: Figure out how pause SetEndpoints sufficiently that this is not needed
 	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
 	if err != errOrderViolation {

--- a/tests/integration/clientv3/ordering_util_test.go
+++ b/tests/integration/clientv3/ordering_util_test.go
@@ -32,11 +32,11 @@ func TestEndpointSwitchResolvesViolation(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 	eps := []string{
-		clus.Members[0].GRPCURL(),
-		clus.Members[1].GRPCURL(),
-		clus.Members[2].GRPCURL(),
+		clus.Members[0].GRPCURL,
+		clus.Members[1].GRPCURL,
+		clus.Members[2].GRPCURL,
 	}
-	cfg := clientv3.Config{Endpoints: []string{clus.Members[0].GRPCURL()}}
+	cfg := clientv3.Config{Endpoints: []string{clus.Members[0].GRPCURL}}
 	cli, err := integration2.NewClient(t, cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -75,7 +75,7 @@ func TestEndpointSwitchResolvesViolation(t *testing.T) {
 	}
 
 	t.Logf("Reconfigure client to speak only to the 'partitioned' member")
-	cli.SetEndpoints(clus.Members[2].GRPCURL())
+	cli.SetEndpoints(clus.Members[2].GRPCURL)
 	time.Sleep(1 * time.Second) // give enough time for the operation
 	_, err = orderingKv.Get(ctx, "foo", clientv3.WithSerializable())
 	if err != ordering.ErrNoGreaterRev {
@@ -97,11 +97,11 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 	defer clus.Terminate(t)
 	cfg := clientv3.Config{
 		Endpoints: []string{
-			clus.Members[0].GRPCURL(),
-			clus.Members[1].GRPCURL(),
-			clus.Members[2].GRPCURL(),
-			clus.Members[3].GRPCURL(),
-			clus.Members[4].GRPCURL(),
+			clus.Members[0].GRPCURL,
+			clus.Members[1].GRPCURL,
+			clus.Members[2].GRPCURL,
+			clus.Members[3].GRPCURL,
+			clus.Members[4].GRPCURL,
 		},
 	}
 	cli, err := integration2.NewClient(t, cfg)
@@ -112,7 +112,7 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 	eps := cli.Endpoints()
 	ctx := context.TODO()
 
-	cli.SetEndpoints(clus.Members[0].GRPCURL())
+	cli.SetEndpoints(clus.Members[0].GRPCURL)
 	time.Sleep(1 * time.Second)
 	_, err = cli.Put(ctx, "foo", "bar")
 	if err != nil {
@@ -152,7 +152,7 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 		t.Fatal(err)
 	}
 	clus.Members[3].WaitStarted(t)
-	cli.SetEndpoints(clus.Members[3].GRPCURL())
+	cli.SetEndpoints(clus.Members[3].GRPCURL)
 	time.Sleep(1 * time.Second) // give enough time for operation
 
 	_, err = OrderingKv.Get(ctx, "foo", clientv3.WithSerializable())

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -47,7 +47,7 @@ func TestCompactionHash(t *testing.T) {
 		},
 	}
 
-	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL(), client, clus.Members[0].Server}, 1000)
+	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL, client, clus.Members[0].Server}, 1000)
 }
 
 type hashTestCase struct {

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -40,7 +40,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lg := zaptest.NewLogger(t)
-	serverEps := []string{clus.Members[0].GRPCURL()}
+	serverEps := []string{clus.Members[0].GRPCURL}
 	prefix := "test-prefix"
 	hostname, _ := os.Hostname()
 	cts := newClusterProxyServer(lg, serverEps, prefix, t)

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -34,7 +34,7 @@ func TestKVProxyRange(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	kvts := newKVProxyServer([]string{clus.Members[0].GRPCURL()}, t)
+	kvts := newKVProxyServer([]string{clus.Members[0].GRPCURL}, t)
 	defer kvts.close()
 
 	// create a client and try to get key from proxy.

--- a/tests/integration/proxy/grpcproxy/register_test.go
+++ b/tests/integration/proxy/grpcproxy/register_test.go
@@ -32,7 +32,7 @@ func TestRegister(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 	cli := clus.Client(0)
-	paddr := clus.Members[0].GRPCURL()
+	paddr := clus.Members[0].GRPCURL
 
 	testPrefix := "test-name"
 	wa := mustCreateWatcher(t, cli, testPrefix)

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -1594,7 +1594,7 @@ func TestTLSGRPCRejectSecureClient(t *testing.T) {
 
 	clus.Members[0].ClientTLSInfo = &integration.TestTLSInfo
 	clus.Members[0].DialOptions = []grpc.DialOption{grpc.WithBlock()}
-	clus.Members[0].GrpcURL = strings.Replace(clus.Members[0].GrpcURL, "http://", "https://", 1)
+	clus.Members[0].GRPCURL = strings.Replace(clus.Members[0].GRPCURL, "http://", "https://", 1)
 	client, err := integration.NewClientV3(clus.Members[0])
 	if client != nil || err == nil {
 		client.Close()
@@ -1758,7 +1758,7 @@ func testTLSReload(
 			}
 			cli, cerr := integration.NewClient(t, clientv3.Config{
 				DialOptions: []grpc.DialOption{grpc.WithBlock()},
-				Endpoints:   []string{clus.Members[0].GRPCURL()},
+				Endpoints:   []string{clus.Members[0].GRPCURL},
 				DialTimeout: time.Second,
 				TLS:         cc,
 			})
@@ -1792,7 +1792,7 @@ func testTLSReload(
 		t.Fatal(terr)
 	}
 	cl, cerr := integration.NewClient(t, clientv3.Config{
-		Endpoints:   []string{clus.Members[0].GRPCURL()},
+		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 5 * time.Second,
 		TLS:         tls,
 	})

--- a/tests/integration/v3_tls_test.go
+++ b/tests/integration/v3_tls_test.go
@@ -64,7 +64,7 @@ func testTLSCipherSuites(t *testing.T, valid bool) {
 		t.Fatal(err)
 	}
 	cli, cerr := integration.NewClient(t, clientv3.Config{
-		Endpoints:   []string{clus.Members[0].GRPCURL()},
+		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         cc,
@@ -127,7 +127,7 @@ func TestTLSMinMaxVersion(t *testing.T) {
 			cc.MinVersion = tt.minVersion
 			cc.MaxVersion = tt.maxVersion
 			cli, cerr := integration.NewClient(t, clientv3.Config{
-				Endpoints:   []string{clus.Members[0].GRPCURL()},
+				Endpoints:   []string{clus.Members[0].GRPCURL},
 				DialTimeout: time.Second,
 				DialOptions: []grpc.DialOption{grpc.WithBlock()},
 				TLS:         cc,


### PR DESCRIPTION
Currently, (`test/framework/`'s) `integration.Member` exports `GrpcURL` already as a struct variable. However, when addressing the `var-naming` linting issues, renaming it from `GrpcURL` to `GRPCURL` clashes with the `GRPCURL()` function.

Given that it's already an exported variable, defining a getter function is unnecessary. This variable's use is also mixed, with calls to both the exported variable (`GrpcURL`) and the function (`GRPCURL()`).

If we prefer to keep the getter function `GRPCURL()`. Then, it would be better to unexport `GrpcURL` (`grpcURL`). But all of the other `GRPC*` variables are exported already. Therefore, it would make sense to unexport all of them, but would increase the rewrite effort.

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
