### PR TITLE
fix: use require.NoError instead of t.Fatal(err) in tests package (part 1)

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -103,9 +105,8 @@ func TestAlarm(t *testing.T) {
 		}
 
 		// put one more key below quota
-		if err := cc.Put(ctx, "4th_test", smallbuf, config.PutOptions{}); err != nil {
-			t.Fatal(err)
-		}
+		err = cc.Put(ctx, "4th_test", smallbuf, config.PutOptions{})
+		require.NoError(t, err)
 	})
 }
 

--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -378,14 +378,12 @@ func TestAuthTxn(t *testing.T) {
 				// keys with 2 suffix are granted to test-user, see Line 399
 				grantedKeys := []string{"c2", "s2", "f2"}
 				for _, key := range keys {
-					if err := cc.Put(ctx, key, "v", config.PutOptions{}); err != nil {
-						t.Fatal(err)
-					}
+					err := cc.Put(ctx, key, "v", config.PutOptions{})
+					require.NoError(t, err)
 				}
 				for _, key := range grantedKeys {
-					if err := cc.Put(ctx, key, "v", config.PutOptions{}); err != nil {
-						t.Fatal(err)
-					}
+					err := cc.Put(ctx, key, "v", config.PutOptions{})
+					require.NoError(t, err)
 				}
 
 				require.NoErrorf(t, setupAuth(cc, []authRole{testRole}, []authUser{rootUser, testUser}), "failed to enable auth")
@@ -394,9 +392,8 @@ func TestAuthTxn(t *testing.T) {
 
 				// grant keys to test-user
 				for _, key := range grantedKeys {
-					if _, err := rootAuthClient.RoleGrantPermission(ctx, testRoleName, key, "", clientv3.PermissionType(clientv3.PermReadWrite)); err != nil {
-						t.Fatal(err)
-					}
+					_, err := rootAuthClient.RoleGrantPermission(ctx, testRoleName, key, "", clientv3.PermissionType(clientv3.PermReadWrite))
+					require.NoError(t, err)
 				}
 				for _, req := range reqs {
 					resp, err := testUserAuthClient.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -249,9 +249,7 @@ func TestMemberRemove(t *testing.T) {
 // It ensures that `MemberRemove` function does not return an "etcdserver: server stopped" error.
 func memberToRemove(ctx context.Context, t *testing.T, client intf.Client, clusterSize int) (memberID uint64, clusterID uint64) {
 	listResp, err := client.MemberList(ctx, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	clusterID = listResp.Header.ClusterId
 	if clusterSize == 1 {
@@ -259,9 +257,7 @@ func memberToRemove(ctx context.Context, t *testing.T, client intf.Client, clust
 	} else {
 		// get status of the specific member that client has connected to
 		statusResp, err := client.Status(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// choose a member that client has not connected to
 		for _, m := range listResp.Members {

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -218,16 +218,13 @@ func downgradeEnable(t *testing.T, epc *e2e.EtcdProcessCluster, ver *semver.Vers
 	c := epc.Etcdctl()
 	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
 		err := c.DowngradeEnable(context.TODO(), ver.String())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 }
 
 func stopEtcd(t *testing.T, ep e2e.EtcdProcess) {
-	if err := ep.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	err := ep.Stop()
+	require.NoError(t, err)
 }
 
 func validateVersion(t *testing.T, cfg *e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess, expect version.Versions) {
@@ -260,14 +257,10 @@ func leader(t *testing.T, epc *e2e.EtcdProcessCluster) e2e.EtcdProcess {
 			Endpoints:   endpoints,
 			DialTimeout: 3 * time.Second,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer cli.Close()
 		resp, err := cli.Status(ctx, endpoints[0])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if resp.Header.GetMemberId() == resp.Leader {
 			return epc.Procs[i]
 		}

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -68,16 +68,12 @@ func corruptTest(cx ctlCtx) {
 	cx.t.Log("connecting clientv3...")
 	eps := cx.epc.EndpointsGRPC()
 	cli1, err := clientv3.New(clientv3.Config{Endpoints: []string{eps[1]}, DialTimeout: 3 * time.Second})
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	defer cli1.Close()
 
 	sresp, err := cli1.Status(context.TODO(), eps[0])
 	cx.t.Logf("checked status sresp:%v err:%v", sresp, err)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	id0 := sresp.Header.GetMemberId()
 
 	cx.t.Log("stopping etcd[0]...")
@@ -86,16 +82,13 @@ func corruptTest(cx ctlCtx) {
 	// corrupting first member by modifying backend offline.
 	fp := datadir.ToBackendFileName(cx.epc.Procs[0].Config().DataDirPath)
 	cx.t.Logf("corrupting backend: %v", fp)
-	if err = cx.corruptFunc(fp); err != nil {
-		cx.t.Fatal(err)
-	}
+	err = cx.corruptFunc(fp)
+	require.NoError(cx.t, err)
 
 	cx.t.Log("restarting etcd[0]")
 	ep := cx.epc.Procs[0]
 	proc, err := e2e.SpawnCmd(append([]string{ep.Config().ExecPath}, ep.Config().Args...), cx.envMap)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	defer proc.Stop()
 
 	cx.t.Log("waiting for etcd[0] failure...")

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -67,33 +67,26 @@ func ctlV3PutFailPerm(cx ctlCtx, key, val string) error {
 }
 
 func authSetupTestUser(cx ctlCtx) {
-	if err := ctlV3User(cx, []string{"add", "test-user", "--interactive=false"}, "User test-user created", []string{"pass"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3User(cx, []string{"grant-role", "test-user", "test-role"}, "Role test-role is granted to user test-user", nil); err != nil {
-		cx.t.Fatal(err)
-	}
+	err := ctlV3User(cx, []string{"add", "test-user", "--interactive=false"}, "User test-user created", []string{"pass"})
+	require.NoError(cx.t, err)
+	err = e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"})
+	require.NoError(cx.t, err)
+	err = ctlV3User(cx, []string{"grant-role", "test-user", "test-role"}, "Role test-role is granted to user test-user", nil)
+	require.NoError(cx.t, err)
 	cmd := append(cx.PrefixArgs(), "role", "grant-permission", "test-role", "readwrite", "foo")
-	if err := e2e.SpawnWithExpectWithEnv(cmd, cx.envMap, expect.ExpectedResponse{Value: "Role test-role updated"}); err != nil {
-		cx.t.Fatal(err)
-	}
+	err = e2e.SpawnWithExpectWithEnv(cmd, cx.envMap, expect.ExpectedResponse{Value: "Role test-role updated"})
+	require.NoError(cx.t, err)
 }
 
 func authTestMemberUpdate(cx ctlCtx) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	err := authEnable(cx)
+	require.NoError(cx.t, err)
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
 	mr, err := getMemberList(cx, false)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 
 	// ordinary user cannot update a member
 	cx.user, cx.pass = "test-user", "pass"
@@ -105,31 +98,25 @@ func authTestMemberUpdate(cx ctlCtx) {
 
 	// root can update a member
 	cx.user, cx.pass = "root", "root"
-	if err = ctlV3MemberUpdate(cx, memberID, peerURL); err != nil {
-		cx.t.Fatal(err)
-	}
+	err = ctlV3MemberUpdate(cx, memberID, peerURL)
+	require.NoError(cx.t, err)
 }
 
 func authTestCertCN(cx ctlCtx) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	err := authEnable(cx)
+	require.NoError(cx.t, err)
 
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3User(cx, []string{"grant-role", "example.com", "test-role"}, "Role test-role is granted to user example.com", nil); err != nil {
-		cx.t.Fatal(err)
-	}
+	err = ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""})
+	require.NoError(cx.t, err)
+	err = e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"})
+	require.NoError(cx.t, err)
+	err = ctlV3User(cx, []string{"grant-role", "example.com", "test-role"}, "Role test-role is granted to user example.com", nil)
+	require.NoError(cx.t, err)
 
 	// grant a new key
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "hoo", "", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	err = ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "hoo", "", false})
+	require.NoError(cx.t, err)
 
 	// try a granted key
 	cx.user, cx.pass = "", ""
@@ -139,7 +126,7 @@ func authTestCertCN(cx ctlCtx) {
 
 	// try a non-granted key
 	cx.user, cx.pass = "", ""
-	err := ctlV3PutFailPerm(cx, "baz", "bar")
+	err = ctlV3PutFailPerm(cx, "baz", "bar")
 	require.ErrorContains(cx.t, err, "permission denied")
 }
 

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -197,9 +197,8 @@ func testIssue6361(t *testing.T) {
 	t.Log("Writing some keys...")
 	kvs := []kv{{"foo1", "val1"}, {"foo2", "val2"}, {"foo3", "val3"}}
 	for i := range kvs {
-		if err = e2e.SpawnWithExpect(append(prefixArgs, "put", kvs[i].key, kvs[i].val), expect.ExpectedResponse{Value: "OK"}); err != nil {
-			t.Fatal(err)
-		}
+		err = e2e.SpawnWithExpect(append(prefixArgs, "put", kvs[i].key, kvs[i].val), expect.ExpectedResponse{Value: "OK"})
+		require.NoError(t, err)
 	}
 
 	fpath := filepath.Join(t.TempDir(), "test.snapshot")
@@ -244,9 +243,8 @@ func testIssue6361(t *testing.T) {
 
 	t.Log("Ensuring the restored member has the correct data...")
 	for i := range kvs {
-		if err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val}); err != nil {
-			t.Fatal(err)
-		}
+		err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val})
+		require.NoError(t, err)
 	}
 
 	t.Log("Adding new member into the cluster")
@@ -281,9 +279,8 @@ func testIssue6361(t *testing.T) {
 
 	t.Log("Ensuring added member has data from incoming snapshot...")
 	for i := range kvs {
-		if err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val}); err != nil {
-			t.Fatal(err)
-		}
+		err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val})
+		require.NoError(t, err)
 	}
 
 	t.Log("Stopping the second member")

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -88,9 +88,8 @@ func TestEtcdMultiPeer(t *testing.T) {
 	}
 
 	for _, p := range procs {
-		if err := e2e.WaitReadyExpectProc(context.TODO(), p, e2e.EtcdServerReadyLines); err != nil {
-			t.Fatal(err)
-		}
+		err := e2e.WaitReadyExpectProc(context.TODO(), p, e2e.EtcdServerReadyLines)
+		require.NoError(t, err)
 	}
 }
 
@@ -247,9 +246,8 @@ func TestEtcdPeerCNAuth(t *testing.T) {
 		} else {
 			expect = []string{"remote error: tls: bad certificate"}
 		}
-		if err := e2e.WaitReadyExpectProc(context.TODO(), p, expect); err != nil {
-			t.Fatal(err)
-		}
+		err := e2e.WaitReadyExpectProc(context.TODO(), p, expect)
+		require.NoError(t, err)
 	}
 }
 
@@ -337,9 +335,8 @@ func TestEtcdPeerMultiCNAuth(t *testing.T) {
 		} else {
 			expect = []string{"remote error: tls: bad certificate"}
 		}
-		if err := e2e.WaitReadyExpectProc(context.TODO(), p, expect); err != nil {
-			t.Fatal(err)
-		}
+		err := e2e.WaitReadyExpectProc(context.TODO(), p, expect)
+		require.NoError(t, err)
 	}
 }
 
@@ -413,9 +410,8 @@ func TestEtcdPeerNameAuth(t *testing.T) {
 		} else {
 			expect = []string{"client certificate authentication failed"}
 		}
-		if err := e2e.WaitReadyExpectProc(context.TODO(), p, expect); err != nil {
-			t.Fatal(err)
-		}
+		err := e2e.WaitReadyExpectProc(context.TODO(), p, expect)
+		require.NoError(t, err)
 	}
 }
 
