### PR TITLE
docs: remove warning that etcd 3.5.0 was not yet released

### DIFF
--- a/client/v3/README.md
+++ b/client/v3/README.md
@@ -11,13 +11,6 @@
 go get go.etcd.io/etcd/client/v3
 ```
 
-Warning: As etcd 3.5.0 was not yet released, the command above does not work. 
-After first pre-release of 3.5.0 [#12498](https://github.com/etcd-io/etcd/issues/12498), 
-etcd can be referenced using: 
-```
-go get go.etcd.io/etcd/client/v3@v3.5.0-pre
-```
-
 ## Get started
 
 Create client using `clientv3.New`:


### PR DESCRIPTION
See description in https://github.com/etcd-io/etcd/issues/18410