### PR TITLE
Makefile: add .PHONY: clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ bin/lazyfs:
 	cp /tmp/lazyfs/lazyfs/build/lazyfs ./bin/lazyfs
 
 # Cleanup
-
+.PHONY: clean
 clean:
 	rm -f ./codecov
 	rm -rf ./covdir


### PR DESCRIPTION
When there is a file called clean in the root path of the project, make clean will report an error

![49c1eeb98a8fe5f6933e0cee0b2443b](https://github.com/etcd-io/etcd/assets/55082705/d981dcc8-93c6-4ed2-8362-1521f355a228)
