### PR TITLE
fix: use require instead of t.Fatal(err) in tests/e2e package

### DIFF
--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -80,8 +80,7 @@ func authSetupTestUser(cx ctlCtx) {
 }
 
 func authTestMemberUpdate(cx ctlCtx) {
-	err := authEnable(cx)
-	require.NoError(cx.t, err)
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
@@ -104,101 +103,77 @@ func authTestMemberUpdate(cx ctlCtx) {
 }
 
 func authTestCertCN(cx ctlCtx) {
-	err := authEnable(cx)
-	require.NoError(cx.t, err)
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
-	err = ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""})
-	require.NoError(cx.t, err)
-	err = e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"})
-	require.NoError(cx.t, err)
-	err = ctlV3User(cx, []string{"grant-role", "example.com", "test-role"}, "Role test-role is granted to user example.com", nil)
-	require.NoError(cx.t, err)
+	require.NoError(cx.t, ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""}))
+	require.NoError(cx.t, e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role created"}))
+	require.NoError(cx.t, ctlV3User(cx, []string{"grant-role", "example.com", "test-role"}, "Role test-role is granted to user example.com", nil))
 
 	// grant a new key
-	err = ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "hoo", "", false})
-	require.NoError(cx.t, err)
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "hoo", "", false}))
 
 	// try a granted key
 	cx.user, cx.pass = "", ""
-	if err = ctlV3Put(cx, "hoo", "bar", ""); err != nil {
+	if err := ctlV3Put(cx, "hoo", "bar", ""); err != nil {
 		cx.t.Error(err)
 	}
 
 	// try a non-granted key
 	cx.user, cx.pass = "", ""
-	err = ctlV3PutFailPerm(cx, "baz", "bar")
-	require.ErrorContains(cx.t, err, "permission denied")
+	require.ErrorContains(cx.t, ctlV3PutFailPerm(cx, "baz", "bar"), "permission denied")
 }
 
 func authTestFromKeyPerm(cx ctlCtx) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
 	// grant keys after z to test-user
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "z", "\x00", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "z", "\x00", false}))
 
 	// try the granted open ended permission
 	cx.user, cx.pass = "test-user", "pass"
 	for i := 0; i < 10; i++ {
 		key := fmt.Sprintf("z%d", i)
-		if err := ctlV3Put(cx, key, "val", ""); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3Put(cx, key, "val", ""))
 	}
 	largeKey := ""
 	for i := 0; i < 10; i++ {
 		largeKey += "\xff"
-		if err := ctlV3Put(cx, largeKey, "val", ""); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3Put(cx, largeKey, "val", ""))
 	}
 
 	// try a non granted key
-	err := ctlV3PutFailPerm(cx, "x", "baz")
-	require.ErrorContains(cx.t, err, "permission denied")
+	require.ErrorContains(cx.t, ctlV3PutFailPerm(cx, "x", "baz"), "permission denied")
 
 	// revoke the open ended permission
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3RoleRevokePermission(cx, "test-role", "z", "", true); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleRevokePermission(cx, "test-role", "z", "", true))
 
 	// try the revoked open ended permission
 	cx.user, cx.pass = "test-user", "pass"
 	for i := 0; i < 10; i++ {
 		key := fmt.Sprintf("z%d", i)
-		err := ctlV3PutFailPerm(cx, key, "val")
-		require.ErrorContains(cx.t, err, "permission denied")
+		require.ErrorContains(cx.t, ctlV3PutFailPerm(cx, key, "val"), "permission denied")
 	}
 
 	// grant the entire keys
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "", "\x00", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "", "\x00", false}))
 
 	// try keys, of course it must be allowed because test-role has a permission of the entire keys
 	cx.user, cx.pass = "test-user", "pass"
 	for i := 0; i < 10; i++ {
 		key := fmt.Sprintf("z%d", i)
-		if err := ctlV3Put(cx, key, "val", ""); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3Put(cx, key, "val", ""))
 	}
 
 	// revoke the entire keys
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3RoleRevokePermission(cx, "test-role", "", "", true); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleRevokePermission(cx, "test-role", "", "", true))
 
 	// try the revoked entire key permission
 	cx.user, cx.pass = "test-user", "pass"
@@ -210,17 +185,13 @@ func authTestFromKeyPerm(cx ctlCtx) {
 }
 
 func authTestWatch(cx ctlCtx) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
 	// grant a key range
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "key", "key4", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "key", "key4", false}))
 
 	tests := []struct {
 		puts []kv
@@ -287,9 +258,7 @@ func authTestWatch(cx ctlCtx) {
 func authTestSnapshot(cx ctlCtx) {
 	maintenanceInitKeys(cx)
 
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
@@ -299,20 +268,14 @@ func authTestSnapshot(cx ctlCtx) {
 
 	// ordinary user cannot save a snapshot
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3SnapshotSave(cx, fpath); err == nil {
-		cx.t.Fatal("ordinary user should not be able to save a snapshot")
-	}
+	require.Errorf(cx.t, ctlV3SnapshotSave(cx, fpath), "ordinary user should not be able to save a snapshot")
 
 	// root can save a snapshot
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3SnapshotSave(cx, fpath); err != nil {
-		cx.t.Fatalf("snapshotTest ctlV3SnapshotSave error (%v)", err)
-	}
+	require.NoErrorf(cx.t, ctlV3SnapshotSave(cx, fpath), "snapshotTest ctlV3SnapshotSave error")
 
 	st, err := getSnapshotStatus(cx, fpath)
-	if err != nil {
-		cx.t.Fatalf("snapshotTest getSnapshotStatus error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "snapshotTest getSnapshotStatus error")
 	if st.Revision != 4 {
 		cx.t.Fatalf("expected 4, got %d", st.Revision)
 	}
@@ -322,28 +285,20 @@ func authTestSnapshot(cx ctlCtx) {
 }
 
 func authTestEndpointHealth(cx ctlCtx) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
-	if err := ctlV3EndpointHealth(cx); err != nil {
-		cx.t.Fatalf("endpointStatusTest ctlV3EndpointHealth error (%v)", err)
-	}
+	require.NoErrorf(cx.t, ctlV3EndpointHealth(cx), "endpointStatusTest ctlV3EndpointHealth error")
 
 	// health checking with an ordinary user "succeeds" since permission denial goes through consensus
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3EndpointHealth(cx); err != nil {
-		cx.t.Fatalf("endpointStatusTest ctlV3EndpointHealth error (%v)", err)
-	}
+	require.NoErrorf(cx.t, ctlV3EndpointHealth(cx), "endpointStatusTest ctlV3EndpointHealth error")
 
 	// succeed if permissions granted for ordinary user
 	cx.user, cx.pass = "root", "root"
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "health", "", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "health", "", false}))
 	cx.user, cx.pass = "test-user", "pass"
 	if err := ctlV3EndpointHealth(cx); err != nil {
 		cx.t.Fatalf("endpointStatusTest ctlV3EndpointHealth error (%v)", err)
@@ -351,59 +306,39 @@ func authTestEndpointHealth(cx ctlCtx) {
 }
 
 func certCNAndUsername(cx ctlCtx, noPassword bool) {
-	if err := authEnable(cx); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, authEnable(cx))
 
 	cx.user, cx.pass = "root", "root"
 	authSetupTestUser(cx)
 
 	if noPassword {
-		if err := ctlV3User(cx, []string{"add", "example.com", "--no-password"}, "User example.com created", []string{""}); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3User(cx, []string{"add", "example.com", "--no-password"}, "User example.com created", []string{""}))
 	} else {
-		if err := ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""}); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3User(cx, []string{"add", "example.com", "--interactive=false"}, "User example.com created", []string{""}))
 	}
