### PR TITLE
Update the error message when client certificate isn't provided for secure metrics url

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -822,7 +822,7 @@ func (e *Etcd) pickGRPCGatewayServeContext(splitHTTP bool) *serveCtx {
 	panic("Expect at least one context able to serve grpc")
 }
 
-var ErrMissingClientTLSInfoForMetricsURL = errors.New("client TLS key/cert (--cert-file, --key-file) must be provided for metrics url")
+var ErrMissingClientTLSInfoForMetricsURL = errors.New("client TLS key/cert (--cert-file, --key-file) must be provided for metrics secure url")
 
 func (e *Etcd) createMetricsListener(murl url.URL) (net.Listener, error) {
 	tlsInfo := &e.cfg.ClientTLSInfo


### PR DESCRIPTION
Follow up https://github.com/etcd-io/etcd/pull/18186#discussion_r1644423850


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
