### PR TITLE
[RFC] Fix Blackhole implementation for e2e tests

### DIFF
--- a/client/pkg/transport/transport.go
+++ b/client/pkg/transport/transport.go
@@ -39,8 +39,8 @@ func NewTransport(info TLSInfo, dialtimeoutd time.Duration) (*http.Transport, er
 			// then a nil URL and nil error will be returned.
 			// Thus, we need to workaround this by manually setting an
 			// ENV named FORWARD_PROXY and parse the URL (which is a localhost in our case)
-			if forwardProxy, exists := os.LookupEnv("FORWARD_PROXY"); exists {
-				return url.Parse(forwardProxy)
+			if httpProxy, exists := os.LookupEnv("FORWARD_PROXY"); exists {
+				return url.Parse(httpProxy)
 			}
 			return http.ProxyFromEnvironment(req)
 		},

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -63,8 +63,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
 
-	t.Logf("Wait 20s for any open connections to expire")
-	time.Sleep(20 * time.Second)
+	t.Logf("Wait 5s for any open connections to expire")
+	time.Sleep(5 * time.Second)
 
 	t.Logf("Wait for new leader election with remaining members")
 	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
@@ -83,6 +83,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	proxy.UnblackholeRx()
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	time.Sleep(5 * time.Second)
 	assertRevision(t, leaderEPC, 21)
 	assertRevision(t, partitionedMember, 21)
 }

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -51,17 +51,20 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 		require.NoError(t, epc.Close(), "failed to close etcd cluster")
 	}()
 
-	leaderId := epc.WaitLeader(t)
-	mockPartitionNodeIndex := leaderId
+	leaderID := epc.WaitLeader(t)
+	mockPartitionNodeIndex := leaderID
 	if !partitionLeader {
-		mockPartitionNodeIndex = (leaderId + 1) % (clusterSize)
+		mockPartitionNodeIndex = (leaderID + 1) % (clusterSize)
 	}
 	partitionedMember := epc.Procs[mockPartitionNodeIndex]
 	// Mock partition
 	proxy := partitionedMember.PeerProxy()
+	forwardProxy := partitionedMember.PeerForwardProxy()
 	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
+	forwardProxy.BlackholeTx()
+	forwardProxy.BlackholeRx()
 
 	t.Logf("Wait 5s for any open connections to expire")
 	time.Sleep(5 * time.Second)
@@ -81,6 +84,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.UnblackholeTx()
 	proxy.UnblackholeRx()
+	forwardProxy.UnblackholeTx()
+	forwardProxy.UnblackholeRx()
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
 	time.Sleep(5 * time.Second)

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -59,12 +59,12 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	partitionedMember := epc.Procs[mockPartitionNodeIndex]
 	// Mock partition
 	proxy := partitionedMember.PeerProxy()
-	forwardProxy := partitionedMember.PeerForwardProxy()
+	httpProxy := partitionedMember.PeerHTTPProxy()
 	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
-	forwardProxy.BlackholeTx()
-	forwardProxy.BlackholeRx()
+	httpProxy.BlackholeTx()
+	httpProxy.BlackholeRx()
 
 	t.Logf("Wait 5s for any open connections to expire")
 	time.Sleep(5 * time.Second)
@@ -84,8 +84,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
 	proxy.UnblackholeTx()
 	proxy.UnblackholeRx()
-	forwardProxy.UnblackholeTx()
-	forwardProxy.UnblackholeRx()
+	httpProxy.UnblackholeTx()
+	httpProxy.UnblackholeRx()
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
 	time.Sleep(5 * time.Second)

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -44,7 +44,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 		e2e.WithSnapshotCount(10),
 		e2e.WithSnapshotCatchUpEntries(10),
 		e2e.WithIsPeerTLS(true),
-		e2e.WithPeerProxy(true),
+		e2e.WithSingleHTTPProxy(true),
 	)
 	require.NoError(t, err, "failed to start etcd cluster: %v", err)
 	defer func() {
@@ -58,13 +58,8 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	}
 	partitionedMember := epc.Procs[mockPartitionNodeIndex]
 	// Mock partition
-	proxy := partitionedMember.PeerProxy()
-	httpProxy := partitionedMember.PeerHTTPProxy()
 	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
