### PR TITLE
fix: enable gofumpt instead of gofmt linter in contrib, etcdctl and etcdutl

### DIFF
--- a/contrib/raftexample/raft.go
+++ b/contrib/raftexample/raft.go
@@ -86,7 +86,8 @@ var defaultSnapshotCount uint64 = 10000
 // commit channel, followed by a nil message (to indicate the channel is
 // current), then new log entries. To shutdown, close proposeC and read errorC.
 func newRaftNode(id int, peers []string, join bool, getSnapshot func() ([]byte, error), proposeC <-chan string,
-	confChangeC <-chan raftpb.ConfChange) (<-chan *commit, <-chan error, <-chan *snap.Snapshotter) {
+	confChangeC <-chan raftpb.ConfChange,
+) (<-chan *commit, <-chan error, <-chan *snap.Snapshotter) {
 	commitC := make(chan *commit)
 	errorC := make(chan error)
 
@@ -218,7 +219,7 @@ func (rc *raftNode) loadSnapshot() *raftpb.Snapshot {
 // openWAL returns a WAL ready for reading.
 func (rc *raftNode) openWAL(snapshot *raftpb.Snapshot) *wal.WAL {
 	if !wal.Exist(rc.waldir) {
-		if err := os.Mkdir(rc.waldir, 0750); err != nil {
+		if err := os.Mkdir(rc.waldir, 0o750); err != nil {
 			log.Fatalf("raftexample: cannot create dir for wal (%v)", err)
 		}
 
@@ -273,7 +274,7 @@ func (rc *raftNode) writeError(err error) {
 
 func (rc *raftNode) startRaft() {
 	if !fileutil.Exist(rc.snapdir) {
-		if err := os.Mkdir(rc.snapdir, 0750); err != nil {
+		if err := os.Mkdir(rc.snapdir, 0o750); err != nil {
 			log.Fatalf("raftexample: cannot create dir for snapshot (%v)", err)
 		}
 	}

--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -139,7 +139,7 @@ func NewCheckPerfCommand() *cobra.Command {
 
 // newCheckPerfCommand executes the "check perf" command.
 func newCheckPerfCommand(cmd *cobra.Command, args []string) {
-	var checkPerfAlias = map[string]string{
+	checkPerfAlias := map[string]string{
 		"s": "s", "small": "s",
 		"m": "m", "medium": "m",
 		"l": "l", "large": "l",
@@ -312,7 +312,7 @@ func NewCheckDatascaleCommand() *cobra.Command {
 
 // newCheckDatascaleCommand executes the "check datascale" command.
 func newCheckDatascaleCommand(cmd *cobra.Command, args []string) {
-	var checkDatascaleAlias = map[string]string{
+	checkDatascaleAlias := map[string]string{
 		"s": "s", "small": "s",
 		"m": "m", "medium": "m",
 		"l": "l", "large": "l",

--- a/etcdctl/ctlv3/command/elect_command.go
+++ b/etcdctl/ctlv3/command/elect_command.go
@@ -28,9 +28,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
 
-var (
-	electListen bool
-)
+var electListen bool
 
 // NewElectCommand returns the cobra command for "elect".
 func NewElectCommand() *cobra.Command {

--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -32,8 +32,10 @@ import (
 	"go.etcd.io/etcd/pkg/v3/flags"
 )
 
-var epClusterEndpoints bool
-var epHashKVRev int64
+var (
+	epClusterEndpoints bool
+	epHashKVRev        int64
+)
 
 // NewEndpointCommand returns the cobra command for "endpoint".
 func NewEndpointCommand() *cobra.Command {

--- a/etcdctl/ctlv3/command/lease_command.go
+++ b/etcdctl/ctlv3/command/lease_command.go
@@ -151,9 +151,7 @@ func leaseListCommandFunc(cmd *cobra.Command, args []string) {
 	display.Leases(*resp)
 }
 
-var (
-	leaseKeepAliveOnce bool
-)
+var leaseKeepAliveOnce bool
 
 // NewLeaseKeepAliveCommand returns the cobra command for "lease keep-alive".
 func NewLeaseKeepAliveCommand() *cobra.Command {

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -111,9 +111,11 @@ func (p *printerRPC) MemberAdd(r v3.MemberAddResponse) { p.p((*pb.MemberAddRespo
 func (p *printerRPC) MemberRemove(id uint64, r v3.MemberRemoveResponse) {
 	p.p((*pb.MemberRemoveResponse)(&r))
 }
+
 func (p *printerRPC) MemberUpdate(id uint64, r v3.MemberUpdateResponse) {
 	p.p((*pb.MemberUpdateResponse)(&r))
 }
+
 func (p *printerRPC) MemberPromote(id uint64, r v3.MemberPromoteResponse) {
 	p.p((*pb.MemberPromoteResponse)(&r))
 }
@@ -134,6 +136,7 @@ func (p *printerRPC) RoleList(r v3.AuthRoleListResponse) { p.p((*pb.AuthRoleList
 func (p *printerRPC) RoleGrantPermission(_ string, r v3.AuthRoleGrantPermissionResponse) {
 	p.p((*pb.AuthRoleGrantPermissionResponse)(&r))
 }
+
 func (p *printerRPC) RoleRevokePermission(_ string, _ string, _ string, r v3.AuthRoleRevokePermissionResponse) {
 	p.p((*pb.AuthRoleRevokePermissionResponse)(&r))
 }
@@ -143,15 +146,19 @@ func (p *printerRPC) UserList(r v3.AuthUserListResponse)         { p.p((*pb.Auth
 func (p *printerRPC) UserChangePassword(r v3.AuthUserChangePasswordResponse) {
 	p.p((*pb.AuthUserChangePasswordResponse)(&r))
 }
+
 func (p *printerRPC) UserGrantRole(_ string, _ string, r v3.AuthUserGrantRoleResponse) {
 	p.p((*pb.AuthUserGrantRoleResponse)(&r))
 }
+
 func (p *printerRPC) UserRevokeRole(_ string, _ string, r v3.AuthUserRevokeRoleResponse) {
 	p.p((*pb.AuthUserRevokeRoleResponse)(&r))
 }
+
 func (p *printerRPC) UserDelete(_ string, r v3.AuthUserDeleteResponse) {
 	p.p((*pb.AuthUserDeleteResponse)(&r))
 }
+
 func (p *printerRPC) AuthStatus(r v3.AuthStatusResponse) {
 	p.p((*pb.AuthStatusResponse)(&r))
 }
@@ -211,8 +218,10 @@ func makeEndpointHealthTable(healthList []epHealth) (hdr []string, rows [][]stri
 }
 
 func makeEndpointStatusTable(statusList []epStatus) (hdr []string, rows [][]string) {
-	hdr = []string{"endpoint", "ID", "version", "storage version", "db size", "in use", "percentage not in use", "quota", "is leader", "is learner", "raft term",
-		"raft index", "raft applied index", "errors"}
+	hdr = []string{
+		"endpoint", "ID", "version", "storage version", "db size", "in use", "percentage not in use", "quota", "is leader", "is learner", "raft term",
+		"raft index", "raft applied index", "errors",
+	}
 	for _, status := range statusList {
 		rows = append(rows, []string{
 			status.Ep,

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -248,9 +248,11 @@ func (p *fieldsPrinter) RoleList(r v3.AuthRoleListResponse) {
 	}
 	fmt.Println()
 }
+
 func (p *fieldsPrinter) RoleGrantPermission(role string, r v3.AuthRoleGrantPermissionResponse) {
 	p.hdr(r.Header)
 }
+
 func (p *fieldsPrinter) RoleRevokePermission(role string, key string, end string, r v3.AuthRoleRevokePermissionResponse) {
 	p.hdr(r.Header)
 }
@@ -259,6 +261,7 @@ func (p *fieldsPrinter) UserChangePassword(r v3.AuthUserChangePasswordResponse) 
 func (p *fieldsPrinter) UserGrantRole(user string, role string, r v3.AuthUserGrantRoleResponse) {
 	p.hdr(r.Header)
 }
+
 func (p *fieldsPrinter) UserRevokeRole(user string, role string, r v3.AuthUserRevokeRoleResponse) {
 	p.hdr(r.Header)
 }

--- a/etcdctl/ctlv3/command/printer_simple.go
+++ b/etcdctl/ctlv3/command/printer_simple.go
@@ -183,9 +183,11 @@ func (s *simplePrinter) MoveLeader(leader, target uint64, r v3.MoveLeaderRespons
 func (s *simplePrinter) DowngradeValidate(r v3.DowngradeResponse) {
 	fmt.Printf("Downgrade validate success, cluster version %s\n", r.Version)
 }
+
 func (s *simplePrinter) DowngradeEnable(r v3.DowngradeResponse) {
 	fmt.Printf("Downgrade enable success, cluster version %s\n", r.Version)
 }
+
 func (s *simplePrinter) DowngradeCancel(r v3.DowngradeResponse) {
 	fmt.Printf("Downgrade cancel success, cluster version %s\n", r.Version)
 }

--- a/etcdctl/ctlv3/command/printer_table.go
+++ b/etcdctl/ctlv3/command/printer_table.go
@@ -34,6 +34,7 @@ func (tp *tablePrinter) MemberList(r v3.MemberListResponse) {
 	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 }
+
 func (tp *tablePrinter) EndpointHealth(r []epHealth) {
 	hdr, rows := makeEndpointHealthTable(r)
 	table := tablewriter.NewWriter(os.Stdout)
@@ -44,6 +45,7 @@ func (tp *tablePrinter) EndpointHealth(r []epHealth) {
 	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 }
+
 func (tp *tablePrinter) EndpointStatus(r []epStatus) {
 	hdr, rows := makeEndpointStatusTable(r)
 	table := tablewriter.NewWriter(os.Stdout)
@@ -54,6 +56,7 @@ func (tp *tablePrinter) EndpointStatus(r []epStatus) {
 	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 }
+
 func (tp *tablePrinter) EndpointHashKV(r []epHashKV) {
 	hdr, rows := makeEndpointHashKVTable(r)
 	table := tablewriter.NewWriter(os.Stdout)

--- a/etcdctl/ctlv3/command/snapshot_command.go
+++ b/etcdctl/ctlv3/command/snapshot_command.go
@@ -27,8 +27,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
 
-var (
-	snapshotExample = util.Normalize(`
+var snapshotExample = util.Normalize(`
 	# Save snapshot to a given file
 	etcdctl snapshot save /backup/etcd-snapshot.db
 
@@ -46,7 +45,6 @@ var (
 
 	# Save snapshot with desirable time format
 	etcdctl snapshot save /mnt/backup/etcd/backup_$(date +%Y%m%d_%H%M%S).db`)
-)
 
 // NewSnapshotCommand returns the cobra command for "snapshot".
 func NewSnapshotCommand() *cobra.Command {

--- a/etcdctl/ctlv3/command/user_command.go
+++ b/etcdctl/ctlv3/command/user_command.go
@@ -26,9 +26,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
 
-var (
-	userShowDetail bool
-)
+var userShowDetail bool
 
 // NewUserCommand returns the cobra command for "user".
 func NewUserCommand() *cobra.Command {

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -38,10 +38,7 @@ const (
 
 var (
 	globalFlags = command.GlobalFlags{}
-)
-
-var (
-	rootCmd = &cobra.Command{
+	rootCmd     = &cobra.Command{
 		Use:        cliName,
 		Short:      cliDescription,
 		SuggestFor: []string{"etcdctl"},

--- a/etcdutl/ctl.go
+++ b/etcdutl/ctl.go
@@ -26,13 +26,11 @@ const (
 	cliDescription = "An administrative command line tool for etcd3."
 )
 
-var (
-	rootCmd = &cobra.Command{
-		Use:        cliName,
-		Short:      cliDescription,
-		SuggestFor: []string{"etcdutl"},
-	}
-)
+var rootCmd = &cobra.Command{
+	Use:        cliName,
+	Short:      cliDescription,
+	SuggestFor: []string{"etcdutl"},
+}
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&etcdutl.OutputFormat, "write-out", "w", "simple", "set the output format (fields, json, protobuf, simple, table)")

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -26,9 +26,7 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/datadir"
 )
 
-var (
-	defragDataDir string
-)
+var defragDataDir string
 
 // NewDefragCommand returns the cobra command for "Defrag".
 func NewDefragCommand() *cobra.Command {

--- a/etcdutl/etcdutl/hashkv_command.go
+++ b/etcdutl/etcdutl/hashkv_command.go
@@ -23,9 +23,7 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-var (
-	hashKVRevision int64
-)
+var hashKVRevision int64
 
 // NewHashKVCommand returns the cobra command for "hashkv".
 func NewHashKVCommand() *cobra.Command {

--- a/etcdutl/etcdutl/printer.go
+++ b/etcdutl/etcdutl/printer.go
@@ -25,9 +25,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
 
-var (
-	OutputFormat string
-)
+var OutputFormat string
 
 type printer interface {
 	DBStatus(snapshot.Status)

--- a/etcdutl/etcdutl/printer_simple.go
+++ b/etcdutl/etcdutl/printer_simple.go
@@ -21,8 +21,7 @@ import (
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
 )
 
-type simplePrinter struct {
-}
+type simplePrinter struct{}
 
 func (s *simplePrinter) DBStatus(ds snapshot.Status) {
 	_, rows := makeDBStatusTable(ds)

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -120,7 +120,8 @@ func SnapshotRestoreCommandFunc(restoreCluster string,
 	initialMmapSize uint64,
 	revisionBump uint64,
 	markCompacted bool,
-	args []string) {
+	args []string,
+) {
 	if len(args) != 1 {
 		err := fmt.Errorf("snapshot restore requires exactly one argument")
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)

--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -119,7 +119,7 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 		return ds, err
 	}
 
-	db, err := bolt.Open(dbPath, 0400, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(dbPath, 0o400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return ds, err
 	}
@@ -449,7 +449,7 @@ func (s *v3Manager) copyAndVerifyDB() error {
 
 	outDbPath := s.outDbPath()
 
-	db, dberr := os.OpenFile(outDbPath, os.O_RDWR|os.O_CREATE, 0600)
+	db, dberr := os.OpenFile(outDbPath, os.O_RDWR|os.O_CREATE, 0o600)
 	if dberr != nil {
 		return dberr
 	}

--- a/etcdutl/snapshot/v3_snapshot_test.go
+++ b/etcdutl/snapshot/v3_snapshot_test.go
@@ -52,7 +52,7 @@ func TestSnapshotStatus(t *testing.T) {
 func TestSnapshotStatusCorruptRevision(t *testing.T) {
 	dbpath := createDB(t, insertKeys(t, 1, 0))
 
-	db, err := bbolt.Open(dbpath, 0600, nil)
+	db, err := bbolt.Open(dbpath, 0o600, nil)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -74,7 +74,7 @@ func TestSnapshotStatusCorruptRevision(t *testing.T) {
 func TestSnapshotStatusNegativeRevisionMain(t *testing.T) {
 	dbpath := createDB(t, insertKeys(t, 1, 0))
 
-	db, err := bbolt.Open(dbpath, 0666, nil)
+	db, err := bbolt.Open(dbpath, 0o666, nil)
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -98,7 +98,7 @@ func TestSnapshotStatusNegativeRevisionMain(t *testing.T) {
 func TestSnapshotStatusNegativeRevisionSub(t *testing.T) {
 	dbpath := createDB(t, insertKeys(t, 1, 0))
 
-	db, err := bbolt.Open(dbpath, 0666, nil)
+	db, err := bbolt.Open(dbpath, 0o666, nil)
 	require.NoError(t, err)
 	defer db.Close()
 


### PR DESCRIPTION
enables and fixes [gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) linter issues in contrib, etcdctl and etcdutl directories