-	if err := e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role-cn"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role-cn created"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3User(cx, []string{"grant-role", "example.com", "test-role-cn"}, "Role test-role-cn is granted to user example.com", nil); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpectWithEnv(append(cx.PrefixArgs(), "role", "add", "test-role-cn"), cx.envMap, expect.ExpectedResponse{Value: "Role test-role-cn created"}))
+	require.NoError(cx.t, ctlV3User(cx, []string{"grant-role", "example.com", "test-role-cn"}, "Role test-role-cn is granted to user example.com", nil))
 
 	// grant a new key for CN based user
-	if err := ctlV3RoleGrantPermission(cx, "test-role-cn", grantingPerm{true, true, "hoo", "", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role-cn", grantingPerm{true, true, "hoo", "", false}))
 
 	// grant a new key for username based user
-	if err := ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "bar", "", false}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3RoleGrantPermission(cx, "test-role", grantingPerm{true, true, "bar", "", false}))
 
 	// try a granted key for CN based user
 	cx.user, cx.pass = "", ""
-	if err := ctlV3Put(cx, "hoo", "bar", ""); err != nil {
-		cx.t.Error(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "hoo", "bar", ""))
 
 	// try a granted key for username based user
 	cx.user, cx.pass = "test-user", "pass"
-	if err := ctlV3Put(cx, "bar", "bar", ""); err != nil {
-		cx.t.Error(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "bar", "bar", ""))
 
 	// try a non-granted key for both of them
 	cx.user, cx.pass = "", ""
-	err := ctlV3PutFailPerm(cx, "baz", "bar")
-	require.ErrorContains(cx.t, err, "permission denied")
+	require.ErrorContains(cx.t, ctlV3PutFailPerm(cx, "baz", "bar"), "permission denied")
 
 	cx.user, cx.pass = "test-user", "pass"
