### PR TITLE
nit: Fix trailing whitespace in etcdmain/help.go

### DIFF
--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -110,7 +110,7 @@ Clustering:
   --initial-cluster 'default=http://localhost:2380'
     Initial cluster configuration for bootstrapping.
   --initial-cluster-state 'new'
-    Initial cluster state ('new' when bootstrapping a new cluster or 'existing' when adding new members to an existing cluster). 
+    Initial cluster state ('new' when bootstrapping a new cluster or 'existing' when adding new members to an existing cluster).
     After successful initialization (bootstrapping or adding), flag is ignored on restarts
   --initial-cluster-token 'etcd-cluster'
     Initial cluster token for the etcd cluster during bootstrap.


### PR DESCRIPTION
Just a small nit that my editor automatically fixed:
Trailing whitespace in server/etcdmain/help.go
