### PR TITLE
Update CHANGELOG-3.5 with backported commit

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 - Fix [add prometheus metric registration for metric `etcd_disk_wal_write_duration_seconds`](https://github.com/etcd-io/etcd/pull/18174).
 - Add [Support multiple values for allowed client and peer TLS identities](https://github.com/etcd-io/etcd/pull/18160)
+- Fix [noisy logs from simple auth token expiration by reducing log level to debug](https://github.com/etcd-io/etcd/pull/18245)
 
 ### Dependencies
 - Compile binaries using [go 1.21.11](https://github.com/etcd-io/etcd/pull/18129).


### PR DESCRIPTION
Mention the 0a960a2 backported to 3.5 release in the changelog.

/assign @ivanvc