### PR TITLE
all: fix setupEmbedCfg functions to set cfg.InitialCluster more safely

### DIFF
--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -206,11 +206,16 @@ func setupEmbedCfg(cfg *embed.Config, curls []url.URL, purls []url.URL) {
 	cfg.ClusterState = "new"
 	cfg.ListenClientUrls, cfg.AdvertiseClientUrls = curls, curls
 	cfg.ListenPeerUrls, cfg.AdvertisePeerUrls = purls, purls
-	cfg.InitialCluster = ""
-	for i := range purls {
-		cfg.InitialCluster += ",default=" + purls[i].String()
+
+	cfg.InitialCluster = joinURLs(purls)
+}
+
+func joinURLs(purls []url.URL) string {
+	initialCluster := make([]string, len(purls))
+	for i, purl := range purls {
+		initialCluster[i] = fmt.Sprintf("default=%s", purl.String())
 	}
-	cfg.InitialCluster = cfg.InitialCluster[1:]
+	return strings.Join(initialCluster, ",")
 }
 
 func TestEmbedEtcdAutoCompactionRetentionRetained(t *testing.T) {

--- a/tests/integration/embed/join_urls_test.go
+++ b/tests/integration/embed/join_urls_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embed_test
+
+import (
+	"net/url"
+	"testing"
+)
+
+func parseURL(s string) url.URL {
+	x, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return *x
+}
+
+func TestJoinURLs(t *testing.T) {
+	tests := []struct {
+		urls []url.URL
+		want string
+	}{
+		{
+			urls: []url.URL{},
+			want: "",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+			},
+			want: "default=http://example.com/#x",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+				parseURL("http://example.com/#y"),
+			},
+			want: "default=http://example.com/#x,default=http://example.com/#y",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+				parseURL("http://example.com/#y"),
+				parseURL("http://example.com/#z"),
+			},
+			want: "default=http://example.com/#x,default=http://example.com/#y,default=http://example.com/#z",
+		},
+	}
+	for i, tt := range tests {
+		if got := joinURLs(tt.urls); got != tt.want {
+			t.Errorf("#%d want: %s, got: %s", i, tt.want, got)
+		}
+	}
+}

--- a/tools/etcd-dump-metrics/etcd.go
+++ b/tools/etcd-dump-metrics/etcd.go
@@ -53,11 +53,15 @@ func setupEmbedCfg(cfg *embed.Config, curls, purls, ics []url.URL) {
 	cfg.ListenClientUrls, cfg.AdvertiseClientUrls = curls, curls
 	cfg.ListenPeerUrls, cfg.AdvertisePeerUrls = purls, purls
 
-	cfg.InitialCluster = ""
-	for i := range ics {
-		cfg.InitialCluster += fmt.Sprintf(",%d=%s", i, ics[i].String())
+	cfg.InitialCluster = joinURLs(ics)
+}
+
+func joinURLs(ics []url.URL) string {
+	initialCluster := make([]string, len(ics))
+	for i, ic := range ics {
+		initialCluster[i] = fmt.Sprintf("%d=%s", i, ic.String())
 	}
-	cfg.InitialCluster = cfg.InitialCluster[1:]
+	return strings.Join(initialCluster, ",")
 }
 
 func getCommand(exec, name, dir, cURL, pURL, cluster string) (args []string) {

--- a/tools/etcd-dump-metrics/join_urls_test.go
+++ b/tools/etcd-dump-metrics/join_urls_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/url"
+	"testing"
+)
+
+func parseURL(s string) url.URL {
+	x, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return *x
+}
+
+func TestJoinURLs(t *testing.T) {
+	tests := []struct {
+		urls []url.URL
+		want string
+	}{
+		{
+			urls: []url.URL{},
+			want: "",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+			},
+			want: "0=http://example.com/#x",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+				parseURL("http://example.com/#y"),
+			},
+			want: "0=http://example.com/#x,1=http://example.com/#y",
+		},
+		{
+			urls: []url.URL{
+				parseURL("http://example.com/#x"),
+				parseURL("http://example.com/#y"),
+				parseURL("http://example.com/#z"),
+			},
+			want: "0=http://example.com/#x,1=http://example.com/#y,2=http://example.com/#z",
+		},
+	}
+	for i, tt := range tests {
+		if got := joinURLs(tt.urls); got != tt.want {
+			t.Errorf("#%d want: %s, got: %s", i, tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
When the slice is empty, it can panic with "index 1 out of bounds". This patch rewrites these functions to set cfg.InitialCluster more safely.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
