### PR TITLE
etcdserver: separate "raft log compact" from snapshot

### DIFF
--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -141,7 +141,7 @@ func newRaftNode(cfg raftNodeConfig) *raftNode {
 		// expect to send a heartbeat within 2 heartbeat intervals.
 		td:              contention.NewTimeoutDetector(2 * cfg.heartbeat),
 		readStateC:      make(chan raft.ReadState, 1),
-		snapshotTracker: SnapshotTracker{},
+		snapshotTracker: *newSnapshotTracker(),
 		msgSnapC:        make(chan raftpb.Message, maxInFlightMsgSnap),
 		applyc:          make(chan toApply),
 		stopped:         make(chan struct{}),

--- a/server/etcdserver/snapshot_tracker.go
+++ b/server/etcdserver/snapshot_tracker.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package etcdserver
 
 import (

--- a/server/etcdserver/snapshot_tracker.go
+++ b/server/etcdserver/snapshot_tracker.go
@@ -1,0 +1,74 @@
+package etcdserver
+
+import (
+	"cmp"
+	"container/heap"
+	"errors"
+	"sync"
+)
+
+// SnapshotTracker keeps track of all ongoing snapshot creation. To safeguard ongoing snapshot creation,
+// only compact the raft log up to the minimum snapshot index in the track.
+type SnapshotTracker struct {
+	h  minHeap[uint64]
+	mu sync.Mutex
+}
+
+// MinSnapi returns the minimum snapshot index in the track or an error if the tracker is empty.
+func (st *SnapshotTracker) MinSnapi() (uint64, error) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.h.Len() == 0 {
+		return 0, errors.New("SnapshotTracker is empty")
+	}
+	return st.h[0], nil
+}
+
+// Track adds a snapi to the tracker. Make sure to call UnTrack once the snapshot has been created.
+func (st *SnapshotTracker) Track(snapi uint64) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	heap.Push(&st.h, snapi)
+}
+
+// UnTrack removes 'snapi' from the tracker. No action taken if 'snapi' is not found.
+func (st *SnapshotTracker) UnTrack(snapi uint64) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	for i := 0; i < len((*st).h); i++ {
+		if (*st).h[i] == snapi {
+			heap.Remove(&st.h, i)
+			return
+		}
+	}
+}
+
+// minHeap implements the heap.Interface for E.
+type minHeap[E interface {
+	cmp.Ordered
+}] []E
+
+func (h minHeap[_]) Len() int {
+	return len(h)
+}
+
+func (h minHeap[_]) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+func (h minHeap[_]) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *minHeap[E]) Push(x any) {
+	*h = append(*h, x.(E))
+}
+
+func (h *minHeap[E]) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/server/etcdserver/snapshot_tracker.go
+++ b/server/etcdserver/snapshot_tracker.go
@@ -11,7 +11,14 @@ import (
 // only compact the raft log up to the minimum snapshot index in the track.
 type SnapshotTracker struct {
 	h  minHeap[uint64]
-	mu sync.Mutex
+	mu *sync.Mutex
+}
+
+func newSnapshotTracker() *SnapshotTracker {
+	return &SnapshotTracker{
+		h:  minHeap[uint64]{},
+		mu: new(sync.Mutex),
+	}
 }
 
 // MinSnapi returns the minimum snapshot index in the track or an error if the tracker is empty.

--- a/server/etcdserver/snapshot_tracker_test.go
+++ b/server/etcdserver/snapshot_tracker_test.go
@@ -2,8 +2,9 @@ package etcdserver
 
 import (
 	"container/heap"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSnapTracker_MinSnapi(t *testing.T) {
@@ -65,6 +66,7 @@ func TestSnapTracker_UnTrack(t *testing.T) {
 
 	st.UnTrack(20)
 	minSnapi, err = st.MinSnapi()
+	assert.Nil(t, err)
 	assert.Equal(t, uint64(40), minSnapi)
 
 	st.UnTrack(40)

--- a/server/etcdserver/snapshot_tracker_test.go
+++ b/server/etcdserver/snapshot_tracker_test.go
@@ -1,0 +1,122 @@
+package etcdserver
+
+import (
+	"container/heap"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSnapTracker_MinSnapi(t *testing.T) {
+	st := SnapshotTracker{}
+
+	_, err := st.MinSnapi()
+	assert.NotNil(t, err, "SnapshotTracker should be empty initially")
+
+	st.Track(10)
+	minSnapi, err := st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(10), minSnapi, "MinSnapi should return the only tracked snapshot index")
+
+	st.Track(5)
+	minSnapi, err = st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(5), minSnapi, "MinSnapi should return the minimum tracked snapshot index")
+
+	st.UnTrack(5)
+	minSnapi, err = st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(10), minSnapi, "MinSnapi should return the remaining tracked snapshot index")
+}
+
+func TestSnapTracker_Track(t *testing.T) {
+	st := SnapshotTracker{}
+	st.Track(20)
+	st.Track(10)
+	st.Track(15)
+
+	assert.Equal(t, 3, st.h.Len(), "SnapshotTracker should have 3 snapshots tracked")
+
+	minSnapi, err := st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(10), minSnapi, "MinSnapi should return the minimum tracked snapshot index")
+}
+
+func TestSnapTracker_UnTrack(t *testing.T) {
+	st := SnapshotTracker{}
+	st.Track(20)
+	st.Track(30)
+	st.Track(40)
+	// track another snapshot with the same index
+	st.Track(20)
+
+	st.UnTrack(30)
+	assert.Equal(t, 3, st.h.Len())
+
+	minSnapi, err := st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(20), minSnapi)
+
+	st.UnTrack(20)
+	assert.Equal(t, 2, st.h.Len())
+
+	minSnapi, err = st.MinSnapi()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(20), minSnapi)
+
+	st.UnTrack(20)
+	minSnapi, err = st.MinSnapi()
+	assert.Equal(t, uint64(40), minSnapi)
+
+	st.UnTrack(40)
+	_, err = st.MinSnapi()
+	assert.NotNil(t, err)
+}
+
+func newMinHeap(elements ...uint64) minHeap[uint64] {
+	h := minHeap[uint64](elements)
+	heap.Init(&h)
+	return h
+}
+
+func TestMinHeapLen(t *testing.T) {
+	h := newMinHeap(3, 2, 1)
+	assert.Equal(t, 3, h.Len())
+}
+
+func TestMinHeapLess(t *testing.T) {
+	h := newMinHeap(3, 2, 1)
+	assert.True(t, h.Less(0, 1))
+}
+
+func TestMinHeapSwap(t *testing.T) {
+	h := newMinHeap(3, 2, 1)
+	h.Swap(0, 1)
+	assert.Equal(t, uint64(2), h[0])
+	assert.Equal(t, uint64(1), h[1])
+	assert.Equal(t, uint64(3), h[2])
+}
+
+func TestMinHeapPushPop(t *testing.T) {
+	h := newMinHeap(3, 2)
+	heap.Push(&h, uint64(1))
+	assert.Equal(t, 3, h.Len())
+
+	got := heap.Pop(&h).(uint64)
+	assert.Equal(t, uint64(1), got)
+}
+
+func TestMinHeapEmpty(t *testing.T) {
+	h := minHeap[uint64]{}
+	assert.Equal(t, 0, h.Len())
+}
+
+func TestMinHeapSingleElement(t *testing.T) {
+	h := newMinHeap(uint64(1))
+	assert.Equal(t, 1, h.Len())
+
+	heap.Push(&h, uint64(2))
+	assert.Equal(t, 2, h.Len())
+
+	got := heap.Pop(&h)
+	assert.Equal(t, uint64(1), got)
+}

