### PR TITLE
github: remove amd64 test actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,11 +3,6 @@ name: Tests
 on: [push, pull_request]
 permissions: read-all
 jobs:
-  amd64:
-    uses: ./.github/workflows/tests-template.yaml
-    with:
-      arch: amd64
-      runs-on: ubuntu-latest
   arm64:
     uses: ./.github/workflows/tests-template.yaml
     with:


### PR DESCRIPTION
The pull-etcd-unit-test-amd64, pull-etcd-unit-test-386, pull-etcd-integration-1-cpu-amd64, pull-etcd-integration-2-cpu-amd64, and pull-etcd-integration-8-cpu-amd64 jobs are already running on the prow infrastructure. It is safe to remove these duplicated workloads from GitHub actions.

Fixes #18065
Part of kubernetes/k8s.io#6102

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
