### PR TITLE
all: don't convert byte slice to string when using verb %s

### DIFF
--- a/client/pkg/transport/timeout_transport_test.go
+++ b/client/pkg/transport/timeout_transport_test.go
@@ -80,6 +80,6 @@ func TestNewTimeoutTransport(t *testing.T) {
 	}
 
 	if bytes.Equal(addr0, addr1) {
-		t.Errorf("addr0 = %s addr1= %s, want not equal", string(addr0), string(addr1))
+		t.Errorf("addr0 = %s addr1= %s, want not equal", addr0, addr1)
 	}
 }

--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -223,7 +223,7 @@ func (s *simplePrinter) RoleGet(role string, r v3.AuthRoleGetResponse) {
 	for _, perm := range r.Perm {
 		if perm.PermType == v3.PermRead || perm.PermType == v3.PermReadWrite {
 			if len(perm.RangeEnd) == 0 {
-				fmt.Printf("\t%s\n", string(perm.Key))
+				fmt.Printf("\t%s\n", perm.Key)
 			} else {
 				printRange((*v3.Permission)(perm))
 			}
@@ -233,7 +233,7 @@ func (s *simplePrinter) RoleGet(role string, r v3.AuthRoleGetResponse) {
 	for _, perm := range r.Perm {
 		if perm.PermType == v3.PermWrite || perm.PermType == v3.PermReadWrite {
 			if len(perm.RangeEnd) == 0 {
-				fmt.Printf("\t%s\n", string(perm.Key))
+				fmt.Printf("\t%s\n", perm.Key)
 			} else {
 				printRange((*v3.Permission)(perm))
 			}

--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -143,10 +143,10 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 		for next, _ := c.First(); next != nil; next, _ = c.Next() {
 			b := tx.Bucket(next)
 			if b == nil {
-				return fmt.Errorf("cannot get hash of bucket %s", string(next))
+				return fmt.Errorf("cannot get hash of bucket %s", next)
 			}
 			if _, err = h.Write(next); err != nil {
-				return fmt.Errorf("cannot write bucket %s : %v", string(next), err)
+				return fmt.Errorf("cannot write bucket %s : %v", next, err)
 			}
 			iskeyb := (string(next) == "key")
 			if err = b.ForEach(func(k, v []byte) error {
@@ -163,7 +163,7 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 				ds.TotalKey++
 				return nil
 			}); err != nil {
-				return fmt.Errorf("cannot write bucket %s : %v", string(next), err)
+				return fmt.Errorf("cannot write bucket %s : %v", next, err)
 			}
 		}
 		return nil

--- a/server/etcdserver/api/etcdhttp/peer_test.go
+++ b/server/etcdserver/api/etcdhttp/peer_test.go
@@ -278,7 +278,7 @@ func TestNewPeerHandlerOnMembersPromotePrefix(t *testing.T) {
 			t.Fatalf("#%d: code = %d, want %d", i, resp.StatusCode, tt.wcode)
 		}
 		if tt.checkBody && strings.Contains(string(body), tt.wKeyWords) {
-			t.Errorf("#%d: body: %s, want body to contain keywords: %s", i, string(body), tt.wKeyWords)
+			t.Errorf("#%d: body: %s, want body to contain keywords: %s", i, body, tt.wKeyWords)
 		}
 	}
 }

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -327,14 +327,14 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 		if strings.Contains(string(b), membership.ErrMemberNotLearner.Error()) {
 			return nil, membership.ErrMemberNotLearner
 		}
-		return nil, fmt.Errorf("member promote: unknown error(%s)", string(b))
+		return nil, fmt.Errorf("member promote: unknown error(%s)", b)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, membership.ErrIDNotFound
 	}
 
 	if resp.StatusCode != http.StatusOK { // all other types of errors
-		return nil, fmt.Errorf("member promote: unknown error(%s)", string(b))
+		return nil, fmt.Errorf("member promote: unknown error(%s)", b)
 	}
 
 	var membs []*membership.Member

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -615,7 +615,7 @@ func HashByRev(ctx context.Context, cid types.ID, cc *http.Client, url string, r
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unknown error: %s", string(b))
+		return nil, fmt.Errorf("unknown error: %s", b)
 	}
 
 	hashResp := &pb.HashKVResponse{}

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -573,7 +573,7 @@ func TestHashKVHandler(t *testing.T) {
 			}
 			if resp.StatusCode != http.StatusOK {
 				if !strings.Contains(string(body), tt.wKeyWords) {
-					t.Errorf("#%d: body: %s, want body to contain keywords: %s", i, string(body), tt.wKeyWords)
+					t.Errorf("#%d: body: %s, want body to contain keywords: %s", i, body, tt.wKeyWords)
 				}
 				return
 			}

--- a/server/lease/leasehttp/http.go
+++ b/server/lease/leasehttp/http.go
@@ -192,12 +192,12 @@ func RenewHTTP(ctx context.Context, id lease.LeaseID, url string, rt http.RoundT
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return -1, fmt.Errorf("lease: unknown error(%s)", string(b))
+		return -1, fmt.Errorf("lease: unknown error(%s)", b)
 	}
 
 	lresp := &pb.LeaseKeepAliveResponse{}
 	if err := lresp.Unmarshal(b); err != nil {
-		return -1, fmt.Errorf(`lease: %v. data = "%s"`, err, string(b))
+		return -1, fmt.Errorf(`lease: %v. data = "%s"`, err, b)
 	}
 	if lresp.ID != int64(id) {
 		return -1, fmt.Errorf("lease: renew id mismatch")

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -394,7 +394,7 @@ func (b *backend) Hash(ignores func(bucketName, keyName []byte) bool) (uint32, e
 		for next, _ := c.First(); next != nil; next, _ = c.Next() {
 			b := tx.Bucket(next)
 			if b == nil {
-				return fmt.Errorf("cannot get hash of bucket %s", string(next))
+				return fmt.Errorf("cannot get hash of bucket %s", next)
 			}
 			h.Write(next)
 			b.ForEach(func(k, v []byte) error {
@@ -598,7 +598,7 @@ func defragdb(odb, tmpdb *bolt.DB, limit int) error {
 	for next, _ := c.First(); next != nil; next, _ = c.Next() {
 		b := tx.Bucket(next)
 		if b == nil {
-			return fmt.Errorf("backend: cannot defrag bucket %s", string(next))
+			return fmt.Errorf("backend: cannot defrag bucket %s", next)
 		}
 
 		tmpb, berr := tmptx.CreateBucketIfNotExists(next)

--- a/server/storage/backend/batch_tx_test.go
+++ b/server/storage/backend/batch_tx_test.go
@@ -52,7 +52,7 @@ func TestBatchTxPut(t *testing.T) {
 		_, gv := tx.UnsafeRange(schema.Test, []byte("foo"), nil, 0)
 		tx.Unlock()
 		if !reflect.DeepEqual(gv[0], v) {
-			t.Errorf("v = %s, want %s", string(gv[0]), string(v))
+			t.Errorf("v = %s, want %s", gv[0], v)
 		}
 		tx.Commit()
 	}

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -114,7 +114,7 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 	t.Logf("Last response: %v", string(lastResponse))
 	if lbPolicy == "pick_first" {
 		if string(lastResponse) != "3500" {
-			t.Fatalf("unexpected total responses from foo: %s", string(lastResponse))
+			t.Fatalf("unexpected total responses from foo: %s", lastResponse)
 		}
 	}
 
@@ -122,12 +122,12 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 	if lbPolicy == "round_robin" {
 		responses, err := strconv.Atoi(string(lastResponse))
 		if err != nil {
-			t.Fatalf("couldn't convert to int: %s", string(lastResponse))
+			t.Fatalf("couldn't convert to int: %s", lastResponse)
 		}
 
 		// Allow 25% tolerance as round robin is not perfect and we don't want the test to flake
 		expected := float64(totalRequests) * 0.5
-		assert.InEpsilon(t, expected, float64(responses), 0.25, "unexpected total responses from foo: %s", string(lastResponse))
+		assert.InEpsilon(t, expected, float64(responses), 0.25, "unexpected total responses from foo: %s", lastResponse)
 	}
 }
 

--- a/tests/integration/snapshot/member_test.go
+++ b/tests/integration/snapshot/member_test.go
@@ -114,10 +114,10 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 	}
 	for i := range gresp.Kvs {
 		if string(gresp.Kvs[i].Key) != kvs[i].k {
-			t.Fatalf("#%d: key expected %s, got %s", i, kvs[i].k, string(gresp.Kvs[i].Key))
+			t.Fatalf("#%d: key expected %s, got %s", i, kvs[i].k, gresp.Kvs[i].Key)
 		}
 		if string(gresp.Kvs[i].Value) != kvs[i].v {
-			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, string(gresp.Kvs[i].Value))
+			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[i].Value)
 		}
 	}
 }

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -95,7 +95,7 @@ func TestSnapshotV3RestoreSingle(t *testing.T) {
 			t.Fatal(err)
 		}
 		if string(gresp.Kvs[0].Value) != kvs[i].v {
-			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, string(gresp.Kvs[0].Value))
+			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 		}
 	}
 }
@@ -132,7 +132,7 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 				t.Fatal(err)
 			}
 			if string(gresp.Kvs[0].Value) != kvs[i].v {
-				t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, string(gresp.Kvs[0].Value))
+				t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 			}
 		}
 	}

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -148,7 +148,7 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 				t.Fatalf("Expected 1 key, got %d", len(resp.Kvs))
 			}
 			if !bytes.Equal([]byte(val), resp.Kvs[0].Value) {
-				t.Fatalf("Unexpected value, expected: %s, got: %s", val, string(resp.Kvs[0].Value))
+				t.Fatalf("Unexpected value, expected: %s, got: %s", val, resp.Kvs[0].Value)
 			}
 			return nil
 		}()


### PR DESCRIPTION
This is unnecessary, as the documentation for 'go doc fmt' says:
%s the uninterpreted bytes of the string or slice

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
