### PR TITLE
Fix deprecation comments from addressing var-naming work

### DIFF
--- a/server/etcdserver/api/etcdhttp/health.go
+++ b/server/etcdserver/api/etcdhttp/health.go
@@ -264,11 +264,11 @@ func (reg *CheckRegistry) RootPath() string {
 }
 
 // InstallHttpEndpoints installs the http handlers for the health checks.
+//
 // Deprecated: Please use (*CheckRegistry) InstallHTTPEndpoints instead.
 //
-//revive:disable:var-naming
+//revive:disable-next-line:var-naming
 func (reg *CheckRegistry) InstallHttpEndpoints(lg *zap.Logger, mux *http.ServeMux) {
-	//revive:enable:var-naming
 	reg.InstallHTTPEndpoints(lg, mux)
 }
 

--- a/server/storage/datadir/datadir.go
+++ b/server/storage/datadir/datadir.go
@@ -32,6 +32,7 @@ func ToSnapDir(dataDir string) string {
 }
 
 // ToWalDir returns the directory path for the member's WAL.
+//
 // Deprecated: use ToWALDir instead.
 //
 //revive:disable-next-line:var-naming

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -111,6 +111,7 @@ func CreateConfigChangeEnts(lg *zap.Logger, ids []uint64, self uint64, term, ind
 
 // GetEffectiveNodeIdsFromWalEntries returns an ordered set of IDs included in the given snapshot and
 // the entries.
+//
 // Deprecated: use GetEffectiveNodeIDsFromWALEntries instead.
 //
 //revive:disable-next-line:var-naming


### PR DESCRIPTION
The deprecation tag/comment must be followed by an empty line, as prompted in https://github.com/etcd-io/etcd/pull/17674#discussion_r1554831812.

Part of #17578.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
