### PR TITLE
Update release-3.5 changelog

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -8,7 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Dependencies
 - Compile binaries using [go 1.21.11](https://github.com/etcd-io/etcd/pull/18129).
-
+- [Fully address CVE-2023-45288 and fix govulncheck CI check](https://github.com/etcd-io/etcd/pull/18170)
 
 ## v3.5.14 (2024-05-29)
 


### PR DESCRIPTION
Fully address CVE-2023-45288 and fix govulncheck CI check

Reference: 
- https://github.com/etcd-io/etcd/pull/18170

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
