### PR TITLE
tests/robustness: fix access of ChoiceWeight

### DIFF
--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -74,9 +74,9 @@ type etcdTraffic struct {
 }
 
 func (t etcdTraffic) WithoutCompact() Traffic {
-	requests := make([]choiceWeight[etcdRequestType], 0, len(t.requests))
+	requests := make([]random.ChoiceWeight[etcdRequestType], 0, len(t.requests))
 	for _, request := range t.requests {
-		if request.choice != Compact {
+		if request.Choice != Compact {
 			requests = append(requests, request)
 		}
 	}

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -54,9 +54,9 @@ type kubernetesTraffic struct {
 }
 
 func (t kubernetesTraffic) WithoutCompact() Traffic {
-	wcs := make([]choiceWeight[KubernetesRequestType], 0, len(t.writeChoices))
+	wcs := make([]random.ChoiceWeight[KubernetesRequestType], 0, len(t.writeChoices))
 	for _, wc := range t.writeChoices {
-		if wc.choice != KubernetesCompact {
+		if wc.Choice != KubernetesCompact {
 			wcs = append(wcs, wc)
 		}
 	}


### PR DESCRIPTION
Not sure what went wrong here...
The CI for https://github.com/etcd-io/etcd/pull/18181 should have failed or marked a conflict?

Notices failures first in: https://github.com/etcd-io/etcd/pull/18201 

/assign @serathius 