### PR TITLE
github/workflows: set read-only default permissions to approve workflow

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,5 +1,6 @@
 ---
 name: Approve GitHub Workflows
+permissions: read-all
 
 on:
   pull_request_target:


### PR DESCRIPTION
As discovered by the OpenSSF Scorecard, the `gh-workflow-approve.yaml` action didn't specify default permissions. This pull request fixes that issue.

Part of https://github.com/etcd-io/etcd/issues/18362.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
