### PR TITLE
Add build subtargets based on ARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,18 @@ include tests/robustness/makefile.mk
 build:
 	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v -mod=readonly" ./scripts/build.sh
 
+PLATFORMS=linux-amd64 linux-386 linux-arm linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64 windows-amd64 windows-arm64
+
+.PHONY: build-all
+build-all:
+	@for platform in $(PLATFORMS); do \
+		$(MAKE) build-$${platform}; \
+	done
+
+.PHONY: build-%
+build-%:
+	GOOS=$$(echo $* | cut -d- -f 1) GOARCH=$$(echo $* | cut -d- -f 2) GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v -mod=readonly" ./scripts/build.sh
+
 .PHONY: tools
 tools:
 	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v -mod=readonly" ./scripts/build_tools.sh


### PR DESCRIPTION
This PR will group similar targets as per architecture into subtargets to build. It also adds a `build-all` target to build all OS-ARCH combinations.

Conversation: https://github.com/kubernetes/test-infra/pull/32672#discussion_r1616735510
Fixes: https://github.com/kubernetes/test-infra/pull/32672

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
