### PR TITLE
Validate bookmarkable checks the last event before progress notify

### DIFF
--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -493,8 +493,7 @@ func TestValidateWatch(t *testing.T) {
 				putPersistedEvent("b", "2", 3, true),
 				putPersistedEvent("c", "3", 4, true),
 			},
-			// TODO: Should fail as it should guarantee that all events between requested revision and bookmark are delivered
-			expectError: "",
+			expectError: errBrokeBookmarkable.Error(),
 		},
 		{
 			name: "Bookmarkable - revision non decreasing - pass",
@@ -583,8 +582,7 @@ func TestValidateWatch(t *testing.T) {
 				putPersistedEvent("b", "2", 3, true),
 				putPersistedEvent("c", "3", 4, true),
 			},
-			// TODO: This should fail as bookmark lowered revision
-			expectError: "",
+			expectError: errBrokeBookmarkable.Error(),
 		},
 		{
 			name: "Bookmarkable - progress precedes event - fail",
@@ -653,8 +651,7 @@ func TestValidateWatch(t *testing.T) {
 				putPersistedEvent("b", "2", 3, true),
 				putPersistedEvent("c", "3", 4, true),
 			},
-			// TODO: This should fail as there is a missing event before bookmark
-			expectError: "",
+			expectError: errBrokeBookmarkable.Error(),
 		},
 		{
 			name: "Bookmarkable - missing event matching watch before bookmark - fail",
@@ -685,8 +682,7 @@ func TestValidateWatch(t *testing.T) {
 				putPersistedEvent("a", "2", 3, false),
 				putPersistedEvent("c", "3", 4, true),
 			},
-			// TODO: This should fail as there is a missing event before bookmark
-			expectError: "",
+			expectError: errBrokeBookmarkable.Error(),
 		},
 		{
 			name: "Bookmarkable - missing event matching watch with prefix before bookmark - fail",
@@ -718,8 +714,7 @@ func TestValidateWatch(t *testing.T) {
 				putPersistedEvent("ab", "2", 3, true),
 				putPersistedEvent("cc", "3", 4, true),
 			},
-			// TODO: This should fail as there is a missing event before bookmark
-			expectError: "",
+			expectError: errBrokeBookmarkable.Error(),
 		},
 		{
 			name: "Reliable - all events history - pass",


### PR DESCRIPTION
cc @MadhavJivrajani @ahrtr @siyuanfoundation

Noticed that watch validation allows just an empty streams. The current validation is:
* `validateReliable` checks `if there are events ordered in time as a < b < c, then if the watch receives events a and c, it is guaranteed to receive b`.
* `validateResumable` checks watch request that should start from specified revision, this allows us to check that first event in the watch stream. The `a` in `a < b < c`.

As watch is eventually consistent it means that watch streams can just finish early and be empty. To make all the pieces we need something to guarantee the `c` in `a < b < c`.

Here is where `validateBookmarkable` could help. It's the only way to be sure that we got events up to some revision. Bookmarkable should guarantee that all events before progress notify were delivered. As we have `validateReliable` we don't really need to check if all events were delivered, just if the last event before progress notification was delivered, our `c` in `a < b < c`.

Marking as draft as code is too complicated to my liking and we need test. As long as validation is using `t.Error` we cannot test if for failures. Before sending PR officially to review I work on refactoring validation to make it more testable. 