### PR TITLE
[3.5] github/govuln: don't swallow govulncheck errors

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -18,4 +18,4 @@ jobs:
 
           go install golang.org/x/vuln/cmd/govulncheck@latest
 
-          find -name go.mod -exec /bin/bash -c 'echo scanning $(dirname {}); govulncheck -C $(dirname {}) -show verbose ./...' \;
+          find . -name go.mod | xargs -I'{}' /bin/bash -c 'echo scanning $(dirname {}); govulncheck -C $(dirname {}) -show verbose ./...'


### PR DESCRIPTION
By running `find -exec`, an error exit code doesn't properly return the error if there's a failure in a command executed. Use `xargs` to force an exit with an error when a command fails to run.

Refer to https://github.com/ivanvc/etcd/actions/runs/9727114371/job/26846300969 for an example of a run that should have failed but didn't.
After updating the workflow to use `xargs`, this is a build with a failure: https://github.com/ivanvc/etcd/actions/runs/9727235294/job/26846574320

Fixes #18173
Related to Slack thread: https://kubernetes.slack.com/archives/C3HD8ARJ5/p1719591918822359

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
