### PR TITLE
WIP: test if watch is sequential

### DIFF
--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -316,6 +316,7 @@ func ToWatchResponse(r clientv3.WatchResponse, baseTime time.Time) model.WatchRe
 	}
 	resp.IsProgressNotify = r.IsProgressNotify()
 	resp.Revision = r.Header.Revision
+	resp.MemberId = r.Header.MemberId
 	err := r.Err()
 	if err != nil {
 		resp.Error = r.Err().Error()

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -101,6 +101,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s testSce
 		watchProgressNotifyEnabled := c.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
 		validateGotAtLeastOneProgressNotify(t, r.Client, s.watch.requestProgress || watchProgressNotifyEnabled)
 	}
+	validateWatchSequential(t, r.Client)
 	validateConfig := validate.Config{ExpectRevisionUnique: s.traffic.ExpectUniqueRevision()}
 	r.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, r.Client, persistedRequests, 5*time.Minute)
 

--- a/tests/robustness/model/watch.go
+++ b/tests/robustness/model/watch.go
@@ -26,5 +26,6 @@ type WatchResponse struct {
 	IsProgressNotify bool
 	Revision         int64
 	Time             time.Duration
+	MemberId         uint64
 	Error            string
 }


### PR DESCRIPTION
WIP:
Added member id in `WatchResponse`.
Change `validateOrdered` to check for `MemberId` for each event, as sequential should check for each process.

Fixes https://github.com/etcd-io/etcd/issues/18141