### PR TITLE
server/storage: change deprecated bolt error to new error package

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 type BucketID int
@@ -124,7 +125,7 @@ func (t *batchTx) UnsafeCreateBucket(bucket Bucket) {
 
 func (t *batchTx) UnsafeDeleteBucket(bucket Bucket) {
 	err := t.tx.DeleteBucket(bucket.Name())
-	if err != nil && err != bolt.ErrBucketNotFound {
+	if err != nil && err != bolterrors.ErrBucketNotFound {
 		t.backend.lg.Fatal(
 			"failed to delete a bucket",
 			zap.Stringer("bucket-name", bucket),


### PR DESCRIPTION
- bbolt v.1.4.0-alpha has deprecated error in errors.go and introduce new error package
- This PR will change from using deprecated error to new error package