### PR TITLE
[3.5] Cleanup github.com/etcd-io/gofail

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -99,15 +99,6 @@
 		]
 	},
 	{
-		"project": "github.com/etcd-io/gofail/runtime",
-		"licenses": [
-			{
-				"type": "Apache License 2.0",
-				"confidence": 1
-			}
-		]
-	},
-	{
 		"project": "github.com/go-logr/logr",
 		"licenses": [
 			{
@@ -523,6 +514,15 @@
 	},
 	{
 		"project": "go.etcd.io/etcd/v3",
+		"licenses": [
+			{
+				"type": "Apache License 2.0",
+				"confidence": 1
+			}
+		]
+	},
+	{
+		"project": "go.etcd.io/gofail/runtime",
 		"licenses": [
 			{
 				"type": "Apache License 2.0",

--- a/tests/functional/cmd/etcd-tester/main.go
+++ b/tests/functional/cmd/etcd-tester/main.go
@@ -18,9 +18,9 @@ package main
 import (
 	"flag"
 
-	_ "github.com/etcd-io/gofail/runtime"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/tests/v3/functional/tester"
+	_ "go.etcd.io/gofail/runtime"
 	"go.uber.org/zap"
 )
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -19,7 +19,6 @@ replace (
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -72,8 +72,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
-github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca h1:Y2I0lxOttdUKz+hNaIdG3FtjuQrTmwXun1opRV65IZc=
-github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca/go.mod h1:49H/RkXP8pKaZy4h0d+NW16rSLhyVBt4o6VLJbmOqDE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
Cleanup `github.com/etcd-io/gofail`, we should only use the new module `go.etcd.io/gofail`
