### PR TITLE
CHANGELOG: add note regarding updating to go 1.22.7

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -14,9 +14,8 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - [Print gRPC metadata in guaranteed order using the official go fmt pkg](https://github.com/etcd-io/etcd/pull/18311).
 
 ### Dependencies
-- Compile binaries using go [1.21.13](https://github.com/etcd-io/etcd/pull/18422).
+- Compile binaries using [go 1.22.7](https://github.com/etcd-io/etcd/pull/18549).
 - Upgrade [bbolt to 1.3.11](https://github.com/etcd-io/etcd/pull/18488).
-
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -11,9 +11,8 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - [Keep the tombstone during compaction if it happens to be the compaction revision](https://github.com/etcd-io/etcd/pull/18474)
 
 ### Dependencies
-- Compile binaries using [go 1.21.13](https://github.com/etcd-io/etcd/pull/18421).
+- Compile binaries using [go 1.22.7](https://github.com/etcd-io/etcd/pull/18550).
 - Upgrade [bbolt to v1.3.11](https://github.com/etcd-io/etcd/pull/18489).
-
 
 <hr>
 


### PR DESCRIPTION
Update 3.4 and 3.5 CHANGELOG to add a note regarding the Go update to 1.22.7.

Part of #18548.

To be merged after https://github.com/etcd-io/etcd/pull/18549, https://github.com/etcd-io/etcd/pull/18550.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
