### PR TITLE
fix: enable error-nil rule from testifylint

### DIFF
--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -38,7 +38,7 @@ func TestMinExpireTime(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 	var eidx uint64 = 1
 	e, err := s.Get("/foo", true, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -60,7 +60,7 @@ func TestStoreGetDirectory(t *testing.T) {
 	s.Create("/foo/baz/ttl", false, "Y", false, TTLOptionSet{ExpireTime: fc.Now().Add(time.Second * 3)})
 	var eidx uint64 = 7
 	e, err := s.Get("/foo", true, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -103,7 +103,7 @@ func TestStoreUpdateValueTTL(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	_, err := s.Update("/foo", "baz", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	e, _ := s.Get("/foo", false, false)
 	assert.Equal(t, *e.Node.Value, "baz")
 	assert.Equal(t, e.EtcdIndex, eidx)
@@ -122,11 +122,11 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 
 	var eidx uint64 = 3
 	_, err := s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = s.Create("/foo/bar", false, "baz", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	e, err := s.Update("/foo/bar", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	e, _ = s.Get("/foo/bar", false, false)
@@ -275,16 +275,16 @@ func TestStoreRefresh(t *testing.T) {
 	s.Create("/bar", true, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	s.Create("/bar/z", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	_, err := s.Update("/foo", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = s.Set("/foo", false, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = s.Update("/bar/z", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = s.CompareAndSwap("/foo", "bar", 0, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // TestStoreRecoverWithExpiration ensures that the store can recover from a previously saved state that includes an expiring key.
@@ -299,7 +299,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.Create("/foo/x", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/y", false, "baz", false, TTLOptionSet{ExpireTime: fc.Now().Add(5 * time.Millisecond)})
 	b, err := s.Save()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -312,12 +312,12 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 
 	e, err := s.Get("/foo/x", false, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, *e.Node.Value, "bar")
 
 	e, err = s.Get("/foo/y", false, false)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	assert.Nil(t, e)
 }
 

--- a/server/etcdserver/apply/uber_applier_test.go
+++ b/server/etcdserver/apply/uber_applier_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/crypto/bcrypt"
@@ -130,7 +131,7 @@ func TestUberApplier_Alarm_Corrupt(t *testing.T) {
 		},
 	})
 	require.NotNil(t, result)
-	require.Nil(t, result.Err)
+	require.NoError(t, result.Err)
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -229,7 +230,7 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 		},
 	})
 	require.NotNil(t, result)
-	require.Nil(t, result.Err)
+	require.NoError(t, result.Err)
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -252,7 +253,7 @@ func TestUberApplier_Alarm_Deactivate(t *testing.T) {
 		},
 	})
 	require.NotNil(t, result)
-	require.Nil(t, result.Err)
+	require.NoError(t, result.Err)
 
 	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}})
 	require.NotNil(t, result)
@@ -267,9 +268,9 @@ func TestUberApplier_Alarm_Deactivate(t *testing.T) {
 		},
 	})
 	require.NotNil(t, result)
-	require.Nil(t, result.Err)
+	require.NoError(t, result.Err)
 
 	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}})
 	require.NotNil(t, result)
