### PR TITLE
Update release-3.4 and release-3.5 CHANGELOG with go version bump

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -10,7 +10,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - [Print gRPC metadata in guaranteed order using the official go fmt pkg](https://github.com/etcd-io/etcd/pull/18311).
 
 ### Dependencies
-- Compile binaries using go [1.21.12](https://github.com/etcd-io/etcd/pull/18272).
+- Compile binaries using go [1.21.13](https://github.com/etcd-io/etcd/pull/18422).
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.16 (TBC)
 
+### Dependencies
+- Compile binaries using [go 1.21.13](https://github.com/etcd-io/etcd/pull/18421).
+
 <hr>
 
 ## v3.5.15 (2024-07-19)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Reference: https://github.com/etcd-io/etcd/issues/18419
