### PR TITLE
Reduce number of concurrent clients to 8 and compactions to avoid flakes

### DIFF
--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -34,6 +34,7 @@ var (
 		keyCount:     10,
 		leaseTTL:     DefaultLeaseTTL,
 		largePutSize: 32769,
+		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
 			{Choice: List, Weight: 15},
@@ -44,15 +45,16 @@ var (
 			{Choice: PutWithLease, Weight: 5},
 			{Choice: LeaseRevoke, Weight: 5},
 			{Choice: CompareAndSet, Weight: 5},
-			{Choice: Put, Weight: 15},
+			{Choice: Put, Weight: 18},
 			{Choice: LargePut, Weight: 5},
-			{Choice: Compact, Weight: 5},
+			{Choice: Compact, Weight: 2},
 		},
 	}
 	EtcdPut Traffic = etcdTraffic{
 		keyCount:     10,
 		largePutSize: 32769,
 		leaseTTL:     DefaultLeaseTTL,
+		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
 			{Choice: List, Weight: 15},
@@ -60,8 +62,7 @@ var (
 			{Choice: StaleList, Weight: 10},
 			{Choice: MultiOpTxn, Weight: 5},
 			{Choice: LargePut, Weight: 5},
-			{Choice: Put, Weight: 35},
-			{Choice: Compact, Weight: 5},
+			{Choice: Put, Weight: 40},
 		},
 	}
 )

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -37,11 +37,12 @@ var (
 		averageKeyCount: 10,
 		resource:        "pods",
 		namespace:       "default",
+		// Please keep the sum of weights equal 1000.
 		writeChoices: []random.ChoiceWeight[KubernetesRequestType]{
-			{Choice: KubernetesUpdate, Weight: 85},
-			{Choice: KubernetesDelete, Weight: 5},
-			{Choice: KubernetesCreate, Weight: 5},
-			{Choice: KubernetesCompact, Weight: 5},
+			{Choice: KubernetesUpdate, Weight: 875},
+			{Choice: KubernetesDelete, Weight: 50},
+			{Choice: KubernetesCreate, Weight: 50},
+			{Choice: KubernetesCompact, Weight: 25},
 		},
 	}
 )

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -45,7 +45,7 @@ var (
 	HighTrafficProfile = Profile{
 		MinimalQPS:                     200,
 		MaximalQPS:                     1000,
-		ClientCount:                    10,
+		ClientCount:                    8,
 		MaxNonUniqueRequestConcurrency: 3,
 	}
 )


### PR DESCRIPTION
Not hitting minimal QPS is expected to be caused by introduction of
compation. Let's avoid it for high throughput test cases.

Reducing number of clients to avoid linearization timeouts.

cc @ah8ad3 @fuweid @MadhavJivrajani @siyuanfoundation 