@@ -522,9 +518,8 @@ func TestEtcdPeerLocalAddr(t *testing.T) {
 		} else {
 			expect = []string{"x509: certificate is valid for 127.0.0.1, not "}
 		}
-		if err := e2e.WaitReadyExpectProc(context.TODO(), p, expect); err != nil {
-			t.Fatal(err)
-		}
+		err := e2e.WaitReadyExpectProc(context.TODO(), p, expect)
+		require.NoError(t, err)
 	}
 }
 

--- a/tests/integration/clientv3/lease/lease_test.go
+++ b/tests/integration/clientv3/lease/lease_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -546,9 +548,8 @@ func TestLeaseTimeToLive(t *testing.T) {
 	kv := clus.RandClient()
 	keys := []string{"foo1", "foo2"}
 	for i := range keys {
-		if _, err = kv.Put(context.TODO(), keys[i], "bar", clientv3.WithLease(resp.ID)); err != nil {
-			t.Fatal(err)
-		}
+		_, err = kv.Put(context.TODO(), keys[i], "bar", clientv3.WithLease(resp.ID))
+		require.NoError(t, err)
 	}
 
 	// linearized read to ensure Puts propagated to server backing lapi

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -102,9 +103,8 @@ func TestLeasingInterval(t *testing.T) {
 
 	keys := []string{"abc/a", "abc/b", "abc/a/a"}
 	for _, k := range keys {
-		if _, err = clus.Client(0).Put(context.TODO(), k, "v"); err != nil {
-			t.Fatal(err)
-		}
+		_, err = clus.Client(0).Put(context.TODO(), k, "v")
+		require.NoError(t, err)
 	}
 
 	resp, err := lkv.Get(context.TODO(), "abc/", clientv3.WithPrefix())
@@ -353,9 +353,8 @@ func TestLeasingGetWithOpts(t *testing.T) {
 		clientv3.WithSerializable(),
 	}
 	for _, opt := range opts {
-		if _, err := lkv.Get(context.TODO(), "k", opt); err != nil {
-			t.Fatal(err)
-		}
+		_, err := lkv.Get(context.TODO(), "k", opt)
+		require.NoError(t, err)
 	}
 
 	var getOpts []clientv3.OpOption
@@ -599,9 +598,8 @@ func TestLeasingTxnOwnerGetRange(t *testing.T) {
 	keyCount := rand.Intn(10) + 1
 	for i := 0; i < keyCount; i++ {
 		k := fmt.Sprintf("k-%d", i)
-		if _, err := clus.Client(0).Put(context.TODO(), k, k+k); err != nil {
-			t.Fatal(err)
-		}
+		_, err := clus.Client(0).Put(context.TODO(), k, k+k)
+		require.NoError(t, err)
 	}
 	if _, err := lkv.Get(context.TODO(), "k-"); err != nil {
 		t.Fatal(err)
@@ -649,9 +647,8 @@ func TestLeasingTxnOwnerGet(t *testing.T) {
 		}
 		presps[i] = presp
 
-		if _, err = lkv.Get(context.TODO(), k); err != nil {
-			t.Fatal(err)
-		}
+		_, err = lkv.Get(context.TODO(), k)
+		require.NoError(t, err)
 		ops = append(ops, clientv3.OpGet(k))
 	}
 
@@ -1161,9 +1158,8 @@ func testLeasingOwnerDelete(t *testing.T, del clientv3.Op) {
 	defer closeLKV()
 
 	for i := 0; i < 8; i++ {
-		if _, err = clus.Client(0).Put(context.TODO(), fmt.Sprintf("key/%d", i), "123"); err != nil {
-			t.Fatal(err)
-		}
+		_, err = clus.Client(0).Put(context.TODO(), fmt.Sprintf("key/%d", i), "123")
+		require.NoError(t, err)
 	}
 
 	if _, err = lkv.Get(context.TODO(), "key/1"); err != nil {
@@ -1214,12 +1210,10 @@ func TestLeasingDeleteRangeBounds(t *testing.T) {
 	defer closeGetKv()
 
 	for _, k := range []string{"j", "m"} {
-		if _, err = clus.Client(0).Put(context.TODO(), k, "123"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err = getkv.Get(context.TODO(), k); err != nil {
-			t.Fatal(err)
-		}
+		_, err = clus.Client(0).Put(context.TODO(), k, "123")
+		require.NoError(t, err)
+		_, err = getkv.Get(context.TODO(), k)
+		require.NoError(t, err)
 	}
 
 	if _, err = delkv.Delete(context.TODO(), "k", clientv3.WithPrefix()); err != nil {
@@ -1274,12 +1268,10 @@ func testLeasingDeleteRangeContend(t *testing.T, op clientv3.Op) {
 	const maxKey = 8
 	for i := 0; i < maxKey; i++ {
 		key := fmt.Sprintf("key/%d", i)
-		if _, err = clus.Client(0).Put(context.TODO(), key, "123"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err = putkv.Get(context.TODO(), key); err != nil {
-			t.Fatal(err)
-		}
+		_, err = clus.Client(0).Put(context.TODO(), key, "123")
+		require.NoError(t, err)
+		_, err = putkv.Get(context.TODO(), key)
+		require.NoError(t, err)
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -1335,16 +1327,13 @@ func TestLeasingPutGetDeleteConcurrent(t *testing.T) {
 	}
 
 	getdel := func(kv clientv3.KV) {
-		if _, err := kv.Put(context.TODO(), "k", "abc"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := kv.Put(context.TODO(), "k", "abc")
+		require.NoError(t, err)
 		time.Sleep(time.Millisecond)
-		if _, err := kv.Get(context.TODO(), "k"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := kv.Delete(context.TODO(), "k"); err != nil {
-			t.Fatal(err)
-		}
+		_, err = kv.Get(context.TODO(), "k")
+		require.NoError(t, err)
+		_, err = kv.Delete(context.TODO(), "k")
+		require.NoError(t, err)
 		time.Sleep(2 * time.Millisecond)
 	}
 
@@ -1503,15 +1492,12 @@ func TestLeasingReconnectOwnerConsistency(t *testing.T) {
 	defer closeLKV()
 	assert.NoError(t, err)
 
-	if _, err = lkv.Put(context.TODO(), "k", "x"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err = lkv.Put(context.TODO(), "kk", "y"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv.Put(context.TODO(), "k", "x")
+	require.NoError(t, err)
+	_, err = lkv.Put(context.TODO(), "kk", "y")
+	require.NoError(t, err)
+	_, err = lkv.Get(context.TODO(), "k")
+	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		v := fmt.Sprintf("%d", i)
@@ -1556,13 +1542,9 @@ func TestLeasingReconnectOwnerConsistency(t *testing.T) {
 	}
 
 	lresp, lerr := lkv.Get(context.TODO(), "k")
-	if lerr != nil {
-		t.Fatal(lerr)
-	}
+	require.NoError(t, lerr)
 	cresp, cerr := clus.Client(0).Get(context.TODO(), "k")
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	if !reflect.DeepEqual(lresp.Kvs, cresp.Kvs) {
 		t.Fatalf("expected %+v, got %+v", cresp, lresp)
 	}
@@ -1582,13 +1564,11 @@ func TestLeasingTxnAtomicCache(t *testing.T) {
 		k := fmt.Sprintf("k-%d", i)
 		puts[i], gets[i] = clientv3.OpPut(k, k), clientv3.OpGet(k)
 	}
-	if _, err = clus.Client(0).Txn(context.TODO()).Then(puts...).Commit(); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Txn(context.TODO()).Then(puts...).Commit()
+	require.NoError(t, err)
 	for i := range gets {
-		if _, err = lkv.Do(context.TODO(), gets[i]); err != nil {
-			t.Fatal(err)
-		}
+		_, err = lkv.Do(context.TODO(), gets[i])
+		require.NoError(t, err)
 	}
 
 	numPutters, numGetters := 16, 16
@@ -1663,9 +1643,8 @@ func TestLeasingReconnectTxn(t *testing.T) {
 	assert.NoError(t, err)
 	defer closeLKV()
 
-	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv.Get(context.TODO(), "k")
+	require.NoError(t, err)
 
 	donec := make(chan struct{})
 	go func() {
@@ -1683,9 +1662,7 @@ func TestLeasingReconnectTxn(t *testing.T) {
 		Then(clientv3.OpGet("k")).
 		Commit()
 	<-donec
-	if lerr != nil {
-		t.Fatal(lerr)
-	}
+	require.NoError(t, lerr)
 }
 
 // TestLeasingReconnectNonOwnerGet checks a get error on an owner will
@@ -1702,9 +1679,8 @@ func TestLeasingReconnectNonOwnerGet(t *testing.T) {
 	// populate a few keys so some leasing gets have keys
 	for i := 0; i < 4; i++ {
 		k := fmt.Sprintf("k-%d", i*2)
-		if _, err = lkv.Put(context.TODO(), k, k[2:]); err != nil {
-			t.Fatal(err)
-		}
+		_, err = lkv.Put(context.TODO(), k, k[2:])
+		require.NoError(t, err)
 	}
 
 	n := 0
@@ -1728,13 +1704,9 @@ func TestLeasingReconnectNonOwnerGet(t *testing.T) {
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("k-%d", i)
 		lresp, lerr := lkv.Get(context.TODO(), k)
-		if lerr != nil {
-			t.Fatal(lerr)
-		}
+		require.NoError(t, lerr)
 		cresp, cerr := clus.Client(0).Get(context.TODO(), k)
-		if cerr != nil {
-			t.Fatal(cerr)
-		}
+		require.NoError(t, cerr)
 		if !reflect.DeepEqual(lresp.Kvs, cresp.Kvs) {
 			t.Fatalf("expected %+v, got %+v", cresp, lresp)
 		}
@@ -1750,27 +1722,21 @@ func TestLeasingTxnRangeCmp(t *testing.T) {
 	assert.NoError(t, err)
 	defer closeLKV()
 
-	if _, err = clus.Client(0).Put(context.TODO(), "k", "a"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Put(context.TODO(), "k", "a")
+	require.NoError(t, err)
 	// k2 version = 2
-	if _, err = clus.Client(0).Put(context.TODO(), "k2", "a"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err = clus.Client(0).Put(context.TODO(), "k2", "a"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Put(context.TODO(), "k2", "a")
+	require.NoError(t, err)
+	_, err = clus.Client(0).Put(context.TODO(), "k2", "a")
+	require.NoError(t, err)
 
 	// cache k
-	if _, err = lkv.Get(context.TODO(), "k"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv.Get(context.TODO(), "k")
+	require.NoError(t, err)
 
 	cmp := clientv3.Compare(clientv3.Version("k").WithPrefix(), "=", 1)
 	tresp, terr := lkv.Txn(context.TODO()).If(cmp).Commit()
-	if terr != nil {
-		t.Fatal(terr)
-	}
+	require.NoError(t, terr)
 	if tresp.Succeeded {
 		t.Fatalf("expected Succeeded=false, got %+v", tresp)
 	}
@@ -1810,9 +1776,7 @@ func TestLeasingDo(t *testing.T) {
 	}
 
 	gresp, err := clus.Client(0).Get(context.TODO(), "a", clientv3.WithPrefix())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(gresp.Kvs) != 0 {
 		t.Fatalf("expected no keys, got %+v", gresp.Kvs)
 	}
@@ -1831,17 +1795,14 @@ func TestLeasingTxnOwnerPutBranch(t *testing.T) {
 	treeOp := makePutTreeOp("tree", &n, 4)
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("tree/%d", i)
-		if _, err = clus.Client(0).Put(context.TODO(), k, "a"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err = lkv.Get(context.TODO(), k); err != nil {
-			t.Fatal(err)
-		}
+		_, err = clus.Client(0).Put(context.TODO(), k, "a")
+		require.NoError(t, err)
+		_, err = lkv.Get(context.TODO(), k)
+		require.NoError(t, err)
 	}
 
-	if _, err = lkv.Do(context.TODO(), treeOp); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv.Do(context.TODO(), treeOp)
+	require.NoError(t, err)
 
 	// lkv shouldn't need to call out to server for updated leased keys
 	clus.Members[0].Stop(t)
@@ -1849,13 +1810,9 @@ func TestLeasingTxnOwnerPutBranch(t *testing.T) {
 	for i := 0; i < n; i++ {
 		k := fmt.Sprintf("tree/%d", i)
 		lkvResp, err := lkv.Get(context.TODO(), k)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		clusResp, err := clus.Client(1).Get(context.TODO(), k)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if !reflect.DeepEqual(clusResp.Kvs, lkvResp.Kvs) {
 			t.Fatalf("expected %+v, got %+v", clusResp.Kvs, lkvResp.Kvs)
 		}
@@ -1925,26 +1882,21 @@ func TestLeasingSessionExpire(t *testing.T) {
 	defer closeLKV2()
 
 	// acquire lease on abc
-	if _, err = lkv.Get(context.TODO(), "abc"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv.Get(context.TODO(), "abc")
+	require.NoError(t, err)
 
 	// down endpoint lkv uses for keepalives
 	clus.Members[0].Stop(t)
-	if err = waitForLeasingExpire(clus.Client(1), "foo/abc"); err != nil {
-		t.Fatal(err)
-	}
+	err = waitForLeasingExpire(clus.Client(1), "foo/abc")
+	require.NoError(t, err)
 	waitForExpireAck(t, lkv)
 	clus.Members[0].Restart(t)
 	integration2.WaitClientV3(t, lkv2)
-	if _, err = lkv2.Put(context.TODO(), "abc", "def"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = lkv2.Put(context.TODO(), "abc", "def")
+	require.NoError(t, err)
 
 	resp, err := lkv.Get(context.TODO(), "abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if v := string(resp.Kvs[0].Value); v != "def" {
 		t.Fatalf("expected %q, got %q", "v", v)
 	}
@@ -1996,15 +1948,13 @@ func TestLeasingSessionExpireCancel(t *testing.T) {
 			assert.NoError(t, err)
 			defer closeLKV()
 
-			if _, err = lkv.Get(context.TODO(), "abc"); err != nil {
-				t.Fatal(err)
-			}
+			_, err = lkv.Get(context.TODO(), "abc")
+			require.NoError(t, err)
 
 			// down endpoint lkv uses for keepalives
 			clus.Members[0].Stop(t)
-			if err := waitForLeasingExpire(clus.Client(1), "foo/abc"); err != nil {
-				t.Fatal(err)
-			}
+			err = waitForLeasingExpire(clus.Client(1), "foo/abc")
+			require.NoError(t, err)
 			waitForExpireAck(t, lkv)
 
 			ctx, cancel := context.WithCancel(context.TODO())

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -50,18 +50,16 @@ func TestMaintenanceHashKV(t *testing.T) {
 	defer clus.Terminate(t)
 
 	for i := 0; i < 3; i++ {
-		if _, err := clus.RandClient().Put(context.Background(), "foo", "bar"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := clus.RandClient().Put(context.Background(), "foo", "bar")
+		require.NoError(t, err)
 	}
 
 	var hv uint32
 	for i := 0; i < 3; i++ {
 		cli := clus.Client(i)
 		// ensure writes are replicated
-		if _, err := cli.Get(context.TODO(), "foo"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := cli.Get(context.TODO(), "foo")
+		require.NoError(t, err)
 		hresp, err := cli.HashKV(context.Background(), clus.Members[i].GRPCURL, 0)
 		if err != nil {
 			t.Fatal(err)

--- a/tests/integration/clientv3/snapshot/v3_snapshot_test.go
+++ b/tests/integration/clientv3/snapshot/v3_snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
@@ -93,9 +94,7 @@ func createSnapshotFile(t *testing.T, cfg *embed.Config, kvs []kv) (version stri
 		"Snapshot creation tests are depending on embedded etcd server so are integration-level tests.")
 
 	srv, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() {
 		srv.Close()
 	}()
@@ -107,24 +106,18 @@ func createSnapshotFile(t *testing.T, cfg *embed.Config, kvs []kv) (version stri
 
 	ccfg := clientv3.Config{Endpoints: []string{cfg.AdvertiseClientUrls[0].String()}}
 	cli, err := integration2.NewClient(t, ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 	for i := range kvs {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
 		_, err = cli.Put(ctx, kvs[i].k, kvs[i].v)
 		cancel()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	dbPath = filepath.Join(t.TempDir(), fmt.Sprintf("snapshot%d.db", time.Now().Nanosecond()))
 	version, err = snapshot.SaveWithVersion(context.Background(), zaptest.NewLogger(t), ccfg, dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return version, dbPath
 }
 

--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
@@ -437,9 +438,8 @@ func TestWatchResumeCompacted(t *testing.T) {
 	numPuts := 5
 	kv := clus.Client(1)
 	for i := 0; i < numPuts; i++ {
-		if _, err := kv.Put(context.TODO(), "foo", "bar"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := kv.Put(context.TODO(), "foo", "bar")
+		require.NoError(t, err)
 	}
 	if _, err := kv.Compact(context.TODO(), 3); err != nil {
 		t.Fatal(err)
@@ -503,9 +503,8 @@ func TestWatchCompactRevision(t *testing.T) {
 	// set some keys
 	kv := clus.RandClient()
 	for i := 0; i < 5; i++ {
-		if _, err := kv.Put(context.TODO(), "foo", "bar"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := kv.Put(context.TODO(), "foo", "bar")
+		require.NoError(t, err)
 	}
 
 	w := clus.RandClient()

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -186,9 +188,8 @@ func TestAddMemberAfterClusterFullRotation(t *testing.T) {
 
 	// remove all the previous three members and add in three new members.
 	for i := 0; i < 3; i++ {
-		if err := c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[1].Server.MemberID())); err != nil {
-			t.Fatal(err)
-		}
+		err := c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[1].Server.MemberID()))
+		require.NoError(t, err)
 		c.WaitMembersForLeader(t, c.Members)
 
 		c.AddMember(t)

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
@@ -148,9 +149,7 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	cfg.Dir = filepath.Join(t.TempDir(), "embed-etcd")
 
 	e, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	<-e.Server.ReadyNotify() // wait for e.Server to join the cluster
 
 	clientCfg := clientv3.Config{
@@ -158,14 +157,10 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	}
 	if secure {
 		clientCfg.TLS, err = testTLSInfo.ClientConfig()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 	cli, err := integration2.NewClient(t, clientCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	// open watch connection
@@ -182,9 +177,7 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 		t.Fatalf("took too long to close server")
 	}
 	err = <-e.Err()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func newEmbedURLs(secure bool, n int) (urls []url.URL) {

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -65,9 +65,8 @@ func testMetricDbSizeDefrag(t *testing.T, name string) {
 	putreq := &pb.PutRequest{Key: []byte("k"), Value: make([]byte, 4096)}
 	for i := 0; i < numPuts; i++ {
 		time.Sleep(10 * time.Millisecond) // to execute multiple backend txn
-		if _, err := kvc.Put(context.TODO(), putreq); err != nil {
-			t.Fatal(err)
-		}
+		_, err := kvc.Put(context.TODO(), putreq)
+		require.NoError(t, err)
 	}
 
 	// wait for backend txn sync

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
@@ -132,17 +133,13 @@ func newClusterProxyServer(lg *zap.Logger, endpoints []string, prefix string, t 
 		DialTimeout: 5 * time.Second,
 	}
 	client, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cts := &clusterproxyTestServer{
 		c: client,
 	}
 	cts.l, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var opts []grpc.ServerOption
 	cts.server = grpc.NewServer(opts...)
 	servec := make(chan struct{})

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -72,9 +73,7 @@ func newKVProxyServer(endpoints []string, t *testing.T) *kvproxyTestServer {
 		DialTimeout: 5 * time.Second,
 	}
 	client, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kvp, _ := grpcproxy.NewKvProxy(client)
 
@@ -88,9 +87,7 @@ func newKVProxyServer(endpoints []string, t *testing.T) *kvproxyTestServer {
 	pb.RegisterKVServer(kvts.server, kvts.kp)
 
 	kvts.l, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	go kvts.server.Serve(kvts.l)
 

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -322,15 +322,12 @@ func TestV3AuthWithLeaseAttach(t *testing.T) {
 
 func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
 	for _, user := range users {
-		if _, err := auth.UserAdd(context.TODO(), &pb.AuthUserAddRequest{Name: user.name, Password: user.password, Options: &authpb.UserAddOptions{NoPassword: false}}); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := auth.RoleAdd(context.TODO(), &pb.AuthRoleAddRequest{Name: user.role}); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := auth.UserGrantRole(context.TODO(), &pb.AuthUserGrantRoleRequest{User: user.name, Role: user.role}); err != nil {
-			t.Fatal(err)
-		}
+		_, err := auth.UserAdd(context.TODO(), &pb.AuthUserAddRequest{Name: user.name, Password: user.password, Options: &authpb.UserAddOptions{NoPassword: false}})
+		require.NoError(t, err)
+		_, err = auth.RoleAdd(context.TODO(), &pb.AuthRoleAddRequest{Name: user.role})
+		require.NoError(t, err)
+		_, err = auth.UserGrantRole(context.TODO(), &pb.AuthUserGrantRoleRequest{User: user.name, Role: user.role})
+		require.NoError(t, err)
 
 		if len(user.key) == 0 {
 			continue
@@ -341,9 +338,8 @@ func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
 			Key:      []byte(user.key),
 			RangeEnd: []byte(user.end),
 		}
-		if _, err := auth.RoleGrantPermission(context.TODO(), &pb.AuthRoleGrantPermissionRequest{Name: user.role, Perm: perm}); err != nil {
-			t.Fatal(err)
-		}
+		_, err = auth.RoleGrantPermission(context.TODO(), &pb.AuthRoleGrantPermissionRequest{Name: user.role, Perm: perm})
+		require.NoError(t, err)
 	}
 }
 

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -489,9 +490,8 @@ func TestV3TxnCmpHeaderRev(t *testing.T) {
 		}
 
 		prev := <-revc
-		if err := <-errCh; err != nil {
-			t.Fatal(err)
-		}
+		err = <-errCh
+		require.NoError(t, err)
 		// put followed txn; should eval to false
 		if prev > tresp.Header.Revision && !tresp.Succeeded {
 			t.Errorf("#%d: got else but put rev %d followed txn rev (%+v)", i, prev, tresp)
@@ -511,9 +511,8 @@ func TestV3TxnRangeCompare(t *testing.T) {
 
 	// put keys, named by expected revision
 	for _, k := range []string{"/a/2", "/a/3", "/a/4", "/f/5"} {
-		if _, err := clus.Client(0).Put(context.TODO(), k, "x"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := clus.Client(0).Put(context.TODO(), k, "x")
+		require.NoError(t, err)
 	}
 
 	tests := []struct {
@@ -1640,33 +1639,27 @@ func TestTLSReloadAtomicReplace(t *testing.T) {
 		if terr != nil {
 			t.Fatal(terr)
 		}
-		if _, err := copyTLSFiles(integration.TestTLSInfoExpired, certsDirExp); err != nil {
-			t.Fatal(err)
-		}
+		_, err := copyTLSFiles(integration.TestTLSInfoExpired, certsDirExp)
+		require.NoError(t, err)
 		return tlsInfo
 	}
 	replaceFunc := func() {
-		if err := os.Rename(certsDir, tmpDir); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Rename(certsDirExp, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		err := os.Rename(certsDir, tmpDir)
+		require.NoError(t, err)
+		err = os.Rename(certsDirExp, certsDir)
+		require.NoError(t, err)
 		// after rename,
 		// 'certsDir' contains expired certs
 		// 'tmpDir' contains valid certs
 		// 'certsDirExp' does not exist
 	}
 	revertFunc := func() {
-		if err := os.Rename(tmpDir, certsDirExp); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Rename(certsDir, tmpDir); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Rename(certsDirExp, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		err := os.Rename(tmpDir, certsDirExp)
+		require.NoError(t, err)
+		err = os.Rename(certsDir, tmpDir)
+		require.NoError(t, err)
+		err = os.Rename(certsDirExp, certsDir)
+		require.NoError(t, err)
 	}
 	testTLSReload(t, cloneFunc, replaceFunc, revertFunc, false)
 }
@@ -1685,14 +1678,12 @@ func TestTLSReloadCopy(t *testing.T) {
 		return tlsInfo
 	}
 	replaceFunc := func() {
-		if _, err := copyTLSFiles(integration.TestTLSInfoExpired, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		_, err := copyTLSFiles(integration.TestTLSInfoExpired, certsDir)
+		require.NoError(t, err)
 	}
 	revertFunc := func() {
-		if _, err := copyTLSFiles(integration.TestTLSInfo, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		_, err := copyTLSFiles(integration.TestTLSInfo, certsDir)
+		require.NoError(t, err)
 	}
 	testTLSReload(t, cloneFunc, replaceFunc, revertFunc, false)
 }
@@ -1711,14 +1702,12 @@ func TestTLSReloadCopyIPOnly(t *testing.T) {
 		return tlsInfo
 	}
 	replaceFunc := func() {
-		if _, err := copyTLSFiles(integration.TestTLSInfoExpiredIP, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		_, err := copyTLSFiles(integration.TestTLSInfoExpiredIP, certsDir)
+		require.NoError(t, err)
 	}
 	revertFunc := func() {
-		if _, err := copyTLSFiles(integration.TestTLSInfoIP, certsDir); err != nil {
-			t.Fatal(err)
-		}
+		_, err := copyTLSFiles(integration.TestTLSInfoIP, certsDir)
+		require.NoError(t, err)
 	}
 	testTLSReload(t, cloneFunc, replaceFunc, revertFunc, true)
 }

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -543,9 +543,8 @@ func testLeaseStress(t *testing.T, stresser func(context.Context, pb.LeaseClient
 	}
 
 	for i := 0; i < 300; i++ {
-		if err := <-errc; err != nil {
-			t.Fatal(err)
-		}
+		err := <-errc
+		require.NoError(t, err)
 	}
 }
 
@@ -640,9 +639,8 @@ func TestV3GetNonExistLease(t *testing.T) {
 
 	for _, m := range clus.Members {
 		// quorum-read to ensure revoke completes before TimeToLive
-		if _, err := integration.ToGRPC(m.Client).KV.Range(ctx, &pb.RangeRequest{Key: []byte("_")}); err != nil {
-			t.Fatal(err)
-		}
+		_, err := integration.ToGRPC(m.Client).KV.Range(ctx, &pb.RangeRequest{Key: []byte("_")})
+		require.NoError(t, err)
 		resp, err := integration.ToGRPC(m.Client).Lease.LeaseTimeToLive(ctx, leaseTTLr)
 		if err != nil {
 			t.Fatalf("expected non nil error, but go %v", err)

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -1274,9 +1274,8 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 	}}
 	for i, tt := range tests {
 		kvc := integration.ToGRPC(clus.RandClient()).KV
-		if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])}); err != nil {
-			t.Fatal(err)
-		}
+		_, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])})
+		require.NoError(t, err)
 
 		ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(wctx)
 		if werr != nil {
@@ -1289,16 +1288,13 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 				RangeEnd: []byte(tt.end),
 				PrevKv:   true,
 			}}}
-		if err := ws.Send(req); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := ws.Recv(); err != nil {
-			t.Fatal(err)
-		}
+		err = ws.Send(req)
+		require.NoError(t, err)
+		_, err = ws.Recv()
+		require.NoError(t, err)
 
-		if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])}); err != nil {
-			t.Fatal(err)
-		}
+		_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])})
+		require.NoError(t, err)
 
 		recv := make(chan *pb.WatchResponse, 1)
 		go func() {

--- a/tests/integration/v3election_grpc_test.go
+++ b/tests/integration/v3election_grpc_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	epb "go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -160,9 +162,8 @@ func TestV3ElectionObserve(t *testing.T) {
 	for i := 1; i < 5; i++ {
 		v := []byte(fmt.Sprintf("%d", i))
 		req := &epb.ProclaimRequest{Leader: c1.Leader, Value: v}
-		if _, err := lc.Proclaim(context.TODO(), req); err != nil {
-			t.Fatal(err)
-		}
+		_, err := lc.Proclaim(context.TODO(), req)
+		require.NoError(t, err)
 	}
 	// start second leader
 	lc.Resign(context.TODO(), &epb.ResignRequest{Leader: c1.Leader})

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
@@ -51,14 +52,10 @@ func TestRobustnessExploratory(t *testing.T) {
 			s.Cluster.Logger = lg
 			ctx := context.Background()
 			c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.Cluster))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer forcestopCluster(c)
 			s.Failpoint, err = failpoint.PickRandom(c, s.Profile)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			t.Run(s.Failpoint.Name(), func(t *testing.T) {
 				testRobustness(ctx, t, lg, s, c)
 			})
@@ -74,9 +71,7 @@ func TestRobustnessRegression(t *testing.T) {
 			s.Cluster.Logger = lg
 			ctx := context.Background()
 			c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.Cluster))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer forcestopCluster(c)
 			testRobustness(ctx, t, lg, s, c)
 		})
@@ -94,9 +89,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenari
 	}()
 	r.Client = runScenario(ctx, t, s, lg, c)
 	persistedRequests, err := report.PersistedRequestsCluster(lg, c)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	failpointImpactingWatch := s.Failpoint == failpoint.SleepBeforeSendWatchResponse
 	if !failpointImpactingWatch {

--- a/tests/robustness/model/deterministic_test.go
+++ b/tests/robustness/model/deterministic_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 )
@@ -35,9 +36,7 @@ func TestModelDeterministic(t *testing.T) {
 					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.expectFailure, ok, DeterministicModel.DescribeOperation(op.req, op.resp.EtcdResponse))
 					var loadedState EtcdState
 					err := json.Unmarshal([]byte(state.(string)), &loadedState)
-					if err != nil {
-						t.Fatalf("Failed to load state: %v", err)
-					}
+					require.NoErrorf(t, err, "Failed to load state")
 					_, resp := loadedState.Step(op.req)
 					t.Errorf("Response diff: %s", cmp.Diff(op.resp, resp))
 					break

--- a/tests/robustness/model/non_deterministic_test.go
+++ b/tests/robustness/model/non_deterministic_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 )
@@ -335,9 +336,7 @@ func TestModelNonDeterministic(t *testing.T) {
 					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.expectFailure, ok, NonDeterministicModel.DescribeOperation(op.req, op.resp))
 					var loadedState nonDeterministicState
 					err := json.Unmarshal([]byte(state.(string)), &loadedState)
-					if err != nil {
-						t.Fatalf("Failed to load state: %v", err)
-					}
+					require.NoErrorf(t, err, "Failed to load state")
 					for i, s := range loadedState {
 						_, resp := s.Step(op.req)
 						t.Errorf("For state %d, response diff: %s", i, cmp.Diff(op.resp, resp))

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -44,15 +45,11 @@ func TestDataReports(t *testing.T) {
 			assert.NoError(t, err)
 
 			persistedRequests, err := report.LoadClusterPersistedRequests(lg, path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			visualize := ValidateAndReturnVisualize(t, zaptest.NewLogger(t), Config{}, reports, persistedRequests, 5*time.Minute)
 
 			err = visualize(filepath.Join(path, "history.html"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
There is no linter for this.
This uses testify instead of testing for
With 
```go
require.NoError(t, err)

require.Error(t, err)
```
instead of

```go
if err != nil {
    t.Fatal(err)
}


if err == nil {
    t.Fatal(err)
}
```