### PR TITLE
Update CHANGELOG 3.4 and 3.5 - ignore raft messages if member id mismatch

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -8,10 +8,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### etcd server
 - Fix [LeaseTimeToLive returns error if leader changed](https://github.com/etcd-io/etcd/pull/17705).
+- Fix [ignore raft messages if member id mismatch](https://github.com/etcd-io/etcd/pull/17814).
 
 ### Package `clientv3`
 - Add [requests retry when receiving ErrGPRCNotSupportedForLearner and endpoints > 1](https://github.com/etcd-io/etcd/pull/17692).
-- Fix [initialization for epMu in client context](https://github.com/etcd-io/etcd/pull/17714)
+- Fix [initialization for epMu in client context](https://github.com/etcd-io/etcd/pull/17714).
 
 ### Dependencies
 - Compile binaries using [go 1.21.9](https://github.com/etcd-io/etcd/pull/17709).

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,10 +9,11 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 - Fix [LeaseTimeToLive returns error if leader changed](https://github.com/etcd-io/etcd/pull/17704).
 - Add [metrics `etcd_disk_wal_write_duration_seconds`](https://github.com/etcd-io/etcd/pull/17616).
+- Fix [ignore raft messages if member id mismatch](https://github.com/etcd-io/etcd/pull/17813).
 
 ### Package `clientv3`
 - Add [requests retry when receiving ErrGPRCNotSupportedForLearner and endpoints > 1](https://github.com/etcd-io/etcd/pull/17641).
-- Fix [initialization for mu in client context](https://github.com/etcd-io/etcd/pull/17699)
+- Fix [initialization for mu in client context](https://github.com/etcd-io/etcd/pull/17699).
 
 ### Dependencies
 - Compile binaries using [go 1.21.9](https://github.com/etcd-io/etcd/pull/17708).


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/pull/17813#pullrequestreview-2008260907 raised by @ahrtr 

Reference:
- https://github.com/etcd-io/etcd/pull/17814
- https://github.com/etcd-io/etcd/pull/17813

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
