### PR TITLE
Remove defunct release-3.5 arm64 github actions workflows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,13 +13,3 @@ jobs:
         'linux-unit-4-cpu-race',
         'linux-386-unit-1-cpu',
         'all-build']"
-  arm64:
-    uses: ./.github/workflows/tests-template.yaml
-    with:
-      arch: arm64
-      runs-on: actuated-arm64-8cpu-32gb
-      targets: "['linux-test-smoke',
-        'linux-integration-1-cpu',
-        'linux-integration-2-cpu',
-        'linux-integration-4-cpu',
-        'linux-unit-4-cpu-race']"


### PR DESCRIPTION
These jobs have now been migrated to prow in:
- https://github.com/kubernetes/test-infra/pull/33733
- https://github.com/kubernetes/test-infra/pull/33734