### PR TITLE
Persist member data with lazyfs enabled

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -70,7 +70,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Cluster.Close()
+	defer forcestopCluster(r.Cluster)
 
 	if s.failpoint == nil {
 		s.failpoint, err = failpoint.PickRandom(r.Cluster)
@@ -95,7 +95,6 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 	if err != nil {
 		t.Fatal(err)
 	}
-	forcestopCluster(r.Cluster)
 
 	watchProgressNotifyEnabled := r.Cluster.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
 	validateGotAtLeastOneProgressNotify(t, r.Client, s.watch.requestProgress || watchProgressNotifyEnabled)

--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -81,8 +81,16 @@ func (r *TestReport) Report(t *testing.T, force bool) {
 
 func persistMemberDataDir(t *testing.T, lg *zap.Logger, member e2e.EtcdProcess, path string) {
 	lg.Info("Saving member data dir", zap.String("member", member.Config().Name), zap.String("path", path))
-	err := os.Rename(member.Config().DataDirPath, path)
+	err := os.Rename(memberDataDir(member), path)
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func memberDataDir(member e2e.EtcdProcess) string {
+	lazyFS := member.LazyFS()
+	if lazyFS != nil {
+		return filepath.Join(lazyFS.LazyFSDir, "data")
+	}
+	return member.Config().DataDirPath
 }

--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -52,7 +52,7 @@ func LoadClusterPersistedRequests(lg *zap.Logger, path string) ([]model.EtcdRequ
 func PersistedRequestsCluster(lg *zap.Logger, cluster *e2e.EtcdProcessCluster) ([]model.EtcdRequest, error) {
 	dataDirs := []string{}
 	for _, proc := range cluster.Procs {
-		dataDirs = append(dataDirs, proc.Config().DataDirPath)
+		dataDirs = append(dataDirs, memberDataDir(proc))
 	}
 	return PersistedRequestsDirs(lg, dataDirs)
 }


### PR DESCRIPTION
Discovered turning off LazyFS before creating the report might result in empty server directory. This PR moves cluster shutdown to defer executed after we generate report and copies the data from lazyfs directory.


cc @MadhavJivrajani @siyuanfoundation @fuweid 