### PR TITLE
robustness: remove head rev match in validateGotAtLeastOneProgressNotify

### DIFF
--- a/tests/robustness/watch.go
+++ b/tests/robustness/watch.go
@@ -129,13 +129,11 @@ func validateGotAtLeastOneProgressNotify(t *testing.T, reports []report.ClientRe
 external:
 	for _, r := range reports {
 		for _, op := range r.Watch {
-			var lastHeadRevision int64 = 1
 			for _, resp := range op.Responses {
-				if resp.IsProgressNotify && resp.Revision == lastHeadRevision {
+				if resp.IsProgressNotify {
 					gotProgressNotify = true
 					break external
 				}
-				lastHeadRevision = resp.Revision
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/etcd-io/etcd/issues/18276

The head rev match might be to restrictive causing validation flakiness. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
