### PR TITLE
tests/robustness: unlock Delete/LeaseRevoke ops

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -16,6 +16,7 @@ package robustness
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 var testRunner = framework.E2eTestRunner
 
 func TestMain(m *testing.M) {
+	rand.Seed(time.Now().UnixNano())
 	testRunner.TestMain(m)
 }
 

--- a/tests/robustness/model/replay.go
+++ b/tests/robustness/model/replay.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -63,44 +64,72 @@ func (r *EtcdReplay) EventsForWatch(watch WatchRequest) (events []PersistedEvent
 }
 
 func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcdResponse) (events []PersistedEvent) {
-	if request.Type != Txn || response.Error != "" {
+	if response.Error != "" {
 		return events
 	}
-	var ops []EtcdOperation
-	if response.Txn.Failure {
-		ops = request.Txn.OperationsOnFailure
-	} else {
-		ops = request.Txn.OperationsOnSuccess
-	}
-	for _, op := range ops {
-		switch op.Type {
-		case RangeOperation:
-		case DeleteOperation:
-			e := PersistedEvent{
-				Event: Event{
-					Type: op.Type,
-					Key:  op.Delete.Key,
-				},
-				Revision: response.Revision,
-			}
-			if _, ok := prevState.KeyValues[op.Delete.Key]; ok {
+
+	switch request.Type {
+	case Txn:
+		var ops []EtcdOperation
+		if response.Txn.Failure {
+			ops = request.Txn.OperationsOnFailure
+		} else {
+			ops = request.Txn.OperationsOnSuccess
+		}
+		for _, op := range ops {
+			switch op.Type {
+			case RangeOperation:
+			case DeleteOperation:
+				e := PersistedEvent{
+					Event: Event{
+						Type: op.Type,
+						Key:  op.Delete.Key,
+					},
+					Revision: response.Revision,
+				}
+				if _, ok := prevState.KeyValues[op.Delete.Key]; ok {
+					events = append(events, e)
+				}
+			case PutOperation:
+				_, leaseExists := prevState.Leases[op.Put.LeaseID]
+				if op.Put.LeaseID != 0 && !leaseExists {
+					break
+				}
+
+				e := PersistedEvent{
+					Event: Event{
+						Type:  op.Type,
+						Key:   op.Put.Key,
+						Value: op.Put.Value,
+					},
+					Revision: response.Revision,
+				}
+				if _, ok := prevState.KeyValues[op.Put.Key]; !ok {
+					e.IsCreate = true
+				}
 				events = append(events, e)
+			default:
+				panic(fmt.Sprintf("unsupported operation type: %v", op))
 			}
-		case PutOperation:
+		}
+	case LeaseRevoke:
+		deletedKeys := []string{}
+		for key := range prevState.Leases[request.LeaseRevoke.LeaseID].Keys {
+			if _, ok := prevState.KeyValues[key]; ok {
+				deletedKeys = append(deletedKeys, key)
+			}
+		}
+
+		sort.Strings(deletedKeys)
+		for _, key := range deletedKeys {
 			e := PersistedEvent{
 				Event: Event{
-					Type:  op.Type,
-					Key:   op.Put.Key,
-					Value: op.Put.Value,
+					Type: DeleteOperation,
+					Key:  key,
 				},
 				Revision: response.Revision,
-			}
-			if _, ok := prevState.KeyValues[op.Put.Key]; !ok {
-				e.IsCreate = true
 			}
 			events = append(events, e)
-		default:
-			panic(fmt.Sprintf("unsupported operation type: %v", op))
 		}
 	}
 	return events

--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -172,7 +172,7 @@ func parseEntryNormal(ent raftpb.Entry) (*model.EtcdRequest, error) {
 	case raftReq.LeaseRevoke != nil:
 		return &model.EtcdRequest{
 			Type:        model.LeaseRevoke,
-			LeaseRevoke: &model.LeaseRevokeRequest{LeaseID: raftReq.LeaseGrant.ID},
+			LeaseRevoke: &model.LeaseRevokeRequest{LeaseID: raftReq.LeaseRevoke.ID},
 		}, nil
 	case raftReq.LeaseGrant != nil:
 		return &model.EtcdRequest{

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -192,6 +192,7 @@ func persistedOperationsReturnTime(allOperations []porcupine.Operation, persiste
 				}
 			}
 		case model.LeaseGrant:
+		case model.LeaseRevoke:
 		default:
 			panic(fmt.Sprintf("Unknown request type: %q", request.Type))
 		}
@@ -216,6 +217,7 @@ func operationReturnTime(operations []porcupine.Operation) map[model.EtcdOperati
 			}
 		case model.Range:
 		case model.LeaseGrant:
+		case model.LeaseRevoke:
 		default:
 			panic(fmt.Sprintf("Unknown request type: %q", request.Type))
 		}


### PR DESCRIPTION
We should return token to that bucket if `nonUniqueWriteLimiter.Take()` return true. After unlock Delete/LeaseRevoke ops, the model should be updated for replay function. There are two updates for `toWatchEvents`.

1. When leaveRevokes op has deleted few keys, we should generate `delete-operation` events based on alphabetical order of deleted keys.
2. When putWithLease op hits non-exist lease, we should ignore that update event.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
