### PR TITLE
fix version order when calling IsValidClusterVersionChange in UpdateCapability

### DIFF
--- a/server/etcdserver/api/capability.go
+++ b/server/etcdserver/api/capability.go
@@ -64,7 +64,7 @@ func UpdateCapability(lg *zap.Logger, v *semver.Version) {
 		return
 	}
 	enableMapMu.Lock()
-	if curVersion != nil && !serverversion.IsValidClusterVersionChange(v, curVersion) {
+	if curVersion != nil && !serverversion.IsValidClusterVersionChange(curVersion, v) {
 		enableMapMu.Unlock()
 		return
 	}


### PR DESCRIPTION
`v` is the version the code want to change the `curVersion` so it should be the `verTo` when calling `IsValidClusterVersionChange`.

This should be a no-op change because Capability does not really change in 3.x. 


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
