### PR TITLE
Add run-govulncheck Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,13 @@ ifeq (, $(shell which yamlfmt))
 endif
 	yamlfmt -conf tools/.yamlfmt .
 
+.PHONY: run-govulncheck
+run-govulncheck:
+ifeq (, $(shell which govulncheck))
+	$(shell go install golang.org/x/vuln/cmd/govulncheck@latest)
+endif
+	PASSES="govuln" ./scripts/test.sh
+
 # Tools
 
 GOLANGCI_LINT_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} github.com/golangci/golangci-lint)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -366,6 +366,10 @@ function markdown_marker_pass {
   fi
 }
 
+function govuln_pass {
+  run_for_modules run govulncheck -show verbose
+}
+
 function govet_pass {
   run_for_modules generic_checker run go vet
 }


### PR DESCRIPTION
Add a `Makefile` target to run govuln across the submodules. This will allow it to be imported into a prow job and remove the logic from the GitHub workflow file.

Part of #18173.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
