### PR TITLE
CHANGELOG: add go 1.22.8 entry for 3.4 and 3.5

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.35 (TBC)
 
+### Dependencies
+- Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18670).
+
 <hr>
 
 ## v3.4.34 (2024-09-11)

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -5,6 +5,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.17 (TBC)
 
+### Dependencies
+- Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18669).
+
 <hr>
 
 ## v3.5.16 (2024-09-10)


### PR DESCRIPTION
Add an entry regarding using Go 1.22.8 for releases 3.4 and 3.5.

Part of: #18665

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
