### PR TITLE
fix: enable formatter rule from testifylint

### DIFF
--- a/client/internal/v2/client_test.go
+++ b/client/internal/v2/client_test.go
@@ -1053,7 +1053,7 @@ func TestHTTPClusterClientResetPinRandom(t *testing.T) {
 	for i := 0; i < round; i++ {
 		hc := &httpClusterClient{rand: rand.New(rand.NewSource(int64(i)))}
 		err := hc.SetEndpoints([]string{"http://127.0.0.1:4001", "http://127.0.0.1:4002", "http://127.0.0.1:4003"})
-		require.NoErrorf(t, err, "#%d: reset error (%v)", i)
+		require.NoErrorf(t, err, "#%d: reset error", i)
 		if hc.endpoints[hc.pinned].String() == "http://127.0.0.1:4001" {
 			pinNum++
 		}

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -190,7 +190,7 @@ func TestRemoveMatchFile(t *testing.T) {
 
 func TestTouchDirAll(t *testing.T) {
 	tmpdir := t.TempDir()
-	assert.Panics(t, func() {
+	assert.Panicsf(t, func() {
 		TouchDirAll(nil, tmpdir)
 	}, "expected panic with nil log")
 

--- a/client/pkg/testutil/assert.go
+++ b/client/pkg/testutil/assert.go
@@ -40,12 +40,12 @@ func AssertNotNil(t *testing.T, v any) {
 // Deprecated: use github.com/stretchr/testify/assert.True instead.
 func AssertTrue(t *testing.T, v bool, msg ...string) {
 	t.Helper()
-	assert.True(t, v, msg)
+	assert.True(t, v, msg) //nolint:testifylint
 }
 
 // AssertFalse
 // Deprecated: use github.com/stretchr/testify/assert.False instead.
 func AssertFalse(t *testing.T, v bool, msg ...string) {
 	t.Helper()
-	assert.False(t, v, msg)
+	assert.False(t, v, msg) //nolint:testifylint
 }

--- a/client/pkg/tlsutil/versions_test.go
+++ b/client/pkg/tlsutil/versions_test.go
@@ -54,7 +54,7 @@ func TestGetVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetTLSVersion(tt.version)
 			if err != nil {
-				assert.True(t, tt.expectError, "GetTLSVersion() returned error while expecting success: %v", err)
+				assert.Truef(t, tt.expectError, "GetTLSVersion() returned error while expecting success: %v", err)
 				return
 			}
 			assert.Equal(t, tt.want, got)

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -511,7 +511,7 @@ func TestNewListenerTLSInfoSelfCert(t *testing.T) {
 	}
 	testNewListenerTLSInfoAccept(t, tlsinfo)
 
-	assert.Panics(t, func() {
+	assert.Panicsf(t, func() {
 		SelfCert(nil, tmpdir, []string{"127.0.0.1"}, 1)
 	}, "expected panic with nil log")
 }

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -17,7 +17,6 @@ package clientv3
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -196,50 +195,50 @@ func TestBackoffJitterFraction(t *testing.T) {
 }
 
 func TestIsHaltErr(t *testing.T) {
-	assert.True(t,
+	assert.Truef(t,
 		isHaltErr(context.TODO(), errors.New("etcdserver: some etcdserver error")),
 		"error created by errors.New should be unavailable error",
 	)
-	assert.False(t,
+	assert.Falsef(t,
 		isHaltErr(context.TODO(), rpctypes.ErrGRPCStopped),
-		fmt.Sprintf(`error "%v" should not be halt error`, rpctypes.ErrGRPCStopped),
+		`error "%v" should not be halt error`, rpctypes.ErrGRPCStopped,
 	)
-	assert.False(t,
+	assert.Falsef(t,
 		isHaltErr(context.TODO(), rpctypes.ErrGRPCNoLeader),
-		fmt.Sprintf(`error "%v" should not be halt error`, rpctypes.ErrGRPCNoLeader),
+		`error "%v" should not be halt error`, rpctypes.ErrGRPCNoLeader,
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
-	assert.False(t,
+	assert.Falsef(t,
 		isHaltErr(ctx, nil),
 		"no error and active context should be halt error",
 	)
 	cancel()
-	assert.True(t,
+	assert.Truef(t,
 		isHaltErr(ctx, nil),
-		"cancel on context should be halte error",
+		"cancel on context should be halt error",
 	)
 }
 
 func TestIsUnavailableErr(t *testing.T) {
-	assert.False(t,
+	assert.Falsef(t,
 		isUnavailableErr(context.TODO(), errors.New("etcdserver: some etcdserver error")),
 		"error created by errors.New should not be unavailable error",
 	)
-	assert.True(t,
+	assert.Truef(t,
 		isUnavailableErr(context.TODO(), rpctypes.ErrGRPCStopped),
-		fmt.Sprintf(`error "%v" should be unavailable error`, rpctypes.ErrGRPCStopped),
+		`error "%v" should be unavailable error`, rpctypes.ErrGRPCStopped,
 	)
-	assert.False(t,
+	assert.Falsef(t,
 		isUnavailableErr(context.TODO(), rpctypes.ErrGRPCNotCapable),
-		fmt.Sprintf("error %v should not be unavailable error", rpctypes.ErrGRPCNotCapable),
+		"error %v should not be unavailable error", rpctypes.ErrGRPCNotCapable,
 	)
 	ctx, cancel := context.WithCancel(context.TODO())
-	assert.False(t,
+	assert.Falsef(t,
 		isUnavailableErr(ctx, nil),
 		"no error and active context should not be unavailable error",
 	)
 	cancel()
-	assert.False(t,
+	assert.Falsef(t,
 		isUnavailableErr(ctx, nil),
 		"cancel on context should not be unavailable error",
 	)

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -85,11 +85,11 @@ func TestConfigFileOtherFields(t *testing.T) {
 		t.Errorf("PeerTLS = %v, want %v", cfg.PeerTLSInfo, ptls)
 	}
 
-	assert.True(t, cfg.ForceNewCluster, "ForceNewCluster does not match")
+	assert.Truef(t, cfg.ForceNewCluster, "ForceNewCluster does not match")
 
-	assert.True(t, cfg.SocketOpts.ReusePort, "ReusePort does not match")
+	assert.Truef(t, cfg.SocketOpts.ReusePort, "ReusePort does not match")
 
-	assert.False(t, cfg.SocketOpts.ReuseAddress, "ReuseAddress does not match")
+	assert.Falsef(t, cfg.SocketOpts.ReuseAddress, "ReuseAddress does not match")
 }
 
 func TestConfigFileFeatureGates(t *testing.T) {
@@ -806,7 +806,7 @@ func TestTLSVersionMinMax(t *testing.T) {
 
 			err := cfg.Validate()
 			if err != nil {
-				assert.True(t, tt.expectError, "Validate() returned error while expecting success: %v", err)
+				assert.Truef(t, tt.expectError, "Validate() returned error while expecting success: %v", err)
 				return
 			}
 

--- a/server/etcdserver/api/membership/storev2_test.go
+++ b/server/etcdserver/api/membership/storev2_test.go
@@ -30,26 +30,26 @@ func TestIsMetaStoreOnly(t *testing.T) {
 
 	metaOnly, err := IsMetaStoreOnly(s)
 	assert.NoError(t, err)
-	assert.True(t, metaOnly, "Just created v2store should be meta-only")
+	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	mustSaveClusterVersionToStore(lg, s, semver.New("3.5.17"))
 	metaOnly, err = IsMetaStoreOnly(s)
 	assert.NoError(t, err)
-	assert.True(t, metaOnly, "Just created v2store should be meta-only")
+	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	mustSaveMemberToStore(lg, s, &Member{ID: 0x00abcd})
 	metaOnly, err = IsMetaStoreOnly(s)
 	assert.NoError(t, err)
-	assert.True(t, metaOnly, "Just created v2store should be meta-only")
+	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	_, err = s.Create("/1/foo", false, "v1", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
 	assert.NoError(t, err)
 	metaOnly, err = IsMetaStoreOnly(s)
 	assert.NoError(t, err)
-	assert.False(t, metaOnly, "Just created v2store should be meta-only")
+	assert.Falsef(t, metaOnly, "Just created v2store should be meta-only")
 
 	_, err = s.Delete("/1/foo", false, false)
 	assert.NoError(t, err)
 	assert.NoError(t, err)
-	assert.False(t, metaOnly, "Just created v2store should be meta-only")
+	assert.Falsef(t, metaOnly, "Just created v2store should be meta-only")
 }

--- a/server/etcdserver/api/v2store/stats_test.go
+++ b/server/etcdserver/api/v2store/stats_test.go
@@ -26,7 +26,7 @@ func TestStoreStatsGetSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Get("/foo", false, false)
-	assert.Equal(t, uint64(1), s.Stats.GetSuccess, "")
+	assert.Equal(t, uint64(1), s.Stats.GetSuccess)
 }
 
 // TestStoreStatsGetFail ensures that a failed Get is recorded in the stats.
@@ -34,14 +34,14 @@ func TestStoreStatsGetFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Get("/no_such_key", false, false)
-	assert.Equal(t, uint64(1), s.Stats.GetFail, "")
+	assert.Equal(t, uint64(1), s.Stats.GetFail)
 }
 
 // TestStoreStatsCreateSuccess ensures that a successful Create is recorded in the stats.
 func TestStoreStatsCreateSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.CreateSuccess, "")
+	assert.Equal(t, uint64(1), s.Stats.CreateSuccess)
 }
 
 // TestStoreStatsCreateFail ensures that a failed Create is recorded in the stats.
@@ -49,7 +49,7 @@ func TestStoreStatsCreateFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.CreateFail, "")
+	assert.Equal(t, uint64(1), s.Stats.CreateFail)
 }
 
 // TestStoreStatsUpdateSuccess ensures that a successful Update is recorded in the stats.
@@ -57,14 +57,14 @@ func TestStoreStatsUpdateSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Update("/foo", "baz", TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.UpdateSuccess, "")
+	assert.Equal(t, uint64(1), s.Stats.UpdateSuccess)
 }
 
 // TestStoreStatsUpdateFail ensures that a failed Update is recorded in the stats.
 func TestStoreStatsUpdateFail(t *testing.T) {
 	s := newStore()
 	s.Update("/foo", "bar", TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.UpdateFail, "")
+	assert.Equal(t, uint64(1), s.Stats.UpdateFail)
 }
 
 // TestStoreStatsCompareAndSwapSuccess ensures that a successful CAS is recorded in the stats.
@@ -72,7 +72,7 @@ func TestStoreStatsCompareAndSwapSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.CompareAndSwap("/foo", "bar", 0, "baz", TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapSuccess, "")
+	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapSuccess)
 }
 
 // TestStoreStatsCompareAndSwapFail ensures that a failed CAS is recorded in the stats.
@@ -80,7 +80,7 @@ func TestStoreStatsCompareAndSwapFail(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.CompareAndSwap("/foo", "wrong_value", 0, "baz", TTLOptionSet{ExpireTime: Permanent})
-	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapFail, "")
+	assert.Equal(t, uint64(1), s.Stats.CompareAndSwapFail)
 }
 
 // TestStoreStatsDeleteSuccess ensures that a successful Delete is recorded in the stats.
@@ -88,14 +88,14 @@ func TestStoreStatsDeleteSuccess(t *testing.T) {
 	s := newStore()
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Delete("/foo", false, false)
-	assert.Equal(t, uint64(1), s.Stats.DeleteSuccess, "")
+	assert.Equal(t, uint64(1), s.Stats.DeleteSuccess)
 }
 
 // TestStoreStatsDeleteFail ensures that a failed Delete is recorded in the stats.
 func TestStoreStatsDeleteFail(t *testing.T) {
 	s := newStore()
 	s.Delete("/foo", false, false)
-	assert.Equal(t, uint64(1), s.Stats.DeleteFail, "")
+	assert.Equal(t, uint64(1), s.Stats.DeleteFail)
 }
 
 // TestStoreStatsExpireCount ensures that the number of expirations is recorded in the stats.
@@ -105,8 +105,8 @@ func TestStoreStatsExpireCount(t *testing.T) {
 	s.clock = fc
 
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	assert.Equal(t, uint64(0), s.Stats.ExpireCount, "")
+	assert.Equal(t, uint64(0), s.Stats.ExpireCount)
 	fc.Advance(600 * time.Millisecond)
 	s.DeleteExpiredKeys(fc.Now())
-	assert.Equal(t, uint64(1), s.Stats.ExpireCount, "")
+	assert.Equal(t, uint64(1), s.Stats.ExpireCount)
 }

--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -31,7 +31,7 @@ func TestMinExpireTime(t *testing.T) {
 	fc := clockwork.NewFakeClockAt(time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC))
 	s.clock = fc
 	// FakeClock starts at 0, so minExpireTime should be far in the future.. but just in case
-	assert.True(t, minExpireTime.After(fc.Now()), "minExpireTime should be ahead of FakeClock!")
+	assert.Truef(t, minExpireTime.After(fc.Now()), "minExpireTime should be ahead of FakeClock!")
 	s.Create("/foo", false, "Y", false, TTLOptionSet{ExpireTime: fc.Now().Add(3 * time.Second)})
 	fc.Advance(5 * time.Second)
 	// Ensure it hasn't expired

--- a/server/etcdserver/cindex/cindex_test.go
+++ b/server/etcdserver/cindex/cindex_test.go
@@ -116,7 +116,7 @@ func TestConsistentIndexDecrease(t *testing.T) {
 				tx.Lock()
 				defer tx.Unlock()
 				if tc.panicExpected {
-					assert.Panics(t, func() { ci.UnsafeSave(tx) }, "Should refuse to decrease cindex")
+					assert.Panicsf(t, func() { ci.UnsafeSave(tx) }, "Should refuse to decrease cindex")
 					return
 				}
 				ci.UnsafeSave(tx)

--- a/server/etcdserver/txn/metrics_test.go
+++ b/server/etcdserver/txn/metrics_test.go
@@ -58,5 +58,5 @@ etcd_server_range_duration_seconds_count{success="true"} 1
 `
 
 	err := testutil.CollectAndCompare(rangeSec, strings.NewReader(expected))
-	require.NoError(t, err, "Collected metrics did not match expected metrics: %v", err)
+	require.NoErrorf(t, err, "Collected metrics did not match expected metrics")
 }

--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -367,7 +367,7 @@ func TestWriteTxnPanic(t *testing.T) {
 		},
 	}
 
-	assert.Panics(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}) }, "Expected panic in Txn with writes")
+	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}) }, "Expected panic in Txn with writes")
 }
 
 func TestCheckTxnAuth(t *testing.T) {

--- a/server/storage/backend/hooks_test.go
+++ b/server/storage/backend/hooks_test.go
@@ -42,9 +42,9 @@ func TestBackendPreCommitHook(t *testing.T) {
 	// Empty commit.
 	tx.Commit()
 
-	assert.Equal(t, ">cc", getCommitsKey(t, be), "expected 2 explicit commits")
+	assert.Equalf(t, ">cc", getCommitsKey(t, be), "expected 2 explicit commits")
 	tx.Commit()
-	assert.Equal(t, ">ccc", getCommitsKey(t, be), "expected 3 explicit commits")
+	assert.Equalf(t, ">ccc", getCommitsKey(t, be), "expected 3 explicit commits")
 }
 
 func TestBackendAutoCommitLimitHook(t *testing.T) {

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -124,9 +124,9 @@ func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
 		rev = s.Rev()
 	}
 	hash, _, err := s.hashByRev(rev)
-	assert.NoError(t, err, "error on rev %v", rev)
+	assert.NoErrorf(t, err, "error on rev %v", rev)
 	_, err = s.Compact(traceutil.TODO(), rev)
-	assert.NoError(t, err, "error on compact %v", rev)
+	assert.NoErrorf(t, err, "error on compact %v", rev)
 	return hash
 }
 

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -641,17 +641,17 @@ func TestIndexCompactAndKeep(t *testing.T) {
 		}
 
 		am := ti.Compact(i)
-		require.Equal(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
+		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
 
 		keep := ti.Keep(i)
-		require.Equal(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
+		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
 
 		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
 		for k := range afterCompacts[j].keyIndexes {
 			ki := afterCompacts[j].keyIndexes[k]
 			nti.tree.ReplaceOrInsert(&ki)
 		}
-		require.True(t, ti.Equal(nti), "#%d: not equal ti", i)
+		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
 	}
 
 	// Once Compact and Keep
@@ -664,10 +664,10 @@ func TestIndexCompactAndKeep(t *testing.T) {
 		}
 
 		am := ti.Compact(i)
-		require.Equal(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
+		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
 
 		keep := ti.Keep(i)
-		require.Equal(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
+		require.Equalf(t, afterCompacts[j].keep, keep, "#%d: keep(%d) != expected", i, i)
 
 		nti := newTreeIndex(zaptest.NewLogger(t)).(*treeIndex)
 		for k := range afterCompacts[j].keyIndexes {
@@ -675,6 +675,6 @@ func TestIndexCompactAndKeep(t *testing.T) {
 			nti.tree.ReplaceOrInsert(&ki)
 		}
 
-		require.True(t, ti.Equal(nti), "#%d: not equal ti", i)
+		require.Truef(t, ti.Equal(nti), "#%d: not equal ti", i)
 	}
 }

--- a/server/storage/mvcc/key_index_test.go
+++ b/server/storage/mvcc/key_index_test.go
@@ -499,9 +499,9 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 		}
 
 		if isTombstone {
-			assert.Empty(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
+			assert.Emptyf(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
 		} else {
-			assert.Equal(t, tt.wam, am,
+			assert.Equalf(t, tt.wam, am,
 				"#%d: ki = %d, compact keep should be equal to keep keep if it's not tombstone", i, ki)
 		}
 
@@ -550,9 +550,9 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 		}
 
 		if isTombstoneRevFn(ki, tt.compact) {
-			assert.Empty(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
+			assert.Emptyf(t, am, "#%d: ki = %d, keep result wants empty because tombstone", i, ki)
 		} else {
-			assert.Equal(t, tt.wam, am,
+			assert.Equalf(t, tt.wam, am,
 				"#%d: ki = %d, compact keep should be equal to keep keep if it's not tombstone", i, ki)
 		}
 

--- a/server/storage/mvcc/testutil/hash.go
+++ b/server/storage/mvcc/testutil/hash.go
@@ -61,24 +61,24 @@ func testCompactionHash(ctx context.Context, t *testing.T, h CompactionHashTestC
 	for i := start; i <= stop; i++ {
 		if i%67 == 0 {
 			err := h.Delete(ctx, PickKey(i+83))
-			assert.NoError(t, err, "error on delete")
+			assert.NoErrorf(t, err, "error on delete")
 		} else {
 			err := h.Put(ctx, PickKey(i), fmt.Sprint(i))
-			assert.NoError(t, err, "error on put")
+			assert.NoErrorf(t, err, "error on put")
 		}
 	}
 	hash1, err := h.HashByRev(ctx, stop)
-	assert.NoError(t, err, "error on hash (rev %v)", stop)
+	assert.NoErrorf(t, err, "error on hash (rev %v)", stop)
 
 	err = h.Compact(ctx, stop)
-	assert.NoError(t, err, "error on compact (rev %v)", stop)
+	assert.NoErrorf(t, err, "error on compact (rev %v)", stop)
 
 	err = h.Defrag(ctx)
-	assert.NoError(t, err, "error on defrag")
+	assert.NoErrorf(t, err, "error on defrag")
 
 	hash2, err := h.HashByRev(ctx, stop)
-	assert.NoError(t, err, "error on hash (rev %v)", stop)
-	assert.Equal(t, hash1, hash2, "hashes do not match on rev %v", stop)
+	assert.NoErrorf(t, err, "error on hash (rev %v)", stop)
+	assert.Equalf(t, hash1, hash2, "hashes do not match on rev %v", stop)
 }
 
 func PickKey(i int64) string {

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -78,7 +78,7 @@ func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expect
 	require.NoError(t, w.Close())
 
 	// repair the wal
-	require.True(t, Repair(lg, p), "'Repair' returned 'false', want 'true'")
+	require.True(t, Repair(lg, p))
 
 	// verify the broken wal has correct permissions
 	bf := filepath.Join(p, filepath.Base(w.tail().Name())+".broken")
@@ -86,7 +86,7 @@ func testRepair(t *testing.T, ents [][]raftpb.Entry, corrupt corruptFunc, expect
 	require.NoError(t, err)
 	expectedPerms := fmt.Sprintf("%o", os.FileMode(fileutil.PrivateFileMode))
 	actualPerms := fmt.Sprintf("%o", fi.Mode().Perm())
-	require.Equal(t, expectedPerms, actualPerms, "unexpected file permissions on .broken wal")
+	require.Equalf(t, expectedPerms, actualPerms, "unexpected file permissions on .broken wal")
 
 	// read it back
 	w, err = Open(lg, p, walpb.Snapshot{})

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -151,15 +151,15 @@ func TestCreateNewWALFile(t *testing.T) {
 			require.NoError(t, err)
 			expectedPerms := fmt.Sprintf("%o", os.FileMode(fileutil.PrivateFileMode))
 			actualPerms := fmt.Sprintf("%o", fi.Mode().Perm())
-			require.Equal(t, expectedPerms, actualPerms, "unexpected file permissions on %q", p)
+			require.Equalf(t, expectedPerms, actualPerms, "unexpected file permissions on %q", p)
 
 			content, err := os.ReadFile(p)
 			require.NoError(t, err)
 
 			if tt.forceNew {
-				require.Empty(t, string(content), "file content should be truncated but it wasn't")
+				require.Emptyf(t, string(content), "file content should be truncated but it wasn't")
 			} else {
-				require.Equal(t, "test data", string(content), "file content should not be truncated but it was")
+				require.Equalf(t, "test data", string(content), "file content should not be truncated but it was")
 			}
 		})
 	}

--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -623,7 +623,7 @@ func TestAuthMemberRemove(t *testing.T) {
 				break
 			}
 		}
-		require.False(t, found, "expect removed member not found in member remove response")
+		require.Falsef(t, found, "expect removed member not found in member remove response")
 	})
 }
 

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -61,7 +61,7 @@ func TestEndpointHashKV(t *testing.T) {
 	t.Log("Check all members' Hash and HashRevision")
 	require.Eventually(t, func() bool {
 		resp, err := cc.HashKV(ctx, 0)
-		require.NoError(t, err, "failed to get endpoint hashkv: %v", err)
+		require.NoErrorf(t, err, "failed to get endpoint hashkv")
 
 		require.Len(t, resp, 3)
 		if resp[0].HashRevision == resp[1].HashRevision && resp[0].HashRevision == resp[2].HashRevision {

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -139,7 +139,7 @@ func TestMemberAdd(t *testing.T) {
 							// whether strictReconfigCheck or whether waitForQuorum
 							require.ErrorContains(t, err, "etcdserver: unhealthy cluster")
 						} else {
-							require.NoError(t, err, "MemberAdd failed")
+							require.NoErrorf(t, err, "MemberAdd failed")
 							if addResp.Member == nil {
 								t.Fatalf("MemberAdd failed, expected: member != nil, got: member == nil")
 							}
@@ -224,7 +224,7 @@ func TestMemberRemove(t *testing.T) {
 						return
 					}
 
-					require.NoError(t, err, "MemberRemove failed")
+					require.NoErrorf(t, err, "MemberRemove failed")
 					t.Logf("removeResp.Members:%v", removeResp.Members)
 					if removeResp.Header.ClusterId != clusterID {
 						t.Fatalf("MemberRemove failed, expected ClusterID: %d, got: %d", clusterID, removeResp.Header.ClusterId)

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -171,6 +171,6 @@ func assertAuthority(t *testing.T, expectAuthorityPattern string, clus *e2e.Etcd
 		}
 		expectAuthority := strings.ReplaceAll(expectAuthorityPattern, "${MEMBER_PORT}", u.Port())
 		expectLine := fmt.Sprintf(`http2: decoded hpack field header field ":authority" = %q`, expectAuthority)
-		assert.True(t, strings.HasSuffix(line, expectLine), fmt.Sprintf("Got %q expected suffix %q", line, expectLine))
+		assert.Truef(t, strings.HasSuffix(line, expectLine), "Got %q expected suffix %q", line, expectLine)
 	}
 }

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -264,7 +264,7 @@ func getKeysOnlyTest(cx ctlCtx) {
 
 	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"})
 	require.NoError(cx.t, err)
-	require.NotContains(cx.t, lines, "val", "got value but passed --keys-only")
+	require.NotContainsf(cx.t, lines, "val", "got value but passed --keys-only")
 }
 
 func getCountOnlyTest(cx ctlCtx) {

--- a/tests/e2e/ctl_v3_member_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_member_no_proxy_test.go
@@ -52,7 +52,7 @@ func TestMemberReplace(t *testing.T) {
 
 	memberID, found, err := getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
-	require.True(t, found, "Member not found")
+	require.Truef(t, found, "Member not found")
 
 	// Need to wait health interval for cluster to accept member changes
 	time.Sleep(etcdserver.HealthInterval)
@@ -62,7 +62,7 @@ func TestMemberReplace(t *testing.T) {
 	require.NoError(t, err)
 	_, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
-	require.False(t, found, "Expected member to be removed")
+	require.Falsef(t, found, "Expected member to be removed")
 	for member.IsRunning() {
 		err = member.Wait(ctx)
 		if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
@@ -119,7 +119,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 
 	memberID, found, err := getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
-	require.True(t, found, "Member not found")
+	require.Truef(t, found, "Member not found")
 
 	// Need to wait health interval for cluster to accept member changes
 	time.Sleep(etcdserver.HealthInterval)
@@ -129,7 +129,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 	require.NoError(t, err)
 	_, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
-	require.False(t, found, "Expected member to be removed")
+	require.Falsef(t, found, "Expected member to be removed")
 	for member.IsRunning() {
 		err = member.Wait(ctx)
 		if err != nil && !strings.Contains(err.Error(), "unexpected exit code") {
@@ -169,7 +169,7 @@ func TestMemberReplaceWithLearner(t *testing.T) {
 
 	learnMemberID, found, err = getMemberIDByName(ctx, cc, memberName)
 	require.NoError(t, err)
-	require.True(t, found, "Member not found")
+	require.Truef(t, found, "Member not found")
 
 	_, err = cc.MemberPromote(ctx, learnMemberID)
 	require.NoError(t, err)

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -71,10 +71,10 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 		e2e.WithClusterSize(1),
 		e2e.WithEnvVars(map[string]string{"GOFAIL_FAILPOINTS": `beforeApplyOneConfChange=sleep("2s")`}),
 	)
-	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	require.NoErrorf(t, err, "failed to start etcd cluster")
 	defer func() {
 		derr := epc.Close()
-		require.NoError(t, derr, "failed to close etcd cluster: %v", derr)
+		require.NoErrorf(t, derr, "failed to close etcd cluster")
 	}()
 
 	t.Log("Adding and then removing a learner")

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -413,12 +413,12 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 	}
 
 	cancelResult, ok := <-watchCh
-	require.True(t, ok, "watchChannel should be open")
+	require.Truef(t, ok, "watchChannel should be open")
 	require.Equal(t, v3rpc.ErrCompacted, cancelResult.Err())
 	require.Truef(t, cancelResult.Canceled, "expected ongoing watch to be cancelled after restoring with --mark-compacted")
 	require.Equal(t, int64(bumpAmount+currentRev), cancelResult.CompactRevision)
 	_, ok = <-watchCh
-	require.False(t, ok, "watchChannel should be closed after restoring with --mark-compacted")
+	require.Falsef(t, ok, "watchChannel should be closed after restoring with --mark-compacted")
 
 	// clients might restart the watch at the old base revision, that should not yield any new data
 	// everything up until bumpAmount+currentRev should return "already compacted"

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -700,7 +700,7 @@ func TestEtcdTLSVersion(t *testing.T) {
 		}, nil,
 	)
 	assert.NoError(t, err)
-	assert.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines), "did not receive expected output from etcd process")
+	assert.NoErrorf(t, e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines), "did not receive expected output from etcd process")
 	assert.NoError(t, proc.Stop())
 
 	proc.Wait() // ensure the port has been released

--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -93,10 +93,10 @@ func mixVersionsSnapshotTestByAddingMember(t *testing.T, cfg *e2e.EtcdProcessClu
 		e2e.WithConfig(cfg),
 		e2e.WithSnapshotCount(10),
 	)
-	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	require.NoErrorf(t, err, "failed to start etcd cluster")
 	defer func() {
 		derr := epc.Close()
-		require.NoError(t, derr, "failed to close etcd cluster: %v", derr)
+		require.NoErrorf(t, derr, "failed to close etcd cluster")
 	}()
 
 	t.Log("Writing 20 keys to the cluster (more than SnapshotCount entries to trigger at least a snapshot)")
@@ -108,7 +108,7 @@ func mixVersionsSnapshotTestByAddingMember(t *testing.T, cfg *e2e.EtcdProcessClu
 	newCfg.ServerConfig.SnapshotCatchUpEntries = 10
 	t.Log("Starting a new etcd instance")
 	_, err = epc.StartNewProc(context.TODO(), &newCfg, t, false /* addAsLearner */)
-	require.NoError(t, err, "failed to start the new etcd instance: %v", err)
+	require.NoErrorf(t, err, "failed to start the new etcd instance")
 	defer epc.CloseProc(context.TODO(), nil)
 
 	assertKVHash(t, epc)
@@ -137,10 +137,10 @@ func mixVersionsSnapshotTestByMockPartition(t *testing.T, cfg *e2e.EtcdProcessCl
 	}
 	t.Logf("Create an etcd cluster with %d member", cfg.ClusterSize)
 	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, clusterOptions...)
-	require.NoError(t, err, "failed to start etcd cluster: %v", err)
+	require.NoErrorf(t, err, "failed to start etcd cluster")
 	defer func() {
 		derr := epc.Close()
-		require.NoError(t, derr, "failed to close etcd cluster: %v", derr)
+		require.NoErrorf(t, derr, "failed to close etcd cluster")
 	}()
 	toPartitionedMember := epc.Procs[mockPartitionNodeIndex]
 
@@ -171,7 +171,7 @@ func writeKVs(t *testing.T, etcdctl *e2e.EtcdctlV3, startIdx, endIdx int) {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
 		err := etcdctl.Put(context.TODO(), key, value, config.PutOptions{})
-		require.NoError(t, err, "failed to put %q, error: %v", key, err)
+		require.NoErrorf(t, err, "failed to put %q", key)
 	}
 }
 

--- a/tests/e2e/promote_experimental_flag_test.go
+++ b/tests/e2e/promote_experimental_flag_test.go
@@ -43,7 +43,7 @@ func TestWarningApplyDuration(t *testing.T) {
 
 	cc := epc.Etcdctl()
 	err = cc.Put(context.TODO(), "foo", "bar", config.PutOptions{})
-	assert.NoError(t, err, "error on put")
+	assert.NoErrorf(t, err, "error on put")
 
 	// verify warning
 	e2e.AssertProcessLogs(t, epc.Procs[0], "request stats")
@@ -70,7 +70,7 @@ func TestExperimentalWarningApplyDuration(t *testing.T) {
 
 	cc := epc.Etcdctl()
 	err = cc.Put(context.TODO(), "foo", "bar", config.PutOptions{})
-	assert.NoError(t, err, "error on put")
+	assert.NoErrorf(t, err, "error on put")
 
 	// verify warning
 	e2e.AssertProcessLogs(t, epc.Procs[0], "request stats")

--- a/tests/e2e/reproduce_17780_test.go
+++ b/tests/e2e/reproduce_17780_test.go
@@ -102,7 +102,7 @@ func TestReproduce17780(t *testing.T) {
 		resp, err := cli.Get(ctx, fmt.Sprintf("%d", next))
 		require.NoError(t, err)
 
-		assert.GreaterOrEqual(t, resp.Header.Revision, int64(expectedRevision),
-			fmt.Sprintf("LeaderIdx: %d, Current: %d", leaderIdx, procIdx))
+		assert.GreaterOrEqualf(t, resp.Header.Revision, int64(expectedRevision),
+			"LeaderIdx: %d, Current: %d", leaderIdx, procIdx)
 	}
 }

--- a/tests/e2e/runtime_reconfiguration_test.go
+++ b/tests/e2e/runtime_reconfiguration_test.go
@@ -67,7 +67,7 @@ func TestRuntimeReconfigGrowClusterSize(t *testing.T) {
 			require.NoError(t, epc.Procs[0].Etcdctl().Health(ctx))
 			defer func() {
 				err := epc.Close()
-				require.NoError(t, err, "failed to close etcd cluster: %v", err)
+				require.NoErrorf(t, err, "failed to close etcd cluster")
 			}()
 
 			for i := 0; i < 2; i++ {
@@ -109,7 +109,7 @@ func TestRuntimeReconfigDecreaseClusterSize(t *testing.T) {
 			require.NoError(t, epc.Procs[0].Etcdctl().Health(ctx))
 			defer func() {
 				err := epc.Close()
-				require.NoError(t, err, "failed to close etcd cluster: %v", err)
+				require.NoErrorf(t, err, "failed to close etcd cluster")
 			}()
 
 			for i := 0; i < 2; i++ {
@@ -147,7 +147,7 @@ func TestRuntimeReconfigRollingUpgrade(t *testing.T) {
 			require.NoError(t, epc.Procs[0].Etcdctl().Health(ctx))
 			defer func() {
 				err := epc.Close()
-				require.NoError(t, err, "failed to close etcd cluster: %v", err)
+				require.NoErrorf(t, err, "failed to close etcd cluster")
 			}()
 
 			for i := 0; i < 2; i++ {

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -447,11 +447,11 @@ func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombsto
 
 						last := receivedEvents[prevEventCount-1]
 
-						assert.Equal(t, last.Type, ev.Type,
+						assert.Equalf(t, last.Type, ev.Type,
 							"last received event type %s, but got event type %s", last.Type, ev.Type)
-						assert.Equal(t, string(last.Kv.Key), string(ev.Kv.Key),
+						assert.Equalf(t, string(last.Kv.Key), string(ev.Kv.Key),
 							"last received event key %s, but got event key %s", string(last.Kv.Key), string(ev.Kv.Key))
-						assert.Equal(t, string(last.Kv.Value), string(ev.Kv.Value),
+						assert.Equalf(t, string(last.Kv.Value), string(ev.Kv.Value),
 							"last received event value %s, but got event value %s", string(last.Kv.Value), string(ev.Kv.Value))
 						continue
 					}
@@ -473,11 +473,11 @@ func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombsto
 
 	t.Logf("Received total number of events: %d", len(receivedEvents))
 	require.Len(t, requestedValues, totalRev)
-	require.Len(t, receivedEvents, totalRev, "should receive %d events", totalRev)
+	require.Lenf(t, receivedEvents, totalRev, "should receive %d events", totalRev)
 	for idx, expected := range requestedValues {
 		ev := receivedEvents[idx]
 
-		require.Equal(t, expected.typ, ev.Type, "#%d expected event %s", idx, expected.typ)
+		require.Equalf(t, expected.typ, ev.Type, "#%d expected event %s", idx, expected.typ)
 
 		updatedKey := string(ev.Kv.Key)
 

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -126,7 +126,7 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 
 		// Allow 25% tolerance as round robin is not perfect and we don't want the test to flake
 		expected := float64(totalRequests) * 0.5
-		assert.InEpsilon(t, expected, float64(responses), 0.25, "unexpected total responses from foo: %s", lastResponse)
+		assert.InEpsilonf(t, expected, float64(responses), 0.25, "unexpected total responses from foo: %s", lastResponse)
 	}
 }
 

--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -47,7 +47,7 @@ func TestPeriodicCheck(t *testing.T) {
 	}
 	testPeriodicCheck(ctx, t, cc, clus, rev, rev+totalRevisions)
 	alarmResponse, err := cc.AlarmList(ctx)
-	assert.NoError(t, err, "error on alarm list")
+	assert.NoErrorf(t, err, "error on alarm list")
 	assert.Equal(t, []*etcdserverpb.AlarmMember(nil), alarmResponse.Alarms)
 }
 
@@ -55,14 +55,14 @@ func testPeriodicCheck(ctx context.Context, t *testing.T, cc *clientv3.Client, c
 	for i := start; i <= stop; i++ {
 		if i%67 == 0 {
 			_, err := cc.Delete(ctx, testutil.PickKey(i+83))
-			assert.NoError(t, err, "error on delete")
+			assert.NoErrorf(t, err, "error on delete")
 		} else {
 			_, err := cc.Put(ctx, testutil.PickKey(i), fmt.Sprint(i))
-			assert.NoError(t, err, "error on put")
+			assert.NoErrorf(t, err, "error on put")
 		}
 	}
 	err := clus.Members[0].Server.CorruptionChecker().PeriodicCheck()
-	assert.NoError(t, err, "error on periodic check (rev %v)", stop)
+	assert.NoErrorf(t, err, "error on periodic check (rev %v)", stop)
 }
 
 func TestPeriodicCheckDetectsCorruption(t *testing.T) {
@@ -78,11 +78,11 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
-		assert.NoError(t, err, "error on put")
+		assert.NoErrorf(t, err, "error on put")
 	}
 
 	err = clus.Members[0].Server.CorruptionChecker().PeriodicCheck()
-	assert.NoError(t, err, "error on periodic check")
+	assert.NoErrorf(t, err, "error on periodic check")
 	clus.Members[0].Stop(t)
 	clus.WaitLeader(t)
 
@@ -95,11 +95,11 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	leader := clus.WaitLeader(t)
 
 	err = clus.Members[leader].Server.CorruptionChecker().PeriodicCheck()
-	assert.NoError(t, err, "error on periodic check")
+	assert.NoErrorf(t, err, "error on periodic check")
 	time.Sleep(50 * time.Millisecond)
 
 	alarmResponse, err := cc.AlarmList(ctx)
-	assert.NoError(t, err, "error on alarm list")
+	assert.NoErrorf(t, err, "error on alarm list")
 	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
 }
 
@@ -126,14 +126,14 @@ func testCompactionHash(ctx context.Context, t *testing.T, cc *clientv3.Client, 
 	for i := start; i <= stop; i++ {
 		if i%67 == 0 {
 			_, err := cc.Delete(ctx, testutil.PickKey(i+83))
-			assert.NoError(t, err, "error on delete")
+			assert.NoErrorf(t, err, "error on delete")
 		} else {
 			_, err := cc.Put(ctx, testutil.PickKey(i), fmt.Sprint(i))
-			assert.NoError(t, err, "error on put")
+			assert.NoErrorf(t, err, "error on put")
 		}
 	}
 	_, err := cc.Compact(ctx, stop)
-	assert.NoError(t, err, "error on compact (rev %v)", stop)
+	assert.NoErrorf(t, err, "error on compact (rev %v)", stop)
 	// Wait for compaction to be compacted
 	time.Sleep(50 * time.Millisecond)
 
@@ -153,7 +153,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
-		assert.NoError(t, err, "error on put")
+		assert.NoErrorf(t, err, "error on put")
 	}
 
 	clus.Members[0].Server.CorruptionChecker().CompactHashCheck()
@@ -173,7 +173,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	clus.Members[leader].Server.CorruptionChecker().CompactHashCheck()
 	time.Sleep(50 * time.Millisecond)
 	alarmResponse, err := cc.AlarmList(ctx)
-	assert.NoError(t, err, "error on alarm list")
+	assert.NoErrorf(t, err, "error on alarm list")
 	assert.Equal(t, []*etcdserverpb.AlarmMember{{Alarm: etcdserverpb.AlarmType_CORRUPT, MemberID: uint64(clus.Members[0].ID())}}, alarmResponse.Alarms)
 }
 
@@ -190,7 +190,7 @@ func TestCompactHashCheckDetectMultipleCorruption(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
-		assert.NoError(t, err, "error on put")
+		assert.NoErrorf(t, err, "error on put")
 	}
 
 	clus.Members[0].Server.CorruptionChecker().CompactHashCheck()
@@ -217,7 +217,7 @@ func TestCompactHashCheckDetectMultipleCorruption(t *testing.T) {
 	clus.Members[leader].Server.CorruptionChecker().CompactHashCheck()
 	time.Sleep(50 * time.Millisecond)
 	alarmResponse, err := cc.AlarmList(ctx)
-	assert.NoError(t, err, "error on alarm list")
+	assert.NoErrorf(t, err, "error on alarm list")
 
 	expectedAlarmMap := map[uint64]etcdserverpb.AlarmType{
 		uint64(clus.Members[0].ID()): etcdserverpb.AlarmType_CORRUPT,

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -26,10 +26,9 @@ import (
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/storage"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
-
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestMetricDbSizeBoot checks that the db size metric is set on boot.
@@ -236,12 +235,12 @@ func TestMetricsRangeDurationSeconds(t *testing.T) {
 	rangeDurationSeconds, err := clus.Members[0].Metric("etcd_server_range_duration_seconds")
 	require.NoError(t, err)
 
-	require.NotEmpty(t, rangeDurationSeconds, "expected a number from etcd_server_range_duration_seconds")
+	require.NotEmptyf(t, rangeDurationSeconds, "expected a number from etcd_server_range_duration_seconds")
 
 	rangeDuration, err := strconv.ParseFloat(rangeDurationSeconds, 64)
-	require.NoError(t, err, "failed to parse duration: %s", err)
+	require.NoErrorf(t, err, "failed to parse duration: %s", rangeDurationSeconds)
 
 	maxRangeDuration := 600.0
-	require.GreaterOrEqual(t, rangeDuration, 0.0, "expected etcd_server_range_duration_seconds to be between 0 and %f, got %f", maxRangeDuration, rangeDuration)
-	require.LessOrEqual(t, rangeDuration, maxRangeDuration, "expected etcd_server_range_duration_seconds to be between 0 and %f, got %f", maxRangeDuration, rangeDuration)
+	require.GreaterOrEqualf(t, rangeDuration, 0.0, "expected etcd_server_range_duration_seconds to be between 0 and %f, got %f", maxRangeDuration, rangeDuration)
+	require.LessOrEqualf(t, rangeDuration, maxRangeDuration, "expected etcd_server_range_duration_seconds to be between 0 and %f, got %f", maxRangeDuration, rangeDuration)
 }

--- a/tests/integration/v3_tls_test.go
+++ b/tests/integration/v3_tls_test.go
@@ -133,8 +133,8 @@ func TestTLSMinMaxVersion(t *testing.T) {
 				TLS:         cc,
 			})
 			if cerr != nil {
-				assert.True(t, tt.expectError, "got TLS handshake error while expecting success: %v", cerr)
-				assert.Equal(t, context.DeadlineExceeded, cerr, "expected %v with TLS handshake failure, got %v", context.DeadlineExceeded, cerr)
+				assert.Truef(t, tt.expectError, "got TLS handshake error while expecting success: %v", cerr)
+				assert.Equal(t, context.DeadlineExceeded, cerr)
 				return
 			}
 

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -1514,7 +1514,7 @@ func TestV3WatchProgressWaitsForSyncNoEvents(t *testing.T) {
 			break
 		}
 	}
-	require.True(t, gotProgressNotification, "Expected to get progress notification")
+	require.Truef(t, gotProgressNotification, "Expected to get progress notification")
 }
 
 // TestV3NoEventsLostOnCompact verifies that slow watchers exit with compacted watch response

--- a/tests/robustness/model/non_deterministic_test.go
+++ b/tests/robustness/model/non_deterministic_test.go
@@ -571,6 +571,6 @@ func TestModelResponseMatch(t *testing.T) {
 		},
 	}
 	for i, tc := range tcs {
-		assert.Equal(t, tc.expectMatch, Match(tc.resp1, tc.resp2), "%d %+v %+v", i, tc.resp1, tc.resp2)
+		assert.Equalf(t, tc.expectMatch, Match(tc.resp1, tc.resp2), "%d %+v %+v", i, tc.resp1, tc.resp2)
 	}
 }

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -112,7 +112,12 @@ linters-settings: # please keep this alphabetized
   testifylint:
     disable:
       - float-compare
-      - formatter
       - go-require
       - require-error
     enable-all: true
+    formatter:
+      # Require f-assertions (e.g. assert.Equalf) if a message is passed to the assertion, even if
+      # there is no variable-length variables, i.e. require require.NoErrorf for both cases below:
+      # require.NoErrorf(t, err, "whatever message")
+      # require.NoErrorf(t, err, "whatever message: %v", v)
+      require-f-funcs: true


### PR DESCRIPTION
This PR enables the `formatter` testifylint rule as part of https://github.com/etcd-io/etcd/issues/18719

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
