### PR TITLE
[3.4] Allow updateClusterVersion when downgrading from 3.5.

### DIFF
--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2636,8 +2636,8 @@ func (s *EtcdServer) monitorVersions() {
 		}
 
 		// update cluster version only if the decided version is greater than
-		// the current cluster version
-		if v != nil && s.cluster.Version().LessThan(*v) {
+		// the current cluster version or it is a valid downgrade
+		if v != nil && membership.IsValidClusterVersionChange(s.cluster.Version(), v, s.Config().NextClusterVersionCompatible) {
 			s.goAttach(func() { s.updateClusterVersion(v.String()) })
 		}
 	}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

https://github.com/etcd-io/etcd/issues/17818

Tested with 1 server cluster downgrade

```bash
bin/etcd
curl http://127.0.0.1:2379/version
>> {"etcdserver":"3.5.13","etcdcluster":"3.5.0"}

# stop 3.5 server and restart with 3.4 binary
../etcd-3.4/bin/etcd --next-cluster-version-compatible
>> ...
>> mvcc: downgrade meta bucket: remove keys [confState, term]
>> ...
>> etcdserver/membership: updated the cluster version from 3.5 to 3.4

curl http://127.0.0.1:2379/version
>> {"etcdserver":"3.4.31","etcdcluster":"3.4.0"}
```