### PR TITLE
[3.4] Skip leadership check if the etcd instance is active processing heartbeats

### DIFF
--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -79,7 +79,9 @@ type apply struct {
 type raftNode struct {
 	lg *zap.Logger
 
-	tickMu *sync.Mutex
+	tickMu *sync.RWMutex
+	// timestamp of the latest tick
+	latestTickTs time.Time
 	raftNodeConfig
 
 	// a chan to send/receive snapshot
@@ -131,8 +133,9 @@ func newRaftNode(cfg raftNodeConfig) *raftNode {
 	raft.SetLogger(lg)
 	r := &raftNode{
 		lg:             cfg.lg,
-		tickMu:         new(sync.Mutex),
+		tickMu:         new(sync.RWMutex),
 		raftNodeConfig: cfg,
+		latestTickTs:   time.Now(),
 		// set up contention detectors for raft heartbeat message.
 		// expect to send a heartbeat within 2 heartbeat intervals.
 		td:         contention.NewTimeoutDetector(2 * cfg.heartbeat),
@@ -154,7 +157,14 @@ func newRaftNode(cfg raftNodeConfig) *raftNode {
 func (r *raftNode) tick() {
 	r.tickMu.Lock()
 	r.Tick()
+	r.latestTickTs = time.Now()
 	r.tickMu.Unlock()
+}
+
+func (r *raftNode) getLatestTickTs() time.Time {
+	r.tickMu.RLock()
+	defer r.tickMu.RUnlock()
+	return r.latestTickTs
 }
 
 // start prepares and starts raftNode in a new goroutine. It is no longer safe

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1174,9 +1174,31 @@ func (s *EtcdServer) revokeExpiredLeases(leases []*lease.Lease) {
 	})
 }
 
+// isActive checks if the etcd instance is still actively processing the
+// heartbeat message (ticks). It returns false if no heartbeat has been
+// received within 3 * tickMs.
+func (s *EtcdServer) isActive() bool {
+	latestTickTs := s.r.getLatestTickTs()
+	threshold := 3 * time.Duration(s.Cfg.TickMs) * time.Millisecond
+	return latestTickTs.Add(threshold).After(time.Now())
+}
+
 // ensureLeadership checks whether current member is still the leader.
 func (s *EtcdServer) ensureLeadership() bool {
 	lg := s.Logger()
+
+	if s.isActive() {
+		if lg != nil {
+			lg.Debug("The member is active, skip checking leadership",
+				zap.Time("latestTickTs", s.r.getLatestTickTs()),
+				zap.Time("now", time.Now()))
+		} else {
+			plog.Debugf("The member is active, skip checking leadership, latestTickTs: %s, now: %s",
+				s.r.getLatestTickTs(), time.Now())
+		}
+
+		return true
+	}
 
 	ctx, cancel := context.WithTimeout(s.ctx, s.Cfg.ReqTimeout())
 	defer cancel()


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/18428 to 3.4.

Resolve https://github.com/etcd-io/etcd/issues/18069 in 3.4.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
