### PR TITLE
etcdctl: add support for filtering by {min,max} x {create,mod} x {revision}

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -125,6 +125,14 @@ RPC: Range
 
 - keys-only -- Get only the keys
 
+- max-create-revision -- restrict results to kvs with create revision lower or equal than the supplied revision
+
+- min-create-revision -- restrict results to kvs with create revision greater or equal than the supplied revision
+
+- max-mod-revision -- restrict results to kvs with modified revision lower or equal than the supplied revision
+
+- min-mod-revision -- restrict results to kvs with modified revision greater or equal than the supplied revision
+
 #### Output
 Prints the data in format below,
 ```


### PR DESCRIPTION
etcdctl is missing options to modify get opts for WithMinCreateRev, WithMaxCreateRev, WithMinModRev, WithMaxModRev.
