### PR TITLE
fix: enable gofmt and whitespace linters

### DIFF
--- a/client/internal/v2/keys_bench_test.go
+++ b/client/internal/v2/keys_bench_test.go
@@ -63,7 +63,6 @@ func benchmarkResponseUnmarshalling(b *testing.B, children, size int) {
 		if newResponse, err = unmarshalSuccessfulKeysResponse(header, body); err != nil {
 			b.Errorf("error unmarshalling response (%v)", err)
 		}
-
 	}
 	if !reflect.DeepEqual(response.Node, newResponse.Node) {
 		b.Errorf("Unexpected difference in a parsed response: \n%+v\n%+v", response, newResponse)

--- a/client/pkg/types/set_test.go
+++ b/client/pkg/types/set_test.go
@@ -137,7 +137,6 @@ func driveSetTests(t *testing.T, s Set) {
 	} {
 		if tt.got != tt.want {
 			t.Fatalf("case %d: want %t, got %t", i, tt.want, tt.got)
-
 		}
 	}
 

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -434,9 +434,7 @@ func TestClientRejectOldCluster(t *testing.T) {
 				t.Errorf("heckVersion err:%v", err)
 			}
 		})
-
 	}
-
 }
 
 type mockMaintenance struct {

--- a/client/v3/maintenance.go
+++ b/client/v3/maintenance.go
@@ -217,7 +217,6 @@ func (m *maintenance) Status(ctx context.Context, endpoint string) (*StatusRespo
 func (m *maintenance) HashKV(ctx context.Context, endpoint string, rev int64) (*HashKVResponse, error) {
 	remote, cancel, err := m.dial(endpoint)
 	if err != nil {
-
 		return nil, ContextError(ctx, err)
 	}
 	defer cancel()

--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -277,7 +277,6 @@ func (s *serverStreamingRetryingStream) receiveMsgAndIndicateRetry(m any) (bool,
 			return false, err // return the original error for simplicity
 		}
 		return true, err
-
 	}
 	return isSafeRetry(s.client, err, s.callOpts), err
 }

--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -732,7 +732,6 @@ func (w *watchGRPCStream) dispatchEvent(pbresp *pb.WatchResponse) bool {
 	}
 
 	return w.unicastResponse(wr, pbresp.WatchId)
-
 }
 
 // broadcastResponse send a watch response to all watch substreams.

--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -86,7 +86,6 @@ var defaultSnapshotCount uint64 = 10000
 // current), then new log entries. To shutdown, close proposeC and read errorC.
 func newRaftNode(id int, peers []string, join bool, getSnapshot func() ([]byte, error), proposeC <-chan string,
 	confChangeC <-chan raftpb.ConfChange) (<-chan *commit, <-chan error, <-chan *snap.Snapshotter) {
-
 	commitC := make(chan *commit)
 	errorC := make(chan error)
 

--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -97,5 +97,4 @@ func printMemberListWithHexJSON(r clientv3.MemberListResponse) {
 	}
 	buffer.WriteString("}")
 	fmt.Println(buffer.String())
-
 }

--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -134,7 +134,6 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 			fmt.Fprintf(os.Stderr, "Invalid command %s (only support watch)\n", l)
 			continue
 		}
-
 	}
 }
 

--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -532,7 +532,6 @@ func (ivt *intervalTree) Insert(ivl Interval, val any) {
 func (ivt *intervalTree) insertFixup(z *intervalNode) {
 	for z.parent.color(ivt.sentinel) == red {
 		if z.parent == z.parent.parent.left { // line 3-15
-
 			y := z.parent.parent.right
 			if y.color(ivt.sentinel) == red {
 				y.c = black

--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -254,7 +254,6 @@ func TestResponseMatchRegularExpr(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			ep, err := NewExpect("echo", "-n", tc.mockOutput)
 			require.NoError(t, err)
 

--- a/pkg/netutil/routes_linux.go
+++ b/pkg/netutil/routes_linux.go
@@ -152,7 +152,6 @@ func getIfaceAddr(idx uint32, family uint8) (*syscall.NetlinkMessage, error) {
 	}
 
 	return nil, fmt.Errorf("could not find address for interface index %v", idx)
-
 }
 
 // Used to get a name of interface.

--- a/server/auth/jwt_test.go
+++ b/server/auth/jwt_test.go
@@ -143,7 +143,6 @@ func testJWTInfo(t *testing.T, opts map[string]string) {
 			if !errors.Is(aerr, ErrVerifyOnly) {
 				t.Fatalf("unexpected error when attempting to sign with public key: %v", aerr)
 			}
-
 		})
 	}
 }
@@ -221,7 +220,6 @@ func TestJWTTokenWithMissingFields(t *testing.T) {
 }
 
 func TestJWTBad(t *testing.T) {
-
 	var badCases = map[string]map[string]string{
 		"no options": {},
 		"invalid method": {

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -749,7 +749,6 @@ func (as *authStore) RoleDelete(r *pb.AuthRoleDeleteRequest) (*pb.AuthRoleDelete
 		}
 
 		tx.UnsafePutUser(updatedUser)
-
 	}
 
 	as.commitRevision(tx)
@@ -1114,7 +1113,6 @@ func decomposeOpts(lg *zap.Logger, optstr string) (string, map[string]string, er
 	}
 
 	return tokenType, typeSpecificOpts, nil
-
 }
 
 // NewTokenProvider creates a new token provider.

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -177,7 +177,6 @@ func TestUserAdd(t *testing.T) {
 
 	if _, ok := as.rangePermCache[userName]; !ok {
 		t.Fatalf("user %s should be added but it doesn't exist in rangePermCache", userName)
-
 	}
 }
 
@@ -270,7 +269,6 @@ func TestUserDelete(t *testing.T) {
 
 	if _, ok := as.rangePermCache[userName]; ok {
 		t.Fatalf("user %s should be deleted but it exists in rangePermCache", userName)
-
 	}
 }
 
@@ -306,7 +304,6 @@ func TestUserDeleteAndPermCache(t *testing.T) {
 
 	if _, ok := as.rangePermCache[newUser]; !ok {
 		t.Fatalf("user %s should exist but it doesn't exist in rangePermCache", deletedUserName)
-
 	}
 }
 
@@ -458,7 +455,6 @@ func TestIsOpPermitted(t *testing.T) {
 	if err := as.isOpPermitted("foo", as.Revision(), perm.Key, perm.RangeEnd, perm.PermType); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatal(err)
 	}
-
 }
 
 func TestGetUser(t *testing.T) {

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -441,7 +441,6 @@ func TestInferLocalAddr(t *testing.T) {
 			require.Equal(t, tt.expectedLocalAddr, cfg.InferLocalAddr())
 		})
 	}
-
 }
 
 func (s *securityConfig) equals(t *transport.TLSInfo) bool {

--- a/server/etcdserver/api/membership/storev2.go
+++ b/server/etcdserver/api/membership/storev2.go
@@ -91,7 +91,6 @@ func mustDeleteMemberFromStore(lg *zap.Logger, s v2store.Store, id types.ID) {
 }
 
 func mustAddToRemovedMembersInStore(lg *zap.Logger, s v2store.Store, id types.ID) {
-
 	if _, err := s.Create(RemovedMemberStoreKey(id), false, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent}); err != nil {
 		lg.Panic(
 			"failed to create removedMember",

--- a/server/etcdserver/api/v2discovery/discovery_test.go
+++ b/server/etcdserver/api/v2discovery/discovery_test.go
@@ -86,7 +86,6 @@ func TestNewProxyFunc(t *testing.T) {
 		if g.String() != w {
 			t.Errorf("%s: proxyURL=%q, want %q", in, g, w)
 		}
-
 	}
 }
 

--- a/server/etcdserver/api/v2error/error_test.go
+++ b/server/etcdserver/api/v2error/error_test.go
@@ -46,5 +46,4 @@ func TestErrorWriteTo(t *testing.T) {
 			t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader)
 		}
 	}
