### PR TITLE
*: keep tombstone if revision == compactAtRev

### DIFF
--- a/server/storage/mvcc/key_index.go
+++ b/server/storage/mvcc/key_index.go
@@ -65,7 +65,8 @@ var (
 // compact(5):
 // generations:
 //
-//	{empty} -> key SHOULD be removed.
+//	{empty}
+//	{5.0(t)}
 //
 // compact(6):
 // generations:
@@ -202,8 +203,7 @@ func (ki *keyIndex) since(lg *zap.Logger, rev int64) []Revision {
 }
 
 // compact compacts a keyIndex by removing the versions with smaller or equal
-// revision than the given atRev except the largest one (If the largest one is
-// a tombstone, it will not be kept).
+// revision than the given atRev except the largest one.
 // If a generation becomes empty during compaction, it will be removed.
 func (ki *keyIndex) compact(lg *zap.Logger, atRev int64, available map[Revision]struct{}) {
 	if ki.isEmpty() {
@@ -221,11 +221,6 @@ func (ki *keyIndex) compact(lg *zap.Logger, atRev int64, available map[Revision]
 		if revIndex != -1 {
 			g.revs = g.revs[revIndex:]
 		}
-		// remove any tombstone
-		if len(g.revs) == 1 && genIdx != len(ki.generations)-1 {
-			delete(available, g.revs[0])
-			genIdx++
-		}
 	}
 
 	// remove the previous generations.
@@ -241,7 +236,12 @@ func (ki *keyIndex) keep(atRev int64, available map[Revision]struct{}) {
 	genIdx, revIndex := ki.doCompact(atRev, available)
 	g := &ki.generations[genIdx]
 	if !g.isEmpty() {
-		// remove any tombstone
+		// If the given `atRev` is a tombstone, we need to skip it.
+		//
+		// Note that this s different from the `compact` function which
+		// keeps tombstone in such case. We need to stay consistent with
+		// existing versions, ensuring they always generate the same hash
+		// values.
 		if revIndex == len(g.revs)-1 && genIdx != len(ki.generations)-1 {
 			delete(available, g.revs[revIndex])
 		}
@@ -262,7 +262,7 @@ func (ki *keyIndex) doCompact(atRev int64, available map[Revision]struct{}) (gen
 	genIdx, g := 0, &ki.generations[0]
 	// find first generation includes atRev or created after atRev
 	for genIdx < len(ki.generations)-1 {
-		if tomb := g.revs[len(g.revs)-1].Main; tomb > atRev {
+		if tomb := g.revs[len(g.revs)-1].Main; tomb >= atRev {
 			break
 		}
 		genIdx++

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -25,10 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -261,8 +264,7 @@ func continuouslyExecuteGetAll(ctx context.Context, t *testing.T, g *errgroup.Gr
 //   - COMPACT r5
 //   - WATCH rev=r5
 //
-// We should get the DELETE event (r5) followed by the PUT event (r6). However, currently we only
-// get the PUT event with returned revision of r6 (key=k, val=v6).
+// We should get the DELETE event (r5) followed by the PUT event (r6).
 func TestDeleteEventDrop_Issue18089(t *testing.T) {
 	e2e.BeforeTest(t)
 	cfg := e2e.DefaultConfig()
@@ -311,24 +313,178 @@ func TestDeleteEventDrop_Issue18089(t *testing.T) {
 	watchChan := c.Watch(ctx, key, clientv3.WithRev(deleteResp.Header.Revision))
 	select {
 	case watchResp := <-watchChan:
-		// TODO(MadhavJivrajani): update conditions once https://github.com/etcd-io/etcd/issues/18089
-		// is resolved. The existing conditions do not mimic the desired behaviour and are there to
-		// test and reproduce etcd-io/etcd#18089.
-		if len(watchResp.Events) != 1 {
-			t.Fatalf("expected exactly one event in response, got: %d", len(watchResp.Events))
-		}
-		if watchResp.Events[0].Type != mvccpb.PUT {
-			t.Fatalf("unexpected event type, expected: %s, got: %s", mvccpb.PUT, watchResp.Events[0].Type)
-		}
-		if string(watchResp.Events[0].Kv.Key) != key {
-			t.Fatalf("unexpected key, expected: %s, got: %s", key, string(watchResp.Events[0].Kv.Key))
-		}
-		if string(watchResp.Events[0].Kv.Value) != v6 {
-			t.Fatalf("unexpected valye, expected: %s, got: %s", v6, string(watchResp.Events[0].Kv.Value))
-		}
+		require.Len(t, watchResp.Events, 2)
+
+		require.Equal(t, mvccpb.DELETE, watchResp.Events[0].Type)
+		deletedKey := string(watchResp.Events[0].Kv.Key)
+		require.Equal(t, key, deletedKey)
+
+		require.Equal(t, mvccpb.PUT, watchResp.Events[1].Type)
+
+		updatedKey := string(watchResp.Events[1].Kv.Key)
+		require.Equal(t, key, updatedKey)
+
+		require.Equal(t, v6, string(watchResp.Events[1].Kv.Value))
 	case <-time.After(100 * time.Millisecond):
 		// we care only about the first response, but have an
 		// escape hatch in case the watch response is delayed.
 		t.Fatal("timed out getting watch response")
+	}
+}
+
+func TestStartWatcherFromCompactedRevision(t *testing.T) {
+	t.Run("compaction on tombstone revision", func(t *testing.T) {
+		testStartWatcherFromCompactedRevision(t, true)
+	})
+	t.Run("compaction on normal revision", func(t *testing.T) {
+		testStartWatcherFromCompactedRevision(t, false)
+	})
+}
+
+func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombstone bool) {
+	e2e.BeforeTest(t)
+	cfg := e2e.DefaultConfig()
+	cfg.Client = e2e.ClientConfig{ConnectionType: e2e.ClientTLS}
+	clus, err := e2e.NewEtcdProcessCluster(context.Background(), t, e2e.WithConfig(cfg), e2e.WithClusterSize(1))
+	require.NoError(t, err)
+	defer clus.Close()
+
+	c := newClient(t, clus.EndpointsGRPC(), cfg.Client)
+	defer c.Close()
+
+	ctx := context.Background()
+	key := "foo"
+	totalRev := 100
+
+	type valueEvent struct {
+		value string
+		typ   mvccpb.Event_EventType
+	}
+
+	var (
+		// requestedValues records all requested change
+		requestedValues = make([]valueEvent, 0)
+		// revisionChan sends each compacted revision via this channel
+		compactionRevChan = make(chan int64)
+		// compactionStep means that client performs a compaction on every 7 operations
+		compactionStep = 7
+	)
+
+	// This goroutine will submit changes on $key $totalRev times. It will
+	// perform compaction after every $compactedAfterChanges changes.
+	// Except for first time, the watcher always receives the compacted
+	// revision as start.
+	go func() {
+		defer close(compactionRevChan)
+
+		lastRevision := int64(1)
+
+		compactionRevChan <- lastRevision
+		for vi := 1; vi <= totalRev; vi++ {
+			var respHeader *etcdserverpb.ResponseHeader
+
+			if vi%compactionStep == 0 && performCompactOnTombstone {
+				t.Logf("DELETE key=%s", key)
+
+				resp, derr := c.KV.Delete(ctx, key)
+				require.NoError(t, derr)
+				respHeader = resp.Header
+
+				requestedValues = append(requestedValues, valueEvent{value: "", typ: mvccpb.DELETE})
+			} else {
+				value := fmt.Sprintf("%d", vi)
+
+				t.Logf("PUT key=%s, val=%s", key, value)
+				resp, perr := c.KV.Put(ctx, key, value)
+				require.NoError(t, perr)
+				respHeader = resp.Header
+
+				requestedValues = append(requestedValues, valueEvent{value: value, typ: mvccpb.PUT})
+			}
+
+			lastRevision = respHeader.Revision
+
+			if vi%compactionStep == 0 {
+				compactionRevChan <- lastRevision
+
+				t.Logf("COMPACT rev=%d", lastRevision)
+				_, err = c.KV.Compact(ctx, lastRevision, clientv3.WithCompactPhysical())
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	receivedEvents := make([]*clientv3.Event, 0)
+
+	fromCompactedRev := false
+	for fromRev := range compactionRevChan {
+		watchChan := c.Watch(ctx, key, clientv3.WithRev(fromRev))
+
+		prevEventCount := len(receivedEvents)
+
+		// firstReceived represents this is first watch response.
+		// Just in case that ETCD sends event one by one.
+		firstReceived := true
+
+		t.Logf("Start to watch key %s starting from revision %d", key, fromRev)
+	watchLoop:
+		for {
+			currentEventCount := len(receivedEvents)
+			if currentEventCount-prevEventCount == compactionStep || currentEventCount == totalRev {
+				break
+			}
+
+			select {
+			case watchResp := <-watchChan:
+				t.Logf("Receive the number of events: %d", len(watchResp.Events))
+				for i := range watchResp.Events {
+					ev := watchResp.Events[i]
+
+					// If the $fromRev is the compacted revision,
+					// the first event should be the same as the last event receives in last watch response.
+					if firstReceived && fromCompactedRev {
+						firstReceived = false
+
+						last := receivedEvents[prevEventCount-1]
+
+						assert.Equal(t, last.Type, ev.Type,
+							"last received event type %s, but got event type %s", last.Type, ev.Type)
+						assert.Equal(t, string(last.Kv.Key), string(ev.Kv.Key),
+							"last received event key %s, but got event key %s", string(last.Kv.Key), string(ev.Kv.Key))
+						assert.Equal(t, string(last.Kv.Value), string(ev.Kv.Value),
+							"last received event value %s, but got event value %s", string(last.Kv.Value), string(ev.Kv.Value))
+						continue
+					}
+					receivedEvents = append(receivedEvents, ev)
+				}
+
+				if len(watchResp.Events) == 0 {
+					require.Equal(t, v3rpc.ErrCompacted, watchResp.Err())
+					break watchLoop
+				}
+
+			case <-time.After(10 * time.Second):
+				t.Fatal("timed out getting watch response")
+			}
+		}
+
+		fromCompactedRev = true
+	}
+
+	t.Logf("Received total number of events: %d", len(receivedEvents))
+	require.Len(t, requestedValues, totalRev)
+	require.Len(t, receivedEvents, totalRev, "should receive %d events", totalRev)
+	for idx, expected := range requestedValues {
+		ev := receivedEvents[idx]
+
+		require.Equal(t, expected.typ, ev.Type, "#%d expected event %s", idx, expected.typ)
+
+		updatedKey := string(ev.Kv.Key)
+
+		require.Equal(t, key, updatedKey)
+		if expected.typ == mvccpb.PUT {
+			updatedValue := string(ev.Kv.Value)
+			require.Equal(t, expected.value, updatedValue)
+		}
 	}
 }


### PR DESCRIPTION
Before this patch, the tombstone can be deleted if its revision is equal compacted revision. It causes that the watch subscriber won't get this DELETE event. Based on Compact API [[1]], we should keep tombstone revision if it's not less than the compaction revision.

> CompactionRequest compacts the key-value store up to a given revision.
> All superseded keys with a revision less than the compaction revision
> will be removed.

[1]: https://etcd.io/docs/latest/dev-guide/api_reference_v3/


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

------------

To Reviewers:

During writing tests, I found that the compact doesn't always remove smaller revision data.
For example,

```
➜  bin/etcdctl put hello world -w json
{"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"revision":2,"raft_term":2}}

➜  bin/etcdctl put hello-v2 world -w json
{"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"revision":3,"raft_term":2}}

➜  bin/etcdctl put hello world-v2 -w json
{"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"revision":4,"raft_term":2}}

➜  bin/etcdctl get --rev 2 hello
hello
world

➜  bin/etcdctl compact 3 --physical=true
compacted revision 3

➜  bin/etcdctl get --rev 2 hello
{"level":"warn","ts":"2024-07-03T20:12:39.086991+0800","logger":"etcd-client","caller":"v3@v3.6.0-alpha.0/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0002105a0/127.0.0.1:2379","method":"/etcdserverpb.KV/Range","attempt":0,"error":"rpc error: code = OutOfRange desc = etcdserver: mvcc: required revision has been compacted"}
Error: etcdserver: mvcc: required revision has been compacted

➜  bin/tools/etcd-dump-db iterate-bucket ./default.etcd/member/snap/db key --decode
rev={Revision:{Main:4 Sub:0} tombstone:false}, value=[key "hello" | val "world-v2" | created 2 | mod 4 | ver 2]
rev={Revision:{Main:3 Sub:0} tombstone:false}, value=[key "hello-v2" | val "world" | created 3 | mod 3 | ver 1]
rev={Revision:{Main:2 Sub:0} tombstone:false}, value=[key "hello" | val "world" | created 2 | mod 2 | ver 1]
```

Not sure we should fix it in the follow-up. Just want to highlight it.
