### PR TITLE
etcdctl: move cobra helper of etcdctl from main pkg to etcdctl pkg

### DIFF
--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -23,6 +23,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/etcdctl/v3/ctlv3/command"
+	"go.etcd.io/etcd/etcdctl/v3/util"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
 
@@ -102,7 +103,7 @@ func init() {
 }
 
 func usageFunc(c *cobra.Command) error {
-	return cobrautl.UsageFunc(c, version.Version, version.APIVersion)
+	return util.UsageFunc(c, version.Version, version.APIVersion)
 }
 
 func Start() error {

--- a/etcdctl/util/help.go
+++ b/etcdctl/util/help.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The etcd Authors
+// Copyright 2025 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // copied from https://github.com/rkt/rkt/blob/master/rkt/help.go
 
-package cobrautl
+package util
 
 import (
 	"fmt"
@@ -151,8 +151,6 @@ func getSubCommands(cmd *cobra.Command) []*cobra.Command {
 	return subCommands
 }
 
-// UsageFunc is the usage function for the cobra command.
-// Deprecated: Please use go.etcd.io/etcd/etcdctl/v3/util instead.
 func UsageFunc(cmd *cobra.Command, version, APIVersion string) error {
 	subCommands := getSubCommands(cmd)
 	tabOut := getTabOutWithWriter(os.Stdout)


### PR DESCRIPTION
This PR moves cobra helper of `etcdctl` from main pkg to `etcdctl` pkg. This will remove cobra dependency from main pkg which wasn't necessary.

This PR was created after suggestion in this comment https://github.com/etcd-io/etcd/pull/18183#discussion_r1687171454
Part of https://github.com/etcd-io/etcd/issues/17777