### PR TITLE
Backport initialization of mu in NewCtxClient to release-3.5

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -86,7 +86,7 @@ func New(cfg Config) (*Client, error) {
 // service interface implementations and do not need connection management.
 func NewCtxClient(ctx context.Context, opts ...Option) *Client {
 	cctx, cancel := context.WithCancel(ctx)
-	c := &Client{ctx: cctx, cancel: cancel, lgMu: new(sync.RWMutex)}
+	c := &Client{ctx: cctx, cancel: cancel, lgMu: new(sync.RWMutex), mu: new(sync.RWMutex)}
 	for _, opt := range opts {
 		opt(c)
 	}


### PR DESCRIPTION
Tested against the demo code provided in PR #17001

References:
- #17001
- #17018


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
