### PR TITLE
CHANGELOG/CHANGELOG-3.5.md: update changelog for gRPC metadata printing

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -11,6 +11,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Add [Support multiple values for allowed client and peer TLS identities](https://github.com/etcd-io/etcd/pull/18160)
 - Fix [noisy logs from simple auth token expiration by reducing log level to debug](https://github.com/etcd-io/etcd/pull/18245)
 
+### Package clientv3
+- [Print gRPC metadata in guaranteed order using the official go fmt pkg](https://github.com/etcd-io/etcd/pull/18312).
+
 ### Dependencies
 - Compile binaries using [go 1.21.12](https://github.com/etcd-io/etcd/pull/18271).
 - [Fully address CVE-2023-45288 and fix govulncheck CI check](https://github.com/etcd-io/etcd/pull/18170)


### PR DESCRIPTION
## Description

In this commit, we update the changelog for gRPC metadata printing in release 3.5 which is mainly a backport from PR #18312.