### PR TITLE
typo: catch-up should be catchup

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -72,7 +72,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [Protection on maintenance request when auth is enabled](https://github.com/etcd-io/etcd/pull/14663).
 - Graduated [`--experimental-warning-unary-request-duration` to `--warning-unary-request-duration`](https://github.com/etcd-io/etcd/pull/14414). Note the experimental flag is deprecated and will be decommissioned in v3.7.
 - Add [field `hash_revision` into `HashKVResponse`](https://github.com/etcd-io/etcd/pull/14537).
-- Add [`etcd --experimental-snapshot-catch-up-entries`](https://github.com/etcd-io/etcd/pull/15033) flag to configure number of entries for a slow follower to catch up after compacting the raft storage entries and defaults to 5k. 
+- Add [`etcd --experimental-snapshot-catchup-entries`](https://github.com/etcd-io/etcd/pull/15033) flag to configure number of entries for a slow follower to catch up after compacting the raft storage entries and defaults to 5k. 
 - Decreased [`--snapshot-count` default value from 100,000 to 10,000](https://github.com/etcd-io/etcd/pull/15408)
 - Add [`etcd --tls-min-version --tls-max-version`](https://github.com/etcd-io/etcd/pull/15156) to enable support for TLS 1.3.
 - Add [quota to endpoint status response](https://github.com/etcd-io/etcd/pull/17877)

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -165,7 +165,7 @@ type Config struct {
 	// We expect the follower has a millisecond level latency with the leader.
 	// The max throughput is around 10K. Keep a 5K entries is enough for helping
 	// follower to catch up.
-	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
+	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catchup-entries"`
 
 	MaxSnapFiles uint `json:"max-snapshots"`
 	//revive:disable-next-line:var-naming

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -62,7 +62,7 @@ func TestConfigFileMemberFields(t *testing.T) {
 		MaxWALFiles            uint   `json:"max-wals"`
 		Name                   string `json:"name"`
 		SnapshotCount          uint64 `json:"snapshot-count"`
-		SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
+		SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catchup-entries"`
 		ListenPeerURLs         string `json:"listen-peer-urls"`
 		ListenClientURLs       string `json:"listen-client-urls"`
 		ListenClientHTTPURLs   string `json:"listen-client-http-urls"`

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -299,7 +299,7 @@ Experimental feature:
     Set time duration after which a warning is generated if a unary request takes more than this duration. It's deprecated, and will be decommissioned in v3.7. Use --warning-unary-request-duration instead.
   --experimental-max-learners '1'
     Set the max number of learner members allowed in the cluster membership.
-  --experimental-snapshot-catch-up-entries '5000'
+  --experimental-snapshot-catchup-entries '5000'
     Number of entries for a slow follower to catch up after compacting the raft storage entries.
   --experimental-compaction-sleep-interval
     Sets the sleep interval between each compaction batch.


### PR DESCRIPTION
Fix a typo. 

Change `experimental-snapshot-catch-up-entries` to `experimental-snapshot-catchup-entries`.

Running `etcd --experimental-snapshot-catch-up-entries 500` gives an error: `flag provided but not defined: -experimental-snapshot-catch-up-entries`

Running `etcd --experimental-snapshot-catchup-entries 500` works without any error.

This line confirms that `catch-up` should be `catchup`:
https://github.com/etcd-io/etcd/blob/4a11ca6c89be94094258aee418ac70e0536a97fa/server/embed/config.go#L770

It took me half an hour to figure this out, and I’d like to save everyone else the trouble.