### PR TITLE
client/v3/watch.go: use `fmt` go pkg for metadata map printing

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -1037,7 +1037,7 @@ func (pr *progressRequest) toPB() *pb.WatchRequest {
 
 func streamKeyFromCtx(ctx context.Context) string {
 	if md, ok := metadata.FromOutgoingContext(ctx); ok {
-		return fmt.Sprintf("%+v", md)
+		return fmt.Sprintf("%+v", map[string][]string(md))
 	}
 	return ""
 }


### PR DESCRIPTION
## Description

Addresses this issue #18303