-	require.Nil(t, result.Err)
+	assert.NoError(t, result.Err)
 }

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -140,7 +140,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 		if tc.expectErr {
 			require.ErrorContains(t, err, tc.expect)
 		} else {
-			require.Nilf(t, err, "#%d: %v", i, err)
+			require.NoErrorf(t, err, "#%d: %v", i, err)
 		}
 	}
 }

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -66,7 +66,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	// create users
 	for i := 0; i < len(usernames); i++ {
 		user, err := json.Marshal(&pb.AuthUserAddRequest{Name: usernames[i], Password: pwds[i], Options: options[i]})
-		assert.Nil(cx.t, err)
+		assert.NoError(cx.t, err)
 
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/add",
@@ -79,7 +79,7 @@ func testCurlV3Auth(cx ctlCtx) {
 
 	// create root role
 	rolereq, err := json.Marshal(&pb.AuthRoleAddRequest{Name: "root"})
-	assert.Nil(cx.t, err)
+	assert.NoError(cx.t, err)
 
 	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/add",
@@ -92,7 +92,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	//grant root role
 	for i := 0; i < len(usernames); i++ {
 		grantroleroot, merr := json.Marshal(&pb.AuthUserGrantRoleRequest{User: usernames[i], Role: "root"})
-		assert.Nil(cx.t, merr)
+		assert.NoError(cx.t, merr)
 
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/grant",
@@ -115,7 +115,7 @@ func testCurlV3Auth(cx ctlCtx) {
 	for i := 0; i < len(usernames); i++ {
 		// put "bar[i]" into "foo[i]"
 		putreq, err := json.Marshal(&pb.PutRequest{Key: []byte(fmt.Sprintf("foo%d", i)), Value: []byte(fmt.Sprintf("bar%d", i))})
-		assert.Nil(cx.t, err)
+		assert.NoError(cx.t, err)
 
 		// fail put no auth
 		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
@@ -128,7 +128,7 @@ func testCurlV3Auth(cx ctlCtx) {
 
 		// auth request
 		authreq, err := json.Marshal(&pb.AuthenticateRequest{Name: usernames[i], Password: pwds[i]})
-		assert.Nil(cx.t, err)
+		assert.NoError(cx.t, err)
 
 		var (
 			authHeader string
@@ -141,14 +141,14 @@ func testCurlV3Auth(cx ctlCtx) {
 			Value:    string(authreq),
 		})
 		proc, err := e2e.SpawnCmd(cmdArgs, cx.envMap)
-		assert.Nil(cx.t, err)
+		assert.NoError(cx.t, err)
 		defer proc.Close()
 
 		cURLRes, err := proc.ExpectFunc(context.Background(), lineFunc)
-		assert.Nil(cx.t, err)
+		assert.NoError(cx.t, err)
 
 		authRes := make(map[string]any)
-		assert.Nil(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
+		assert.NoError(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
 
 		token, ok := authRes[rpctypes.TokenFieldNameGRPC].(string)
 		if !ok {

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -38,15 +38,15 @@ func TestLeasingPutGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lKV1, closeLKV1, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV1()
 
 	lKV2, closeLKV2, err := leasing.NewKV(clus.Client(1), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV2()
 
 	lKV3, closeLKV3, err := leasing.NewKV(clus.Client(2), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV3()
 
 	resp, err := lKV1.Get(context.TODO(), "abc")
@@ -96,7 +96,7 @@ func TestLeasingInterval(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	keys := []string{"abc/a", "abc/b", "abc/a/a"}
@@ -135,7 +135,7 @@ func TestLeasingPutInvalidateNew(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -169,7 +169,7 @@ func TestLeasingPutInvalidateExisting(t *testing.T) {
 	}
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -199,17 +199,17 @@ func TestLeasingGetNoLeaseTTL(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	lresp, err := clus.Client(0).Grant(context.TODO(), 60)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = clus.Client(0).Put(context.TODO(), "k", "v", clientv3.WithLease(lresp.ID))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gresp, err := lkv.Get(context.TODO(), "k")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, gresp.Kvs, 1)
 
 	clus.Members[0].Stop(t)
@@ -228,7 +228,7 @@ func TestLeasingGetSerializable(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "cached", "abc"); err != nil {
@@ -268,7 +268,7 @@ func TestLeasingPrevKey(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -294,7 +294,7 @@ func TestLeasingRevGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	putResp, err := clus.Client(0).Put(context.TODO(), "k", "abc")
@@ -330,7 +330,7 @@ func TestLeasingGetWithOpts(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -375,7 +375,7 @@ func TestLeasingConcurrentPut(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	// force key into leasing key cache
@@ -422,7 +422,7 @@ func TestLeasingDisconnectedGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "cached", "abc"); err != nil {
@@ -451,7 +451,7 @@ func TestLeasingDeleteOwner(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -485,11 +485,11 @@ func TestLeasingDeleteNonOwner(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV2()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -520,7 +520,7 @@ func TestLeasingOverwriteResponse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -554,7 +554,7 @@ func TestLeasingOwnerPutResponse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -592,7 +592,7 @@ func TestLeasingTxnOwnerGetRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	keyCount := rand.Intn(10) + 1
@@ -623,7 +623,7 @@ func TestLeasingTxnOwnerGet(t *testing.T) {
 	client := clus.Client(0)
 
 	lkv, closeLKV, err := leasing.NewKV(client, "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	defer func() {
 		// In '--tags cluster_proxy' mode the client need to be closed before
@@ -707,7 +707,7 @@ func TestLeasingTxnOwnerDeleteRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	keyCount := rand.Intn(10) + 1
@@ -746,7 +746,7 @@ func TestLeasingTxnOwnerDelete(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -777,7 +777,7 @@ func TestLeasingTxnOwnerIf(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -871,11 +871,11 @@ func TestLeasingTxnCancel(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(1), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV2()
 
 	// acquire lease but disconnect so no revoke in time
@@ -905,11 +905,11 @@ func TestLeasingTxnNonOwnerPut(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV2()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "abc"); err != nil {
@@ -983,11 +983,11 @@ func TestLeasingTxnRandIfThenOrElse(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err1)
+	assert.NoError(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	defer closeLKV2()
 
 	keyCount := 16
@@ -1089,7 +1089,7 @@ func TestLeasingOwnerPutError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1110,7 +1110,7 @@ func TestLeasingOwnerDeleteError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1131,7 +1131,7 @@ func TestLeasingNonOwnerPutError(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	clus.Members[0].Stop(t)
@@ -1156,7 +1156,7 @@ func testLeasingOwnerDelete(t *testing.T, del clientv3.Op) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "0/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	for i := 0; i < 8; i++ {
@@ -1205,11 +1205,11 @@ func TestLeasingDeleteRangeBounds(t *testing.T) {
 	defer clus.Terminate(t)
 
 	delkv, closeDelKV, err := leasing.NewKV(clus.Client(0), "0/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeDelKV()
 
 	getkv, closeGetKv, err := leasing.NewKV(clus.Client(0), "0/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeGetKv()
 
 	for _, k := range []string{"j", "m"} {
@@ -1263,11 +1263,11 @@ func testLeasingDeleteRangeContend(t *testing.T, op clientv3.Op) {
 	defer clus.Terminate(t)
 
 	delkv, closeDelKV, err := leasing.NewKV(clus.Client(0), "0/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeDelKV()
 
 	putkv, closePutKV, err := leasing.NewKV(clus.Client(0), "0/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closePutKV()
 
 	const maxKey = 8
@@ -1328,7 +1328,7 @@ func TestLeasingPutGetDeleteConcurrent(t *testing.T) {
 	lkvs := make([]clientv3.KV, 16)
 	for i := range lkvs {
 		lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		defer closeLKV()
 		lkvs[i] = lkv
 	}
@@ -1385,11 +1385,11 @@ func TestLeasingReconnectOwnerRevoke(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err1)
+	assert.NoError(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(1), "foo/")
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	defer closeLKV2()
 
 	if _, err := lkv1.Get(context.TODO(), "k"); err != nil {
@@ -1446,11 +1446,11 @@ func TestLeasingReconnectOwnerRevokeCompact(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv1, closeLKV1, err1 := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err1)
+	assert.NoError(t, err1)
 	defer closeLKV1()
 
 	lkv2, closeLKV2, err2 := leasing.NewKV(clus.Client(1), "foo/")
-	assert.Nil(t, err2)
+	assert.NoError(t, err2)
 	defer closeLKV2()
 
 	if _, err := lkv1.Get(context.TODO(), "k"); err != nil {
@@ -1500,7 +1500,7 @@ func TestLeasingReconnectOwnerConsistency(t *testing.T) {
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
 	defer closeLKV()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	if _, err = lkv.Put(context.TODO(), "k", "x"); err != nil {
 		t.Fatal(err)
@@ -1573,7 +1573,7 @@ func TestLeasingTxnAtomicCache(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	puts, gets := make([]clientv3.Op, 16), make([]clientv3.Op, 16)
@@ -1659,7 +1659,7 @@ func TestLeasingReconnectTxn(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
@@ -1695,7 +1695,7 @@ func TestLeasingReconnectNonOwnerGet(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	// populate a few keys so some leasing gets have keys
@@ -1746,7 +1746,7 @@ func TestLeasingTxnRangeCmp(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	if _, err = clus.Client(0).Put(context.TODO(), "k", "a"); err != nil {
@@ -1781,7 +1781,7 @@ func TestLeasingDo(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	ops := []clientv3.Op{
@@ -1823,7 +1823,7 @@ func TestLeasingTxnOwnerPutBranch(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	n := 0
@@ -1916,11 +1916,11 @@ func TestLeasingSessionExpire(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/", concurrency.WithTTL(1))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV()
 
 	lkv2, closeLKV2, err := leasing.NewKV(clus.Client(0), "foo/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer closeLKV2()
 
 	// acquire lease on abc
@@ -1992,7 +1992,7 @@ func TestLeasingSessionExpireCancel(t *testing.T) {
 			defer clus.Terminate(t)
 
 			lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "foo/", concurrency.WithTTL(1))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			defer closeLKV()
 
 			if _, err = lkv.Get(context.TODO(), "abc"); err != nil {

--- a/tests/integration/v2store/store_tag_test.go
+++ b/tests/integration/v2store/store_tag_test.go
@@ -33,7 +33,7 @@ func TestStoreRecover(t *testing.T) {
 	s.Update("/foo/x", "barbar", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	s.Create("/foo/y", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	b, err := s.Save()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	s2 := v2store.New()
 	s2.Recovery(b)
@@ -42,11 +42,11 @@ func TestStoreRecover(t *testing.T) {
 	assert.Equal(t, e.Node.CreatedIndex, uint64(2))
 	assert.Equal(t, e.Node.ModifiedIndex, uint64(3))
 	assert.Equal(t, e.EtcdIndex, eidx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, *e.Node.Value, "barbar")
 
 	e, err = s.Get("/foo/y", false, false)
 	assert.Equal(t, e.EtcdIndex, eidx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, *e.Node.Value, "baz")
 }

--- a/tests/integration/v2store/store_test.go
+++ b/tests/integration/v2store/store_test.go
@@ -35,9 +35,9 @@ func TestNewStoreWithNamespaces(t *testing.T) {
 	s := v2store.New("/0", "/1")
 
 	_, err := s.Get("/0", false, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = s.Get("/1", false, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // TestStoreGetValue ensures that the store can retrieve an existing value.
@@ -47,7 +47,7 @@ func TestStoreGetValue(t *testing.T) {
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	var eidx uint64 = 1
 	e, err := s.Get("/foo", false, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "get")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -66,7 +66,7 @@ func TestStoreGetSorted(t *testing.T) {
 	s.Create("/foo/y/b", false, "0", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	var eidx uint64 = 6
 	e, err := s.Get("/foo", true, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 
 	var yNodes v2store.NodeExterns
@@ -96,7 +96,7 @@ func TestSet(t *testing.T) {
 	// Set /foo=""
 	var eidx uint64 = 1
 	e, err := s.Set("/foo", false, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -110,7 +110,7 @@ func TestSet(t *testing.T) {
 	// Set /foo="bar"
 	eidx = 2
 	e, err = s.Set("/foo", false, "bar", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -128,7 +128,7 @@ func TestSet(t *testing.T) {
 	// Set /foo="baz" (for testing prevNode)
 	eidx = 3
 	e, err = s.Set("/foo", false, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -147,7 +147,7 @@ func TestSet(t *testing.T) {
 	// Set /a/b/c/d="efg"
 	eidx = 4
 	e, err = s.Set("/a/b/c/d", false, "efg", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Node.Key, "/a/b/c/d")
 	assert.False(t, e.Node.Dir)
@@ -160,7 +160,7 @@ func TestSet(t *testing.T) {
 	// Set /dir as a directory
 	eidx = 5
 	e, err = s.Set("/dir", true, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "set")
 	assert.Equal(t, e.Node.Key, "/dir")
@@ -179,7 +179,7 @@ func TestStoreCreateValue(t *testing.T) {
 	// Create /foo=bar
 	var eidx uint64 = 1
 	e, err := s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -193,7 +193,7 @@ func TestStoreCreateValue(t *testing.T) {
 	// Create /empty=""
 	eidx = 2
 	e, err = s.Create("/empty", false, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/empty")
@@ -211,7 +211,7 @@ func TestStoreCreateDirectory(t *testing.T) {
 
 	var eidx uint64 = 1
 	e, err := s.Create("/foo", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "create")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -244,7 +244,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	// update /foo="bzr"
 	var eidx uint64 = 2
 	e, err := s.Update("/foo", "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "update")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -265,7 +265,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	// update /foo=""
 	eidx = 3
 	e, err = s.Update("/foo", "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "update")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -304,7 +304,7 @@ func TestStoreDeleteValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.Delete("/foo", false, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "delete")
 	// check prevNode
@@ -323,7 +323,7 @@ func TestStoreDeleteDirectory(t *testing.T) {
 	// delete /foo with dir = true and recursive = false
 	// this should succeed, since the directory is empty
 	e, err := s.Delete("/foo", true, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "delete")
 	// check prevNode
@@ -333,18 +333,18 @@ func TestStoreDeleteDirectory(t *testing.T) {
 
 	// create directory /foo and directory /foo/bar
 	_, err = s.Create("/foo/bar", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// delete /foo with dir = true and recursive = false
 	// this should fail, since the directory is not empty
 	_, err = s.Delete("/foo", true, false)
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	// delete /foo with dir=false and recursive = true
 	// this should succeed, since recursive implies dir=true
 	// and recursively delete should be able to delete all
 	// items under the given directory
 	e, err = s.Delete("/foo", false, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.Action, "delete")
 }
 
@@ -366,19 +366,19 @@ func TestRootRdOnly(t *testing.T) {
 
 	for _, tt := range []string{"/", "/0"} {
 		_, err := s.Set(tt, true, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		_, err = s.Delete(tt, true, true)
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		_, err = s.Create(tt, true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		_, err = s.Update(tt, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		require.NotNil(t, err)
+		require.Error(t, err)
 
 		_, err = s.CompareAndSwap(tt, "", 0, "", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -388,7 +388,7 @@ func TestStoreCompareAndDeletePrevValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndDelete("/foo", "bar", 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndDelete")
 	assert.Equal(t, e.Node.Key, "/foo")
@@ -422,7 +422,7 @@ func TestStoreCompareAndDeletePrevIndex(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndDelete("/foo", "", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndDelete")
 	// check prevNode
@@ -439,7 +439,7 @@ func TestStoreCompareAndDeletePrevIndexFailsIfNotMatch(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, _err := s.CompareAndDelete("/foo", "", 100)
-	require.NotNil(t, _err)
+	require.Error(t, _err)
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeTestFailed)
 	assert.Equal(t, err.Message, "Compare failed")
@@ -455,7 +455,7 @@ func TestStoreCompareAndDeleteDirectoryFail(t *testing.T) {
 
 	s.Create("/foo", true, "", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	_, _err := s.CompareAndDelete("/foo", "", 0)
-	require.NotNil(t, _err)
+	require.Error(t, _err)
 	err := _err.(*v2error.Error)
 	assert.Equal(t, err.ErrorCode, v2error.EcodeNotFile)
 }
@@ -468,7 +468,7 @@ func TestStoreCompareAndSwapPrevValue(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndSwap("/foo", "bar", 0, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndSwap")
 	assert.Equal(t, *e.Node.Value, "baz")
@@ -506,7 +506,7 @@ func TestStoreCompareAndSwapPrevIndex(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	e, err := s.CompareAndSwap("/foo", "", 1, "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, e.EtcdIndex, eidx)
 	assert.Equal(t, e.Action, "compareAndSwap")
 	assert.Equal(t, *e.Node.Value, "baz")
@@ -564,7 +564,7 @@ func TestStoreWatchRecursiveCreate(t *testing.T) {
 	s := v2store.New()
 	var eidx uint64
 	w, err := s.Watch("/foo", true, false, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -595,7 +595,7 @@ func TestStoreWatchRecursiveUpdate(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	w, err := s.Watch("/foo", true, false, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 2
 	s.Update("/foo/bar", "baz", v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
@@ -626,7 +626,7 @@ func TestStoreWatchRecursiveDelete(t *testing.T) {
 	var eidx uint64 = 1
 	s.Create("/foo/bar", false, "baz", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	w, err := s.Watch("/foo", true, false, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, w.StartIndex(), eidx)
 	eidx = 2
 	s.Delete("/foo/bar", false, false)

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -397,7 +397,7 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
 		Username:    "root",
 		Password:    "123",
 	})
-	assert.Nil(t, cerr)
+	assert.NoError(t, cerr)
 	defer c.Close()
 
 	var wg sync.WaitGroup
@@ -405,13 +405,13 @@ func TestV3AuthOldRevConcurrent(t *testing.T) {
 		defer wg.Done()
 		role, user := fmt.Sprintf("test-role-%d", i), fmt.Sprintf("test-user-%d", i)
 		_, err := c.RoleAdd(context.TODO(), role)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		_, err = c.RoleGrantPermission(context.TODO(), role, "\x00", clientv3.GetPrefixRangeEnd(""), clientv3.PermissionType(clientv3.PermReadWrite))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		_, err = c.UserAdd(context.TODO(), user, "123")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		_, err = c.Put(context.TODO(), "a", "b")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}
 	// needs concurrency to trigger
 	numRoles := 2
@@ -466,7 +466,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 
 	wChan := c.Watch(ctx, "non-allowed-key", clientv3.WithRev(1))
 	watchResponse := <-wChan
-	require.NotNil(t, watchResponse.Err()) // permission denied
+	require.Error(t, watchResponse.Err()) // permission denied
 
 	_, err := c.Put(ctx, "k1", "val")
 	if err != nil {

--- a/tests/integration/v3_stm_test.go
+++ b/tests/integration/v3_stm_test.go
@@ -281,7 +281,7 @@ func TestSTMSerializableSnapshotPut(t *testing.T) {
 	cli := clus.Client(0)
 	// key with lower create/mod revision than keys being updated
 	_, err := cli.Put(context.TODO(), "a", "0")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tries := 0
 	applyf := func(stm concurrency.STM) error {
@@ -296,12 +296,12 @@ func TestSTMSerializableSnapshotPut(t *testing.T) {
 
 	iso := concurrency.WithIsolation(concurrency.SerializableSnapshot)
 	_, err = concurrency.NewSTM(cli, applyf, iso)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = concurrency.NewSTM(cli, applyf, iso)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	resp, err := cli.Get(context.TODO(), "b")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	if resp.Kvs[0].Version != 2 {
 		t.Fatalf("bad version. got %+v, expected version 2", resp)
 	}

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -111,7 +111,6 @@ linters-settings: # please keep this alphabetized
       - ST1019 # Importing the same package multiple times.
   testifylint:
     disable:
-      - error-nil
       - expected-actual
       - float-compare
       - formatter


### PR DESCRIPTION
This fixes [error-nil](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-nil) rule from [testifylint](https://github.com/Antonboom/testifylint).

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->