### PR TITLE
CHANGELOG/CHANGELOG-3.4.md: update changelog for gRPC metadata printing

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.34 (TBD)
 
+### Package clientv3
+- [Print gRPC metadata in guaranteed order using the official go fmt pkg](https://github.com/etcd-io/etcd/pull/18311).
+
 ### Dependencies
 - Compile binaries using go [1.21.12](https://github.com/etcd-io/etcd/pull/18272).
 


### PR DESCRIPTION
## Description

In this commit, we update the changelog for gRPC metadata printing in release 3.4 which is mainly a backport from PR #18311.
