### PR TITLE
Allow duplicated puts in robustness 

### DIFF
--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -46,56 +46,56 @@ func TestValidateSerializableOperations(t *testing.T) {
 				},
 				{
 					Input:  rangeRequest("a", "z", 2, 0),
-					Output: rangeResponse(1, keyValue("a", "1", 2)),
+					Output: rangeResponse(1, keyValueRevision("a", "1", 2)),
 				},
 				{
 					Input: rangeRequest("a", "z", 3, 0),
 					Output: rangeResponse(2,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
 					),
 				},
 				{
 					Input: rangeRequest("a", "z", 4, 0),
 					Output: rangeResponse(3,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
-						keyValue("c", "3", 4),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
+						keyValueRevision("c", "3", 4),
 					),
 				},
 				{
 					Input: rangeRequest("a", "z", 4, 3),
 					Output: rangeResponse(3,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
-						keyValue("c", "3", 4),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
+						keyValueRevision("c", "3", 4),
 					),
 				},
 				{
 					Input: rangeRequest("a", "z", 4, 4),
 					Output: rangeResponse(3,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
-						keyValue("c", "3", 4),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
+						keyValueRevision("c", "3", 4),
 					),
 				},
 				{
 					Input: rangeRequest("a", "z", 4, 2),
 					Output: rangeResponse(3,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
 					),
 				},
 				{
 					Input: rangeRequest("b\x00", "z", 4, 2),
 					Output: rangeResponse(1,
-						keyValue("c", "3", 4),
+						keyValueRevision("c", "3", 4),
 					),
 				},
 				{
 					Input: rangeRequest("b", "", 4, 0),
 					Output: rangeResponse(1,
-						keyValue("b", "2", 3),
+						keyValueRevision("b", "2", 3),
 					),
 				},
 				{
@@ -115,9 +115,9 @@ func TestValidateSerializableOperations(t *testing.T) {
 				{
 					Input: rangeRequest("a", "z", 4, 0),
 					Output: rangeResponse(3,
-						keyValue("c", "3", 4),
-						keyValue("b", "2", 3),
-						keyValue("a", "1", 2),
+						keyValueRevision("c", "3", 4),
+						keyValueRevision("b", "2", 3),
+						keyValueRevision("a", "1", 2),
 					),
 				},
 			},
@@ -149,7 +149,7 @@ func TestValidateSerializableOperations(t *testing.T) {
 				{
 					Input: rangeRequest("a", "z", 2, 0),
 					Output: rangeResponse(3,
-						keyValue("b", "2", 3),
+						keyValueRevision("b", "2", 3),
 					),
 				},
 			},
@@ -166,8 +166,8 @@ func TestValidateSerializableOperations(t *testing.T) {
 				{
 					Input: rangeRequest("a", "z", 2, 0),
 					Output: rangeResponse(3,
-						keyValue("a", "1", 2),
-						keyValue("b", "2", 3),
+						keyValueRevision("a", "1", 2),
+						keyValueRevision("b", "2", 3),
 					),
 				},
 			},
@@ -284,7 +284,7 @@ func errorResponse(err error) model.MaybeEtcdResponse {
 	}
 }
 
-func keyValue(key, value string, rev int64) model.KeyValue {
+func keyValueRevision(key, value string, rev int64) model.KeyValue {
 	return model.KeyValue{
 		Key: key,
 		ValueRevision: model.ValueRevision{

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -76,7 +76,6 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 			continue
 		}
 		var resourceVersion int64
-		var matchingEvent *client.TimedWatchEvent
 		var txnPersisted bool
 		var persistedReturnTime *int64
 		for _, etcdOp := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
@@ -89,20 +88,17 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 				Value: etcdOp.Put.Value,
 			}]
 			if ok {
-				matchingEvent = &event
+				eventTime := event.Time.Nanoseconds()
+				// Set revision and time based on watchEvent.
+				if eventTime < op.Return {
+					op.Return = eventTime
+				}
+				resourceVersion = event.Revision
 			}
 			if returnTime, found := persistedOperations[etcdOp]; found {
 				persistedReturnTime = &returnTime
 				txnPersisted = true
 			}
-		}
-		if matchingEvent != nil {
-			eventTime := matchingEvent.Time.Nanoseconds()
-			// Set revision and time based on watchEvent.
-			if eventTime < op.Return {
-				op.Return = eventTime
-			}
-			resourceVersion = matchingEvent.Revision
 		}
 		if persistedReturnTime != nil {
 			// Set return time based on persisted return time.

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -75,7 +75,7 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 			newOperations = append(newOperations, op)
 			continue
 		}
