### PR TITLE
api: wrap underlying EtcdError error

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -239,8 +239,9 @@ var (
 // EtcdError defines gRPC server errors.
 // (https://github.com/grpc/grpc-go/blob/master/rpc_util.go#L319-L323)
 type EtcdError struct {
-	code codes.Code
-	desc string
+	code         codes.Code
+	desc         string
+	wrappedError error
 }
 
 // Code returns grpc/codes.Code.
@@ -251,6 +252,10 @@ func (e EtcdError) Code() codes.Code {
 
 func (e EtcdError) Error() string {
 	return e.desc
+}
+
+func (e EtcdError) Unwrap() error {
+	return e.wrappedError
 }
 
 func Error(err error) error {
@@ -268,7 +273,7 @@ func Error(err error) error {
 	} else {
 		desc = verr.Error()
 	}
-	return EtcdError{code: ev.Code(), desc: desc}
+	return EtcdError{code: ev.Code(), desc: desc, wrappedError: err}
 }
 
 func ErrorDesc(err error) string {

--- a/api/v3rpc/rpctypes/error_test.go
+++ b/api/v3rpc/rpctypes/error_test.go
@@ -15,6 +15,7 @@
 package rpctypes
 
 import (
+	"errors"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -38,5 +39,22 @@ func TestConvert(t *testing.T) {
 	}
 	if ev2, ok := status.FromError(e2); ok && ev2.Code() != e3.(EtcdError).Code() {
 		t.Fatalf("expected them to be equal, got %v / %v", ev2.Code(), e3.(EtcdError).Code())
+	}
+}
+
+func TestComparingWrappedError(t *testing.T) {
+	errTest := errors.New("test error")
+	e1 := Error(ErrGRPCEmptyKey)
+	e2 := Error(status.Error(codes.InvalidArgument, "etcdserver: key is not provided"))
+	e3 := Error(errTest)
+
+	if !errors.Is(e1, ErrGRPCEmptyKey) {
+		t.Fatalf("expected %v to be an ErrGRPCEmptyKey wrapped error", e1)
+	}
+	if !errors.Is(e2, ErrGRPCEmptyKey) {
+		t.Fatalf("expected %v to be an ErrGRPCEmptyKey wrapped error", e1)
+	}
+	if !errors.Is(e3, errTest) {
+		t.Fatalf("expected %v to be an errTest wrapped error", e3)
 	}
 }


### PR DESCRIPTION
Without wrapping, using `errors.Is()` (or even trying to compare the error with `==`) fails as EtcdError swallows the underlying error.

Related to #18493.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