-	err = ctlV3PutFailPerm(cx, "baz", "bar")
-	require.ErrorContains(cx.t, err, "permission denied")
+	require.ErrorContains(cx.t, ctlV3PutFailPerm(cx, "baz", "bar"), "permission denied")
 }
 
 func authTestCertCNAndUsername(cx ctlCtx) {

--- a/tests/e2e/ctl_v3_defrag_test.go
+++ b/tests/e2e/ctl_v3_defrag_test.go
@@ -17,6 +17,8 @@ package e2e
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -28,9 +30,7 @@ func TestCtlV3DefragOffline(t *testing.T) {
 func maintenanceInitKeys(cx ctlCtx) {
 	kvs := []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
 	for i := range kvs {
-		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3Put(cx, kvs[i].key, kvs[i].val, ""))
 	}
 }
 

--- a/tests/e2e/ctl_v3_elect_test.go
+++ b/tests/e2e/ctl_v3_elect_test.go
@@ -35,9 +35,7 @@ func testElect(cx ctlCtx) {
 	name := "a"
 
 	holder, ch, err := ctlV3Elect(cx, name, "p1", false)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 
 	l1 := ""
 	select {
@@ -51,9 +49,7 @@ func testElect(cx ctlCtx) {
 
 	// blocked process that won't win the election
 	blocked, ch, err := ctlV3Elect(cx, name, "p2", true)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	select {
 	case <-time.After(100 * time.Millisecond):
 	case <-ch:
@@ -62,9 +58,7 @@ func testElect(cx ctlCtx) {
 
 	// overlap with a blocker that will win the election
 	blockAcquire, ch, err := ctlV3Elect(cx, name, "p2", false)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	defer func(blockAcquire *expect.ExpectProcess) {
 		err = blockAcquire.Stop()
 		require.NoError(cx.t, err)
@@ -78,9 +72,7 @@ func testElect(cx ctlCtx) {
 	}
 
 	// kill blocked process with clean shutdown
-	if err = blocked.Signal(os.Interrupt); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, blocked.Signal(os.Interrupt))
 	err = e2e.CloseWithTimeout(blocked, time.Second)
 	if err != nil {
 		// due to being blocked, this can potentially get killed and thus exit non-zero sometimes
@@ -88,12 +80,8 @@ func testElect(cx ctlCtx) {
 	}
 
 	// kill the holder with clean shutdown
-	if err = holder.Signal(os.Interrupt); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err = e2e.CloseWithTimeout(holder, time.Second); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, holder.Signal(os.Interrupt))
+	require.NoError(cx.t, e2e.CloseWithTimeout(holder, time.Second))
 
 	// blockAcquire should win the election
 	select {

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -135,10 +135,7 @@ func TestAuthority(t *testing.T) {
 				client, err := e2e.NewEtcdctl(cfg.Client, endpoints)
 				require.NoError(t, err)
 				for i := 0; i < 100; i++ {
-					err = client.Put(ctx, "foo", "bar", config.PutOptions{})
-					if err != nil {
-						t.Fatal(err)
-					}
+					require.NoError(t, client.Put(ctx, "foo", "bar", config.PutOptions{}))
 				}
 
 				testutils.ExecuteWithTimeout(t, 5*time.Second, func() {
@@ -167,9 +164,7 @@ func assertAuthority(t *testing.T, expectAuthorityPattern string, clus *e2e.Etcd
 		line = strings.TrimSuffix(line, "\r")
 
 		u, err := url.Parse(clus.Procs[i].EndpointsGRPC()[0])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		expectAuthority := strings.ReplaceAll(expectAuthorityPattern, "${MEMBER_PORT}", u.Port())
 		expectLine := fmt.Sprintf(`http2: decoded hpack field header field ":authority" = %q`, expectAuthority)
 		assert.Truef(t, strings.HasSuffix(line, expectLine), "Got %q expected suffix %q", line, expectLine)

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -57,14 +57,11 @@ func TestCtlV3GetRevokedCRL(t *testing.T) {
 
 func testGetRevokedCRL(cx ctlCtx) {
 	// test reject
-	err := ctlV3Put(cx, "k", "v", "")
-	require.ErrorContains(cx.t, err, "context deadline exceeded")
+	require.ErrorContains(cx.t, ctlV3Put(cx, "k", "v", ""), "context deadline exceeded")
 
 	// test accept
 	cx.epc.Cfg.Client.RevokeCerts = false
-	if err := ctlV3Put(cx, "k", "v", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "k", "v", ""))
 }
 
 func putTest(cx ctlCtx) {
@@ -83,18 +80,10 @@ func putTest(cx ctlCtx) {
 }
 
 func putTestIgnoreValue(cx ctlCtx) {
-	if err := ctlV3Put(cx, "foo", "bar", ""); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Put(cx, "foo", "", "", "--ignore-value"); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "foo", "bar", ""))
+	require.NoError(cx.t, ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}))
+	require.NoError(cx.t, ctlV3Put(cx, "foo", "", "", "--ignore-value"))
+	require.NoError(cx.t, ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}))
 }
 
 func putTestIgnoreLease(cx ctlCtx) {
@@ -159,9 +148,7 @@ func getTest(cx ctlCtx) {
 }
 
 func getFormatTest(cx ctlCtx) {
-	if err := ctlV3Put(cx, "abc", "123", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "abc", "123", ""))
 
 	tests := []struct {
 		format    string
@@ -247,13 +234,9 @@ func getMinMaxCreateModRevTest(cx ctlCtx) {
 }
 
 func getKeysOnlyTest(cx ctlCtx) {
-	if err := ctlV3Put(cx, "key", "val", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3Put(cx, "key", "val", ""))
 	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--keys-only", "key"}...)
-	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -265,33 +248,17 @@ func getKeysOnlyTest(cx ctlCtx) {
 
 func getCountOnlyTest(cx ctlCtx) {
 	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 0"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Put(cx, "key", "val", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 0"}))
+	require.NoError(cx.t, ctlV3Put(cx, "key", "val", ""))
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 1"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Put(cx, "key1", "val", ""); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Put(cx, "key1", "val", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 1"}))
+	require.NoError(cx.t, ctlV3Put(cx, "key1", "val", ""))
+	require.NoError(cx.t, ctlV3Put(cx, "key1", "val", ""))
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 2"}); err != nil {
-		cx.t.Fatal(err)
-	}
-	if err := ctlV3Put(cx, "key2", "val", ""); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 2"}))
+	require.NoError(cx.t, ctlV3Put(cx, "key2", "val", ""))
 	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	if err := e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 3"}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 3"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/tests/e2e/ctl_v3_make_mirror_test.go
+++ b/tests/e2e/ctl_v3_make_mirror_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -100,26 +102,14 @@ func testMirrorCommand(cx ctlCtx, flags []string, sourcekvs []kv, destkvs []kvEx
 	cmdArgs = append(cmdArgs, flags...)
 	cmdArgs = append(cmdArgs, fmt.Sprintf("localhost:%d", mirrorcfg.BasePort))
 	proc, err := e2e.SpawnCmd(cmdArgs, cx.envMap)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 	defer func() {
-		err = proc.Stop()
-		if err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, proc.Stop())
 	}()
 
 	for i := range sourcekvs {
-		if err = ctlV3Put(cx, sourcekvs[i].key, sourcekvs[i].val, ""); err != nil {
-			cx.t.Fatal(err)
-		}
+		require.NoError(cx.t, ctlV3Put(cx, sourcekvs[i].key, sourcekvs[i].val, ""))
 	}
-	if err = ctlV3Get(cx, []string{srcprefix, "--prefix"}, sourcekvs...); err != nil {
-		cx.t.Fatal(err)
-	}
-
-	if err = ctlV3Watch(mirrorctx, []string{destprefix, "--rev", "1", "--prefix"}, destkvs...); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3Get(cx, []string{srcprefix, "--prefix"}, sourcekvs...))
+	require.NoError(cx.t, ctlV3Watch(mirrorctx, []string{destprefix, "--rev", "1", "--prefix"}, destkvs...))
 }

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -256,16 +256,12 @@ func memberListWithHexTest(cx ctlCtx) {
 
 func memberAddTest(cx ctlCtx) {
 	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+11)
-	if err := ctlV3MemberAdd(cx, peerURL, false); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3MemberAdd(cx, peerURL, false))
 }
 
 func memberAddAsLearnerTest(cx ctlCtx) {
 	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+11)
-	if err := ctlV3MemberAdd(cx, peerURL, true); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3MemberAdd(cx, peerURL, true))
 }
 
 func ctlV3MemberAdd(cx ctlCtx, peerURL string, isLearner bool) error {
@@ -280,15 +276,11 @@ func ctlV3MemberAdd(cx ctlCtx, peerURL string, isLearner bool) error {
 
 func memberUpdateTest(cx ctlCtx) {
 	mr, err := getMemberList(cx, false)
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 
 	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+11)
 	memberID := fmt.Sprintf("%x", mr.Members[0].ID)
-	if err = ctlV3MemberUpdate(cx, memberID, peerURL); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, ctlV3MemberUpdate(cx, memberID, peerURL))
 }
 
 func ctlV3MemberUpdate(cx ctlCtx, memberID, peerURL string) error {
@@ -310,6 +302,5 @@ func TestRemoveNonExistingMember(t *testing.T) {
 	require.Error(t, err)
 
 	// Ensure that membership is properly bootstrapped.
-	err = epc.Restart(ctx)
-	assert.NoError(t, err)
+	assert.NoError(t, epc.Restart(ctx))
 }

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -71,9 +71,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 		}
 		var err error
 		tcfg, err = tinfo.ClientConfig()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	var leadIdx int
@@ -85,9 +83,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 			DialTimeout: 3 * time.Second,
 			TLS:         tcfg,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		resp, err := cli.Status(ctx, ep)
 		if err != nil {

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -82,12 +82,9 @@ func snapshotCorruptTest(cx ctlCtx) {
 
 	// corrupt file
 	f, oerr := os.OpenFile(fpath, os.O_WRONLY, 0)
-	if oerr != nil {
-		cx.t.Fatal(oerr)
-	}
-	if _, err := f.Write(make([]byte, 512)); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, oerr)
+	_, err := f.Write(make([]byte, 512))
+	require.NoError(cx.t, err)
 	f.Close()
 
 	datadir := cx.t.TempDir()
@@ -129,9 +126,7 @@ func snapshotStatusBeforeRestoreTest(cx ctlCtx) {
 			fpath),
 		cx.envMap,
 		expect.ExpectedResponse{Value: "added member"})
-	if serr != nil {
-		cx.t.Fatal(serr)
-	}
+	require.NoError(cx.t, serr)
 }
 
 func ctlV3SnapshotSave(cx ctlCtx, fpath string) error {
@@ -204,21 +199,17 @@ func testIssue6361(t *testing.T) {
 	fpath := filepath.Join(t.TempDir(), "test.snapshot")
 
 	t.Log("etcdctl saving snapshot...")
-	if err = e2e.SpawnWithExpects(append(prefixArgs, "snapshot", "save", fpath),
+	require.NoError(t, e2e.SpawnWithExpects(append(prefixArgs, "snapshot", "save", fpath),
 		nil,
 		expect.ExpectedResponse{Value: fmt.Sprintf("Snapshot saved at %s", fpath)},
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	t.Log("Stopping the original server...")
-	if err = epc.Procs[0].Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, epc.Procs[0].Stop())
 
 	newDataDir := filepath.Join(t.TempDir(), "test.data")
 	t.Log("etcdctl restoring the snapshot...")
-	err = e2e.SpawnWithExpect([]string{
+	require.NoError(t, e2e.SpawnWithExpect([]string{
 		e2e.BinPath.Etcdutl, "snapshot", "restore", fpath,
 		"--name", epc.Procs[0].Config().Name,
 		"--initial-cluster", epc.Procs[0].Config().InitialCluster,
@@ -226,10 +217,7 @@ func testIssue6361(t *testing.T) {
 		"--initial-advertise-peer-urls", epc.Procs[0].Config().PeerURL.String(),
 		"--data-dir", newDataDir,
 	},
-		expect.ExpectedResponse{Value: "added member"})
-	if err != nil {
-		t.Fatal(err)
-	}
+		expect.ExpectedResponse{Value: "added member"}))
 
 	t.Log("(Re)starting the etcd member using the restored snapshot...")
 	epc.Procs[0].Config().DataDirPath = newDataDir
@@ -238,23 +226,17 @@ func testIssue6361(t *testing.T) {
 			epc.Procs[0].Config().Args[i+1] = newDataDir
 		}
 	}
-	if err = epc.Procs[0].Restart(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, epc.Procs[0].Restart(context.TODO()))
 
 	t.Log("Ensuring the restored member has the correct data...")
 	for i := range kvs {
-		err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val})
-		require.NoError(t, err)
+		require.NoError(t, e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val}))
 	}
 
 	t.Log("Adding new member into the cluster")
 	clientURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+30)
 	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+31)
