### PR TITLE
Bump shellcheck to latest v0.10.0 release

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -60,7 +60,7 @@ fi
 PASSES=${PASSES:-"gofmt bom dep build unit"}
 KEEP_GOING_SUITE=${KEEP_GOING_SUITE:-false}
 PKG=${PKG:-}
-SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.8.0"}
+SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.10.0"}
 
 if [ -z "${GOARCH:-}" ]; then
   GOARCH=$(go env GOARCH);


### PR DESCRIPTION
Just noticed we're using a release of `shellcheck` from 2021: https://github.com/koalaman/shellcheck/releases

This pull request bumps us to latest `0.10.0` release which came out in March 2024, looks ok:

```bash
 james  ~  D  etcd   main                                                                       last: 0m 0s  11:27:26 
 ➜ make verify-shellcheck
PASSES="shellcheck" ./scripts/test.sh
Running with --race
Starting at: Mon 24 Jun 2024 11:27:33 NZST

'shellcheck' started at Mon 24 Jun 2024 11:27:33 NZST
Tool: 'shellcheck' not found on PATH. https://github.com/koalaman/shellcheck#installing
Installing shellcheck v0.10.0
shellcheck-v0.10.0/LICENSE.txt
shellcheck-v0.10.0/README.txt
shellcheck-v0.10.0/shellcheck
% './bin/shellcheck' '-fgcc' 'scripts/build-binary.sh' 'scripts/build-docker.sh' 'scripts/build_lib.sh' 'scripts/build-release.sh' 'scripts/build.sh' 'scripts/build_tools.sh' 'scripts/codecov_upload.sh' 'scripts/fix.sh' 'scripts/fuzzing.sh' 'scripts/genproto.sh' 'scripts/install-marker.sh' 'scripts/measure-testgrid-flakiness.sh' 'scripts/release_mod.sh' 'scripts/release.sh' 'scripts/sync_go_toolchain_directive.sh' 'scripts/test_images.sh' 'scripts/test_lib.sh' 'scripts/test.sh' 'scripts/updatebom.sh' 'scripts/update_dep.sh' 'scripts/update_proto_annotations.sh' 'scripts/verify_genproto.sh' 'scripts/verify_go_versions.sh' 'scripts/verify_proto_annotations.sh'
'shellcheck' PASSED and completed at Mon 24 Jun 2024 11:27:43 NZST
SUCCESS
```

We should merge this before https://github.com/etcd-io/etcd/pull/18216#pullrequestreview-2134426526 is addressed.