### PR TITLE
Reduce client concurrency for high traffic robustness tests

### DIFF
--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -45,7 +45,7 @@ var (
 	HighTrafficProfile = Profile{
 		MinimalQPS:                     200,
 		MaximalQPS:                     1000,
-		ClientCount:                    12,
+		ClientCount:                    10,
 		MaxNonUniqueRequestConcurrency: 3,
 	}
 )


### PR DESCRIPTION
The `TestRobustnessExploratoryKubernetesHighTrafficClusterOfSize1` has been flaking due to linearization validation timing out.

As per the discussion in https://github.com/etcd-io/etcd/issues/18208 this PR tries to address the linearization timeout issues observed during CI runs by reducing the number of concurrent clients from 12 to 10 in the HighTrafficProfile for robustness tests.

cc: @MadhavJivrajani @serathius @siyuanfoundation 