-	err = e2e.SpawnWithExpect(append(prefixArgs, "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL)), expect.ExpectedResponse{Value: " added to cluster "})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, e2e.SpawnWithExpect(append(prefixArgs, "member", "add", "newmember", fmt.Sprintf("--peer-urls=%s", peerURL)), expect.ExpectedResponse{Value: " added to cluster "}))
 
 	newDataDir2 := t.TempDir()
 	defer os.RemoveAll(newDataDir2)
@@ -271,25 +253,19 @@ func testIssue6361(t *testing.T) {
 		"--listen-peer-urls", peerURL, "--initial-advertise-peer-urls", peerURL,
 		"--initial-cluster", initialCluster2, "--initial-cluster-state", "existing", "--data-dir", newDataDir2,
 	}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err = nepc.Expect("ready to serve client requests"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	_, err = nepc.Expect("ready to serve client requests")
+	require.NoError(t, err)
 
 	prefixArgs = []string{e2e.BinPath.Etcdctl, "--endpoints", clientURL, "--dial-timeout", dialTimeout.String()}
 
 	t.Log("Ensuring added member has data from incoming snapshot...")
 	for i := range kvs {
-		err = e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val})
-		require.NoError(t, err)
+		require.NoError(t, e2e.SpawnWithExpect(append(prefixArgs, "get", kvs[i].key), expect.ExpectedResponse{Value: kvs[i].val}))
 	}
 
 	t.Log("Stopping the second member")
-	if err = nepc.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, nepc.Stop())
 	t.Log("Test logic done")
 }
 
@@ -377,7 +353,7 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 	newDataDir := filepath.Join(t.TempDir(), "test.data")
 	t.Log("etcdctl restoring the snapshot...")
 	bumpAmount := 10000
-	err = e2e.SpawnWithExpect([]string{
+	require.NoError(t, e2e.SpawnWithExpect([]string{
 		e2e.BinPath.Etcdutl,
 		"snapshot",
 		"restore", fpath,
@@ -388,8 +364,7 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 		"--bump-revision", fmt.Sprintf("%d", bumpAmount),
 		"--mark-compacted",
 		"--data-dir", newDataDir,
-	}, expect.ExpectedResponse{Value: "added member"})
-	require.NoError(t, err)
+	}, expect.ExpectedResponse{Value: "added member"}))
 
 	t.Log("(Re)starting the etcd member using the restored snapshot...")
 	epc.Procs[0].Config().DataDirPath = newDataDir

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
@@ -113,9 +114,7 @@ func TestCtlV3DialWithHTTPScheme(t *testing.T) {
 
 func dialWithSchemeTest(cx ctlCtx) {
 	cmdArgs := append(cx.prefixArgs(cx.epc.EndpointsGRPC()), "put", "foo", "bar")
-	if err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "OK"}); err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "OK"}))
 }
 
 type ctlCtx struct {

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -81,12 +83,8 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 
 	// step 4: sanity test on the etcd cluster
 	etcdctl := []string{e2e.BinPath.Etcdctl, "--endpoints", strings.Join(epc.EndpointsGRPC(), ",")}
-	if err := e2e.SpawnWithExpect(append(etcdctl, "put", "key", "value"), expect.ExpectedResponse{Value: "OK"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := e2e.SpawnWithExpect(append(etcdctl, "get", "key"), expect.ExpectedResponse{Value: "value"}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, e2e.SpawnWithExpect(append(etcdctl, "put", "key", "value"), expect.ExpectedResponse{Value: "OK"}))
+	require.NoError(t, e2e.SpawnWithExpect(append(etcdctl, "get", "key"), expect.ExpectedResponse{Value: "value"}))
 }
 
 func bootstrapEtcdClusterUsingV3Discovery(t *testing.T, discoveryEndpoints []string, discoveryToken string, clusterSize int, clientTLSType e2e.ClientConnType, isClientAutoTLS bool) (*e2e.EtcdProcessCluster, error) {

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -39,15 +39,9 @@ func TestEtcdExampleConfig(t *testing.T) {
 	e2e.SkipInShortMode(t)
 
 	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--config-file", exampleConfigFile}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines); err != nil {
-		t.Fatal(err)
-	}
-	if err = proc.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines))
+	require.NoError(t, proc.Stop())
 }
 
 func TestEtcdMultiPeer(t *testing.T) {
@@ -81,9 +75,7 @@ func TestEtcdMultiPeer(t *testing.T) {
 			"--initial-cluster", ic,
 		}
 		p, err := e2e.SpawnCmd(args, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		procs[i] = p
 	}
 
@@ -109,15 +101,9 @@ func TestEtcdUnixPeers(t *testing.T) {
 		}, nil,
 	)
 	defer os.Remove("etcd.unix:1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines); err != nil {
-		t.Fatal(err)
-	}
-	if err = proc.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, e2e.EtcdServerReadyLines))
+	require.NoError(t, proc.Stop())
 }
 
 // TestEtcdListenMetricsURLsWithMissingClientTLSInfo checks that the HTTPs listen metrics URL
@@ -158,19 +144,13 @@ func TestEtcdListenMetricsURLsWithMissingClientTLSInfo(t *testing.T) {
 	}
 
 	proc, err := e2e.SpawnCmd(commonArgs, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() {
-		if err := proc.Stop(); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, proc.Stop())
 		_ = proc.Close()
 	}()
 
-	if err := e2e.WaitReadyExpectProc(context.TODO(), proc, []string{embed.ErrMissingClientTLSInfoForMetricsURL.Error()}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, []string{embed.ErrMissingClientTLSInfoForMetricsURL.Error()}))
 }
 
 // TestEtcdPeerCNAuth checks that the inter peer auth based on CN of cert is working correctly.
