### PR TITLE
[release-3.4]  Setup a way to consistently manage go versions across scripts and go.mods

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,32 @@
+---
+name: Static Analysis
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: |
+          set -euo pipefail
+
+          make verify
+      - run: |
+          set -euo pipefail
+
+          make fix
+
+          DIFF=$(git status --porcelain)
+
+          if [ -n "$DIFF" ]; then
+            echo "These files were modified:"
+            echo
+            echo "$DIFF"
+            echo
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -547,3 +547,17 @@ gofail-enable: install-gofail
 .PHONY: gofail-disable
 gofail-disable: install-gofail
 	PASSES="toggle_failpoints" ./test
+
+.PHONY: verify
+verify: verify-go-versions
+
+.PHONY: verify-go-versions
+verify-go-versions:
+	./scripts/verify_go_versions.sh
+
+.PHONY: fix
+fix: sync-toolchain-directive
+
+.PHONY: sync-toolchain-directive
+sync-toolchain-directive:
+	./scripts/sync_go_toolchain_directive.sh

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.etcd.io/etcd
 
 go 1.21
 
+toolchain go1.21.10
+
 require (
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa

--- a/scripts/sync_go_toolchain_directive.sh
+++ b/scripts/sync_go_toolchain_directive.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script looks at the version present in the .go-version file and treats
+# that to be the value of the toolchain directive that go should use. It then
+# updates the toolchain directives of all go.mod files to reflect this version.
+#
+# We do this to ensure that .go-version acts as the source of truth for go versions.
+
+set -euo pipefail
+
+ROOT_MODULE="go.etcd.io/etcd"
+
+if [[ "$(go list)" != "${ROOT_MODULE}" ]]; then
+  echo "must be run from '${ROOT_MODULE}' module directory"
+  exit 255
+fi
+
+ETCD_ROOT_DIR=$(go list -f '{{.Dir}}' "${ROOT_MODULE}")
+
+TARGET_GO_VERSION="${TARGET_GO_VERSION:-"$(cat "${ETCD_ROOT_DIR}/.go-version")"}"
+find . -name 'go.mod' -exec go mod edit -toolchain=go"${TARGET_GO_VERSION}" {} \;

--- a/scripts/verify_go_versions.sh
+++ b/scripts/verify_go_versions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# This script verifies that the value of the toolchain directive in the
+# go.mod files always match that of the .go-version file to ensure that
+# we accidentally don't test and release with differing versions of Go.
+
+set -euo pipefail
+
+ROOT_MODULE="go.etcd.io/etcd"
+
+if [[ "$(go list)" != "${ROOT_MODULE}" ]]; then
+  echo "must be run from '${ROOT_MODULE}' module directory"
+  exit 255
+fi
+
+ETCD_ROOT_DIR=$(go list -f '{{.Dir}}' "${ROOT_MODULE}")
+
+target_go_version="${target_go_version:-"$(cat "${ETCD_ROOT_DIR}/.go-version")"}"
+echo "expected go toolchain directive: go${target_go_version}"
+echo
+
+toolchain_out_of_sync="false"
+go_line_violation="false"
+
+# verify_go_versions takes a go.mod filepath as an argument
+# and checks if:
+#  (1) go directive <= version in .go-version
+#  (2) toolchain directive == version in .go-version
+function verify_go_versions() {
+    # shellcheck disable=SC2086
+    toolchain_version="$(go mod edit -json $1 | jq -r .Toolchain)"
+    # shellcheck disable=SC2086
+    go_line_version="$(go mod edit -json $1 | jq -r .Go)"
+    if [[ "go${target_go_version}" != "${toolchain_version}" ]]; then
+        echo "FAIL: go toolchain directive out of sync for $1, got: ${toolchain_version}"
+        toolchain_out_of_sync="true"
+    fi
+    if ! printf '%s\n' "${go_line_version}" "${target_go_version}" | sort --check=silent --version-sort; then
+        echo "FAIL: go directive in $1 is greater than maximum allowed: go${target_go_version}"
+        go_line_violation="true"
+    fi
+}
+
+while read -r mod; do
+    verify_go_versions "${mod}";
+done < <(find . -name 'go.mod')
+
+if [[ "${toolchain_out_of_sync}" == "true" ]]; then
+    echo
+    echo "FAIL: Please run scripts/sync_go_toolchain_directive.sh or update .go-version to rectify this error"
+fi
+
+if [[ "${go_line_violation}" == "true" ]]; then
+    echo
+    echo "FAIL: Please update .go-version to rectify this error, any go directive should be <= .go-version"
+fi
+
+if [[ "${go_line_violation}" == "true" ]] || [[ "${toolchain_out_of_sync}" == "true" ]]; then
+    exit 1
+fi

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -2,6 +2,8 @@ module go.etcd.io/etcd/tools/v3
 
 go 1.21
 
+toolchain go1.21.10
+
 require (
 	github.com/gogo/protobuf v1.3.2
 	go.etcd.io/gofail v0.1.0


### PR DESCRIPTION
Replicating https://github.com/etcd-io/etcd/pull/17876 

This commit adds a script to sync the version present in .go-version across all go.mod files as the toolchain directive. As part of that, this commit also modifies go.mod files that did not have synced toolchain directives.

Additionally, this also adds a script to verify all toolchain and go directives against the version present in .go-version as follows: (1) The go directive <= version in .go-version
(2) The toolchain directive == version in .go-version

This script runs as part of the `make verify` target, making it run as a presbumit by default.

/assign @ahrtr 