### PR TITLE
fix(server): enforce listen-metrics-urls client TLS info when its scheme is https/unixs

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -822,7 +822,7 @@ func (e *Etcd) pickGRPCGatewayServeContext(splitHTTP bool) *serveCtx {
 	panic("Expect at least one context able to serve grpc")
 }
 
-var errMissingClientTLSInfoForMetricsURL = errors.New("client TLS key/cert (--cert-file, --key-file) must be provided for metrics url")
+var ErrMissingClientTLSInfoForMetricsURL = errors.New("client TLS key/cert (--cert-file, --key-file) must be provided for metrics url")
 
 func (e *Etcd) createMetricsListener(murl url.URL) (net.Listener, error) {
 	tlsInfo := &e.cfg.ClientTLSInfo
@@ -831,7 +831,7 @@ func (e *Etcd) createMetricsListener(murl url.URL) (net.Listener, error) {
 		tlsInfo = nil
 	case "https", "unixs":
 		if e.cfg.ClientTLSInfo.Empty() {
-			return nil, errMissingClientTLSInfoForMetricsURL
+			return nil, ErrMissingClientTLSInfoForMetricsURL
 		}
 	}
 	return transport.NewListenerWithOpts(murl.Host, murl.Scheme,

--- a/server/embed/etcd_test.go
+++ b/server/embed/etcd_test.go
@@ -1,0 +1,24 @@
+package embed
+
+import (
+	"net/url"
+	"testing"
+
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+)
+
+func TestEmptyClientTLSInfo_createMetricsListener(t *testing.T) {
+	e := &Etcd{
+		cfg: Config{
+			ClientTLSInfo: transport.TLSInfo{},
+		},
+	}
+
+	murl := url.URL{
+		Scheme: "https",
+		Host:   "localhost:8080",
+	}
+	if _, err := e.createMetricsListener(murl); err != errMissingClientTLSInfoForMetricsURL {
+		t.Fatalf("expected error %v, got %v", errMissingClientTLSInfoForMetricsURL, err)
+	}
+}

--- a/server/embed/etcd_test.go
+++ b/server/embed/etcd_test.go
@@ -18,7 +18,7 @@ func TestEmptyClientTLSInfo_createMetricsListener(t *testing.T) {
 		Scheme: "https",
 		Host:   "localhost:8080",
 	}
-	if _, err := e.createMetricsListener(murl); err != errMissingClientTLSInfoForMetricsURL {
-		t.Fatalf("expected error %v, got %v", errMissingClientTLSInfoForMetricsURL, err)
+	if _, err := e.createMetricsListener(murl); err != ErrMissingClientTLSInfoForMetricsURL {
+		t.Fatalf("expected error %v, got %v", ErrMissingClientTLSInfoForMetricsURL, err)
 	}
 }

--- a/server/embed/etcd_test.go
+++ b/server/embed/etcd_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package embed
 
 import (

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -238,7 +238,7 @@ Profiling and Monitoring:
   --metrics 'basic'
     Set level of detail for exported metrics, specify 'extensive' to include server side grpc histogram metrics.
   --listen-metrics-urls ''
-    List of URLs to listen on for the metrics and health endpoints.
+    List of URLs to listen on for the /metrics and /health endpoints. For https, the client URL TLS info is used.
 
 Logging:
   --logger 'zap'

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"go.etcd.io/etcd/pkg/v3/expect"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -116,6 +117,60 @@ func TestEtcdUnixPeers(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = proc.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestEtcdListenMetricsURLsWithMissingClientTLSInfo checks that the HTTPs listen metrics URL
+// but without the client TLS info will fail its verification.
+func TestEtcdListenMetricsURLsWithMissingClientTLSInfo(t *testing.T) {
+	e2e.SkipInShortMode(t)
+
+	tempDir := t.TempDir()
+	defer os.RemoveAll(tempDir)
+
+	caFile, certFiles, keyFiles, err := generateCertsForIPs(tempDir, []net.IP{net.ParseIP("127.0.0.1")})
+	require.NoError(t, err)
+
+	// non HTTP but metrics URL is HTTPS, invalid when the client TLS info is not provided
+	clientURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort)
+	peerURL := fmt.Sprintf("https://localhost:%d", e2e.EtcdProcessBasePort+1)
+	listenMetricsURL := fmt.Sprintf("https://localhost:%d", e2e.EtcdProcessBasePort+2)
+
+	commonArgs := []string{
+		e2e.BinPath.Etcd,
+		"--name", "e0",
+		"--data-dir", tempDir,
+
+		"--listen-client-urls", clientURL,
+		"--advertise-client-urls", clientURL,
+
+		"--initial-advertise-peer-urls", peerURL,
+		"--listen-peer-urls", peerURL,
+
+		"--initial-cluster", "e0=" + peerURL,
+
+		"--listen-metrics-urls", listenMetricsURL,
+
+		"--peer-cert-file", certFiles[0],
+		"--peer-key-file", keyFiles[0],
+		"--peer-trusted-ca-file", caFile,
+		"--peer-client-cert-auth",
+	}
+
+	proc, err := e2e.SpawnCmd(commonArgs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := proc.Stop(); err != nil {
+			t.Error(err)
+		}
+		proc.Wait() // ensure the port has been released
+		_ = proc.Close()
+	}()
+
+	if err := e2e.WaitReadyExpectProc(context.TODO(), proc, []string{embed.ErrMissingClientTLSInfoForMetricsURL.Error()}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -166,7 +166,6 @@ func TestEtcdListenMetricsURLsWithMissingClientTLSInfo(t *testing.T) {
 		if err := proc.Stop(); err != nil {
 			t.Error(err)
 		}
-		proc.Wait() // ensure the port has been released
 		_ = proc.Close()
 	}()
 


### PR DESCRIPTION
Otherwise, it will fail with

> cannot listen on TLS for 127.0.0.1:8080: KeyFile and CertFile are not presented

We should instead explicitly fail fast, with a clear error message.

Also, adding some documentation how to configure TLS for metrics URLs.

c.f., https://github.com/etcd-io/etcd/issues/8060