### PR TITLE
 [3.5] Backport github/workflows: set read-only default permissions to approve workflow 

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,5 +1,6 @@
 ---
 name: Approve GitHub Workflows
+permissions: read-all
 
 on:
   pull_request_target:


### PR DESCRIPTION
Backports commit: 5a02298ad5a947214ba02655b0a93ac01d4c178a from https://github.com/etcd-io/etcd/pull/18368 to `release-3.5`.

Finishes off one aspect of https://github.com/etcd-io/etcd/issues/18362.