### PR TITLE
fix: enable compares and negative-positive rules from testifylint

### DIFF
--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -443,6 +443,6 @@ func testCtlV3ReadAfterWrite(t *testing.T, ops ...clientv3.OpOption) {
 	stopc <- struct{}{}
 
 	<-donec
-	assert.Greater(t, count, 0)
+	assert.Positive(t, count)
 	t.Logf("Checked the key/value %d times", count)
 }

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -139,7 +139,7 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 	}()
 
 	wg.Wait()
-	assert.Greater(t, count, 0)
+	assert.Positive(t, count)
 	t.Logf("Checked the member list %d times", count)
 }
 

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -449,7 +449,7 @@ func hasKVs(t *testing.T, ctl *e2e.EtcdctlV3, kvs []testutils.KV, currentRev int
 		require.Equal(t, int64(baseRev+i), v.Kvs[0].CreateRevision)
 		require.Equal(t, int64(baseRev+i), v.Kvs[0].ModRevision)
 		require.Equal(t, int64(1), v.Kvs[0].Version)
-		require.True(t, int64(currentRev) >= v.Kvs[0].ModRevision)
+		require.GreaterOrEqual(t, int64(currentRev), v.Kvs[0].ModRevision)
 	}
 }
 

--- a/tests/e2e/hashkv_test.go
+++ b/tests/e2e/hashkv_test.go
@@ -225,7 +225,7 @@ func verifyConsistentHashKVAcrossAllMembers(t *testing.T, cli *e2e.EtcdctlV3, ha
 	require.NoError(t, err)
 
 	require.Greater(t, len(resp), 1)
-	require.True(t, resp[0].Hash != 0)
+	require.NotEqual(t, resp[0].Hash, 0)
 	t.Logf("One Hash value is %d", resp[0].Hash)
 
 	for i := 1; i < len(resp); i++ {

--- a/tests/e2e/reproduce_17780_test.go
+++ b/tests/e2e/reproduce_17780_test.go
@@ -88,7 +88,7 @@ func TestReproduce17780(t *testing.T) {
 	// Revision 4 should be deleted by compaction.
 	resp, err = cli.Get(ctx, fmt.Sprintf("%d", 4))
 	require.NoError(t, err)
-	require.True(t, resp.Count == 0)
+	require.Equal(t, resp.Count, int64(0))
 
 	next := 20
 	for i := 12; i <= next; i++ {

--- a/tests/e2e/v3_curl_cluster_test.go
+++ b/tests/e2e/v3_curl_cluster_test.go
@@ -66,7 +66,7 @@ func testCurlV3ClusterOperations(cx ctlCtx) {
 			break
 		}
 	}
-	require.True(cx.t, len(newMemberIDStr) > 0)
+	require.Positive(cx.t, newMemberIDStr)
 
 	// update member
 	cx.t.Logf("Update peerURL from %q to %q for member %q", peerURL, updatedPeerURL, newMemberIDStr)

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -456,7 +456,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 		watchStartCh <- struct{}{}
 		watchResponse := <-wChan
 		t.Logf("watch response from k1: %v", watchResponse)
-		assert.True(t, len(watchResponse.Events) != 0)
+		assert.NotEmpty(t, watchResponse.Events)
 		watchEndCh <- struct{}{}
 	}()
 

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -111,13 +111,11 @@ linters-settings: # please keep this alphabetized
       - ST1019 # Importing the same package multiple times.
   testifylint:
     disable:
-      - compares
       - error-is-as
       - error-nil
       - expected-actual
       - float-compare
       - formatter
       - go-require
-      - negative-positive
       - require-error
     enable-all: true


### PR DESCRIPTION
This fixes [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) and [negative-positive](https://github.com/Antonboom/testifylint?tab=readme-ov-file#negative-positive) rules from [testifylint](https://github.com/Antonboom/testifylint).

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->