@@ -233,9 +213,7 @@ func TestEtcdPeerCNAuth(t *testing.T) {
 		commonArgs = append(commonArgs, args...)
 
 		p, err := e2e.SpawnCmd(commonArgs, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		procs[i] = p
 	}
 
@@ -322,9 +300,7 @@ func TestEtcdPeerMultiCNAuth(t *testing.T) {
 
 		commonArgs = append(commonArgs, args...)
 		p, err := e2e.SpawnCmd(commonArgs, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		procs[i] = p
 	}
 
@@ -397,9 +373,7 @@ func TestEtcdPeerNameAuth(t *testing.T) {
 		commonArgs = append(commonArgs, args...)
 
 		p, err := e2e.SpawnCmd(commonArgs, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		procs[i] = p
 	}
 
@@ -505,9 +479,7 @@ func TestEtcdPeerLocalAddr(t *testing.T) {
 		commonArgs = append(commonArgs, args...)
 
 		p, err := e2e.SpawnCmd(commonArgs, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		procs[i] = p
 	}
 
@@ -554,9 +526,7 @@ func TestGrpcproxyAndCommonName(t *testing.T) {
 		}
 	}()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestGrpcproxyAndListenCipherSuite(t *testing.T) {
@@ -589,12 +559,8 @@ func TestGrpcproxyAndListenCipherSuite(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			pw, err := e2e.SpawnCmd(test.args, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err = pw.Stop(); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			require.NoError(t, pw.Stop())
 		})
 	}
 }
@@ -603,15 +569,9 @@ func TestBootstrapDefragFlag(t *testing.T) {
 	e2e.SkipInShortMode(t)
 
 	proc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "--experimental-bootstrap-defrag-threshold-megabytes", "1000"}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = e2e.WaitReadyExpectProc(context.TODO(), proc, []string{"Skipping defragmentation"}); err != nil {
-		t.Fatal(err)
-	}
-	if err = proc.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, e2e.WaitReadyExpectProc(context.TODO(), proc, []string{"Skipping defragmentation"}))
+	require.NoError(t, proc.Stop())
 
 	// wait for the process to exit, otherwise test will have leaked goroutine
 	if err := proc.Close(); err != nil {

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -137,10 +137,7 @@ func waitForEndpointInLog(ctx context.Context, proxyProc *expect.ExpectProcess, 
 	defer cancel()
 
 	_, err := proxyProc.ExpectFunc(ctx, func(s string) bool {
-		if strings.Contains(s, endpoint) {
-			return true
-		}
-		return false
+		return strings.Contains(s, endpoint)
 	})
 
 	return err

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -27,9 +29,7 @@ var defaultGatewayEndpoint = "127.0.0.1:23790"
 
 func TestGateway(t *testing.T) {
 	ec, err := e2e.NewEtcdProcessCluster(context.TODO(), t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer ec.Stop()
 
 	eps := strings.Join(ec.EndpointsGRPC(), ",")
@@ -48,12 +48,8 @@ func TestGateway(t *testing.T) {
 
 func startGateway(t *testing.T, endpoints string) *expect.ExpectProcess {
 	p, err := expect.NewExpect(e2e.BinPath.Etcd, "gateway", "--endpoints="+endpoints, "start")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, err = p.Expect("ready to proxy client requests")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return p
 }

--- a/tests/e2e/http_health_check_test.go
+++ b/tests/e2e/http_health_check_test.go
@@ -365,9 +365,7 @@ func triggerNoSpaceAlarm(ctx context.Context, t *testing.T, clus *e2e.EtcdProces
 	etcdctl := clus.Etcdctl()
 	for {
 		if err := etcdctl.Put(ctx, "foo", buf, config.PutOptions{}); err != nil {
-			if !strings.Contains(err.Error(), "etcdserver: mvcc: database space exceeded") {
-				t.Fatal(err)
-			}
+			require.ErrorContains(t, err, "etcdserver: mvcc: database space exceeded")
 			break
 		}
 	}

--- a/tests/e2e/logging_test.go
+++ b/tests/e2e/logging_test.go
@@ -99,8 +99,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			}
 
 			time.Sleep(time.Second)
-			err = epc.Close()
-			require.NoErrorf(t, err, "closing etcd processes")
+			require.NoErrorf(t, epc.Close(), "closing etcd processes")
 
 			// Now that the processes are closed we can collect all log lines. This must happen after closing, else we
 			// might not get all log lines.

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -140,15 +140,12 @@ func TestEtctlutlMigrate(t *testing.T) {
 
 			t.Log("Write keys to ensure wal snapshot is created and all v3.5 fields are set...")
 			for i := 0; i < 10; i++ {
-				if err = e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), expect.ExpectedResponse{Value: "OK"}); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, e2e.SpawnWithExpect(append(prefixArgs, "put", fmt.Sprintf("%d", i), "value"), expect.ExpectedResponse{Value: "OK"}))
 			}
 
 			t.Log("Stopping the server...")
-			if err = epc.Procs[0].Stop(); err != nil {
-				t.Fatal(err)
-			}
+			err = epc.Procs[0].Stop()
+			require.NoError(t, err)
 
 			t.Log("etcdutl migrate...")
 			memberDataDir := epc.Procs[0].Config().DataDirPath
@@ -157,12 +154,10 @@ func TestEtctlutlMigrate(t *testing.T) {
 				args = append(args, "--force")
 			}
 			err = e2e.SpawnWithExpect(args, expect.ExpectedResponse{Value: tc.expectLogsSubString})
-			if err != nil {
-				if tc.expectLogsSubString != "" {
-					require.ErrorContains(t, err, tc.expectLogsSubString)
-				} else {
-					t.Fatal(err)
-				}
+			if err != nil && tc.expectLogsSubString != "" {
+				require.ErrorContains(t, err, tc.expectLogsSubString)
+			} else {
+				require.NoError(t, err)
 			}
 
 			t.Log("etcdutl migrate...")

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -243,13 +243,9 @@ func filterSnapshotFiles(path string) bool {
 func assertSnapshotsMatch(t testing.TB, firstDataDir, secondDataDir string, patch func([]byte) []byte) {
 	lg := zaptest.NewLogger(t)
 	firstFiles, err := fileutil.ListFiles(firstDataDir, filterSnapshotFiles)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	secondFiles, err := fileutil.ListFiles(secondDataDir, filterSnapshotFiles)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.NotEmpty(t, firstFiles)
 	assert.NotEmpty(t, secondFiles)
 	assert.Equal(t, len(firstFiles), len(secondFiles))
@@ -257,13 +253,9 @@ func assertSnapshotsMatch(t testing.TB, firstDataDir, secondDataDir string, patc
 	sort.Strings(secondFiles)
 	for i := 0; i < len(firstFiles); i++ {
 		firstSnapshot, err := snap.Read(lg, firstFiles[i])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		secondSnapshot, err := snap.Read(lg, secondFiles[i])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assertMembershipEqual(t, openSnap(patch(firstSnapshot.Data)), openSnap(patch(secondSnapshot.Data)))
 	}
 }

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -68,49 +68,41 @@ func testCurlV3Auth(cx ctlCtx) {
 		user, err := json.Marshal(&pb.AuthUserAddRequest{Name: usernames[i], Password: pwds[i], Options: options[i]})
 		require.NoError(cx.t, err)
 
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/add",
 			Value:    string(user),
 			Expected: expect.ExpectedResponse{Value: "revision"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3Auth failed to add user %v (%v)", usernames[i], err)
-		}
+		}), "testCurlV3Auth failed to add user %v", usernames[i])
 	}
 
 	// create root role
 	rolereq, err := json.Marshal(&pb.AuthRoleAddRequest{Name: "root"})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/add",
 		Value:    string(rolereq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3Auth failed to create role (%v)", err)
-	}
+	}), "testCurlV3Auth failed to create role")
 
 	// grant root role
 	for i := 0; i < len(usernames); i++ {
 		grantroleroot, merr := json.Marshal(&pb.AuthUserGrantRoleRequest{User: usernames[i], Role: "root"})
 		require.NoError(cx.t, merr)
 
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/grant",
 			Value:    string(grantroleroot),
 			Expected: expect.ExpectedResponse{Value: "revision"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3Auth failed to grant role (%v)", err)
-		}
+		}), "testCurlV3Auth failed to grant role")
 	}
 
 	// enable auth
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/enable",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3Auth failed to enable auth (%v)", err)
-	}
+	}), "testCurlV3Auth failed to enable auth")
 
 	for i := 0; i < len(usernames); i++ {
 		// put "bar[i]" into "foo[i]"
@@ -118,13 +110,11 @@ func testCurlV3Auth(cx ctlCtx) {
 		require.NoError(cx.t, err)
 
 		// fail put no auth
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/kv/put",
 			Value:    string(putreq),
 			Expected: expect.ExpectedResponse{Value: "etcdserver: user name is empty"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3Auth failed to put without token (%v)", err)
-		}
+		}), "testCurlV3Auth failed to put without token")
 
 		// auth request
 		authreq, err := json.Marshal(&pb.AuthenticateRequest{Name: usernames[i], Password: pwds[i]})
