### PR TITLE
[3.5] Backport DefaultSnapshotCount 10K

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -71,7 +71,7 @@ import (
 )
 
 const (
-	DefaultSnapshotCount = 100000
+	DefaultSnapshotCount = 10000
 
 	// DefaultSnapshotCatchUpEntries is the number of entries for a slow follower
 	// to catch-up after compacting the raft storage entries.


### PR DESCRIPTION
An experiment in https://github.com/etcd-io/etcd/issues/17098#issuecomment-2345636549 suggests that setting a low `snapshot-count` can reduce the heap size. ￼

v3.5 might benefit from setting `DefaultSnapshotCount` to 10_000, which is already the default in v3.6.

---

Here is a table copied from https://github.com/etcd-io/etcd/issues/17098#issuecomment-2345636549, showing how heap size is affected by `--snapshot-count` and `--experimental-snapshot-catchup-entries`.

* `putSize`: average size of `put` requests

| putSize | --snapshot-count | --experimental-snapshot<br/>-catchup-entries | heap size<br/>v3.5.16 | heap size<br/>v3.6.0-alpha.0 |
|---------|------------------|----------------------------------------------|-----------------------|------------------------------|
| 1 KB    | 10000            | 5000                                         | 6 MB ~ 28 MB          | 13 MB ~ 31.7 MB              |
| 10 KB   | 10000            | 5000                                         | 64 MB ~ 180 MB        |                              |
| 100 KB  | 10000            | 5000                                         | 569 MB ~ 1.5 GB       | 536 MB ~ 1.62 GB             |
| 1 MB    | 10000            | 5000                                         | 5 GB ~ 14.2 GB        |                              |
| ---     | ---              | ---                                          | ---                   | ---                          |
| 1 KB    | 100000           | 5000                                         | 15 MB ~ 143 MB        | 15 MB ~ 152 MB               |
| 10 KB   | 100000           | 5000                                         | 67 MB ~ 1.1GB         |                              |
| 100 KB  | 100000           | 5000                                         | 900 MB ~ 10.6 GB      | 690 MB ~ 10.4 GB             |
| ---     | ---              | ---                                          | ---                   | ---                          |
| 1 MB    | 500              | 500                                          | 550 MB ~ 1 GB         |                              |


