### PR TITLE
KEP-4578: migrate experimental-initial-corrupt-check flag to feature gate.

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -48,6 +48,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
+	"go.etcd.io/etcd/server/v3/features"
 	"go.etcd.io/etcd/server/v3/storage"
 	"go.etcd.io/etcd/server/v3/verify"
 )
@@ -203,7 +204,6 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		TokenTTL:                                 cfg.AuthTokenTTL,
 		CORS:                                     cfg.CORS,
 		HostWhitelist:                            cfg.HostWhitelist,
-		InitialCorruptCheck:                      cfg.ExperimentalInitialCorruptCheck,
 		CorruptCheckTime:                         cfg.ExperimentalCorruptCheckTime,
 		CompactHashCheckEnabled:                  cfg.ExperimentalCompactHashCheckEnabled,
 		CompactHashCheckTime:                     cfg.ExperimentalCompactHashCheckTime,
@@ -259,7 +259,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 
 	// newly started member ("memberInitialized==false")
 	// does not need corruption check
-	if memberInitialized && srvcfg.InitialCorruptCheck {
+	if memberInitialized && srvcfg.ServerFeatureGate.Enabled(features.InitialCorruptCheck) {
 		if err = e.Server.CorruptionChecker().InitialCheck(); err != nil {
 			// set "EtcdServer" to nil, so that it does not block on "EtcdServer.Close()"
 			// (nothing to close since rafthttp transports have not been started)

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -273,7 +273,7 @@ Experimental distributed tracing:
     Number of samples to collect per million spans for distributed tracing. Disabled by default.
 
 Experimental feature:
-  --experimental-initial-corrupt-check 'false'
+  --experimental-initial-corrupt-check 'false'. It's deprecated, and will be decommissioned in v3.7. Use '--feature-gates=InitialCorruptCheck=true' instead.
     Enable to check data corruption before serving any client/peer traffic.
   --experimental-corrupt-check-time '0s'
     Duration of time between cluster corruption check passes.

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -45,18 +45,25 @@ const (
 	// alpha: v3.6
 	// main PR: https://github.com/etcd-io/etcd/pull/18279
 	StopGRPCServiceOnDefrag featuregate.Feature = "StopGRPCServiceOnDefrag"
+	// InitialCorruptCheck enable to check data corruption before serving any client/peer traffic.
+	// owner: @serathius
+	// alpha: v3.6
+	// main PR: https://github.com/etcd-io/etcd/pull/10524
+	InitialCorruptCheck featuregate.Feature = "InitialCorruptCheck"
 )
 
 var (
 	DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		DistributedTracing:      {Default: false, PreRelease: featuregate.Alpha},
 		StopGRPCServiceOnDefrag: {Default: false, PreRelease: featuregate.Alpha},
+		InitialCorruptCheck:     {Default: false, PreRelease: featuregate.Alpha},
 	}
 	// ExperimentalFlagToFeatureMap is the map from the cmd line flags of experimental features
 	// to their corresponding feature gates.
 	// Deprecated: only add existing experimental features here. DO NOT use for new features.
 	ExperimentalFlagToFeatureMap = map[string]featuregate.Feature{
 		"experimental-stop-grpc-service-on-defrag": StopGRPCServiceOnDefrag,
+		"experimental-initial-corrupt-check":       InitialCorruptCheck,
 	}
 )
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

migrating experimental-initial-corrupt-check flag to feature gate.

part of https://github.com/etcd-io/etcd/issues/18023

