### PR TITLE
[RFC] Attempt to make Blockhole blocking on L7

### DIFF
--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -63,8 +63,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
 
-	t.Logf("Wait 20s for any open connections to expire")
-	time.Sleep(20 * time.Second)
+	t.Logf("Wait 5s for any open connections to expire")
+	time.Sleep(5 * time.Second)
 
 	t.Logf("Wait for new leader election with remaining members")
 	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
@@ -83,6 +83,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.UnblackholeRx()
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	time.Sleep(5 * time.Second)
 	assertRevision(t, leaderEPC, 21)
 	assertRevision(t, partitionedMember, 21)
 }

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -43,6 +43,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 		e2e.WithClusterSize(clusterSize),
 		e2e.WithSnapshotCount(10),
 		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithSSLTerminationProxy(true),
 		e2e.WithIsPeerTLS(true),
 		e2e.WithPeerProxy(true),
 	)
@@ -68,6 +69,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 
 	t.Logf("Wait for new leader election with remaining members")
 	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
+
 	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot.)")
 	writeKVs(t, leaderEPC.Etcdctl(), 0, 20)
 	e2e.AssertProcessLogs(t, leaderEPC, "saved snapshot")
@@ -76,7 +78,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	assertRevision(t, leaderEPC, 21)
 	assertRevision(t, partitionedMember, 1)
 
-	// Wait for some time to restore the network
+	// Wait for 1s before restoring the network
+	t.Logf("Wait 1s before restoring the network")
 	time.Sleep(1 * time.Second)
 	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.UnblackholeTx()

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestBlackholeByMockingPartitionLeader(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, true)
+}
+
+func TestBlackholeByMockingPartitionFollower(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, false)
+}
+
+func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLeader bool) {
+	e2e.BeforeTest(t)
+
+	t.Logf("Create an etcd cluster with %d member\n", clusterSize)
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t,
+		e2e.WithClusterSize(clusterSize),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithIsPeerTLS(true),
+		e2e.WithPeerProxy(true),
+	)
+	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	defer func() {
+		require.NoError(t, epc.Close(), "failed to close etcd cluster")
+	}()
+
+	leaderId := epc.WaitLeader(t)
+	mockPartitionNodeIndex := leaderId
+	if !partitionLeader {
+		mockPartitionNodeIndex = (leaderId + 1) % (clusterSize)
+	}
+	partitionedMember := epc.Procs[mockPartitionNodeIndex]
+	// Mock partition
+	proxy := partitionedMember.PeerProxy()
+	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.BlackholeTx()
+	proxy.BlackholeRx()
+
+	t.Logf("Wait 20s for any open connections to expire")
+	time.Sleep(20 * time.Second)
+
+	t.Logf("Wait for new leader election with remaining members")
+	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
+	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot.)")
+	writeKVs(t, leaderEPC.Etcdctl(), 0, 20)
+	e2e.AssertProcessLogs(t, leaderEPC, "saved snapshot")
+
+	t.Log("Verifying the partitionedMember is missing new writes")
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 1)
+
+	// Wait for some time to restore the network
+	time.Sleep(1 * time.Second)
+	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.UnblackholeTx()
+	proxy.UnblackholeRx()
+
+	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 21)
+}
+
+func waitLeader(t testing.TB, epc *e2e.EtcdProcessCluster, excludeNode int) int {
+	var membs []e2e.EtcdProcess
+	for i := 0; i < len(epc.Procs); i++ {
+		if i == excludeNode {
+			continue
+		}
+		membs = append(membs, epc.Procs[i])
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return epc.WaitMembersForLeader(ctx, t, membs)
+}
+
+func assertRevision(t testing.TB, member e2e.EtcdProcess, expectedRevision int64) {
+	responses, err := member.Etcdctl().Status(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, expectedRevision, responses[0].Header.Revision, "revision mismatch")
+}

--- a/tests/robustness/failpoint/network.go
+++ b/tests/robustness/failpoint/network.go
@@ -64,9 +64,6 @@ func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, proces
 func Blackhole(ctx context.Context, t *testing.T, member e2e.EtcdProcess, clus *e2e.EtcdProcessCluster, shouldWaitTillSnapshot bool) error {
 	proxy := member.PeerProxy()
 
-	// Blackholing will cause peers to not be able to use streamWriters registered with member
-	// but peer traffic is still possible because member has 'pipeline' with peers
-	// TODO: find a way to stop all traffic
 	t.Logf("Blackholing traffic from and to member %q", member.Config().Name)
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()


### PR DESCRIPTION
Based on [the idea from @fuweid](https://github.com/etcd-io/etcd/issues/17737#issuecomment-2053608094), this PR attempts to employ blocking on L7 but without using external tools.

# Main ideas
The main idea is
1) utilize the `X-PeerURLs` field from the header, as we know all traffic to peer will contain this header field.
2) As we also know all nodes will create direct connections with their peers, so the traffic blocking will have to happen at all nodes' proxies, contrary to the current design, where only the proxy of the peer is being blackholed.

Based on the main ideas, we introduce an SSL termination proxy so we can obtain the `X-PeerURLs` field from the header.

# PoC Implementation Issues

There are 2 known issues with this approach
1) still leaking some traffic. But the leaked traffic (as discussed later, it won't affect the blackhole idea that we would like to achieve) as stream and pipeline traffic between raft nodes are now properly terminated
2) we would need to employ an SSL termination proxy, which might lead to a small performance hit

For 1), this way of blocking (by utilizing `X-PeerURLs` from the header) will miss certain types of traffic to certain endpoints, as the traffic to some endpoints doesn't have the `X-PeerURLs` field. Currently, the known ones are: `/members`, `/version`, and `/raft/probing`.
As you can see from the log, its header doesn't contain the `X-PeerURLs` field, but only the following fields:
- `map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /members`
- `map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /version`
- `map[Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] /raft/probing`

For 2), in order to read out `X-PeerURLs` from the header, we need to terminate the SSL connection, as we can't drop cleartext traffic (ref [1]). Thus, a new option `e2e.WithSSLTerminationProxy(true)` is introduced, which will change the network flow into
```
A -- B's SSL termination proxy - B's transparent proxy - B
       ^ newly introduced                ^ in the original codebase
```

# Known improvements required before turning RFC into PR

The prototype needs to be further improved for code review after fixing the following issues:
- blocking only RX or TX traffic (as currently a call to `blackholeTX` or `blackholeRX` will black both TX and RX traffic instead of just the specified one.
- slowness when performing test cleanup (I think this is related to the SSL timeout setting, but I haven't looked into it yet)
- coding style improvements

References:
[1] https://github.com/etcd-io/etcd/issues/15595

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
