### PR TITLE
server/proxy/tcpproxy: use net.JoinHostPort rather than formatAddr

### DIFF
--- a/server/proxy/tcpproxy/userspace.go
+++ b/server/proxy/tcpproxy/userspace.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"math/rand"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -70,29 +69,13 @@ type TCPProxy struct {
 	pickCount int // for round robin
 }
 
-// The parameter host is returned by net.SplitHostPort previously,
-// so it must be a valid host. This function is only to check whether
-// it's an IPv6 IP address.
-func isIPv6(host string) bool {
-	return strings.IndexRune(host, ':') != -1
-}
-
-// A literal IPv6 address in hostport must be enclosed in square
-// brackets, as in "[::1]:80", "[::1%lo0]:80".
-func formatAddr(host string, port uint16) string {
-	if isIPv6(host) {
-		return fmt.Sprintf("[%s]:%d", host, port)
-	}
-	return fmt.Sprintf("%s:%d", host, port)
-}
-
 func (tp *TCPProxy) Run() error {
 	tp.donec = make(chan struct{})
 	if tp.MonitorInterval == 0 {
 		tp.MonitorInterval = 5 * time.Minute
 	}
 	for _, srv := range tp.Endpoints {
-		addr := formatAddr(srv.Target, srv.Port)
+		addr := net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port))
 		tp.remotes = append(tp.remotes, &remote{srv: srv, addr: addr})
 	}
 

--- a/server/proxy/tcpproxy/userspace_test.go
+++ b/server/proxy/tcpproxy/userspace_test.go
@@ -129,34 +129,3 @@ func TestUserspaceProxyPriority(t *testing.T) {
 		t.Errorf("got = %s, want %s", got, want)
 	}
 }
-
-func TestFormatAddr(t *testing.T) {
-	addrs := []struct {
-		host         string
-		port         uint16
-		expectedAddr string
-	}{
-		{
-			"192.168.1.10",
-			2379,
-			"192.168.1.10:2379",
-		},
-		{
-			"::1",
-			2379,
-			"[::1]:2379",
-		},
-		{
-			"2001:db8::ff00:42:8329",
-			80,
-			"[2001:db8::ff00:42:8329]:80",
-		},
-	}
-
-	for _, addr := range addrs {
-		actualAddr := formatAddr(addr.host, addr.port)
-		if actualAddr != addr.expectedAddr {
-			t.Errorf("actualAddr: %s, expectedAddr: %s", actualAddr, addr.expectedAddr)
-		}
-	}
-}


### PR DESCRIPTION
formatAddr is just like net.JoinHostPort, I think we can use net.JoinHostPort
directly, it's simpler and clearer.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
