### PR TITLE
server/embed: address golangci var-naming issues

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -149,8 +149,9 @@ func init() {
 
 // Config holds the arguments for configuring an etcd server.
 type Config struct {
-	Name   string `json:"name"`
-	Dir    string `json:"data-dir"`
+	Name string `json:"name"`
+	Dir  string `json:"data-dir"`
+	//revive:disable-next-line:var-naming
 	WalDir string `json:"wal-dir"`
 
 	SnapshotCount uint64 `json:"snapshot-count"`
@@ -163,7 +164,8 @@ type Config struct {
 	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
 
 	MaxSnapFiles uint `json:"max-snapshots"`
-	MaxWalFiles  uint `json:"max-wals"`
+	//revive:disable-next-line:var-naming
+	MaxWalFiles uint `json:"max-wals"`
 
 	// TickMs is the number of milliseconds between heartbeat ticks.
 	// TODO: decouple tickMs and heartbeat tick (current heartbeat tick = 1).
@@ -231,8 +233,11 @@ type Config struct {
 	CipherSuites []string `json:"cipher-suites"`
 
 	// TlsMinVersion is the minimum accepted TLS version between client/server and peers.
+	//revive:disable-next-line:var-naming
 	TlsMinVersion string `json:"tls-min-version"`
+
 	// TlsMaxVersion is the maximum accepted TLS version between client/server and peers.
+	//revive:disable-next-line:var-naming
 	TlsMaxVersion string `json:"tls-max-version"`
 
 	ClusterState          string `json:"initial-cluster-state"`

--- a/server/embed/util.go
+++ b/server/embed/util.go
@@ -21,9 +21,9 @@ import (
 )
 
 func isMemberInitialized(cfg *Config) bool {
-	waldir := cfg.WalDir
-	if waldir == "" {
-		waldir = filepath.Join(cfg.Dir, "member", "wal")
+	walDir := cfg.WalDir
+	if walDir == "" {
+		walDir = filepath.Join(cfg.Dir, "member", "wal")
 	}
-	return wal.Exist(waldir)
+	return wal.Exist(walDir)
 }

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -57,7 +57,7 @@ func TestConfigFileMemberFields(t *testing.T) {
 	yc := struct {
 		Dir                    string `json:"data-dir"`
 		MaxSnapFiles           uint   `json:"max-snapshots"`
-		MaxWalFiles            uint   `json:"max-wals"`
+		MaxWALFiles            uint   `json:"max-wals"`
 		Name                   string `json:"name"`
 		SnapshotCount          uint64 `json:"snapshot-count"`
 		SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`


### PR DESCRIPTION
Addresses issues with `config.{TLSMinVersion,TLSMaxVersion,WALDir,MaxWALFiles}`.

This is part 1 of 2 from `server/embed`, as it's the package with the most changes.

Part of #17578.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
