### PR TITLE
etcd 3.4: install shellcheck and report if not installed.

### DIFF
--- a/test
+++ b/test
@@ -397,12 +397,30 @@ function release_pass {
 }
 
 function shellcheck_pass {
+	if ! command -v shellcheck >/dev/null; then
+        echo "shellcheck: command not found. Installing ShellCheck..."
+        # Determine the platform and install shellcheck accordingly
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            if command -v apt-get >/dev/null; then
+                sudo apt-get update
+                sudo apt-get install -y shellcheck
+            else
+                echo "Unsupported Linux distribution. Please install ShellCheck manually."
+                return 1
+            fi
+		else
+            echo "Unsupported operating system. Please install ShellCheck manually."
+            return 1
+        fi
+	fi
 	if command -v shellcheck >/dev/null; then
 		shellcheckResult=$(shellcheck -fgcc build test scripts/*.sh 2>&1 || true)
 		if [ -n "${shellcheckResult}" ]; then
 			echo -e "shellcheck checking failed:\\n${shellcheckResult}"
 			exit 255
 		fi
+	else
+		echo "Skipping shellcheck..."
 	fi
 }
 


### PR DESCRIPTION
Looking into https://github.com/etcd-io/etcd/issues/17472, it appears that shellcheck is not installed. I added some code to install it, though I'm not sure if this is the correct place to do this. 

At the very least, I think we should add an else block to inform that shellcheck isn't installed:

	if command -v shellcheck >/dev/null; then
		shellcheckResult=$(shellcheck -fgcc build test scripts/*.sh 2>&1 || true)
		if [ -n "${shellcheckResult}" ]; then
			echo -e "shellcheck checking failed:\\n${shellcheckResult}"
			exit 255
		fi
	else
		echo "Skipping shellcheck..."
	fi