### PR TITLE
feat(etcdctl): add --max-send-bytes and --max-recv-bytes options

### DIFF
--- a/client/v3/config.go
+++ b/client/v3/config.go
@@ -106,13 +106,15 @@ type Config struct {
 // environment variables or config file. It is a fully declarative configuration,
 // and can be serialized & deserialized to/from JSON.
 type ConfigSpec struct {
-	Endpoints        []string      `json:"endpoints"`
-	RequestTimeout   time.Duration `json:"request-timeout"`
-	DialTimeout      time.Duration `json:"dial-timeout"`
-	KeepAliveTime    time.Duration `json:"keepalive-time"`
-	KeepAliveTimeout time.Duration `json:"keepalive-timeout"`
-	Secure           *SecureConfig `json:"secure"`
-	Auth             *AuthConfig   `json:"auth"`
+	Endpoints          []string      `json:"endpoints"`
+	RequestTimeout     time.Duration `json:"request-timeout"`
+	DialTimeout        time.Duration `json:"dial-timeout"`
+	KeepAliveTime      time.Duration `json:"keepalive-time"`
+	KeepAliveTimeout   time.Duration `json:"keepalive-timeout"`
+	MaxCallSendMsgSize int           `json:"max-request-bytes"`
+	MaxCallRecvMsgSize int           `json:"max-recv-bytes"`
+	Secure             *SecureConfig `json:"secure"`
+	Auth               *AuthConfig   `json:"auth"`
 }
 
 type SecureConfig struct {
@@ -170,6 +172,8 @@ func NewClientConfig(confSpec *ConfigSpec, lg *zap.Logger) (*Config, error) {
 		DialTimeout:          confSpec.DialTimeout,
 		DialKeepAliveTime:    confSpec.KeepAliveTime,
 		DialKeepAliveTimeout: confSpec.KeepAliveTimeout,
+		MaxCallSendMsgSize:   confSpec.MaxCallSendMsgSize,
+		MaxCallRecvMsgSize:   confSpec.MaxCallRecvMsgSize,
 		TLS:                  tlsCfg,
 	}
 

--- a/etcdctl/ctlv3/command/global.go
+++ b/etcdctl/ctlv3/command/global.go
@@ -47,6 +47,8 @@ type GlobalFlags struct {
 	CommandTimeOut        time.Duration
 	KeepAliveTime         time.Duration
 	KeepAliveTimeout      time.Duration
+	MaxCallSendMsgSize    int
+	MaxCallRecvMsgSize    int
 	DNSClusterServiceName string
 
 	TLS transport.TLSInfo
@@ -128,6 +130,8 @@ func clientConfigFromCmd(cmd *cobra.Command) *clientv3.ConfigSpec {
 	cfg.DialTimeout = dialTimeoutFromCmd(cmd)
 	cfg.KeepAliveTime = keepAliveTimeFromCmd(cmd)
 	cfg.KeepAliveTimeout = keepAliveTimeoutFromCmd(cmd)
+	cfg.MaxCallSendMsgSize = maxCallSendMsgSizeFromCmd(cmd)
+	cfg.MaxCallRecvMsgSize = maxCallRecvMsgSizeFromCmd(cmd)
 
 	cfg.Secure = secureCfgFromCmd(cmd)
 	cfg.Auth = authCfgFromCmd(cmd)
@@ -199,6 +203,22 @@ func keepAliveTimeoutFromCmd(cmd *cobra.Command) time.Duration {
 		cobrautl.ExitWithError(cobrautl.ExitError, err)
 	}
 	return keepAliveTimeout
+}
+
+func maxCallSendMsgSizeFromCmd(cmd *cobra.Command) int {
+	maxRequestBytes, err := cmd.Flags().GetInt("max-request-bytes")
+	if err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
+	return maxRequestBytes
+}
+
+func maxCallRecvMsgSizeFromCmd(cmd *cobra.Command) int {
+	maxReceiveBytes, err := cmd.Flags().GetInt("max-recv-bytes")
+	if err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
+	return maxReceiveBytes
 }
 
 func secureCfgFromCmd(cmd *cobra.Command) *clientv3.SecureConfig {

--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -110,6 +110,8 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 	dialTimeout := dialTimeoutFromCmd(cmd)
 	keepAliveTime := keepAliveTimeFromCmd(cmd)
 	keepAliveTimeout := keepAliveTimeoutFromCmd(cmd)
+	maxCallSendMsgSize := maxCallSendMsgSizeFromCmd(cmd)
+	maxCallRecvMsgSize := maxCallRecvMsgSizeFromCmd(cmd)
 	sec := &clientv3.SecureConfig{
 		Cert:              mmcert,
 		Key:               mmkey,
@@ -120,12 +122,14 @@ func makeMirrorCommandFunc(cmd *cobra.Command, args []string) {
 	auth := authDestCfg()
 
 	cc := &clientv3.ConfigSpec{
-		Endpoints:        []string{args[0]},
-		DialTimeout:      dialTimeout,
-		KeepAliveTime:    keepAliveTime,
-		KeepAliveTimeout: keepAliveTimeout,
-		Secure:           sec,
-		Auth:             auth,
+		Endpoints:          []string{args[0]},
+		DialTimeout:        dialTimeout,
+		KeepAliveTime:      keepAliveTime,
+		KeepAliveTimeout:   keepAliveTimeout,
+		MaxCallSendMsgSize: maxCallSendMsgSize,
+		MaxCallRecvMsgSize: maxCallRecvMsgSize,
+		Secure:             sec,
+		Auth:               auth,
 	}
 	dc := mustClient(cc)
 	c := mustClientFromCmd(cmd)

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -62,6 +62,8 @@ func init() {
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.CommandTimeOut, "command-timeout", defaultCommandTimeOut, "timeout for short running command (excluding dial timeout)")
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.KeepAliveTime, "keepalive-time", defaultKeepAliveTime, "keepalive time for client connections")
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.KeepAliveTimeout, "keepalive-timeout", defaultKeepAliveTimeOut, "keepalive timeout for client connections")
+	rootCmd.PersistentFlags().IntVar(&globalFlags.MaxCallSendMsgSize, "max-request-bytes", 0, "client-side request send limit in bytes (if 0, it defaults to 2.0 MiB (2 * 1024 * 1024).)")
+	rootCmd.PersistentFlags().IntVar(&globalFlags.MaxCallRecvMsgSize, "max-recv-bytes", 0, "client-side response receive limit in bytes (if 0, it defaults to \"math.MaxInt32\")")
 
 	// TODO: secure by default when etcd enables secure gRPC by default.
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.Insecure, "insecure-transport", true, "disable transport security for client connections")


### PR DESCRIPTION
Add `--max-send-bytes` and `--max-recv-bytes` options for `etcdctl` to configure `MaxCallSendMsgSize` and `MaxCallRecvMsgSize`.

This was mentioned in #13054 and #12576, but it wasn't fixed.
We ran into this issue when trying to sync large kv using `make-mirror` and adding this option solves the issue.