### PR TITLE
use uint64 for priority variable

### DIFF
--- a/client/v3/experimental/recipes/priority_queue.go
+++ b/client/v3/experimental/recipes/priority_queue.go
@@ -41,6 +41,13 @@ func (q *PriorityQueue) Enqueue(val string, pr uint16) error {
 	return err
 }
 
+// EnqueueUint64 puts a value into a queue with a given uint64 priority.
+func (q *PriorityQueue) EnqueueUint64(val string, pr uint64) error {
+	prefix := fmt.Sprintf("%s%05d", q.key, pr)
+	_, err := newSequentialKV(q.client, prefix, val)
+	return err
+}
+
 // Dequeue returns Enqueue()'d items in FIFO order. If the
 // queue is empty, Dequeue blocks until items are available.
 func (q *PriorityQueue) Dequeue() (string, error) {


### PR DESCRIPTION
Changing priority variable from uint16 to uint64 allows for a wider range of values. For instance, we have a use case where we need unix timestamp in nanoseconds granularity which is not supported by uint16 but requires uint64.