-
 }

--- a/server/etcdserver/api/v2stats/queue.go
+++ b/server/etcdserver/api/v2stats/queue.go
@@ -74,7 +74,6 @@ func (q *statsQueue) Insert(p *RequestStats) {
 
 	q.items[q.back] = p
 	q.totalReqSize += q.items[q.back].Size
-
 }
 
 // Rate function returns the package rate and byte rate

--- a/server/etcdserver/api/v2store/event_history.go
+++ b/server/etcdserver/api/v2store/event_history.go
@@ -125,5 +125,4 @@ func (eh *EventHistory) clone() *EventHistory {
 		Queue:      clonedQueue,
 		LastIndex:  eh.LastIndex,
 	}
-
 }

--- a/server/etcdserver/api/v2store/event_test.go
+++ b/server/etcdserver/api/v2store/event_test.go
@@ -24,7 +24,6 @@ import (
 // Add 200 events into that queue, and test if the
 // previous 100 events have been swapped out.
 func TestEventQueue(t *testing.T) {
-
 	eh := newEventHistory(100)
 
 	// Add
@@ -114,7 +113,6 @@ func TestEventIndexHistoryCleared(t *testing.T) {
 // Add 1000 events into that queue, and test if scanning
 // works still for previous events.
 func TestFullEventQueue(t *testing.T) {
-
 	eh := newEventHistory(10)
 
 	// Add

--- a/server/etcdserver/api/v2store/heap_test.go
+++ b/server/etcdserver/api/v2store/heap_test.go
@@ -41,7 +41,6 @@ func TestHeapPushPop(t *testing.T) {
 		}
 		min = node.ExpireTime
 	}
-
 }
 
 func TestHeapUpdate(t *testing.T) {
@@ -88,7 +87,5 @@ func TestHeapUpdate(t *testing.T) {
 				t.Fatal("heap sort wrong!")
 			}
 		}
-
 	}
-
 }

--- a/server/etcdserver/api/v2store/node.go
+++ b/server/etcdserver/api/v2store/node.go
@@ -277,7 +277,6 @@ func (n *node) Repr(recursive, sorted bool, clock clockwork.Clock) *NodeExtern {
 		i := 0
 
 		for _, child := range children {
-
 			if child.IsHidden() { // get will not list hidden node
 				continue
 			}

--- a/server/etcdserver/api/v2store/node_extern.go
+++ b/server/etcdserver/api/v2store/node_extern.go
@@ -62,7 +62,6 @@ func (eNode *NodeExtern) loadInternalNode(n *node, recursive, sorted bool, clock
 		if sorted {
 			sort.Sort(eNode.Nodes)
 		}
-
 	} else { // node is a file
 		value, _ := n.Read()
 		eNode.Value = &value

--- a/server/etcdserver/api/v2store/store.go
+++ b/server/etcdserver/api/v2store/store.go
@@ -258,7 +258,6 @@ func getCompareFailCause(n *node, which int, prevValue string, prevIndex uint64)
 
 func (s *store) CompareAndSwap(nodePath string, prevValue string, prevIndex uint64,
 	value string, expireOpts TTLOptionSet) (*Event, error) {
-
 	var err *v2error.Error
 
 	s.worldLock.Lock()
@@ -565,7 +564,6 @@ func (s *store) Update(nodePath string, newValue string, expireOpts TTLOptionSet
 
 func (s *store) internalCreate(nodePath string, dir bool, value string, unique, replace bool,
 	expireTime time.Time, action string) (*Event, *v2error.Error) {
-
 	currIndex, nextIndex := s.CurrentIndex, s.CurrentIndex+1
 
 	if unique { // append unique item under the node path
@@ -624,7 +622,6 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 		eNode.Value = &valueCopy
 
 		n = newKV(s, nodePath, value, nextIndex, d, expireTime)
-
 	} else { // create directory
 		eNode.Dir = true
 
@@ -653,7 +650,6 @@ func (s *store) internalGet(nodePath string) (*node, *v2error.Error) {
 	nodePath = path.Clean(path.Join("/", nodePath))
 
 	walkFunc := func(parent *node, name string) (*node, *v2error.Error) {
-
 		if !parent.IsDir() {
 			err := v2error.NewError(v2error.EcodeNotDir, parent.Path, s.CurrentIndex)
 			return nil, err
@@ -707,7 +703,6 @@ func (s *store) DeleteExpiredKeys(cutoff time.Time) {
 
 		s.WatcherHub.notify(e)
 	}
-
 }
 
 // checkDir will check whether the component is a directory under parent node.

--- a/server/etcdserver/api/v2store/store_bench_test.go
+++ b/server/etcdserver/api/v2store/store_bench_test.go
@@ -156,7 +156,6 @@ func BenchmarkWatchWithSetBatch(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		<-watchers[i].EventChan()
 	}
-
 }
 
 func BenchmarkWatchOneKey(b *testing.B) {

--- a/server/etcdserver/api/v2store/watcher_test.go
+++ b/server/etcdserver/api/v2store/watcher_test.go
@@ -86,5 +86,4 @@ func TestWatcher(t *testing.T) {
 	if e != re {
 		t.Fatal("recv != send")
 	}
-
 }

--- a/server/etcdserver/api/v3rpc/grpc.go
+++ b/server/etcdserver/api/v3rpc/grpc.go
@@ -57,7 +57,6 @@ func Server(s *etcdserver.EtcdServer, tls *tls.Config, interceptor grpc.UnarySer
 	if s.Cfg.ExperimentalEnableDistributedTracing {
 		chainUnaryInterceptors = append(chainUnaryInterceptors, otelgrpc.UnaryServerInterceptor(s.Cfg.ExperimentalTracerOptions...))
 		chainStreamInterceptors = append(chainStreamInterceptors, otelgrpc.StreamServerInterceptor(s.Cfg.ExperimentalTracerOptions...))
-
 	}
 
 	opts = append(opts, grpc.ChainUnaryInterceptor(chainUnaryInterceptors...))

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -217,7 +217,6 @@ func TestAuthApplierV3_Apply(t *testing.T) {
 			require.Equalf(t, result, tc.expectResult, "Apply: got %v, expect: %v", result, tc.expectResult)
 		})
 	}
-
 }
 
 // TestAuthApplierV3_AdminPermission ensures the admin permission is checked for certain
@@ -823,5 +822,4 @@ func TestCheckLeasePutsKeys(t *testing.T) {
 
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: aa.as.Revision()}
 	assert.NoError(t, aa.checkLeasePutsKeys(l), "bob should be able to access key 'a'")
-
 }

--- a/server/etcdserver/cindex/cindex_test.go
+++ b/server/etcdserver/cindex/cindex_test.go
@@ -30,7 +30,6 @@ import (
 
 // TestConsistentIndex ensures that LoadConsistentIndex/Save/ConsistentIndex and backend.BatchTx can work well together.
 func TestConsistentIndex(t *testing.T) {
-
 	be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 	ci := NewConsistentIndex(be)
 
@@ -133,7 +132,6 @@ func TestConsistentIndexDecrease(t *testing.T) {
 }
 
 func TestFakeConsistentIndex(t *testing.T) {
-
 	r := rand.Uint64()
 	ci := NewFakeConsistentIndex(r)
 	index := ci.ConsistentIndex()
@@ -146,5 +144,4 @@ func TestFakeConsistentIndex(t *testing.T) {
 	if index != r {
 		t.Errorf("expected %d,got %d", r, index)
 	}
-
 }

--- a/server/storage/backend/verify_test.go
+++ b/server/storage/backend/verify_test.go
@@ -73,7 +73,6 @@ func TestLockVerify(t *testing.T) {
 	defer revertVerifyFunc()
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-
 			be, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
 			be.SetTxPostLockInsideApplyHook(tc.txPostLockInsideApplyHook)
 

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -64,7 +64,7 @@ func TestIndexGet(t *testing.T) {
 
 func TestIndexRange(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2")}
-	allRevs := []Revision{Revision{Main: 1}, Revision{Main: 2}, Revision{Main: 3}}
+	allRevs := []Revision{{Main: 1}, {Main: 2}, {Main: 3}}
 
 	ti := newTreeIndex(zaptest.NewLogger(t))
 	for i := range allKeys {
@@ -142,7 +142,7 @@ func TestIndexTombstone(t *testing.T) {
 
 func TestIndexRevision(t *testing.T) {
 	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2"), []byte("foo2"), []byte("foo1"), []byte("foo")}
-	allRevs := []Revision{Revision{Main: 1}, Revision{Main: 2}, Revision{Main: 3}, Revision{Main: 4}, Revision{Main: 5}, Revision{Main: 6}}
+	allRevs := []Revision{{Main: 1}, {Main: 2}, {Main: 3}, {Main: 4}, {Main: 5}, {Main: 6}}
 
 	ti := newTreeIndex(zaptest.NewLogger(t))
 	for i := range allKeys {
@@ -162,23 +162,23 @@ func TestIndexRevision(t *testing.T) {
 		},
 		// single key that found
 		{
-			[]byte("foo"), nil, 6, 0, []Revision{Revision{Main: 6}}, 1,
+			[]byte("foo"), nil, 6, 0, []Revision{{Main: 6}}, 1,
 		},
 		// various range keys, fixed atRev, unlimited
 		{
-			[]byte("foo"), []byte("foo1"), 6, 0, []Revision{Revision{Main: 6}}, 1,
+			[]byte("foo"), []byte("foo1"), 6, 0, []Revision{{Main: 6}}, 1,
 		},
 		{
-			[]byte("foo"), []byte("foo2"), 6, 0, []Revision{Revision{Main: 6}, Revision{Main: 5}}, 2,
+			[]byte("foo"), []byte("foo2"), 6, 0, []Revision{{Main: 6}, {Main: 5}}, 2,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 6, 0, []Revision{Revision{Main: 6}, Revision{Main: 5}, Revision{Main: 4}}, 3,
+			[]byte("foo"), []byte("fop"), 6, 0, []Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 6, 0, []Revision{Revision{Main: 5}, Revision{Main: 4}}, 2,
+			[]byte("foo1"), []byte("fop"), 6, 0, []Revision{{Main: 5}, {Main: 4}}, 2,
 		},
 		{
-			[]byte("foo2"), []byte("fop"), 6, 0, []Revision{Revision{Main: 4}}, 1,
+			[]byte("foo2"), []byte("fop"), 6, 0, []Revision{{Main: 4}}, 1,
 		},
 		{
 			[]byte("foo3"), []byte("fop"), 6, 0, nil, 0,
@@ -188,38 +188,38 @@ func TestIndexRevision(t *testing.T) {
 			[]byte("foo1"), []byte("fop"), 1, 0, nil, 0,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 2, 0, []Revision{Revision{Main: 2}}, 1,
+			[]byte("foo1"), []byte("fop"), 2, 0, []Revision{{Main: 2}}, 1,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 3, 0, []Revision{Revision{Main: 2}, Revision{Main: 3}}, 2,
+			[]byte("foo1"), []byte("fop"), 3, 0, []Revision{{Main: 2}, {Main: 3}}, 2,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 4, 0, []Revision{Revision{Main: 2}, Revision{Main: 4}}, 2,
+			[]byte("foo1"), []byte("fop"), 4, 0, []Revision{{Main: 2}, {Main: 4}}, 2,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 5, 0, []Revision{Revision{Main: 5}, Revision{Main: 4}}, 2,
+			[]byte("foo1"), []byte("fop"), 5, 0, []Revision{{Main: 5}, {Main: 4}}, 2,
 		},
 		{
-			[]byte("foo1"), []byte("fop"), 6, 0, []Revision{Revision{Main: 5}, Revision{Main: 4}}, 2,
+			[]byte("foo1"), []byte("fop"), 6, 0, []Revision{{Main: 5}, {Main: 4}}, 2,
 		},
 		// fixed range keys, fixed atRev, various limit
 		{
-			[]byte("foo"), []byte("fop"), 6, 1, []Revision{Revision{Main: 6}}, 3,
+			[]byte("foo"), []byte("fop"), 6, 1, []Revision{{Main: 6}}, 3,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 6, 2, []Revision{Revision{Main: 6}, Revision{Main: 5}}, 3,
+			[]byte("foo"), []byte("fop"), 6, 2, []Revision{{Main: 6}, {Main: 5}}, 3,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 6, 3, []Revision{Revision{Main: 6}, Revision{Main: 5}, Revision{Main: 4}}, 3,
+			[]byte("foo"), []byte("fop"), 6, 3, []Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 3, 1, []Revision{Revision{Main: 1}}, 3,
+			[]byte("foo"), []byte("fop"), 3, 1, []Revision{{Main: 1}}, 3,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 3, 2, []Revision{Revision{Main: 1}, Revision{Main: 2}}, 3,
+			[]byte("foo"), []byte("fop"), 3, 2, []Revision{{Main: 1}, {Main: 2}}, 3,
 		},
 		{
-			[]byte("foo"), []byte("fop"), 3, 3, []Revision{Revision{Main: 1}, Revision{Main: 2}, Revision{Main: 3}}, 3,
+			[]byte("foo"), []byte("fop"), 3, 3, []Revision{{Main: 1}, {Main: 2}, {Main: 3}}, 3,
 		},
 	}
 	for i, tt := range tests {
@@ -285,32 +285,32 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 1}, Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 2}, Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 3}, Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 1}: {},
+				{Main: 1}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 1}: {},
+				{Main: 1}: {},
 			},
 		},
 		{
@@ -320,34 +320,34 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 1}, Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 2}, Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 3}, Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
 			},
 		},
 		{
@@ -357,36 +357,36 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 1}, Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 2}, Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 3}, Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 3}, {Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
-				Revision{Main: 3}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
+				{Main: 3}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
-				Revision{Main: 3}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
+				{Main: 3}: {},
 			},
 		},
 		{
@@ -396,36 +396,36 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 1}, Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 1}, {Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 2}, Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
-				Revision{Main: 4}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
+				{Main: 4}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 1}: {},
-				Revision{Main: 2}: {},
-				Revision{Main: 4}: {},
+				{Main: 1}: {},
+				{Main: 2}: {},
+				{Main: 4}: {},
 			},
 		},
 		{
@@ -435,36 +435,36 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 2}, Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 2}, {Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 2}: {},
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 2}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 2}: {},
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 2}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 		},
 		{
@@ -474,36 +474,36 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 6}, Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 6}, {Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 6}: {},
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 6}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 6}: {},
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 6}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 		},
 		{
@@ -513,35 +513,35 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 2}, revs: []Revision{Revision{Main: 7}}},
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 3, created: Revision{Main: 2}, revs: []Revision{{Main: 7}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 4}, Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 4}, {Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 7}: {},
-				Revision{Main: 4}: {},
-				Revision{Main: 5}: {},
+				{Main: 7}: {},
+				{Main: 4}: {},
+				{Main: 5}: {},
 			},
 		},
 		{
@@ -551,32 +551,32 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 5}, Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 5}, {Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 				{
 					key:      []byte("foo2"),
 					modified: Revision{Main: 8},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 3}, revs: []Revision{Revision{Main: 8}}},
