### PR TITLE
update: `cobra.ExactValidArgs` method is deprecated

### DIFF
--- a/etcdctl/ctlv3/command/completion_command.go
+++ b/etcdctl/ctlv3/command/completion_command.go
@@ -65,7 +65,7 @@ PowerShell:
 `,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":

--- a/etcdutl/etcdutl/completion_commmand.go
+++ b/etcdutl/etcdutl/completion_commmand.go
@@ -65,7 +65,7 @@ PowerShell:
 `,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		Run: func(cmd *cobra.Command, args []string) {
 			switch args[0] {
 			case "bash":


### PR DESCRIPTION
`cobra.ExactValidArgs` method is deprecated I update `cobra.ExactValidArgs` method to `cobra.MatchAll` method