### PR TITLE
[3.4] release: push tag after creating it

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -70,7 +70,7 @@ main() {
     git checkout "${BRANCH}" || exit 2
     git pull origin
   fi
-  
+
   # If a release version tag already exists, use it.
   log_callout "Checking tag: ${RELEASE_VERSION}"
   local remote_tag_exists
@@ -125,7 +125,7 @@ main() {
 
     # Push the version change if it's not already been pushed.
     if [ "$DRY_RUN" != "true" ] && [ "$(git rev-list --count "origin/${BRANCH}..${BRANCH}")" -gt 0 ]; then
-      read -p "Push version bump up to ${VERSION} to github.com/etcd-io/etcd [y/N]? " -r confirm
+      read -p "Push version bump up to ${VERSION} to ${REPOSITORY} [y/N]? " -r confirm
       [[ "${confirm,,}" == "y" ]] || exit 1
       git push
     fi
@@ -142,6 +142,12 @@ main() {
         exit 1
       fi
       git tag --local-user "${KEYID}" --sign "${RELEASE_VERSION}" --message "${RELEASE_VERSION}"
+
+      if [ "$DRY_RUN" != "true" ]; then
+        read -p "Push tag ${RELEASE_VERSION} to ${REPOSITORY} [y/N]? " -r confirm
+        [[ "${confirm,,}" == "y" ]] || exit 1
+        git push origin "${RELEASE_VERSION}"
+      fi
     fi
 
     # Verify the latest commit has the version tag
@@ -185,7 +191,6 @@ main() {
     log_error "Error: Expected clean working tree, but 'git diff --stat' reported: ${diff}"
     exit 1
   fi
-  
 
   # Build release.
   # TODO: check the release directory for all required build artifacts.


### PR DESCRIPTION
As found in https://github.com/etcd-io/etcd/issues/18486#issuecomment-2347374985, running release-3.4's release script created the tag but didn't push it. This pull request addresses that issue.

I verified this by running the script with my fork and pointing the `REPOSITORY` environment variable to it:

1. `version/version.go` bump commit: https://github.com/ivanvc/etcd/commit/d2e6638c13addb522c12f2f47ab7a7a10bf57802
2. tag: https://github.com/ivanvc/etcd/releases/tag/v3.4.102

Part of https://github.com/etcd-io/etcd/issues/18486

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
