### PR TITLE
Update the comment for `MaxCallSendMsgSize` and `MaxCallRecvMsgSize`

### DIFF
--- a/client/v3/config.go
+++ b/client/v3/config.go
@@ -45,16 +45,16 @@ type Config struct {
 	DialKeepAliveTimeout time.Duration `json:"dial-keep-alive-timeout"`
 
 	// MaxCallSendMsgSize is the client-side request send limit in bytes.
-	// If 0, it defaults to 2.0 MiB (2 * 1024 * 1024).
-	// Make sure that "MaxCallSendMsgSize" < server-side default send/recv limit.
+	// Defaults to `math.MaxInt32` if not set.
+	// Refer to https://pkg.go.dev/google.golang.org/grpc@v1.67.1#MaxCallSendMsgSize.
+	// Make sure that "MaxCallSendMsgSize" < server-side default recv limit.
 	// ("--max-request-bytes" flag to etcd or "embed.Config.MaxRequestBytes").
 	MaxCallSendMsgSize int
 
 	// MaxCallRecvMsgSize is the client-side response receive limit.
-	// If 0, it defaults to "math.MaxInt32", because range response can
-	// easily exceed request send limits.
-	// Make sure that "MaxCallRecvMsgSize" >= server-side default send/recv limit.
-	// ("--max-recv-bytes" flag to etcd).
+	// Defaults to 4MB if not set.
+	// Refer to https://pkg.go.dev/google.golang.org/grpc@v1.67.1#MaxCallRecvMsgSize.
+	// Make sure that "MaxCallRecvMsgSize" >= server-side default send limit.
 	MaxCallRecvMsgSize int
 
 	// TLS holds the client secure credentials, if any.


### PR DESCRIPTION
gRPC has already changed the default values, refer to 
- https://github.com/grpc/grpc-go/blob/v1.67.1/rpc_util.go#L368-L371
- https://github.com/grpc/grpc-go/blob/v1.67.1/rpc_util.go#L344-L347

This PR just makes sure the comment is aligned with the real values. 

I am open to set a default values at etcd side (instead of using grpc's default values) in a followup to ensure
- client.MaxSendByte (default: not set for now) =< server.MaxRecvByte (defaults to 1.5MB)
- client.MaxRecvByte (default: not set for now) >= server.MaxSendByte (defaults to `math.MaxInt32`)

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
