### PR TITLE
testutils: add ExpectExactNTimes function to LogObserver

### DIFF
--- a/tests/framework/testutils/log_observer_test.go
+++ b/tests/framework/testutils/log_observer_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestLogObserver_Timeout(t *testing.T) {
 	logger.Info(t.Name())
 
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
-	_, err := logOb.Expect(ctx, "unknown", 1)
+	_, err := logOb.ExpectAtLeastNTimes(ctx, "unknown", 1)
 	cancel()
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 
@@ -53,7 +54,7 @@ func TestLogObserver_Expect(t *testing.T) {
 	go func() {
 		defer close(resCh)
 
-		res, err := logOb.Expect(ctx, t.Name(), 2)
+		res, err := logOb.ExpectAtLeastNTimes(ctx, t.Name(), 2)
 		require.NoError(t, err)
 		resCh <- res
 	}()
@@ -80,4 +81,77 @@ func TestLogObserver_Expect(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(logOb.entries))
+}
+
+// TestLogObserver_ExpectExactNTimes tests the behavior of ExpectExactNTimes.
+// It covers 4 scenarios:
+//
+// 1. Occurrences in log is less than expected when duration ends.
+// 2. Occurrences in log is exactly as expected when duration ends.
+// 3. Occurrences in log is greater than expected when duration ends.
+// 4. context deadline exceeded before duration ends
+func TestLogObserver_ExpectExactNTimes(t *testing.T) {
+	logCore, logOb := NewLogObserver(zap.InfoLevel)
+
+	logger := zap.New(logCore)
+
+	// Log messages at 0ms, 100ms, 200ms
+	msgs := []string{"Hello " + t.Name(), t.Name() + ", World", t.Name()}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+
+	// When duration ends at 50ms, there's only one message in the log.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := logOb.ExpectExactNTimes(ctx, t.Name(), 2, 50*time.Millisecond)
+		assert.ErrorContains(t, err, "failed to expect, expected: 2, got: 1")
+	}()
+
+	// When duration ends at 150ms, there are 2 messages in the log.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		lines, err := logOb.ExpectExactNTimes(ctx, t.Name(), 2, 150*time.Millisecond)
+		assert.NoError(t, err)
+		assert.Len(t, lines, 2)
+		for i := 0; i < 2; i++ {
+			// lines should be like:
+			// 2023-04-16T11:46:19.367+0800 INFO	Hello TestLogObserver_ExpectExactNTimes
+			// 2023-04-16T11:46:19.408+0800	INFO	TestLogObserver_ExpectExactNTimes, World
+			//
+			// msgs:
+			// Hello TestLogObserver_ExpectExactNTimes
+			// TestLogObserver_ExpectExactNTimes, World
+			// TestLogObserver_ExpectExactNTimes
+			strings.HasSuffix(lines[i], msgs[i])
+		}
+	}()
+
+	// Before duration ends at 250ms, there are already 3 messages in the log.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := logOb.ExpectExactNTimes(ctx, t.Name(), 2, 250*time.Millisecond)
+		assert.ErrorContains(t, err,"failed to expect; too many occurrences; expected: 2, got:3")
+	}()
+
+	// context deadline exceeded at 300ms before the 400ms duration can end.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := logOb.ExpectExactNTimes(ctx, t.Name(), 3, 400*time.Millisecond)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	}()
+
+	// Log messages at 0ms, 100ms, 200ms
+	for _, msg := range msgs {
+		logger.Info(msg)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	wg.Wait()
 }

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -177,7 +177,7 @@ func expectMemberLog(t *testing.T, m *integration.Member, timeout time.Duration,
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 
-	lines, err := m.LogObserver.Expect(ctx, s, count)
+	lines, err := m.LogObserver.ExpectAtLeastNTimes(ctx, s, count)
 	if err != nil {
 		t.Fatalf("failed to expect (log:%s, count:%v): %v", s, count, err)
 	}


### PR DESCRIPTION
Context https://github.com/etcd-io/etcd/pull/18635#discussion_r1775086281

#18635 needs this.