### PR TITLE
changelog:  add 3.4 and 3.5 note about go 1.21.10

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -10,6 +10,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [Memberlist results not updated when proxy node down](https://github.com/etcd-io/etcd/pull/17896).
 
 ### Dependencies
+- Compile binaries using go [1.21.10](https://github.com/etcd-io/etcd/pull/17981).
 - Upgrade [bbolt to 1.3.10](https://github.com/etcd-io/etcd/pull/17945).
 
 <hr>

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -22,7 +22,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [initialization for mu in client context](https://github.com/etcd-io/etcd/pull/17699).
 
 ### Dependencies
-- Compile binaries using [go 1.21.9](https://github.com/etcd-io/etcd/pull/17708).
+- Compile binaries using [go 1.21.10](https://github.com/etcd-io/etcd/pull/17980).
 - Upgrade [bbolt to v1.3.10](https://github.com/etcd-io/etcd/pull/17943).
 
 <hr>


### PR DESCRIPTION
Updates 3.4 and 3.5 CHANGELOGs to add a line that the binaries are compiled with go version 1.21.10
Related to #17964 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
