### PR TITLE
client/pkg/testutil: add shouldSkip func for interestingGoroutines

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -130,28 +130,44 @@ func interestingGoroutines() (gs []string) {
 			continue
 		}
 		stack := strings.TrimSpace(sl[1])
-		if stack == "" ||
-			strings.Contains(stack, "sync.(*WaitGroup).Done") ||
-			strings.Contains(stack, "os.(*file).close") ||
-			strings.Contains(stack, "os.(*Process).Release") ||
-			strings.Contains(stack, "created by os/signal.init") ||
-			strings.Contains(stack, "runtime/panic.go") ||
-			strings.Contains(stack, "created by testing.RunTests") ||
-			strings.Contains(stack, "created by testing.runTests") ||
-			strings.Contains(stack, "created by testing.(*T).Run") ||
-			strings.Contains(stack, "testing.Main(") ||
-			strings.Contains(stack, "runtime.goexit") ||
-			strings.Contains(stack, "go.etcd.io/etcd/client/pkg/v3/testutil.interestingGoroutines") ||
-			strings.Contains(stack, "go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop") ||
-			strings.Contains(stack, "github.com/golang/glog.(*loggingT).flushDaemon") ||
-			strings.Contains(stack, "created by runtime.gc") ||
-			strings.Contains(stack, "created by text/template/parse.lex") ||
-			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
-			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") ||
-			strings.Contains(stack, "net.(*netFD).Close(") ||
-			strings.Contains(stack, "testing.(*T).Run") {
+		if stack == "" {
 			continue
 		}
+
+		shouldSkip := func() bool {
+			var uninterestingMsgs = [...]string{
+				"sync.(*WaitGroup).Done",
+				"os.(*file).close",
+				"os.(*Process).Release",
+				"created by os/signal.init",
+				"runtime/panic.go",
+				"created by testing.RunTests",
+				"created by testing.runTests",
+				"created by testing.(*T).Run",
+				"testing.Main(",
+				"runtime.goexit",
+				"go.etcd.io/etcd/client/pkg/v3/testutil.interestingGoroutines",
+				"go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop",
+				"github.com/golang/glog.(*loggingT).flushDaemon",
+				"created by runtime.gc",
+				"created by text/template/parse.lex",
+				"runtime.MHeap_Scavenger",
+				"rcrypto/internal/boring.(*PublicKeyRSA).finalize",
+				"net.(*netFD).Close(",
+				"testing.(*T).Run",
+			}
+			for _, msg := range uninterestingMsgs {
+				if strings.Contains(stack, msg) {
+					return true
+				}
+			}
+			return false
+		}()
+
+		if shouldSkip {
+			continue
+		}
+
 		gs = append(gs, stack)
 	}
 	sort.Strings(gs)


### PR DESCRIPTION
interestingGoroutines uses so many strings.Contains checks to determine
whether to continue, I think it can be avoided.

This patch introduces shouldSkip func to do the checks in a loop
to make the logic clearer.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
