### PR TITLE
[3.4] Allow new server to join higher cluster version if NextClusterVersionCompatible is true

### DIFF
--- a/etcdmain/help.go
+++ b/etcdmain/help.go
@@ -126,7 +126,7 @@ Clustering:
   --enable-v2 '` + strconv.FormatBool(embed.DefaultEnableV2) + `'
     Accept etcd V2 client requests.
   --next-cluster-version-compatible 'false'
-  Enable 3.4 to be compatible with next version 3.5, to allow 3.4 server to join 3.5 cluster and start on 3.5 schema.
+    Enable 3.4 to be compatible with next version 3.5, to allow 3.4 server to join 3.5 cluster and start on 3.5 schema.
 
 Security:
   --cert-file ''

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -233,13 +233,16 @@ func decideClusterVersion(lg *zap.Logger, vers map[string]*version.Versions) *se
 // cluster version in the range of [MinClusterVersion, Version] and no known members has a cluster version
 // out of the range.
 // We set this rule since when the local member joins, another member might be offline.
-func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper) bool {
+func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local types.ID, rt http.RoundTripper, nextClusterVersionCompatible bool) bool {
 	vers := getVersions(lg, cl, local, rt)
 	minV := semver.Must(semver.NewVersion(version.MinClusterVersion))
 	maxV := semver.Must(semver.NewVersion(version.Version))
 	maxV = &semver.Version{
 		Major: maxV.Major,
 		Minor: maxV.Minor,
+	}
+	if nextClusterVersionCompatible {
+		maxV.Minor += 1
 	}
 	return isCompatibleWithVers(lg, vers, local, minV, maxV)
 }

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -371,7 +371,7 @@ func NewServer(cfg ServerConfig) (srv *EtcdServer, err error) {
 		if err = membership.ValidateClusterAndAssignIDs(cfg.Logger, cl, existingCluster); err != nil {
 			return nil, fmt.Errorf("error validating peerURLs %s: %v", existingCluster, err)
 		}
-		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt) {
+		if !isCompatibleWithCluster(cfg.Logger, cl, cl.MemberByName(cfg.Name).ID, prt, cfg.NextClusterVersionCompatible) {
 			return nil, fmt.Errorf("incompatible with current running cluster")
 		}
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Part of https://github.com/etcd-io/etcd/issues/15878#issuecomment-1910886682.

https://github.com/etcd-io/etcd/pull/17330 allows existing server to be downgraded to 3.4, with `haveWAL=true`. 
This PR would allow a brand new 3.4 server to join an existing 3.5 cluster. 
This would enable the downgrade method of stopping a 3.5 server and starting a new 3.4 server one by one.

Tested with `TestMixVersionsSnapshotByAddingMember` e2e test in https://github.com/etcd-io/etcd/pull/17531 