### PR TITLE
etcd 3.5: Install shellcheck if not exists.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ clean:
 	rm -rf ./release
 	rm -rf ./coverage/*.err ./coverage/*.out
 	rm -rf ./tests/e2e/default.proxy
+	rm -rf ./bin/shellcheck*
 	find ./ -name "127.0.0.1:*" -o -name "localhost:*" -o -name "*.log" -o -name "agent-*" -o -name "*.coverprofile" -o -name "testname-proxy-*" | $(XARGS)
 
 docker-clean:


### PR DESCRIPTION
Backporting shellcheck installation method to 3.5 as described here: https://github.com/etcd-io/etcd/pull/18216#pullrequestreview-2134426526

Related issue: https://github.com/etcd-io/etcd/issues/17472