### PR TITLE
fix: enable empty and len rules from testifylint

### DIFF
--- a/client/pkg/logutil/zap_test.go
+++ b/client/pkg/logutil/zap_test.go
@@ -53,6 +53,6 @@ func TestEncodeTimePrecisionToMicroSeconds(t *testing.T) {
 	regex := `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.(\d+)(Z|[+-]\d{4})`
 	re := regexp.MustCompile(regex)
 	matches := re.FindStringSubmatch(fields.Timestamp)
-	require.Equal(t, 3, len(matches))
-	require.Equalf(t, fractionSecondsPrecision, len(matches[1]), "unexpected timestamp %s", fields.Timestamp)
+	require.Len(t, matches, 3)
+	require.Lenf(t, matches[1], fractionSecondsPrecision, "unexpected timestamp %s", fields.Timestamp)
 }

--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -64,7 +64,7 @@ func TestStoreGetDirectory(t *testing.T) {
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
-	assert.Equal(t, len(e.Node.Nodes), 2)
+	assert.Len(t, e.Node.Nodes, 2)
 	var bazNodes NodeExterns
 	for _, node := range e.Node.Nodes {
 		switch node.Key {
@@ -73,7 +73,7 @@ func TestStoreGetDirectory(t *testing.T) {
 			assert.False(t, node.Dir)
 		case "/foo/baz":
 			assert.True(t, node.Dir)
-			assert.Equal(t, len(node.Nodes), 2)
+			assert.Len(t, node.Nodes, 2)
 			bazNodes = node.Nodes
 		default:
 			t.Errorf("key = %s, not matched", node.Key)

--- a/server/storage/backend/tx_buffer_test.go
+++ b/server/storage/backend/tx_buffer_test.go
@@ -29,7 +29,7 @@ func Test_bucketBuffer_CopyUsed_After_Add(t *testing.T) {
 		bb.add([]byte(k), []byte(v))
 		bbCopy := bb.CopyUsed()
 		assert.Equal(t, bb.used, bbCopy.used)
-		assert.Equal(t, bbCopy.used, len(bbCopy.buf))
+		assert.Len(t, bbCopy.buf, bbCopy.used)
 		assert.GreaterOrEqual(t, len(bb.buf), len(bbCopy.buf))
 	}
 }
@@ -85,7 +85,7 @@ func Test_bucketBuffer_CopyUsed(t *testing.T) {
 			} else {
 				bbCopy := bb.CopyUsed()
 				assert.Equal(t, tt.wantUsed, bbCopy.used)
-				assert.Equal(t, tt.wantBufLen, len(bbCopy.buf))
+				assert.Len(t, bbCopy.buf, tt.wantBufLen)
 			}
 		})
 	}
@@ -132,7 +132,7 @@ func TestDedupe(t *testing.T) {
 				bb.add([]byte(tt.keys[i]), []byte(tt.vals[i]))
 			}
 			bb.dedupe()
