### PR TITLE
Fix wait time docs, tests to indicate trigger deadline geq to wait deadline.

### DIFF
--- a/pkg/wait/wait_time.go
+++ b/pkg/wait/wait_time.go
@@ -19,9 +19,9 @@ import "sync"
 type WaitTime interface {
 	// Wait returns a chan that waits on the given logical deadline.
 	// The chan will be triggered when Trigger is called with a
-	// deadline that is later than the one it is waiting for.
+	// deadline that is later than or equal to the one it is waiting for.
 	Wait(deadline uint64) <-chan struct{}
-	// Trigger triggers all the waiting chans with an earlier logical deadline.
+	// Trigger triggers all the waiting chans with an equal or earlier logical deadline.
 	Trigger(deadline uint64)
 }
 

--- a/pkg/wait/wait_time_test.go
+++ b/pkg/wait/wait_time_test.go
@@ -57,7 +57,7 @@ func TestWaitTestStress(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		chs = append(chs, wt.Wait(uint64(i)))
 	}
-	wt.Trigger(10000 + 1)
+	wt.Trigger(10000 - 1)
 
 	for _, ch := range chs {
 		select {
@@ -81,6 +81,6 @@ func BenchmarkTriggerAnd10KWaitTime(b *testing.B) {
 		for j := 0; j < 10000; j++ {
 			wt.Wait(uint64(j))
 		}
-		wt.Trigger(10000 + 1)
+		wt.Trigger(10000 - 1)
 	}
 }

--- a/pkg/wait/wait_time_test.go
+++ b/pkg/wait/wait_time_test.go
@@ -54,10 +54,10 @@ func TestWaitTime(t *testing.T) {
 func TestWaitTestStress(t *testing.T) {
 	chs := make([]<-chan struct{}, 0)
 	wt := NewTimeList()
-	for i := 0; i < 10000; i++ {
+	for i := 0; i <= 10000; i++ {
 		chs = append(chs, wt.Wait(uint64(i)))
 	}
-	wt.Trigger(10000 - 1)
+	wt.Trigger(10000)
 
 	for _, ch := range chs {
 		select {
@@ -78,9 +78,9 @@ func BenchmarkWaitTime(b *testing.B) {
 func BenchmarkTriggerAnd10KWaitTime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wt := NewTimeList()
-		for j := 0; j < 10000; j++ {
+		for j := 0; j <= 10000; j++ {
 			wt.Wait(uint64(j))
 		}
-		wt.Trigger(10000 - 1)
+		wt.Trigger(10000)
 	}
 }


### PR DESCRIPTION
Wait time implementation in fact supports a trigger deadline that is greater than or equal to wait deadlines, rather than greater than wait deadlines. Updates docs and a couple tests accordingly.