### PR TITLE
Update 3.5 changelog to cover two major fixes

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -5,6 +5,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.17 (TBC)
 
+### etcd server
+- Fix [watchserver related goroutine leakage](https://github.com/etcd-io/etcd/pull/18784)
+- Fix [risk of a partial write txn being applied](https://github.com/etcd-io/etcd/pull/18799)
+
 ### Dependencies
 - Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18669).
 


### PR DESCRIPTION
Update changelog to cover the following two fixes:
- https://github.com/etcd-io/etcd/pull/18784
- https://github.com/etcd-io/etcd/pull/18799
