### PR TITLE
etcdserver: separate "raft log compact" from snapshot

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -58,6 +58,10 @@ type ServerConfig struct {
 	// follower to catch up.
 	SnapshotCatchUpEntries uint64
 
+	// CompactRaftLogEveryNApplies improves performance by compacting raft log once every N applies.
+	// Minimum value is 1, which means compacting raft log every apply.
+	CompactRaftLogEveryNApplies uint64
+
 	MaxSnapFiles uint
 	MaxWALFiles  uint
 

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -921,7 +921,7 @@ func TestCompactRaftLog(t *testing.T) {
 	}
 
 	currentIndex := uint64(0)
-	for currentIndex < snapshotCatchUpEntries+CompactRaftLogEveryNApplies-1 {
+	for currentIndex < snapshotCatchUpEntries+DefaultCompactRaftLogEveryNApplies-1 {
 		currentIndex++
 		putFooBar(currentIndex)
 	}
@@ -930,8 +930,8 @@ func TestCompactRaftLog(t *testing.T) {
 	// no compaction occurred before entries size reaches snapshotCatchUpEntries+CompactRaftLogEveryNApplies
 	fi, li, cnt := mustGetEntriesInfo()
 	assert.Equal(t, uint64(1), fi)
-	assert.Equal(t, snapshotCatchUpEntries+CompactRaftLogEveryNApplies-1, li)
-	assert.Equal(t, snapshotCatchUpEntries+CompactRaftLogEveryNApplies-1, cnt)
+	assert.Equal(t, snapshotCatchUpEntries+DefaultCompactRaftLogEveryNApplies-1, li)
+	assert.Equal(t, snapshotCatchUpEntries+DefaultCompactRaftLogEveryNApplies-1, cnt)
 
 	// trigger the first compaction
 	currentIndex++

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -147,8 +147,9 @@ type ClusterConfig struct {
 	MaxTxnOps       uint
 	MaxRequestBytes uint
 
-	SnapshotCount          uint64
-	SnapshotCatchUpEntries uint64
+	SnapshotCount               uint64
+	SnapshotCatchUpEntries      uint64
+	CompactRaftLogEveryNApplies uint64
 
 	GRPCKeepAliveMinTime        time.Duration
 	GRPCKeepAliveInterval       time.Duration
@@ -277,6 +278,7 @@ func (c *Cluster) mustNewMember(t testutil.TB) *Member {
 			MaxRequestBytes:                     c.Cfg.MaxRequestBytes,
 			SnapshotCount:                       c.Cfg.SnapshotCount,
 			SnapshotCatchUpEntries:              c.Cfg.SnapshotCatchUpEntries,
+			CompactRaftLogEveryNApplies:         c.Cfg.CompactRaftLogEveryNApplies,
 			GRPCKeepAliveMinTime:                c.Cfg.GRPCKeepAliveMinTime,
 			GRPCKeepAliveInterval:               c.Cfg.GRPCKeepAliveInterval,
 			GRPCKeepAliveTimeout:                c.Cfg.GRPCKeepAliveTimeout,
@@ -603,6 +605,7 @@ type MemberConfig struct {
 	MaxRequestBytes             uint
 	SnapshotCount               uint64
 	SnapshotCatchUpEntries      uint64
+	CompactRaftLogEveryNApplies uint64
 	GRPCKeepAliveMinTime        time.Duration
 	GRPCKeepAliveInterval       time.Duration
 	GRPCKeepAliveTimeout        time.Duration
@@ -689,6 +692,10 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 	m.SnapshotCatchUpEntries = etcdserver.DefaultSnapshotCatchUpEntries
 	if mcfg.SnapshotCatchUpEntries != 0 {
 		m.SnapshotCatchUpEntries = mcfg.SnapshotCatchUpEntries
+	}
+	m.CompactRaftLogEveryNApplies = etcdserver.DefaultCompactRaftLogEveryNApplies
+	if mcfg.CompactRaftLogEveryNApplies != 0 {
+		m.CompactRaftLogEveryNApplies = mcfg.CompactRaftLogEveryNApplies
 	}
 
 	// for the purpose of integration testing, simple token is enough

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -55,9 +55,10 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	integration.BeforeTest(t)
 
 	clus := integration.NewCluster(t, &integration.ClusterConfig{
-		Size:                   3,
-		SnapshotCount:          10,
-		SnapshotCatchUpEntries: 5,
+		Size:                        3,
+		SnapshotCount:               10,
+		SnapshotCatchUpEntries:      5,
+		CompactRaftLogEveryNApplies: 1,
 	})
 	defer clus.Terminate(t)
 
@@ -110,7 +111,9 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	//
 	// Since there is no way to confirm server has compacted the log, we
 	// use log monitor to watch and expect "compacted Raft logs" content.
-	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "compacted Raft logs", 2)
+	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "compacted Raft logs", 17)
+	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "\"compact-index\": 6", 1)
+	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "\"compact-index\": 17", 1)
 
 	// After RecoverPartition, leader L will send snapshot to slow F_m0
 	// follower, because F_m0(index:8) is 'out of date' compared to


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/17098. This PR separates "raft log compact" from snapshot.

### Changes
* Introduce a new variable `CompactRaftLogEveryNApplies` to control how often raft log is compacted
* Make `CompactRaftLogEveryNApplies` tunable.
* Fix the failing test case [`TestV3WatchRestoreSnapshotUnsync`](https://github.com/etcd-io/etcd/blob/9f59ef8ead097f836271f125d0e3774ddae4e71d/tests/integration/v3_watch_restore_test.go#L54) by setting `CompactRaftLogEveryNApplies` to `1`, ensuring compaction occurs after each snapshot.

### Need Help
This PR also breaks some e2e test cases:
* [`TestRecoverSnapshotBackend`](https://github.com/etcd-io/etcd/blob/9f59ef8ead097f836271f125d0e3774ddae4e71d/tests/e2e/leader_snapshot_no_proxy_test.go#L36)
* [`TestMixVersionsSnapshotByMockingPartition`](https://github.com/etcd-io/etcd/blob/9f59ef8ead097f836271f125d0e3774ddae4e71d/tests/e2e/etcd_mix_versions_test.go#L117C6-L117C47)

because they expect a compaction right after the snapshot to ensure a snapshot is sent to their followers.

I haven’t figured out a fix yet, other than making `CompactRaftLogEveryNApplies` a command-line argument, but that doesn’t seem ideal.

### To Do
- [ ] Fix failing tests
- [ ] Benchmark different values for `CompactRaftLogEveryNApplies`: 1, 10, 100, 1000, and choose the best on as default value.