-			assert.Equal(t, bb.used, len(tt.expectedKeys))
+			assert.Len(t, tt.expectedKeys, bb.used)
 			for i := 0; i < bb.used; i++ {
 				assert.Equal(t, bb.buf[i].key, []byte(tt.expectedKeys[i]))
 				assert.Equal(t, bb.buf[i].val, []byte(tt.expectedVals[i]))

--- a/server/storage/mvcc/key_index_test.go
+++ b/server/storage/mvcc/key_index_test.go
@@ -499,7 +499,7 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 		}
 
 		if isTombstone {
-			assert.Equal(t, 0, len(am), "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
+			assert.Empty(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
 		} else {
 			assert.Equal(t, tt.wam, am,
 				"#%d: ki = %d, compact keep should be equal to keep keep if it's not tombstone", i, ki)
@@ -550,7 +550,7 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 		}
 
 		if isTombstoneRevFn(ki, tt.compact) {
-			assert.Equal(t, 0, len(am), "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
+			assert.Empty(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
 		} else {
 			assert.Equal(t, tt.wam, am,
 				"#%d: ki = %d, compact keep should be equal to keep keep if it's not tombstone", i, ki)

--- a/tests/common/auth_util.go
+++ b/tests/common/auth_util.go
@@ -108,13 +108,13 @@ func setupAuth(c interfaces.Client, roles []authRole, users []authUser) error {
 }
 
 func requireRolePermissionEqual(t *testing.T, expectRole authRole, actual []*authpb.Permission) {
-	require.Equal(t, 1, len(actual))
+	require.Len(t, actual, 1)
 	require.Equal(t, expectRole.permission, clientv3.PermissionType(actual[0].PermType))
 	require.Equal(t, expectRole.key, string(actual[0].Key))
 	require.Equal(t, expectRole.keyEnd, string(actual[0].RangeEnd))
 }
 
 func requireUserRolesEqual(t *testing.T, expectUser authUser, actual []string) {
-	require.Equal(t, 1, len(actual))
+	require.Len(t, actual, 1)
 	require.Equal(t, expectUser.role, actual[0])
 }

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -63,7 +63,7 @@ func TestEndpointHashKV(t *testing.T) {
 		resp, err := cc.HashKV(ctx, 0)
 		require.NoError(t, err, "failed to get endpoint hashkv: %v", err)
 
-		require.Equal(t, 3, len(resp))
+		require.Len(t, resp, 3)
 		if resp[0].HashRevision == resp[1].HashRevision && resp[0].HashRevision == resp[2].HashRevision {
 			require.Equal(t, resp[0].Hash, resp[1].Hash)
 			require.Equal(t, resp[0].Hash, resp[2].Hash)

--- a/tests/e2e/ctl_v3_auth_cluster_test.go
+++ b/tests/e2e/ctl_v3_auth_cluster_test.go
@@ -70,7 +70,7 @@ func TestAuthCluster(t *testing.T) {
 
 	// make sure writes to both endpoints are successful
 	endpoints := epc.EndpointsGRPC()
-	assert.Equal(t, len(endpoints), 2)
+	assert.Len(t, endpoints, 2)
 	for _, endpoint := range epc.EndpointsGRPC() {
 		if err := epc.Etcdctl(testUserClientOpts, e2e.WithEndpoints([]string{endpoint})).Put(ctx, "/test/key", endpoint, config.PutOptions{}); err != nil {
 			t.Fatalf("failed to write to Put to %q (%v)", endpoint, err)

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -134,7 +134,7 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 			}
 
 			count++
-			require.Equal(t, 1, len(mresp.Members))
+			require.Len(t, mresp.Members, 1)
 		}
 	}()
 
@@ -152,7 +152,7 @@ func memberListTest(cx ctlCtx) {
 func memberListSerializableTest(cx ctlCtx) {
 	resp, err := getMemberList(cx, false)
 	require.NoError(cx.t, err)
-	require.Equal(cx.t, 1, len(resp.Members))
+	require.Len(cx.t, resp.Members, 1)
 
 	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+11)
 	err = ctlV3MemberAdd(cx, peerURL, false)
@@ -160,7 +160,7 @@ func memberListSerializableTest(cx ctlCtx) {
 
 	resp, err = getMemberList(cx, true)
 	require.NoError(cx.t, err)
-	require.Equal(cx.t, 2, len(resp.Members))
+	require.Len(cx.t, resp.Members, 2)
 }
 
 func ctlV3MemberList(cx ctlCtx) error {

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -243,7 +243,7 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 	users, ok := resp["users"]
 	require.True(cx.t, ok)
 	userSlice := users.([]any)
-	require.Equal(cx.t, 2, len(userSlice))
+	require.Len(cx.t, userSlice, 2)
 	require.Equal(cx.t, "user1", userSlice[0])
 	require.Equal(cx.t, "user3", userSlice[1])
 }
@@ -372,7 +372,7 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 	roles, ok := resp["roles"]
 	require.True(cx.t, ok)
 	roleSlice := roles.([]any)
-	require.Equal(cx.t, 2, len(roleSlice))
+	require.Len(cx.t, roleSlice, 2)
 	require.Equal(cx.t, "role1", roleSlice[0])
 	require.Equal(cx.t, "role3", roleSlice[1])
 }

--- a/tests/e2e/v3_curl_cluster_test.go
+++ b/tests/e2e/v3_curl_cluster_test.go
@@ -53,7 +53,7 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 	// list members and get the new member's ID
 	cx.t.Log("Listing members after adding a member")
 	members := mustListMembers(cx)
-	require.Equal(cx.t, 2, len(members))
+	require.Len(cx.t, members, 2)
 	cx.t.Logf("members: %+v", members)
 
 	var newMemberIDStr string
@@ -107,7 +107,7 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 	// list members again after deleting a member
 	cx.t.Log("Listing members again after deleting a member")
 	members = mustListMembers(cx)
-	require.Equal(cx.t, 1, len(members))
+	require.Len(cx.t, members, 1)
 }
 
 func mustListMembers(cx ctlCtx) []any {

--- a/tests/e2e/v3_curl_kv_test.go
+++ b/tests/e2e/v3_curl_kv_test.go
@@ -164,7 +164,7 @@ func testCurlV3KVTxn(cx ctlCtx) {
 
 	succeeded, responses := mustExecuteTxn(cx, string(jsonDat))
 	require.True(cx.t, succeeded)
-	require.Equal(cx.t, 1, len(responses))
+	require.Len(cx.t, responses, 1)
 	putResponse := responses[0].(map[string]any)
 	_, ok := putResponse["response_put"]
 	require.True(cx.t, ok)

--- a/tests/e2e/v3_lease_no_proxy_test.go
+++ b/tests/e2e/v3_lease_no_proxy_test.go
@@ -159,7 +159,7 @@ func testLeaseRevokeIssue(t *testing.T, clusterSize int, connectToOneFollower bo
 	t.Log("Confirming the lease isn't revoked")
 	leases, err := client.Leases(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(leases.Leases))
+	require.Len(t, leases.Leases, 1)
 
 	t.Log("Waiting for the keepAlive goroutine to exit")
 	close(stopC)

--- a/tests/framework/testutils/log_observer_test.go
+++ b/tests/framework/testutils/log_observer_test.go
@@ -38,7 +38,7 @@ func TestLogObserver_Timeout(t *testing.T) {
 	cancel()
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 
-	assert.Equal(t, 1, len(logOb.entries))
+	assert.Len(t, logOb.entries, 1)
 }
 
 func TestLogObserver_Expect(t *testing.T) {
@@ -65,7 +65,7 @@ func TestLogObserver_Expect(t *testing.T) {
 	}
 
 	res := <-resCh
-	assert.Equal(t, 2, len(res))
+	assert.Len(t, res, 2)
 
 	// The logged message should be like
 	//
@@ -79,5 +79,5 @@ func TestLogObserver_Expect(t *testing.T) {
 		assert.True(t, strings.HasSuffix(res[idx], expected))
 	}
 
-	assert.Equal(t, 2, len(logOb.entries))
+	assert.Len(t, logOb.entries, 2)
 }

--- a/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
@@ -158,7 +158,7 @@ func TestDoubleBarrierTooManyClients(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	// Make sure the extra `b.Enter()` did not create a new ephemeral key
-	assert.Equal(t, waiters, len(resp.Kvs))
+	assert.Len(t, resp.Kvs, waiters)
 	close(donec)
 
 	wgDone.Wait()

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -211,7 +211,7 @@ func TestLeasingGetNoLeaseTTL(t *testing.T) {
 
 	gresp, err := lkv.Get(context.TODO(), "k")
 	testutil.AssertNil(t, err)
-	assert.Equal(t, len(gresp.Kvs), 1)
+	assert.Len(t, gresp.Kvs, 1)
 
 	clus.Members[0].Stop(t)
 

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -377,7 +377,7 @@ func TestMaintenanceSnapshotContentDigest(t *testing.T) {
 
 	checksumInBytes, err := io.ReadAll(snapFile)
 	require.NoError(t, err)
-	require.Equal(t, int(checksumSize), len(checksumInBytes))
+	require.Len(t, checksumInBytes, int(checksumSize))
 
 	// remove the checksum part and rehash
 	err = snapFile.Truncate(snapSize - checksumSize)

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -183,6 +183,6 @@ func TestEtcdEndpointManager(t *testing.T) {
 	assert.NoError(t, err)
 	eptsOther, err := emOther.List(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, len(epts), 1)
-	assert.Equal(t, len(eptsOther), 1)
+	assert.Len(t, epts, 1)
+	assert.Len(t, eptsOther, 1)
 }

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -110,14 +110,12 @@ linters-settings: # please keep this alphabetized
   testifylint:
     disable:
       - compares
-      - empty
       - error-is-as
       - error-nil
       - expected-actual
       - float-compare
       - formatter
       - go-require
-      - len
       - negative-positive
       - nil-compare
       - require-error


### PR DESCRIPTION
This fixes [empty](https://github.com/Antonboom/testifylint?tab=readme-ov-file#empty) and [len](https://github.com/Antonboom/testifylint?tab=readme-ov-file#len) rules from [testifylint](https://github.com/Antonboom/testifylint).