-	proxy.BlackholeTx()
-	proxy.BlackholeRx()
-	httpProxy.BlackholeTx()
-	httpProxy.BlackholeRx()
+	epc.SingleHTTPProxyInstance.BlackholePeer(partitionedMember.Config().PeerURL)
 
 	t.Logf("Wait 5s for any open connections to expire")
 	time.Sleep(5 * time.Second)
@@ -82,10 +77,7 @@ func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLea
 	// Wait for some time to restore the network
 	time.Sleep(1 * time.Second)
 	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
-	proxy.UnblackholeTx()
-	proxy.UnblackholeRx()
-	httpProxy.UnblackholeTx()
-	httpProxy.UnblackholeRx()
+	epc.SingleHTTPProxyInstance.UnblackholePeer(partitionedMember.Config().PeerURL)
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
 	time.Sleep(5 * time.Second)

--- a/tests/e2e/blackhole_test.go
+++ b/tests/e2e/blackhole_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestBlackholeByMockingPartitionLeader(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, true)
+}
+
+func TestBlackholeByMockingPartitionFollower(t *testing.T) {
+	blackholeTestByMockingPartition(t, 3, false)
+}
+
+func blackholeTestByMockingPartition(t *testing.T, clusterSize int, partitionLeader bool) {
+	e2e.BeforeTest(t)
+
+	t.Logf("Create an etcd cluster with %d member\n", clusterSize)
+	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t,
+		e2e.WithClusterSize(clusterSize),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithIsPeerTLS(true),
+		e2e.WithPeerProxy(true),
+	)
+	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	defer func() {
+		require.NoError(t, epc.Close(), "failed to close etcd cluster")
+	}()
+
+	leaderId := epc.WaitLeader(t)
+	mockPartitionNodeIndex := leaderId
+	if !partitionLeader {
+		mockPartitionNodeIndex = (leaderId + 1) % (clusterSize)
+	}
+	partitionedMember := epc.Procs[mockPartitionNodeIndex]
+	// Mock partition
+	proxy := partitionedMember.PeerProxy()
+	t.Logf("Blackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.BlackholeTx()
+	proxy.BlackholeRx()
+
+	t.Logf("Wait 20s for any open connections to expire")
+	time.Sleep(20 * time.Second)
+
+	t.Logf("Wait for new leader election with remaining members")
+	leaderEPC := epc.Procs[waitLeader(t, epc, mockPartitionNodeIndex)]
+	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot.)")
+	writeKVs(t, leaderEPC.Etcdctl(), 0, 20)
+	e2e.AssertProcessLogs(t, leaderEPC, "saved snapshot")
+
+	t.Log("Verifying the partitionedMember is missing new writes")
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 1)
+
+	// Wait for some time to restore the network
+	time.Sleep(1 * time.Second)
+	t.Logf("Unblackholing traffic from and to member %q", partitionedMember.Config().Name)
+	proxy.UnblackholeTx()
+	proxy.UnblackholeRx()
+
+	leaderEPC = epc.Procs[epc.WaitLeader(t)]
+	assertRevision(t, leaderEPC, 21)
+	assertRevision(t, partitionedMember, 21)
+}
+
+func waitLeader(t testing.TB, epc *e2e.EtcdProcessCluster, excludeNode int) int {
+	var membs []e2e.EtcdProcess
+	for i := 0; i < len(epc.Procs); i++ {
+		if i == excludeNode {
+			continue
+		}
+		membs = append(membs, epc.Procs[i])
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return epc.WaitMembersForLeader(ctx, t, membs)
+}
+
+func assertRevision(t testing.TB, member e2e.EtcdProcess, expectedRevision int64) {
+	responses, err := member.Etcdctl().Status(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, expectedRevision, responses[0].Header.Revision, "revision mismatch")
+}

--- a/tests/robustness/failpoint/network.go
+++ b/tests/robustness/failpoint/network.go
@@ -62,20 +62,11 @@ func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, proces
 }
 
 func Blackhole(ctx context.Context, t *testing.T, member e2e.EtcdProcess, clus *e2e.EtcdProcessCluster, shouldWaitTillSnapshot bool) error {
-	proxy := member.PeerProxy()
-	httpProxy := member.PeerHTTPProxy()
-
 	t.Logf("Blackholing traffic from and to member %q", member.Config().Name)
-	proxy.BlackholeTx()
-	proxy.BlackholeRx()
-	httpProxy.BlackholeTx()
-	httpProxy.BlackholeRx()
+	clus.SingleHTTPProxyInstance.BlackholePeer(member.Config().PeerURL)
 	defer func() {
 		t.Logf("Traffic restored from and to member %q", member.Config().Name)
-		proxy.UnblackholeTx()
-		proxy.UnblackholeRx()
-		httpProxy.UnblackholeTx()
-		httpProxy.UnblackholeRx()
+		clus.SingleHTTPProxyInstance.UnblackholePeer(member.Config().PeerURL)
 	}()
 
 	if shouldWaitTillSnapshot {

--- a/tests/robustness/failpoint/network.go
+++ b/tests/robustness/failpoint/network.go
@@ -63,19 +63,19 @@ func (tb triggerBlackhole) Available(config e2e.EtcdProcessClusterConfig, proces
 
 func Blackhole(ctx context.Context, t *testing.T, member e2e.EtcdProcess, clus *e2e.EtcdProcessCluster, shouldWaitTillSnapshot bool) error {
 	proxy := member.PeerProxy()
-	forwardProxy := member.PeerForwardProxy()
+	httpProxy := member.PeerHTTPProxy()
 
 	t.Logf("Blackholing traffic from and to member %q", member.Config().Name)
 	proxy.BlackholeTx()
 	proxy.BlackholeRx()
-	forwardProxy.BlackholeTx()
-	forwardProxy.BlackholeRx()
+	httpProxy.BlackholeTx()
+	httpProxy.BlackholeRx()
 	defer func() {
 		t.Logf("Traffic restored from and to member %q", member.Config().Name)
 		proxy.UnblackholeTx()
 		proxy.UnblackholeRx()
-		forwardProxy.UnblackholeTx()
-		forwardProxy.UnblackholeRx()
+		httpProxy.UnblackholeTx()
+		httpProxy.UnblackholeRx()
 	}()
 
 	if shouldWaitTillSnapshot {


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Thanks to @fuweid  for the input regarding https://github.com/etcd-io/etcd/pull/17938.

This is currently a PoC for using just 1 HTTP proxy to deal with blackhole requirements. 

# Problem

A peer will
(a) receive traffic from its peers
(b) initiate connections to its peers (via stream and pipeline).

Thus, the current mechanism of only blocking peer traffic via the peer's existing proxy is insufficient, since only scenario (a) is handled, and scenario (b) is not blocked at all.

# Main idea

We introduce 1 shared HTTP proxy for all peers, where all peers will be proxying all the connections through it. 

Instead of the current per-peer proxy design, and having to have separated listen and advertise ports.

The modified architecture will look something like this:
```
A -- shared HTTP proxy ----- B
        ^ newly introduced
```

By adding this HTTP proxy, we can block all in and out traffic that is initiated from a peer to others, without having to resort to external tools, such as iptables. It's verified that the blocking of traffic is complete, compared to previous solutions [2][3].

# Implementation

The main subtasks are
- set up an environment variable `FORWARD_PROXY`, because go will not parse HTTP_PROXY and HTTPS_PROXY that is using localhost or 127.0.0.1, regardless if the port is present or not
- implement the shared HTTP proxy by extending the existing proxy server code (we need to be able to identify the source sender)
- remove the existing proxy setup (the per-peer proxy)
- implement enable/disable of the HTTP proxy in the e2e test

# Testing

- `make gofail-enable && make build && make gofail-disable && \
go test -timeout 60s -run ^TestBlackholeByMockingPartitionLeader$ go.etcd.io/etcd/tests/v3/e2e -v -count=1`
- `make gofail-enable && make build && make gofail-disable && \
go test -timeout 60s -run ^TestBlackholeByMockingPartitionFollower$ go.etcd.io/etcd/tests/v3/e2e -v -count=1`

# References

[1] Tracking issue https://github.com/etcd-io/etcd/issues/17737
[2] PR (V1) https://github.com/henrybear327/etcd/tree/fix/e2e_blackhole
[3] PR (V2) https://github.com/etcd-io/etcd/pull/17891
[4] PR (V3) https://github.com/etcd-io/etcd/pull/17938