--- a/server/etcdserver/snapshot_tracker_test.go
+++ b/server/etcdserver/snapshot_tracker_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package etcdserver
 
 import (

--- a/server/etcdserver/snapshot_tracker_test.go
+++ b/server/etcdserver/snapshot_tracker_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSnapTracker_MinSnapi(t *testing.T) {
-	st := SnapshotTracker{}
+	st := *newSnapshotTracker()
 
 	_, err := st.MinSnapi()
 	assert.NotNil(t, err, "SnapshotTracker should be empty initially")
@@ -30,7 +30,7 @@ func TestSnapTracker_MinSnapi(t *testing.T) {
 }
 
 func TestSnapTracker_Track(t *testing.T) {
-	st := SnapshotTracker{}
+	st := *newSnapshotTracker()
 	st.Track(20)
 	st.Track(10)
 	st.Track(15)
@@ -43,7 +43,7 @@ func TestSnapTracker_Track(t *testing.T) {
 }
 
 func TestSnapTracker_UnTrack(t *testing.T) {
-	st := SnapshotTracker{}
+	st := *newSnapshotTracker()
 	st.Track(20)
 	st.Track(30)
 	st.Track(40)


### PR DESCRIPTION
I'm looking into https://github.com/etcd-io/etcd/issues/17098 @serathius and made changes to separate the compact logic from the snapshot logic. 

I ran `rw-benchmark.sh` several times to observe performance changes. I expected this patch to slow down etcd, but it seems to have improved rw-benchmark.sh results. I’m not sure how. Similar results were observed on both cloud VMs (8vCPU, 16GB Memory, NVMe) and a bare-metal machine (8CPU, 32GB Memory, SSD).

Since the `rw-benchmark.sh` script was taking forever to finish, I adjusted the parameters to complete the benchmark within a few hours. 

Below are the script and the results from running it on a Vultr bare-metal machine (8 CPUs, 32GB Memory, SSD, Ubuntu 24.04  LTS  x64).

```
export RATIO_LIST="4/1"
export REPEAT_COUNT=3
export RUN_COUNT=50000
./rw-benchmark.sh
```

![compare](https://github.com/etcd-io/etcd/assets/27894831/7c7043c0-95f8-4d84-bbb1-4b1fc44d14f4)
[main.csv](https://github.com/user-attachments/files/15982965/main.csv)
[issue-17098-patch.csv](https://github.com/user-attachments/files/15982967/issue-17098-patch.csv)


