### PR TITLE
dependency(gh_action): bump upload and download artifact from 3 to 4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           docker image save -o /tmp/etcd-img.tar gcr.io/etcd-development/etcd
       - name: upload-image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: etcd-img
           path: /tmp/etcd-img.tar
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: get-image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           name: etcd-img
           path: /tmp


### PR DESCRIPTION
Supercedes #17744 and #17743. The two dependencies must be updated simultaneously as they're not backward compatible.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