@@ -157,14 +147,12 @@ func testCurlV3Auth(cx ctlCtx) {
 
 		authHeader = "Authorization: " + token
 		// put with auth
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/kv/put",
 			Value:    string(putreq),
 			Header:   authHeader,
 			Expected: expect.ExpectedResponse{Value: "revision"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3Auth failed to auth put with user (%v) (%v)", usernames[i], err)
-		}
+		}), "testCurlV3Auth failed to auth put with user (%v)", usernames[i])
 	}
 }
 
@@ -176,25 +164,21 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 		user, err := json.Marshal(&pb.AuthUserAddRequest{Name: usernames[i], Password: "123"})
 		require.NoError(cx.t, err)
 
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/add",
 			Value:    string(user),
 			Expected: expect.ExpectedResponse{Value: "revision"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthUserBasicOperations failed to add user %v (%v)", usernames[i], err)
-		}
+		}), "testCurlV3AuthUserBasicOperations failed to add user %v", usernames[i])
 	}
 
 	// change password
 	user, err := json.Marshal(&pb.AuthUserChangePasswordRequest{Name: "user1", Password: "456"})
 	require.NoError(cx.t, err)
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/user/changepw",
 		Value:    string(user),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthUserBasicOperations failed to change user's password(%v)", err)
-	}
+	}), "testCurlV3AuthUserBasicOperations failed to change user's password")
 
 	// get users
 	usernames = []string{"user1", "userX"}
@@ -205,13 +189,11 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 		})
 
 		require.NoError(cx.t, err)
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/get",
 			Value:    string(user),
 			Expected: expect.ExpectedResponse{Value: expectedResponse[i]},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthUserBasicOperations failed to get user %v (%v)", usernames[i], err)
-		}
+		}), "testCurlV3AuthUserBasicOperations failed to get user %v", usernames[i])
 	}
 
 	// delete users
@@ -222,13 +204,11 @@ func testCurlV3AuthUserBasicOperations(cx ctlCtx) {
 			Name: usernames[i],
 		})
 		require.NoError(cx.t, err)
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/user/delete",
 			Value:    string(user),
 			Expected: expect.ExpectedResponse{Value: expectedResponse[i]},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthUserBasicOperations failed to delete user %v (%v)", usernames[i], err)
-		}
+		}), "testCurlV3AuthUserBasicOperations failed to delete user %v", usernames[i])
 	}
 
 	// list users
@@ -258,25 +238,21 @@ func testCurlV3AuthUserGrantRevokeRoles(cx ctlCtx) {
 	user, err := json.Marshal(&pb.AuthUserAddRequest{Name: username, Password: "123"})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/user/add",
 		Value:    string(user),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthUserGrantRevokeRoles failed to add user %v (%v)", username, err)
-	}
+	}), "testCurlV3AuthUserGrantRevokeRoles failed to add user %v", username)
 
 	// create role
 	role, err := json.Marshal(&pb.AuthRoleAddRequest{Name: rolename})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/add",
 		Value:    string(role),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthUserGrantRevokeRoles failed to add role %v (%v)", rolename, err)
-	}
+	}), "testCurlV3AuthUserGrantRevokeRoles failed to add role %v", rolename)
 
 	// grant role to user
 	grantRoleReq, err := json.Marshal(&pb.AuthUserGrantRoleRequest{
@@ -285,13 +261,11 @@ func testCurlV3AuthUserGrantRevokeRoles(cx ctlCtx) {
 	})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/user/grant",
 		Value:    string(grantRoleReq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthUserGrantRevokeRoles failed to grant role to user (%v)", err)
-	}
+	}), "testCurlV3AuthUserGrantRevokeRoles failed to grant role to user")
 
 	//  revoke role from user
 	revokeRoleReq, err := json.Marshal(&pb.AuthUserRevokeRoleRequest{
@@ -300,13 +274,11 @@ func testCurlV3AuthUserGrantRevokeRoles(cx ctlCtx) {
 	})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/user/revoke",
 		Value:    string(revokeRoleReq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthUserGrantRevokeRoles failed to revoke role from user (%v)", err)
-	}
+	}), "testCurlV3AuthUserGrantRevokeRoles failed to revoke role from user")
 }
 
 func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
@@ -317,13 +289,11 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 		role, err := json.Marshal(&pb.AuthRoleAddRequest{Name: rolenames[i]})
 		require.NoError(cx.t, err)
 
-		if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/role/add",
 			Value:    string(role),
 			Expected: expect.ExpectedResponse{Value: "revision"},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthRoleBasicOperations failed to add role %v (%v)", rolenames[i], err)
-		}
+		}), "testCurlV3AuthRoleBasicOperations failed to add role %v", rolenames[i])
 	}
 
 	// get roles
@@ -334,13 +304,11 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 			Role: rolenames[i],
 		})
 		require.NoError(cx.t, err)
-		if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/role/get",
 			Value:    string(role),
 			Expected: expect.ExpectedResponse{Value: expectedResponse[i]},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthRoleBasicOperations failed to get role %v (%v)", rolenames[i], err)
-		}
+		}), "testCurlV3AuthRoleBasicOperations failed to get role %v", rolenames[i])
 	}
 
 	// delete roles
@@ -351,13 +319,11 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 			Role: rolenames[i],
 		})
 		require.NoError(cx.t, err)
-		if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+		require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 			Endpoint: "/v3/auth/role/delete",
 			Value:    string(role),
 			Expected: expect.ExpectedResponse{Value: expectedResponse[i]},
