### PR TITLE
Add operations removed from linearization into the visualization

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -13,6 +13,8 @@ replace (
 	go.etcd.io/etcd/server/v3 => ../server
 )
 
+replace github.com/anishathalye/porcupine v0.1.4 => github.com/serathius/porcupine v0.0.0-20240412083641-c39cbb308579
+
 require (
 	github.com/anishathalye/porcupine v0.1.4
 	github.com/coreos/go-semver v0.3.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
-github.com/anishathalye/porcupine v0.1.4 h1:rRekB2jH1mbtLPEzuqyMHp4scU52Bcc1jgkPi1kWFQA=
-github.com/anishathalye/porcupine v0.1.4/go.mod h1:/X9OQYnVb7DzfKCQVO4tI1Aq+o56UJW+RvN/5U4EuZA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
@@ -114,6 +112,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/serathius/porcupine v0.0.0-20240412083641-c39cbb308579 h1:q6fG8QQ9ZnYKaGo0knFHuYFmpM9qk5jBWi3MCiMpTNY=
+github.com/serathius/porcupine v0.0.0-20240412083641-c39cbb308579/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -28,10 +28,10 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/model"
 )
 
-func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []porcupine.Operation, timeout time.Duration) (result porcupine.CheckResult, visualize func(basepath string) error) {
+func validateLinearizableOperationsAndVisualize(lg *zap.Logger, linearizable, nonLinearizable []porcupine.Operation, timeout time.Duration) (result porcupine.CheckResult, visualize func(basepath string) error) {
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
 	start := time.Now()
-	result, info := porcupine.CheckOperationsVerbose(model.NonDeterministicModel, operations, timeout)
+	result, info := porcupine.CheckOperationsVerbose(model.NonDeterministicModel, linearizable, timeout)
 	switch result {
 	case porcupine.Illegal:
 		lg.Error("Linearization failed", zap.Duration("duration", time.Since(start)))
@@ -42,6 +42,7 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []por
 	default:
 		panic(fmt.Sprintf("Unknown Linearization result %s", result))
 	}
+	info.AddOperations(nonLinearizable)
 	return result, func(path string) error {
 		lg.Info("Saving visualization", zap.String("path", path))
 		err := porcupine.VisualizePath(model.NonDeterministicModel, info, path)

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -30,9 +30,9 @@ import (
 
 // ValidateAndReturnVisualize returns visualize as porcupine.linearizationInfo used to generate visualization is private.
 func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, reports []report.ClientReport, timeout time.Duration) (visualize func(basepath string) error) {
-	patchedOperations := patchedOperationHistory(reports)
-	linearizable, visualize := validateLinearizableOperationsAndVisualize(lg, patchedOperations, timeout)
-	if linearizable != porcupine.Ok {
+	linearizable, nonLinearizable := patchedOperationHistory(reports)
+	result, visualize := validateLinearizableOperationsAndVisualize(lg, linearizable, nonLinearizable, timeout)
+	if result != porcupine.Ok {
 		t.Error("Failed linearization, skipping further validation")
 		return visualize
 	}
@@ -44,7 +44,7 @@ func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, report
 		return visualize
 	}
 	validateWatch(t, lg, cfg, reports, eventHistory)
-	validateSerializableOperations(t, lg, patchedOperations, eventHistory)
+	validateSerializableOperations(t, lg, linearizable, eventHistory)
 	return visualize
 }
 


### PR DESCRIPTION
Draft waiting on https://github.com/anishathalye/porcupine/pull/17 to be merged, sending for review to show the results:

![image](https://github.com/etcd-io/etcd/assets/5873433/a9743514-2ddc-4d31-b612-aba54001e4d6)
