### PR TITLE
[Robustness] Collect failed read operations to calculate request success rate

### DIFF
--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -248,6 +248,21 @@ type EtcdRequest struct {
 	Defragment  *DefragmentRequest
 }
 
+func (r *EtcdRequest) IsRead() bool {
+	if r.Type == Range {
+		return true
+	}
+	if r.Type != Txn {
+		return false
+	}
+	for _, op := range append(r.Txn.OperationsOnSuccess, r.Txn.OperationsOnFailure...) {
+		if op.Type != RangeOperation {
+			return false
+		}
+	}
+	return true
+}
+
 type RangeRequest struct {
 	RangeOptions
 	Revision int64

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -36,6 +36,17 @@ type ClientReport struct {
 	Watch    []model.WatchOperation
 }
 
+func (r ClientReport) SuccessfulOperations() int {
+	count := 0
+	for _, op := range r.KeyValue {
+		resp := op.Output.(model.MaybeEtcdResponse)
+		if resp.Error == "" {
+			count++
+		}
+	}
+	return count
+}
+
 func (r ClientReport) WatchEventCount() int {
 	count := 0
 	for _, op := range r.Watch {

--- a/tests/robustness/report/client_test.go
+++ b/tests/robustness/report/client_test.go
@@ -42,7 +42,7 @@ func TestPersistLoadClientReports(t *testing.T) {
 		Key:         []byte("key"),
 		ModRevision: 2,
 		Value:       []byte("value"),
-	}}})
+	}}}, nil)
 
 	start = time.Since(baseTime)
 	time.Sleep(time.Nanosecond)

--- a/tests/robustness/traffic/client.go
+++ b/tests/robustness/traffic/client.go
@@ -107,12 +107,9 @@ func (c *RecordingClient) Range(ctx context.Context, start, end string, revision
 	defer c.kvMux.Unlock()
 	callTime := time.Since(c.baseTime)
 	resp, err := c.client.Get(ctx, start, ops...)
-	if err != nil {
-		return nil, err
-	}
 	returnTime := time.Since(c.baseTime)
-	c.kvOperations.AppendRange(start, end, revision, limit, callTime, returnTime, resp)
-	return resp, nil
+	c.kvOperations.AppendRange(start, end, revision, limit, callTime, returnTime, resp, err)
+	return resp, err
 }
 
 func (c *RecordingClient) Put(ctx context.Context, key, value string) (*clientv3.PutResponse, error) {

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -39,7 +39,7 @@ func TestPatchHistory(t *testing.T) {
 				start := time.Since(baseTime)
 				time.Sleep(time.Nanosecond)
 				stop := time.Since(baseTime)
-				h.AppendRange("key", "", 0, 0, start, stop, &clientv3.GetResponse{})
+				h.AppendRange("key", "", 0, 0, start, stop, &clientv3.GetResponse{}, nil)
 			},
 			expectRemains: true,
 		},


### PR DESCRIPTION
cc @ahrtr @jmhbnz @MadhavJivrajani @siyuanfoundation 

Hope this will help debugging of arm64 failures. I expect the reason behind low QPS on arm is request timeout, currently set to 40ms. It's possible a lot of read request timeout due to lower single core performance. This PR will calculate a request success rate so we can confirm that.