### PR TITLE
e2e test: add schema version verification in mix_version_test.

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -202,6 +202,9 @@ func newCluster(t *testing.T, clusterSize int, snapshotCount uint64) *e2e.EtcdPr
 		if errC := epc.Close(); errC != nil {
 			t.Fatalf("error closing etcd processes (%v)", errC)
 		}
+		for _, proc := range epc.Procs {
+			require.NoError(t, proc.VerifySchemaVersion(epc.Cfg.Logger, true))
+		}
 	})
 	return epc
 }

--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -92,11 +92,15 @@ func mixVersionsSnapshotTestByAddingMember(t *testing.T, cfg *e2e.EtcdProcessClu
 	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t,
 		e2e.WithConfig(cfg),
 		e2e.WithSnapshotCount(10),
+		e2e.WithKeepDataDir(true),
 	)
 	require.NoError(t, err, "failed to start etcd cluster: %v", err)
 	defer func() {
 		derr := epc.Close()
 		require.NoError(t, derr, "failed to close etcd cluster: %v", derr)
+		for _, proc := range epc.Procs {
+			require.NoError(t, proc.VerifySchemaVersion(epc.Cfg.Logger, true))
+		}
 	}()
 
 	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot)")
@@ -135,11 +139,15 @@ func mixVersionsSnapshotTestByMockPartition(t *testing.T, cfg *e2e.EtcdProcessCl
 		e2e.WithConfig(cfg),
 		e2e.WithSnapshotCount(10),
 		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithKeepDataDir(true),
 	)
 	require.NoError(t, err, "failed to start etcd cluster: %v", err)
 	defer func() {
 		derr := epc.Close()
 		require.NoError(t, derr, "failed to close etcd cluster: %v", derr)
+		for _, proc := range epc.Procs {
+			require.NoError(t, proc.VerifySchemaVersion(epc.Cfg.Logger, true))
+		}
 	}()
 	toPartitionedMember := epc.Procs[mockPartitionNodeIndex]
 


### PR DESCRIPTION
https://github.com/etcd-io/etcd/issues/17752

Verify storage version is consistent with expected at the end of tests. 
Since `storageVersion` is the only field added in 3.6, checking the storage version only would be enough, and there is no need to check the buckets one by one. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
