### PR TITLE
Fix remove member failed.

### DIFF
--- a/server/etcdserver/util.go
+++ b/server/etcdserver/util.go
@@ -33,7 +33,7 @@ func isConnectedToQuorumSince(transport rafthttp.Transporter, since time.Time, s
 // remote member since the given time.
 func isConnectedSince(transport rafthttp.Transporter, since time.Time, remote types.ID) bool {
 	t := transport.ActiveSince(remote)
-	return !t.IsZero() && !t.After(since)
+	return !t.IsZero() && t.Before(since)
 }
 
 // isConnectedFullySince checks whether the local member is connected to all

--- a/server/etcdserver/util.go
+++ b/server/etcdserver/util.go
@@ -33,7 +33,7 @@ func isConnectedToQuorumSince(transport rafthttp.Transporter, since time.Time, s
 // remote member since the given time.
 func isConnectedSince(transport rafthttp.Transporter, since time.Time, remote types.ID) bool {
 	t := transport.ActiveSince(remote)
-	return !t.IsZero() && t.Before(since)
+	return !t.IsZero() && !t.After(since)
 }
 
 // isConnectedFullySince checks whether the local member is connected to all

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -196,7 +196,7 @@ func TestMemberRemove(t *testing.T) {
 				continue
 			}
 			t.Run(quorumTc.name+"/"+clusterTc.name, func(t *testing.T) {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 14*time.Second)
 				defer cancel()
 				c := clusterTc.config
 				c.StrictReconfigCheck = quorumTc.strictReconfigCheck

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -207,7 +207,8 @@ func TestMemberRemove(t *testing.T) {
 
 				testutils.ExecuteUntil(ctx, t, func() {
 					if quorumTc.waitForQuorum {
-						time.Sleep(etcdserver.HealthInterval)
+						// wait for health interval + leader election
+						time.Sleep(etcdserver.HealthInterval + 2*time.Second)
 					}
 
 					memberID, clusterID := memberToRemove(ctx, t, cc, c.ClusterSize)


### PR DESCRIPTION
Fixes #17653

Why the test failed?
The [quorum](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/server/etcdserver/server.go#L1597) was not reached because one member was "down".

Why was one node "down"?
It wasn't, actually. The node connected outside `HealthInterval`:
`2024-03-25T17:44:33.8754342Z {"Time":"2024-03-25T17:44:33.830596472Z","Action":"output","Package":"go.etcd.io/etcd/tests/v3/common","Test":"TestMemberRemove/StrictReconfigCheck/WaitForQuorum/PeerAutoTLS","Output":"/home/runner/work/etcd/etcd/bin/etcd (TestMemberRemoveStrictReconfigCheckWaitForQuorumPeerAutoTLS-test-0) (58753): {\"level\":\"info\",\"ts\":\"2024-03-25T17:44:33.825435Z\",\"caller\":\"rafthttp/peer_status.go:53\",\"msg\":\"peer became active\",\"peer-id\":\"c61f33e98087dec2\"}\r\n"}`

The remove command was issued later than 5 seconds interval:
```
2024-03-25T17:44:39.1538189Z {"Time":"2024-03-25T17:44:39.13219045Z","Action":"output","Package":"go.etcd.io/etcd/tests/v3/common","Test":"TestMemberRemove/StrictReconfigCheck/WaitForQuorum/PeerAutoTLS","Output":"/home/runner/work/etcd/etcd/bin/etcdctl (/home/runner/work/etcd/etcd/bin/etcdctl_--endpoints=http://localhost:20000_member_list_-w_json) (58781):
{\"header\":
  {
    \"cluster_id\":5772825840910905659, \"member_id\":47555275972384877, \"raft_term\":2},
    \"members\":[
      {\"ID\":47555275972384877,\"name\":\"TestMemberRemoveStrictReconfigCheckWaitForQuorumPeerAutoTLS-test-0\",\"peerURLs\":[\"https://localhost:20001\"],\"clientURLs\":[\"http://localhost:20000\"]},
      {\"ID\":14276186421764546242,\"name\":\"TestMemberRemoveStrictReconfigCheckWaitForQuorumPeerAutoTLS-test-2\",\"peerURLs\":[\"https://localhost:20011\"],\"clientURLs\":[\"http://localhost:20010\"]},
      {\"ID\":15493022389670793866,\"name\":\"TestMemberRemoveStrictReconfigCheckWaitForQuorumPeerAutoTLS-test-1\",\"peerURLs\":[\"https://localhost:20006\"],\"clientURLs\":[\"http://localhost:20005\"]}
    ]
  }\r\n"
}
```

Another log message:
`"rejecting member remove request; local member has not been connected to all peers, reconfigure breaks active quorum","requested-member-remove":"c61f33e98087dec2","active-peers":2`.

Proposed fix consists of two parts:
1. Reuse of [isConnectedToQuorumSince](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/server/etcdserver/util.go#L28):
  - Another usage of [isConnectedToQuorumSince](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/server/etcdserver/server.go#L2389) passes all the cluster members, not only voting members. I wonder which is correct. In case of the current test it doesn't matter since all members are joined as `isLearner: false`.
 - The equation that is used to calculate if the quorum is reached is different. Consider numConnectedSince = 2 and total members = 3 (the situation in the test):
  `isConnectedToQuorumSince`: 2 >= (3/2)+1 == 2 >= 2 == true, i.e. quorum is reached
  whereas current equation `(active - 1) < 1+((len(m)-1)/2)`: 2 - 1 < 1 + ((3-1)/2) == 1 < 1 + 1 == true, i.e. quorum is not reached
2. Use additional pause as in [snapshot member test](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/tests/integration/snapshot/member_test.go#L49)
3. Esoteric case when the check time is exactly `activeSince + [HealthInterval](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/server/etcdserver/server.go#L90), then [... && t.Before(since)](https://github.com/etcd-io/etcd/blob/a7f5d4b4e4569bd316277ebf1347785e0467c64d/server/etcdserver/util.go#L36) returns false, but it should be true.

Apart from that as members be gone at any moment we can just add retry in test instead of all the above :).