### PR TITLE
github/workflows: skip robustness tests in forks

### DIFF
--- a/.github/workflows/robustness-template.yaml
+++ b/.github/workflows/robustness-template.yaml
@@ -30,6 +30,8 @@ permissions: read-all
 
 jobs:
   test:
+    # this is to prevent the job to run at forked projects
+    if: github.repository == 'etcd-io/etcd'
     timeout-minutes: 210
     runs-on: ${{ fromJson(inputs.runs-on) }}
     steps:


### PR DESCRIPTION
Robustness tests require a larger instance size, which user forks cannot access. It also tries to trigger an ARM64 build that runs on actuated infrastructure. By not running them on user forks, contributors won't be notified that their builds are failing due to timeouts trying to run the job, while the tests will still run on etcd-io/etcd pull requests and commits.

Part of #17912 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
