### PR TITLE
fix: enable error-is-as rule from testifylint

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -193,7 +193,7 @@ func (ep *ExpectProcess) ExpectFunc(ctx context.Context, f func(string) bool) (s
 
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("context done before matching log found")
+			return "", fmt.Errorf("context done before matching log found: %w", ctx.Err())
 		case <-time.After(time.Millisecond * 10):
 			// continue loop
 		}

--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -64,7 +64,7 @@ func TestExpectFuncTimeout(t *testing.T) {
 
 	_, err = ep.ExpectFunc(ctx, func(a string) bool { return false })
 
-	require.ErrorAs(t, err, &context.DeadlineExceeded)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	if err = ep.Stop(); err != nil {
 		t.Fatal(err)

--- a/tests/framework/testutils/log_observer_test.go
+++ b/tests/framework/testutils/log_observer_test.go
@@ -16,7 +16,6 @@ package testutils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ func TestLogObserver_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
 	_, err := logOb.Expect(ctx, "unknown", 1)
 	cancel()
-	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	assert.Len(t, logOb.entries, 1)
 }

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -111,7 +111,6 @@ linters-settings: # please keep this alphabetized
       - ST1019 # Importing the same package multiple times.
   testifylint:
     disable:
-      - error-is-as
       - error-nil
       - expected-actual
       - float-compare


### PR DESCRIPTION
This PR enables the `error-is-as` testifylint rule as part of https://github.com/etcd-io/etcd/issues/18719

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
