### PR TITLE
test: update CouldSetSnapshotCatchupEntries to use 3.5.14.

### DIFF
--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -130,10 +130,10 @@ func mixVersionsSnapshotTestByMockPartition(t *testing.T, cfg *e2e.EtcdProcessCl
 		t.Skipf("%q does not exist", e2e.BinPath.EtcdLastRelease)
 	}
 
-	clusterOptions := []e2e.EPClusterOption{e2e.WithConfig(cfg), e2e.WithSnapshotCount(10)}
-	// TODO: remove version check after 3.5.14 release.
-	if cfg.Version == e2e.CurrentVersion {
-		clusterOptions = append(clusterOptions, e2e.WithSnapshotCatchUpEntries(10))
+	clusterOptions := []e2e.EPClusterOption{
+		e2e.WithConfig(cfg),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
 	}
 	t.Logf("Create an etcd cluster with %d member", cfg.ClusterSize)
 	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, clusterOptions...)
@@ -162,10 +162,8 @@ func mixVersionsSnapshotTestByMockPartition(t *testing.T, cfg *e2e.EtcdProcessCl
 	assertKVHash(t, epc)
 
 	leaderEPC = epc.Procs[epc.WaitLeader(t)]
-	if cfg.Version == e2e.CurrentVersion {
-		t.Log("Verify logs to check snapshot be sent from leader to follower")
-		e2e.AssertProcessLogs(t, leaderEPC, "sent database snapshot")
-	}
+	t.Log("Verify logs to check snapshot be sent from leader to follower")
+	e2e.AssertProcessLogs(t, leaderEPC, "sent database snapshot")
 }
 
 func writeKVs(t *testing.T, etcdctl *e2e.EtcdctlV3, startIdx, endIdx int) {

--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestEtcdServerProcessConfig(t *testing.T) {
 	v3_5_12 := semver.Version{Major: 3, Minor: 5, Patch: 12}
-	v3_5_13 := semver.Version{Major: 3, Minor: 5, Patch: 13}
+	v3_5_14 := semver.Version{Major: 3, Minor: 5, Patch: 14}
 	tcs := []struct {
 		name                 string
 		config               *EtcdProcessClusterConfig
@@ -78,7 +78,7 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			expectArgsContain: []string{
 				"--experimental-snapshot-catchup-entries=100",
 			},
-			mockBinaryVersion: &v3_5_13,
+			mockBinaryVersion: &v3_5_14,
 		},
 		{
 			name:   "CatchUpEntriesNoVersion",

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -527,6 +527,6 @@ func CouldSetSnapshotCatchupEntries(execPath string) bool {
 		return false
 	}
 	// snapshot-catchup-entries flag was backported in https://github.com/etcd-io/etcd/pull/17808
-	v3_5_13 := semver.Version{Major: 3, Minor: 5, Patch: 13}
-	return v.Compare(v3_5_13) >= 0
+	v3_5_14 := semver.Version{Major: 3, Minor: 5, Patch: 14}
+	return v.Compare(v3_5_14) >= 0
 }


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
