### PR TITLE
reproduce write latency

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -83,7 +83,7 @@ func NewReport(precision string) Report { return newReport(precision) }
 
 func newReport(precision string) *report {
 	r := &report{
-		results:   make(chan Result, 16),
+		results:   make(chan Result, 65536),
 		precision: precision,
 	}
 	r.stats.ErrorDist = make(map[string]int)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Related to https://github.com/etcd-io/etcd/issues/18109

Please run 

```
GOWORK=off make build
GOWORK=off make tools

rm -rf default.etcd

# start etcd with 10GB quota
bin/etcd --quota-backend-bytes=10737418240
```

In another terminal run

```
bin/tools/benchmark watch-latency --streams 1 --watchers-per-stream 1 --prevkv=true --put-total=10000 --put-rate=400 --key-size=256 --val-size=262144
```

Result I got with multiple runs

```
Put summary:

Summary:
  Total:	20.6745 secs.
  Slowest:	1.4204 secs.
  Fastest:	0.0564 secs.
  Average:	0.7613 secs.
  Stddev:	0.2624 secs.
  Requests/sec:	502.9860

Response time histogram:
  0.0564 [1]	|
  0.1928 [333]	|∎∎
  0.3292 [402]	|∎∎∎
  0.4656 [1016]	|∎∎∎∎∎∎∎
  0.6020 [486]	|∎∎∎
  0.7384 [791]	|∎∎∎∎∎∎
  0.8748 [5092]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  1.0112 [1142]	|∎∎∎∎∎∎∎∎
  1.1476 [291]	|∎∎
  1.2840 [568]	|∎∎∎∎
  1.4204 [277]	|∎∎

Latency distribution:
  10% in 0.3665 secs.
  25% in 0.6338 secs.
  50% in 0.8286 secs.
  75% in 0.8611 secs.
  90% in 1.0341 secs.
  95% in 1.2456 secs.
  99% in 1.4002 secs.
  99.9% in 1.4185 secs.
```


