### PR TITLE
Fix robustness test logs by identifing failpoint availability on temporary cluster before creating subtest

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -44,24 +44,37 @@ func TestMain(m *testing.M) {
 func TestRobustnessExploratory(t *testing.T) {
 	testRunner.BeforeTest(t)
 	for _, s := range exploratoryScenarios(t) {
-		t.Run(s.name, func(t *testing.T) {
+		ctx := context.Background()
+		s.failpoint = randomFailpointForConfig(ctx, t, s.profile, s.cluster)
+		t.Run(s.name+"/"+s.failpoint.Name(), func(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			s.cluster.Logger = lg
-			ctx := context.Background()
 			c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.cluster))
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer forcestopCluster(c)
-			s.failpoint, err = failpoint.PickRandom(c, s.profile)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Run(s.failpoint.Name(), func(t *testing.T) {
-				testRobustness(ctx, t, lg, s, c)
-			})
+			testRobustness(ctx, t, lg, s, c)
 		})
 	}
+}
+
+// TODO: Implement lightweight a way to generate list of failpoints without needing to start a cluster
+func randomFailpointForConfig(ctx context.Context, t *testing.T, profile traffic.Profile, config e2e.EtcdProcessClusterConfig) failpoint.Failpoint {
+	config.Logger = zap.NewNop()
+	c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&config))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := failpoint.PickRandom(c, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = forcestopCluster(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
 }
 
 func TestRobustnessRegression(t *testing.T) {


### PR DESCRIPTION
cc @ahrtr @fuweid @henrybear327 @siyuanfoundation @MadhavJivrajani 

