### PR TITLE
Revert "tests: temporary disable coverage redesign Go experiment"

### DIFF
--- a/scripts/codecov_upload.sh
+++ b/scripts/codecov_upload.sh
@@ -8,7 +8,7 @@ set -o pipefail
 LOG_FILE=${1:-test-coverage.log}
 
 # We collect the coverage
-GOEXPERIMENT=nocoverageredesign COVERDIR=covdir PASSES='build cov' ./scripts/test.sh 2>&1 | tee "${LOG_FILE}"
+COVERDIR=covdir PASSES='build cov' ./scripts/test.sh 2>&1 | tee "${LOG_FILE}"
 test_success="$?"
 
 # We try to upload whatever we have:


### PR DESCRIPTION
With the update to Go 1.22.2, this workaround is no longer needed.

This reverts commit da7ab15f80c06373e03267e11497da71a028a3aa.

Fixes #17560.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
