### PR TITLE
api: address revive unexported-return issues

### DIFF
--- a/api/etcdserverpb/raft_internal_stringer.go
+++ b/api/etcdserverpb/raft_internal_stringer.go
@@ -72,13 +72,13 @@ func (as *InternalRaftStringer) String() string {
 	return as.Request.String()
 }
 
-// txnRequestStringer implements a custom proto String to replace value bytes fields with value size
-// fields in any nested txn and put operations.
+// txnRequestStringer implements fmt.Stringer, a custom proto String to replace value bytes
+// fields with value size fields in any nested txn and put operations.
 type txnRequestStringer struct {
 	Request *TxnRequest
 }
 
-func NewLoggableTxnRequest(request *TxnRequest) *txnRequestStringer {
+func NewLoggableTxnRequest(request *TxnRequest) fmt.Stringer {
 	return &txnRequestStringer{request}
 }
 
@@ -155,8 +155,8 @@ func (m *loggableValueCompare) Reset()         { *m = loggableValueCompare{} }
 func (m *loggableValueCompare) String() string { return proto.CompactTextString(m) }
 func (*loggableValueCompare) ProtoMessage()    {}
 
-// loggablePutRequest implements a custom proto String to replace value bytes field with a value
-// size field.
+// loggablePutRequest implements proto.Message, a custom proto String to replace value bytes
+// field with a value size field.
 // To preserve proto encoding of the key bytes, a faked out proto type is used here.
 type loggablePutRequest struct {
 	Key         []byte `protobuf:"bytes,1,opt,name=key,proto3"`
@@ -167,7 +167,7 @@ type loggablePutRequest struct {
 	IgnoreLease bool   `protobuf:"varint,6,opt,name=ignore_lease,proto3"`
 }
 
-func NewLoggablePutRequest(request *PutRequest) *loggablePutRequest {
+func NewLoggablePutRequest(request *PutRequest) proto.Message {
 	return &loggablePutRequest{
 		request.Key,
 		int64(len(request.Value)),


### PR DESCRIPTION
This is the first pull request aiming to enable the `unexported-return` revive lint rule from golangci-lint.

The aim is to ensure that the structs returned from exported functions are exported, too.

In this pull request, the following structs are now exported:

* `etcdserverpb.TxnRequestStringer`, previously `txnRequestStringer`, as it is returned by the exported function `NewLoggableTxnRequest()`.
* `etcdserverpb.LoggablePutRequest`, previously `loggablePutRequest`, as it is returned by the exported function `NewLoggablePutRequest()`.

Part of #18370.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
