### PR TITLE
Use errors.Is for error equality checks

### DIFF
--- a/client/pkg/fileutil/lock_flock.go
+++ b/client/pkg/fileutil/lock_flock.go
@@ -17,6 +17,7 @@
 package fileutil
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -28,7 +29,7 @@ func flockTryLockFile(path string, flag int, perm os.FileMode) (*LockedFile, err
 	}
 	if err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		f.Close()
-		if err == syscall.EWOULDBLOCK {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
 			err = ErrLocked
 		}
 		return nil, err

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	mrand "math/rand"
@@ -427,7 +428,7 @@ func (s *server) ioCopy(dst io.Writer, src io.Reader, ptype proxyType) {
 	for {
 		nr1, err := src.Read(buf)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return
 			}
 			// connection already closed
@@ -545,7 +546,7 @@ func (s *server) ioCopy(dst io.Writer, src io.Reader, ptype proxyType) {
 		var nw int
 		nw, err = dst.Write(data)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return
 			}
 			select {

--- a/server/etcdserver/api/v3compactor/periodic.go
+++ b/server/etcdserver/api/v3compactor/periodic.go
@@ -16,6 +16,7 @@ package v3compactor
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -139,7 +140,7 @@ func (pc *Periodic) Run() {
 			)
 			startTime := pc.clock.Now()
 			_, err := pc.c.Compact(pc.ctx, &pb.CompactionRequest{Revision: rev})
-			if err == nil || err == mvcc.ErrCompacted {
+			if err == nil || errors.Is(err, mvcc.ErrCompacted) {
 				pc.lg.Info(
 					"completed auto periodic compaction",
 					zap.Int64("revision", rev),

--- a/server/etcdserver/api/v3discovery/discovery.go
+++ b/server/etcdserver/api/v3discovery/discovery.go
@@ -192,7 +192,7 @@ func newDiscovery(lg *zap.Logger, dcfg *DiscoveryConfig, id types.ID) (*discover
 func (d *discovery) getCluster() (string, error) {
 	cls, clusterSize, rev, err := d.checkCluster()
 	if err != nil {
-		if err == ErrFullCluster {
+		if errors.Is(err, ErrFullCluster) {
 			return cls.getInitClusterStr(clusterSize)
 		}
 		return "", err
@@ -303,7 +303,7 @@ func (d *discovery) checkClusterRetry() (*clusterInfo, int, int64, error) {
 func (d *discovery) checkCluster() (*clusterInfo, int, int64, error) {
 	clusterSize, err := d.getClusterSize()
 	if err != nil {
-		if err == ErrSizeNotFound || err == ErrBadSizeKey {
+		if errors.Is(err, ErrSizeNotFound) || errors.Is(err, ErrBadSizeKey) {
 			return nil, 0, 0, err
 		}
 

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -307,7 +307,7 @@ func (ep *EtcdServerProcess) IsRunning() bool {
 	}
 
 	exitCode, err := ep.proc.ExitCode()
-	if err == expect.ErrProcessRunning {
+	if errors.Is(err, expect.ErrProcessRunning) {
 		return true
 	}
 

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -17,6 +17,7 @@ package clientv3test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -50,12 +51,12 @@ func TestKVPutError(t *testing.T) {
 	ctx := context.TODO()
 
 	_, err := kv.Put(ctx, "", "bar")
-	if err != rpctypes.ErrEmptyKey {
+	if !errors.Is(err, rpctypes.ErrEmptyKey) {
 		t.Fatalf("expected %v, got %v", rpctypes.ErrEmptyKey, err)
 	}
 
 	_, err = kv.Put(ctx, "key", strings.Repeat("a", int(maxReqBytes+100)))
-	if err != rpctypes.ErrRequestTooLarge {
+	if !errors.Is(err, rpctypes.ErrRequestTooLarge) {
 		t.Fatalf("expected %v, got %v", rpctypes.ErrRequestTooLarge, err)
 	}
 
@@ -67,7 +68,7 @@ func TestKVPutError(t *testing.T) {
 	time.Sleep(1 * time.Second) // give enough time for commit
 
 	_, err = kv.Put(ctx, "foo2", strings.Repeat("a", int(maxReqBytes-50)))
-	if err != rpctypes.ErrNoSpace { // over quota
+	if !errors.Is(err, rpctypes.ErrNoSpace) { // over quota
 		t.Fatalf("expected %v, got %v", rpctypes.ErrNoSpace, err)
 	}
 }
@@ -118,7 +119,7 @@ func TestKVPutWithIgnoreValue(t *testing.T) {
 	kv := clus.RandClient()
 
 	_, err := kv.Put(context.TODO(), "foo", "", clientv3.WithIgnoreValue())
-	if err != rpctypes.ErrKeyNotFound {
+	if !errors.Is(err, rpctypes.ErrKeyNotFound) {
 		t.Fatalf("err expected %v, got %v", rpctypes.ErrKeyNotFound, err)
 	}
 
@@ -157,7 +158,7 @@ func TestKVPutWithIgnoreLease(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	if _, err := kv.Put(context.TODO(), "zoo", "bar", clientv3.WithIgnoreLease()); err != rpctypes.ErrKeyNotFound {
+	if _, err := kv.Put(context.TODO(), "zoo", "bar", clientv3.WithIgnoreLease()); !errors.Is(err, rpctypes.ErrKeyNotFound) {
 		t.Fatalf("err expected %v, got %v", rpctypes.ErrKeyNotFound, err)
 	}
 
@@ -199,7 +200,7 @@ func TestKVPutWithRequireLeader(t *testing.T) {
 
 	kv := clus.Client(0)
 	_, err := kv.Put(clientv3.WithRequireLeader(context.Background()), "foo", "bar")
-	if err != rpctypes.ErrNoLeader {
+	if !errors.Is(err, rpctypes.ErrNoLeader) {
 		t.Fatal(err)
 	}
 
@@ -413,12 +414,12 @@ func TestKVCompactError(t *testing.T) {
 	}
 
 	_, err = kv.Compact(ctx, 6)
-	if err != rpctypes.ErrCompacted {
+	if !errors.Is(err, rpctypes.ErrCompacted) {
 		t.Fatalf("expected %v, got %v", rpctypes.ErrCompacted, err)
 	}
 
 	_, err = kv.Compact(ctx, 100)
-	if err != rpctypes.ErrFutureRev {
+	if !errors.Is(err, rpctypes.ErrFutureRev) {
 		t.Fatalf("expected %v, got %v", rpctypes.ErrFutureRev, err)
 	}
 }
@@ -443,7 +444,7 @@ func TestKVCompact(t *testing.T) {
 		t.Fatalf("couldn't compact kv space (%v)", err)
 	}
 	_, err = kv.Compact(ctx, 7)
-	if err == nil || err != rpctypes.ErrCompacted {
+	if err == nil || !errors.Is(err, rpctypes.ErrCompacted) {
 		t.Fatalf("error got %v, want %v", err, rpctypes.ErrCompacted)
 	}
 
@@ -472,7 +473,7 @@ func TestKVCompact(t *testing.T) {
 	}
 
 	_, err = kv.Compact(ctx, 1000)
-	if err == nil || err != rpctypes.ErrFutureRev {
+	if err == nil || !errors.Is(err, rpctypes.ErrFutureRev) {
 		t.Fatalf("error got %v, want %v", err, rpctypes.ErrFutureRev)
 	}
 }
@@ -750,7 +751,7 @@ func TestKVLargeRequests(t *testing.T) {
 		_, err := cli.Put(context.TODO(), "foo", strings.Repeat("a", test.valueSize))
 
 		if _, ok := err.(rpctypes.EtcdError); ok {
-			if err != test.expectError {
+			if !errors.Is(err, test.expectError) {
 				t.Errorf("#%d: expected %v, got %v", i, test.expectError, err)
 			}
 		} else if err != nil && !strings.HasPrefix(err.Error(), test.expectError.Error()) {

--- a/tests/integration/clientv3/metrics_test.go
+++ b/tests/integration/clientv3/metrics_test.go
@@ -17,6 +17,7 @@ package clientv3test
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -165,7 +166,7 @@ func getHTTPBodyAsLines(t *testing.T, url string) []string {
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			} else {
 				t.Fatalf("error reading: %v", err)

--- a/tests/integration/clientv3/util.go
+++ b/tests/integration/clientv3/util.go
@@ -16,6 +16,7 @@ package clientv3test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -64,7 +65,7 @@ func IsClientTimeout(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err == context.DeadlineExceeded {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 	ev, ok := status.FromError(err)
@@ -79,7 +80,7 @@ func IsCanceled(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return true
 	}
 	ev, ok := status.FromError(err)
@@ -94,7 +95,7 @@ func IsUnavailable(err error) bool {
 	if err == nil {
 		return false
 	}
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return true
 	}
 	ev, ok := status.FromError(err)

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"testing"
 	"time"
 
@@ -167,7 +168,7 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 
 func shouldRetry(err error) bool {
 	if clientv3test.IsClientTimeout(err) || clientv3test.IsServerCtxTimeout(err) ||
-		err == rpctypes.ErrTimeout || err == rpctypes.ErrTimeoutDueToLeaderFail {
+		errors.Is(err, rpctypes.ErrTimeout) || errors.Is(err, rpctypes.ErrTimeoutDueToLeaderFail) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Update `err == *` expressions to `errors.Is(err, *)`, as a preferred means of error equality checks that can handle wrapping (https://pkg.go.dev/errors#pkg-overview).

This PR updates all cases to be fixed in a number of files, but not all files. The rest of the cases should be addressed in a separate PR.