### PR TITLE
Experiments with replacing index implementation of `btree with key -> revisions` with `revision list of immutable trees`

### DIFF
--- a/server/storage/mvcc/index_bench_test.go
+++ b/server/storage/mvcc/index_bench_test.go
@@ -24,21 +24,21 @@ import (
 	"go.uber.org/zap"
 )
 
-func BenchmarkIndexCompactBase(b *testing.B)          { benchmarkIndexCompact(b, 3, 100) }
-func BenchmarkIndexCompactLongKey(b *testing.B)       { benchmarkIndexCompact(b, 512, 100) }
-func BenchmarkIndexCompactLargeKeySpace(b *testing.B) { benchmarkIndexCompact(b, 3, 100000) }
+//func BenchmarkIndexCompactBase(b *testing.B)          { benchmarkIndexCompact(b, 3, 100) }
+//func BenchmarkIndexCompactLongKey(b *testing.B)       { benchmarkIndexCompact(b, 512, 100) }
+//func BenchmarkIndexCompactLargeKeySpace(b *testing.B) { benchmarkIndexCompact(b, 3, 100000) }
 
-func BenchmarkIndexKeepBase(b *testing.B)          { benchmarkIndexKeep(b, 3, 100) }
-func BenchmarkIndexKeepLongKey(b *testing.B)       { benchmarkIndexKeep(b, 512, 100) }
-func BenchmarkIndexKeepLargeKeySpace(b *testing.B) { benchmarkIndexKeep(b, 3, 100000) }
+//func BenchmarkIndexKeepBase(b *testing.B)          { benchmarkIndexKeep(b, 3, 100) }
+//func BenchmarkIndexKeepLongKey(b *testing.B)       { benchmarkIndexKeep(b, 512, 100) }
+//func BenchmarkIndexKeepLargeKeySpace(b *testing.B) { benchmarkIndexKeep(b, 3, 100000) }
 
 func BenchmarkIndexPutBase(b *testing.B)          { benchmarkIndexPut(b, 3, 100) }
 func BenchmarkIndexPutLongKey(b *testing.B)       { benchmarkIndexPut(b, 512, 100) }
 func BenchmarkIndexPutLargeKeySpace(b *testing.B) { benchmarkIndexPut(b, 3, 100000) }
 
-func BenchmarkIndexTombstoneBase(b *testing.B)          { benchmarkIndexTombstone(b, 3, 100, 25) }
-func BenchmarkIndexTombstoneLongKey(b *testing.B)       { benchmarkIndexTombstone(b, 512, 100, 25) }
-func BenchmarkIndexTombstoneLargeKeySpace(b *testing.B) { benchmarkIndexTombstone(b, 3, 100000, 25) }
+//func BenchmarkIndexTombstoneBase(b *testing.B)          { benchmarkIndexTombstone(b, 3, 100, 25) }
+//func BenchmarkIndexTombstoneLongKey(b *testing.B)       { benchmarkIndexTombstone(b, 512, 100, 25) }
+//func BenchmarkIndexTombstoneLargeKeySpace(b *testing.B) { benchmarkIndexTombstone(b, 3, 100000, 25) }
 
 func BenchmarkIndexGetBase(b *testing.B)          { benchmarkIndexGet(b, 3, 100, 1, 25) }
 func BenchmarkIndexGetRepeatedKeys(b *testing.B)  { benchmarkIndexGet(b, 3, 100, 1000, 25) }

--- a/server/storage/mvcc/index_bench_test.go
+++ b/server/storage/mvcc/index_bench_test.go
@@ -15,55 +15,382 @@
 package mvcc
 
 import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
 	"testing"
 
 	"go.uber.org/zap"
 )
 
-func BenchmarkIndexCompact1(b *testing.B)       { benchmarkIndexCompact(b, 1) }
-func BenchmarkIndexCompact100(b *testing.B)     { benchmarkIndexCompact(b, 100) }
-func BenchmarkIndexCompact10000(b *testing.B)   { benchmarkIndexCompact(b, 10000) }
-func BenchmarkIndexCompact100000(b *testing.B)  { benchmarkIndexCompact(b, 100000) }
-func BenchmarkIndexCompact1000000(b *testing.B) { benchmarkIndexCompact(b, 1000000) }
+func BenchmarkIndexCompactBase(b *testing.B)          { benchmarkIndexCompact(b, 3, 100) }
+func BenchmarkIndexCompactLongKey(b *testing.B)       { benchmarkIndexCompact(b, 512, 100) }
+func BenchmarkIndexCompactLargeKeySpace(b *testing.B) { benchmarkIndexCompact(b, 3, 100000) }
 
