### PR TITLE
Separate persisted responses without knowing their revision to prevent duplicating state during linearization

### DIFF
--- a/tests/robustness/model/describe.go
+++ b/tests/robustness/model/describe.go
@@ -28,8 +28,11 @@ func describeEtcdResponse(request EtcdRequest, response MaybeEtcdResponse) strin
 	if response.ClientError != "" {
 		return fmt.Sprintf("err: %q", response.ClientError)
 	}
-	if response.PartialResponse {
-		return fmt.Sprintf("unknown, rev: %d", response.Revision)
+	if response.Persisted {
+		if response.PersistedRevision != 0 {
+			return fmt.Sprintf("unknown, rev: %d", response.PersistedRevision)
+		}
+		return fmt.Sprintf("unknown")
 	}
 	switch request.Type {
 	case Range:

--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -365,7 +365,7 @@ func failedResponse(err error) MaybeEtcdResponse {
 }
 
 func partialResponse(revision int64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{PartialResponse: true, EtcdResponse: EtcdResponse{Revision: revision}}
+	return MaybeEtcdResponse{Persisted: true, PersistedRevision: revision}
 }
 
 func putRequest(key, value string) EtcdRequest {

--- a/tests/robustness/model/non_deterministic_test.go
+++ b/tests/robustness/model/non_deterministic_test.go
@@ -391,7 +391,7 @@ func TestModelResponseMatch(t *testing.T) {
 		},
 		{
 			resp1:       getResponse("key", "a", 1, 1),
-			resp2:       partialResponse(0),
+			resp2:       partialResponse(2),
 			expectMatch: false,
 		},
 		{
@@ -416,8 +416,13 @@ func TestModelResponseMatch(t *testing.T) {
 		},
 		{
 			resp1:       putResponse(3),
-			resp2:       partialResponse(0),
+			resp2:       partialResponse(1),
 			expectMatch: false,
+		},
+		{
+			resp1:       putResponse(3),
+			resp2:       partialResponse(0),
+			expectMatch: true,
 		},
 		{
 			resp1:       deleteResponse(1, 5),
@@ -446,13 +451,18 @@ func TestModelResponseMatch(t *testing.T) {
 		},
 		{
 			resp1:       deleteResponse(0, 5),
-			resp2:       partialResponse(0),
+			resp2:       partialResponse(4),
 			expectMatch: false,
+		},
+		{
+			resp1:       deleteResponse(0, 5),
+			resp2:       partialResponse(0),
+			expectMatch: true,
 		},
 		{
 			resp1:       deleteResponse(1, 5),
 			resp2:       partialResponse(0),
-			expectMatch: false,
+			expectMatch: true,
 		},
 		{
 			resp1:       deleteResponse(0, 5),
@@ -491,12 +501,72 @@ func TestModelResponseMatch(t *testing.T) {
 		},
 		{
 			resp1:       compareRevisionAndPutResponse(true, 7),
-			resp2:       partialResponse(0),
+			resp2:       partialResponse(4),
+			expectMatch: false,
+		},
+		{
+			resp1:       compareRevisionAndPutResponse(false, 7),
+			resp2:       partialResponse(3),
 			expectMatch: false,
 		},
 		{
 			resp1:       compareRevisionAndPutResponse(false, 7),
 			resp2:       partialResponse(0),
+			expectMatch: true,
+		},
+		{
+			resp1:       MaybeEtcdResponse{EtcdResponse: EtcdResponse{Revision: 1, Txn: &TxnResponse{Failure: false, Results: []EtcdOperationResult{{Deleted: 1}}}}},
+			resp2:       failedResponse(errors.New("failed request")),
+			expectMatch: false,
+		},
+		{
+			resp1:       failedResponse(errors.New("failed request 1")),
+			resp2:       failedResponse(errors.New("failed request 2")),
+			expectMatch: false,
+		},
+		{
+			resp1:       failedResponse(errors.New("failed request")),
+			resp2:       failedResponse(errors.New("failed request")),
+			expectMatch: true,
+		},
+		{
+			resp1:       putResponse(2),
+			resp2:       MaybeEtcdResponse{Persisted: true},
+			expectMatch: true,
+		},
+		{
+			resp1:       putResponse(2),
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
+			expectMatch: true,
+		},
+		{
+			resp1:       putResponse(2),
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 3},
+			expectMatch: false,
+		},
+		{
+			resp1:       failedResponse(errors.New("failed request")),
+			resp2:       MaybeEtcdResponse{Persisted: true},
+			expectMatch: true,
+		},
+		{
+			resp1:       failedResponse(errors.New("failed request")),
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
+			expectMatch: true,
+		},
+		{
+			resp1:       MaybeEtcdResponse{Persisted: true},
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
+			expectMatch: true,
+		},
+		{
+			resp1:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
+			expectMatch: true,
+		},
+		{
+			resp1:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 1},
+			resp2:       MaybeEtcdResponse{Persisted: true, PersistedRevision: 2},
 			expectMatch: false,
 		},
 	}

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -83,7 +83,7 @@ func filterSerializableOperations(clients []report.ClientReport) []porcupine.Ope
 }
 
 func validateSerializableRead(lg *zap.Logger, replay *model.EtcdReplay, request model.EtcdRequest, response model.MaybeEtcdResponse) error {
-	if response.PartialResponse || response.Error != "" {
+	if response.Persisted || response.Error != "" {
 		return nil
 	}
 	state, err := replay.StateForRevision(request.Range.Revision)

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -67,7 +67,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000000, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 1000000000, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key2", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 3, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true}},
 				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -95,7 +95,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 			watchOperations: watchPutEvent("key", "value", 2, 3),
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 3, Output: model.MaybeEtcdResponse{PartialResponse: true, EtcdResponse: model.EtcdResponse{Revision: 2}}},
+				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true, PersistedRevision: 2}},
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequestWithLease("key", "value", 123),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000000, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 1000000000, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequestWithLease("key2", "value", 234),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 3, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true}},
 				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -212,7 +212,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000000, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 1000000000, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -267,7 +267,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000000, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 1000000000, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{


### PR DESCRIPTION
/cc @siyuanfoundation @MadhavJivrajani @fuweid @fykaa @henrybear327