### PR TITLE
[3.5] add experimental-snapshot-catchup-entries flag

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -151,7 +151,7 @@ type Config struct {
 	// follower to catch up.
 	// WARNING: only change this for tests.
 	// Always use "DefaultSnapshotCatchUpEntries"
-	SnapshotCatchUpEntries uint64
+	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
 
 	MaxSnapFiles uint `json:"max-snapshots"`
 	MaxWalFiles  uint `json:"max-wals"`

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -302,6 +302,7 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.ExperimentalMemoryMlock, "experimental-memory-mlock", cfg.ec.ExperimentalMemoryMlock, "Enable to enforce etcd pages (in particular bbolt) to stay in RAM.")
 	fs.BoolVar(&cfg.ec.ExperimentalTxnModeWriteWithSharedBuffer, "experimental-txn-mode-write-with-shared-buffer", true, "Enable the write transaction to use a shared buffer in its readonly check operations.")
 	fs.UintVar(&cfg.ec.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
+	fs.Uint64Var(&cfg.ec.SnapshotCatchUpEntries, "experimental-snapshot-catchup-entries", cfg.ec.SnapshotCatchUpEntries, "Number of entries for a slow follower to catch up after compacting the raft storage entries. (WARNING: only use this flag for tests.)")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -302,7 +302,7 @@ func newConfig() *config {
 	fs.BoolVar(&cfg.ec.ExperimentalMemoryMlock, "experimental-memory-mlock", cfg.ec.ExperimentalMemoryMlock, "Enable to enforce etcd pages (in particular bbolt) to stay in RAM.")
 	fs.BoolVar(&cfg.ec.ExperimentalTxnModeWriteWithSharedBuffer, "experimental-txn-mode-write-with-shared-buffer", true, "Enable the write transaction to use a shared buffer in its readonly check operations.")
 	fs.UintVar(&cfg.ec.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
-	fs.Uint64Var(&cfg.ec.SnapshotCatchUpEntries, "experimental-snapshot-catchup-entries", cfg.ec.SnapshotCatchUpEntries, "Number of entries for a slow follower to catch up after compacting the raft storage entries. (WARNING: only use this flag for tests.)")
+	fs.Uint64Var(&cfg.ec.SnapshotCatchUpEntries, "experimental-snapshot-catchup-entries", cfg.ec.SnapshotCatchUpEntries, "(WARNING: Use this flag with caution!) Number of entries for a slow follower to catch up after compacting the raft storage entries.")
 
 	// unsafe
 	fs.BoolVar(&cfg.ec.UnsafeNoFsync, "unsafe-no-fsync", false, "Disables fsync, unsafe, will cause data loss.")

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -505,7 +505,10 @@ func TestFlagsPresentInHelp(t *testing.T) {
 			// Ignored flags do not need to be in the help
 			return
 		}
-
+		if f.Name == "experimental-snapshot-catchup-entries" {
+			// Ignore because it is supposed to only be used in tests.
+			return
+		}
 		flagText := fmt.Sprintf("--%s", f.Name)
 		if !strings.Contains(flagsline, flagText) && !strings.Contains(usageline, flagText) {
 			t.Errorf("Neither flagsline nor usageline in help.go contains flag named %s", flagText)

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -158,7 +158,8 @@ type EtcdProcessClusterConfig struct {
 
 	MetricsURLScheme string
 
-	SnapshotCount int // default is 10000
+	SnapshotCount          int // default is 10000
+	SnapshotCatchUpEntries int // default is 5000
 
 	ClientTLS             ClientConnType
 	ClientCertAuthEnabled bool
@@ -400,6 +401,12 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 		execPath = BinPathLastRelease
 	default:
 		panic(fmt.Sprintf("Unknown cluster version %v", cfg.Version))
+	}
+
+	// the "--experimental-snapshot-catchup-entries" flag is not available in 3.4.
+	// so it should not be set if the process execPath is not BinPath.
+	if cfg.SnapshotCatchUpEntries > 0 && execPath == BinPath {
+		args = append(args, "--experimental-snapshot-catchup-entries", fmt.Sprintf("%d", cfg.SnapshotCatchUpEntries))
 	}
 
 	return &EtcdServerProcessConfig{


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

https://github.com/etcd-io/etcd/issues/17752

This is import prerequisite to verify that in a mixed version cluster, the follower receives a snapshot that has the correct schema for that version. 

Did not add the flag to help file so that it is a hidden flag that only is used for testing.
