### PR TITLE
Prevent picking a failpoint that waiting till snapshot that doesn't support lower snapshot catchup entries but allow reproducing issue #15271

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -78,10 +78,6 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 			t.Fatal(err)
 		}
 	}
-	err = failpoint.Validate(r.Cluster, s.failpoint)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// t.Failed() returns false during panicking. We need to forcibly
 	// save data on panicking.

--- a/tests/robustness/scenarios.go
+++ b/tests/robustness/scenarios.go
@@ -81,6 +81,11 @@ func exploratoryScenarios(t *testing.T) []testScenario {
 		e2e.WithCompactionBatchLimit(100),
 		e2e.WithWatchProcessNotifyInterval(100 * time.Millisecond),
 	}
+	// snapshot-catchup-entries flag was backported in https://github.com/etcd-io/etcd/pull/17808
+	v3_5_13 := semver.Version{Major: 3, Minor: 5, Patch: 13}
+	if v.Compare(v3_5_13) >= 0 {
+		baseOptions = append(baseOptions, e2e.WithSnapshotCatchUpEntries(100))
+	}
 	scenarios := []testScenario{}
 	for _, tp := range trafficProfiles {
 		name := filepath.Join(tp.Traffic.Name(), tp.Profile.Name, "ClusterOfSize1")
@@ -104,9 +109,6 @@ func exploratoryScenarios(t *testing.T) []testScenario {
 		clusterOfSize3Options := baseOptions
 		clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithIsPeerTLS(true))
 		clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithPeerProxy(true))
-		if !v.LessThan(version.V3_6) {
-			clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithSnapshotCatchUpEntries(100))
-		}
 		scenarios = append(scenarios, testScenario{
 			name:    name,
 			traffic: tp.Traffic,


### PR DESCRIPTION
Overdid it in https://github.com/etcd-io/etcd/pull/17967

cc @MadhavJivrajani  for fast review.