### PR TITLE
fix: enable thelper linter in client directory

### DIFF
--- a/client/internal/v2/keys_bench_test.go
+++ b/client/internal/v2/keys_bench_test.go
@@ -49,6 +49,7 @@ func createTestResponse(children, size int) *Response {
 }
 
 func benchmarkResponseUnmarshalling(b *testing.B, children, size int) {
+	b.Helper()
 	header := http.Header{}
 	header.Add("X-Etcd-Index", "123456")
 	response := createTestResponse(children, size)

--- a/client/pkg/fileutil/preallocate_test.go
+++ b/client/pkg/fileutil/preallocate_test.go
@@ -23,16 +23,23 @@ import (
 
 func TestPreallocateExtend(t *testing.T) {
 	pf := func(f *os.File, sz int64) error { return Preallocate(f, sz, true) }
-	tf := func(t *testing.T, f *os.File) { testPreallocateExtend(t, f, pf) }
+	tf := func(t *testing.T, f *os.File) {
+		t.Helper()
+		testPreallocateExtend(t, f, pf)
+	}
 	runPreallocTest(t, tf)
 }
 
 func TestPreallocateExtendTrunc(t *testing.T) {
-	tf := func(t *testing.T, f *os.File) { testPreallocateExtend(t, f, preallocExtendTrunc) }
+	tf := func(t *testing.T, f *os.File) {
+		t.Helper()
+		testPreallocateExtend(t, f, preallocExtendTrunc)
+	}
 	runPreallocTest(t, tf)
 }
 
 func testPreallocateExtend(t *testing.T, f *os.File, pf func(*os.File, int64) error) {
+	t.Helper()
 	size := int64(64 * 1000)
 	require.NoError(t, pf(f, size))
 
@@ -45,6 +52,7 @@ func testPreallocateExtend(t *testing.T, f *os.File, pf func(*os.File, int64) er
 
 func TestPreallocateFixed(t *testing.T) { runPreallocTest(t, testPreallocateFixed) }
 func testPreallocateFixed(t *testing.T, f *os.File) {
+	t.Helper()
 	size := int64(64 * 1000)
 	require.NoError(t, Preallocate(f, size, false))
 
@@ -56,6 +64,7 @@ func testPreallocateFixed(t *testing.T, f *os.File) {
 }
 
 func runPreallocTest(t *testing.T, test func(*testing.T, *os.File)) {
+	t.Helper()
 	p := t.TempDir()
 
 	f, err := os.CreateTemp(p, "")

--- a/client/pkg/fileutil/read_dir_test.go
+++ b/client/pkg/fileutil/read_dir_test.go
@@ -51,6 +51,7 @@ func TestReadDir(t *testing.T) {
 }
 
 func writeFunc(t *testing.T, path string) {
+	t.Helper()
 	fh, err := os.Create(path)
 	require.NoErrorf(t, err, "error creating file")
 	assert.NoErrorf(t, fh.Close(), "error closing file")

--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -24,20 +24,21 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
-func BeforeTest(t testing.TB) {
-	RegisterLeakDetection(t)
+func BeforeTest(tb testing.TB) {
+	tb.Helper()
+	RegisterLeakDetection(tb)
 
 	revertVerifyFunc := verify.EnableAllVerifications()
 
 	path, err := os.Getwd()
-	assert.NoError(t, err)
-	tempDir := t.TempDir()
-	assert.NoError(t, os.Chdir(tempDir))
-	t.Logf("Changing working directory to: %s", tempDir)
+	assert.NoError(tb, err)
+	tempDir := tb.TempDir()
+	assert.NoError(tb, os.Chdir(tempDir))
+	tb.Logf("Changing working directory to: %s", tempDir)
 
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		revertVerifyFunc()
-		assert.NoError(t, os.Chdir(path))
+		assert.NoError(tb, os.Chdir(path))
 	})
 }
 

--- a/client/pkg/testutil/testutil.go
+++ b/client/pkg/testutil/testutil.go
@@ -30,6 +30,7 @@ func WaitSchedule() {
 }
 
 func MustNewURLs(t *testing.T, urls []string) []url.URL {
+	t.Helper()
 	if urls == nil {
 		return nil
 	}
@@ -42,6 +43,7 @@ func MustNewURLs(t *testing.T, urls []string) []url.URL {
 }
 
 func MustNewURL(t *testing.T, s string) *url.URL {
+	t.Helper()
 	u, err := url.Parse(s)
 	if err != nil {
 		t.Fatalf("parse %v error: %v", s, err)
@@ -51,6 +53,7 @@ func MustNewURL(t *testing.T, s string) *url.URL {
 
 // FatalStack helps to fatal the test and print out the stacks of all running goroutines.
 func FatalStack(t *testing.T, s string) {
+	t.Helper()
 	stackTrace := make([]byte, 1024*1024)
 	n := runtime.Stack(stackTrace, true)
 	t.Errorf("---> Test failed: %s", s)

--- a/client/pkg/tlsutil/cipher_suites_test.go
+++ b/client/pkg/tlsutil/cipher_suites_test.go
@@ -27,6 +27,7 @@ func TestGetCipherSuite_not_existing(t *testing.T) {
 }
 
 func CipherSuiteExpectedToExist(tb testing.TB, cipher string, expectedID uint16) {
+	tb.Helper()
 	vid, ok := GetCipherSuite(cipher)
 	if !ok {
 		tb.Errorf("Expected %v cipher to exist", cipher)

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -35,10 +35,12 @@ import (
 )
 
 func createSelfCert(t *testing.T) (*TLSInfo, error) {
+	t.Helper()
 	return createSelfCertEx(t, "127.0.0.1")
 }
 
 func createSelfCertEx(t *testing.T, host string, additionalUsages ...x509.ExtKeyUsage) (*TLSInfo, error) {
+	t.Helper()
 	d := t.TempDir()
 	info, err := SelfCert(zaptest.NewLogger(t), d, []string{host + ":0"}, 1, additionalUsages...)
 	if err != nil {
@@ -218,6 +220,7 @@ func TestNewListenerWithSocketOpts(t *testing.T) {
 }
 
 func testNewListenerTLSInfoAccept(t *testing.T, tlsInfo TLSInfo) {
+	t.Helper()
 	ln, err := NewListener("127.0.0.1:0", "https", &tlsInfo)
 	require.NoErrorf(t, err, "unexpected NewListener error")
 	defer ln.Close()
@@ -254,6 +257,7 @@ func TestNewListenerTLSInfoSkipClientSANVerify(t *testing.T) {
 }
 
 func testNewListenerTLSInfoClientCheck(t *testing.T, skipClientSANVerify, goodClientHost, acceptExpected bool) {
+	t.Helper()
 	tlsInfo, err := createSelfCert(t)
 	require.NoErrorf(t, err, "unable to create cert")
 

--- a/client/pkg/transport/timeout_dialer_test.go
+++ b/client/pkg/transport/timeout_dialer_test.go
@@ -89,6 +89,7 @@ type testBlockingServer struct {
 }
 
 func (ts *testBlockingServer) Start(t *testing.T) {
+	t.Helper()
 	for i := 0; i < ts.n; i++ {
 		conn, err := ts.ln.Accept()
 		if err != nil {

--- a/client/pkg/types/set_test.go
+++ b/client/pkg/types/set_test.go
@@ -38,6 +38,7 @@ func equal(a, b []string) bool {
 }
 
 func driveSetTests(t *testing.T, s Set) {
+	t.Helper()
 	// Verify operations on an empty set
 	values := s.Values()
 	if len(values) != 0 {

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func NewClient(t *testing.T, cfg Config) (*Client, error) {
+	t.Helper()
 	if cfg.Logger == nil {
 		cfg.Logger = zaptest.NewLogger(t).Named("client")
 	}


### PR DESCRIPTION
enables and fixes [thelper](https://golangci-lint.run/usage/linters/#thelper) linter issues in client directory