### PR TITLE
Address remaining var naming linter warnings

### DIFF
--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -35,7 +35,7 @@ var (
 	restoreCluster      string
 	restoreClusterToken string
 	restoreDataDir      string
-	restoreWalDir       string
+	restoreWALDir       string
 	restorePeerURLs     string
 	restoreName         string
 	skipHashCheck       bool
@@ -73,7 +73,7 @@ func NewSnapshotRestoreCommand() *cobra.Command {
 		Run:   snapshotRestoreCommandFunc,
 	}
 	cmd.Flags().StringVar(&restoreDataDir, "data-dir", "", "Path to the output data directory")
-	cmd.Flags().StringVar(&restoreWalDir, "wal-dir", "", "Path to the WAL directory (use --data-dir if none given)")
+	cmd.Flags().StringVar(&restoreWALDir, "wal-dir", "", "Path to the WAL directory (use --data-dir if none given)")
 	cmd.Flags().StringVar(&restoreCluster, "initial-cluster", initialClusterFromName(defaultName), "Initial cluster configuration for restore bootstrap")
 	cmd.Flags().StringVar(&restoreClusterToken, "initial-cluster-token", "etcd-cluster", "Initial cluster token for the etcd cluster during restore bootstrap")
 	cmd.Flags().StringVar(&restorePeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster")
@@ -106,14 +106,14 @@ func SnapshotStatusCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func snapshotRestoreCommandFunc(_ *cobra.Command, args []string) {
-	SnapshotRestoreCommandFunc(restoreCluster, restoreClusterToken, restoreDataDir, restoreWalDir,
+	SnapshotRestoreCommandFunc(restoreCluster, restoreClusterToken, restoreDataDir, restoreWALDir,
 		restorePeerURLs, restoreName, skipHashCheck, initialMmapSize, revisionBump, markCompacted, args)
 }
 
 func SnapshotRestoreCommandFunc(restoreCluster string,
 	restoreClusterToken string,
 	restoreDataDir string,
-	restoreWalDir string,
+	restoreWALDir string,
 	restorePeerURLs string,
 	restoreName string,
 	skipHashCheck bool,
@@ -136,7 +136,7 @@ func SnapshotRestoreCommandFunc(restoreCluster string,
 		dataDir = restoreName + ".etcd"
 	}
 
-	walDir := restoreWalDir
+	walDir := restoreWALDir
 	if walDir == "" {
 		walDir = datadir.ToWALDir(dataDir)
 	}

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -43,14 +43,14 @@ func TestStatus(t *testing.T) {
 				if len(rs) != tc.config.ClusterSize {
 					t.Fatalf("wrong number of status responses. expected:%d, got:%d ", tc.config.ClusterSize, len(rs))
 				}
-				memberIds := make(map[uint64]struct{})
+				memberIDs := make(map[uint64]struct{})
 				for _, r := range rs {
 					if r == nil {
 						t.Fatalf("status response is nil")
 					}
-					memberIds[r.Header.MemberId] = struct{}{}
+					memberIDs[r.Header.MemberId] = struct{}{}
 				}
-				if len(rs) != len(memberIds) {
+				if len(rs) != len(memberIDs) {
 					t.Fatalf("found duplicated members")
 				}
 			})

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -51,7 +51,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 
 	p := t.TempDir()
 
-	mustCreateWalLog(t, p)
+	mustCreateWALLog(t, p)
 
 	argtests := []struct {
 		name         string
@@ -96,7 +96,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 
 }
 
-func mustCreateWalLog(t *testing.T, path string) {
+func mustCreateWALLog(t *testing.T, path string) {
 	memberdir := filepath.Join(path, "member")
 	err := os.Mkdir(memberdir, 0744)
 	if err != nil {

--- a/tools/etcd-dump-logs/raw_test.go
+++ b/tools/etcd-dump-logs/raw_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_readRaw(t *testing.T) {
 	path := t.TempDir()
-	mustCreateWalLog(t, path)
+	mustCreateWALLog(t, path)
 	var out bytes.Buffer
 	readRaw(nil, walDir(path), &out)
 	assert.Equal(t,


### PR DESCRIPTION
This is the last PR from #17578, before enabling the linter. Addresses miscellaneous violations in `etcdutl`, `tools/etcd-dump-logs`, and `tests/common`.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
