### PR TITLE
[3.5] client/v3/watch.go: use fmt go pkg for gRPC metadata map printing

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -1036,7 +1036,7 @@ func (pr *progressRequest) toPB() *pb.WatchRequest {
 
 func streamKeyFromCtx(ctx context.Context) string {
 	if md, ok := metadata.FromOutgoingContext(ctx); ok {
-		return fmt.Sprintf("%+v", md)
+		return fmt.Sprintf("%+v", map[string][]string(md))
 	}
 	return ""
 }


### PR DESCRIPTION
## Description

This PR backports the changes from #18308 PR to the release-3.5 branch.

## Issue

Addresses Issue #18303 in the backport release-3.5.