### PR TITLE
Add tools/mod to module_dirs

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -166,7 +166,7 @@ function run_for_module {
 }
 
 function module_dirs() {
-  echo "api pkg client/pkg client/internal/v2 client/v3 server etcdutl etcdctl tests tools/rw-heatmaps tools/testgrid-analysis ."
+  echo "api pkg client/pkg client/internal/v2 client/v3 server etcdutl etcdctl tests tools/mod tools/rw-heatmaps tools/testgrid-analysis ."
 }
 
 # maybe_run [cmd...] runs given command depending on the DRY_RUN flag.

--- a/tools/mod/doc.go
+++ b/tools/mod/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The etcd Authors
+// Copyright 2024 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build libs
+// As this directory implements the pattern for tracking tool dependencies as documented here:
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module, it doesn't
+// contain any valid go source code in the directory directly. This would break scripts for
+// unit testing, golangci-lint, and coverage calculation.
+//
+// Thus, to ensure tools to run normally, we've added this empty file.
 
-// This file implements that pattern:
-// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
-// for etcd. Thanks to this file 'go mod tidy' does not removes dependencies.
-
-package libs
-
-import (
-	_ "github.com/gogo/protobuf/proto"
-)
+package mod

--- a/tools/mod/tools.go
+++ b/tools/mod/tools.go
@@ -15,7 +15,7 @@
 //go:build tools
 
 // This file implements that pattern:
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 // for etcd. Thanks to this file 'go mod tidy' does not removes dependencies.
 
 package tools


### PR DESCRIPTION
As `tools/mod` also contains the `go.mod` file, we should look into adding it to the `module_dirs` variable, so that when executing `./scripts/fix.sh`, the proper checks and fixes can be applied.

To address the issue of broken unit tests and code coverage due to `tools/mod` directory's lack of Go code, we've introduced a new `doc.go` file. This file acts as a placeholder, enabling tools like `golangci-lint` and `go test` to function correctly.

Discovered when working on https://github.com/etcd-io/etcd/pull/18575, where running `./scripts/fix.sh` missed fixing the go mod file in `tools/mod`, causing the CI pipeline to fail.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
