### PR TITLE
Fix govulncheck CI check on release-3.4

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -16,4 +16,6 @@ jobs:
       - run: |
           set -euo pipefail
 
-          go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+
+          find -name go.mod -exec /bin/bash -c 'echo scanning $(dirname {}); govulncheck -C $(dirname {}) -show verbose ./...' \;


### PR DESCRIPTION
This commit fixed the Go Vulnerability Checker CI job, which isn't scanning for all go.mod files within the project.

Reference:
- https://github.com/etcd-io/etcd/discussions/18168


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