-		}); err != nil {
-			cx.t.Fatalf("testCurlV3AuthRoleBasicOperations failed to delete role %v (%v)", rolenames[i], err)
-		}
+		}), "testCurlV3AuthRoleBasicOperations failed to delete role %v", rolenames[i])
 	}
 
 	// list roles
@@ -384,13 +350,11 @@ func testCurlV3AuthRoleManagePermission(cx ctlCtx) {
 	role, err := json.Marshal(&pb.AuthRoleAddRequest{Name: rolename})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/add",
 		Value:    string(role),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthRoleManagePermission failed to add role %v (%v)", rolename, err)
-	}
+	}), "testCurlV3AuthRoleManagePermission failed to add role %v", rolename)
 
 	// grant permission
 	grantPermissionReq, err := json.Marshal(&pb.AuthRoleGrantPermissionRequest{
@@ -402,13 +366,11 @@ func testCurlV3AuthRoleManagePermission(cx ctlCtx) {
 	})
 	require.NoError(cx.t, err)
 
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/grant",
 		Value:    string(grantPermissionReq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthRoleManagePermission failed to grant permission to role %v (%v)", rolename, err)
-	}
+	}), "testCurlV3AuthRoleManagePermission failed to grant permission to role %v", rolename)
 
 	// revoke permission
 	revokePermissionReq, err := json.Marshal(&pb.AuthRoleRevokePermissionRequest{
@@ -417,40 +379,32 @@ func testCurlV3AuthRoleManagePermission(cx ctlCtx) {
 	})
 	require.NoError(cx.t, err)
 
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/role/revoke",
 		Value:    string(revokePermissionReq),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthRoleManagePermission failed to revoke permission from role %v (%v)", rolename, err)
-	}
+	}), "testCurlV3AuthRoleManagePermission failed to revoke permission from role %v", rolename)
 }
 
 func testCurlV3AuthEnableDisableStatus(cx ctlCtx) {
 	// enable auth
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/enable",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{Value: "etcdserver: root user does not exist"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthEnableDisableStatus failed to enable auth (%v)", err)
-	}
+	}), "testCurlV3AuthEnableDisableStatus failed to enable auth")
 
 	// disable auth
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/disable",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthEnableDisableStatus failed to disable auth (%v)", err)
-	}
+	}), "testCurlV3AuthEnableDisableStatus failed to disable auth")
 
 	// auth status
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/auth/status",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3AuthEnableDisableStatus failed to get auth status (%v)", err)
-	}
+	}), "testCurlV3AuthEnableDisableStatus failed to get auth status")
 }

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -69,9 +71,7 @@ func testCurlV3LeaseGrant(cx ctlCtx) {
 			expected: `"grantedTTL"`,
 		},
 	}
-	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
-	}
+	require.NoErrorf(cx.t, CURLWithExpected(cx, tests), "testCurlV3LeaseGrant")
 }
 
 func testCurlV3LeaseRevoke(cx ctlCtx) {
@@ -89,9 +89,7 @@ func testCurlV3LeaseRevoke(cx ctlCtx) {
 			expected: `"revision":"`,
 		},
 	}
-	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testCurlV3LeaseRevoke: %v", err)
-	}
+	require.NoErrorf(cx.t, CURLWithExpected(cx, tests), "testCurlV3LeaseRevoke")
 }
 
 func testCurlV3LeaseLeases(cx ctlCtx) {
@@ -109,9 +107,7 @@ func testCurlV3LeaseLeases(cx ctlCtx) {
 			expected: gwLeaseIDExpected(leaseID),
 		},
 	}
-	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
-	}
+	require.NoErrorf(cx.t, CURLWithExpected(cx, tests), "testCurlV3LeaseGrant")
 }
 
 func testCurlV3LeaseKeepAlive(cx ctlCtx) {
@@ -129,9 +125,7 @@ func testCurlV3LeaseKeepAlive(cx ctlCtx) {
 			expected: gwLeaseIDExpected(leaseID),
 		},
 	}
