### PR TITLE
fix(v3compactor): flaky TestPeriodicSkipRevNotChange test by increasing timeout

### DIFF
--- a/server/etcdserver/api/v3compactor/periodic_test.go
+++ b/server/etcdserver/api/v3compactor/periodic_test.go
@@ -180,7 +180,7 @@ func TestPeriodicSkipRevNotChange(t *testing.T) {
 
 	fc := clockwork.NewFakeClock()
 	rg := &fakeRevGetter{testutil.NewRecorderStreamWithWaitTimout(0), 0}
-	compactable := &fakeCompactable{testutil.NewRecorderStreamWithWaitTimout(10 * time.Millisecond)}
+	compactable := &fakeCompactable{testutil.NewRecorderStreamWithWaitTimout(20 * time.Millisecond)}
 	tb := newPeriodic(zaptest.NewLogger(t), fc, retentionDuration, rg, compactable)
 
 	tb.Run()


### PR DESCRIPTION
This should fix https://github.com/etcd-io/etcd/issues/17487, see also comments in issue. 

@ahrtr and I were both not sure if this is a change of the test logic (I think it is not) and how the 10ms timeout was initially chosen. Maybe someone else knows more in that regard? Anyway this change makes the test reliable for me.