### PR TITLE
changelog/3.4: set 3.4.33 release date

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
-## v3.4.33 (TBD)
+## v3.4.34 (TBD)
+
+<hr>
+
+## v3.4.33 (2024-06-13)
 
 ### etcd grpc-proxy
 - Fix [Memberlist results not updated when proxy node down](https://github.com/etcd-io/etcd/pull/17896).


### PR DESCRIPTION
The 3.4.33 release date was not set after the tag was pushed. Set it to 2024-06-13.

Part of #18014.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
