### PR TITLE
fix: enable nil-compare rule from testifylint

### DIFF
--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -146,7 +146,7 @@ func TestPageWriterPageBytes(t *testing.T) {
 				}, "expected panic when pageBytes is %d", tc.pageBytes)
 			} else {
 				pw := NewPageWriter(cw, tc.pageBytes, 0)
-				assert.NotEqual(t, pw, nil)
+				assert.NotNil(t, pw)
 			}
 		})
 	}

--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2error"
 )
 
@@ -38,7 +38,7 @@ func TestMinExpireTime(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 	var eidx uint64 = 1
 	e, err := s.Get("/foo", true, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -60,7 +60,7 @@ func TestStoreGetDirectory(t *testing.T) {
 	s.Create("/foo/baz/ttl", false, "Y", false, TTLOptionSet{ExpireTime: fc.Now().Add(time.Second * 3)})
 	var eidx uint64 = 7
 	e, err := s.Get("/foo", true, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -103,14 +103,14 @@ func TestStoreUpdateValueTTL(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	_, err := s.Update("/foo", "baz", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	e, _ := s.Get("/foo", false, false)
 	assert.Equal(t, *e.Node.Value, "baz")
 	assert.Equal(t, e.EtcdIndex, eidx)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	e, err = s.Get("/foo", false, false)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	assert.Equal(t, err.(*v2error.Error).ErrorCode, v2error.EcodeKeyNotFound)
 }
 
@@ -122,11 +122,11 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 
 	var eidx uint64 = 3
 	_, err := s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	_, err = s.Create("/foo/bar", false, "baz", false, TTLOptionSet{ExpireTime: Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	e, err := s.Update("/foo/bar", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	e, _ = s.Get("/foo/bar", false, false)
@@ -136,7 +136,7 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	e, err = s.Get("/foo/bar", false, false)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	assert.Equal(t, err.(*v2error.Error).ErrorCode, v2error.EcodeKeyNotFound)
 }
 
@@ -155,7 +155,7 @@ func TestStoreWatchExpire(t *testing.T) {
 	assert.Equal(t, w.StartIndex(), eidx)
 	c := w.EventChan()
 	e := nbselect(c)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	eidx = 4
@@ -193,7 +193,7 @@ func TestStoreWatchExpireRefresh(t *testing.T) {
 	assert.Equal(t, w.StartIndex(), eidx)
 	c := w.EventChan()
 	e := nbselect(c)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	eidx = 3
@@ -275,16 +275,16 @@ func TestStoreRefresh(t *testing.T) {
 	s.Create("/bar", true, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	s.Create("/bar/z", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	_, err := s.Update("/foo", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	_, err = s.Set("/foo", false, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	_, err = s.Update("/bar/z", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	_, err = s.CompareAndSwap("/foo", "bar", 0, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 }
 
 // TestStoreRecoverWithExpiration ensures that the store can recover from a previously saved state that includes an expiring key.
@@ -299,7 +299,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.Create("/foo/x", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/y", false, "baz", false, TTLOptionSet{ExpireTime: fc.Now().Add(5 * time.Millisecond)})
 	b, err := s.Save()
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -312,13 +312,13 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 
 	e, err := s.Get("/foo/x", false, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, *e.Node.Value, "bar")
 
 	e, err = s.Get("/foo/y", false, false)
-	testutil.AssertNotNil(t, err)
-	testutil.AssertNil(t, e)
+	require.NotNil(t, err)
+	assert.Nil(t, e)
 }
 
 // TestStoreWatchExpireWithHiddenKey ensures that the store doesn't see expirations of hidden keys.
@@ -333,11 +333,11 @@ func TestStoreWatchExpireWithHiddenKey(t *testing.T) {
 	w, _ := s.Watch("/", true, false, 0)
 	c := w.EventChan()
 	e := nbselect(c)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	e = nbselect(c)
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
 	e = nbselect(c)

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -21,12 +21,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/authpb"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -66,7 +66,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	// create users
 	for i := 0; i < len(usernames); i++ {
 		user, err := json.Marshal(&pb.AuthUserAddRequest{Name: usernames[i], Password: pwds[i], Options: options[i]})
-		testutil.AssertNil(cx.t, err)
+		assert.Nil(cx.t, err)
 
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/add",
@@ -79,7 +79,7 @@ func testCurlV3Auth(cx ctlCtx) {
 
 	// create root role
 	rolereq, err := json.Marshal(&pb.AuthRoleAddRequest{Name: "root"})
-	testutil.AssertNil(cx.t, err)
+	assert.Nil(cx.t, err)
 
 	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/add",
@@ -92,7 +92,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	//grant root role
 	for i := 0; i < len(usernames); i++ {
 		grantroleroot, merr := json.Marshal(&pb.AuthUserGrantRoleRequest{User: usernames[i], Role: "root"})
-		testutil.AssertNil(cx.t, merr)
+		assert.Nil(cx.t, merr)
 
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/grant",
@@ -115,7 +115,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	for i := 0; i < len(usernames); i++ {
 		// put "bar[i]" into "foo[i]"
 		putreq, err := json.Marshal(&pb.PutRequest{Key: []byte(fmt.Sprintf("foo%d", i)), Value: []byte(fmt.Sprintf("bar%d", i))})
-		testutil.AssertNil(cx.t, err)
+		assert.Nil(cx.t, err)
 
 		// fail put no auth
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
@@ -128,7 +128,7 @@ func testCurlV3Auth(cx ctlCtx) {
 
 		// auth request
 		authreq, err := json.Marshal(&pb.AuthenticateRequest{Name: usernames[i], Password: pwds[i]})
-		testutil.AssertNil(cx.t, err)
+		assert.Nil(cx.t, err)
 
 		var (
 			authHeader string
@@ -141,14 +141,14 @@ func testCurlV3Auth(cx ctlCtx) {
 			Value:    string(authreq),
 		})
 		proc, err := e2e.SpawnCmd(cmdArgs, cx.envMap)
-		testutil.AssertNil(cx.t, err)
+		assert.Nil(cx.t, err)
 		defer proc.Close()
 
 		cURLRes, err := proc.ExpectFunc(context.Background(), lineFunc)
-		testutil.AssertNil(cx.t, err)
+		assert.Nil(cx.t, err)
 
 		authRes := make(map[string]any)
-		testutil.AssertNil(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
+		assert.Nil(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
 
 		token, ok := authRes[rpctypes.TokenFieldNameGRPC].(string)
 		if !ok {

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/client/v3/leasing"
@@ -39,15 +38,15 @@ func TestLeasingPutGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lKV1, closeLKV1, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV1()
 
 	lKV2, closeLKV2, err := leasing.NewKV(clus.Client(1), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV2()
 
 	lKV3, closeLKV3, err := leasing.NewKV(clus.Client(2), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV3()
 
 	resp, err := lKV1.Get(context.TODO(), "abc")
@@ -97,7 +96,7 @@ func TestLeasingInterval(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	keys := []string{"abc/a", "abc/b", "abc/a/a"}
@@ -136,7 +135,7 @@ func TestLeasingPutInvalidateNew(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -170,7 +169,7 @@ func TestLeasingPutInvalidateExisting(t *testing.T) {
 	}
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -200,17 +199,17 @@ func TestLeasingGetNoLeaseTTL(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	lresp, err := clus.Client(0).Grant(context.TODO(), 60)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	_, err = clus.Client(0).Put(context.TODO(), "k", "v", clientv3.WithLease(lresp.ID))
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	gresp, err := lkv.Get(context.TODO(), "k")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Len(t, gresp.Kvs, 1)
 
 	clus.Members[0].Stop(t)
@@ -229,7 +228,7 @@ func TestLeasingGetSerializable(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "cached", "abc"); err != nil {
@@ -269,7 +268,7 @@ func TestLeasingPrevKey(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -295,7 +294,7 @@ func TestLeasingRevGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	putResp, err := clus.Client(0).Put(context.TODO(), "k", "abc")
@@ -331,7 +330,7 @@ func TestLeasingGetWithOpts(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -376,7 +375,7 @@ func TestLeasingConcurrentPut(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	// force key into leasing key cache
@@ -423,7 +422,7 @@ func TestLeasingDisconnectedGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "cached", "abc"); err != nil {
@@ -452,7 +451,7 @@ func TestLeasingDeleteOwner(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -486,11 +485,11 @@ func TestLeasingDeleteNonOwner(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV2()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -521,7 +520,7 @@ func TestLeasingOverwriteResponse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -555,7 +554,7 @@ func TestLeasingOwnerPutResponse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -593,7 +592,7 @@ func TestLeasingTxnOwnerGetRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	keyCount := rand.Intn(10) + 1
@@ -624,7 +623,7 @@ func TestLeasingTxnOwnerGet(t *testing.T) {
 	client := clus.Client(0)
 
 	lkv, closeLKV, err := leasing.NewKV(client, "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	defer func() {
 		// In '--tags cluster_proxy' mode the client need to be closed before
@@ -708,7 +707,7 @@ func TestLeasingTxnOwnerDeleteRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	keyCount := rand.Intn(10) + 1
@@ -747,7 +746,7 @@ func TestLeasingTxnOwnerDelete(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -778,7 +777,7 @@ func TestLeasingTxnOwnerIf(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -872,11 +871,11 @@ func TestLeasingTxnCancel(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(1), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV2()
 
 	// acquire lease but disconnect so no revoke in time
@@ -906,11 +905,11 @@ func TestLeasingTxnNonOwnerPut(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV2()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -984,11 +983,11 @@ func TestLeasingTxnRandIfThenOrElse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err1)
+	assert.Nil(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err2)
+	assert.Nil(t, err2)
 	defer closeLKV2()
 
 	keyCount := 16
@@ -1090,7 +1089,7 @@ func TestLeasingOwnerPutError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1111,7 +1110,7 @@ func TestLeasingOwnerDeleteError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1132,7 +1131,7 @@ func TestLeasingNonOwnerPutError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	clus.Members[0].Stop(t)
@@ -1157,7 +1156,7 @@ func testLeasingOwnerDelete(t *testing.T, del clientv3.Op) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "0/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	for i := 0; i < 8; i++ {
@@ -1206,11 +1205,11 @@ func TestLeasingDeleteRangeBounds(t *testing.T) {
 	defer clus.Terminate(t)
 
 	delkv, closeDelKV, err := leasing.NewKV(clus.Client(0), "0/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeDelKV()
 
 	getkv, closeGetKv, err := leasing.NewKV(clus.Client(0), "0/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeGetKv()
 
 	for _, k := range []string{"j", "m"} {
@@ -1264,11 +1263,11 @@ func testLeasingDeleteRangeContend(t *testing.T, op clientv3.Op) {
 	defer clus.Terminate(t)
 
 	delkv, closeDelKV, err := leasing.NewKV(clus.Client(0), "0/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeDelKV()
 
 	putkv, closePutKV, err := leasing.NewKV(clus.Client(0), "0/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closePutKV()
 
 	const maxKey = 8
@@ -1329,7 +1328,7 @@ func TestLeasingPutGetDeleteConcurrent(t *testing.T) {
 	lkvs := make([]clientv3.KV, 16)
 	for i := range lkvs {
 		lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-		testutil.AssertNil(t, err)
+		assert.Nil(t, err)
 		defer closeLKV()
 		lkvs[i] = lkv
 	}
@@ -1386,11 +1385,11 @@ func TestLeasingReconnectOwnerRevoke(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err1)
+	assert.Nil(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(1), "foo/")
-	testutil.AssertNil(t, err2)
+	assert.Nil(t, err2)
 	defer closeLKV2()
 
 	if _, err := lkv1.Get(context.TODO(), "k"); err != nil {
@@ -1447,11 +1446,11 @@ func TestLeasingReconnectOwnerRevokeCompact(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err1)
+	assert.Nil(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(1), "foo/")
-	testutil.AssertNil(t, err2)
+	assert.Nil(t, err2)
 	defer closeLKV2()
 
 	if _, err := lkv1.Get(context.TODO(), "k"); err != nil {
@@ -1501,7 +1500,7 @@ func TestLeasingReconnectOwnerConsistency(t *testing.T) {
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
 	defer closeLKV()
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	if _, err = lkv.Put(context.TODO(), "k", "x"); err != nil {
 		t.Fatal(err)
@@ -1574,7 +1573,7 @@ func TestLeasingTxnAtomicCache(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	puts, gets := make([]clientv3.Op, 16), make([]clientv3.Op, 16)
@@ -1660,7 +1659,7 @@ func TestLeasingReconnectTxn(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1696,7 +1695,7 @@ func TestLeasingReconnectNonOwnerGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	// populate a few keys so some leasing gets have keys
@@ -1747,7 +1746,7 @@ func TestLeasingTxnRangeCmp(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "a"); err != nil {
@@ -1782,7 +1781,7 @@ func TestLeasingDo(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	ops := []clientv3.Op{
@@ -1824,7 +1823,7 @@ func TestLeasingTxnOwnerPutBranch(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	n := 0
@@ -1918,11 +1917,11 @@ func TestLeasingSessionExpire(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/", concurrency.WithTTL(1))
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "foo/")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	defer closeLKV2()
 
 	// acquire lease on abc
@@ -1994,7 +1993,7 @@ func TestLeasingSessionExpireCancel(t *testing.T) {
 			defer clus.Terminate(t)
 
 			lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/", concurrency.WithTTL(1))
-			testutil.AssertNil(t, err)
+			assert.Nil(t, err)
 			defer closeLKV()
 
 			if _, err = lkv.Get(context.TODO(), "abc"); err != nil {

--- a/tests/integration/v2store/store_tag_test.go
+++ b/tests/integration/v2store/store_tag_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2store"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
@@ -34,7 +33,7 @@ func TestStoreRecover(t *testing.T) {
 	s.Update("/foo/x", "barbar", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	s.Create("/foo/y", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	b, err := s.Save()
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	s2 := v2store.New()
 	s2.Recovery(b)
@@ -43,11 +42,11 @@ func TestStoreRecover(t *testing.T) {
 	assert.Equal(t, e.Node.CreatedIndex, uint64(2))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(3))
 	assert.Equal(t, e.EtcdIndex, eidx)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, *e.Node.Value, "barbar")
 
 	e, err = s.Get("/foo/y", false, false)
 	assert.Equal(t, e.EtcdIndex, eidx)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, *e.Node.Value, "baz")
 }

--- a/tests/integration/v2store/store_test.go
+++ b/tests/integration/v2store/store_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2error"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2store"
 )
@@ -35,9 +35,9 @@ func TestNewStoreWithNamespaces(t *testing.T) {
 	s := v2store.New("/0", "/1")
 
 	_, err := s.Get("/0", false, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	_, err = s.Get("/1", false, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 }
 
 // TestStoreGetValue ensures that the store can retrieve an existing value.
@@ -47,7 +47,7 @@ func TestStoreGetValue(t *testing.T) {
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	var eidx uint64 = 1
 	e, err := s.Get("/foo", false, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -66,7 +66,7 @@ func TestStoreGetSorted(t *testing.T) {
 	s.Create("/foo/y/b", false, "0", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	var eidx uint64 = 6
 	e, err := s.Get("/foo", true, true)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 
 	var yNodes v2store.NodeExterns
@@ -96,50 +96,50 @@ func TestSet(t *testing.T) {
 	// Set /foo=""
 	var eidx uint64 = 1
 	e, err := s.Set("/foo", false, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(1))
 
 	// Set /foo="bar"
 	eidx = 2
 	e, err = s.Set("/foo", false, "bar", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "bar")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(2))
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(1))
 	// Set /foo="baz" (for testing prevNode)
 	eidx = 3
 	e, err = s.Set("/foo", false, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "baz")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(3))
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(2))
@@ -147,27 +147,27 @@ func TestSet(t *testing.T) {
 	// Set /a/b/c/d="efg"
 	eidx = 4
 	e, err = s.Set("/a/b/c/d", false, "efg", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Node.Key, "/a/b/c/d")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "efg")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(4))
 
 	// Set /dir as a directory
 	eidx = 5
 	e, err = s.Set("/dir", true, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/dir")
 	assert.True(t, e.Node.Dir)
-	testutil.AssertNil(t, e.Node.Value)
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Value)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(5))
 }
@@ -179,28 +179,28 @@ func TestStoreCreateValue(t *testing.T) {
 	// Create /foo=bar
 	var eidx uint64 = 1
 	e, err := s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/foo")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "bar")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(1))
 
 	// Create /empty=""
 	eidx = 2
 	e, err = s.Create("/empty", false, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/empty")
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, *e.Node.Value, "")
-	testutil.AssertNil(t, e.Node.Nodes)
-	testutil.AssertNil(t, e.Node.Expiration)
+	assert.Nil(t, e.Node.Nodes)
+	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(2))
 
@@ -212,7 +212,7 @@ func TestStoreCreateDirectory(t *testing.T) {
 
 	var eidx uint64 = 1
 	e, err := s.Create("/foo", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -233,7 +233,7 @@ func TestStoreCreateFailsIfExists(t *testing.T) {
 	assert.Equal(t, err.Message, "Key already exists")
 	assert.Equal(t, err.Cause, "/foo")
 	assert.Equal(t, err.Index, uint64(1))
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreUpdateValue ensures that the store can update a key if it already exists.
@@ -245,7 +245,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	// update /foo="bzr"
 	var eidx uint64 = 2
 	e, err := s.Update("/foo", "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "update")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -266,7 +266,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	// update /foo=""
 	eidx = 3
 	e, err = s.Update("/foo", "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "update")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -295,7 +295,7 @@ func TestStoreUpdateFailsIfDirectory(t *testing.T) {
 	assert.Equal(t, err.ErrorCode, v2error.EcodeNotFile)
 	assert.Equal(t, err.Message, "Not a file")
 	assert.Equal(t, err.Cause, "/foo")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreDeleteValue ensures that the store can delete a value.
@@ -305,11 +305,11 @@ func TestStoreDeleteValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.Delete("/foo", false, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "delete")
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 }
@@ -324,28 +324,28 @@ func TestStoreDeleteDirectory(t *testing.T) {
 	// delete /foo with dir = true and recursive = false
 	// this should succeed, since the directory is empty
 	e, err := s.Delete("/foo", true, false)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "delete")
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.True(t, e.PrevNode.Dir)
 
 	// create directory /foo and directory /foo/bar
 	_, err = s.Create("/foo/bar", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	// delete /foo with dir = true and recursive = false
 	// this should fail, since the directory is not empty
 	_, err = s.Delete("/foo", true, false)
-	testutil.AssertNotNil(t, err)
+	require.NotNil(t, err)
 
 	// delete /foo with dir=false and recursive = true
 	// this should succeed, since recursive implies dir=true
 	// and recursively delete should be able to delete all
 	// items under the given directory
 	e, err = s.Delete("/foo", false, true)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.Action, "delete")
 
 }
@@ -360,7 +360,7 @@ func TestStoreDeleteDirectoryFailsIfNonRecursiveAndDir(t *testing.T) {
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeNotFile)
 	assert.Equal(t, err.Message, "Not a file")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 func TestRootRdOnly(t *testing.T) {
@@ -368,19 +368,19 @@ func TestRootRdOnly(t *testing.T) {
 
 	for _, tt := range []string{"/", "/0"} {
 		_, err := s.Set(tt, true, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		testutil.AssertNotNil(t, err)
+		require.NotNil(t, err)
 
 		_, err = s.Delete(tt, true, true)
-		testutil.AssertNotNil(t, err)
+		require.NotNil(t, err)
 
 		_, err = s.Create(tt, true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		testutil.AssertNotNil(t, err)
+		require.NotNil(t, err)
 
 		_, err = s.Update(tt, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		testutil.AssertNotNil(t, err)
+		require.NotNil(t, err)
 
 		_, err = s.CompareAndSwap(tt, "", 0, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		testutil.AssertNotNil(t, err)
+		require.NotNil(t, err)
 	}
 }
 
@@ -390,13 +390,13 @@ func TestStoreCompareAndDeletePrevValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndDelete("/foo", "bar", 0)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndDelete")
 	assert.Equal(t, e.Node.Key, "/foo")
 
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(1))
@@ -412,7 +412,7 @@ func TestStoreCompareAndDeletePrevValueFailsIfNotMatch(t *testing.T) {
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeTestFailed)
 	assert.Equal(t, err.Message, "Compare failed")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	e, _ = s.Get("/foo", false, false)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, *e.Node.Value, "bar")
@@ -424,11 +424,11 @@ func TestStoreCompareAndDeletePrevIndex(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndDelete("/foo", "", 1)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndDelete")
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(1))
@@ -441,11 +441,11 @@ func TestStoreCompareAndDeletePrevIndexFailsIfNotMatch(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, _err := s.CompareAndDelete("/foo", "", 100)
-	testutil.AssertNotNil(t, _err)
+	require.NotNil(t, _err)
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeTestFailed)
 	assert.Equal(t, err.Message, "Compare failed")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	e, _ = s.Get("/foo", false, false)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, *e.Node.Value, "bar")
@@ -457,7 +457,7 @@ func TestStoreCompareAndDeleteDirectoryFail(t *testing.T) {
 
 	s.Create("/foo", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	_, _err := s.CompareAndDelete("/foo", "", 0)
-	testutil.AssertNotNil(t, _err)
+	require.NotNil(t, _err)
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeNotFile)
 }
@@ -470,12 +470,12 @@ func TestStoreCompareAndSwapPrevValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndSwap("/foo", "bar", 0, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndSwap")
 	assert.Equal(t, *e.Node.Value, "baz")
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(1))
@@ -495,7 +495,7 @@ func TestStoreCompareAndSwapPrevValueFailsIfNotMatch(t *testing.T) {
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeTestFailed)
 	assert.Equal(t, err.Message, "Compare failed")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	e, _ = s.Get("/foo", false, false)
 	assert.Equal(t, *e.Node.Value, "bar")
 	assert.Equal(t, e.EtcdIndex, eidx)
@@ -508,12 +508,12 @@ func TestStoreCompareAndSwapPrevIndex(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndSwap("/foo", "", 1, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndSwap")
 	assert.Equal(t, *e.Node.Value, "baz")
 	// check prevNode
-	testutil.AssertNotNil(t, e.PrevNode)
+	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, e.PrevNode.Key, "/foo")
 	assert.Equal(t, *e.PrevNode.Value, "bar")
 	assert.Equal(t, e.PrevNode.ModifiedIndex, uint64(1))
@@ -534,7 +534,7 @@ func TestStoreCompareAndSwapPrevIndexFailsIfNotMatch(t *testing.T) {
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeTestFailed)
 	assert.Equal(t, err.Message, "Compare failed")
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	e, _ = s.Get("/foo", false, false)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, *e.Node.Value, "bar")
@@ -555,7 +555,7 @@ func TestStoreWatchCreate(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/foo")
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -566,7 +566,7 @@ func TestStoreWatchRecursiveCreate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64
 	w, err := s.Watch("/foo", true, false, 0)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -597,7 +597,7 @@ func TestStoreWatchRecursiveUpdate(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	w, err := s.Watch("/foo", true, false, 0)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 2
 	s.Update("/foo/bar", "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -628,7 +628,7 @@ func TestStoreWatchRecursiveDelete(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	w, err := s.Watch("/foo", true, false, 0)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 2
 	s.Delete("/foo/bar", false, false)
@@ -683,7 +683,7 @@ func TestStoreWatchStream(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "bar")
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 	// second modification
@@ -696,7 +696,7 @@ func TestStoreWatchStream(t *testing.T) {
 	assert.Equal(t, *e.Node.Value, "baz")
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -714,7 +714,7 @@ func TestStoreWatchCreateWithHiddenKey(t *testing.T) {
 	assert.Equal(t, e.Node.Key, "/_foo")
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -726,18 +726,18 @@ func TestStoreWatchRecursiveCreateWithHiddenKey(t *testing.T) {
 	w, _ := s.Watch("/foo", true, false, 0)
 	s.Create("/foo/_bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e := nbselect(w.EventChan())
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 	w, _ = s.Watch("/foo", true, false, 0)
 	s.Create("/foo/_baz", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 	s.Create("/foo/_baz/quux", false, "quux", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	select {
 	case e = <-w.EventChan():
-		testutil.AssertNil(t, e)
+		assert.Nil(t, e)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -753,7 +753,7 @@ func TestStoreWatchUpdateWithHiddenKey(t *testing.T) {
 	assert.Equal(t, e.Action, "update")
 	assert.Equal(t, e.Node.Key, "/_foo")
 	e = nbselect(w.EventChan())
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreWatchRecursiveUpdateWithHiddenKey ensures that the store doesn't
@@ -764,7 +764,7 @@ func TestStoreWatchRecursiveUpdateWithHiddenKey(t *testing.T) {
 	w, _ := s.Watch("/foo", true, false, 0)
 	s.Update("/foo/_bar", "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e := nbselect(w.EventChan())
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreWatchDeleteWithHiddenKey ensures that the store can watch for key deletions.
@@ -779,7 +779,7 @@ func TestStoreWatchDeleteWithHiddenKey(t *testing.T) {
 	assert.Equal(t, e.Action, "delete")
 	assert.Equal(t, e.Node.Key, "/_foo")
 	e = nbselect(w.EventChan())
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreWatchRecursiveDeleteWithHiddenKey ensures that the store doesn't see
@@ -790,7 +790,7 @@ func TestStoreWatchRecursiveDeleteWithHiddenKey(t *testing.T) {
 	w, _ := s.Watch("/foo", true, false, 0)
 	s.Delete("/foo/_bar", false, false)
 	e := nbselect(w.EventChan())
-	testutil.AssertNil(t, e)
+	assert.Nil(t, e)
 }
 
 // TestStoreWatchRecursiveCreateDeeperThanHiddenKey ensures that the store does see
@@ -802,7 +802,7 @@ func TestStoreWatchRecursiveCreateDeeperThanHiddenKey(t *testing.T) {
 	s.Create("/_foo/bar/baz", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 
 	e := timeoutSelect(t, w.EventChan())
-	testutil.AssertNotNil(t, e)
+	require.NotNil(t, e)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/_foo/bar/baz")

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/authpb"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
@@ -397,7 +397,7 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
 		Username:    "root",
 		Password:    "123",
 	})
-	testutil.AssertNil(t, cerr)
+	assert.Nil(t, cerr)
 	defer c.Close()
 
 	var wg sync.WaitGroup
@@ -405,13 +405,13 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
 		defer wg.Done()
 		role, user := fmt.Sprintf("test-role-%d", i), fmt.Sprintf("test-user-%d", i)
 		_, err := c.RoleAdd(context.TODO(), role)
-		testutil.AssertNil(t, err)
+		assert.Nil(t, err)
 		_, err = c.RoleGrantPermission(context.TODO(), role, "\x00", clientv3.GetPrefixRangeEnd(""), clientv3.PermissionType(clientv3.PermReadWrite))
-		testutil.AssertNil(t, err)
+		assert.Nil(t, err)
 		_, err = c.UserAdd(context.TODO(), user, "123")
-		testutil.AssertNil(t, err)
+		assert.Nil(t, err)
 		_, err = c.Put(context.TODO(), "a", "b")
-		testutil.AssertNil(t, err)
+		assert.Nil(t, err)
 	}
 	// needs concurrency to trigger
 	numRoles := 2
@@ -466,7 +466,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 
 	wChan := c.Watch(ctx, "non-allowed-key", clientv3.WithRev(1))
 	watchResponse := <-wChan
-	testutil.AssertNotNil(t, watchResponse.Err()) // permission denied
+	require.NotNil(t, watchResponse.Err()) // permission denied
 
 	_, err := c.Put(ctx, "k1", "val")
 	if err != nil {

--- a/tests/integration/v3_stm_test.go
+++ b/tests/integration/v3_stm_test.go
@@ -21,7 +21,8 @@ import (
 	"strconv"
 	"testing"
 
-	"go.etcd.io/etcd/client/pkg/v3/testutil"
+	"github.com/stretchr/testify/assert"
+
 	v3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -280,7 +281,7 @@ func TestSTMSerializableSnapshotPut(t *testing.T) {
 	cli := clus.Client(0)
 	// key with lower create/mod revision than keys being updated
 	_, err := cli.Put(context.TODO(), "a", "0")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	tries := 0
 	applyf := func(stm concurrency.STM) error {
@@ -295,12 +296,12 @@ func TestSTMSerializableSnapshotPut(t *testing.T) {
 
 	iso := concurrency.WithIsolation(concurrency.SerializableSnapshot)
 	_, err = concurrency.NewSTM(cli, applyf, iso)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	_, err = concurrency.NewSTM(cli, applyf, iso)
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 
 	resp, err := cli.Get(context.TODO(), "b")
-	testutil.AssertNil(t, err)
+	assert.Nil(t, err)
 	if resp.Kvs[0].Version != 2 {
 		t.Fatalf("bad version. got %+v, expected version 2", resp)
 	}

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -117,6 +117,5 @@ linters-settings: # please keep this alphabetized
       - formatter
       - go-require
       - negative-positive
-      - nil-compare
       - require-error
     enable-all: true


### PR DESCRIPTION
This fixes [nil-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#nil-compare) rule from [testifylint](https://github.com/Antonboom/testifylint).

It also replaces `testutil.AssertNil` and `testutil.AssertNotNil` by `assert.Nil` and `require.NotNil`

The require package is used for NotNil replacement because of the Fatal method being used in testutil version of the method.


<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->