### PR TITLE
server/storage: address golangci var-naming issues

### DIFF
--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -94,7 +94,7 @@ func (o *migrateOptions) Config() (*migrateConfig, error) {
 	dbPath := datadir.ToBackendFileName(o.dataDir)
 	c.be = backend.NewDefaultBackend(GetLogger(), dbPath)
 
-	walPath := datadir.ToWalDir(o.dataDir)
+	walPath := datadir.ToWALDir(o.dataDir)
 	w, err := wal.OpenForRead(c.lg, walPath, walpb.Snapshot{})
 	if err != nil {
 		return nil, fmt.Errorf(`failed to open wal: %v`, err)

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -138,7 +138,7 @@ func SnapshotRestoreCommandFunc(restoreCluster string,
 
 	walDir := restoreWalDir
 	if walDir == "" {
-		walDir = datadir.ToWalDir(dataDir)
+		walDir = datadir.ToWALDir(dataDir)
 	}
 
 	lg := GetLogger()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -307,7 +307,7 @@ func (c *ServerConfig) WALDir() string {
 	if c.DedicatedWALDir != "" {
 		return c.DedicatedWALDir
 	}
-	return datadir.ToWalDir(c.DataDir)
+	return datadir.ToWALDir(c.DataDir)
 }
 
 func (c *ServerConfig) SnapDir() string { return filepath.Join(c.MemberDir(), "snap") }

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -694,7 +694,7 @@ func (wal *bootstrappedWAL) CommitedEntries() []raftpb.Entry {
 func (wal *bootstrappedWAL) NewConfigChangeEntries() []raftpb.Entry {
 	return serverstorage.CreateConfigChangeEnts(
 		wal.lg,
-		serverstorage.GetEffectiveNodeIDsFromWalEntries(wal.lg, wal.snapshot, wal.ents),
+		serverstorage.GetEffectiveNodeIDsFromWALEntries(wal.lg, wal.snapshot, wal.ents),
 		uint64(wal.meta.nodeID),
 		wal.st.Term,
 		wal.st.Commit,

--- a/server/etcdserver/bootstrap_test.go
+++ b/server/etcdserver/bootstrap_test.go
@@ -230,7 +230,7 @@ func createDataDir(t *testing.T) (string, error) {
 	}
 
 	// create ${dataDir}/member/wal
-	err = os.MkdirAll(datadir.ToWalDir(dataDir), 0700)
+	err = os.MkdirAll(datadir.ToWALDir(dataDir), 0700)
 	if err != nil {
 		return "", err
 	}

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -69,7 +69,7 @@ func TestGetIDs(t *testing.T) {
 		if tt.confState != nil {
 			snap.Metadata.ConfState = *tt.confState
 		}
-		idSet := serverstorage.GetEffectiveNodeIDsFromWalEntries(lg, &snap, tt.ents)
+		idSet := serverstorage.GetEffectiveNodeIDsFromWALEntries(lg, &snap, tt.ents)
 		if !reflect.DeepEqual(idSet, tt.widSet) {
 			t.Errorf("#%d: idset = %#v, want %#v", i, idSet, tt.widSet)
 		}

--- a/server/storage/datadir/datadir.go
+++ b/server/storage/datadir/datadir.go
@@ -31,7 +31,15 @@ func ToSnapDir(dataDir string) string {
 	return filepath.Join(ToMemberDir(dataDir), snapDirSegment)
 }
 
+// ToWalDir returns the directory path for the member's WAL.
+// Deprecated: use ToWALDir instead.
+//
+//revive:disable-next-line:var-naming
 func ToWalDir(dataDir string) string {
+	return ToWALDir(dataDir)
+}
+
+func ToWALDir(dataDir string) string {
 	return filepath.Join(ToMemberDir(dataDir), walDirSegment)
 }
 

--- a/server/storage/datadir/datadir_test.go
+++ b/server/storage/datadir/datadir_test.go
@@ -37,12 +37,12 @@ func TestToSnapDir(t *testing.T) {
 	assert.Equal(t, "/dir/data-dir/member/snap", result)
 }
 
-func TestToWalDir(t *testing.T) {
-	result := datadir.ToWalDir("/dir/data-dir")
+func TestToWALDir(t *testing.T) {
+	result := datadir.ToWALDir("/dir/data-dir")
 	assert.Equal(t, "/dir/data-dir/member/wal", result)
 }
 
-func TestToWalDirSlash(t *testing.T) {
-	result := datadir.ToWalDir("/dir/data-dir/")
+func TestToWALDirSlash(t *testing.T) {
+	result := datadir.ToWALDir("/dir/data-dir/")
 	assert.Equal(t, "/dir/data-dir/member/wal", result)
 }

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -109,13 +109,22 @@ func CreateConfigChangeEnts(lg *zap.Logger, ids []uint64, self uint64, term, ind
 	return ents
 }
 
-// GetEffectiveNodeIDsFromWalEntries returns an ordered set of IDs included in the given snapshot and
+// GetEffectiveNodeIdsFromWalEntries returns an ordered set of IDs included in the given snapshot and
+// the entries.
+// Deprecated: use GetEffectiveNodeIDsFromWALEntries instead.
+//
+//revive:disable-next-line:var-naming
+func GetEffectiveNodeIdsFromWalEntries(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
+	return GetEffectiveNodeIDsFromWALEntries(lg, snap, ents)
+}
+
+// GetEffectiveNodeIDsFromWALEntries returns an ordered set of IDs included in the given snapshot and
 // the entries. The given snapshot/entries can contain three kinds of
 // ID-related entry:
 // - ConfChangeAddNode, in which case the contained ID will Be added into the set.
 // - ConfChangeRemoveNode, in which case the contained ID will Be removed from the set.
 // - ConfChangeAddLearnerNode, in which the contained ID will Be added into the set.
-func GetEffectiveNodeIDsFromWalEntries(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
+func GetEffectiveNodeIDsFromWALEntries(lg *zap.Logger, snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
 	ids := make(map[uint64]bool)
 	if snap != nil {
 		for _, id := range snap.Metadata.ConfState.Voters {

--- a/server/verify/verify.go
+++ b/server/verify/verify.go
@@ -132,7 +132,7 @@ func validateConsistentIndex(cfg Config, hardstate *raftpb.HardState, snapshot *
 }
 
 func validateWAL(cfg Config) (*walpb.Snapshot, *raftpb.HardState, error) {
-	walDir := datadir.ToWalDir(cfg.DataDir)
+	walDir := datadir.ToWALDir(cfg.DataDir)
 
 	walSnaps, err := wal2.ValidSnapshotEntries(cfg.Logger, walDir)
 	if err != nil {


### PR DESCRIPTION
Addresses the `var-naming` lint issues in `server/storage`.

The use of `Wal` and `WAL` across the project is inconsistent. This was a good opportunity to standardize it.

I deprecated two functions:
* `datadir.ToWalDir` -> `datadir.ToWALDir`
* `serverstorage.GetEffectiveNodeIDsFromWalEntries` -> `serverstorage.GetEffectiveNodeIDsFromWALEntries`

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