-func benchmarkIndexCompact(b *testing.B, size int) {
+func BenchmarkIndexKeepBase(b *testing.B)          { benchmarkIndexKeep(b, 3, 100) }
+func BenchmarkIndexKeepLongKey(b *testing.B)       { benchmarkIndexKeep(b, 512, 100) }
+func BenchmarkIndexKeepLargeKeySpace(b *testing.B) { benchmarkIndexKeep(b, 3, 100000) }
+
+func BenchmarkIndexPutBase(b *testing.B)          { benchmarkIndexPut(b, 3, 100) }
+func BenchmarkIndexPutLongKey(b *testing.B)       { benchmarkIndexPut(b, 512, 100) }
+func BenchmarkIndexPutLargeKeySpace(b *testing.B) { benchmarkIndexPut(b, 3, 100000) }
+
+func BenchmarkIndexTombstoneBase(b *testing.B)          { benchmarkIndexTombstone(b, 3, 100, 25) }
+func BenchmarkIndexTombstoneLongKey(b *testing.B)       { benchmarkIndexTombstone(b, 512, 100, 25) }
+func BenchmarkIndexTombstoneLargeKeySpace(b *testing.B) { benchmarkIndexTombstone(b, 3, 100000, 25) }
+
+func BenchmarkIndexGetBase(b *testing.B)          { benchmarkIndexGet(b, 3, 100, 1, 25) }
+func BenchmarkIndexGetRepeatedKeys(b *testing.B)  { benchmarkIndexGet(b, 3, 100, 1000, 25) }
+func BenchmarkIndexGetAccurate(b *testing.B)      { benchmarkIndexGet(b, 3, 100, 1, 0) }
+func BenchmarkIndexGetMisses(b *testing.B)        { benchmarkIndexGet(b, 3, 100, 1, 1000) }
+func BenchmarkIndexGetLongKey(b *testing.B)       { benchmarkIndexGet(b, 512, 100, 1, 25) }
+func BenchmarkIndexGetLargeKeySpace(b *testing.B) { benchmarkIndexGet(b, 3, 100000, 1, 25) }
+
+func BenchmarkIndexRangeBase(b *testing.B)            { benchmarkIndexRange(b, 3, 100, 1, 0.1) }
+func BenchmarkIndexRangeHighSelectivity(b *testing.B) { benchmarkIndexRange(b, 3, 10, 1, 1) }
+func BenchmarkIndexRangeLongKey(b *testing.B)         { benchmarkIndexRange(b, 512, 100, 1, 0.1) }
+func BenchmarkIndexRangeRepeatedKeys(b *testing.B)    { benchmarkIndexRange(b, 3, 50, 1000, 0.1) }
+func BenchmarkIndexRangeLargeKeySpace(b *testing.B)   { benchmarkIndexRange(b, 3, 100000, 1, 0.00005) }
+
+func BenchmarkIndexRevisionsBase(b *testing.B)            { benchmarkIndexRevisions(b, 3, 100, 1, 0, 0.1) }
+func BenchmarkIndexRevisionsHighSelectivity(b *testing.B) { benchmarkIndexRevisions(b, 3, 10, 1, 0, 1) }
+func BenchmarkIndexRevisionsLongKey(b *testing.B)         { benchmarkIndexRevisions(b, 512, 100, 1, 0, 0.1) }
+func BenchmarkIndexRevisionsRepeatedKeys(b *testing.B) {
+	benchmarkIndexRevisions(b, 3, 50, 10000, 0, 0.1)
+}
+func BenchmarkIndexRevisionsLargeKeySpace(b *testing.B) {
+	benchmarkIndexRevisions(b, 3, 100000, 1, 0, 0.00005)
+}
+func BenchmarkIndexRevisionsLimit(b *testing.B) {
+	benchmarkIndexRevisions(b, 3, 100000, 1, 5, 0.1)
+}
+
+func BenchmarkIndexCountRevisionsBase(b *testing.B) { benchmarkIndexCountRevisions(b, 3, 100, 1, 0.1) }
+func BenchmarkIndexCountRevisionsHighSelectivity(b *testing.B) {
+	benchmarkIndexCountRevisions(b, 3, 10, 1, 1)
+}
+func BenchmarkIndexCountRevisionsLongKey(b *testing.B) {
+	benchmarkIndexCountRevisions(b, 512, 100, 1, 0.1)
+}
+func BenchmarkIndexCountRevisionsRepeatedKeys(b *testing.B) {
+	benchmarkIndexCountRevisions(b, 3, 50, 1000, 0.1)
+}
+func BenchmarkIndexCountRevisionsLargeKeySpace(b *testing.B) {
+	benchmarkIndexCountRevisions(b, 3, 100000, 1, 0.00005)
+}
+
+func benchmarkIndexCompact(b *testing.B, keyLength, keySpace int) {
 	log := zap.NewNop()
 	kvindex := newTreeIndex(log)
 
-	bytesN := 64
-	keys := createBytesSlice(bytesN, size)
-	for i := 1; i < size; i++ {
-		kvindex.Put(keys[i], Revision{Main: int64(i), Sub: int64(i)})
+	keys := createBytesSlice(keyLength, keySpace)
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 1; i < b.N; i++ {
-		kvindex.Compact(int64(i))
+	for i := 0; i < b.N; i++ {
+		kvindex.Compact(int64(i + 1))
 	}
 }
 
-func BenchmarkIndexPut(b *testing.B) {
+func benchmarkIndexKeep(b *testing.B, keyLength, keySpace int) {
 	log := zap.NewNop()
 	kvindex := newTreeIndex(log)
 
-	bytesN := 64
-	keys := createBytesSlice(bytesN, b.N)
+	keys := createBytesSlice(keyLength, keySpace)
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
+	}
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 1; i < b.N; i++ {
-		kvindex.Put(keys[i], Revision{Main: int64(i), Sub: int64(i)})
+	for i := 0; i < b.N; i++ {
+		kvindex.Keep(int64(i + 1))
 	}
 }
 
-func BenchmarkIndexGet(b *testing.B) {
+func benchmarkIndexPut(b *testing.B, keyLength, keySpace int) {
 	log := zap.NewNop()
 	kvindex := newTreeIndex(log)
 
-	bytesN := 64
-	keys := createBytesSlice(bytesN, b.N)
-	for i := 1; i < b.N; i++ {
-		kvindex.Put(keys[i], Revision{Main: int64(i), Sub: int64(i)})
-	}
+	keys := createBytesSlice(keyLength, keySpace)
+
+	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 1; i < b.N; i++ {
-		kvindex.Get(keys[i], int64(i))
+	for i := 0; i < b.N; i++ {
+		kvindex.Put(keys[i%len(keys)], Revision{Main: int64(i + 1), Sub: int64(i)})
 	}
+}
+
+func benchmarkIndexTombstone(b *testing.B, keyLength, keySpace, percentMisses int) {
+	log := zap.NewNop()
+	indexes := []index{}
+	keys := createBytesSlice(keyLength, keySpace+keySpace*percentMisses/100)
+	dups := map[string]struct{}{}
+	j := 0
+	for i := 0; i < len(keys); i++ {
+		_, dup := dups[string(keys[i])]
+		if dup {
+			continue
+		}
+		keys[j] = keys[i]
+		dups[string(keys[i])] = struct{}{}
+		j++
+	}
+	for i := 0; i < b.N/len(keys)+1; i++ {
+		index := newTreeIndex(log)
+		for j := 0; j < keySpace; j++ {
+			key := keys[j]
+			rev := int64(j + 1)
+			index.Put(key, Revision{Main: rev})
+		}
+		indexes = append(indexes, index)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	deleteCount := 0
+	for i := 0; i < b.N; i++ {
+		index := indexes[i/len(keys)]
+		key := keys[i%len(keys)]
+		rev := int64(i%len(keys) + 2)
+		err := index.Tombstone(key, Revision{Main: rev})
+		if !errors.Is(err, ErrRevisionNotFound) {
+			deleteCount += 1
+		}
+	}
+	b.ReportMetric(float64(deleteCount)/float64(b.N), "delete/op")
+}
+
+var (
+	// global vars to ensure benchmarked function are not optimized.
+	rev, created Revision
+	ver          int64
+	err          error
+)
+
+func benchmarkIndexGet(b *testing.B, keyLength, keySpace, keyRepeats, percentMisses int) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	keys := createBytesSlice(keyLength, keySpace)
+	revisions := len(keys) * keyRepeats
+	for i := 0; i < revisions; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
+	}
+	keys = append(keys, createBytesSlice(keyLength, keySpace*percentMisses/100)...)
+
+	type keyRev struct {
+		key []byte
+		rev int64
+	}
+	keyRevs := make([]keyRev, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		key := keys[rand.Intn(len(keys))]
+		rev := int64(rand.Intn(revisions) + 1)
+		keyRevs = append(keyRevs, keyRev{
+			key: key,
+			rev: rev,
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	keyCount := 0
+	for i := 0; i < b.N; i++ {
+		kr := keyRevs[i]
+		rev, created, ver, err = kvindex.Get(kr.key, kr.rev)
+		if !errors.Is(err, ErrRevisionNotFound) {
+			keyCount += 1
+		}
+	}
+	b.ReportMetric(float64(keyCount)/float64(b.N), "keys/op")
+}
+
+var (
+	// global vars to ensure benchmarked function are not optimized.
+	keys  [][]byte
+	revs  []Revision
+	total int
+)
+
+func benchmarkIndexRevisions(b *testing.B, keyLength, keySpace, keyRepeats, limit int, selectivity float64) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	keys := createBytesSlice(keyLength, keySpace)
+	revisions := len(keys) * keyRepeats
+	for i := 0; i < revisions; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
+	}
+
+	type keyRev struct {
+		key, end []byte
+		rev      int64
+	}
+	keyRevs := make([]keyRev, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		keyFloat := rand.Float64() * (1 - selectivity)
+		endFloat := keyFloat + selectivity
+		key := FloatToBytes(keyFloat, keyLength)
+		end := FloatToBytes(endFloat, keyLength)
+		rev := int64(rand.Intn(revisions) + 1)
+		keyRevs = append(keyRevs, keyRev{
+			key: key,
+			end: end,
+			rev: rev,
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	revCount := 0
+	totalCount := 0
+	for i := 0; i < b.N; i++ {
+		kr := keyRevs[i]
+		revs, total = kvindex.Revisions(kr.key, kr.end, kr.rev, limit)
+		revCount += len(revs)
+		totalCount += total
+	}
+	b.ReportMetric(float64(revCount)/float64(b.N), "revs/op")
+	b.ReportMetric(float64(totalCount)/float64(b.N), "total/op")
+}
+
+func benchmarkIndexRange(b *testing.B, keyLength, keySpace, keyRepeats int, selectivity float64) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	keys := createBytesSlice(keyLength, keySpace)
+	revisions := len(keys) * keyRepeats
+	for i := 0; i < revisions; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
+	}
+
+	type keyRev struct {
+		key, end []byte
+		rev      int64
+	}
+	keyRevs := make([]keyRev, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		keyFloat := rand.Float64() * (1 - selectivity)
+		endFloat := keyFloat + selectivity
+		key := FloatToBytes(keyFloat, keyLength)
+		end := FloatToBytes(endFloat, keyLength)
+		rev := int64(rand.Intn(revisions) + 1)
+		keyRevs = append(keyRevs, keyRev{
+			key: key,
+			end: end,
+			rev: rev,
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	keyCount := 0
+	for i := 0; i < b.N; i++ {
+		kr := keyRevs[i]
+		keys, revs = kvindex.Range(kr.key, kr.end, kr.rev)
+		keyCount += len(keys)
+	}
+	b.ReportMetric(float64(keyCount)/float64(b.N), "keys/op")
+}
+
+func benchmarkIndexCountRevisions(b *testing.B, keyLength, keySpace, keyRepeats int, selectivity float64) {
+	log := zap.NewNop()
+	kvindex := newTreeIndex(log)
+
+	keys := createBytesSlice(keyLength, keySpace)
+	revisions := len(keys) * keyRepeats
+	for i := 0; i < revisions; i++ {
+		key := keys[i%len(keys)]
+		kvindex.Put(key, Revision{Main: int64(i + 1), Sub: int64(i)})
+	}
+
+	type keyRev struct {
+		key, end []byte
+		rev      int64
+	}
+	keyRevs := make([]keyRev, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		keyFloat := rand.Float64() * (1 - selectivity)
+		endFloat := keyFloat + selectivity
+		key := FloatToBytes(keyFloat, keyLength)
+		end := FloatToBytes(endFloat, keyLength)
+		rev := int64(rand.Intn(revisions) + 1)
+		keyRevs = append(keyRevs, keyRev{
+			key: key,
+			end: end,
+			rev: rev,
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	totalCount := 0
+	for i := 0; i < b.N; i++ {
+		kr := keyRevs[i]
+		totalCount += kvindex.CountRevisions(kr.key, kr.end, kr.rev)
+	}
+	b.ReportMetric(float64(totalCount)/float64(b.N), "total/op")
+}
+
+func TestBytesToFloat(t *testing.T) {
+	assert.InDelta(t, 0.0, bytesToFloat([]byte("\x00")), 0.01)
+	assert.InDelta(t, 0.25, bytesToFloat([]byte("\x40")), 0.0000001)
+	assert.InDelta(t, 0.25, bytesToFloat([]byte("\x40\x00")), 0.0000001)
+	assert.InDelta(t, 0.5, bytesToFloat([]byte("\x7f")), 0.01)
+	assert.InDelta(t, 0.5, bytesToFloat([]byte("\x7f\xff")), 0.0001)
+	assert.InDelta(t, 0.5, bytesToFloat([]byte("\x7f\xff\xff")), 0.0000001)
+	assert.InDelta(t, 0.75, bytesToFloat([]byte("\xc0")), 0.0000001)
+	assert.InDelta(t, 0.75, bytesToFloat([]byte("\xc0\x00")), 0.0000001)
+	assert.InDelta(t, 1.0, bytesToFloat([]byte("\xff")), 0.01)
+	assert.InDelta(t, 1.0, bytesToFloat([]byte("\xff\xff")), 0.0001)
+	assert.InDelta(t, 1.0, bytesToFloat([]byte("\xff\xff\xff")), 0.00001)
+}
+
+func bytesToFloat(bytes []byte) float64 {
+	if len(bytes) == 0 {
+		panic("empty bytes")
+	}
+	var result float64
+	var factor = 1.0
+	for _, b := range bytes {
+		factor /= 256
+		result += float64(b) * factor
+	}
+	return result
+}
+
+func TestFloatToBytes(t *testing.T) {
+	assert.Equal(t, []byte("\x00"), FloatToBytes(0, 1))
+	assert.Equal(t, []byte("\x3f"), FloatToBytes(0.25, 1))
+	assert.Equal(t, []byte("\x3f\xff"), FloatToBytes(0.25, 2))
+	assert.Equal(t, []byte("\x7f"), FloatToBytes(0.5, 1))
+	assert.Equal(t, []byte("\x7f\xff"), FloatToBytes(0.5, 2))
+	assert.Equal(t, []byte("\x7f\xff\xff"), FloatToBytes(0.5, 3))
+	assert.Equal(t, []byte("\xbf"), FloatToBytes(0.75, 1))
+	assert.Equal(t, []byte("\xbf\xff"), FloatToBytes(0.75, 2))
+	assert.Equal(t, []byte("\xff"), FloatToBytes(1.0, 1))
+	assert.Equal(t, []byte("\xff\xff"), FloatToBytes(1.0, 2))
+	assert.Equal(t, []byte("\xff\xff\xff"), FloatToBytes(1.0, 3))
+}
+func FloatToBytes(f float64, length int) []byte {
+	if f < 0 || f > 1 {
+		panic(fmt.Sprintf("expected float between (0, 1), got: %f", f))
+	}
+	result := make([]byte, length)
+	result[0] = uint8(f * 255)
+	if length > 1 {
+		f -= float64(result[0]) / 256
+		f *= 256
+		result[1] = uint8(f * 255)
+	}
+	if length > 2 {
+		f -= float64(result[1]) / 256
+		f *= 256
+		result[2] = uint8(f * 255)
+	}
+	return result
 }

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -19,15 +19,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
 func TestIndexGet(t *testing.T) {
 	ti := newTreeIndex(zaptest.NewLogger(t))
 	ti.Put([]byte("foo"), Revision{Main: 2})
-	ti.Put([]byte("foo"), Revision{Main: 4})
-	ti.Tombstone([]byte("foo"), Revision{Main: 6})
+	ti.Put([]byte("foo"), Revision{Main: 3})
+	ti.Tombstone([]byte("foo"), Revision{Main: 4})
 
 	tests := []struct {
 		rev int64
@@ -40,10 +39,8 @@ func TestIndexGet(t *testing.T) {
 		{0, Revision{}, Revision{}, 0, ErrRevisionNotFound},
 		{1, Revision{}, Revision{}, 0, ErrRevisionNotFound},
 		{2, Revision{Main: 2}, Revision{Main: 2}, 1, nil},
-		{3, Revision{Main: 2}, Revision{Main: 2}, 1, nil},
-		{4, Revision{Main: 4}, Revision{Main: 2}, 2, nil},
-		{5, Revision{Main: 4}, Revision{Main: 2}, 2, nil},
-		{6, Revision{}, Revision{}, 0, ErrRevisionNotFound},
+		{3, Revision{Main: 3}, Revision{Main: 2}, 2, nil},
+		{4, Revision{}, Revision{}, 0, ErrRevisionNotFound},
 	}
 	for i, tt := range tests {
 		rev, created, ver, err := ti.Get([]byte("foo"), tt.rev)
@@ -64,14 +61,14 @@ func TestIndexGet(t *testing.T) {
 
 func TestIndexRange(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2")}
-	allRevs := []Revision{{Main: 1}, {Main: 2}, {Main: 3}}
+	allRevs := []Revision{{Main: 2}, {Main: 3}, {Main: 4}}
 
 	ti := newTreeIndex(zaptest.NewLogger(t))
 	for i := range allKeys {
 		ti.Put(allKeys[i], allRevs[i])
 	}
 
-	atRev := int64(3)
+	atRev := int64(4)
 	tests := []struct {
 		key, end []byte
 		wkeys    [][]byte
@@ -113,7 +110,7 @@ func TestIndexRange(t *testing.T) {
 	for i, tt := range tests {
 		keys, revs := ti.Range(tt.key, tt.end, atRev)
 		if !reflect.DeepEqual(keys, tt.wkeys) {
-			t.Errorf("#%d: keys = %+v, want %+v", i, keys, tt.wkeys)
+			t.Errorf("#%d: keys = %s, want %s", i, keys, tt.wkeys)
 		}
 		if !reflect.DeepEqual(revs, tt.wrevs) {
 			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
@@ -123,19 +120,19 @@ func TestIndexRange(t *testing.T) {
 
 func TestIndexTombstone(t *testing.T) {
 	ti := newTreeIndex(zaptest.NewLogger(t))
-	ti.Put([]byte("foo"), Revision{Main: 1})
+	ti.Put([]byte("foo"), Revision{Main: 2})
 
-	err := ti.Tombstone([]byte("foo"), Revision{Main: 2})
+	err := ti.Tombstone([]byte("foo"), Revision{Main: 3})
 	if err != nil {
 		t.Errorf("tombstone error = %v, want nil", err)
 	}
 
-	_, _, _, err = ti.Get([]byte("foo"), 2)
-	if !errors.Is(err, ErrRevisionNotFound) {
+	_, _, _, err = ti.Get([]byte("foo"), 3)
+	if err != ErrRevisionNotFound {
 		t.Errorf("get error = %v, want ErrRevisionNotFound", err)
 	}
-	err = ti.Tombstone([]byte("foo"), Revision{Main: 3})
-	if !errors.Is(err, ErrRevisionNotFound) {
+	err = ti.Tombstone([]byte("foo"), Revision{Main: 4})
+	if err != ErrRevisionNotFound {
 		t.Errorf("tombstone error = %v, want %v", err, ErrRevisionNotFound)
 	}
 }
@@ -234,447 +231,447 @@ func TestIndexRevision(t *testing.T) {
 	}
 }
 
-func TestIndexCompactAndKeep(t *testing.T) {
-	maxRev := int64(20)
-
-	// key: "foo"
-	// modified: 10
-	// generations:
-	//	{{10, 0}}
-	//	{{1, 0}, {5, 0}, {9, 0}(t)}
-	//
-	// key: "foo1"
-	// modified: 10, 1
-	// generations:
-	//	{{10, 1}}
-	//	{{2, 0}, {6, 0}, {7, 0}(t)}
-	//
-	// key: "foo2"
-	// modified: 8
-	// generations:
-	//	{empty}
-	//	{{3, 0}, {4, 0}, {8, 0}(t)}
-	//
-	buildTreeIndex := func() index {
-		ti := newTreeIndex(zaptest.NewLogger(t))
-
-		ti.Put([]byte("foo"), Revision{Main: 1})
-		ti.Put([]byte("foo1"), Revision{Main: 2})
-		ti.Put([]byte("foo2"), Revision{Main: 3})
-		ti.Put([]byte("foo2"), Revision{Main: 4})
-		ti.Put([]byte("foo"), Revision{Main: 5})
-		ti.Put([]byte("foo1"), Revision{Main: 6})
-		require.NoError(t, ti.Tombstone([]byte("foo1"), Revision{Main: 7}))
-		require.NoError(t, ti.Tombstone([]byte("foo2"), Revision{Main: 8}))
-		require.NoError(t, ti.Tombstone([]byte("foo"), Revision{Main: 9}))
-		ti.Put([]byte("foo"), Revision{Main: 10})
-		ti.Put([]byte("foo1"), Revision{Main: 10, Sub: 1})
-		return ti
-	}
-
-	afterCompacts := []struct {
-		atRev      int
-		keyIndexes []keyIndex
-		keep       map[Revision]struct{}
-		compacted  map[Revision]struct{}
-	}{
-		{
-			atRev: 1,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 1}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 1}: {},
-			},
-		},
-		{
-			atRev: 2,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-			},
-		},
-		{
-			atRev: 3,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-				{Main: 3}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-				{Main: 3}: {},
-			},
-		},
-		{
-			atRev: 4,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-				{Main: 4}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 1}: {},
-				{Main: 2}: {},
-				{Main: 4}: {},
-			},
-		},
-		{
-			atRev: 5,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 2}: {},
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 2}: {},
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-		},
-		{
-			atRev: 6,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 6}, {Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 6}: {},
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 6}: {},
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-		},
-		{
-			atRev: 7,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 7}: {},
-				{Main: 4}: {},
-				{Main: 5}: {},
-			},
-		},
-		{
-			atRev: 8,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-				{
-					key:      []byte("foo2"),
-					modified: Revision{Main: 8},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 8}}},
-						{},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 5}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 8}: {},
-				{Main: 5}: {},
-			},
-		},
-		{
-			atRev: 9,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{},
-			compacted: map[Revision]struct{}{
-				{Main: 9}: {},
-			},
-		},
-		{
-			atRev: 10,
-			keyIndexes: []keyIndex{
-				{
-					key:      []byte("foo"),
-					modified: Revision{Main: 10},
-					generations: []generation{
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
-					},
-				},
-				{
-					key:      []byte("foo1"),
-					modified: Revision{Main: 10, Sub: 1},
-					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
-					},
-				},
-			},
-			keep: map[Revision]struct{}{
-				{Main: 10}:         {},
-				{Main: 10, Sub: 1}: {},
-			},
-			compacted: map[Revision]struct{}{
-				{Main: 10}:         {},
-				{Main: 10, Sub: 1}: {},
-			},
-		},
-	}
-
-	ti := buildTreeIndex()
-	// Continuous Compact and Keep
-	for i := int64(1); i < maxRev; i++ {
-		j := i - 1
-		if i >= int64(len(afterCompacts)) {
-			j = int64(len(afterCompacts)) - 1
-		}
-
-		am := ti.Compact(i)
-		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
-
-		keep := ti.Keep(i)
-		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
-
-		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
-		for k := range afterCompacts[j].keyIndexes {
-			ki := afterCompacts[j].keyIndexes[k]
-			nti.tree.ReplaceOrInsert(&ki)
-		}
-		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
-	}
-
-	// Once Compact and Keep
-	for i := int64(1); i < maxRev; i++ {
-		ti := buildTreeIndex()
-
-		j := i - 1
-		if i >= int64(len(afterCompacts)) {
-			j = int64(len(afterCompacts)) - 1
-		}
-
-		am := ti.Compact(i)
-		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
-
-		keep := ti.Keep(i)
-		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
-
-		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
-		for k := range afterCompacts[j].keyIndexes {
-			ki := afterCompacts[j].keyIndexes[k]
-			nti.tree.ReplaceOrInsert(&ki)
-		}
-
-		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
-	}
-}
+//func TestIndexCompactAndKeep(t *testing.T) {
+//	maxRev := int64(20)
+//
+//	// key: "foo"
+//	// modified: 10
+//	// generations:
+//	//	{{10, 0}}
+//	//	{{1, 0}, {5, 0}, {9, 0}(t)}
+//	//
+//	// key: "foo1"
+//	// modified: 10, 1
+//	// generations:
+//	//	{{10, 1}}
+//	//	{{2, 0}, {6, 0}, {7, 0}(t)}
+//	//
+//	// key: "foo2"
+//	// modified: 8
+//	// generations:
+//	//	{empty}
+//	//	{{3, 0}, {4, 0}, {8, 0}(t)}
+//	//
+//	buildTreeIndex := func() index {
+//		ti := newTreeIndex(zaptest.NewLogger(t))
+//
+//		ti.Put([]byte("foo"), Revision{Main: 1})
+//		ti.Put([]byte("foo1"), Revision{Main: 2})
+//		ti.Put([]byte("foo2"), Revision{Main: 3})
+//		ti.Put([]byte("foo2"), Revision{Main: 4})
+//		ti.Put([]byte("foo"), Revision{Main: 5})
+//		ti.Put([]byte("foo1"), Revision{Main: 6})
+//		require.NoError(t, ti.Tombstone([]byte("foo1"), Revision{Main: 7}))
+//		require.NoError(t, ti.Tombstone([]byte("foo2"), Revision{Main: 8}))
+//		require.NoError(t, ti.Tombstone([]byte("foo"), Revision{Main: 9}))
+//		ti.Put([]byte("foo"), Revision{Main: 10})
+//		ti.Put([]byte("foo1"), Revision{Main: 10, Sub: 1})
+//		return ti
+//	}
+//
+//	afterCompacts := []struct {
+//		atRev      int
+//		keyIndexes []keyIndex
+//		keep       map[Revision]struct{}
+//		compacted  map[Revision]struct{}
+//	}{
+//		{
+//			atRev: 1,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 1}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 1}: {},
+//			},
+//		},
+//		{
+//			atRev: 2,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//			},
+//		},
+//		{
+//			atRev: 3,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//				{Main: 3}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//				{Main: 3}: {},
+//			},
+//		},
+//		{
+//			atRev: 4,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//				{Main: 4}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 1}: {},
+//				{Main: 2}: {},
+//				{Main: 4}: {},
+//			},
+//		},
+//		{
+//			atRev: 5,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 2}: {},
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 2}: {},
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//		},
+//		{
+//			atRev: 6,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 6}, {Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 6}: {},
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 6}: {},
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//		},
+//		{
+//			atRev: 7,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 7}}},
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 7}: {},
+//				{Main: 4}: {},
+//				{Main: 5}: {},
+//			},
+//		},
+//		{
+//			atRev: 8,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo2"),
+//					modified: Revision{Main: 8},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 8}}},
+//						{},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 5}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 8}: {},
+//				{Main: 5}: {},
+//			},
+//		},
+//		{
+//			atRev: 9,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 9}}},
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{},
+//			compacted: map[Revision]struct{}{
+//				{Main: 9}: {},
+//			},
+//		},
+//		{
+//			atRev: 10,
+//			keyIndexes: []keyIndex{
+//				{
+//					key:      []byte("foo"),
+//					modified: Revision{Main: 10},
+//					generations: []generation{
+//						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
+//					},
+//				},
+//				{
+//					key:      []byte("foo1"),
+//					modified: Revision{Main: 10, Sub: 1},
+//					generations: []generation{
+//						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
+//					},
+//				},
+//			},
+//			keep: map[Revision]struct{}{
+//				{Main: 10}:         {},
+//				{Main: 10, Sub: 1}: {},
+//			},
+//			compacted: map[Revision]struct{}{
+//				{Main: 10}:         {},
+//				{Main: 10, Sub: 1}: {},
+//			},
+//		},
+//	}
+//
+//	ti := buildTreeIndex()
+//	// Continuous Compact and Keep
+//	for i := int64(1); i < maxRev; i++ {
+//		j := i - 1
+//		if i >= int64(len(afterCompacts)) {
+//			j = int64(len(afterCompacts)) - 1
+//		}
+//
+//		am := ti.Compact(i)
+//		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
+//
+//		keep := ti.Keep(i)
+//		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
+//
+//		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
+//		for k := range afterCompacts[j].keyIndexes {
+//			ki := afterCompacts[j].keyIndexes[k]
+//			nti.tree.ReplaceOrInsert(&ki)
+//		}
+//		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
+//	}
+//
+//	// Once Compact and Keep
+//	for i := int64(1); i < maxRev; i++ {
+//		ti := buildTreeIndex()
+//
+//		j := i - 1
+//		if i >= int64(len(afterCompacts)) {
+//			j = int64(len(afterCompacts)) - 1
+//		}
+//
+//		am := ti.Compact(i)
+//		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
+//
+//		keep := ti.Keep(i)
+//		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
+//
+//		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
+//		for k := range afterCompacts[j].keyIndexes {
+//			ki := afterCompacts[j].keyIndexes[k]
+//			nti.tree.ReplaceOrInsert(&ki)
+//		}
+//
+//		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
+//	}
+//}


### PR DESCRIPTION
Recently talked with Marcel from Cillium about his recent issue with etcd being overloaded with LIST with limit. Even with low limit, the list will range all the keys to count the total number of keys (not a great feature).

My idea was to improve performance of getting key count within range by using interval trees. For now I didn't managed to implement it as I have already started seeing issues finding a good implementation of immutable tree. For now I tried with AVL trees.

The results:
```
name                                   old time/op    new time/op    delta
IndexPutBase-12                          81.7ns ± 2%   674.5ns ± 6%   +725.35%  (p=0.000 n=10+10)
IndexPutLongKey-12                       82.4ns ± 1%   708.7ns ± 3%   +760.02%  (p=0.000 n=10+10)
IndexPutLargeKeySpace-12                  309ns ± 1%    1931ns ± 1%   +525.73%  (p=0.000 n=10+8)
IndexGetBase-12                          96.6ns ± 2%    57.7ns ± 3%    -40.24%  (p=0.000 n=10+10)
IndexGetRepeatedKeys-12                   700ns ±10%     383ns ± 3%    -45.24%  (p=0.000 n=10+10)
IndexGetAccurate-12                      98.2ns ± 5%    57.2ns ± 3%    -41.74%  (p=0.000 n=10+10)
IndexGetMisses-12                        94.3ns ± 3%    60.0ns ± 3%    -36.39%  (p=0.000 n=10+10)
IndexGetLongKey-12                        107ns ± 1%      67ns ± 2%    -37.77%  (p=0.000 n=8+9)
IndexGetLargeKeySpace-12                  347ns ± 1%    1135ns ± 2%   +226.70%  (p=0.000 n=10+10)
IndexRangeBase-12                         405ns ± 4%     512ns ± 2%    +26.67%  (p=0.000 n=10+8)
IndexRangeHighSelectivity-12              354ns ± 1%     452ns ± 2%    +27.61%  (p=0.000 n=10+10)
IndexRangeLongKey-12                      655ns ± 4%     616ns ± 5%     -6.00%  (p=0.001 n=10+10)
IndexRangeRepeatedKeys-12                3.94µs ± 7%    0.80µs ± 6%    -79.56%  (p=0.000 n=9+10)
IndexRangeLargeKeySpace-12                872ns ± 1%    2072ns ± 1%   +137.70%  (p=0.000 n=10+10)
IndexRevisionsBase-12                     296ns ± 3%     391ns ± 2%    +31.90%  (p=0.000 n=10+10)
IndexRevisionsHighSelectivity-12          241ns ± 1%     327ns ± 1%    +35.55%  (p=0.000 n=10+10)
IndexRevisionsLongKey-12                  496ns ± 7%     453ns ± 5%     -8.64%  (p=0.000 n=10+10)
IndexRevisionsRepeatedKeys-12            35.4µs ±18%     1.3µs ± 5%    -96.38%  (p=0.000 n=10+10)
IndexRevisionsLargeKeySpace-12            702ns ± 1%    1901ns ± 1%   +170.71%  (p=0.000 n=10+10)
IndexRevisionsLimit-12                    244µs ± 3%     253µs ± 2%     +3.75%  (p=0.000 n=10+10)
IndexCountRevisionsBase-12                219ns ± 3%     323ns ± 4%    +47.27%  (p=0.000 n=10+10)
IndexCountRevisionsHighSelectivity-12     168ns ± 5%     252ns ± 5%    +49.64%  (p=0.000 n=10+10)
IndexCountRevisionsLongKey-12             379ns ± 1%     358ns ± 6%     -5.32%  (p=0.002 n=8+10)
IndexCountRevisionsRepeatedKeys-12       3.97µs ±14%    0.46µs ± 7%    -88.41%  (p=0.000 n=10+10)
IndexCountRevisionsLargeKeySpace-12       601ns ± 1%    1804ns ± 3%   +199.98%  (p=0.000 n=10+10)
```

Pros:
* Writers don't block readers thanks to CopyOnWrite data structure
* Much better performance when there are small number of keys reused as we don't lookup in list of revisions.
* Trivial compaction thank to revision list

Cons:
* Additional allocations for Puts make them really slow (should improve with btree)
* Lower performance with large number of keys (should improve with btree)
* No ready implementation of btree and interval tree
* Not sure if tombstones can be properly implemented.

The main blocker for this approach is reducing the cost of Puts and improving the 

Even if the idea doesn't stick I expect we can keep the benchmarks.