### PR TITLE
fix(tests/e2e): ensure spawned cmds are closed

### DIFF
--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -111,6 +111,7 @@ func TestV2DeprecationWriteOnlySnapshot(t *testing.T) {
 	t.Log("Verify its infeasible to start etcd with --v2-deprecation=write-only mode")
 	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--v2-deprecation=write-only", "--data-dir=" + memberDataDir}, nil)
 	assert.NoError(t, err)
+	defer proc.Close()
 
 	_, err = proc.Expect("detected disallowed custom content in v2store for stage --v2-deprecation=write-only")
 	assert.NoError(t, err)


### PR DESCRIPTION
This should fix https://github.com/etcd-io/etcd/issues/18412.

After the test case is done Go's testing pkg tries to cleanup the temporary directories that were created by calls to `TempDir()`. This cleanup sometimes failed with errors like:

```
testing.go:1231: TempDir RemoveAll cleanup: unlinkat /tmp/TestV2DeprecationWriteOnlySnapshot1900751190/002/member-0/member/snap: directory not empty
```

I belive the cleanup sometimes happened before the etcd process was stopped which lead to the above error. Adding the defer statement to make sure the process is done before the test case returns seems to fix the error for me.

Before my changes I was able to reliably reproduce the issue with
```
go test -v -count 1000 -run "^TestV2DeprecationWriteOnlySnapshot$"
```
and with the changes from this PR I'm no longer able to reproduce this.