### PR TITLE
Add nested owners files to automate labeling pull requests

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - github_actions

--- a/Documentation/OWNERS
+++ b/Documentation/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/documentation

--- a/client/v3/OWNERS
+++ b/client/v3/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/clientv3

--- a/contrib/OWNERS
+++ b/contrib/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/contrib

--- a/contrib/mixin/OWNERS
+++ b/contrib/mixin/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/observability

--- a/etcdctl/OWNERS
+++ b/etcdctl/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/etcdctl

--- a/etcdutl/OWNERS
+++ b/etcdutl/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/etcdutl

--- a/security/OWNERS
+++ b/security/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/security

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/testing

--- a/tests/robustness/OWNERS
+++ b/tests/robustness/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/robustness-testing

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/tooling

--- a/tools/benchmark/OWNERS
+++ b/tools/benchmark/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/performance

--- a/tools/etcd-dump-db/OWNERS
+++ b/tools/etcd-dump-db/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/debugging

--- a/tools/etcd-dump-logs/OWNERS
+++ b/tools/etcd-dump-logs/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/debugging

--- a/tools/etcd-dump-metrics/OWNERS
+++ b/tools/etcd-dump-metrics/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/observability

--- a/tools/local-tester/OWNERS
+++ b/tools/local-tester/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/testing

--- a/tools/rw-heatmaps/OWNERS
+++ b/tools/rw-heatmaps/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/performance

--- a/tools/testgrid-analysis/OWNERS
+++ b/tools/testgrid-analysis/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+  - area/testing


### PR DESCRIPTION
This pull request proposes adding an initial set of nested `OWNERS` files with `labels:` populated in order to automate labeling for pull requests now that we have enabled the `owners-label` prow plugin in https://github.com/kubernetes/test-infra/pull/32589.

I've structured the `OWNERS` files with the assumption that inheritance works, we need to test/verify this.  For example, a pull request for `tools/rw-heatmaps` should in theory be allocated both the `area/tooling` and `area/performance` labels based on the inheritance.

Moving forward we can also use the nested `OWNERS` files to further delegate approvers and reviewers for specific directories of `etcd-io/etcd` code.

Fixes: https://github.com/etcd-io/etcd/issues/17970