### PR TITLE
Update changelog for the performance regression caused by ensureLeadership in leaseRenew

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.34 (TBD)
 
+### etcd server
+- Fix [performance regression issue caused by the `ensureLeadership` in lease renew](https://github.com/etcd-io/etcd/pull/18440).
+
 ### Package clientv3
 - [Print gRPC metadata in guaranteed order using the official go fmt pkg](https://github.com/etcd-io/etcd/pull/18311).
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.16 (TBC)
 
+### etcd server
+- Fix [performance regression issue caused by the `ensureLeadership` in lease renew](https://github.com/etcd-io/etcd/pull/18439).
+
 ### Dependencies
 - Compile binaries using [go 1.21.13](https://github.com/etcd-io/etcd/pull/18421).
 


### PR DESCRIPTION
Linked to,
- https://github.com/etcd-io/etcd/pull/18428
- https://github.com/etcd-io/etcd/pull/18439
- https://github.com/etcd-io/etcd/pull/18440
- https://github.com/etcd-io/etcd/issues/18069


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
