### PR TITLE
Define a `DLocker` interface for distributed locker

### DIFF
--- a/contrib/lock/README.md
+++ b/contrib/lock/README.md
@@ -64,7 +64,7 @@ If things go well the second client process invoked as `./client 2` finishes soo
 After checking this, please hit any key for `./client 1` and resume the process. It will show an output like below:
 ```
 resuming client 1
-expected fail to write to storage with old lease version: error: given version (694d82254d5fa305) is different from the existing version (694d82254e18770a)
+expected fail to write to storage with old lease version: error: given version (8) is smaller than the existing version (10)
 ```
 
 [fencing]: https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html

--- a/contrib/lock/storage/storage.go
+++ b/contrib/lock/storage/storage.go
@@ -78,8 +78,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		}
 	} else if strings.Compare(req.Op, "write") == 0 {
 		if val, ok := data[req.Key]; ok {
-			if req.Version != val.version {
-				writeResponse(response{"", -1, fmt.Sprintf("given version (%x) is different from the existing version (%x)", req.Version, val.version)}, w)
+			if req.Version < val.version {
+				writeResponse(response{"", -1, fmt.Sprintf("given version (%d) is smaller than the existing version (%d)", req.Version, val.version)}, w)
 			} else {
 				data[req.Key].val = req.Val
 				data[req.Key].version = req.Version


### PR DESCRIPTION
Also updated the [contrib/lock](https://github.com/etcd-io/etcd/tree/main/contrib/lock) example to demo how to use the `DLocker`. 

For more background, please refer to [the article by Martin Kleppmann](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html).

- It should be an improvement to help users better use etcd as a distributed lock.
- It's also backward compatible. It won't break any existing applications


