### PR TITLE
bugfix: register of walWriteSec

### DIFF
--- a/server/storage/wal/metrics.go
+++ b/server/storage/wal/metrics.go
@@ -47,5 +47,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(walFsyncSec)
+	prometheus.MustRegister(walWriteSec)
 	prometheus.MustRegister(walWriteBytes)
 }


### PR DESCRIPTION
bugfix: https://github.com/etcd-io/etcd/pull/17618.

`walWriteSec` should be registered in prometheus.

/cc @Akiqqqqqqq 