### PR TITLE
tools/benchmark/cmd: don't panic with nil values in hashKV function

### DIFF
--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -170,14 +170,14 @@ func hashKV(cmd *cobra.Command, clients []*v3.Client) {
 	host := eps[0]
 
 	st := time.Now()
-	rh, eh := clients[0].HashKV(context.Background(), host, 0)
-	if eh != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get the hashkv of endpoint %s (%v)\n", host, eh)
+	rh, err := clients[0].HashKV(context.Background(), host, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get the hashkv of endpoint %s (%v)\n", host, err)
 		panic(err)
 	}
-	rt, es := clients[0].Status(context.Background(), host)
-	if es != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get the status of endpoint %s (%v)\n", host, es)
+	rt, err := clients[0].Status(context.Background(), host)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get the status of endpoint %s (%v)\n", host, err)
 		panic(err)
 	}
 


### PR DESCRIPTION
hashKV checks nilness of 'eh' and 'es', but doesn't use them. Instead
it panics with 'err' which is definitely nil.

This should be avoided, See:
https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness#nilpanic

This patch renames 'eh' and 'es' to 'err' in order to correct the real
errors to panic.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
