### PR TITLE
Update release date for v3.5.14

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 <hr>
 
-## v3.5.14 (TBD)
+## v3.5.15 (TBD)
+
+<hr>
+
+## v3.5.14 (2024-05-29)
 
 ### etcd server
 - Fix [LeaseTimeToLive returns error if leader changed](https://github.com/etcd-io/etcd/pull/17704).


### PR DESCRIPTION
Part of #18013. Set the v3.5.14 release date to today.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow