### PR TITLE
embed: fix typo client-listen-x to listen-client-x

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -664,7 +664,7 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 			sctx = newServeCtx(cfg.logger)
 			sctxs[addr] = sctx
 		} else if !sctx.httpOnly {
-			return nil, fmt.Errorf("cannot bind both --client-listen-urls and --client-listen-http-urls on the same url %s", u.String())
+			return nil, fmt.Errorf("cannot bind both --listen-client-urls and --listen-client-http-urls on the same url %s", u.String())
 		}
 		sctx.secure = sctx.secure || secure
 		sctx.insecure = sctx.insecure || !secure


### PR DESCRIPTION
When I was separating GRPC and HTTP ports, the following error occurred, causing ETCD to not start properly and causing confusion for me.

error log:

```text
cannot bind both --client-listen-urls and --client-listen-http-urls on the same url https://192.168.31.23:2379
```

key config:

```text
...
    --listen-client-urls=https://127.0.0.1:2379,https://192.168.31.23:2379 \
    --listen-client-http-urls=https://192.168.31.23:2379 \
...
```

 It should be a spelling error in the error log output, client-listen-* will be listen-client-*. I hope it can help others.
