### PR TITLE
fix: use require.NoError instead of t.Fatal(err) in contrib and tools packages

### DIFF
--- a/contrib/raftexample/kvstore_test.go
+++ b/contrib/raftexample/kvstore_test.go
@@ -17,6 +17,8 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_kvstore_snapshot(t *testing.T) {
@@ -29,14 +31,11 @@ func Test_kvstore_snapshot(t *testing.T) {
 	}
 
 	data, err := s.getSnapshot()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s.kvStore = nil
 
-	if err := s.recoverFromSnapshot(data); err != nil {
-		t.Fatal(err)
-	}
+	err = s.recoverFromSnapshot(data)
+	require.NoError(t, err)
 	v, _ = s.Lookup("foo")
 	if v != "bar" {
 		t.Fatalf("foo has unexpected value, got %s", v)

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -96,9 +98,8 @@ func (clus *cluster) Close() (err error) {
 
 func (clus *cluster) closeNoErrors(t *testing.T) {
 	t.Log("closing cluster...")
-	if err := clus.Close(); err != nil {
-		t.Fatal(err)
-	}
+	err := clus.Close()
+	require.NoError(t, err)
 	t.Log("closing cluster [done]")
 }
 
@@ -201,27 +202,19 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	cli := srv.Client()
 
 	req, err := http.NewRequest(http.MethodPut, url, body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "text/html; charset=utf-8")
 	_, err = cli.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// wait for a moment for processing message, otherwise get would be failed.
 	<-time.After(time.Second)
 
 	resp, err := cli.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	if gotValue := string(data); wantValue != gotValue {

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/api/v3/authpb"
@@ -36,9 +37,7 @@ import (
 func TestEtcdDumpLogEntryType(t *testing.T) {
 	// directory where the command is
 	binDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// TODO(ptabor): The test does not run by default from ./scripts/test.sh.
 	dumpLogsBinary := path.Join(binDir + "/etcd-dump-logs")
@@ -79,13 +78,9 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 		t.Run(argtest.name, func(t *testing.T) {
 			cmd := exec.Command(dumpLogsBinary, argtest.args...)
 			actual, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			expected, err := os.ReadFile(path.Join(binDir, argtest.fileExpected))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			assert.EqualValues(t, string(expected), string(actual))
 			// The output files contains a lot of trailing whitespaces... difficult to diagnose without printing them explicitly.
@@ -98,21 +93,15 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 func mustCreateWALLog(t *testing.T, path string) {
 	memberdir := filepath.Join(path, "member")
 	err := os.Mkdir(memberdir, 0744)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	waldir := walDir(path)
 	snapdir := snapDir(path)
 
 	w, err := wal.Create(zaptest.NewLogger(t), waldir, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = os.Mkdir(snapdir, 0744)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ents := make([]raftpb.Entry, 0)
 
@@ -124,9 +113,7 @@ func mustCreateWALLog(t *testing.T, path string) {
 
 	// force commit newly appended entries
 	err = w.Save(raftpb.HardState{}, ents)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	w.Close()
 }
 


### PR DESCRIPTION
There is no linter for this.
This uses testify instead of testing for
With 
```go
require.NoError(t, err)

require.Error(t, err)
```
instead of

```go
if err != nil {
    t.Fatal(err)
}


if err == nil {
    t.Fatal(err)
}
```