### PR TITLE
fix: use require instead of t.Fatal(err) in tests/robustness package

### DIFF
--- a/tests/robustness/client/watch.go
+++ b/tests/robustness/client/watch.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/robustness/identity"
 	"go.etcd.io/etcd/tests/v3/robustness/report"
@@ -32,9 +34,7 @@ func CollectClusterWatchEvents(ctx context.Context, t *testing.T, clus *e2e.Etcd
 	memberMaxRevisionChans := make([]chan int64, len(clus.Procs))
 	for i, member := range clus.Procs {
 		c, err := NewRecordingClient(member.EndpointsGRPC(), ids, baseTime)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		memberMaxRevisionChan := make(chan int64, 1)
 		memberMaxRevisionChans[i] = memberMaxRevisionChan
 		wg.Add(1)

--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -56,9 +57,8 @@ func (f memberReplace) Inject(ctx context.Context, t *testing.T, lg *zap.Logger,
 	if err != nil {
 		return nil, err
 	}
-	if !found {
-		t.Fatal("Member not found")
-	}
+	require.Truef(t, found, "Member not found")
+
 	// Need to wait health interval for cluster to accept member changes
 	time.Sleep(etcdserver.HealthInterval)
 	lg.Info("Removing member", zap.String("member", member.Config().Name))
@@ -70,9 +70,7 @@ func (f memberReplace) Inject(ctx context.Context, t *testing.T, lg *zap.Logger,
 	if err != nil {
 		return nil, err
 	}
-	if found {
-		t.Fatal("Expected member to be removed")
-	}
+	require.Falsef(t, found, "Expected member to be removed")
 
 	for member.IsRunning() {
 		err = member.Kill()

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/anishathalye/porcupine"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/tests/v3/robustness/model"
@@ -53,9 +54,7 @@ func persistClientReports(t *testing.T, lg *zap.Logger, path string, reports []C
 	for _, r := range reports {
 		clientDir := filepath.Join(path, fmt.Sprintf("client-%d", r.ClientID))
 		err := os.MkdirAll(clientDir, 0700)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if len(r.Watch) != 0 {
 			persistWatchOperations(t, lg, filepath.Join(clientDir, "watch.json"), r.Watch)
 		} else {

--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -45,17 +46,11 @@ func testResultsDirectory(t *testing.T) string {
 	}
 	path, err := filepath.Abs(filepath.Join(
 		resultsDirectory, strings.ReplaceAll(t.Name(), "/", "_"), fmt.Sprintf("%v", time.Now().UnixNano())))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = os.RemoveAll(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = os.MkdirAll(path, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return path
 }
 
@@ -84,9 +79,7 @@ func (r *TestReport) Report(t *testing.T, force bool) {
 func persistMemberDataDir(t *testing.T, lg *zap.Logger, member e2e.EtcdProcess, path string) {
 	lg.Info("Saving member data dir", zap.String("member", member.Config().Name), zap.String("path", path))
 	err := os.Rename(memberDataDir(member), path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func memberDataDir(member e2e.EtcdProcess) string {

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -153,9 +155,7 @@ func Exploratory(_ *testing.T) []TestScenario {
 
 func Regression(t *testing.T) []TestScenario {
 	v, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
-	if err != nil {
-		t.Fatalf("Failed checking etcd version binary, binary: %q, err: %v", e2e.BinPath.Etcd, err)
-	}
+	require.NoErrorf(t, err, "Failed checking etcd version binary, binary: %q", e2e.BinPath.Etcd)
 
 	scenarios := []TestScenario{}
 	scenarios = append(scenarios, TestScenario{

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/anishathalye/porcupine"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/tests/v3/robustness/model"
@@ -30,9 +31,7 @@ import (
 // ValidateAndReturnVisualize returns visualize as porcupine.linearizationInfo used to generate visualization is private.
 func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, reports []report.ClientReport, persistedRequests []model.EtcdRequest, timeout time.Duration) (visualize func(basepath string) error) {
 	err := checkValidationAssumptions(reports, persistedRequests)
-	if err != nil {
-		t.Fatalf("Broken validation assumptions: %s", err)
-	}
+	require.NoErrorf(t, err, "Broken validation assumptions")
 	linearizableOperations := patchLinearizableOperations(reports, persistedRequests)
 	serializableOperations := filterSerializableOperations(reports)
 


### PR DESCRIPTION
There is no linter for this.
This uses testify instead of testing for t.Fatal calls

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->