### PR TITLE
CHANGELOG: set release 3.4.34 date

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
-## v3.4.34 (TBD)
+## v3.4.35 (TBC)
+
+<hr>
+
+## v3.4.34 (2024-09-11)
 
 ### etcd server
 - Fix [performance regression issue caused by the `ensureLeadership` in lease renew](https://github.com/etcd-io/etcd/pull/18440).


### PR DESCRIPTION
Set the v3.4.34 release date to today.

Part of #18486.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
