### PR TITLE
make: fix running fix target after verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,11 @@ verify-genproto:
 verify-yamllint:
 ifeq (, $(shell which yamllint))
 	@echo "Installing yamllint..."
-	python3 -m venv bin/python
-	bin/python/bin/python3 -m pip install yamllint
-	./bin/python/bin/yamllint --config-file tools/.yamllint .
+	tmpdir=$$(mktemp -d); \
+	trap "rm -rf $$tmpdir" EXIT; \
+	python3 -m venv $$tmpdir; \
+	$$tmpdir/bin/python3 -m pip install yamllint; \
+	$$tmpdir/bin/yamllint --config-file tools/.yamllint .
 else
 	@echo "yamllint already installed..."
 	yamllint --config-file tools/.yamllint .


### PR DESCRIPTION
Define a Python virtual environment to install `yamllint`, if not installed locally, in a temporary directory and delete it after the run of the `verify-yamllint` command. This avoids the issue of building the build of materials that doesn't follow symlinks in the virtual environment directory.

Fixes #17936.
Related to:
* kubernetes/test-infra#32563
* #17637 
* #17929

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
