### PR TITLE
fix: enable float-compare rule from testifylint

### DIFF
--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -192,7 +192,7 @@ func TestBackoffJitterFraction(t *testing.T) {
 	require.NotNil(t, c)
 	defer c.Close()
 
-	require.Equal(t, backoffJitterFraction, c.cfg.BackoffJitterFraction)
+	require.InDelta(t, backoffJitterFraction, c.cfg.BackoffJitterFraction, 0.01)
 }
 
 func TestIsHaltErr(t *testing.T) {

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -111,7 +111,6 @@ linters-settings: # please keep this alphabetized
       - ST1019 # Importing the same package multiple times.
   testifylint:
     disable:
-      - float-compare
       - go-require
       - require-error
     enable-all: true


### PR DESCRIPTION
This fixes [float-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#float-compare) rule from [testifylint](https://github.com/Antonboom/testifylint).

Related to #18719

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->