### PR TITLE
increase/commit auth revision when auth enable

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -286,9 +286,8 @@ func (as *authStore) AuthEnable() error {
 	as.enabled = true
 	as.tokenProvider.enable()
 
+	as.commitRevision(tx)
 	as.refreshRangePermCache(tx)
-
-	as.setRevision(tx.UnsafeReadAuthRevision())
 
 	as.lg.Info("enabled authentication")
 	return nil


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Since all the auth store update function should update auth revision, i.e., calling `commitRevision`. 
`AuthEnable` has already called `commitRevision`, `AuthDisable` also should call `commitRevision`. 
