### PR TITLE
fix dial-timeout not affected for client watch command

### DIFF
--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -78,7 +78,7 @@ func watchCommandFunc(cmd *cobra.Command, args []string) {
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
 
-	c := mustClientFromCmd(cmd)
+	c := mustBlockClientFromCmd(cmd)
 	wc, err := getWatchChan(c, watchArgs)
 	if err != nil {
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)


### PR DESCRIPTION
fix #18335

https://github.com/etcd-io/etcd/blob/e7f572914d79f0705b3dc8ca28d9a14b0f854d49/client/v3/client.go#L327-L330

As noted before, it is wrong to not have `grpc.WithBlock()`

in the test, we will also addoption `grpc.WithBlock(`
https://github.com/etcd-io/etcd/blob/e7f572914d79f0705b3dc8ca28d9a14b0f854d49/client/v3/client_test.go#L104-L118
