### PR TITLE
fix: enable thelper linter in pkg and server directories (part 1)

### DIFF
--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -27,6 +27,7 @@ import (
 func init() { setDflSignal = func(syscall.Signal) {} }
 
 func waitSig(t *testing.T, c <-chan os.Signal, sig os.Signal) {
+	t.Helper()
 	select {
 	case s := <-c:
 		if s != sig {

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -47,6 +47,7 @@ func TestServer_Unix_Secure_DelayTx(t *testing.T)   { testServer(t, "unix", true
 func TestServer_TCP_Secure_DelayTx(t *testing.T)    { testServer(t, "tcp", true, true) }
 
 func testServer(t *testing.T, scheme string, secure bool, delayTx bool) {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	srcAddr, dstAddr := newUnixAddr(), newUnixAddr()
 	if scheme == "tcp" {
@@ -178,6 +179,7 @@ func createTLSInfo(lg *zap.Logger, secure bool) transport.TLSInfo {
 func TestServer_Unix_Insecure_DelayAccept(t *testing.T) { testServerDelayAccept(t, false) }
 func TestServer_Unix_Secure_DelayAccept(t *testing.T)   { testServerDelayAccept(t, true) }
 func testServerDelayAccept(t *testing.T, secure bool) {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	srcAddr, dstAddr := newUnixAddr(), newUnixAddr()
 	defer func() {
@@ -486,6 +488,7 @@ func TestServerHTTP_Secure_DelayTx(t *testing.T)   { testServerHTTP(t, true, tru
 func TestServerHTTP_Insecure_DelayRx(t *testing.T) { testServerHTTP(t, false, false) }
 func TestServerHTTP_Secure_DelayRx(t *testing.T)   { testServerHTTP(t, true, false) }
 func testServerHTTP(t *testing.T, secure, delayTx bool) {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	scheme := "tcp"
 	ln1, ln2 := listen(t, scheme, "localhost:0", transport.TLSInfo{}), listen(t, scheme, "localhost:0", transport.TLSInfo{})
@@ -634,6 +637,7 @@ func newUnixAddr() string {
 }
 
 func listen(t *testing.T, scheme, addr string, tlsInfo transport.TLSInfo) (ln net.Listener) {
+	t.Helper()
 	var err error
 	if !tlsInfo.Empty() {
 		ln, err = transport.NewListener(addr, scheme, &tlsInfo)
@@ -647,6 +651,7 @@ func listen(t *testing.T, scheme, addr string, tlsInfo transport.TLSInfo) (ln ne
 }
 
 func send(t *testing.T, data []byte, scheme, addr string, tlsInfo transport.TLSInfo) {
+	t.Helper()
 	var out net.Conn
 	var err error
 	if !tlsInfo.Empty() {
@@ -670,6 +675,7 @@ func send(t *testing.T, data []byte, scheme, addr string, tlsInfo transport.TLSI
 }
 
 func receive(t *testing.T, ln net.Listener) (data []byte) {
+	t.Helper()
 	buf := bytes.NewBuffer(make([]byte, 0, 1024))
 	for {
 		in, err := ln.Accept()
@@ -691,6 +697,7 @@ func receive(t *testing.T, ln net.Listener) (data []byte) {
 // Waits until a proxy is ready to serve.
 // Aborts test on proxy start-up error.
 func waitForServer(t *testing.T, s Server) {
+	t.Helper()
 	select {
 	case <-s.Ready():
 	case err := <-s.Error():

--- a/server/auth/jwt_test.go
+++ b/server/auth/jwt_test.go
@@ -90,6 +90,7 @@ func TestJWTInfo(t *testing.T) {
 }
 
 func testJWTInfo(t *testing.T, opts map[string]string) {
+	t.Helper()
 	lg := zap.NewNop()
 	jwt, err := newTokenProviderJWT(lg, opts)
 	if err != nil {

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -92,6 +92,7 @@ func encodePassword(s string) string {
 }
 
 func setupAuthStore(t *testing.T) (store *authStore, teardownfunc func(t *testing.T)) {
+	t.Helper()
 	tp, err := NewTokenProvider(zaptest.NewLogger(t), tokenTypeSimple, dummyIndexWaiter, simpleTokenTTLDefault)
 	if err != nil {
 		t.Fatal(err)
@@ -1152,6 +1153,7 @@ func TestAuthInfoFromCtxWithRootJWT(t *testing.T) {
 
 // testAuthInfoFromCtxWithRoot ensures "WithRoot" properly embeds token in the context.
 func testAuthInfoFromCtxWithRoot(t *testing.T, opts string) {
+	t.Helper()
 	tp, err := NewTokenProvider(zaptest.NewLogger(t), opts, dummyIndexWaiter, simpleTokenTTLDefault)
 	if err != nil {
 		t.Fatal(err)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func mustNewURLs(t *testing.T, urls []string) []url.URL {
+	t.Helper()
 	if len(urls) == 0 {
 		return nil
 	}

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -476,6 +476,7 @@ func TestParseFeatureGateFlags(t *testing.T) {
 }
 
 func mustCreateCfgFile(t *testing.T, b []byte) *os.File {
+	t.Helper()
 	tmpfile, err := os.CreateTemp("", "servercfg")
 	if err != nil {
 		t.Fatal(err)
@@ -494,6 +495,7 @@ func mustCreateCfgFile(t *testing.T, b []byte) *os.File {
 }
 
 func validateMemberFlags(t *testing.T, cfg *config) {
+	t.Helper()
 	wcfg := &embed.Config{
 		Dir:                    "testdir",
 		ListenPeerUrls:         []url.URL{{Scheme: "http", Host: "localhost:8000"}, {Scheme: "https", Host: "localhost:8001"}},
@@ -536,6 +538,7 @@ func validateMemberFlags(t *testing.T, cfg *config) {
 }
 
 func validateClusteringFlags(t *testing.T, cfg *config) {
+	t.Helper()
 	wcfg := newConfig()
 	wcfg.ec.AdvertisePeerUrls = []url.URL{{Scheme: "http", Host: "localhost:8000"}, {Scheme: "https", Host: "localhost:8001"}}
 	wcfg.ec.AdvertiseClientUrls = []url.URL{{Scheme: "http", Host: "localhost:7000"}, {Scheme: "https", Host: "localhost:7001"}}

--- a/server/etcdserver/api/rafthttp/pipeline_test.go
+++ b/server/etcdserver/api/rafthttp/pipeline_test.go
@@ -298,6 +298,7 @@ func (n *nopReadCloser) Read(p []byte) (int, error) { return 0, io.EOF }
 func (n *nopReadCloser) Close() error               { return nil }
 
 func startTestPipeline(t *testing.T, tr *Transport, picker *urlPicker) *pipeline {
+	t.Helper()
 	p := &pipeline{
 		peerID:        types.ID(1),
 		tr:            tr,

--- a/server/etcdserver/api/rafthttp/snapshot_test.go
+++ b/server/etcdserver/api/rafthttp/snapshot_test.go
@@ -94,6 +94,7 @@ func TestSnapshotSend(t *testing.T) {
 }
 
 func testSnapshotSend(t *testing.T, sm *snap.Message) (bool, []os.DirEntry) {
+	t.Helper()
 	d := t.TempDir()
 
 	r := &fakeRaft{}

--- a/server/etcdserver/api/rafthttp/urlpick_test.go
+++ b/server/etcdserver/api/rafthttp/urlpick_test.go
@@ -68,6 +68,7 @@ func TestURLPickerUnreachable(t *testing.T) {
 }
 
 func mustNewURLPicker(t *testing.T, us []string) *urlPicker {
+	t.Helper()
 	urls := testutil.MustNewURLs(t, us)
 	return newURLPicker(urls)
 }

--- a/server/etcdserver/api/v3compactor/periodic_test.go
+++ b/server/etcdserver/api/v3compactor/periodic_test.go
@@ -240,6 +240,7 @@ func TestPeriodicSkipRevNotChange(t *testing.T) {
 }
 
 func waitOneAction(t *testing.T, r testutil.Recorder) {
+	t.Helper()
 	if actions, _ := r.Wait(1); len(actions) != 1 {
 		t.Errorf("expect 1 action, got %v instead", len(actions))
 	}

--- a/server/etcdserver/api/v3rpc/validationfuzz_test.go
+++ b/server/etcdserver/api/v3rpc/validationfuzz_test.go
@@ -155,6 +155,7 @@ func FuzzTxnDeleteRangeRequest(f *testing.F) {
 }
 
 func verifyCheck(t *testing.T, check func() error) {
+	t.Helper()
 	errCheck := check()
 	if errCheck != nil {
 		t.Skip("Validation not passing. Skipping the apply.")
@@ -162,6 +163,7 @@ func verifyCheck(t *testing.T, check func() error) {
 }
 
 func execTransaction(t *testing.T, req *pb.RequestOp) {
+	t.Helper()
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, b)
 	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -71,6 +71,7 @@ type fakeSnapshotServer struct{}
 func (*fakeSnapshotServer) ForceSnapshot() {}
 
 func defaultAuthApplierV3(t *testing.T) *authApplierV3 {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	be, _ := betesting.NewDefaultTmpBackend(t)
 	t.Cleanup(func() {
@@ -125,6 +126,7 @@ const (
 )
 
 func mustCreateRolesAndEnableAuth(t *testing.T, authApplier *authApplierV3) {
+	t.Helper()
 	_, err := authApplier.UserAdd(&pb.AuthUserAddRequest{Name: userRoot, Options: &authpb.UserAddOptions{NoPassword: true}})
 	require.NoError(t, err)
 	_, err = authApplier.RoleAdd(&pb.AuthRoleAddRequest{Name: roleRoot})

--- a/server/etcdserver/apply/uber_applier_test.go
+++ b/server/etcdserver/apply/uber_applier_test.go
@@ -37,6 +37,7 @@ import (
 const memberID = 111195
 
 func defaultUberApplier(t *testing.T) UberApplier {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	be, _ := betesting.NewDefaultTmpBackend(t)
 	t.Cleanup(func() {

--- a/server/lease/leasehttp/http_test.go
+++ b/server/lease/leasehttp/http_test.go
@@ -93,6 +93,7 @@ func TestTimeToLiveHTTPTimeout(t *testing.T) {
 }
 
 func testApplyTimeout(t *testing.T, f func(*lease.Lease, string) error) {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	be, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
 	defer betesting.Close(t, be)

--- a/server/lease/lessor_test.go
+++ b/server/lease/lessor_test.go
@@ -210,6 +210,7 @@ func TestLessorRevoke(t *testing.T) {
 }
 
 func renew(t *testing.T, le *lessor, id LeaseID) int64 {
+	t.Helper()
 	ch := make(chan int64, 1)
 	errch := make(chan error, 1)
 	go func() {
@@ -689,6 +690,7 @@ func (fd *fakeDeleter) DeleteRange(key, end []byte) (int64, int64) {
 }
 
 func NewTestBackend(t *testing.T) (string, backend.Backend) {
+	t.Helper()
 	lg := zaptest.NewLogger(t)
 	tmpPath := t.TempDir()
 	bcfg := backend.DefaultBackendConfig(lg)

--- a/server/storage/backend/batch_tx_test.go
+++ b/server/storage/backend/batch_tx_test.go
@@ -349,6 +349,7 @@ func TestRangeAfterOverwriteAndDeleteMatch(t *testing.T) {
 }
 
 func checkRangeResponseMatch(t *testing.T, tx backend.BatchTx, rtx backend.ReadTx, bucket backend.Bucket, key, endKey []byte, limit int64) {
+	t.Helper()
 	tx.Lock()
 	ks1, vs1 := tx.UnsafeRange(bucket, key, endKey, limit)
 	tx.Unlock()
@@ -366,6 +367,7 @@ func checkRangeResponseMatch(t *testing.T, tx backend.BatchTx, rtx backend.ReadT
 }
 
 func checkForEach(t *testing.T, tx backend.BatchTx, rtx backend.ReadTx, expectedKeys, expectedValues [][]byte) {
+	t.Helper()
 	tx.Lock()
 	checkUnsafeForEach(t, tx, expectedKeys, expectedValues)
 	tx.Unlock()
@@ -376,6 +378,7 @@ func checkForEach(t *testing.T, tx backend.BatchTx, rtx backend.ReadTx, expected
 }
 
 func checkUnsafeForEach(t *testing.T, tx backend.UnsafeReader, expectedKeys, expectedValues [][]byte) {
+	t.Helper()
 	var ks, vs [][]byte
 	tx.UnsafeForEach(schema.Test, func(k, v []byte) error {
 		ks = append(ks, k)
@@ -393,9 +396,9 @@ func checkUnsafeForEach(t *testing.T, tx backend.UnsafeReader, expectedKeys, exp
 
 // runWriteback is used test the txWriteBuffer.writeback function, which is called inside tx.Unlock().
 // The parameters are chosen based on defaultBatchLimit = 10000
-func runWriteback(t testing.TB, kss, vss [][]string, isSeq bool) {
-	b, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
-	defer betesting.Close(t, b)
+func runWriteback(tb testing.TB, kss, vss [][]string, isSeq bool) {
+	b, _ := betesting.NewTmpBackend(tb, time.Hour, 10000)
+	defer betesting.Close(tb, b)
 
 	tx := b.BatchTx()
 
@@ -444,6 +447,7 @@ func BenchmarkWritebackNonSeqBatches1000BatchSize10(b *testing.B) {
 }
 
 func benchmarkWriteback(b *testing.B, batches, batchSize int, isSeq bool) {
+	b.Helper()
 	// kss and vss are key and value arrays to write with size batches*batchSize
 	var kss, vss [][]string
 	for i := 0; i < batches; i++ {

--- a/server/storage/backend/hooks_test.go
+++ b/server/storage/backend/hooks_test.go
@@ -94,11 +94,11 @@ func TestBackendAutoCommitBatchIntervalHook(t *testing.T) {
 	waitUntil(ctx, t, func() bool { return getCommitsKey(t, be) == ">ccc" })
 }
 
-func waitUntil(ctx context.Context, t testing.TB, f func() bool) {
+func waitUntil(ctx context.Context, tb testing.TB, f func() bool) {
 	for !f() {
 		select {
 		case <-ctx.Done():
-			t.Fatalf("Context cancelled/timedout without condition met: %v", ctx.Err())
+			tb.Fatalf("Context cancelled/timedout without condition met: %v", ctx.Err())
 		default:
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/server/storage/mvcc/testutil/hash.go
+++ b/server/storage/mvcc/testutil/hash.go
@@ -58,6 +58,7 @@ type KeyValueHash struct {
 }
 
 func testCompactionHash(ctx context.Context, t *testing.T, h CompactionHashTestCase, start, stop int64) {
+	t.Helper()
 	for i := start; i <= stop; i++ {
 		if i%67 == 0 {
 			err := h.Delete(ctx, PickKey(i+83))

--- a/server/storage/wal/testing/waltesting.go
+++ b/server/storage/wal/testing/waltesting.go
@@ -28,32 +28,32 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
-	t.Helper()
-	dir, err := os.MkdirTemp(t.TempDir(), "etcd_wal_test")
+func NewTmpWAL(tb testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
+	tb.Helper()
+	dir, err := os.MkdirTemp(tb.TempDir(), "etcd_wal_test")
 	if err != nil {
 		panic(err)
 	}
 	tmpPath := filepath.Join(dir, "wal")
-	lg := zaptest.NewLogger(t)
+	lg := zaptest.NewLogger(tb)
 	w, err := wal.Create(lg, tmpPath, nil)
 	if err != nil {
-		t.Fatalf("Failed to create WAL: %v", err)
+		tb.Fatalf("Failed to create WAL: %v", err)
 	}
 	err = w.Close()
 	if err != nil {
-		t.Fatalf("Failed to close WAL: %v", err)
+		tb.Fatalf("Failed to close WAL: %v", err)
 	}
 	if len(reqs) != 0 {
 		w, err = wal.Open(lg, tmpPath, walpb.Snapshot{})
 		if err != nil {
-			t.Fatalf("Failed to open WAL: %v", err)
+			tb.Fatalf("Failed to open WAL: %v", err)
 		}
 
 		var state raftpb.HardState
 		_, state, _, err = w.ReadAll()
 		if err != nil {
-			t.Fatalf("Failed to read WAL: %v", err)
+			tb.Fatalf("Failed to read WAL: %v", err)
 		}
 		var entries []raftpb.Entry
 		for _, req := range reqs {
@@ -66,27 +66,27 @@ func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL,
 		}
 		err = w.Save(state, entries)
 		if err != nil {
-			t.Fatalf("Failed to save WAL: %v", err)
+			tb.Fatalf("Failed to save WAL: %v", err)
 		}
 		err = w.Close()
 		if err != nil {
-			t.Fatalf("Failed to close WAL: %v", err)
+			tb.Fatalf("Failed to close WAL: %v", err)
 		}
 	}
 
 	w, err = wal.OpenForRead(lg, tmpPath, walpb.Snapshot{})
 	if err != nil {
-		t.Fatalf("Failed to open WAL: %v", err)
+		tb.Fatalf("Failed to open WAL: %v", err)
 	}
 	return w, tmpPath
 }
 
-func Reopen(t testing.TB, walPath string) *wal.WAL {
-	t.Helper()
-	lg := zaptest.NewLogger(t)
+func Reopen(tb testing.TB, walPath string) *wal.WAL {
+	tb.Helper()
+	lg := zaptest.NewLogger(tb)
 	w, err := wal.OpenForRead(lg, walPath, walpb.Snapshot{})
 	if err != nil {
-		t.Fatalf("Failed to open WAL: %v", err)
+		tb.Fatalf("Failed to open WAL: %v", err)
 	}
 	return w
 }


### PR DESCRIPTION
enables and fixes [thelper](https://golangci-lint.run/usage/linters/#thelper) linter issues in pkg and server directories

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->