### PR TITLE
server/etcdmain: eliminate deprecated tlsConfig.BuildNameToCertificate()

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -576,7 +576,6 @@ func newHTTPTransport(ca, cert, key string) (*http.Transport, error) {
 			Certificates: []tls.Certificate{keyPair},
 			RootCAs:      caPool,
 		}
-		tlsConfig.BuildNameToCertificate()
 		tr.TLSClientConfig = tlsConfig
 	} else if grpcProxyInsecureSkipTLSVerify {
 		tlsConfig := &tls.Config{InsecureSkipVerify: grpcProxyInsecureSkipTLSVerify}


### PR DESCRIPTION
As the doc is saying:

Deprecated: NameToCertificate only allows associating a single certificate
with a given name. Leave that field nil to let the library select the first
compatible chain from Certificates.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
