### PR TITLE
tests/e2e: check compactOnRev > tombstoneRevs[0]

### DIFF
--- a/tests/e2e/hashkv_test.go
+++ b/tests/e2e/hashkv_test.go
@@ -81,6 +81,7 @@ func TestVerifyHashKVAfterCompact(t *testing.T) {
 				// If compaction revision isn't a tombstone, select a revision in the middle of two tombstones.
 				if !compactedOnTombstoneRev {
 					compactedOnRev = (tombstoneRevs[0] + tombstoneRevs[1]) / 2
+					require.Greater(t, compactedOnRev, tombstoneRevs[0])
 					require.Greater(t, tombstoneRevs[1], compactedOnRev)
 				}
 


### PR DESCRIPTION
Follow-up: https://github.com/etcd-io/etcd/pull/18369#discussion_r1698144827


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

ping @ahrtr 
