### PR TITLE
fix(tests/common): increase token ttl to fix flaky TestAuthLeaseTimeToLive test

### DIFF
--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -28,7 +28,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-var tokenTTL = time.Second
+var tokenTTL = time.Second * 3
 var defaultAuthToken = fmt.Sprintf("jwt,pub-key=%s,priv-key=%s,sign-method=RS256,ttl=%s",
 	mustAbsPath("../fixtures/server.crt"), mustAbsPath("../fixtures/server.key.insecure"), tokenTTL)
 


### PR DESCRIPTION
A simple fix for https://github.com/etcd-io/etcd/issues/18585.

Apparently under some load it can happen that the auth token expires before it was used/renewed which leads to this test (maybe other tests are affected by this as well?) being flaky (from what I saw, roughly ~0.3% of test runs). See also my comment https://github.com/etcd-io/etcd/issues/18585#issuecomment-2383054323. I figured out that simply increasing the TTL of the token to 3s seems to solve the test flakyness. In order to verify I made the following changes in `tests/framework/e2e/e2e.go` to be able to run the test using `stress`:

```patch
@@ -16,7 +16,9 @@ package e2e
 
 import (
        "context"
+       "net"
        "os"
+       "strconv"
        "testing"
 
        "go.etcd.io/etcd/client/pkg/v3/testutil"
@@ -44,6 +46,21 @@ func (e e2eRunner) BeforeTest(t testing.TB) {
 }
 
 func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) intf.Cluster {
+       lis, err := net.Listen("tcp", ":0")
+       if err != nil {
+               panic(err)
+       }
+       lis.Close()
+
+       _, port, err := net.SplitHostPort(lis.Addr().String())
+       if err != nil {
+               panic(err)
+       }
+
+       t.Logf("using base port: %s", port)
+
+       p, _ := strconv.Atoi(port)
+
        cfg := config.NewClusterConfig(opts...)
        e2eConfig := NewConfig(
                WithClusterSize(cfg.ClusterSize),
@@ -51,6 +68,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.
                WithStrictReconfigCheck(cfg.StrictReconfigCheck),
                WithAuthTokenOpts(cfg.AuthToken),
                WithSnapshotCount(cfg.SnapshotCount),
+               WithBasePort(p),
        )
 
        if cfg.ClusterContext != nil {
```

With the change in this PR and the above mentioned patch I executed `TestAuthLeaseTimeToLive`>10k times using `stress` and didn't get a single test failure because of an expired token. (There were failures but all of them were due to port conflicts as the code above contains a race between requesting a free port and actually using it if ran in parallel)