### PR TITLE
fix: enable require-error rule from testifylint in client, pkg and server packages

### DIFF
--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
@@ -31,9 +32,9 @@ func BeforeTest(tb testing.TB) {
 	revertVerifyFunc := verify.EnableAllVerifications()
 
 	path, err := os.Getwd()
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
 	tempDir := tb.TempDir()
-	assert.NoError(tb, os.Chdir(tempDir))
+	require.NoError(tb, os.Chdir(tempDir))
 	tb.Logf("Changing working directory to: %s", tempDir)
 
 	tb.Cleanup(func() {

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -559,7 +559,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 	now := time.Now()
 	if secure {
 		tp, terr := transport.NewTransport(tlsInfo, 3*time.Second)
-		assert.NoError(t, terr)
+		require.NoError(t, terr)
 		cli := &http.Client{Transport: tp}
 		resp, err = cli.Post("https://"+srcAddr+"/hello", "", strings.NewReader(data))
 		defer cli.CloseIdleConnections()
@@ -568,7 +568,7 @@ func testServerHTTP(t *testing.T, secure, delayTx bool) {
 		resp, err = http.Post("http://"+srcAddr+"/hello", "", strings.NewReader(data))
 		defer http.DefaultClient.CloseIdleConnections()
 	}
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	d, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)

--- a/server/etcdserver/api/membership/storev2_test.go
+++ b/server/etcdserver/api/membership/storev2_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2store"
@@ -29,23 +30,23 @@ func TestIsMetaStoreOnly(t *testing.T) {
 	s := v2store.New("/0", "/1")
 
 	metaOnly, err := IsMetaStoreOnly(s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	mustSaveClusterVersionToStore(lg, s, semver.New("3.5.17"))
 	metaOnly, err = IsMetaStoreOnly(s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	mustSaveMemberToStore(lg, s, &Member{ID: 0x00abcd})
 	metaOnly, err = IsMetaStoreOnly(s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
 	_, err = s.Create("/1/foo", false, "v1", false, v2store.TTLOptionSet{ExpireTime: v2store.Permanent})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	metaOnly, err = IsMetaStoreOnly(s)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Falsef(t, metaOnly, "Just created v2store should be meta-only")
 
 	_, err = s.Delete("/1/foo", false, false)

--- a/server/etcdserver/api/v2store/store_ttl_test.go
+++ b/server/etcdserver/api/v2store/store_ttl_test.go
@@ -38,7 +38,7 @@ func TestMinExpireTime(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 	var eidx uint64 = 1
 	e, err := s.Get("/foo", true, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, eidx, e.EtcdIndex)
 	assert.Equal(t, "get", e.Action)
 	assert.Equal(t, "/foo", e.Node.Key)
@@ -60,7 +60,7 @@ func TestStoreGetDirectory(t *testing.T) {
 	s.Create("/foo/baz/ttl", false, "Y", false, TTLOptionSet{ExpireTime: fc.Now().Add(time.Second * 3)})
 	var eidx uint64 = 7
 	e, err := s.Get("/foo", true, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, eidx, e.EtcdIndex)
 	assert.Equal(t, "get", e.Action)
 	assert.Equal(t, "/foo", e.Node.Key)
@@ -103,7 +103,7 @@ func TestStoreUpdateValueTTL(t *testing.T) {
 	var eidx uint64 = 2
 	s.Create("/foo", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	_, err := s.Update("/foo", "baz", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	e, _ := s.Get("/foo", false, false)
 	assert.Equal(t, "baz", *e.Node.Value)
 	assert.Equal(t, eidx, e.EtcdIndex)
@@ -122,11 +122,11 @@ func TestStoreUpdateDirTTL(t *testing.T) {
 
 	var eidx uint64 = 3
 	_, err := s.Create("/foo", true, "", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = s.Create("/foo/bar", false, "baz", false, TTLOptionSet{ExpireTime: Permanent})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	e, err := s.Update("/foo/bar", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, e.Node.Dir)
 	assert.Equal(t, eidx, e.EtcdIndex)
 	e, _ = s.Get("/foo/bar", false, false)
@@ -275,13 +275,13 @@ func TestStoreRefresh(t *testing.T) {
 	s.Create("/bar", true, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	s.Create("/bar/z", false, "bar", false, TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond)})
 	_, err := s.Update("/foo", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.Set("/foo", false, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.Update("/bar/z", "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.CompareAndSwap("/foo", "bar", 0, "", TTLOptionSet{ExpireTime: fc.Now().Add(500 * time.Millisecond), Refresh: true})
 	assert.NoError(t, err)
@@ -299,7 +299,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.Create("/foo/x", false, "bar", false, TTLOptionSet{ExpireTime: Permanent})
 	s.Create("/foo/y", false, "baz", false, TTLOptionSet{ExpireTime: fc.Now().Add(5 * time.Millisecond)})
 	b, err := s.Save()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -312,7 +312,7 @@ func TestStoreRecoverWithExpiration(t *testing.T) {
 	s.DeleteExpiredKeys(fc.Now())
 
 	e, err := s.Get("/foo/x", false, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, eidx, e.EtcdIndex)
 	assert.Equal(t, "bar", *e.Node.Value)
 

--- a/server/etcdserver/version/version_test.go
+++ b/server/etcdserver/version/version_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -64,7 +65,7 @@ func TestDowngradeSingleNode(t *testing.T) {
 	c.StepMonitors()
 	assert.Equal(t, newCluster(lg, 1, version.V3_6), c)
 
-	assert.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
+	require.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
 	c.StepMonitors()
 	assert.Equal(t, version.V3_5, c.clusterVersion)
 
@@ -80,7 +81,7 @@ func TestDowngradeThreeNode(t *testing.T) {
 	c.StepMonitors()
 	assert.Equal(t, newCluster(lg, 3, version.V3_6), c)
 
-	assert.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
+	require.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
 	c.StepMonitors()
 	assert.Equal(t, version.V3_5, c.clusterVersion)
 
@@ -100,7 +101,7 @@ func TestNewerMemberCanReconnectDuringDowngrade(t *testing.T) {
 	c.StepMonitors()
 	assert.Equal(t, newCluster(lg, 3, version.V3_6), c)
 
-	assert.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
+	require.NoError(t, c.Version().DowngradeEnable(context.Background(), &version.V3_5))
 	c.StepMonitors()
 	assert.Equal(t, version.V3_5, c.clusterVersion)
 

--- a/server/storage/backend/backend_bench_test.go
+++ b/server/storage/backend/backend_bench_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
 	"go.etcd.io/etcd/server/v3/storage/schema"
@@ -34,11 +34,11 @@ func BenchmarkBackendPut(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		keys[i] = make([]byte, 64)
 		_, err := rand.Read(keys[i])
-		assert.NoError(b, err)
+		require.NoError(b, err)
 	}
 	value := make([]byte, 128)
 	_, err := rand.Read(value)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	batchTx := backend.BatchTx()
 

--- a/server/storage/backend/backend_test.go
+++ b/server/storage/backend/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	bolt "go.etcd.io/bbolt"
@@ -70,7 +71,7 @@ func TestBackendSnapshot(t *testing.T) {
 	if _, err := snap.WriteTo(f); err != nil {
 		t.Fatal(err)
 	}
-	assert.NoError(t, f.Close())
+	require.NoError(t, f.Close())
 
 	// bootstrap new backend from the snapshot
 	bcfg := backend.DefaultBackendConfig(zaptest.NewLogger(t))
@@ -332,7 +333,7 @@ func TestBackendWritebackForEach(t *testing.T) {
 	}
 	rtx := b.ReadTx()
 	rtx.RLock()
-	assert.NoError(t, rtx.UnsafeForEach(schema.Key, getSeq))
+	require.NoError(t, rtx.UnsafeForEach(schema.Key, getSeq))
 	rtx.RUnlock()
 
 	partialSeq := seq
@@ -341,7 +342,7 @@ func TestBackendWritebackForEach(t *testing.T) {
 	b.ForceCommit()
 
 	tx.Lock()
-	assert.NoError(t, tx.UnsafeForEach(schema.Key, getSeq))
+	require.NoError(t, tx.UnsafeForEach(schema.Key, getSeq))
 	tx.Unlock()
 
 	if seq != partialSeq {

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/pkg/v3/traceutil"
@@ -124,7 +125,7 @@ func testHashByRev(t *testing.T, s *store, rev int64) KeyValueHash {
 		rev = s.Rev()
 	}
 	hash, _, err := s.hashByRev(rev)
-	assert.NoErrorf(t, err, "error on rev %v", rev)
+	require.NoErrorf(t, err, "error on rev %v", rev)
 	_, err = s.Compact(traceutil.TODO(), rev)
 	assert.NoErrorf(t, err, "error on compact %v", rev)
 	return hash

--- a/server/storage/mvcc/kvstore_bench_test.go
+++ b/server/storage/mvcc/kvstore_bench_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/pkg/v3/traceutil"
@@ -152,7 +152,7 @@ func benchmarkStoreRestore(revsPerKey int, b *testing.B) {
 			txn.End()
 		}
 	}
-	assert.NoError(b, s.Close())
+	require.NoError(b, s.Close())
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/server/storage/mvcc/testutil/hash.go
+++ b/server/storage/mvcc/testutil/hash.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/bbolt"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -61,23 +62,23 @@ func testCompactionHash(ctx context.Context, t *testing.T, h CompactionHashTestC
 	for i := start; i <= stop; i++ {
 		if i%67 == 0 {
 			err := h.Delete(ctx, PickKey(i+83))
-			assert.NoErrorf(t, err, "error on delete")
+			require.NoErrorf(t, err, "error on delete")
 		} else {
 			err := h.Put(ctx, PickKey(i), fmt.Sprint(i))
-			assert.NoErrorf(t, err, "error on put")
+			require.NoErrorf(t, err, "error on put")
 		}
 	}
 	hash1, err := h.HashByRev(ctx, stop)
-	assert.NoErrorf(t, err, "error on hash (rev %v)", stop)
+	require.NoErrorf(t, err, "error on hash (rev %v)", stop)
 
 	err = h.Compact(ctx, stop)
-	assert.NoErrorf(t, err, "error on compact (rev %v)", stop)
+	require.NoErrorf(t, err, "error on compact (rev %v)", stop)
 
 	err = h.Defrag(ctx)
-	assert.NoErrorf(t, err, "error on defrag")
+	require.NoErrorf(t, err, "error on defrag")
 
 	hash2, err := h.HashByRev(ctx, stop)
-	assert.NoErrorf(t, err, "error on hash (rev %v)", stop)
+	require.NoErrorf(t, err, "error on hash (rev %v)", stop)
 	assert.Equalf(t, hash1, hash2, "hashes do not match on rev %v", stop)
 }
 

--- a/server/storage/wal/version_test.go
+++ b/server/storage/wal/version_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -96,7 +97,7 @@ func TestEtcdVersionFromEntry(t *testing.T) {
 				maxVer = maxVersion(maxVer, ver)
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expect, maxVer)
 		})
 	}
@@ -166,7 +167,7 @@ func TestEtcdVersionFromMessage(t *testing.T) {
 				maxVer = maxVersion(maxVer, ver)
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expect, maxVer)
 		})
 	}
@@ -242,7 +243,7 @@ func TestEtcdVersionFromFieldOptionsString(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.input, func(t *testing.T) {
 			ver, err := etcdVersionFromOptionsString(tc.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, ver, tc.expect)
 		})
 	}

--- a/server/storage/wal/wal_test.go
+++ b/server/storage/wal/wal_test.go
@@ -298,7 +298,7 @@ func TestVerify(t *testing.T) {
 	}
 
 	hs := raftpb.HardState{Term: 1, Vote: 3, Commit: 5}
-	assert.NoError(t, w.Save(hs, nil))
+	require.NoError(t, w.Save(hs, nil))
 
 	// to verify the WAL is not corrupted at this point
 	hardstate, err := Verify(lg, walDir, walpb.Snapshot{})


### PR DESCRIPTION
This fixes [require-error](https://github.com/Antonboom/testifylint?tab=readme-ov-file#require-error) rule from [testifylint](https://github.com/Antonboom/testifylint) in client, pkg and server packages

Related to #18719

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->