+						{ver: 3, created: Revision{Main: 3}, revs: []Revision{{Main: 8}}},
 						{},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 5}: {},
+				{Main: 5}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 8}: {},
-				Revision{Main: 5}: {},
+				{Main: 8}: {},
+				{Main: 5}: {},
 			},
 		},
 		{
@@ -586,21 +586,21 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 3, created: Revision{Main: 1}, revs: []Revision{Revision{Main: 9}}},
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 3, created: Revision{Main: 1}, revs: []Revision{{Main: 9}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 9}: {},
+				{Main: 9}: {},
 			},
 		},
 		{
@@ -610,24 +610,24 @@ func TestIndexCompactAndKeep(t *testing.T) {
 					key:      []byte("foo"),
 					modified: Revision{Main: 10},
 					generations: []generation{
-						{ver: 1, created: Revision{Main: 10}, revs: []Revision{Revision{Main: 10}}},
+						{ver: 1, created: Revision{Main: 10}, revs: []Revision{{Main: 10}}},
 					},
 				},
 				{
 					key:      []byte("foo1"),
 					modified: Revision{Main: 10, Sub: 1},
 					generations: []generation{
-						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{Revision{Main: 10, Sub: 1}}},
+						{ver: 1, created: Revision{Main: 10, Sub: 1}, revs: []Revision{{Main: 10, Sub: 1}}},
 					},
 				},
 			},
 			keep: map[Revision]struct{}{
-				Revision{Main: 10}:         {},
-				Revision{Main: 10, Sub: 1}: {},
+				{Main: 10}:         {},
+				{Main: 10, Sub: 1}: {},
 			},
 			compacted: map[Revision]struct{}{
-				Revision{Main: 10}:         {},
-				Revision{Main: 10, Sub: 1}: {},
+				{Main: 10}:         {},
+				{Main: 10, Sub: 1}: {},
 			},
 		},
 	}

