### PR TITLE
tests: fix server_test.go

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1598,11 +1598,14 @@ func TestIsActive(t *testing.T) {
 	}
 }
 
-// newDummyPutReqReady creates a dummy raft.Ready.
+// newDummyPutReqReady creates a raft.Ready.
 //
-// In unit tests, EtcdServer doesn't append raft log entries upon start like the full-featured etcd does.
-// This can crash the program when creating a raft log snapshot due to no available entries.
-// To append raft log entries, we can send a newDummyPutReqReady() to raft.Node's readyc after the server starts.
+// In unit tests, a manually created EtcdServer doesn't append raft log
+// entries on startup like the full-featured etcd does in bootstrap.
+// This can crash the program when creating a raft log snapshot if there
+// are no available entries.
+// To work around this, we can send a newDummyPutReqReady() to raft.Node's readyc
+// after the server starts to ensure the entries are appended.
 func newDummyPutReqReady() raft.Ready {
 	req := &pb.InternalRaftRequest{
 		Header: &pb.RequestHeader{ID: 1},


### PR DESCRIPTION
#18494 creates a non-empty raft log snapshot on server startup, which requires:

1. There are  available entries in raft log.
2. A non-nil `kv` is set :
https://github.com/etcd-io/etcd/blob/981061a4958e8d386b025dbecd43af9b974709e2/server/etcdserver/server.go#L2132-L2143

---

This PR fixes the failed tests in `server_test.go` by :
1. Appending raft log entries by sending a put request to raft.Node's readyc
2. Setting a non-nil `kv` for `EtcdServer`

---

Part of https://github.com/etcd-io/etcd/issues/17098
