### PR TITLE
[3.4] installed revive on CI and added doc.go to fix revive linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ clean:
 	rm -f ./clientv3/integration/127.0.0.1:* ./clientv3/integration/localhost:*
 	rm -f ./clientv3/ordering/127.0.0.1:* ./clientv3/ordering/localhost:*
 	rm -rf ./bin/shellcheck*
+	rm -rf ./bin/revive*
 
 docker-clean:
 	docker images

--- a/clientv3/internal/endpoint/doc.go
+++ b/clientv3/internal/endpoint/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package endpoint provides utilities for interpreting and handling etcd
+// server endpoints with credential requirements.
+package endpoint

--- a/clientv3/internal/resolver/doc.go
+++ b/clientv3/internal/resolver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package resolver provides a manual resolver for etcd endpoints using gRPC.
+package resolver

--- a/clientv3/naming/endpoints/doc.go
+++ b/clientv3/naming/endpoints/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package endpoints provides utilities for managing and watching etcd endpoints,
+// including functions to add, remove, and list endpoints stored in etcd.
+package endpoints

--- a/clientv3/naming/endpoints/internal/doc.go
+++ b/clientv3/naming/endpoints/internal/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package internal defines operations and structures for endpoint updates
+// in etcd's storage system.
+package internal

--- a/clientv3/naming/resolver/doc.go
+++ b/clientv3/naming/resolver/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package resolver provides a gRPC resolver for discovering etcd endpoints.
+package resolver

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -242,7 +242,7 @@ func isCompatibleWithCluster(lg *zap.Logger, cl *membership.RaftCluster, local t
 		Minor: maxV.Minor,
 	}
 	if nextClusterVersionCompatible {
-		maxV.Minor += 1
+		maxV.Minor++
 	}
 	return isCompatibleWithVers(lg, vers, local, minV, maxV)
 }

--- a/etcdserver/etcdserverpb/doc.go
+++ b/etcdserver/etcdserverpb/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package etcdserverpb provides protocol buffer types and utilities for etcd
+// server operations, including custom stringers for redacting sensitive
+// information in requests.
+package etcdserverpb

--- a/functional/rpcpb/doc.go
+++ b/functional/rpcpb/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package rpcpb provides gRPC-based utilities and functions for interacting
+// with etcd members.
+package rpcpb

--- a/pkg/grpc_testing/doc.go
+++ b/pkg/grpc_testing/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package grpc_testing provides utilities and helper functions for testing
+// gRPC services, including a customizable StubServer for use in test cases.
+package grpc_testing

--- a/raft/confchange/doc.go
+++ b/raft/confchange/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package confchange provides utilities for managing Raft configuration changes.
+package confchange

--- a/raft/quorum/doc.go
+++ b/raft/quorum/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package quorum provides types and utilities for managing quorum-based
+// voting and indexing in Raft.
+package quorum

--- a/raft/raftpb/doc.go
+++ b/raft/raftpb/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package raftpb provides protocol buffer types for the Raft consensus algorithm.
+package raftpb

--- a/raft/tracker/doc.go
+++ b/raft/tracker/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package tracker provides utilities and data structures for tracking the
+// progress and configuration of nodes within an etcd cluster, including
+// vote tracking and configuration changes.
+package tracker

--- a/test
+++ b/test
@@ -39,6 +39,7 @@ source ./build
 
 PASSES=${PASSES:-}
 SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.10.0"}
+REVIVE_VERSION=${REVIVE_VERSION:-"v1.3.7"}
 
 # build before setting up test GOPATH
 if [[ "${PASSES}" == *"functional"* ]]; then
@@ -543,8 +544,27 @@ function staticcheck_pass {
 }
 
 function revive_pass {
-	if command -v revive >/dev/null; then
-		reviveResult=$(revive -config ./tests/revive.toml -exclude "vendor/..." ./... 2>&1 || true)
+	REVIVE=revive
+
+	if ! command -v $REVIVE >/dev/null; then
+		echo "Installing revive $REVIVE_VERSION"
+		if [ "$GOARCH" == "amd64" ]; then
+			URL="https://github.com/mgechev/revive/releases/download/${REVIVE_VERSION}/revive_linux_amd64.tar.gz"
+		elif [[ "$GOARCH" == "arm" || "$GOARCH" == "arm64" ]]; then
+			URL="https://github.com/mgechev/revive/releases/download/${REVIVE_VERSION}/revive_linux_arm64.tar.gz"
+		else
+			echo "Unsupported architecture: $GOARCH"
+			exit 255
+		fi
+
+		wget -qO- "$URL" | tar -xzv -C /tmp/ > /dev/null
+		mkdir -p ./bin
+		mv /tmp/revive ./bin/
+		REVIVE=./bin/revive
+	fi
+
+	if command -v $REVIVE >/dev/null; then
+		reviveResult=$($REVIVE -config ./tests/revive.toml -exclude "vendor/..." ./... 2>&1 || true)
 		if [ -n "${reviveResult}" ]; then
 			echo -e "revive checking failed:\\n${reviveResult}"
 			exit 255

--- a/wal/walpb/doc.go
+++ b/wal/walpb/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package verify is analyzing persistent state of etcd to find potential
-// inconsistencies.
-// In particular it covers cross-checking between different aspacts of etcd
-// storage like WAL & Backend.
-package verify
+// Package walpb provides protocol buffer definitions and utilities for
+// working with etcd's Write-Ahead Log (WAL).
+package walpb


### PR DESCRIPTION
This is meant to address the failing revive checks mentioned in this issue: https://github.com/etcd-io/etcd/issues/17472

Screenshot of Revive linter errors:
![image](https://github.com/etcd-io/etcd/assets/38776199/4bcdaba9-6edc-4c08-95dd-3ae033d8668c)

Output with code changes:
![image](https://github.com/etcd-io/etcd/assets/38776199/7d7da8c7-d31c-4052-bdbb-70a99ffc21e3)
