### PR TITLE
Use Go 1.20 error joining instead of multierr

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
@@ -1140,7 +1139,7 @@ func (cfg *Config) GetDNSClusterNames() ([]string, error) {
 		zap.Error(httpCerr),
 	)
 
-	return clusterStrs, multierr.Combine(cerr, httpCerr)
+	return clusterStrs, errors.Join(cerr, httpCerr)
 }
 
 func (cfg *Config) InitialClusterFromName(name string) (ret string) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -36,7 +36,6 @@ require (
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
 	go.opentelemetry.io/otel/sdk v1.27.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.25.0
@@ -66,6 +65,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.27.0 // indirect
 	go.opentelemetry.io/otel/trace v1.27.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect


### PR DESCRIPTION
This still allows the errors to be unwrapped, and drops the direct dependency on multierr.