### PR TITLE
[3.5] client/pkg/testutil: update interestingGoroutines

### DIFF
--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -148,7 +148,8 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
 			strings.Contains(stack, "rcrypto/internal/boring.(*PublicKeyRSA).finalize") ||
 			strings.Contains(stack, "net.(*netFD).Close(") ||
-			strings.Contains(stack, "testing.(*T).Run") {
+			strings.Contains(stack, "testing.(*T).Run") ||
+			strings.Contains(stack, "crypto/tls.(*certCache).evict") {
 			continue
 		}
 		gs = append(gs, stack)


### PR DESCRIPTION
The Go runtime uses runtime Finalizer to delete cert [[1]]. The interestingGoroutines is able to collect stack like,

```plain
leak.go:103: Found leaked goroutined BEFORE test appears to have leaked :
        sync.(*Map).LoadAndDelete(0xc00031e180, {0xe07320, 0xc00009fde0})
                /usr/local/go/src/sync/map.go:272 +0x192
        sync.(*Map).Delete(...)
                /usr/local/go/src/sync/map.go:297
        crypto/tls.(*certCache).evict(...)
                /usr/local/go/src/crypto/tls/cache.go:73
        crypto/tls.(*certCache).active.func1(0x0?)
                /usr/local/go/src/crypto/tls/cache.go:65 +0x67
```

It's caused by GC instead of leaky goroutine. interestingGoroutines should skip it.

Backport of #18287

[1]: https://github.com/golang/go/blob/8e1fdea8316d840fd07e9d6e026048e53290948b/src/crypto/tls/cache.go#L63


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