-		var resourceVersion int64
+		var txnRevision int64
 		var txnPersisted bool
 		for _, etcdOp := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
 			if etcdOp.Type != model.PutOperation {
@@ -92,7 +92,7 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 				if eventTime < op.Return {
 					op.Return = eventTime
 				}
-				resourceVersion = event.Revision
+				txnRevision = event.Revision
 			}
 			if returnTime, found := persistedOperations[etcdOp]; found {
 				txnPersisted = true
@@ -108,8 +108,8 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 				// Remove non persisted operations
 				continue
 			} else {
-				if resourceVersion != 0 {
-					op.Output = model.MaybeEtcdResponse{Persisted: true, PersistedRevision: resourceVersion}
+				if txnRevision != 0 {
+					op.Output = model.MaybeEtcdResponse{Persisted: true, PersistedRevision: txnRevision}
 				} else {
 					op.Output = model.MaybeEtcdResponse{Persisted: true}
 				}

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -78,15 +78,16 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 		var resourceVersion int64
 		var matchingEvent *client.TimedWatchEvent
 		for _, etcdOp := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
-			if etcdOp.Type == model.PutOperation {
-				event, ok := watchEvents[model.Event{
-					Type:  etcdOp.Type,
-					Key:   etcdOp.Put.Key,
-					Value: etcdOp.Put.Value,
-				}]
-				if ok {
-					matchingEvent = &event
-				}
+			if etcdOp.Type != model.PutOperation {
+				continue
+			}
+			event, ok := watchEvents[model.Event{
+				Type:  etcdOp.Type,
+				Key:   etcdOp.Put.Key,
+				Value: etcdOp.Put.Value,
+			}]
+			if ok {
+				matchingEvent = &event
 			}
 		}
 		if matchingEvent != nil {

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -77,6 +77,7 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 		}
 		var resourceVersion int64
 		var matchingEvent *client.TimedWatchEvent
+		var txnPersisted bool
 		var persistedReturnTime *int64
 		for _, etcdOp := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
 			if etcdOp.Type != model.PutOperation {
@@ -92,6 +93,7 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 			}
 			if returnTime, found := persistedOperations[etcdOp]; found {
 				persistedReturnTime = &returnTime
+				txnPersisted = true
 			}
 		}
 		if matchingEvent != nil {
@@ -109,7 +111,7 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 			}
 		}
 		if isUniqueTxn(request.Txn) {
-			if persistedReturnTime == nil {
+			if !txnPersisted {
 				// Remove non persisted operations
 				continue
 			} else {

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -26,9 +26,10 @@ import (
 func patchLinearizableOperations(reports []report.ClientReport, persistedRequests []model.EtcdRequest) []porcupine.Operation {
 	allOperations := relevantOperations(reports)
 	watchRevision := requestRevision(reports)
+	clientRequestsCount := countClientRequests(reports)
 	returnTime := returnTime(allOperations, reports, persistedRequests)
 	persistedRequestsCount := countPersistedRequests(persistedRequests)
-	return patchOperations(allOperations, watchRevision, returnTime, persistedRequestsCount)
+	return patchOperations(allOperations, clientRequestsCount, watchRevision, returnTime, persistedRequestsCount)
 }
 
 func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
@@ -46,7 +47,7 @@ func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
 	return ops
 }
 
-func patchOperations(operations []porcupine.Operation, watchRevision, returnTime, persistedRequestCount map[keyValue]int64) []porcupine.Operation {
+func patchOperations(operations []porcupine.Operation, clientRequestCount, watchRevision, returnTime, persistedRequestCount map[keyValue]int64) []porcupine.Operation {
 	newOperations := make([]porcupine.Operation, 0, len(operations))
 
 	for _, op := range operations {
@@ -63,14 +64,16 @@ func patchOperations(operations []porcupine.Operation, watchRevision, returnTime
 			switch etcdOp.Type {
 			case model.PutOperation:
 				kv := keyValue{Key: etcdOp.Put.Key, Value: etcdOp.Put.Value}
-				revision, ok := watchRevision[kv]
-				if ok {
-					txnRevision = revision
+				if count := clientRequestCount[kv]; count == 1 {
+					revision, ok := watchRevision[kv]
+					if ok {
+						txnRevision = revision
+					}
+					if t, ok := returnTime[kv]; ok && t < op.Return {
+						op.Return = t
+					}
 				}
-				if t, ok := returnTime[kv]; ok && t < op.Return {
-					op.Return = t
-				}
-				_, ok = persistedRequestCount[kv]
+				_, ok := persistedRequestCount[kv]
 				if ok {
 					txnPersisted = true
 				}
@@ -80,7 +83,7 @@ func patchOperations(operations []porcupine.Operation, watchRevision, returnTime
 				panic(fmt.Sprintf("unknown operation type %q", etcdOp.Type))
 			}
 		}
-		if isUniqueTxn(request.Txn) {
+		if isUniqueTxn(request.Txn, clientRequestCount) {
 			if !txnPersisted {
 				// Remove non persisted operations
 				continue
@@ -98,26 +101,29 @@ func patchOperations(operations []porcupine.Operation, watchRevision, returnTime
 	return newOperations
 }
 
-func isUniqueTxn(request *model.TxnRequest) bool {
-	return (hasUniqueWriteOperation(request.OperationsOnSuccess) || !hasWriteOperation(request.OperationsOnSuccess)) && (hasUniqueWriteOperation(request.OperationsOnFailure) || !hasWriteOperation(request.OperationsOnFailure))
+func isUniqueTxn(request *model.TxnRequest, clientRequestCount map[keyValue]int64) bool {
+	return isUniqueOps(request.OperationsOnSuccess, clientRequestCount) && isUniqueOps(request.OperationsOnFailure, clientRequestCount)
 }
 
-func hasWriteOperation(ops []model.EtcdOperation) bool {
-	for _, etcdOp := range ops {
-		if etcdOp.Type == model.PutOperation || etcdOp.Type == model.DeleteOperation {
-			return true
+func isUniqueOps(ops []model.EtcdOperation, clientRequestCount map[keyValue]int64) bool {
+	hasUniqueWrite := false
+	hasWrite := false
+	for _, operation := range ops {
+		switch operation.Type {
+		case model.PutOperation:
+			hasWrite = true
+			kv := keyValue{Key: operation.Put.Key, Value: operation.Put.Value}
+			if count := clientRequestCount[kv]; count == 1 {
+				hasUniqueWrite = true
+			}
+		case model.DeleteOperation:
+			hasWrite = true
+		case model.RangeOperation:
+		default:
+			panic(fmt.Sprintf("unknown operation type %q", operation.Type))
 		}
 	}
-	return false
-}
-
-func hasUniqueWriteOperation(ops []model.EtcdOperation) bool {
-	for _, etcdOp := range ops {
-		if etcdOp.Type == model.PutOperation {
-			return true
-		}
-	}
-	return false
+	return hasUniqueWrite || !hasWrite
 }
 
 func returnTime(allOperations []porcupine.Operation, reports []report.ClientReport, persistedRequests []model.EtcdRequest) map[keyValue]int64 {
@@ -132,10 +138,9 @@ func returnTime(allOperations []porcupine.Operation, reports []report.ClientRepo
 					continue
 				}
 				kv := keyValue{Key: etcdOp.Put.Key, Value: etcdOp.Put.Value}
-				if _, found := earliestReturnTime[kv]; found {
-					panic("Unexpected duplicate event in persisted requests.")
+				if t, ok := earliestReturnTime[kv]; !ok || t > op.Return {
+					earliestReturnTime[kv] = op.Return
 				}
-				earliestReturnTime[kv] = op.Return
 			}
 		case model.Range:
 		case model.LeaseGrant:
@@ -193,6 +198,17 @@ func returnTime(allOperations []porcupine.Operation, reports []report.ClientRepo
 		}
 	}
 	return earliestReturnTime
+}
+
+func countClientRequests(reports []report.ClientReport) map[keyValue]int64 {
+	counter := map[keyValue]int64{}
+	for _, client := range reports {
+		for _, op := range client.KeyValue {
+			request := op.Input.(model.EtcdRequest)
+			countRequest(counter, request)
+		}
+	}
+	return counter
 }
 
 func countPersistedRequests(requests []model.EtcdRequest) map[keyValue]int64 {

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -19,16 +19,16 @@ import (
 
 	"github.com/anishathalye/porcupine"
 
-	"go.etcd.io/etcd/tests/v3/robustness/client"
 	"go.etcd.io/etcd/tests/v3/robustness/model"
 	"go.etcd.io/etcd/tests/v3/robustness/report"
 )
 
 func patchLinearizableOperations(reports []report.ClientReport, persistedRequests []model.EtcdRequest) []porcupine.Operation {
 	allOperations := relevantOperations(reports)
-	uniqueEvents := uniqueWatchEvents(reports)
-	operationsReturnTime := persistedOperationsReturnTime(allOperations, persistedRequests)
-	return patchOperations(allOperations, uniqueEvents, operationsReturnTime)
+	watchRevision := requestRevision(reports)
+	watchReturnTime := watchReturnTime(reports)
+	persistedReturnTime := persistedReturnTime(allOperations, persistedRequests)
+	return patchOperations(allOperations, watchRevision, watchReturnTime, persistedReturnTime)
 }
 
 func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
@@ -46,25 +46,7 @@ func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
 	return ops
 }
 
-func uniqueWatchEvents(reports []report.ClientReport) map[model.Event]client.TimedWatchEvent {
-	persisted := map[model.Event]client.TimedWatchEvent{}
-	for _, r := range reports {
-		for _, op := range r.Watch {
-			for _, resp := range op.Responses {
-				for _, event := range resp.Events {
-					responseTime := resp.Time
-					if prev, found := persisted[event.Event]; found && prev.Time < responseTime {
-						responseTime = prev.Time
-					}
-					persisted[event.Event] = client.TimedWatchEvent{Time: responseTime, WatchEvent: event}
-				}
-			}
-		}
-	}
-	return persisted
-}
-
-func patchOperations(operations []porcupine.Operation, watchEvents map[model.Event]client.TimedWatchEvent, persistedOperations map[model.EtcdOperation]int64) []porcupine.Operation {
+func patchOperations(operations []porcupine.Operation, watchRevision, watchReturnTime, persistedReturnTime map[keyValue]int64) []porcupine.Operation {
 	newOperations := make([]porcupine.Operation, 0, len(operations))
 
 	for _, op := range operations {
@@ -80,20 +62,15 @@ func patchOperations(operations []porcupine.Operation, watchEvents map[model.Eve
 		for _, etcdOp := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
 			switch etcdOp.Type {
 			case model.PutOperation:
-				event, ok := watchEvents[model.Event{
-					Type:  etcdOp.Type,
-					Key:   etcdOp.Put.Key,
-					Value: etcdOp.Put.Value,
-				}]
+				kv := keyValue{Key: etcdOp.Put.Key, Value: etcdOp.Put.Value}
+				revision, ok := watchRevision[kv]
 				if ok {
-					eventTime := event.Time.Nanoseconds()
-					// Set revision and time based on watchEvent.
-					if eventTime < op.Return {
-						op.Return = eventTime
-					}
-					txnRevision = event.Revision
+					txnRevision = revision
 				}
-				returnTime, ok := persistedOperations[etcdOp]
+				if t, ok := watchReturnTime[kv]; ok && t < op.Return {
+					op.Return = t
+				}
+				returnTime, ok := persistedReturnTime[kv]
 				if ok {
 					// Set return time based on persisted return time.
 					if returnTime < op.Return {
@@ -147,9 +124,9 @@ func hasUniqueWriteOperation(ops []model.EtcdOperation) bool {
 	return false
 }
 
-func persistedOperationsReturnTime(allOperations []porcupine.Operation, persistedRequests []model.EtcdRequest) map[model.EtcdOperation]int64 {
+func persistedReturnTime(allOperations []porcupine.Operation, persistedRequests []model.EtcdRequest) map[keyValue]int64 {
 	operationReturnTime := operationReturnTime(allOperations)
-	persisted := map[model.EtcdOperation]int64{}
+	persisted := map[keyValue]int64{}
 
 	lastReturnTime := maxReturnTime(operationReturnTime)
 
@@ -163,11 +140,12 @@ func persistedOperationsReturnTime(allOperations []porcupine.Operation, persiste
 				if op.Type != model.PutOperation {
 					continue
 				}
-				if _, found := persisted[op]; found {
+				kv := keyValue{Key: op.Put.Key, Value: op.Put.Value}
+				if _, found := persisted[kv]; found {
 					panic(fmt.Sprintf("Unexpected duplicate event in persisted requests. %d %+v", i, op))
 				}
 				hasPut = true
-				persisted[op] = lastReturnTime
+				persisted[kv] = lastReturnTime
 			}
 			if hasPut {
 				newReturnTime := requestReturnTime(operationReturnTime, request)
@@ -236,4 +214,55 @@ func requestReturnTime(operationTime map[model.EtcdOperation]int64, request mode
 	default:
 		panic(fmt.Sprintf("Unknown request type: %q", request.Type))
 	}
+}
+
+func watchReturnTime(reports []report.ClientReport) map[keyValue]int64 {
+	earliestTime := map[keyValue]int64{}
+	for _, client := range reports {
+		for _, watch := range client.Watch {
+			for _, resp := range watch.Responses {
+				for _, event := range resp.Events {
+					switch event.Type {
+					case model.RangeOperation:
+					case model.PutOperation:
+						kv := keyValue{Key: event.Key, Value: event.Value}
+						if t, ok := earliestTime[kv]; !ok || t > resp.Time.Nanoseconds() {
+							earliestTime[kv] = resp.Time.Nanoseconds()
+						}
+					case model.DeleteOperation:
+					default:
+						panic(fmt.Sprintf("unknown event type %q", event.Type))
+					}
+				}
+			}
+		}
+	}
+	return earliestTime
+}
+
+func requestRevision(reports []report.ClientReport) map[keyValue]int64 {
+	requestRevision := map[keyValue]int64{}
+	for _, client := range reports {
+		for _, watch := range client.Watch {
+			for _, resp := range watch.Responses {
+				for _, event := range resp.Events {
+					switch event.Type {
+					case model.RangeOperation:
+					case model.PutOperation:
+						kv := keyValue{Key: event.Key, Value: event.Value}
+						requestRevision[kv] = event.Revision
+					case model.DeleteOperation:
+					default:
+						panic(fmt.Sprintf("unknown event type %q", event.Type))
+					}
+				}
+			}
+		}
+	}
+	return requestRevision
+}
+
+type keyValue struct {
+	Key   string
+	Value model.ValueOrHash
 }

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -26,9 +26,9 @@ import (
 func patchLinearizableOperations(reports []report.ClientReport, persistedRequests []model.EtcdRequest) []porcupine.Operation {
 	allOperations := relevantOperations(reports)
 	watchRevision := requestRevision(reports)
-	watchReturnTime := watchReturnTime(reports)
-	persistedReturnTime := persistedReturnTime(allOperations, persistedRequests)
-	return patchOperations(allOperations, watchRevision, watchReturnTime, persistedReturnTime)
+	returnTime := returnTime(allOperations, reports, persistedRequests)
+	persistedRequestsCount := countPersistedRequests(persistedRequests)
+	return patchOperations(allOperations, watchRevision, returnTime, persistedRequestsCount)
 }
 
 func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
@@ -46,7 +46,7 @@ func relevantOperations(reports []report.ClientReport) []porcupine.Operation {
 	return ops
 }
 
-func patchOperations(operations []porcupine.Operation, watchRevision, watchReturnTime, persistedReturnTime map[keyValue]int64) []porcupine.Operation {
+func patchOperations(operations []porcupine.Operation, watchRevision, returnTime, persistedRequestCount map[keyValue]int64) []porcupine.Operation {
 	newOperations := make([]porcupine.Operation, 0, len(operations))
 
 	for _, op := range operations {
@@ -67,15 +67,11 @@ func patchOperations(operations []porcupine.Operation, watchRevision, watchRetur
 				if ok {
 					txnRevision = revision
 				}
-				if t, ok := watchReturnTime[kv]; ok && t < op.Return {
+				if t, ok := returnTime[kv]; ok && t < op.Return {
 					op.Return = t
 				}
-				returnTime, ok := persistedReturnTime[kv]
+				_, ok = persistedRequestCount[kv]
 				if ok {
-					// Set return time based on persisted return time.
-					if returnTime < op.Return {
-						op.Return = returnTime
-					}
 					txnPersisted = true
 				}
 			case model.DeleteOperation:
@@ -124,48 +120,10 @@ func hasUniqueWriteOperation(ops []model.EtcdOperation) bool {
 	return false
 }
 
-func persistedReturnTime(allOperations []porcupine.Operation, persistedRequests []model.EtcdRequest) map[keyValue]int64 {
-	operationReturnTime := operationReturnTime(allOperations)
-	persisted := map[keyValue]int64{}
-
-	lastReturnTime := maxReturnTime(operationReturnTime)
-
-	for i := len(persistedRequests) - 1; i >= 0; i-- {
-		request := persistedRequests[i]
-		switch request.Type {
-		case model.Txn:
-			hasPut := false
-			lastReturnTime--
-			for _, op := range request.Txn.OperationsOnSuccess {
-				if op.Type != model.PutOperation {
-					continue
-				}
-				kv := keyValue{Key: op.Put.Key, Value: op.Put.Value}
-				if _, found := persisted[kv]; found {
-					panic(fmt.Sprintf("Unexpected duplicate event in persisted requests. %d %+v", i, op))
-				}
-				hasPut = true
-				persisted[kv] = lastReturnTime
-			}
-			if hasPut {
-				newReturnTime := requestReturnTime(operationReturnTime, request)
-				if newReturnTime != -1 {
-					lastReturnTime = min(lastReturnTime, newReturnTime)
-				}
-			}
-		case model.LeaseGrant:
-		case model.LeaseRevoke:
-		case model.Compact:
-		default:
-			panic(fmt.Sprintf("Unknown request type: %q", request.Type))
-		}
-	}
-	return persisted
-}
-
-func operationReturnTime(operations []porcupine.Operation) map[model.EtcdOperation]int64 {
-	newOperations := map[model.EtcdOperation]int64{}
-	for _, op := range operations {
+func returnTime(allOperations []porcupine.Operation, reports []report.ClientReport, persistedRequests []model.EtcdRequest) map[keyValue]int64 {
+	earliestReturnTime := map[keyValue]int64{}
+	var lastReturnTime int64
+	for _, op := range allOperations {
 		request := op.Input.(model.EtcdRequest)
 		switch request.Type {
 		case model.Txn:
@@ -173,10 +131,11 @@ func operationReturnTime(operations []porcupine.Operation) map[model.EtcdOperati
 				if etcdOp.Type != model.PutOperation {
 					continue
 				}
-				if _, found := newOperations[etcdOp]; found {
+				kv := keyValue{Key: etcdOp.Put.Key, Value: etcdOp.Put.Value}
+				if _, found := earliestReturnTime[kv]; found {
 					panic("Unexpected duplicate event in persisted requests.")
 				}
-				newOperations[etcdOp] = op.Return
+				earliestReturnTime[kv] = op.Return
 			}
 		case model.Range:
 		case model.LeaseGrant:
@@ -185,39 +144,11 @@ func operationReturnTime(operations []porcupine.Operation) map[model.EtcdOperati
 		default:
 			panic(fmt.Sprintf("Unknown request type: %q", request.Type))
 		}
-	}
-	return newOperations
-}
-
-func maxReturnTime(operationTime map[model.EtcdOperation]int64) int64 {
-	var maxReturnTime int64
-	for _, returnTime := range operationTime {
-		if returnTime > maxReturnTime {
-			maxReturnTime = returnTime
+		if op.Return > lastReturnTime {
+			lastReturnTime = op.Return
 		}
 	}
-	return maxReturnTime
-}
 
-func requestReturnTime(operationTime map[model.EtcdOperation]int64, request model.EtcdRequest) int64 {
-	switch request.Type {
-	case model.Txn:
-		for _, op := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
-			if op.Type != model.PutOperation {
-				continue
-			}
-			if time, found := operationTime[op]; found {
-				return time
-			}
-		}
-		return -1
-	default:
-		panic(fmt.Sprintf("Unknown request type: %q", request.Type))
-	}
-}
-
-func watchReturnTime(reports []report.ClientReport) map[keyValue]int64 {
-	earliestTime := map[keyValue]int64{}
 	for _, client := range reports {
 		for _, watch := range client.Watch {
 			for _, resp := range watch.Responses {
@@ -226,8 +157,8 @@ func watchReturnTime(reports []report.ClientReport) map[keyValue]int64 {
 					case model.RangeOperation:
 					case model.PutOperation:
 						kv := keyValue{Key: event.Key, Value: event.Value}
-						if t, ok := earliestTime[kv]; !ok || t > resp.Time.Nanoseconds() {
-							earliestTime[kv] = resp.Time.Nanoseconds()
+						if t, ok := earliestReturnTime[kv]; !ok || t > resp.Time.Nanoseconds() {
+							earliestReturnTime[kv] = resp.Time.Nanoseconds()
 						}
 					case model.DeleteOperation:
 					default:
@@ -237,7 +168,63 @@ func watchReturnTime(reports []report.ClientReport) map[keyValue]int64 {
 			}
 		}
 	}
-	return earliestTime
+
+	for i := len(persistedRequests) - 1; i >= 0; i-- {
+		request := persistedRequests[i]
+		switch request.Type {
+		case model.Txn:
+			lastReturnTime--
+			for _, op := range request.Txn.OperationsOnSuccess {
+				if op.Type != model.PutOperation {
+					continue
+				}
+				kv := keyValue{Key: op.Put.Key, Value: op.Put.Value}
+				returnTime, ok := earliestReturnTime[kv]
+				if ok {
+					lastReturnTime = min(returnTime, lastReturnTime)
+					earliestReturnTime[kv] = lastReturnTime
+				}
+			}
+		case model.LeaseGrant:
+		case model.LeaseRevoke:
+		case model.Compact:
+		default:
+			panic(fmt.Sprintf("Unknown request type: %q", request.Type))
+		}
+	}
+	return earliestReturnTime
+}
+
+func countPersistedRequests(requests []model.EtcdRequest) map[keyValue]int64 {
+	counter := map[keyValue]int64{}
+	for _, request := range requests {
+		countRequest(counter, request)
+	}
+	return counter
+}
+
+func countRequest(counter map[keyValue]int64, request model.EtcdRequest) {
+	switch request.Type {
+	case model.Txn:
+		for _, operation := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
+			switch operation.Type {
+			case model.PutOperation:
+				kv := keyValue{Key: operation.Put.Key, Value: operation.Put.Value}
+				counter[kv]++
+			case model.DeleteOperation:
+			case model.RangeOperation:
+			default:
+				panic(fmt.Sprintf("unknown operation type %q", operation.Type))
+			}
+		}
+	case model.LeaseGrant:
+	case model.LeaseRevoke:
+	case model.Compact:
+	case model.Defragment:
+	case model.Range:
+	default:
+		panic(fmt.Sprintf("unknown request type %q", request.Type))
+	}
 }
 
 func requestRevision(reports []report.ClientReport) map[keyValue]int64 {

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:unparam
 package validate
 
 import (
@@ -71,7 +72,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 		},
 		{
-			name: "failed put remains if there is a matching event, return time based on next persisted request",
+			name: "failed put remains if there is a matching event, uniqueness allows for return time to be based on next persisted request",
 			historyFunc: func(h *model.AppendableHistory) {
 				h.AppendPut("key1", "value", 1, 2, nil, errors.New("failed"))
 				h.AppendPut("key2", "value", 3, 4, &clientv3.PutResponse{}, nil)
@@ -86,7 +87,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 		},
 		{
-			name: "failed put remains if there is a matching event, revision and return time based on watch",
+			name: "failed put remains if there is a matching persisted request, uniqueness allows for revision and return time to be based on watch",
 			historyFunc: func(h *model.AppendableHistory) {
 				h.AppendPut("key", "value", 1, 2, nil, errors.New("failed"))
 			},
@@ -96,6 +97,22 @@ func TestPatchHistory(t *testing.T) {
 			watchOperations: watchResponse(3, putEvent("key", "value", 2)),
 			expectedRemainingOperations: []porcupine.Operation{
 				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true, PersistedRevision: 2}},
+			},
+		},
+		{
+			name: "failed put remains if there is a matching persisted request, lack of uniqueness causes time to be untouched regardless of persisted event and watch",
+			historyFunc: func(h *model.AppendableHistory) {
+				h.AppendPut("key", "value", 1, 2, nil, errors.New("failed"))
+				h.AppendPut("key", "value", 3, 4, &clientv3.PutResponse{}, nil)
+			},
+			persistedRequest: []model.EtcdRequest{
+				putRequest("key", "value"),
+				putRequest("key", "value"),
+			},
+			watchOperations: watchResponse(3, putEvent("key", "value", 2), putEvent("key", "value", 3)),
+			expectedRemainingOperations: []porcupine.Operation{
+				{Return: 1000000004, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
 		{
@@ -137,7 +154,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 		},
 		{
-			name: "failed put with lease remains if there is a matching event, return time based on next persisted request",
+			name: "failed put with lease remains if there is a matching event, uniqueness allows return time to be based on next persisted request",
 			historyFunc: func(h *model.AppendableHistory) {
 				h.AppendPutWithLease("key1", "value", 123, 1, 2, nil, errors.New("failed"))
 				h.AppendPutWithLease("key2", "value", 234, 3, 4, &clientv3.PutResponse{}, nil)
@@ -148,6 +165,35 @@ func TestPatchHistory(t *testing.T) {
 			},
 			expectedRemainingOperations: []porcupine.Operation{
 				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
+			},
+		},
+		{
+			name: "failed put with lease remains if there is a matching event, uniqueness allows for revision and return time to be based on watch",
+			historyFunc: func(h *model.AppendableHistory) {
+				h.AppendPutWithLease("key", "value", 123, 1, 2, nil, errors.New("failed"))
+			},
+			persistedRequest: []model.EtcdRequest{
+				putRequestWithLease("key", "value", 123),
+			},
+			watchOperations: watchResponse(3, putEvent("key", "value", 2)),
+			expectedRemainingOperations: []porcupine.Operation{
+				{Return: 3, Output: model.MaybeEtcdResponse{Persisted: true, PersistedRevision: 2}},
+			},
+		},
+		{
+			name: "failed put with lease remains if there is a matching persisted request, lack of uniqueness causes time to be untouched regardless of persisted event and watch",
+			historyFunc: func(h *model.AppendableHistory) {
+				h.AppendPutWithLease("key", "value", 123, 1, 2, nil, errors.New("failed"))
+				h.AppendPutWithLease("key", "value", 321, 3, 4, &clientv3.PutResponse{}, nil)
+			},
+			persistedRequest: []model.EtcdRequest{
+				putRequestWithLease("key", "value", 123),
+				putRequestWithLease("key", "value", 321),
+			},
+			watchOperations: watchResponse(3, putEvent("key", "value", 2), putEvent("key", "value", 3)),
+			expectedRemainingOperations: []porcupine.Operation{
+				{Return: 1000000004, Output: model.MaybeEtcdResponse{Error: "failed"}},
 				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -59,11 +59,7 @@ type Config struct {
 }
 
 func checkValidationAssumptions(reports []report.ClientReport, persistedRequests []model.EtcdRequest) error {
-	err := validatePutOperationUnique(reports)
-	if err != nil {
-		return err
-	}
-	err = validateEmptyDatabaseAtStart(reports)
+	err := validateEmptyDatabaseAtStart(reports)
 	if err != nil {
 		return err
 	}
@@ -75,36 +71,6 @@ func checkValidationAssumptions(reports []report.ClientReport, persistedRequests
 	err = validateNonConcurrentClientRequests(reports)
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-func validatePutOperationUnique(reports []report.ClientReport) error {
-	type KV struct {
-		Key   string
-		Value model.ValueOrHash
-	}
-	putValue := map[KV]struct{}{}
-	for _, r := range reports {
-		for _, op := range r.KeyValue {
-			request := op.Input.(model.EtcdRequest)
-			if request.Type != model.Txn {
-				continue
-			}
-			for _, op := range append(request.Txn.OperationsOnSuccess, request.Txn.OperationsOnFailure...) {
-				if op.Type != model.PutOperation {
-					continue
-				}
-				kv := KV{
-					Key:   op.Put.Key,
-					Value: op.Put.Value,
-				}
-				if _, ok := putValue[kv]; ok {
-					return fmt.Errorf("non unique put %v, required to patch operation history", kv)
-				}
-				putValue[kv] = struct{}{}
-			}
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Rewrite patching history, so instead of patching only  puts by assuming all of them are unique, rather count client calls and only allow patching for writes that were called once. 

This is needed to implement Kubernetes like compaction that reuses same key.

cc @ah8ad3 @ahrtr @MadhavJivrajani @henrybear327

