### PR TITLE
fix: enable errorlint in module `go.etcd.io/etcd/client/v2`

### DIFF
--- a/client/internal/v2/client.go
+++ b/client/internal/v2/client.go
@@ -365,10 +365,10 @@ func (c *httpClusterClient) Do(ctx context.Context, act httpAction) (*http.Respo
 		resp, body, err = hc.Do(ctx, action)
 		if err != nil {
 			cerr.Errors = append(cerr.Errors, err)
-			if err == ctx.Err() {
+			if errors.Is(err, ctx.Err()) {
 				return nil, nil, ctx.Err()
 			}
-			if err == context.Canceled || err == context.DeadlineExceeded {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return nil, nil, err
 			}
 		} else if resp.StatusCode/100 == 5 {
@@ -542,7 +542,7 @@ func (c *simpleHTTPClient) Do(ctx context.Context, act httpAction) (*http.Respon
 			var err error
 			isWait, err = strconv.ParseBool(ws)
 			if err != nil {
-				return nil, nil, fmt.Errorf("wrong wait value %s (%v for %+v)", ws, err, req)
+				return nil, nil, fmt.Errorf("wrong wait value %s (%w for %+v)", ws, err, req)
 			}
 		}
 	}

--- a/client/internal/v2/client_test.go
+++ b/client/internal/v2/client_test.go
@@ -167,7 +167,7 @@ func TestSimpleHTTPClientDoNilRequest(t *testing.T) {
 	tr.errchan <- errors.New("fixture")
 
 	_, _, err := c.Do(context.Background(), &nilAction{})
-	if err != ErrNoRequest {
+	if !errors.Is(err, ErrNoRequest) {
 		t.Fatalf("expected non-nil error, got nil")
 	}
 }
@@ -250,7 +250,7 @@ func TestSimpleHTTPClientDoCancelContextResponseBodyClosedWithBlockingBody(t *te
 	}()
 
 	_, _, err := c.Do(ctx, &fakeAction{})
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected %+v, got %+v", context.Canceled, err)
 	}
 
@@ -430,7 +430,7 @@ func TestHTTPClusterClientDo(t *testing.T) {
 			tt.ctx = context.Background()
 		}
 		resp, _, err := tt.client.Do(tt.ctx, nil)
-		if (tt.wantErr == nil && tt.wantErr != err) || (tt.wantErr != nil && tt.wantErr.Error() != err.Error()) {
+		if (tt.wantErr == nil && !errors.Is(err, tt.wantErr)) || (tt.wantErr != nil && tt.wantErr.Error() != err.Error()) {
 			t.Errorf("#%d: got err=%v, want=%v", i, err, tt.wantErr)
 			continue
 		}
@@ -470,7 +470,7 @@ func TestHTTPClusterClientDoDeadlineExceedContext(t *testing.T) {
 
 	select {
 	case err := <-errc:
-		if err != context.DeadlineExceeded {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("err = %+v, want %+v", err, context.DeadlineExceeded)
 		}
 	case <-time.After(time.Second):
@@ -520,7 +520,7 @@ func TestHTTPClusterClientDoCanceledContext(t *testing.T) {
 
 	select {
 	case err := <-errc:
-		if err != errFakeCancelContext {
+		if !errors.Is(err, errFakeCancelContext) {
 			t.Errorf("err = %+v, want %+v", err, errFakeCancelContext)
 		}
 	case <-time.After(time.Second):
@@ -736,7 +736,7 @@ func TestRedirectFollowingHTTPClient(t *testing.T) {
 	for i, tt := range tests {
 		client := &redirectFollowingHTTPClient{client: tt.client, checkRedirect: tt.checkRedirect}
 		resp, _, err := client.Do(context.Background(), nil)
-		if (tt.wantErr == nil && tt.wantErr != err) || (tt.wantErr != nil && tt.wantErr.Error() != err.Error()) {
+		if (tt.wantErr == nil && !errors.Is(err, tt.wantErr)) || (tt.wantErr != nil && tt.wantErr.Error() != err.Error()) {
 			t.Errorf("#%d: got err=%v, want=%v", i, err, tt.wantErr)
 			continue
 		}
@@ -866,7 +866,7 @@ func TestHTTPClusterClientAutoSyncCancelContext(t *testing.T) {
 	cancel()
 
 	err = hc.AutoSync(ctx, time.Hour)
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("incorrect error value: want=%v got=%v", context.Canceled, err)
 	}
 }

--- a/client/internal/v2/keys.go
+++ b/client/internal/v2/keys.go
@@ -459,7 +459,7 @@ func (hw *httpWatcher) Next(ctx context.Context) (*Response, error) {
 
 		resp, err := unmarshalHTTPResponse(httpresp.StatusCode, httpresp.Header, body)
 		if err != nil {
-			if err == ErrEmptyBody {
+			if errors.Is(err, ErrEmptyBody) {
 				continue
 			}
 			return nil, err

--- a/client/internal/v2/keys_test.go
+++ b/client/internal/v2/keys_test.go
@@ -830,9 +830,10 @@ func TestUnmarshalFailedKeysResponse(t *testing.T) {
 
 func TestUnmarshalFailedKeysResponseBadJSON(t *testing.T) {
 	err := unmarshalFailedKeysResponse([]byte(`{"er`))
+	var cErr Error
 	if err == nil {
 		t.Errorf("got nil error")
-	} else if _, ok := err.(Error); ok {
+	} else if errors.As(err, &cErr) {
 		t.Errorf("error is of incorrect type *Error: %#v", err)
 	}
 }

--- a/client/internal/v2/util.go
+++ b/client/internal/v2/util.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"errors"
 	"regexp"
 )
 
@@ -30,24 +31,18 @@ func init() {
 
 // IsKeyNotFound returns true if the error code is ErrorCodeKeyNotFound.
 func IsKeyNotFound(err error) bool {
-	if cErr, ok := err.(Error); ok {
-		return cErr.Code == ErrorCodeKeyNotFound
-	}
-	return false
+	var cErr Error
+	return errors.As(err, &cErr) && cErr.Code == ErrorCodeKeyNotFound
 }
 
 // IsRoleNotFound returns true if the error means role not found of v2 API.
 func IsRoleNotFound(err error) bool {
-	if ae, ok := err.(authError); ok {
-		return roleNotFoundRegExp.MatchString(ae.Message)
-	}
-	return false
+	var ae authError
+	return errors.As(err, &ae) && roleNotFoundRegExp.MatchString(ae.Message)
 }
 
 // IsUserNotFound returns true if the error means user not found of v2 API.
 func IsUserNotFound(err error) bool {
-	if ae, ok := err.(authError); ok {
-		return userNotFoundRegExp.MatchString(ae.Message)
-	}
-	return false
+	var ae authError
+	return errors.As(err, &ae) && userNotFoundRegExp.MatchString(ae.Message)
 }


### PR DESCRIPTION
This enable errorlint in module `go.etcd.io/etcd/client/v2`

Related to #18576