-	if err := CURLWithExpected(cx, tests); err != nil {
-		cx.t.Fatalf("testCurlV3LeaseGrant: %v", err)
-	}
+	require.NoErrorf(cx.t, CURLWithExpected(cx, tests), "testCurlV3LeaseGrant")
 }
 
 func gwLeaseIDExpected(leaseID int64) string {
@@ -141,44 +135,34 @@ func gwLeaseIDExpected(leaseID int64) string {
 func gwLeaseTTLWithKeys(cx ctlCtx, leaseID int64) string {
 	d := &pb.LeaseTimeToLiveRequest{ID: leaseID, Keys: true}
 	s, err := e2e.DataMarshal(d)
-	if err != nil {
-		cx.t.Fatalf("gwLeaseTTLWithKeys: error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "gwLeaseTTLWithKeys: error")
 	return s
 }
 
 func gwLeaseKeepAlive(cx ctlCtx, leaseID int64) string {
 	d := &pb.LeaseKeepAliveRequest{ID: leaseID}
 	s, err := e2e.DataMarshal(d)
-	if err != nil {
-		cx.t.Fatalf("gwLeaseKeepAlive: Marshal error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "gwLeaseKeepAlive: Marshal error")
 	return s
 }
 
 func gwLeaseGrant(cx ctlCtx, leaseID int64, ttl int64) string {
 	d := &pb.LeaseGrantRequest{ID: leaseID, TTL: ttl}
 	s, err := e2e.DataMarshal(d)
-	if err != nil {
-		cx.t.Fatalf("gwLeaseGrant: Marshal error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "gwLeaseGrant: Marshal error")
 	return s
 }
 
 func gwLeaseRevoke(cx ctlCtx, leaseID int64) string {
 	d := &pb.LeaseRevokeRequest{ID: leaseID}
 	s, err := e2e.DataMarshal(d)
-	if err != nil {
-		cx.t.Fatalf("gwLeaseRevoke: Marshal error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "gwLeaseRevoke: Marshal error")
 	return s
 }
 
 func gwKVPutLease(cx ctlCtx, k string, v string, leaseID int64) string {
 	d := pb.PutRequest{Key: []byte(k), Value: []byte(v), Lease: leaseID}
 	s, err := e2e.DataMarshal(d)
-	if err != nil {
-		cx.t.Fatalf("gwKVPutLease: Marshal error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "gwKVPutLease: Marshal error")
 	return s
 }

--- a/tests/e2e/v3_curl_lock_test.go
+++ b/tests/e2e/v3_curl_lock_test.go
@@ -46,11 +46,9 @@ func testCurlV3LockOperations(cx ctlCtx) {
 	require.True(cx.t, ok)
 
 	// unlock
-	if err = e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/lock/unlock",
 		Value:    fmt.Sprintf(`{"key": "%v"}`, key),
 		Expected: expect.ExpectedResponse{Value: "revision"},
-	}); err != nil {
-		cx.t.Fatalf("testCurlV3LockOperations failed to execute unlock (%v)", err)
-	}
+	}), "testCurlV3LockOperations failed to execute unlock")
 }

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -30,12 +30,10 @@ func TestCurlV3MaintenanceAlarmMissiongAlarm(t *testing.T) {
 }
 
 func testCurlV3MaintenanceAlarmMissiongAlarm(cx ctlCtx) {
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/alarm",
 		Value:    `{"action": "ACTIVATE"}`,
-	}); err != nil {
-		cx.t.Fatalf("failed post maintenance alarm (%v)", err)
-	}
+	}), "failed post maintenance alarm")
 }
 
 func TestCurlV3MaintenanceStatus(t *testing.T) {
@@ -58,8 +56,8 @@ func testCurlV3MaintenanceStatus(cx ctlCtx) {
 		}
 	}
 
-	actualVersion, _ := resp["version"]
-	require.Equal(cx.t, version.Version, actualVersion)
+	require.Contains(cx.t, resp, "version")
+	require.Equal(cx.t, version.Version, resp["version"])
 }
 
 func TestCurlV3MaintenanceDefragment(t *testing.T) {
@@ -67,15 +65,13 @@ func TestCurlV3MaintenanceDefragment(t *testing.T) {
 }
 
 func testCurlV3MaintenanceDefragment(cx ctlCtx) {
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/defragment",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{
 			Value: "{}",
 		},
-	}); err != nil {
-		cx.t.Fatalf("failed post maintenance defragment request: (%v)", err)
-	}
+	}), "failed post maintenance defragment request")
 }
 
 func TestCurlV3MaintenanceHash(t *testing.T) {
@@ -125,15 +121,13 @@ func TestCurlV3MaintenanceSnapshot(t *testing.T) {
 }
 
 func testCurlV3MaintenanceSnapshot(cx ctlCtx) {
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/snapshot",
 		Value:    "{}",
 		Expected: expect.ExpectedResponse{
 			Value: `"result":{"blob":`,
 		},
-	}); err != nil {
-		cx.t.Fatalf("failed post maintenance snapshot request: (%v)", err)
-	}
+	}), "failed post maintenance snapshot request")
 }
 
 func TestCurlV3MaintenanceMoveleader(t *testing.T) {
@@ -141,15 +135,13 @@ func TestCurlV3MaintenanceMoveleader(t *testing.T) {
 }
 
 func testCurlV3MaintenanceMoveleader(cx ctlCtx) {
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/transfer-leadership",
 		Value:    `{"targetID": 123}`,
 		Expected: expect.ExpectedResponse{
 			Value: `"message":"etcdserver: bad leader transferee"`,
 		},
-	}); err != nil {
-		cx.t.Fatalf("failed post maintenance moveleader request: (%v)", err)
-	}
+	}), "failed post maintenance moveleader request")
 }
 
 func TestCurlV3MaintenanceDowngrade(t *testing.T) {
@@ -157,13 +149,11 @@ func TestCurlV3MaintenanceDowngrade(t *testing.T) {
 }
 
 func testCurlV3MaintenanceDowngrade(cx ctlCtx) {
-	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{
+	require.NoErrorf(cx.t, e2e.CURLPost(cx.epc, e2e.CURLReq{
 		Endpoint: "/v3/maintenance/downgrade",
 		Value:    `{"action": 0, "version": "3.0"}`,
 		Expected: expect.ExpectedResponse{
 			Value: `"message":"etcdserver: invalid downgrade target version"`,
 		},
-	}); err != nil {
-		cx.t.Fatalf("failed post maintenance downgrade request: (%v)", err)
-	}
+	}), "failed post maintenance downgrade request")
 }

--- a/tests/e2e/v3_curl_maxstream_test.go
+++ b/tests/e2e/v3_curl_maxstream_test.go
@@ -44,9 +44,7 @@ func TestCurlV3_MaxStreams_BelowLimit_NoTLS_Medium(t *testing.T) {
 
 func TestCurlV3_MaxStreamsNoTLS_BelowLimit_Large(t *testing.T) {
 	f, err := setRLimit(10240)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer f()
 	testCurlV3MaxStream(t, false, withCfg(*e2e.NewConfigNoTLS()), withMaxConcurrentStreams(1000), withTestTimeout(200*time.Second))
 }
@@ -91,9 +89,7 @@ func testCurlV3MaxStream(t *testing.T, reachLimit bool, opts ...ctlOption) {
 	// Step 2: create the cluster
 	t.Log("Creating an etcd cluster")
 	epc, err := e2e.NewEtcdProcessCluster(context.TODO(), t, e2e.WithConfig(&cx.cfg))
-	if err != nil {
-		t.Fatalf("Failed to start etcd cluster: %v", err)
-	}
+	require.NoErrorf(t, err, "Failed to start etcd cluster")
 	cx.epc = epc
 	cx.dataDir = epc.Procs[0].Config().DataDirPath
 
@@ -146,9 +142,7 @@ func submitConcurrentWatch(cx ctlCtx, number int, wgDone *sync.WaitGroup, closeC
 			Key: []byte("foo"),
 		},
 	})
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 
 	var wgSchedule sync.WaitGroup
 
@@ -193,9 +187,7 @@ func submitConcurrentWatch(cx ctlCtx, number int, wgDone *sync.WaitGroup, closeC
 			go func(i int) {
 				defer wgDone.Done()
 
-				if err := createWatchConnection(); err != nil {
-					cx.t.Fatalf("testCurlV3MaxStream watch failed: %d, error: %v", i, err)
-				}
+				require.NoErrorf(cx.t, createWatchConnection(), "testCurlV3MaxStream watch failed: %d", i)
 			}(i)
 		}
 
@@ -208,9 +200,7 @@ func submitRangeAfterConcurrentWatch(cx ctlCtx, expectedValue string) {
 	rangeData, err := json.Marshal(&pb.RangeRequest{
 		Key: []byte("foo"),
 	})
-	if err != nil {
-		cx.t.Fatal(err)
-	}
+	require.NoError(cx.t, err)
 
 	cx.t.Log("Submitting range request...")
 	if err := e2e.CURLPost(cx.epc, e2e.CURLReq{Endpoint: "/v3/kv/range", Value: string(rangeData), Expected: expect.ExpectedResponse{Value: expectedValue}, Timeout: 5}); err != nil {

--- a/tests/e2e/v3_lease_no_proxy_test.go
+++ b/tests/e2e/v3_lease_no_proxy_test.go
@@ -66,9 +66,7 @@ func testLeaseRevokeIssue(t *testing.T, clusterSize int, connectToOneFollower bo
 	)
 	require.NoError(t, err)
 	defer func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	}()
 
 	leaderIdx := epc.WaitLeader(t)

--- a/tests/e2e/zap_logging_test.go
+++ b/tests/e2e/zap_logging_test.go
@@ -33,14 +33,10 @@ func TestServerJsonLogging(t *testing.T) {
 		e2e.WithClusterSize(1),
 		e2e.WithLogLevel("debug"),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster")
 	logs := epc.Procs[0].Logs()
 	time.Sleep(time.Second)
-	if err = epc.Close(); err != nil {
-		t.Fatalf("error closing etcd processes (%v)", err)
-	}
+	require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	var entry logEntry
 	lines := logs.Lines()
 	if len(lines) == 0 {


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal calls

Related to #18972