### PR TITLE
Ensure compaction is executed at even intervals to avoid overload

### DIFF
--- a/tests/robustness/random/random.go
+++ b/tests/robustness/random/random.go
@@ -28,6 +28,10 @@ func RandString(size int) string {
 	return data.String()
 }
 
+func RandRange(start, end int64) int64 {
+	return rand.Int63n(end-start) + start
+}
+
 type ChoiceWeight[T any] struct {
 	Choice T
 	Weight int


### PR DESCRIPTION
Should reduce number of flakes due to etcd being overloaded by too many compaction at once