### PR TITLE
KEP-4578: migrate experimental-enable-lease-checkpoint and experimental-enable-lease-checkpoint-persist flag to feature gate.

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -1070,11 +1070,11 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	if !cfg.ExperimentalEnableLeaseCheckpointPersist && cfg.ExperimentalEnableLeaseCheckpoint {
+	if !cfg.ServerFeatureGate.Enabled(features.EnableLeaseCheckpointPersist) && cfg.ServerFeatureGate.Enabled(features.EnableLeaseCheckpoint) {
 		cfg.logger.Warn("Detected that checkpointing is enabled without persistence. Consider enabling experimental-enable-lease-checkpoint-persist")
 	}
 
-	if cfg.ExperimentalEnableLeaseCheckpointPersist && !cfg.ExperimentalEnableLeaseCheckpoint {
+	if cfg.ServerFeatureGate.Enabled(features.EnableLeaseCheckpointPersist) && !cfg.ServerFeatureGate.Enabled(features.EnableLeaseCheckpoint) {
 		return fmt.Errorf("setting experimental-enable-lease-checkpoint-persist requires experimental-enable-lease-checkpoint")
 	}
 

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -213,7 +213,6 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		EnableGRPCGateway:                        cfg.EnableGRPCGateway,
 		ExperimentalEnableDistributedTracing:     cfg.ExperimentalEnableDistributedTracing,
 		UnsafeNoFsync:                            cfg.UnsafeNoFsync,
-		EnableLeaseCheckpoint:                    cfg.ExperimentalEnableLeaseCheckpoint,
 		LeaseCheckpointPersist:                   cfg.ExperimentalEnableLeaseCheckpointPersist,
 		CompactionBatchLimit:                     cfg.ExperimentalCompactionBatchLimit,
 		CompactionSleepInterval:                  cfg.ExperimentalCompactionSleepInterval,

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -281,7 +281,7 @@ Experimental feature:
     Enable leader to periodically check followers compaction hashes.
   --experimental-compact-hash-check-time '1m'
     Duration of time between leader checks followers compaction hashes.
-  --experimental-enable-lease-checkpoint 'false'
+  --experimental-enable-lease-checkpoint 'false'.It's deprecated, and will be decommissioned in v3.7. Use '--feature-gates=EnableLeaseCheckpoint=true' instead.
     ExperimentalEnableLeaseCheckpoint enables primary lessor to persist lease remainingTTL to prevent indefinite auto-renewal of long lived leases.
   --experimental-compaction-batch-limit 1000
     ExperimentalCompactionBatchLimit sets the maximum revisions deleted in each compaction batch.
@@ -305,7 +305,7 @@ Experimental feature:
     Sets the sleep interval between each compaction batch.
   --experimental-downgrade-check-time
     Duration of time between two downgrade status checks.
-  --experimental-enable-lease-checkpoint-persist 'false'
+  --experimental-enable-lease-checkpoint-persist 'false'.It's deprecated, and will be decommissioned in v3.7. Use '--feature-gates=EnableLeaseCheckpointPersist=true' instead.
     Enable persisting remainingTTL to prevent indefinite auto-renewal of long lived leases. Always enabled in v3.6. Should be used to ensure smooth upgrade from v3.5 clusters with this feature enabled. Requires experimental-enable-lease-checkpoint to be enabled.
   --experimental-memory-mlock
     Enable to enforce etcd pages (in particular bbolt) to stay in RAM.

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -45,18 +45,35 @@ const (
 	// alpha: v3.6
 	// main PR: https://github.com/etcd-io/etcd/pull/18279
 	StopGRPCServiceOnDefrag featuregate.Feature = "StopGRPCServiceOnDefrag"
+
+	// EnableLeaseCheckpoint enables leader to send regular checkpoints to other members to prevent reset of remaining TTL on leader change.
+	// owner: @
+	// alpha: v3.6
+	EnableLeaseCheckpoint featuregate.Feature = "EnableLeaseCheckpoint"
+	// EnableLeaseCheckpointPersist enables persisting remainingTTL to prevent indefinite auto-renewal of long lived leases. Always enabled in v3.6. Should be used to ensure smooth upgrade from v3.5 clusters with this feature enabled.
+	// Requires EnableLeaseCheckpoint featuragate to be enabled.
+	// Deprecated in v3.6.
+	// TODO: Delete in v3.7
+	// owner: @serathius
+	// alpha: v3.6
+	// main PR: https://github.com/etcd-io/etcd/pull/13508
+	EnableLeaseCheckpointPersist featuregate.Feature = "EnableLeaseCheckpointPersist"
 )
 
 var (
 	DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		DistributedTracing:      {Default: false, PreRelease: featuregate.Alpha},
-		StopGRPCServiceOnDefrag: {Default: false, PreRelease: featuregate.Alpha},
+		DistributedTracing:           {Default: false, PreRelease: featuregate.Alpha},
+		StopGRPCServiceOnDefrag:      {Default: false, PreRelease: featuregate.Alpha},
+		EnableLeaseCheckpoint:        {Default: false, PreRelease: featuregate.Alpha},
+		EnableLeaseCheckpointPersist: {Default: false, PreRelease: featuregate.Alpha},
 	}
 	// ExperimentalFlagToFeatureMap is the map from the cmd line flags of experimental features
 	// to their corresponding feature gates.
 	// Deprecated: only add existing experimental features here. DO NOT use for new features.
 	ExperimentalFlagToFeatureMap = map[string]featuregate.Feature{
-		"experimental-stop-grpc-service-on-defrag": StopGRPCServiceOnDefrag,
+		"experimental-stop-grpc-service-on-defrag":     StopGRPCServiceOnDefrag,
+		"experimental-enable-lease-checkpoint":         EnableLeaseCheckpoint,
+		"experimental-enable-lease-checkpoint-persist": EnableLeaseCheckpointPersist,
 	}
 )
 


### PR DESCRIPTION



Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

part of https://github.com/etcd-io/etcd/issues/18023

When I opened this PR, I found that these two flags were not in the migration list of https://github.com/etcd-io/etcd/issues/18023.

/hold  
for confirm whether need to continue with the PR to complete `experimental-enable-lease-checkpoint` and `experimental-enable-lease-checkpoint-persist` flag migration.


