### PR TITLE
[3.4] Install shellcheck if it is not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 	rm -f ./integration/127.0.0.1:* ./integration/localhost:*
 	rm -f ./clientv3/integration/127.0.0.1:* ./clientv3/integration/localhost:*
 	rm -f ./clientv3/ordering/127.0.0.1:* ./clientv3/ordering/localhost:*
+	rm -rf ./bin/shellcheck*
 
 docker-clean:
 	docker images

--- a/scripts/install-marker.sh
+++ b/scripts/install-marker.sh
@@ -10,7 +10,7 @@ if [ -z "$1" ]; then
 fi
 
 MARKER_URL=https://storage.googleapis.com/etcd/test-binaries/marker-v0.4.0-x86_64-unknown-linux-gnu
-if [ ${ARCH} == "darwin" ]; then
+if [ "${ARCH}" == "darwin" ]; then
     MARKER_URL=https://storage.googleapis.com/etcd/test-binaries/marker-v0.4.0-x86_64-apple-darwin
 fi
 

--- a/test
+++ b/test
@@ -167,7 +167,7 @@ function unit_pass {
 	else
 		USERTIMEOUT="${TIMEOUT}"
 	fi
-	go test ${GO_TEST_FLAG} -timeout "${USERTIMEOUT}"  "${COVER}" ${RACE} -cpu "${TEST_CPUS}" ${RUN_ARG} "$@" "${TEST[@]}"
+	go test "${GO_TEST_FLAG}" -timeout "${USERTIMEOUT}"  "${COVER}" "${RACE}" -cpu "${TEST_CPUS}" "${RUN_ARG}" "$@" "${TEST[@]}"
 }
 
 function integration_pass {
@@ -204,12 +204,12 @@ function integration_pass {
 }
 
 function integration_extra {
-	go test -timeout 1m -v ${RACE} -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/client/integration"
-	go test -timeout 25m -v ${RACE} -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/clientv3/integration/..."
+	go test -timeout 1m -v "${RACE}" -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/client/integration"
+	go test -timeout 25m -v "${RACE}" -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/clientv3/integration/..."
 	go test -timeout 1m -v -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/contrib/raftexample"
-	go test -timeout 5m -v ${RACE} -tags v2v3 "$@" "${REPO_PATH}/etcdserver/api/v2store"
-	go test -timeout 5m -v ${RACE} -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/proxy/grpcproxy"
-	go test -timeout 1m -v ${RACE} -cpu "${TEST_CPUS}" -run=Example "$@" "${TEST[@]}"
+	go test -timeout 5m -v "${RACE}" -tags v2v3 "$@" "${REPO_PATH}/etcdserver/api/v2store"
+	go test -timeout 5m -v "${RACE}" -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/proxy/grpcproxy"
+	go test -timeout 1m -v "${RACE}" -cpu "${TEST_CPUS}" -run=Example "$@" "${TEST[@]}"
 }
 
 function functional_pass {
@@ -343,7 +343,7 @@ function e2e_pass {
 		USERTIMEOUT="${TIMEOUT}"
 	fi
 
-	go test -timeout "${USERTIMEOUT}" -v -cpu "${TEST_CPUS}" ${RUN_ARG}  "$@" "${REPO_PATH}/tests/e2e"
+	go test -timeout "${USERTIMEOUT}" -v -cpu "${TEST_CPUS}" "${RUN_ARG}"  "$@" "${REPO_PATH}/tests/e2e"
 }
 
 function integration_e2e_pass {
@@ -359,8 +359,8 @@ function integration_e2e_pass {
 }
 
 function grpcproxy_pass {
-	go test -timeout 30m -v ${RACE} -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/integration"
-	go test -timeout 30m -v ${RACE} -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/clientv3/integration"
+	go test -timeout 30m -v "${RACE}" -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/integration"
+	go test -timeout 30m -v "${RACE}" -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/clientv3/integration"
 	go test -timeout 30m -v -tags cluster_proxy "$@" "${REPO_PATH}/tests/e2e"
 }
 

--- a/test
+++ b/test
@@ -38,6 +38,7 @@ export ETCD_VERIFY=all
 source ./build
 
 PASSES=${PASSES:-}
+SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.10.0"}
 
 # build before setting up test GOPATH
 if [[ "${PASSES}" == *"functional"* ]]; then
@@ -397,12 +398,33 @@ function release_pass {
 }
 
 function shellcheck_pass {
-	if command -v shellcheck >/dev/null; then
-		shellcheckResult=$(shellcheck -fgcc build test scripts/*.sh 2>&1 || true)
+	SHELLCHECK=shellcheck
+
+	if ! command -v $SHELLCHECK >/dev/null; then
+		echo "Installing shellcheck $SHELLCHECK_VERSION"
+		if [ "$GOARCH" == "amd64" ]; then
+			URL="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+		elif [[ "$GOARCH" == "arm" || "$GOARCH" == "arm64" ]]; then
+			URL="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.aarch64.tar.xz"
+		else
+			echo "Unsupported architecture: $GOARCH"
+			exit 255
+		fi
+
+		wget -qO- "$URL" | tar -xJv -C /tmp/ --strip-components=1
+		mkdir -p ./bin
+		mv /tmp/shellcheck ./bin/
+		SHELLCHECK=./bin/shellcheck
+	fi
+
+	if command -v $SHELLCHECK >/dev/null; then
+		shellcheckResult=$(${SHELLCHECK} -fgcc build test scripts/*.sh 2>&1 || true)
 		if [ -n "${shellcheckResult}" ]; then
 			echo -e "shellcheck checking failed:\\n${shellcheckResult}"
 			exit 255
 		fi
+	else
+		echo "Skipping shellcheck..."
 	fi
 }
 


### PR DESCRIPTION
Backporting shellcheck installation method to 3.4 as described here: https://github.com/etcd-io/etcd/pull/18216#pullrequestreview-2134426526

This is based on commit 4f23883 and pull request etcd-io#14872.

Related issue: https://github.com/etcd-io/etcd/issues/17472

Fixed outstanding shellcheck errors [SC2086] by adding double quotes to variables where needed.