### PR TITLE
server,tests: add additional lease metrics and test

### DIFF
--- a/server/lease/metrics.go
+++ b/server/lease/metrics.go
@@ -49,6 +49,48 @@ var (
 			// 1 second -> 3 months
 			Buckets: prometheus.ExponentialBuckets(1, 2, 24),
 		})
+
+	leaseAttached = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "attach_total",
+		Help:      "The number of leases that are attached to a lease item.",
+	})
+
+	leaseDetached = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "detach_total",
+		Help:      "The number of leases that are detached from a lease item.",
+	})
+
+	initLeaseCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "initial_lease_count",
+		Help:      "Reports an initial lease count.",
+	})
+
+	leaseGrantError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "grant_errors",
+		Help:      "Error count by type to count for lease grants.",
+	}, []string{"error"})
+
+	leaseRevokeError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "revoke_errors",
+		Help:      "Error count by type to count for lease revokes.",
+	}, []string{"error"})
+
+	leaseRenewError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "etcd_debugging",
+		Subsystem: "lease",
+		Name:      "renew_errors",
+		Help:      "Error count by type to count for lease renewals.",
+	}, []string{"error"})
 )
 
 func init() {
@@ -56,4 +98,9 @@ func init() {
 	prometheus.MustRegister(leaseRevoked)
 	prometheus.MustRegister(leaseRenewed)
 	prometheus.MustRegister(leaseTotalTTLs)
+	prometheus.MustRegister(leaseAttached)
+	prometheus.MustRegister(leaseDetached)
+	prometheus.MustRegister(leaseGrantError)
+	prometheus.MustRegister(leaseRevokeError)
+	prometheus.MustRegister(leaseRenewError)
 }


### PR DESCRIPTION
- metrics to capture leases attached and detached
- metrics to capture duration to grant, revoke, and renew leases
- metric to capture initial lease count at startup

**Help**
- Primarily I'd like to get feedback, I think these metrics can be useful, especially under heavy load.
- Need help with the last part of the testing, where I try to capture the count the count at initial startup, please let me know if my understanding is wanting in this case. More specifically - [this](https://github.com/etcd-io/etcd/pull/18711/files#diff-2d7b95e0dbdfa5eee525091e31daea409a4d08800053c3554d41daf9ffe0a81fR170-R193).
  - Currently that part of the test does not pass.
  - My understanding is that when the cluster recovers the lease should exist in the database and should reflect in terms of metric and `LeaseLeases` response.