### PR TITLE
Handle read-only write txn failures gracefully

### DIFF
--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -307,7 +307,7 @@ func setup(t *testing.T, setup testSetup) (mvcc.KV, lease.Lessor) {
 	return s, lessor
 }
 
-func TestReadonlyTxnError(t *testing.T) {
+func TestReadonlyTxnError_WhenOperationFails(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, b)
 	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})
@@ -322,6 +322,7 @@ func TestReadonlyTxnError(t *testing.T) {
 	s.Put([]byte("foo"), []byte("bar"), lease.NoLease)
 
 	txn := &pb.TxnRequest{
+		// note: since there are no compare terms here, we default to the success path
 		Success: []*pb.RequestOp{
 			{
 				Request: &pb.RequestOp_RequestRange{
@@ -339,7 +340,7 @@ func TestReadonlyTxnError(t *testing.T) {
 	}
 }
 
-func TestWriteTxnPanicWithoutApply(t *testing.T) {
+func TestWriteTxnPanic_WhenOperationFails(t *testing.T) {
 	b, bePath := betesting.NewDefaultTmpBackend(t)
 	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})
 	defer s.Close()
@@ -350,6 +351,7 @@ func TestWriteTxnPanicWithoutApply(t *testing.T) {
 
 	// write txn that puts some data and then fails in range due to cancelled context
 	txn := &pb.TxnRequest{
+		// note: since there are no compare terms here, we default to the success path
 		Success: []*pb.RequestOp{
 			{
 				Request: &pb.RequestOp_RequestPut{
@@ -374,12 +376,80 @@ func TestWriteTxnPanicWithoutApply(t *testing.T) {
 	require.NoErrorf(t, err, "failed to compute DB file hash before txn")
 
 	// we verify the following properties below:
-	// 1. server panics after a write txn aply fails (invariant: server should never try to move on from a failed write)
+	// 1. server panics after a write txn apply fails (invariant: server should never try to move on from a failed write)
 	// 2. no writes from the txn are applied to the backend (invariant: failed write should have no side-effect on DB state besides panic)
 	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}) }, "Expected panic in Txn with writes")
 	dbHashAfter, err := computeFileHash(bePath)
 	require.NoErrorf(t, err, "failed to compute DB file hash after txn")
 	require.Equalf(t, dbHashBefore, dbHashAfter, "mismatch in DB hash before and after failed write txn")
+}
+
+func TestWriteTxnError_WhenPerformsReadonlyOperations(t *testing.T) {
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})
+	defer s.Close()
+
+	// setup cancelled context
+	ctx, cancel := context.WithCancel(context.TODO())
+	cancel()
+
+	// put some data to prevent early termination in rangeKeys
+	// we are expecting failure on cancelled context check
+	s.Put([]byte("foo"), []byte("bar"), lease.NoLease)
+
+	txn := &pb.TxnRequest{
+		// note: since there are no compare terms here, we default to the success path
+		Success: []*pb.RequestOp{
+			{
+				Request: &pb.RequestOp_RequestRange{
+					RequestRange: &pb.RangeRequest{
+						Key: []byte("foo"),
+					},
+				},
+			},
+			{
+				// Including a nested write txn below that is also effectively read-only - to test recursive correctness.
+				Request: &pb.RequestOp_RequestTxn{
+					RequestTxn: &pb.TxnRequest{
+						Success: []*pb.RequestOp{
+							{
+								Request: &pb.RequestOp_RequestRange{
+									RequestRange: &pb.RangeRequest{
+										Key: []byte("foo"),
+									},
+								},
+							},
+						},
+						Failure: []*pb.RequestOp{
+							{
+								Request: &pb.RequestOp_RequestPut{
+									RequestPut: &pb.PutRequest{
+										Key:   []byte("foo2"),
+										Value: []byte("bar2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Failure: []*pb.RequestOp{
+			{
+				Request: &pb.RequestOp_RequestPut{
+					RequestPut: &pb.PutRequest{
+						Key:   []byte("foo3"),
+						Value: []byte("bar3"),
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{})
+	if err == nil || !strings.Contains(err.Error(), "applyTxn: failed Range: rangeKeys: context cancelled: context canceled") {
+		t.Fatalf("Expected context canceled error, got %v", err)
+	}
 }
 
 func TestCheckTxnAuth(t *testing.T) {


### PR DESCRIPTION
Following up from https://github.com/etcd-io/etcd/issues/18667#issuecomment-2397913066.

The idea is simple:
1. We have two kinds of txns - read-only and write
2. Read-only txns do not have any write operations inside their success/failure operation blocks - these are already bypassing apply layer and served directly via linearizable read loop ([xref](https://github.com/etcd-io/etcd/blob/448fb7e36c11971d610bef241f2ffb7ddf39788d/server/etcdserver/v3_server.go#L161-L192))
3. Write txns have at least 1 write operation inside their success/failure operation blocks - however during txn execution (apply time), the actual operation paths chosen based on "compare" outputs could effectively render them as read-only txns

This change improves the behavior for 3 by avoiding an unnecessary panic when such read-only txns see an error - instead return the error back to server handler and move on with applying subsequent entries. Panic + server restart seems unnecessary overhead in such cases. This also paves a way to bring back context-based timeouts for such txns. One case where that could help is during high write contention scenarios where CAS operations often end up going to "failure" block and triggers a (potentially slow) range request.

/cc @serathius @ahrtr 