### PR TITLE
Improve release documentation

### DIFF
--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -72,12 +72,11 @@ which don't need to be executed before releasing each version.
    - `docker login gcr.io`
    - `docker login quay.io`
 5. Clone the etcd repository and checkout the target branch,
-   - `git clone git@github.com:etcd-io/etcd.git`
-   - `git checkout release-3.X`
+   - `git clone --branch release-3.X git@github.com:etcd-io/etcd.git`
 6. Run the release script under the repository's root directory, replacing `${VERSION}` with a value without the `v` prefix, i.e. `3.5.13`.
    - `DRY_RUN=false ./scripts/release.sh ${VERSION}`
 
-   It generates all release binaries under the directory `./release` and images. Binaries are pushed to the Google Cloud bucket
+   It generates all release binaries under the directory `/tmp/etcd-release-${VERSION}/etcd/release/` and images. Binaries are pushed to the Google Cloud bucket
    under project `etcd-development`, and images are pushed to `quay.io` and `gcr.io`.
 7. Publish the release page on GitHub
    - Set the release title as the version name
@@ -88,7 +87,7 @@ which don't need to be executed before releasing each version.
    - Publish the release
 8. Announce to the etcd-dev googlegroup
 
-   Follow the format of previous release emails sent to etcd-dev@googlegroups.com, see an example below. After sending out the email, ask one of the mailing list maintainers to approve the email from the pending list.
+   Follow the format of previous release emails sent to etcd-dev@googlegroups.com, see an example below. After sending out the email, ask one of the mailing list maintainers to approve the email from the pending list. Additionally, label the release email as `Release`.
 
 ```text
 Hello,


### PR DESCRIPTION
This commit will improve the release documentation guide by incorporating the following points:
```
1. Step 5 can be simplified to do a single-branch checkout
2. Step 6 should clarify that the release directory is in /tmp/etcd-release-${VERSION}/etcd/release/
3. Step 8 mention to add the "Release" label to the announcement message
```
Reference: https://github.com/etcd-io/etcd/issues/18485#issuecomment-2341751693

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