--- a/server/storage/mvcc/key_index_test.go
+++ b/server/storage/mvcc/key_index_test.go
@@ -94,14 +94,14 @@ func TestKeyIndexSince(t *testing.T) {
 	ki.compact(zaptest.NewLogger(t), 4, make(map[Revision]struct{}))
 
 	allRevs := []Revision{
-		Revision{Main: 4},
-		Revision{Main: 6},
-		Revision{Main: 8},
-		Revision{Main: 10},
-		Revision{Main: 12},
-		Revision{Main: 14},
-		Revision{Main: 15, Sub: 1},
-		Revision{Main: 16},
+		{Main: 4},
+		{Main: 6},
+		{Main: 8},
+		{Main: 10},
+		{Main: 12},
+		{Main: 14},
+		{Main: 15, Sub: 1},
+		{Main: 16},
 	}
 	tests := []struct {
 		rev int64
@@ -143,7 +143,7 @@ func TestKeyIndexPut(t *testing.T) {
 	wki := &keyIndex{
 		key:         []byte("foo"),
 		modified:    Revision{Main: 5},
-		generations: []generation{{created: Revision{Main: 5}, ver: 1, revs: []Revision{Revision{Main: 5}}}},
+		generations: []generation{{created: Revision{Main: 5}, ver: 1, revs: []Revision{{Main: 5}}}},
 	}
 	if !reflect.DeepEqual(ki, wki) {
 		t.Errorf("ki = %+v, want %+v", ki, wki)
@@ -154,7 +154,7 @@ func TestKeyIndexPut(t *testing.T) {
 	wki = &keyIndex{
 		key:         []byte("foo"),
 		modified:    Revision{Main: 7},
-		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{Revision{Main: 5}, Revision{Main: 7}}}},
+		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{{Main: 5}, {Main: 7}}}},
 	}
 	if !reflect.DeepEqual(ki, wki) {
 		t.Errorf("ki = %+v, want %+v", ki, wki)
@@ -168,7 +168,7 @@ func TestKeyIndexRestore(t *testing.T) {
 	wki := &keyIndex{
 		key:         []byte("foo"),
 		modified:    Revision{Main: 7},
-		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{Revision{Main: 7}}}},
+		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{{Main: 7}}}},
 	}
 	if !reflect.DeepEqual(ki, wki) {
 		t.Errorf("ki = %+v, want %+v", ki, wki)
@@ -187,7 +187,7 @@ func TestKeyIndexTombstone(t *testing.T) {
 	wki := &keyIndex{
 		key:         []byte("foo"),
 		modified:    Revision{Main: 7},
-		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{Revision{Main: 5}, Revision{Main: 7}}}, {}},
+		generations: []generation{{created: Revision{Main: 5}, ver: 2, revs: []Revision{{Main: 5}, {Main: 7}}}, {}},
 	}
 	if !reflect.DeepEqual(ki, wki) {
 		t.Errorf("ki = %+v, want %+v", ki, wki)
@@ -204,8 +204,8 @@ func TestKeyIndexTombstone(t *testing.T) {
 		key:      []byte("foo"),
 		modified: Revision{Main: 15},
 		generations: []generation{
-			{created: Revision{Main: 5}, ver: 2, revs: []Revision{Revision{Main: 5}, Revision{Main: 7}}},
-			{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 9}, Revision{Main: 15}}},
+			{created: Revision{Main: 5}, ver: 2, revs: []Revision{{Main: 5}, {Main: 7}}},
+			{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 9}, {Main: 15}}},
 			{},
 		},
 	}
