### PR TITLE
release: properly change working dir if tmp location already exists

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -86,10 +86,12 @@ main() {
   # Set up release directory.
   local reldir="/tmp/etcd-release-${VERSION}"
   log_callout "Preparing temporary directory: ${reldir}"
-  if [ ! -d "${reldir}/etcd" ] && [ "${IN_PLACE}" == 0 ]; then
-    mkdir -p "${reldir}"
-    cd "${reldir}"
-    run git clone "${REPOSITORY}" --branch "${BRANCH}" --depth 1
+  if [ "${IN_PLACE}" == 0 ]; then
+    if [ ! -d "${reldir}/etcd" ]; then
+      mkdir -p "${reldir}"
+      cd "${reldir}"
+      run git clone "${REPOSITORY}" --branch "${BRANCH}" --depth 1
+    fi
     run cd "${reldir}/etcd" || exit 2
     run git checkout "${BRANCH}" || exit 2
     run git pull origin


### PR DESCRIPTION
I identified this issue while working on #18649. Currently, if we follow the practice of testing the release script in the first step when doing a release with `DRY=true` and then rerun the script, the script won't change directories into the freshly cloned repository. Instead, it will use the current directory, which may be prone to unwanted changes accidentally being pushed as part of the release.

With this approach, running it after a DRY run will yield the error:

```
In workspace '/tmp/etcd-release-3.5.124/etcd' the branch: release-3.5 diverges from the origin.
Consider cleaning up / renaming this directory or (cd /tmp/etcd-release-3.5.124/etcd && git reset --hard origin/release-3.5)
```

However, I feel the best experience would be to replace:

```
    run git checkout "${BRANCH}" || exit 2
    run git pull origin
```

With a fetch and the hard reset to avoid manual intervention. But, I didn't want to implement it without alignment on this.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
