### PR TITLE
discuss: fdatasync over fsync in WAL

### DIFF
--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -90,8 +90,8 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 			}
 
 			start := time.Now()
-			if err = fileutil.Fsync(f.File); err != nil {
-				lg.Warn("failed to fsync", zap.String("path", f.Name()), zap.Error(err))
+			if err = fileutil.Fdatasync(f.File); err != nil {
+				lg.Warn("failed to fdatasync", zap.String("path", f.Name()), zap.Error(err))
 				return false
 			}
 			walFsyncSec.Observe(time.Since(start).Seconds())

--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -215,10 +215,10 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 		return nil
 	}
 	start := time.Now()
-	if perr = fileutil.Fsync(pdir); perr != nil {
+	if perr = fileutil.Fdatasync(pdir); perr != nil {
 		dirCloser()
 		lg.Warn(
-			"failed to fsync the parent data directory file",
+			"failed to fdatasync the parent data directory file",
 			zap.String("parent-dir-path", filepath.Dir(w.dir)),
 			zap.String("dir-path", w.dir),
 			zap.Error(perr),
@@ -795,7 +795,7 @@ func (w *WAL) cut() error {
 		return err
 	}
 	start := time.Now()
-	if err = fileutil.Fsync(w.dirFile); err != nil {
+	if err = fileutil.Fdatasync(w.dirFile); err != nil {
 		return err
 	}
 	walFsyncSec.Observe(time.Since(start).Seconds())


### PR DESCRIPTION
I'm sure there is a good reason for using `fsync` over `fdatasync`, but from my testing I was able to see a pretty big drop in reported latency.

<img width="922" alt="image" src="https://github.com/user-attachments/assets/f1e88a90-99c2-487a-93b5-17fbe2557185">
(`etcd.disk.wal.fsync.duration.seconds per member_id * 1000` to get `ms`)

the `check perf` subcommand yielded slightly better results also (although they are close, I am getting over 4k wps consistently. Was getting <4k before).

before
```
etcdctl check perf --load=l
 60 / 60 Boooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00% 1m0s
FAIL: Throughput too low: 3955 writes/s
Slowest request took too long: 0.744556s
PASS: Stddev is 0.043627s
FAIL
```
after
```
etcdctl check perf --load=l
 60 / 60 Boooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00% 1m0s
FAIL: Throughput too low: 4152 writes/s
Slowest request took too long: 0.561690s
PASS: Stddev is 0.047042s
FAIL
``` 

I opened this PR to get an understanding into why `fsync` is used in the WAL over `fdatasync`.

Thanks!

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
