### PR TITLE
update broken link in mixin readme

### DIFF
--- a/contrib/mixin/README.md
+++ b/contrib/mixin/README.md
@@ -18,7 +18,7 @@ grafana7x: true,
 
 ## Background
 
-* For more information about monitoring mixins, see this [design doc](https://docs.google.com/document/d/1A9xvzwqnFVSOZ5fD3blKODXfsat5fg6ZhnKu9LK3lB4/edit#).
+* For more information about monitoring mixins, see this [design doc](https://github.com/monitoring-mixins/docs/blob/master/design.pdf).
 
 ## Testing alerts
 


### PR DESCRIPTION
old link doesn't exist

according to https://github.com/monitoring-mixins/docs/blob/master/README.md the pdf is related to the google doc file