### PR TITLE
Ensure proper gofail package version in robustness tests

### DIFF
--- a/tests/robustness/makefile.mk
+++ b/tests/robustness/makefile.mk
@@ -101,6 +101,7 @@ $(GOPATH)/bin/gofail: tools/mod/go.mod tools/mod/go.sum
 	  (cd server; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  (cd etcdctl; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  (cd etcdutl; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
+	  (cd tools/mod; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  FAILPOINTS=true ./build;
 
 /tmp/etcd-v3.5.12-beforeSendWatchResponse/bin: $(GOPATH)/bin/gofail
@@ -124,9 +125,7 @@ $(GOPATH)/bin/gofail: tools/mod/go.mod tools/mod/go.sum
 	cd /tmp/etcd-release-3.5-failpoints/; \
 	  git clone --depth 1 --branch release-3.5 https://github.com/etcd-io/etcd.git .; \
 	  go get go.etcd.io/gofail@${GOFAIL_VERSION}; \
-	  (cd server; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
-	  (cd etcdctl; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
-	  (cd etcdutl; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
+	  (cd tools/mod; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  FAILPOINTS=true ./build;
 
 /tmp/etcd-v3.4.23-failpoints/bin:
@@ -136,6 +135,7 @@ $(GOPATH)/bin/gofail: tools/mod/go.mod tools/mod/go.sum
 	cd /tmp/etcd-v3.4.$*-failpoints/; \
 	  git clone --depth 1 --branch v3.4.$* https://github.com/etcd-io/etcd.git .; \
 	  go get go.etcd.io/gofail@${GOFAIL_VERSION}; \
+	  (cd tools/mod; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  FAILPOINTS=true ./build;
 
 /tmp/etcd-release-3.4-failpoints/bin: $(GOPATH)/bin/gofail
@@ -144,4 +144,5 @@ $(GOPATH)/bin/gofail: tools/mod/go.mod tools/mod/go.sum
 	cd /tmp/etcd-release-3.4-failpoints/; \
 	  git clone --depth 1 --branch release-3.4 https://github.com/etcd-io/etcd.git .; \
 	  go get go.etcd.io/gofail@${GOFAIL_VERSION}; \
+	  (cd tools/mod; go get go.etcd.io/gofail@${GOFAIL_VERSION}); \
 	  FAILPOINTS=true ./build;


### PR DESCRIPTION
Addition of  tools/mod package into older branches moved the source of truth for gofail version, so the existing makefile code stopped overriding changes. This resulted in robustness tests flaking with release of gofail@v0.2.0 that allowed new type of failpoint. 

This PR should help us ensure that gofail version is set properly on older branches.

Before we see `downgraded go.etcd.io/gofail v0.2.0 => v0.1.0` line in the following build logs
```
$ make /tmp/etcd-release-3.5-failpoints/bin 
rm -rf /tmp/etcd-release-3.5-failpoints/
mkdir -p /tmp/etcd-release-3.5-failpoints/
cd /tmp/etcd-release-3.5-failpoints/; \
  git clone --depth 1 --branch release-3.5 https://github.com/etcd-io/etcd.git .; \
  go get go.etcd.io/gofail@v0.2.0; \
  (cd server; go get go.etcd.io/gofail@v0.2.0); \
  (cd etcdctl; go get go.etcd.io/gofail@v0.2.0); \
  (cd etcdutl; go get go.etcd.io/gofail@v0.2.0); \
  FAILPOINTS=true ./build;
Cloning into '.'...
remote: Enumerating objects: 1656, done.
remote: Counting objects: 100% (1656/1656), done.
remote: Compressing objects: 100% (1465/1465), done.
remote: Total 1656 (delta 355), reused 667 (delta 149), pack-reused 0
Receiving objects: 100% (1656/1656), 4.26 MiB | 15.26 MiB/s, done.
Resolving deltas: 100% (355/355), done.
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
go: upgraded github.com/stretchr/testify v1.8.4 => v1.9.0
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
DEPRECATED!!! Use build.sh script instead.

% 'gofail' 'enable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
go: removed go.etcd.io/etcd/etcdctl/v3 v3.5.15
go: removed go.etcd.io/etcd/etcdutl/v3 v3.5.15
go: removed go.etcd.io/etcd/server/v3 v3.5.15
go: removed go.etcd.io/etcd/tests/v3 v3.5.15
go: downgraded go.etcd.io/gofail v0.2.0 => v0.1.0
go: downgraded go.etcd.io/gofail v0.2.0 => v0.1.0
go: downgraded go.etcd.io/gofail v0.2.0 => v0.1.0
go: downgraded go.etcd.io/gofail v0.2.0 => v0.1.0
go: upgraded github.com/stretchr/testify v1.8.4 => v1.9.0
% 'gofail' 'enable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
% 'rm' '-f' 'bin/etcd'
% (cd server && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcd' '.')
% 'rm' '-f' 'bin/etcdutl'
% (cd etcdutl && 'env' 'GO_BUILD_FLAGS=' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcdutl' '.')
% 'rm' '-f' 'bin/etcdctl'
% (cd etcdctl && 'env' 'GO_BUILD_FLAGS=' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcdctl' '.')
SUCCESS: etcd_build (GOARCH=amd64)
```

With the change we no longer get it:
```
make /tmp/etcd-release-3.5-failpoints/bin 
rm -rf /tmp/etcd-release-3.5-failpoints/
mkdir -p /tmp/etcd-release-3.5-failpoints/
cd /tmp/etcd-release-3.5-failpoints/; \
  git clone --depth 1 --branch release-3.5 https://github.com/etcd-io/etcd.git .; \
  go get go.etcd.io/gofail@v0.2.0; \
  (cd tools/mod; go get go.etcd.io/gofail@v0.2.0); \
  FAILPOINTS=true ./build;
Cloning into '.'...
remote: Enumerating objects: 1656, done.
remote: Counting objects: 100% (1656/1656), done.
remote: Compressing objects: 100% (1465/1465), done.
remote: Total 1656 (delta 355), reused 667 (delta 149), pack-reused 0
Receiving objects: 100% (1656/1656), 4.26 MiB | 9.02 MiB/s, done.
Resolving deltas: 100% (355/355), done.
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
DEPRECATED!!! Use build.sh script instead.

% 'gofail' 'enable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
go: upgraded github.com/stretchr/testify v1.8.4 => v1.9.0
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
go: upgraded github.com/stretchr/testify v1.8.4 => v1.9.0
go: upgraded go.etcd.io/gofail v0.1.0 => v0.2.0
% 'gofail' 'enable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
% 'rm' '-f' 'bin/etcd'
% (cd server && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcd' '.')
% 'rm' '-f' 'bin/etcdutl'
% (cd etcdutl && 'env' 'GO_BUILD_FLAGS=' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcdutl' '.')
% 'rm' '-f' 'bin/etcdctl'
% (cd etcdctl && 'env' 'GO_BUILD_FLAGS=' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=6abcc18-FAILPOINTS' '-o=../bin/etcdctl' '.')
SUCCESS: etcd_build (GOARCH=amd64)

```

