### PR TITLE
tests: fix MustNewMember

### DIFF
--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1682,7 +1682,8 @@ func (p SortableProtoMemberSliceByPeerURLs) Less(i, j int) bool {
 func (p SortableProtoMemberSliceByPeerURLs) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
 // MustNewMember creates a new member instance based on the response of V3 Member Add API.
-func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse) *Member {
+// Pass nil for tlsinfo if the member's PeerURLs don't use HTTPS.
+func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse, tlsinfo *transport.TLSInfo) *Member {
 	m := c.mustNewMember(t)
 	m.IsLearner = resp.Member.IsLearner
 	m.NewCluster = false
@@ -1700,7 +1701,7 @@ func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse)
 	m.PeerURLs = urls
 	var listeners []net.Listener
 	for _, url := range urls {
-		l, err := transport.NewListener(url.Host, url.Scheme, nil)
+		l, err := transport.NewListener(url.Host, url.Scheme, tlsinfo)
 		if err != nil {
 			t.Fatal("failed to listen on %v: %v", url, err)
 		}

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1700,17 +1700,7 @@ func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse)
 	m.PeerURLs = urls
 	var listeners []net.Listener
 	for _, url := range urls {
-		var l net.Listener
-		var err error
-		switch url.Scheme {
-		case "http", "https":
-			l, err = net.Listen("tcp", url.Host)
-		case "unix", "unixs":
-			l, err = net.Listen("unix", url.Host)
-		default:
-			err = fmt.Errorf("unsupported scheme: %s", url.Scheme)
-		}
-
+		l, err := transport.NewListener(url.Host, url.Scheme, nil)
 		if err != nil {
 			t.Fatal("failed to listen on %v: %v", url, err)
 		}

--- a/tests/integration/clientv3/cluster_test.go
+++ b/tests/integration/clientv3/cluster_test.go
@@ -264,7 +264,7 @@ func TestMemberPromote(t *testing.T) {
 
 	// create and launch learner member based on the response of V3 Member Add API.
 	// (the response has information on peer urls of the existing members in cluster)
-	learnerMember := clus.MustNewMember(t, memberAddResp)
+	learnerMember := clus.MustNewMember(t, memberAddResp, nil)
 
 	if err = learnerMember.Launch(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The original `MustNewMember` function creates a new member without using the specific PeerURLs, causing the leader to fail when sending snapshots to the new member through those PeerURLs.

This PR fixes the `MustNewMember` by overriding the new member’s PeerURLs.

#18494 depends on this PR

Part of https://github.com/etcd-io/etcd/issues/17098
