### PR TITLE
fix: enable gofumpt instead of gofmt linter in client

### DIFF
--- a/client/internal/v2/auth_user.go
+++ b/client/internal/v2/auth_user.go
@@ -23,9 +23,7 @@ import (
 	"path"
 )
 
-var (
-	defaultV2AuthPrefix = "/v2/auth"
-)
+var defaultV2AuthPrefix = "/v2/auth"
 
 type User struct {
 	User     string   `json:"user"`

--- a/client/internal/v2/client_test.go
+++ b/client/internal/v2/client_test.go
@@ -283,7 +283,7 @@ func TestSimpleHTTPClientDoCancelContextWaitForRoundTrip(t *testing.T) {
 
 	select {
 	case <-donechan:
-		//expected behavior
+		// expected behavior
 		return
 	case <-time.After(time.Second):
 		t.Fatalf("simpleHTTPClient.Do did not exit within 1s")
@@ -493,7 +493,8 @@ func (f fakeCancelContext) Value(key any) any { return 1 }
 
 func withTimeout(parent context.Context, _timeout time.Duration) (
 	ctx context.Context,
-	cancel context.CancelFunc) {
+	cancel context.CancelFunc,
+) {
 	ctx = parent
 	cancel = func() {
 		ctx = nil

--- a/client/internal/v2/curl.go
+++ b/client/internal/v2/curl.go
@@ -22,9 +22,7 @@ import (
 	"os"
 )
 
-var (
-	cURLDebug = false
-)
+var cURLDebug = false
 
 func EnablecURLDebug() {
 	cURLDebug = true

--- a/client/internal/v2/keys.go
+++ b/client/internal/v2/keys.go
@@ -79,9 +79,7 @@ const (
 	PrevNoExist = PrevExistType("false")
 )
 
-var (
-	defaultV2KeysPrefix = "/v2/keys"
-)
+var defaultV2KeysPrefix = "/v2/keys"
 
 // NewKeysAPI builds a KeysAPI that interacts with etcd's key-value
 // API over HTTP.

--- a/client/pkg/fileutil/dir_unix.go
+++ b/client/pkg/fileutil/dir_unix.go
@@ -20,7 +20,7 @@ import "os"
 
 const (
 	// PrivateDirMode grants owner to make/remove files inside the directory.
-	PrivateDirMode = 0700
+	PrivateDirMode = 0o700
 )
 
 // OpenDir opens a directory for syncing.

--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// PrivateFileMode grants owner to read/write a file.
-	PrivateFileMode = 0600
+	PrivateFileMode = 0o600
 )
 
 // IsDirWriteable checks if dir is writable by writing and removing a file
@@ -125,7 +125,7 @@ func CheckDirPermission(dir string, perm os.FileMode) error {
 	if !Exist(dir) {
 		return fmt.Errorf("directory %q empty, cannot check permission", dir)
 	}
-	//check the existing permission on the directory
+	// check the existing permission on the directory
 	dirInfo, err := os.Stat(dir)
 	if err != nil {
 		return err

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -34,7 +34,7 @@ import (
 func TestIsDirWriteable(t *testing.T) {
 	tmpdir := t.TempDir()
 	require.NoErrorf(t, IsDirWriteable(tmpdir), "unexpected IsDirWriteable error")
-	require.NoErrorf(t, os.Chmod(tmpdir, 0444), "unexpected os.Chmod error")
+	require.NoErrorf(t, os.Chmod(tmpdir, 0o444), "unexpected os.Chmod error")
 	me, err := user.Current()
 	if err != nil {
 		// err can be non-nil when cross compiled
@@ -68,7 +68,7 @@ func TestCreateDirAll(t *testing.T) {
 func TestExist(t *testing.T) {
 	fdir := filepath.Join(os.TempDir(), fmt.Sprint(time.Now().UnixNano()+rand.Int63n(1000)))
 	os.RemoveAll(fdir)
-	if err := os.Mkdir(fdir, 0666); err != nil {
+	if err := os.Mkdir(fdir, 0o666); err != nil {
 		t.Skip(err)
 	}
 	defer os.RemoveAll(fdir)
@@ -150,7 +150,7 @@ func TestDirPermission(t *testing.T) {
 	// create a new dir with 0700
 	require.NoError(t, CreateDirAll(zaptest.NewLogger(t), tmpdir2))
 	// check dir permission with mode different than created dir
-	if err := CheckDirPermission(tmpdir2, 0600); err == nil {
+	if err := CheckDirPermission(tmpdir2, 0o600); err == nil {
 		t.Errorf("expected error, got nil")
 	}
 }

--- a/client/pkg/fileutil/lock.go
+++ b/client/pkg/fileutil/lock.go
@@ -19,8 +19,6 @@ import (
 	"os"
 )
 
-var (
-	ErrLocked = errors.New("fileutil: file already locked")
-)
+var ErrLocked = errors.New("fileutil: file already locked")
 
 type LockedFile struct{ *os.File }

--- a/client/pkg/testutil/leak.go
+++ b/client/pkg/testutil/leak.go
@@ -135,7 +135,7 @@ func interestingGoroutines() (gs []string) {
 		}
 
 		shouldSkip := func() bool {
-			var uninterestingMsgs = [...]string{
+			uninterestingMsgs := [...]string{
 				"sync.(*WaitGroup).Done",
 				"os.(*file).close",
 				"os.(*Process).Release",

--- a/client/pkg/transport/limit_listen.go
+++ b/client/pkg/transport/limit_listen.go
@@ -23,9 +23,7 @@ import (
 	"time"
 )
 
-var (
-	ErrNotTCP = errors.New("only tcp connections have keepalive")
-)
+var ErrNotTCP = errors.New("only tcp connections have keepalive")
 
 // LimitListener returns a Listener that accepts at most n simultaneous
 // connections from the provided Listener.

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -330,7 +330,7 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 	if err != nil {
 		return info, err
 	}
-	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		info.Logger.Warn(
 			"cannot key file",

--- a/client/pkg/transport/listener_test.go
+++ b/client/pkg/transport/listener_test.go
@@ -610,7 +610,7 @@ func TestNewListenerWithACRLFile(t *testing.T) {
 				require.NoErrorf(t, err, "unable to create revocation list")
 			}
 
-			err = os.WriteFile(tlsInfo.CRLFile, revocationListContents, 0600)
+			err = os.WriteFile(tlsInfo.CRLFile, revocationListContents, 0o600)
 			require.NoErrorf(t, err, "unable to write revocation list")
 
 			chHandshakeFailure := make(chan error, 1)

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -458,7 +458,7 @@ func newClient(cfg *Config) (*Client, error) {
 	client.Auth = NewAuth(client)
 	client.Maintenance = NewMaintenance(client)
 
-	//get token with established connection
+	// get token with established connection
 	ctx, cancel = client.ctx, func() {}
 	if client.cfg.DialTimeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, client.cfg.DialTimeout)
@@ -467,7 +467,7 @@ func newClient(cfg *Config) (*Client, error) {
 	if err != nil {
 		client.Close()
 		cancel()
-		//TODO: Consider fmt.Errorf("communicating with [%s] failed: %v", strings.Join(cfg.Endpoints, ";"), err)
+		// TODO: Consider fmt.Errorf("communicating with [%s] failed: %v", strings.Join(cfg.Endpoints, ";"), err)
 		return nil, err
 	}
 	cancel()

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -55,7 +55,8 @@ func TestDialCancel(t *testing.T) {
 	ep := "unix://dialcancel:12345"
 	cfg := Config{
 		Endpoints:   []string{ep},
-		DialTimeout: 30 * time.Second}
+		DialTimeout: 30 * time.Second,
+	}
 	c, err := NewClient(t, cfg)
 	require.NoError(t, err)
 
@@ -338,7 +339,7 @@ func TestSyncFiltersMembers(t *testing.T) {
 
 func TestMinSupportedVersion(t *testing.T) {
 	testutil.BeforeTest(t)
-	var tests = []struct {
+	tests := []struct {
 		name                string
 		currentVersion      semver.Version
 		minSupportedVersion semver.Version
@@ -379,7 +380,7 @@ func TestMinSupportedVersion(t *testing.T) {
 
 func TestClientRejectOldCluster(t *testing.T) {
 	testutil.BeforeTest(t)
-	var tests = []struct {
+	tests := []struct {
 		name          string
 		endpoints     []string
 		versions      []string

--- a/client/v3/compare.go
+++ b/client/v3/compare.go
@@ -18,8 +18,10 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
-type CompareTarget int
-type CompareResult int
+type (
+	CompareTarget int
+	CompareResult int
+)
 
 const (
 	CompareVersion CompareTarget = iota

--- a/client/v3/concurrency/mutex.go
+++ b/client/v3/concurrency/mutex.go
@@ -26,9 +26,11 @@ import (
 )
 
 // ErrLocked is returned by TryLock when Mutex is already locked by another session.
-var ErrLocked = errors.New("mutex: Locked by another session")
-var ErrSessionExpired = errors.New("mutex: session is expired")
-var ErrLockReleased = errors.New("mutex: lock has already been released")
+var (
+	ErrLocked         = errors.New("mutex: Locked by another session")
+	ErrSessionExpired = errors.New("mutex: session is expired")
+	ErrLockReleased   = errors.New("mutex: lock has already been released")
+)
 
 // Mutex implements the sync Locker interface with etcd
 type Mutex struct {
@@ -164,6 +166,7 @@ func (lm *lockerMutex) Lock() {
 		panic(err)
 	}
 }
+
 func (lm *lockerMutex) Unlock() {
 	client := lm.s.Client()
 	if err := lm.Mutex.Unlock(client.Ctx()); err != nil {

--- a/client/v3/kv.go
+++ b/client/v3/kv.go
@@ -80,12 +80,15 @@ func (op OpResponse) Txn() *TxnResponse    { return op.txn }
 func (resp *PutResponse) OpResponse() OpResponse {
 	return OpResponse{put: resp}
 }
+
 func (resp *GetResponse) OpResponse() OpResponse {
 	return OpResponse{get: resp}
 }
+
 func (resp *DeleteResponse) OpResponse() OpResponse {
 	return OpResponse{del: resp}
 }
+
 func (resp *TxnResponse) OpResponse() OpResponse {
 	return OpResponse{txn: resp}
 }

--- a/client/v3/mirror/syncer.go
+++ b/client/v3/mirror/syncer.go
@@ -74,8 +74,10 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 
 		var key string
 
-		opts := []clientv3.OpOption{clientv3.WithLimit(batchLimit), clientv3.WithRev(s.rev),
-			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)}
+		opts := []clientv3.OpOption{
+			clientv3.WithLimit(batchLimit), clientv3.WithRev(s.rev),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+		}
 
 		if len(s.prefix) == 0 {
 			// If len(s.prefix) == 0, we will sync the entire key-value space.

--- a/client/v3/retry.go
+++ b/client/v3/retry.go
@@ -101,6 +101,7 @@ func RetryKVClient(c *Client) pb.KVClient {
 		kc: pb.NewKVClient(c.conn),
 	}
 }
+
 func (rkv *retryKVClient) Range(ctx context.Context, in *pb.RangeRequest, opts ...grpc.CallOption) (resp *pb.RangeResponse, err error) {
 	return rkv.kc.Range(ctx, in, append(opts, withRepeatablePolicy())...)
 }

--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -359,14 +359,12 @@ func contextErrToGRPCErr(err error) error {
 	}
 }
 
-var (
-	defaultOptions = &options{
-		retryPolicy: nonRepeatable,
-		max:         0, // disable
-		backoffFunc: backoffLinearWithJitter(50*time.Millisecond /*jitter*/, 0.10),
-		retryAuth:   true,
-	}
-)
+var defaultOptions = &options{
+	retryPolicy: nonRepeatable,
+	max:         0, // disable
+	backoffFunc: backoffLinearWithJitter(50*time.Millisecond /*jitter*/, 0.10),
+	retryAuth:   true,
+}
 
 // backoffFunc denotes a family of functions that control the backoff duration between call retries.
 //

--- a/client/v3/sort.go
+++ b/client/v3/sort.go
@@ -14,8 +14,10 @@
 
 package clientv3
 
-type SortTarget int
-type SortOrder int
+type (
+	SortTarget int
+	SortOrder  int
+)
 
 const (
 	SortNone SortOrder = iota

--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -221,8 +221,7 @@ type watchRequest struct {
 }
 
 // progressRequest is issued by the subscriber to request watch progress
-type progressRequest struct {
-}
+type progressRequest struct{}
 
 // watcherStream represents a registered watcher
 type watcherStream struct {
@@ -261,8 +260,10 @@ func NewWatchFromWatchClient(wc pb.WatchClient, c *Client) Watcher {
 }
 
 // never closes
-var valCtxCh = make(chan struct{})
-var zeroTime = time.Unix(0, 0)
+var (
+	valCtxCh = make(chan struct{})
+	zeroTime = time.Unix(0, 0)
+)
 
 // ctx with only the values; never Done
 type valCtx struct{ context.Context }


### PR DESCRIPTION
enables and fixes [gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) linter issues in client directory