### PR TITLE
Remove gsutil acl command for bucket permissions from release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -280,9 +280,6 @@ main() {
 
     log_callout "Pushing container manifest list to gcr.io ${RELEASE_VERSION}"
     maybe_run docker manifest push "gcr.io/etcd-development/etcd:${RELEASE_VERSION}"
-
-    log_callout "Setting permissions using gsutil..."
-    maybe_run gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
   fi
 
   ### Release validation


### PR DESCRIPTION
As outlined in https://github.com/etcd-io/etcd/issues/18013#issuecomment-2140934998 and https://github.com/etcd-io/etcd/issues/18013#issuecomment-2197759674 we have verified our `etcd-development/etcd` bucket in use for `gcr.io` is already fully public and manually verified that new objects pushed to the bucket automatically become public without needing `gsutil acl ...` command run.

This pull request will dramatically reduce output spam from this script when publishing a release which can make it frustrating to scrollback and review output.

We should merge and backport this before `v3.5.15` is released.

Fixes #18013