### PR TITLE
fix: use require instead of t.Fatal(err) in tests/integration package

### DIFF
--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -208,9 +208,7 @@ func TestIssue2681(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 5, DisableStrictReconfigCheck: true})
 	defer c.Terminate(t)
 
-	if err := c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[4].Server.MemberID())); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[4].Server.MemberID())))
 	c.WaitMembersForLeader(t, c.Members)
 
 	c.AddMember(t)
@@ -234,9 +232,7 @@ func testIssue2746(t *testing.T, members int) {
 		clusterMustProgress(t, c.Members)
 	}
 
-	if err := c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[members-1].Server.MemberID())); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.RemoveMember(t, c.Members[0].Client, uint64(c.Members[members-1].Server.MemberID())))
 	c.WaitMembersForLeader(t, c.Members)
 
 	c.AddMember(t)
@@ -312,9 +308,7 @@ func TestIssue3699(t *testing.T) {
 	t.Logf("Restarting member '0'...")
 	// bring back node a
 	// node a will remain useless as long as d is the leader.
-	if err := c.Members[0].Restart(t); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.Members[0].Restart(t))
 	t.Logf("Restarted member '0'.")
 
 	select {
@@ -530,9 +524,7 @@ func TestConcurrentRemoveMember(t *testing.T) {
 	defer c.Terminate(t)
 
 	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
@@ -540,9 +532,8 @@ func TestConcurrentRemoveMember(t *testing.T) {
 		c.Members[0].Client.MemberRemove(context.Background(), removeID)
 		close(done)
 	}()
-	if _, err := c.Members[0].Client.MemberRemove(context.Background(), removeID); err != nil {
-		t.Fatal(err)
-	}
+	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	require.NoError(t, err)
 	<-done
 }
 
@@ -552,9 +543,7 @@ func TestConcurrentMoveLeader(t *testing.T) {
 	defer c.Terminate(t)
 
 	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
@@ -562,8 +551,7 @@ func TestConcurrentMoveLeader(t *testing.T) {
 		c.Members[0].Client.MoveLeader(context.Background(), removeID)
 		close(done)
 	}()
-	if _, err := c.Members[0].Client.MemberRemove(context.Background(), removeID); err != nil {
-		t.Fatal(err)
-	}
+	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	require.NoError(t, err)
 	<-done
 }

--- a/tests/integration/grpc_test.go
+++ b/tests/integration/grpc_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -105,9 +106,7 @@ func TestAuthority(t *testing.T) {
 				putRequestMethod := "/etcdserverpb.KV/Put"
 				for i := 0; i < 100; i++ {
 					_, err := kv.Put(context.TODO(), "foo", "bar")
-					if err != nil {
-						t.Fatal(err)
-					}
+					require.NoError(t, err)
 				}
 
 				assertAuthority(t, tc.expectAuthorityPattern, clus, putRequestMethod)
@@ -121,9 +120,7 @@ func setupTLS(t *testing.T, useTLS bool, cfg integration.ClusterConfig) (integra
 	if useTLS {
 		cfg.ClientTLS = &integration.TestTLSInfo
 		tlsConfig, err := integration.TestTLSInfo.ClientConfig()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		return cfg, tlsConfig
 	}
 	return cfg, nil
@@ -138,9 +135,7 @@ func setupClient(t *testing.T, endpointPattern string, clus *integration.Cluster
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tlsConfig,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return kv
 }
 

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/storage/mvcc/testutil"
@@ -36,9 +38,7 @@ func TestCompactionHash(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cc, err := clus.ClusterClient(t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {

--- a/tests/integration/member_test.go
+++ b/tests/integration/member_test.go
@@ -58,9 +58,7 @@ func TestRestartMember(t *testing.T) {
 		c.WaitMembersForLeader(t, membs)
 		clusterMustProgress(t, membs)
 		err := c.Members[i].Restart(t)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 	c.WaitMembersForLeader(t, c.Members)
 	clusterMustProgress(t, c.Members)

--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/status"
 
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -95,7 +97,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			getWorker(ctx, t, clus)
+			getWorker(ctx, t, clus) //nolint:testifylint
 		}()
 	}
 
@@ -103,9 +105,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 	wg.Wait()
 	kv := clus.Client(0)
 	resp, err := kv.Get(context.Background(), "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("Revision %d", resp.Header.Revision)
 }
 
@@ -116,9 +116,7 @@ func putWorker(ctx context.Context, t *testing.T, clus *integration.Cluster) {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
-		if silenceConnectionErrors(err) != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, silenceConnectionErrors(err))
 	}
 }
 
@@ -130,9 +128,7 @@ func getWorker(ctx context.Context, t *testing.T, clus *integration.Cluster) {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
-		if silenceConnectionErrors(err) != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, silenceConnectionErrors(err))
 		if resp == nil {
 			continue
 		}

--- a/tests/integration/tracing_test.go
+++ b/tests/integration/tracing_test.go
@@ -40,9 +40,7 @@ func TestTracing(t *testing.T) {
 		"Wal creation tests are depending on embedded etcd server so are integration-level tests.")
 	// set up trace collector
 	listener, err := net.Listen("tcp", "localhost:")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	traceFound := make(chan struct{})
 	defer close(traceFound)
@@ -64,9 +62,7 @@ func TestTracing(t *testing.T) {
 
 	// start an etcd instance with tracing enabled
 	etcdSrv, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer etcdSrv.Close()
 
 	select {

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
@@ -37,9 +38,7 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 		"Wal creation tests are depending on embedded etcd server so are integration-level tests.")
 	cfg := integration.NewEmbedConfig(t, "default")
 	srv, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	select {
 	case <-srv.Server.ReadyNotify():
 	case <-time.After(3 * time.Second):
@@ -76,15 +75,11 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 	srv.Close()
 
 	w, err := wal.Open(zap.NewNop(), cfg.Dir+"/member/wal", walpb.Snapshot{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer w.Close()
 
 	walVersion, err := wal.ReadWALVersion(w)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, &semver.Version{Major: 3, Minor: 5}, walVersion.MinimalEtcdVersion())
 }
 

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -101,9 +101,8 @@ func TestV3AuthTokenWithDisable(t *testing.T) {
 	}()
 
 	time.Sleep(10 * time.Millisecond)
-	if _, err := c.AuthDisable(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	_, err := c.AuthDisable(context.TODO())
+	require.NoError(t, err)
 	time.Sleep(10 * time.Millisecond)
 
 	cancel()
@@ -168,14 +167,11 @@ func testV3AuthWithLeaseRevokeWithRoot(t *testing.T, ccfg integration.ClusterCon
 	defer rootc.Close()
 
 	leaseResp, err := rootc.Grant(context.TODO(), 2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	leaseID := leaseResp.ID
 
-	if _, err = rootc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(leaseID)); err != nil {
-		t.Fatal(err)
-	}
+	_, err = rootc.Put(context.TODO(), "foo", "bar", clientv3.WithLease(leaseID))
+	require.NoError(t, err)
 
 	// wait for lease expire
 	time.Sleep(3 * time.Second)
@@ -229,15 +225,11 @@ func TestV3AuthWithLeaseRevoke(t *testing.T) {
 	defer rootc.Close()
 
 	leaseResp, err := rootc.Grant(context.TODO(), 90)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	leaseID := leaseResp.ID
 	// permission of k3 isn't granted to user1
 	_, err = rootc.Put(context.TODO(), "k3", "val", clientv3.WithLease(leaseID))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	userc, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
 	if cerr != nil {
@@ -288,31 +280,21 @@ func TestV3AuthWithLeaseAttach(t *testing.T) {
 	defer user2c.Close()
 
 	leaseResp, err := user1c.Grant(context.TODO(), 90)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	leaseID := leaseResp.ID
 	// permission of k2 is also granted to user2
 	_, err = user1c.Put(context.TODO(), "k2", "val", clientv3.WithLease(leaseID))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = user2c.Revoke(context.TODO(), leaseID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	leaseResp, err = user1c.Grant(context.TODO(), 90)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	leaseID = leaseResp.ID
 	// permission of k1 isn't granted to user2
 	_, err = user1c.Put(context.TODO(), "k1", "val", clientv3.WithLease(leaseID))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = user2c.Revoke(context.TODO(), leaseID)
 	if err == nil {
@@ -353,9 +335,8 @@ func authSetupRoot(t *testing.T, auth pb.AuthClient) {
 		},
 	}
 	authSetupUsers(t, auth, root)
-	if _, err := auth.AuthEnable(context.TODO(), &pb.AuthEnableRequest{}); err != nil {
-		t.Fatal(err)
-	}
+	_, err := auth.AuthEnable(context.TODO(), &pb.AuthEnableRequest{})
+	require.NoError(t, err)
 }
 
 func TestV3AuthNonAuthorizedRPCs(t *testing.T) {

--- a/tests/integration/v3_election_test.go
+++ b/tests/integration/v3_election_test.go
@@ -155,9 +155,8 @@ func TestElectionFailover(t *testing.T) {
 	}()
 
 	// invoke leader failover
-	if err := ss[0].Close(); err != nil {
-		t.Fatal(err)
-	}
+	err := ss[0].Close()
+	require.NoError(t, err)
 
 	// check new leader
 	e = concurrency.NewElection(ss[2], "test-election")
@@ -192,13 +191,11 @@ func TestElectionSessionRecampaign(t *testing.T) {
 	defer session.Orphan()
 
 	e := concurrency.NewElection(session, "test-elect")
-	if err := e.Campaign(context.TODO(), "abc"); err != nil {
-		t.Fatal(err)
-	}
+	err = e.Campaign(context.TODO(), "abc")
+	require.NoError(t, err)
 	e2 := concurrency.NewElection(session, "test-elect")
-	if err := e2.Campaign(context.TODO(), "def"); err != nil {
-		t.Fatal(err)
-	}
+	err = e2.Campaign(context.TODO(), "def")
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -217,22 +214,19 @@ func TestElectionOnPrefixOfExistingKey(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cli := clus.RandClient()
-	if _, err := cli.Put(context.TODO(), "testa", "value"); err != nil {
-		t.Fatal(err)
-	}
+	_, err := cli.Put(context.TODO(), "testa", "value")
+	require.NoError(t, err)
 	s, serr := concurrency.NewSession(cli)
 	if serr != nil {
 		t.Fatal(serr)
 	}
 	e := concurrency.NewElection(s, "test")
 	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
-	err := e.Campaign(ctx, "abc")
+	err = e.Campaign(ctx, "abc")
 	cancel()
-	if err != nil {
-		// after 5 seconds, deadlock results in
-		// 'context deadline exceeded' here.
-		t.Fatal(err)
-	}
+	// after 5 seconds, deadlock results in
+	// 'context deadline exceeded' here.
+	require.NoError(t, err)
 }
 
 // TestElectionOnSessionRestart tests that a quick restart of leader (resulting
@@ -245,9 +239,7 @@ func TestElectionOnSessionRestart(t *testing.T) {
 	cli := clus.RandClient()
 
 	session, err := concurrency.NewSession(cli)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	e := concurrency.NewElection(session, "test-elect")
 	if cerr := e.Campaign(context.TODO(), "abc"); cerr != nil {
@@ -293,9 +285,7 @@ func TestElectionObserveCompacted(t *testing.T) {
 	cli := clus.Client(0)
 
 	session, err := concurrency.NewSession(cli)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer session.Orphan()
 
 	e := concurrency.NewElection(session, "test-elect")

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -56,9 +57,7 @@ func TestFailover(t *testing.T) {
 			defer clus.Terminate(t)
 
 			cc, err := integration2.TestTLSInfo.ClientConfig()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			// Create an etcd client before or after first server down
 			t.Logf("Creating an etcd client [%s]", tc.name)
 			cli, err := tc.testFunc(t, cc, clus)

--- a/tests/integration/v3_grpc_inflight_test.go
+++ b/tests/integration/v3_grpc_inflight_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -38,9 +39,8 @@ func TestV3MaintenanceDefragmentInflightRange(t *testing.T) {
 
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
-	if _, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
-		t.Fatal(err)
-	}
+	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
@@ -69,9 +69,8 @@ func TestV3KVInflightRangeRequests(t *testing.T) {
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
 
-	if _, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
-		t.Fatal(err)
-	}
+	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 

--- a/tests/integration/v3_kv_test.go
+++ b/tests/integration/v3_kv_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/namespace"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -33,23 +35,15 @@ func TestKVWithEmptyValue(t *testing.T) {
 	client := clus.RandClient()
 
 	_, err := client.Put(context.Background(), "my-namespace/foobar", "data")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, err = client.Put(context.Background(), "my-namespace/foobar1", "data")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, err = client.Put(context.Background(), "namespace/foobar1", "data")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Range over all keys.
 	resp, err := client.Get(context.Background(), "", clientv3.WithFromKey())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
 	}
@@ -57,24 +51,18 @@ func TestKVWithEmptyValue(t *testing.T) {
 	// Range over all keys in a namespace.
 	client.KV = namespace.NewKV(client.KV, "my-namespace/")
 	resp, err = client.Get(context.Background(), "", clientv3.WithFromKey())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
 	}
 
 	// Remove all keys without WithFromKey/WithPrefix func
 	_, err = client.Delete(context.Background(), "")
-	if err == nil {
-		// fatal error duo to without WithFromKey/WithPrefix func called.
-		t.Fatal(err)
-	}
+	// fatal error duo to without WithFromKey/WithPrefix func called.
+	require.Error(t, err)
 
 	respDel, err := client.Delete(context.Background(), "", clientv3.WithFromKey())
-	if err != nil {
-		// fatal error duo to with WithFromKey/WithPrefix func called.
-		t.Fatal(err)
-	}
+	// fatal error duo to with WithFromKey/WithPrefix func called.
+	require.NoError(t, err)
 	t.Logf("delete keys:%d", respDel.Deleted)
 }

--- a/tests/integration/v3_leadership_test.go
+++ b/tests/integration/v3_leadership_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -59,15 +60,11 @@ func testMoveLeader(t *testing.T, auto bool) {
 	target := uint64(clus.Members[(oldLeadIdx+1)%3].Server.MemberID())
 	if auto {
 		err := clus.Members[oldLeadIdx].Server.TryTransferLeadershipOnShutdown()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	} else {
 		mvc := integration.ToGRPC(clus.Client(oldLeadIdx)).Maintenance
 		_, err := mvc.MoveLeader(context.TODO(), &pb.MoveLeaderRequest{TargetID: target})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	// wait until leader transitions have happened

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -51,9 +51,7 @@ func TestV3LeasePromote(t *testing.T) {
 	lresp, err := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 3})
 	ttl := time.Duration(lresp.TTL) * time.Second
 	afterGrant := time.Now()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
@@ -203,9 +201,8 @@ func TestV3LeaseNegativeID(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 			// restore lessor from db file
 			clus.Members[2].Stop(t)
-			if err = clus.Members[2].Restart(t); err != nil {
-				t.Fatal(err)
-			}
+			err = clus.Members[2].Restart(t)
+			require.NoError(t, err)
 
 			// revoke lease should remove key
 			integration.WaitClientV3(t, clus.Members[2].Client)
@@ -217,9 +214,7 @@ func TestV3LeaseNegativeID(t *testing.T) {
 			for _, m := range clus.Members {
 				getr := &pb.RangeRequest{Key: tc.k}
 				getresp, err := integration.ToGRPC(m.Client).KV.Range(ctx, getr)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				if revision == 0 {
 					revision = getresp.Header.Revision
 				}
@@ -386,9 +381,7 @@ func TestV3LeaseCheckpoint(t *testing.T) {
 			defer cancel()
 			c := integration.ToGRPC(clus.RandClient())
 			lresp, err := c.Lease.LeaseGrant(ctx, &pb.LeaseGrantRequest{TTL: int64(tc.ttl.Seconds())})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			for i := 0; i < tc.leaderChanges; i++ {
 				// wait for a checkpoint to occur
@@ -442,9 +435,7 @@ func TestV3LeaseExists(t *testing.T) {
 	lresp, err := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(
 		ctx0,
 		&pb.LeaseGrantRequest{TTL: 30})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
@@ -469,9 +460,7 @@ func TestV3LeaseLeases(t *testing.T) {
 		lresp, err := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(
 			ctx0,
 			&pb.LeaseGrantRequest{TTL: 30})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if lresp.Error != "" {
 			t.Fatal(lresp.Error)
 		}
@@ -481,9 +470,7 @@ func TestV3LeaseLeases(t *testing.T) {
 	lresp, err := integration.ToGRPC(clus.RandClient()).Lease.LeaseLeases(
 		context.Background(),
 		&pb.LeaseLeasesRequest{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for i := range lresp.Leases {
 		if lresp.Leases[i].ID != ids[i] {
 			t.Fatalf("#%d: lease ID expected %d, got %d", i, ids[i], lresp.Leases[i].ID)
@@ -530,9 +517,7 @@ func testLeaseStress(t *testing.T, stresser func(context.Context, pb.LeaseClient
 
 	if useClusterClient {
 		clusterClient, err := clus.ClusterClient(t)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		for i := 0; i < 300; i++ {
 			go func() { errc <- stresser(ctx, integration.ToGRPC(clusterClient).Lease) }()
 		}
@@ -630,9 +615,7 @@ func TestV3GetNonExistLease(t *testing.T) {
 		t.Errorf("failed to create lease %v", err)
 	}
 	_, err = lc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	leaseTTLr := &pb.LeaseTimeToLiveRequest{
 		ID:   lresp.ID,
@@ -665,49 +648,33 @@ func TestV3LeaseSwitch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	lresp1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(ctx, &pb.LeaseGrantRequest{TTL: 30})
-	if err1 != nil {
-		t.Fatal(err1)
-	}
+	require.NoError(t, err1)
 	lresp2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(ctx, &pb.LeaseGrantRequest{TTL: 30})
-	if err2 != nil {
-		t.Fatal(err2)
-	}
+	require.NoError(t, err2)
 
 	// attach key on lease1 then switch it to lease2
 	put1 := &pb.PutRequest{Key: []byte(key), Lease: lresp1.ID}
 	_, err := integration.ToGRPC(clus.RandClient()).KV.Put(ctx, put1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	put2 := &pb.PutRequest{Key: []byte(key), Lease: lresp2.ID}
 	_, err = integration.ToGRPC(clus.RandClient()).KV.Put(ctx, put2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// revoke lease1 should not remove key
 	_, err = integration.ToGRPC(clus.RandClient()).Lease.LeaseRevoke(ctx, &pb.LeaseRevokeRequest{ID: lresp1.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rreq := &pb.RangeRequest{Key: []byte("foo")}
 	rresp, err := integration.ToGRPC(clus.RandClient()).KV.Range(context.TODO(), rreq)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 1 {
 		t.Fatalf("unexpect removal of key")
 	}
 
 	// revoke lease2 should remove key
 	_, err = integration.ToGRPC(clus.RandClient()).Lease.LeaseRevoke(ctx, &pb.LeaseRevokeRequest{ID: lresp2.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rresp, err = integration.ToGRPC(clus.RandClient()).KV.Range(context.TODO(), rreq)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 0 {
 		t.Fatalf("lease removed but key remains")
 	}
@@ -728,9 +695,7 @@ func TestV3LeaseFailover(t *testing.T) {
 
 	// create lease
 	lresp, err := lc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 5})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
@@ -745,9 +710,7 @@ func TestV3LeaseFailover(t *testing.T) {
 	ctx, cancel := context.WithCancel(mctx)
 	defer cancel()
 	lac, err := lc.LeaseKeepAlive(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// send keep alive to old leader until the old leader starts
 	// to drop lease request.
@@ -792,9 +755,7 @@ func TestV3LeaseRequireLeader(t *testing.T) {
 	ctx, cancel := context.WithCancel(mctx)
 	defer cancel()
 	lac, err := lc.LeaseKeepAlive(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	donec := make(chan struct{})
 	go func() {
@@ -827,16 +788,12 @@ func TestV3LeaseRecoverAndRevoke(t *testing.T) {
 	lsc := integration.ToGRPC(clus.Client(0)).Lease
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// restart server and ensure lease still exists
 	clus.Members[0].Stop(t)
@@ -846,22 +803,16 @@ func TestV3LeaseRecoverAndRevoke(t *testing.T) {
 	// overwrite old client with newly dialed connection
 	// otherwise, error with "grpc: RPC failed fast due to transport failure"
 	nc, err := integration.NewClientV3(clus.Members[0])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	kvc = integration.ToGRPC(nc).KV
 	lsc = integration.ToGRPC(nc).Lease
 	defer nc.Close()
 
 	// revoke should delete the key
 	_, err = lsc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rresp, err := kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 0 {
 		t.Fatalf("lease removed but key remains")
 	}
@@ -878,22 +829,16 @@ func TestV3LeaseRevokeAndRecover(t *testing.T) {
 	lsc := integration.ToGRPC(clus.Client(0)).Lease
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// revoke should delete the key
 	_, err = lsc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// restart server and ensure revoked key doesn't exist
 	clus.Members[0].Stop(t)
@@ -903,16 +848,12 @@ func TestV3LeaseRevokeAndRecover(t *testing.T) {
 	// overwrite old client with newly dialed connection
 	// otherwise, error with "grpc: RPC failed fast due to transport failure"
 	nc, err := integration.NewClientV3(clus.Members[0])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	kvc = integration.ToGRPC(nc).KV
 	defer nc.Close()
 
 	rresp, err := kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 0 {
 		t.Fatalf("lease removed but key remains")
 	}
@@ -930,22 +871,16 @@ func TestV3LeaseRecoverKeyWithDetachedLease(t *testing.T) {
 	lsc := integration.ToGRPC(clus.Client(0)).Lease
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if lresp.Error != "" {
 		t.Fatal(lresp.Error)
 	}
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// overwrite lease with none
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// restart server and ensure lease still exists
 	clus.Members[0].Stop(t)
@@ -955,22 +890,16 @@ func TestV3LeaseRecoverKeyWithDetachedLease(t *testing.T) {
 	// overwrite old client with newly dialed connection
 	// otherwise, error with "grpc: RPC failed fast due to transport failure"
 	nc, err := integration.NewClientV3(clus.Members[0])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	kvc = integration.ToGRPC(nc).KV
 	lsc = integration.ToGRPC(nc).Lease
 	defer nc.Close()
 
 	// revoke the detached lease
 	_, err = lsc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: lresp.ID})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rresp, err := kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 1 {
 		t.Fatalf("only detached lease removed, key should remain")
 	}
@@ -988,18 +917,14 @@ func TestV3LeaseRecoverKeyWithMutipleLease(t *testing.T) {
 	var leaseIDs []int64
 	for i := 0; i < 2; i++ {
 		lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if lresp.Error != "" {
 			t.Fatal(lresp.Error)
 		}
 		leaseIDs = append(leaseIDs, lresp.ID)
 
 		_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	// restart server and ensure lease still exists
@@ -1015,36 +940,26 @@ func TestV3LeaseRecoverKeyWithMutipleLease(t *testing.T) {
 	// overwrite old client with newly dialed connection
 	// otherwise, error with "grpc: RPC failed fast due to transport failure"
 	nc, err := integration.NewClientV3(clus.Members[0])
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	kvc = integration.ToGRPC(nc).KV
 	lsc = integration.ToGRPC(nc).Lease
 	defer nc.Close()
 
 	// revoke the old lease
 	_, err = lsc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: leaseIDs[0]})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// key should still exist
 	rresp, err := kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 1 {
 		t.Fatalf("only detached lease removed, key should remain")
 	}
 
 	// revoke the latest lease
 	_, err = lsc.LeaseRevoke(context.TODO(), &pb.LeaseRevokeRequest{ID: leaseIDs[1]})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rresp, err = kvc.Range(context.TODO(), &pb.RangeRequest{Key: []byte("foo")})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 0 {
 		t.Fatalf("lease removed but key remains")
 	}
@@ -1149,20 +1064,15 @@ func testLeaseRemoveLeasedKey(t *testing.T, act func(*integration.Cluster, int64
 	defer clus.Terminate(t)
 
 	leaseID, err := acquireLeaseAndKey(clus, "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if err = act(clus, leaseID); err != nil {
-		t.Fatal(err)
-	}
+	err = act(clus, leaseID)
+	require.NoError(t, err)
 
 	// confirm no key
 	rreq := &pb.RangeRequest{Key: []byte("foo")}
 	rresp, err := integration.ToGRPC(clus.RandClient()).KV.Range(context.TODO(), rreq)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(rresp.Kvs) != 0 {
 		t.Fatalf("lease removed but key remains")
 	}

--- a/tests/integration/v3_tls_test.go
+++ b/tests/integration/v3_tls_test.go
@@ -62,9 +62,7 @@ func testTLSCipherSuites(t *testing.T, valid bool) {
 	defer clus.Terminate(t)
 
 	cc, err := cliTLS.ClientConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cli, cerr := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -65,9 +67,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.Client(0)).Watch.Watch(ctx)
-	if errW != nil {
-		t.Fatal(errW)
-	}
+	require.NoError(t, errW)
 	if err := wStream.Send(&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 5},
 	}}); err != nil {

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -594,19 +594,15 @@ func TestV3WatchEmptyKey(t *testing.T) {
 			Key: []byte("foo"),
 		},
 	}}
-	if err := ws.Send(req); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ws.Recv(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, ws.Send(req))
+	_, err := ws.Recv()
+	require.NoError(t, err)
 
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	if _, err := kvc.Put(context.TODO(), preq); err != nil {
-		t.Fatal(err)
-	}
+	_, err = kvc.Put(context.TODO(), preq)
+	require.NoError(t, err)
 
 	// check received PUT
 	resp, rerr := ws.Recv()
@@ -1240,12 +1236,9 @@ func TestV3WatchWithFilter(t *testing.T) {
 			Filters: []pb.WatchCreateRequest_FilterType{pb.WatchCreateRequest_NOPUT},
 		},
 	}}
-	if err := ws.Send(req); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := ws.Recv(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, ws.Send(req))
+	_, err := ws.Recv()
+	require.NoError(t, err)
 
 	recv := make(chan *pb.WatchResponse, 1)
 	go func() {
@@ -1260,9 +1253,8 @@ func TestV3WatchWithFilter(t *testing.T) {
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	if _, err := kvc.Put(context.TODO(), preq); err != nil {
-		t.Fatal(err)
-	}
+	_, err = kvc.Put(context.TODO(), preq)
+	require.NoError(t, err)
 
 	select {
 	case <-recv:
@@ -1271,9 +1263,8 @@ func TestV3WatchWithFilter(t *testing.T) {
 	}
 
 	dreq := &pb.DeleteRangeRequest{Key: []byte("foo")}
-	if _, err := kvc.DeleteRange(context.TODO(), dreq); err != nil {
-		t.Fatal(err)
-	}
+	_, err = kvc.DeleteRange(context.TODO(), dreq)
+	require.NoError(t, err)
 
 	select {
 	case resp := <-recv:
@@ -1386,9 +1377,7 @@ func TestV3WatchCancellation(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	minWatches, err := clus.Members[0].Metric("etcd_debugging_mvcc_watcher_total")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var expected string
 	if integration.ThroughProxy {
@@ -1425,9 +1414,7 @@ func TestV3WatchCloseCancelRace(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	minWatches, err := clus.Members[0].Metric("etcd_debugging_mvcc_watcher_total")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var expected string
 	if integration.ThroughProxy {

--- a/tests/integration/v3election_grpc_test.go
+++ b/tests/integration/v3election_grpc_test.go
@@ -35,13 +35,9 @@ func TestV3ElectionCampaign(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
-	if err1 != nil {
-		t.Fatal(err1)
-	}
+	require.NoError(t, err1)
 	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
-	if err2 != nil {
-		t.Fatal(err2)
-	}
+	require.NoError(t, err2)
 
 	lc := integration.ToGRPC(clus.Client(0)).Election
 	req1 := &epb.CampaignRequest{Name: []byte("foo"), Lease: lease1.ID, Value: []byte("abc")}
@@ -129,13 +125,9 @@ func TestV3ElectionObserve(t *testing.T) {
 	}
 
 	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
-	if err1 != nil {
-		t.Fatal(err1)
-	}
+	require.NoError(t, err1)
 	c1, cerr1 := lc.Campaign(context.TODO(), &epb.CampaignRequest{Name: []byte("foo"), Lease: lease1.ID, Value: []byte("0")})
-	if cerr1 != nil {
-		t.Fatal(cerr1)
-	}
+	require.NoError(t, cerr1)
 
 	// overlap other leader so it waits on resign
 	leader2c := make(chan struct{})

--- a/tests/integration/v3lock_grpc_test.go
+++ b/tests/integration/v3lock_grpc_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	lockpb "go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -32,13 +34,9 @@ func TestV3LockLockWaiter(t *testing.T) {
 	defer clus.Terminate(t)
 
 	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
-	if err1 != nil {
-		t.Fatal(err1)
-	}
+	require.NoError(t, err1)
 	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
-	if err2 != nil {
-		t.Fatal(err2)
-	}
+	require.NoError(t, err2)
 
 	lc := integration.ToGRPC(clus.Client(0)).Lock
 	l1, lerr1 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal calls

Related to #18972