@@ -232,9 +232,9 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 2}, Revision{Main: 4}, Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 2}, {Main: 4}, {Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
@@ -246,14 +246,14 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 2}, Revision{Main: 4}, Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 2}, {Main: 4}, {Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 2}: {},
+				{Main: 2}: {},
 			},
 		},
 		{
@@ -262,14 +262,14 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 2}, Revision{Main: 4}, Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 2}, {Main: 4}, {Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 2}: {},
+				{Main: 2}: {},
 			},
 		},
 		{
@@ -278,14 +278,14 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 4}, Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 4}, {Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 4}: {},
+				{Main: 4}: {},
 			},
 		},
 		{
@@ -294,14 +294,14 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 4}, Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 4}, {Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 4}: {},
+				{Main: 4}: {},
 			},
 		},
 		{
@@ -310,14 +310,14 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 2}, ver: 3, revs: []Revision{Revision{Main: 6}}},
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 6}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 6}: {},
+				{Main: 6}: {},
 			},
 		},
 		{
@@ -326,8 +326,8 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
@@ -339,13 +339,13 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 8}: {},
+				{Main: 8}: {},
 			},
 		},
 		{
@@ -354,13 +354,13 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 8}, Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 8}, {Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 8}: {},
+				{Main: 8}: {},
 			},
 		},
 		{
@@ -369,13 +369,13 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 10}: {},
+				{Main: 10}: {},
 			},
 		},
 		{
@@ -384,13 +384,13 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 10}, Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 10}, {Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 10}: {},
+				{Main: 10}: {},
 			},
 		},
 		{
@@ -399,13 +399,13 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 8}, ver: 3, revs: []Revision{Revision{Main: 12}}},
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 8}, ver: 3, revs: []Revision{{Main: 12}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 12}: {},
+				{Main: 12}: {},
 			},
 		},
 		{
@@ -414,7 +414,7 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
@@ -426,12 +426,12 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 14}, Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 14}, {Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 14}: {},
+				{Main: 14}: {},
 			},
 		},
 		{
@@ -440,12 +440,12 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 15, Sub: 1}, Revision{Main: 16}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 15, Sub: 1}, {Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 15, Sub: 1}: {},
+				{Main: 15, Sub: 1}: {},
 			},
 		},
 		{
@@ -454,12 +454,12 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 16},
 				generations: []generation{
-					{created: Revision{Main: 14}, ver: 3, revs: []Revision{Revision{Main: 16}}},
+					{created: Revision{Main: 14}, ver: 3, revs: []Revision{{Main: 16}}},
 					{},
 				},
 			},
 			map[Revision]struct{}{
-				Revision{Main: 16}: {},
+				{Main: 16}: {},
 			},
 		},
 		{
@@ -597,11 +597,11 @@ func TestKeyIndexCompactOnFurtherRev(t *testing.T) {
 		key:      []byte("foo"),
 		modified: Revision{Main: 2},
 		generations: []generation{
-			{created: Revision{Main: 1}, ver: 2, revs: []Revision{Revision{Main: 2}}},
+			{created: Revision{Main: 1}, ver: 2, revs: []Revision{{Main: 2}}},
 		},
 	}
 	wam := map[Revision]struct{}{
-		Revision{Main: 2}: {},
+		{Main: 2}: {},
 	}
 	if !reflect.DeepEqual(ki, wki) {
 		t.Errorf("ki = %+v, want %+v", ki, wki)
@@ -628,7 +628,7 @@ func TestKeyIndexIsEmpty(t *testing.T) {
 				key:      []byte("foo"),
 				modified: Revision{Main: 2},
 				generations: []generation{
-					{created: Revision{Main: 1}, ver: 2, revs: []Revision{Revision{Main: 2}}},
+					{created: Revision{Main: 1}, ver: 2, revs: []Revision{{Main: 2}}},
 				},
 			},
 			false,
@@ -698,7 +698,7 @@ func TestGenerationIsEmpty(t *testing.T) {
 	}{
 		{nil, true},
 		{&generation{}, true},
-		{&generation{revs: []Revision{Revision{Main: 1}}}, false},
+		{&generation{revs: []Revision{{Main: 1}}}, false},
 	}
 	for i, tt := range tests {
 		g := tt.g.isEmpty()
@@ -712,7 +712,7 @@ func TestGenerationWalk(t *testing.T) {
 	g := &generation{
 		ver:     3,
 		created: Revision{Main: 2},
-		revs:    []Revision{Revision{Main: 2}, Revision{Main: 4}, Revision{Main: 6}},
+		revs:    []Revision{{Main: 2}, {Main: 4}, {Main: 6}},
 	}
 	tests := []struct {
 		f  func(rev Revision) bool

--- a/server/storage/mvcc/kvstore_compaction_test.go
+++ b/server/storage/mvcc/kvstore_compaction_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestScheduleCompaction(t *testing.T) {
-	revs := []Revision{Revision{Main: 1}, Revision{Main: 2}, Revision{Main: 3}}
+	revs := []Revision{{Main: 1}, {Main: 2}, {Main: 3}}
 
 	tests := []struct {
 		rev   int64

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -199,11 +199,11 @@ func TestStoreRange(t *testing.T) {
 		r    rangeResp
 	}{
 		{
-			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{Revision{Main: 2}}},
+			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 		{
-			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{Revision{Main: 2}, Revision{Main: 3}}},
+			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{{Main: 2}, {Main: 3}}},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 	}
@@ -335,7 +335,7 @@ func TestStoreCompact(t *testing.T) {
 	fi := s.kvindex.(*fakeIndex)
 
 	s.currentRev = 3
-	fi.indexCompactRespc <- map[Revision]struct{}{Revision{Main: 1}: {}}
+	fi.indexCompactRespc <- map[Revision]struct{}{{Main: 1}: {}}
 	key1 := newTestRevBytes(Revision{Main: 1})
 	key2 := newTestRevBytes(Revision{Main: 2})
 	b.tx.rangeRespc <- rangeResp{[][]byte{}, [][]byte{}}
@@ -420,7 +420,7 @@ func TestStoreRestore(t *testing.T) {
 	}
 
 	gens := []generation{
-		{created: Revision{Main: 4}, ver: 2, revs: []Revision{Revision{Main: 3}, Revision{Main: 5}}},
+		{created: Revision{Main: 4}, ver: 2, revs: []Revision{{Main: 3}, {Main: 5}}},
 		{created: Revision{Main: 0}, ver: 0, revs: nil},
 	}
 	ki := &keyIndex{key: []byte("foo"), modified: Revision{Main: 5}, generations: gens}

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -369,7 +369,6 @@ func TestWatchRestore(t *testing.T) {
 			if events[0].Kv.ModRevision != wantRev {
 				t.Errorf("Expected revision to match, got %d, want %d", events[0].Kv.ModRevision, wantRev)
 			}
-
 		}
 	}
 

--- a/server/storage/schema/version_test.go
+++ b/server/storage/schema/version_test.go
@@ -129,7 +129,6 @@ func TestVersionSnapshot(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expectVersion, ver.String())
-
 		})
 	}
 }

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -1126,7 +1126,6 @@ func TestValidSnapshotEntriesAfterPurgeWal(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-
 	}()
 	files, _, err := selectWALFiles(nil, p, snap0)
 	if err != nil {

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestCompact(t *testing.T) {
-
 	testRunner.BeforeTest(t)
 	tcs := []struct {
 		name    string

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestStatus(t *testing.T) {
-
 	testRunner.BeforeTest(t)
 
 	for _, tc := range clusterTestCases() {

--- a/tests/e2e/ctl_v3_auth_cluster_test.go
+++ b/tests/e2e/ctl_v3_auth_cluster_test.go
@@ -95,7 +95,6 @@ func TestAuthCluster(t *testing.T) {
 		assert.Equal(t, hashKvs[0].Hash, hashKvs[1].Hash)
 		return true
 	}, time.Second*5, time.Millisecond*100)
-
 }
 
 func applyTLSWithRootCommonName() func() {

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -294,7 +294,6 @@ func authTestWatch(cx ctlCtx) {
 
 		<-donec
 	}
-
 }
 
 func authTestSnapshot(cx ctlCtx) {

--- a/tests/e2e/hashkv_test.go
+++ b/tests/e2e/hashkv_test.go
@@ -145,8 +145,8 @@ func TestVerifyHashKVAfterCompactionOnLastTombstone_MixVersions(t *testing.T) {
 	}
 
 	for _, keys := range [][]string{
-		[]string{"key0"},
-		[]string{"key0", "key1"},
+		{"key0"},
+		{"key0", "key1"},
 	} {
 		t.Run(fmt.Sprintf("#%v", keys), func(t *testing.T) {
 			ctx := context.Background()
@@ -172,7 +172,6 @@ func TestVerifyHashKVAfterCompactionOnLastTombstone_MixVersions(t *testing.T) {
 			for rev := compactOnRev; rev <= lastestRev; rev++ {
 				verifyConsistentHashKVAcrossAllMembers(t, cli, rev)
 			}
-
 		})
 	}
 }

--- a/tests/integration/clientv3/concurrency/session_test.go
+++ b/tests/integration/clientv3/concurrency/session_test.go
@@ -49,7 +49,6 @@ func TestSessionOptions(t *testing.T) {
 	case <-time.After(time.Millisecond * 100):
 		t.Fatal("session did not get orphaned as expected")
 	}
-
 }
 func TestSessionTTLOptions(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
@@ -73,7 +72,6 @@ func TestSessionTTLOptions(t *testing.T) {
 	}
 	if resp.TTL == -1 {
 		t.Errorf("client lease should not be expired: %d", resp.TTL)
-
 	}
 	if resp.TTL == 60 {
 		t.Errorf("default TTL value is used in the session, instead of set TTL: %d", setTTL)
@@ -81,7 +79,6 @@ func TestSessionTTLOptions(t *testing.T) {
 	if resp.TTL >= int64(setTTL) || resp.TTL < int64(setTTL)-20 {
 		t.Errorf("Session TTL from lease should be less, but close to set TTL %d, have: %d", setTTL, resp.TTL)
 	}
-
 }
 
 func TestSessionCtx(t *testing.T) {

--- a/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
@@ -66,7 +66,6 @@ func testBarrier(t *testing.T, waiters int, chooseClient func() *clientv3.Client
 			case donec <- struct{}{}:
 			case <-stopc:
 			}
-
 		}()
 	}
 

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -1899,7 +1899,6 @@ func randCmps(pfx string, dat []*clientv3.PutResponse) (cmps []clientv3.Cmp, the
 			cmp = clientv3.Compare(clientv3.CreateRevision(k), "=", rev)
 		case 3:
 			cmp = clientv3.Compare(clientv3.CreateRevision(k), "!=", rev+1)
-
 		}
 		cmps = append(cmps, cmp)
 	}

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
-
 	// Setup two new dummy stub servers
 	payloadBody := []byte{'1'}
 	s1 := grpctesting.NewDummyStubServer(payloadBody)
@@ -133,7 +132,6 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 
 // TestEtcdGrpcResolverPickFirst mimics scenarios described in grpc_naming.md doc.
 func TestEtcdGrpcResolverPickFirst(t *testing.T) {
-
 	integration2.BeforeTest(t)
 
 	// Pick first is the default load balancer policy for grpc-go
@@ -142,7 +140,6 @@ func TestEtcdGrpcResolverPickFirst(t *testing.T) {
 
 // TestEtcdGrpcResolverRoundRobin mimics scenarios described in grpc_naming.md doc.
 func TestEtcdGrpcResolverRoundRobin(t *testing.T) {
-
 	integration2.BeforeTest(t)
 
 	// Round robin is a common alternative for more production oriented scenarios

--- a/tests/integration/v2store/store_test.go
+++ b/tests/integration/v2store/store_test.go
@@ -203,7 +203,6 @@ func TestStoreCreateValue(t *testing.T) {
 	testutil.AssertNil(t, e.Node.Expiration)
 	assert.Equal(t, e.Node.TTL, int64(0))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(2))
-
 }
 
 // TestStoreCreateDirectory ensures that the store can create a new directory if it doesn't already exist.
@@ -347,7 +346,6 @@ func TestStoreDeleteDirectory(t *testing.T) {
 	e, err = s.Delete("/foo", false, true)
 	testutil.AssertNil(t, err)
 	assert.Equal(t, e.Action, "delete")
-
 }
 
 // TestStoreDeleteDirectoryFailsIfNonRecursiveAndDir ensures that the

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -1408,7 +1408,6 @@ func TestV3WatchCloseCancelRace(t *testing.T) {
 // TestV3WatchProgressWaitsForSync checks that progress notifications
 // don't get sent until the watcher is synchronised
 func TestV3WatchProgressWaitsForSync(t *testing.T) {
-
 	// Disable for gRPC proxy, as it does not support requesting
 	// progress notifications
 	if integration.ThroughProxy {

--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -262,7 +262,6 @@ func (c *RecordingClient) Watch(ctx context.Context, key string, rev int64, with
 		WithPrevKV:         withPrevKV,
 	}
 	return c.watch(ctx, request)
-
 }
 
 func (c *RecordingClient) watch(ctx context.Context, request model.WatchRequest) clientv3.WatchChan {

--- a/tests/robustness/options/cluster_options_test.go
+++ b/tests/robustness/options/cluster_options_test.go
@@ -43,12 +43,12 @@ func TestWithClusterOptionGroups(t *testing.T) {
 	}
 
 	expectedServerConfigs := []embed.Config{
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
-		embed.Config{SnapshotCount: 100, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
-		embed.Config{SnapshotCount: 150, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
+		{SnapshotCount: 100, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 101, ElectionMs: 1001},
+		{SnapshotCount: 150, SnapshotCatchUpEntries: 100, TickMs: 202, ElectionMs: 2002},
 	}
 	for i, tt := range expectedServerConfigs {
 		cluster := *e2e.NewConfig(opts...)
@@ -77,20 +77,20 @@ func TestWithOptionsSubset(t *testing.T) {
 	}
 
 	expectedServerConfigs := []embed.Config{
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
 		// both SnapshotCount and TickMs&ElectionMs are not default values.
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
 		// only TickMs&ElectionMs are not default values.
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
 		// both SnapshotCount and TickMs&ElectionMs are not default values.
-		embed.Config{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
+		{SnapshotCount: 200, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
 		// both SnapshotCount and TickMs&ElectionMs are not default values.
-		embed.Config{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
+		{SnapshotCount: 10000, SnapshotCatchUpEntries: 100, TickMs: 50, ElectionMs: 500},
 		// only SnapshotCount is not default value.
-		embed.Config{SnapshotCount: 100, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
+		{SnapshotCount: 100, SnapshotCatchUpEntries: 100, TickMs: 100, ElectionMs: 1000},
 	}
 	for i, tt := range expectedServerConfigs {
 		cluster := *e2e.NewConfig(opts...)

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     # - deadcode
     # - structcheck
     # - varcheck
+    - gofmt
     - goimports
     - ineffassign
     - nakedret
@@ -28,6 +29,7 @@ linters:
     - unconvert # Remove unnecessary type conversions
     - unparam
     - unused
+    - whitespace
 linters-settings: # please keep this alphabetized
   goimports:
     local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.

--- a/tools/benchmark/cmd/mvcc-put.go
+++ b/tools/benchmark/cmd/mvcc-put.go
@@ -56,7 +56,6 @@ func init() {
 	// TODO: after the PR https://github.com/spf13/cobra/pull/220 is merged, the below pprof related flags should be moved to RootCmd
 	mvccPutCmd.Flags().StringVar(&cpuProfPath, "cpuprofile", "", "the path of file for storing cpu profile result")
 	mvccPutCmd.Flags().StringVar(&memProfPath, "memprofile", "", "the path of file for storing heap profile result")
-
 }
 
 func createBytesSlice(bytesN, sliceN int) [][]byte {

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -115,7 +115,6 @@ func mustCreateConn() *clientv3.Client {
 		}
 		cfg.Username = username
 		cfg.Password = password
-
 	}
 
 	client, err := clientv3.New(cfg)

--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -233,7 +233,6 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 	bar.Finish()
 	close(r.Results())
 	fmt.Printf("Watch events received summary:\n%s", <-rc)
-
 }
 
 func recvWatchChan(wch clientv3.WatchChan, results chan<- report.Result, nrRxed *int32) {

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -93,7 +93,6 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 			assert.EqualValues(t, strings.ReplaceAll(string(expected), " ", "_"), strings.ReplaceAll(string(actual), " ", "_"))
 		})
 	}
-
 }
 
 func mustCreateWALLog(t *testing.T, path string) {

--- a/tools/etcd-dump-metrics/metrics.go
+++ b/tools/etcd-dump-metrics/metrics.go
@@ -207,7 +207,6 @@ func parse(lines []string) (mss []metric) {
 			mss[i].grpcCodes = sortMap(codes)
 			mss[i].metrics = sortMap(metrics)
 		}
-
 	}
 	return mss
 }

--- a/tools/local-tester/bridge/bridge.go
+++ b/tools/local-tester/bridge/bridge.go
@@ -238,7 +238,6 @@ func main() {
 				log.Fatal(err)
 			}
 			l = newListener
-
 		}
 		acceptFaults = append(acceptFaults, f)
 	}


### PR DESCRIPTION
Enables and fixes [gofmt](https://golangci-lint.run/usage/linters/#gofmt) and [whitespaces](https://golangci-lint.run/usage/linters/#whitespace) linters.