### PR TITLE
Fix e2e/ctl_v3_auth_test.go:123:5: declaration of err shadows declara…

### DIFF
--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -120,7 +120,7 @@ func authTestCertCN(cx ctlCtx) {
 
 	// try a granted key
 	cx.user, cx.pass = "", ""
-	if err := ctlV3Put(cx, "hoo", "bar", ""); err != nil {
+	if err = ctlV3Put(cx, "hoo", "bar", ""); err != nil {
 		cx.t.Error(err)
 	}
 


### PR DESCRIPTION
…tion at line 106

The error was detected in https://github.com/etcd-io/etcd/pull/18779

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/18779/pull-etcd-verify/1849478681680941056

It's weird why the main branch didn't see this failure. @ivanvc 

```
stderr: e2e/ctl_v3_auth_test.go:123:5: declaration of "err" shadows declaration at line 106
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
