### PR TITLE
server/config: address golangci var-naming issues

### DIFF
--- a/server/config/v2_deprecation.go
+++ b/server/config/v2_deprecation.go
@@ -18,17 +18,48 @@ type V2DeprecationEnum string
 
 const (
 	// No longer supported in v3.6
-	V2_DEPR_0_NOT_YET = V2DeprecationEnum("not-yet")
+	V2Depr0NotYet = V2DeprecationEnum("not-yet")
+	// No longer supported in v3.6
+	//
+	// Deprecated: Please use V2Depr0NotYet.
+	//revive:disable-next-line:var-naming
+	V2_DEPR_0_NOT_YET = V2Depr0NotYet
 	// Default in v3.6.  Meaningful v2 state is not allowed.
 	// The V2 files are maintained for v3.5 rollback.
-	V2_DEPR_1_WRITE_ONLY = V2DeprecationEnum("write-only")
+
+	V2Depr1WriteOnly = V2DeprecationEnum("write-only")
+	// Default in v3.6.  Meaningful v2 state is not allowed.
+	// The V2 files are maintained for v3.5 rollback.
+	//
+	// Deprecated: Please use V2Depr1WriteOnly.
+	//revive:disable-next-line:var-naming
+	V2_DEPR_1_WRITE_ONLY = V2Depr1WriteOnly
+
 	// V2store is WIPED if found !!!
-	V2_DEPR_1_WRITE_ONLY_DROP = V2DeprecationEnum("write-only-drop-data")
+	V2Depr1WriteOnlyDrop = V2DeprecationEnum("write-only-drop-data")
+	// V2store is WIPED if found !!!
+	//
+	// Deprecated: Pleae use V2Depr1WriteOnlyDrop.
+	//revive:disable-next-line:var-naming
+	V2_DEPR_1_WRITE_ONLY_DROP = V2Depr1WriteOnlyDrop
+
 	// V2store is neither written nor read. Usage of this configuration is blocking
 	// ability to rollback to etcd v3.5.
-	V2_DEPR_2_GONE = V2DeprecationEnum("gone")
+	V2Depr2Gone = V2DeprecationEnum("gone")
+	// V2store is neither written nor read. Usage of this configuration is blocking
+	// ability to rollback to etcd v3.5.
+	//
+	// Deprecated: Please use V2Depr2Gone
+	//revive:disable-next-line:var-naming
+	V2_DEPR_2_GONE = V2Depr2Gone
 
-	V2_DEPR_DEFAULT = V2_DEPR_1_WRITE_ONLY
+	// Default deprecation level.
+	V2DeprDefault = V2Depr1WriteOnly
+	// Default deprecation level.
+	//
+	// Deprecated: Please use V2DeprDefault.
+	//revive:disable-next-line:var-naming
+	V2_DEPR_DEFAULT = V2DeprDefault
 )
 
 func (e V2DeprecationEnum) IsAtLeast(v2d V2DeprecationEnum) bool {
@@ -37,13 +68,13 @@ func (e V2DeprecationEnum) IsAtLeast(v2d V2DeprecationEnum) bool {
 
 func (e V2DeprecationEnum) level() int {
 	switch e {
-	case V2_DEPR_0_NOT_YET:
+	case V2Depr0NotYet:
 		return 0
-	case V2_DEPR_1_WRITE_ONLY:
+	case V2Depr1WriteOnly:
 		return 1
-	case V2_DEPR_1_WRITE_ONLY_DROP:
+	case V2Depr1WriteOnlyDrop:
 		return 2
-	case V2_DEPR_2_GONE:
+	case V2Depr2Gone:
 		return 3
 	}
 	panic("Unknown V2DeprecationEnum: " + e)

--- a/server/config/v2_deprecation_test.go
+++ b/server/config/v2_deprecation_test.go
@@ -22,14 +22,14 @@ func TestV2DeprecationEnum_IsAtLeast(t *testing.T) {
 		v2d  V2DeprecationEnum
 		want bool
 	}{
-		{V2_DEPR_0_NOT_YET, V2_DEPR_0_NOT_YET, true},
-		{V2_DEPR_0_NOT_YET, V2_DEPR_1_WRITE_ONLY_DROP, false},
-		{V2_DEPR_0_NOT_YET, V2_DEPR_2_GONE, false},
-		{V2_DEPR_2_GONE, V2_DEPR_1_WRITE_ONLY_DROP, true},
-		{V2_DEPR_2_GONE, V2_DEPR_0_NOT_YET, true},
-		{V2_DEPR_2_GONE, V2_DEPR_2_GONE, true},
-		{V2_DEPR_1_WRITE_ONLY, V2_DEPR_1_WRITE_ONLY_DROP, false},
-		{V2_DEPR_1_WRITE_ONLY_DROP, V2_DEPR_1_WRITE_ONLY, true},
+		{V2Depr0NotYet, V2Depr0NotYet, true},
+		{V2Depr0NotYet, V2Depr1WriteOnlyDrop, false},
+		{V2Depr0NotYet, V2Depr2Gone, false},
+		{V2Depr2Gone, V2Depr1WriteOnlyDrop, true},
+		{V2Depr2Gone, V2Depr0NotYet, true},
+		{V2Depr2Gone, V2Depr2Gone, true},
+		{V2Depr1WriteOnly, V2Depr1WriteOnlyDrop, false},
+		{V2Depr1WriteOnlyDrop, V2Depr1WriteOnly, true},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.e)+" >= "+string(tt.v2d), func(t *testing.T) {

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -546,7 +546,7 @@ func NewConfig() *Config {
 		ExperimentalCompactHashCheckEnabled: false,
 		ExperimentalCompactHashCheckTime:    DefaultExperimentalCompactHashCheckTime,
 
-		V2Deprecation: config.V2_DEPR_DEFAULT,
+		V2Deprecation: config.V2DeprDefault,
 
 		DiscoveryCfg: v3discovery.DiscoveryConfig{
 			ConfigSpec: clientv3.ConfigSpec{
@@ -1149,7 +1149,7 @@ func (cfg *Config) ElectionTicks() int { return int(cfg.ElectionMs / cfg.TickMs)
 
 func (cfg *Config) V2DeprecationEffective() config.V2DeprecationEnum {
 	if cfg.V2Deprecation == "" {
-		return config.V2_DEPR_DEFAULT
+		return config.V2DeprDefault
 	}
 	return cfg.V2Deprecation
 }

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -91,9 +91,9 @@ func newConfig() *config {
 			fallbackFlagProxy,
 		),
 		v2deprecation: flags.NewSelectiveStringsValue(
-			string(cconfig.V2_DEPR_1_WRITE_ONLY),
-			string(cconfig.V2_DEPR_1_WRITE_ONLY_DROP),
-			string(cconfig.V2_DEPR_2_GONE)),
+			string(cconfig.V2Depr1WriteOnly),
+			string(cconfig.V2Depr1WriteOnlyDrop),
+			string(cconfig.V2Depr2Gone)),
 	}
 	fs := cfg.cf.flagSet
 	fs.Usage = func() {
@@ -157,7 +157,7 @@ func (cfg *config) parse(arguments []string) error {
 	}
 
 	if cfg.ec.V2Deprecation == "" {
-		cfg.ec.V2Deprecation = cconfig.V2_DEPR_DEFAULT
+		cfg.ec.V2Deprecation = cconfig.V2DeprDefault
 	}
 
 	cfg.ec.WarningUnaryRequestDuration, perr = cfg.parseWarningUnaryRequestDuration()

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -162,7 +162,7 @@ Clustering:
     Auto compaction retention length. 0 means disable auto compaction.
   --auto-compaction-mode 'periodic'
     Interpret 'auto-compaction-retention' one of: periodic|revision. 'periodic' for duration based retention, defaulting to hours if no time unit is provided (e.g. '5m'). 'revision' for revision number based retention.
-  --v2-deprecation '` + string(cconfig.V2_DEPR_DEFAULT) + `'
+  --v2-deprecation '` + string(cconfig.V2DeprDefault) + `'
     Phase of v2store deprecation. Allows to opt-in for higher compatibility mode.
     Supported values:
       'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -39,7 +39,7 @@ func AssertNoV2StoreContent(lg *zap.Logger, st v2store.Store, deprecationStage c
 	if metaOnly {
 		return nil
 	}
-	if deprecationStage.IsAtLeast(config.V2_DEPR_1_WRITE_ONLY) {
+	if deprecationStage.IsAtLeast(config.V2Depr1WriteOnly) {
 		return fmt.Errorf("detected disallowed custom content in v2store for stage --v2-deprecation=%s", deprecationStage)
 	}
 	lg.Warn("detected custom v2store content. Etcd v3.5 is the last version allowing to access it using API v2. Please remove the content.")


### PR DESCRIPTION
Addresses issues in V2 Deprecation constant names. The current constants are in upper snake_case; use Go's camelCase and deprecate their old names.

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
