### PR TITLE
Add function to create WAL files

### DIFF
--- a/server/storage/wal/file_pipeline.go
+++ b/server/storage/wal/file_pipeline.go
@@ -75,7 +75,7 @@ func (fp *filePipeline) Close() error {
 func (fp *filePipeline) alloc() (f *fileutil.LockedFile, err error) {
 	// count % 2 so this file isn't the same as the one last published
 	fpath := filepath.Join(fp.dir, fmt.Sprintf("%d.tmp", fp.count%2))
-	if f, err = fileutil.LockFile(fpath, os.O_CREATE|os.O_WRONLY, fileutil.PrivateFileMode); err != nil {
+	if f, err = createNewWALFile[*fileutil.LockedFile](fpath, false); err != nil {
 		return nil, err
 	}
 	if err = fileutil.Preallocate(f.File, fp.size, true); err != nil {

--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -67,7 +67,7 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 
 		case errors.Is(err, io.ErrUnexpectedEOF):
 			brokenName := f.Name() + ".broken"
-			bf, bferr := os.OpenFile(brokenName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileutil.PrivateFileMode)
+			bf, bferr := createNewWALFile[*os.File](brokenName, true)
 			if bferr != nil {
 				lg.Warn("failed to create backup file", zap.String("path", brokenName), zap.Error(bferr))
 				return false


### PR DESCRIPTION
Relates to https://github.com/etcd-io/etcd/pull/18574#discussion_r1758781591

This PR adds a new function to consolidate WAL file creation into a single function to help reduce errors and make the process more consistent.