### PR TITLE
Update jmhbnz project role in owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,9 @@
 
 approvers:
   - ahrtr           # Benjamin Wang <benjamin.ahrtr@gmail.com> <benjamin.wang@broadcom.com>
+  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
   - serathius       # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
   - spzala          # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe       # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
 reviewers:
-  - jmhbnz          # James Blair <jablair@redhat.com> <mail@jamesblair.net>
   - fuweid          # Wei Fu <fuweid89@gmail.com>


### PR DESCRIPTION
This pull request updates our `OWNERS` file to reflect https://github.com/kubernetes/org/pull/4838.