### PR TITLE
tests/e2e: ignore discovery tests when cluster_proxy tag is set

### DIFF
--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !cluster_proxy
+
 package e2e
 
 import (


### PR DESCRIPTION
Ignore `e2e/discovery_test.go` when `cluster_proxy` tag is set.

Fixes #16098.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
