### PR TITLE
 [3.4] Remove gsutil acl command for bucket permissions

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -247,9 +247,6 @@ main() {
       log_callout "Pushing container images to gcr.io ${RELEASE_VERSION}${TARGET_ARCH}"
       docker push "gcr.io/etcd-development/etcd:${RELEASE_VERSION}${TARGET_ARCH}"
     done
-
-    log_callout "Setting permissions using gsutil..."
-    gsutil -m acl ch -u allUsers:R -r gs://artifacts.etcd-development.appspot.com
   fi
 
   ### Release validation


### PR DESCRIPTION
With verification completed during release `v3.5.15` we are certain this improvement is safe so we should now also backport https://github.com/etcd-io/etcd/pull/18250/commits/f0246a9f84f7839825d68511ac65eb52eb24e81d to `release-3.4`.

> The bucket is already fully public so new releases don't need to run this command.
> 
> This will prevent significant terminal spam during the release process as there are thousands of objects in the bucket.

