### PR TITLE
Suppress noisy basic auth token deletion log

### DIFF
--- a/server/auth/simple_token.go
+++ b/server/auth/simple_token.go
@@ -168,7 +168,7 @@ func (t *tokenSimple) enable() {
 
 	delf := func(tk string) {
 		if username, ok := t.simpleTokens[tk]; ok {
-			t.lg.Info(
+			t.lg.Debug(
 				"deleted a simple token",
 				zap.String("user-name", username),
 				zap.String("token", tk),


### PR DESCRIPTION
Right now the basic auth tokens that are deleted after `--auth-token-ttl` cause info-level logs to be emitted. Change this to debug. This helps with the issue at #18244 where calling `/readyz` frequently pollutes the etcd server logs with this log message.

Fixes #18244.
