### PR TITLE
Fix risk of a partial write txn being applied

### DIFF
--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -16,6 +16,9 @@ package txn
 
 import (
 	"context"
+	"crypto/sha256"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -336,8 +339,8 @@ func TestReadonlyTxnError(t *testing.T) {
 	}
 }
 
-func TestWriteTxnPanic(t *testing.T) {
-	b, _ := betesting.NewDefaultTmpBackend(t)
+func TestWriteTxnPanicWithoutApply(t *testing.T) {
+	b, bePath := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, b)
 	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})
 	defer s.Close()
@@ -366,6 +369,26 @@ func TestWriteTxnPanic(t *testing.T) {
 			},
 		},
 	}
+
+	// compute DB file hash before applying the txn
+	dbHashBefore, err := computeFileHash(bePath)
+	if err != nil {
+		t.Fatalf("failed to compute DB file hash before txn: %v", err)
+	}
+
+	// we verify the following things below:
+	// - server panics after a write txn aply fails (invariant being tested: server should never try to move on from a failed write)
+	// - no writes from the txn are applied to the backend (invariant being tested: failed write should have no side-effect on DB state besides panic)
+	defer func() {
+		dbHashAfter, err := computeFileHash(bePath)
+		if err != nil {
+			t.Fatalf("failed to compute DB file hash after txn: %v", err)
+		}
+
+		if dbHashAfter != dbHashBefore {
+			t.Fatalf("expected DB hash after failed txn: %s, got: %s", dbHashBefore, dbHashAfter)
+		}
+	}()
 
 	assert.Panics(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}) }, "Expected panic in Txn with writes")
 }
@@ -564,6 +587,20 @@ func setupAuth(t *testing.T, be backend.Backend) auth.AuthStore {
 	require.NoError(t, err)
 
 	return as
+}
+
+func computeFileHash(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+	return string(h.Sum(nil)), nil
 }
 
 // CheckTxnAuth variables setup.


### PR DESCRIPTION
Fixes https://github.com/etcd-io/etcd/issues/18679

I was able to confirm this risk exists based on the unit test failing with txnWrite.End() still around. I did have to add a few milliseconds of wait time between the txn End and panic to reliably reproduce it because it depends on whether backend commit happens in that window or not.

/cc @serathius @ahrtr 