### PR TITLE
Replace run.skip-files with issues.exclude-files in golangci config

### DIFF
--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -1,7 +1,6 @@
 ---
 run:
   timeout: 30m
-  skip-files: [^zz_generated.*]
 issues:
   max-same-issues: 0
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -9,6 +8,8 @@ issues:
     # exclude ineffassing linter for generated files for conversion
     - path: conversion\.go
       linters: [ineffassign]
+  exclude-files:
+    - ^zz_generated.*
 linters:
   disable-all: true
   enable: # please keep this alphabetized


### PR DESCRIPTION
Address the warning "The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.", as seen in this [CI run log](https://github.com/etcd-io/etcd/actions/runs/8517852373/job/23329049363#step:6:29)

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
