### PR TITLE
fix: use require.NoError instead of t.Fatal(err) in client package

### DIFF
--- a/client/internal/v2/go.mod
+++ b/client/internal/v2/go.mod
@@ -5,6 +5,7 @@ go 1.23
 toolchain go1.23.2
 
 require (
+	github.com/stretchr/testify v1.9.0
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
@@ -14,7 +15,6 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/client/internal/v2/members_test.go
+++ b/client/internal/v2/members_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/client/pkg/v3/types"
 )
 
@@ -312,9 +314,7 @@ func TestMemberCreateRequestMarshal(t *testing.T) {
 	want := []byte(`{"peerURLs":["http://127.0.0.1:8081","https://127.0.0.1:8080"]}`)
 
 	got, err := json.Marshal(&req)
-	if err != nil {
-		t.Fatalf("Marshal returned unexpected err=%v", err)
-	}
+	require.NoErrorf(t, err, "Marshal returned unexpected err")
 
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("Failed to marshal memberCreateRequest: want=%s, got=%s", want, got)

--- a/client/pkg/fileutil/lock_test.go
+++ b/client/pkg/fileutil/lock_test.go
@@ -18,36 +18,28 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLockAndUnlock(t *testing.T) {
 	f, err := os.CreateTemp("", "lock")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	f.Close()
 	defer func() {
-		err = os.Remove(f.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Remove(f.Name()))
 	}()
 
 	// lock the file
 	l, err := LockFile(f.Name(), os.O_WRONLY, PrivateFileMode)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// try lock a locked file
-	if _, err = TryLockFile(f.Name(), os.O_WRONLY, PrivateFileMode); err != ErrLocked {
-		t.Fatal(err)
-	}
+	_, err = TryLockFile(f.Name(), os.O_WRONLY, PrivateFileMode)
+	require.ErrorIs(t, err, ErrLocked)
 
 	// unlock the file
-	if err = l.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, l.Close())
 
 	// try lock the unlocked file
 	dupl, err := TryLockFile(f.Name(), os.O_WRONLY, PrivateFileMode)
@@ -75,9 +67,7 @@ func TestLockAndUnlock(t *testing.T) {
 	}
 
 	// unlock
-	if err = dupl.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, dupl.Close())
 
 	// the previously blocked routine should be unblocked
 	select {

--- a/client/pkg/fileutil/preallocate_test.go
+++ b/client/pkg/fileutil/preallocate_test.go
@@ -17,6 +17,8 @@ package fileutil
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPreallocateExtend(t *testing.T) {
@@ -32,14 +34,10 @@ func TestPreallocateExtendTrunc(t *testing.T) {
 
 func testPreallocateExtend(t *testing.T, f *os.File, pf func(*os.File, int64) error) {
 	size := int64(64 * 1000)
-	if err := pf(f, size); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, pf(f, size))
 
 	stat, err := f.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if stat.Size() != size {
 		t.Errorf("size = %d, want %d", stat.Size(), size)
 	}
@@ -48,14 +46,10 @@ func testPreallocateExtend(t *testing.T, f *os.File, pf func(*os.File, int64) er
 func TestPreallocateFixed(t *testing.T) { runPreallocTest(t, testPreallocateFixed) }
 func testPreallocateFixed(t *testing.T, f *os.File) {
 	size := int64(64 * 1000)
-	if err := Preallocate(f, size, false); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, Preallocate(f, size, false))
 
 	stat, err := f.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if stat.Size() != 0 {
 		t.Errorf("size = %d, want %d", stat.Size(), 0)
 	}
@@ -65,8 +59,6 @@ func runPreallocTest(t *testing.T, test func(*testing.T, *os.File)) {
 	p := t.TempDir()
 
 	f, err := os.CreateTemp(p, "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	test(t, f)
 }

--- a/client/pkg/fileutil/read_dir_test.go
+++ b/client/pkg/fileutil/read_dir_test.go
@@ -19,6 +19,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadDir(t *testing.T) {
@@ -29,9 +32,7 @@ func TestReadDir(t *testing.T) {
 		writeFunc(t, filepath.Join(tmpdir, f))
 	}
 	fs, err := ReadDir(tmpdir)
-	if err != nil {
-		t.Fatalf("error calling ReadDir: %v", err)
-	}
+	require.NoErrorf(t, err, "error calling ReadDir")
 	wfs := []string{"abc", "def", "ghi", "xyz"}
 	if !reflect.DeepEqual(fs, wfs) {
 		t.Fatalf("ReadDir: got %v, want %v", fs, wfs)
@@ -42,9 +43,7 @@ func TestReadDir(t *testing.T) {
 		writeFunc(t, filepath.Join(tmpdir, f))
 	}
 	fs, err = ReadDir(tmpdir, WithExt(".wal"))
-	if err != nil {
-		t.Fatalf("error calling ReadDir: %v", err)
-	}
+	require.NoErrorf(t, err, "error calling ReadDir")
 	wfs = []string{"abc.wal", "def.wal", "ghi.wal", "xyz.wal"}
 	if !reflect.DeepEqual(fs, wfs) {
 		t.Fatalf("ReadDir: got %v, want %v", fs, wfs)
@@ -53,10 +52,6 @@ func TestReadDir(t *testing.T) {
 
 func writeFunc(t *testing.T, path string) {
 	fh, err := os.Create(path)
-	if err != nil {
-		t.Fatalf("error creating file: %v", err)
-	}
-	if err = fh.Close(); err != nil {
-		t.Fatalf("error closing file: %v", err)
-	}
+	require.NoErrorf(t, err, "error creating file")
+	assert.NoErrorf(t, fh.Close(), "error closing file")
 }

--- a/client/pkg/transport/keepalive_listener_test.go
+++ b/client/pkg/transport/keepalive_listener_test.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewKeepAliveListener tests NewKeepAliveListener returns a listener
@@ -26,20 +28,14 @@ import (
 // TODO: verify the keepalive option is set correctly
 func TestNewKeepAliveListener(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unexpected listen error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected listen error")
 
 	ln, err = NewKeepAliveListener(ln, "http", nil)
-	if err != nil {
-		t.Fatalf("unexpected NewKeepAliveListener error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected NewKeepAliveListener error")
 
 	go http.Get("http://" + ln.Addr().String())
 	conn, err := ln.Accept()
-	if err != nil {
-		t.Fatalf("unexpected Accept error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected Accept error")
 	if _, ok := conn.(*keepAliveConn); !ok {
 		t.Fatalf("Unexpected conn type: %T, wanted *keepAliveConn", conn)
 	}
@@ -47,31 +43,21 @@ func TestNewKeepAliveListener(t *testing.T) {
 	ln.Close()
 
 	ln, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unexpected Listen error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected Listen error")
 
 	// tls
 	tlsinfo, err := createSelfCert(t)
-	if err != nil {
-		t.Fatalf("unable to create tmpfile: %v", err)
-	}
+	require.NoErrorf(t, err, "unable to create tmpfile")
 	tlsInfo := TLSInfo{CertFile: tlsinfo.CertFile, KeyFile: tlsinfo.KeyFile}
 	tlsInfo.parseFunc = fakeCertificateParserFunc(nil)
 	tlscfg, err := tlsInfo.ServerConfig()
-	if err != nil {
-		t.Fatalf("unexpected serverConfig error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected serverConfig error")
 	tlsln, err := NewKeepAliveListener(ln, "https", tlscfg)
-	if err != nil {
-		t.Fatalf("unexpected NewKeepAliveListener error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected NewKeepAliveListener error")
 
 	go http.Get("https://" + tlsln.Addr().String())
 	conn, err = tlsln.Accept()
-	if err != nil {
-		t.Fatalf("unexpected Accept error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected Accept error")
 	if _, ok := conn.(*tls.Conn); !ok {
 		t.Errorf("failed to accept *tls.Conn")
 	}
@@ -81,9 +67,7 @@ func TestNewKeepAliveListener(t *testing.T) {
 
 func TestNewKeepAliveListenerTLSEmptyConfig(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unexpected listen error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected listen error")
 
 	_, err = NewKeepAliveListener(ln, "https", nil)
 	if err == nil {

--- a/client/pkg/transport/timeout_dialer_test.go
+++ b/client/pkg/transport/timeout_dialer_test.go
@@ -18,15 +18,15 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadWriteTimeoutDialer(t *testing.T) {
 	stop := make(chan struct{})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unexpected listen error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected listen error")
 	defer func() {
 		stop <- struct{}{}
 	}()
@@ -38,9 +38,7 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 		rdtimeoutd: 10 * time.Millisecond,
 	}
 	conn, err := d.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatalf("unexpected dial error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected dial error")
 	defer conn.Close()
 
 	// fill the socket buffer
@@ -64,9 +62,7 @@ func TestReadWriteTimeoutDialer(t *testing.T) {
 	}
 
 	conn, err = d.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatalf("unexpected dial error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected dial error")
 	defer conn.Close()
 
 	buf := make([]byte, 10)

--- a/client/pkg/transport/timeout_listener_test.go
+++ b/client/pkg/transport/timeout_listener_test.go
@@ -18,15 +18,15 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewTimeoutListener tests that NewTimeoutListener returns a
 // rwTimeoutListener struct with timeouts set.
 func TestNewTimeoutListener(t *testing.T) {
 	l, err := NewTimeoutListener("127.0.0.1:0", "http", nil, time.Hour, time.Hour)
-	if err != nil {
-		t.Fatalf("unexpected NewTimeoutListener error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected NewTimeoutListener error")
 	defer l.Close()
 	tln := l.(*rwTimeoutListener)
 	if tln.readTimeout != time.Hour {
@@ -39,9 +39,7 @@ func TestNewTimeoutListener(t *testing.T) {
 
 func TestWriteReadTimeoutListener(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unexpected listen error: %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected listen error")
 	wln := rwTimeoutListener{
 		Listener:     ln,
 		writeTimeout: 10 * time.Millisecond,

--- a/client/pkg/transport/timeout_transport_test.go
+++ b/client/pkg/transport/timeout_transport_test.go
@@ -21,15 +21,15 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewTimeoutTransport tests that NewTimeoutTransport returns a transport
 // that can dial out timeout connections.
 func TestNewTimeoutTransport(t *testing.T) {
 	tr, err := NewTimeoutTransport(TLSInfo{}, time.Hour, time.Hour, time.Hour)
-	if err != nil {
-		t.Fatalf("unexpected NewTimeoutTransport error: %v", err)
-	}
+	require.NoError(t, err)
 
 	remoteAddr := func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(r.RemoteAddr))
@@ -38,9 +38,7 @@ func TestNewTimeoutTransport(t *testing.T) {
 
 	defer srv.Close()
 	conn, err := tr.Dial("tcp", srv.Listener.Addr().String())
-	if err != nil {
-		t.Fatalf("unexpected dial error: %v", err)
-	}
+	require.NoError(t, err)
 	defer conn.Close()
 
 	tconn, ok := conn.(*timeoutConn)
@@ -56,28 +54,18 @@ func TestNewTimeoutTransport(t *testing.T) {
 
 	// ensure not reuse timeout connection
 	req, err := http.NewRequest("GET", srv.URL, nil)
-	if err != nil {
-		t.Fatalf("unexpected err %v", err)
-	}
+	require.NoError(t, err)
 	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected err %v", err)
-	}
+	require.NoError(t, err)
 	addr0, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	if err != nil {
-		t.Fatalf("unexpected err %v", err)
-	}
+	require.NoError(t, err)
 
 	resp, err = tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("unexpected err %v", err)
-	}
+	require.NoError(t, err)
 	addr1, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	if err != nil {
-		t.Fatalf("unexpected err %v", err)
-	}
+	require.NoError(t, err)
 
 	if bytes.Equal(addr0, addr1) {
 		t.Errorf("addr0 = %s addr1= %s, want not equal", addr0, addr1)

--- a/client/pkg/transport/tls_test.go
+++ b/client/pkg/transport/tls_test.go
@@ -19,13 +19,13 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateSecureEndpoints(t *testing.T) {
 	tlsInfo, err := createSelfCert(t)
-	if err != nil {
-		t.Fatalf("unable to create cert: %v", err)
-	}
+	require.NoErrorf(t, err, "unable to create cert")
 
 	remoteAddr := func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(r.RemoteAddr))

--- a/client/pkg/transport/transport_test.go
+++ b/client/pkg/transport/transport_test.go
@@ -20,15 +20,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewTransportTLSInvalidCipherSuitesTLS12 expects a client with invalid
 // cipher suites fail to handshake with the server.
 func TestNewTransportTLSInvalidCipherSuitesTLS12(t *testing.T) {
 	tlsInfo, err := createSelfCert(t)
-	if err != nil {
-		t.Fatalf("unable to create cert: %v", err)
-	}
+	require.NoErrorf(t, err, "unable to create cert")
 
 	cipherSuites := []uint16{
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -44,9 +44,7 @@ func TestNewTransportTLSInvalidCipherSuitesTLS12(t *testing.T) {
 	srvTLS.CipherSuites, cliTLS.CipherSuites = cipherSuites[:2], cipherSuites[2:]
 
 	ln, err := NewListener("127.0.0.1:0", "https", &srvTLS)
-	if err != nil {
-		t.Fatalf("unexpected NewListener error: %v", err)
-	}
+	require.NoError(t, err)
 	defer ln.Close()
 
 	donec := make(chan struct{})

--- a/client/pkg/types/id_test.go
+++ b/client/pkg/types/id_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIDString(t *testing.T) {
@@ -79,9 +81,7 @@ func TestIDFromStringFail(t *testing.T) {
 
 	for i, tt := range tests {
 		_, err := IDFromString(tt)
-		if err == nil {
-			t.Fatalf("#%d: IDFromString expected error, but err=nil", i)
-		}
+		require.Errorf(t, err, "#%d: IDFromString expected error", i)
 	}
 }
 

--- a/client/pkg/types/urlsmap_test.go
+++ b/client/pkg/types/urlsmap_test.go
@@ -18,14 +18,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
 func TestParseInitialCluster(t *testing.T) {
 	c, err := NewURLsMap("mem1=http://10.0.0.1:2379,mem1=http://128.193.4.20:2379,mem2=http://10.0.0.2:2379,default=http://127.0.0.1:2379")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 	wc := URLsMap(map[string]URLs{
 		"mem1":    testutil.MustNewURLs(t, []string{"http://10.0.0.1:2379", "http://128.193.4.20:2379"}),
 		"mem2":    testutil.MustNewURLs(t, []string{"http://10.0.0.2:2379"}),
@@ -102,9 +102,7 @@ func TestParse(t *testing.T) {
 // URI (https://github.com/golang/go/issues/6530).
 func TestNewURLsMapIPV6(t *testing.T) {
 	c, err := NewURLsMap("mem1=http://[2001:db8::1]:2380,mem1=http://[fe80::6e40:8ff:feb1:58e4%25en0]:2380,mem2=http://[fe80::92e2:baff:fe7c:3224%25ext0]:2380")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
+	require.NoError(t, err)
 	wc := URLsMap(map[string]URLs{
 		"mem1": testutil.MustNewURLs(t, []string{"http://[2001:db8::1]:2380", "http://[fe80::6e40:8ff:feb1:58e4%25en0]:2380"}),
 		"mem2": testutil.MustNewURLs(t, []string{"http://[fe80::92e2:baff:fe7c:3224%25ext0]:2380"}),

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -49,9 +49,7 @@ func TestDialCancel(t *testing.T) {
 
 	// accept first connection so client is created with dial timeout
 	ln, err := net.Listen("unix", "dialcancel:12345")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer ln.Close()
 
 	ep := "unix://dialcancel:12345"
@@ -59,9 +57,7 @@ func TestDialCancel(t *testing.T) {
 		Endpoints:   []string{ep},
 		DialTimeout: 30 * time.Second}
 	c, err := NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// connect to ipv4 black hole so dial blocks
 	c.SetEndpoints("http://254.0.0.1:12345")
@@ -150,9 +146,10 @@ func TestDialTimeout(t *testing.T) {
 func TestDialNoTimeout(t *testing.T) {
 	cfg := Config{Endpoints: []string{"127.0.0.1:12345"}}
 	c, err := NewClient(t, cfg)
-	if c == nil || err != nil {
+	if c == nil {
 		t.Fatalf("new client with DialNoWait should succeed, got %v", err)
 	}
+	require.NoErrorf(t, err, "new client with DialNoWait should succeed")
 	c.Close()
 }
 
@@ -289,9 +286,7 @@ func TestAuthTokenBundleNoOverwrite(t *testing.T) {
 
 	// Create a mock AuthServer to handle Authenticate RPCs.
 	lis, err := net.Listen("unix", "etcd-auth-test:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer lis.Close()
 	addr := "unix://" + lis.Addr().String()
 	srv := grpc.NewServer()
@@ -307,18 +302,14 @@ func TestAuthTokenBundleNoOverwrite(t *testing.T) {
 		Username:    "foo",
 		Password:    "bar",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer c.Close()
 	oldTokenBundle := c.authTokenBundle
 
 	// Call the public Dial again, which should preserve the original
 	// authTokenBundle.
 	gc, err := c.Dial(addr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer gc.Close()
 	newTokenBundle := c.authTokenBundle
 

--- a/client/v3/config_test.go
+++ b/client/v3/config_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -138,9 +139,7 @@ func TestNewClientConfig(t *testing.T) {
 			lg, _ := logutil.CreateDefaultZapLogger(zap.InfoLevel)
 
 			cfg, err := NewClientConfig(&tc.spec, lg)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedConf, *cfg)
 		})
@@ -149,9 +148,7 @@ func TestNewClientConfig(t *testing.T) {
 
 func TestNewClientConfigWithSecureCfg(t *testing.T) {
 	tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	scfg := &SecureConfig{
 		Cert:   tls.CertFile,
@@ -166,7 +163,8 @@ func TestNewClientConfigWithSecureCfg(t *testing.T) {
 		KeepAliveTimeout: 5 * time.Second,
 		Secure:           scfg,
 	}, nil)
-	if err != nil || cfg == nil || cfg.TLS == nil {
+	require.NoErrorf(t, err, "Unexpected result client config")
+	if cfg == nil || cfg.TLS == nil {
 		t.Fatalf("Unexpected result client config: %v", err)
 	}
 }

--- a/client/v3/yaml/config_test.go
+++ b/client/v3/yaml/config_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -78,18 +79,11 @@ func TestConfigFromFile(t *testing.T) {
 		}
 
 		b, err := yaml.Marshal(tt.ym)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		_, err = tmpfile.Write(b)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = tmpfile.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, tmpfile.Close())
 
 		cfg, cerr := NewConfig(tmpfile.Name())
 		if cerr != nil && !tt.werr {


### PR DESCRIPTION
There is no linter for this.
This uses testify instead of testing for
With 
```go
require.NoError(t, err)

require.Error(t, err)
```
instead of

```go
if err != nil {
    t.Fatal(err)
}


if err == nil {
    t.Fatal(err)
}
```