### PR TITLE
command: Use errors.Is for error equality check in ep_command.go

### DIFF
--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -137,7 +138,7 @@ func epHealthCommandFunc(cmd *cobra.Command, args []string) {
 			_, err = cli.Get(ctx, "health")
 			eh := epHealth{Ep: ep, Health: false, Took: time.Since(st).String()}
 			// permission denied is OK since proposal goes through consensus to get it
-			if err == nil || err == rpctypes.ErrPermissionDenied {
+			if err == nil || errors.Is(err, rpctypes.ErrPermissionDenied) {
 				eh.Health = true
 			} else {
 				eh.Error = err.Error()


### PR DESCRIPTION
Follow up on https://github.com/etcd-io/etcd/pull/18615#issuecomment-2367198258 for using errors.Is in `etcdctl` module, as part of https://github.com/etcd-io/etcd/issues/18576.

Use errors.Is for error equality check in `ep_command.go`.
