### PR TITLE
config: support AllowedCN and AllowedHostname through config file

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -123,6 +123,12 @@ peer-transport-security:
   # Peer TLS using generated certificates.
   auto-tls: false
 
+  # Allowed CN for inter peer authentication.
+  allowed-cn:
+
+  # Allowed TLS hostname for inter peer authentication.
+  allowed-hostname:
+
 # The validity period of the self-signed certificate, the unit is year.
 self-signed-cert-validity: 1
 

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -466,13 +466,15 @@ type configJSON struct {
 }
 
 type securityConfig struct {
-	CertFile       string `json:"cert-file"`
-	KeyFile        string `json:"key-file"`
-	ClientCertFile string `json:"client-cert-file"`
-	ClientKeyFile  string `json:"client-key-file"`
-	CertAuth       bool   `json:"client-cert-auth"`
-	TrustedCAFile  string `json:"trusted-ca-file"`
-	AutoTLS        bool   `json:"auto-tls"`
+	CertFile        string `json:"cert-file"`
+	KeyFile         string `json:"key-file"`
+	ClientCertFile  string `json:"client-cert-file"`
+	ClientKeyFile   string `json:"client-key-file"`
+	CertAuth        bool   `json:"client-cert-auth"`
+	TrustedCAFile   string `json:"trusted-ca-file"`
+	AutoTLS         bool   `json:"auto-tls"`
+	AllowedCN       string `json:"allowed-cn"`
+	AllowedHostname string `json:"allowed-hostname"`
 }
 
 // NewConfig creates a new Config populated with default values.
@@ -847,6 +849,8 @@ func (cfg *configYAML) configFromFile(path string) error {
 		tls.ClientKeyFile = ysc.ClientKeyFile
 		tls.ClientCertAuth = ysc.CertAuth
 		tls.TrustedCAFile = ysc.TrustedCAFile
+		tls.AllowedCN = ysc.AllowedCN
+		tls.AllowedHostname = ysc.AllowedHostname
 	}
 	copySecurityDetails(&cfg.ClientTLSInfo, &cfg.ClientSecurityJSON)
 	copySecurityDetails(&cfg.PeerTLSInfo, &cfg.PeerSecurityJSON)

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -40,7 +40,8 @@ func notFoundErr(service, domain string) error {
 
 func TestConfigFileOtherFields(t *testing.T) {
 	ctls := securityConfig{TrustedCAFile: "cca", CertFile: "ccert", KeyFile: "ckey"}
-	ptls := securityConfig{TrustedCAFile: "pca", CertFile: "pcert", KeyFile: "pkey"}
+	// Note AllowedCN and AllowedHostname are mutually exclusive, this test is just to verify the fields can be correctly marshalled & unmarshalled.
+	ptls := securityConfig{TrustedCAFile: "pca", CertFile: "pcert", KeyFile: "pkey", AllowedCN: "etcd", AllowedHostname: "whatever.example.com"}
 	yc := struct {
 		ClientSecurityCfgFile securityConfig       `json:"client-transport-security"`
 		PeerSecurityCfgFile   securityConfig       `json:"peer-transport-security"`
@@ -155,7 +156,12 @@ func TestUpdateDefaultClusterFromNameOverwrite(t *testing.T) {
 func (s *securityConfig) equals(t *transport.TLSInfo) bool {
 	return s.CertFile == t.CertFile &&
 		s.CertAuth == t.ClientCertAuth &&
-		s.TrustedCAFile == t.TrustedCAFile
+		s.TrustedCAFile == t.TrustedCAFile &&
+		s.ClientCertFile == t.ClientCertFile &&
+		s.ClientKeyFile == t.ClientKeyFile &&
+		s.KeyFile == t.KeyFile &&
+		s.AllowedCN == t.AllowedCN &&
+		s.AllowedHostname == t.AllowedHostname
 }
 
 func mustCreateCfgFile(t *testing.T, b []byte) *os.File {


### PR DESCRIPTION
Allow setting AllowedCN and AllowedHostname tls fields through the config file for peer transport security.

Closes: #17867