### PR TITLE
fix: use require instead of t.Fatal(err) in tests/common package

### DIFF
--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -51,22 +52,17 @@ func TestCompact(t *testing.T) {
 			testutils.ExecuteUntil(ctx, t, func() {
 				var kvs = []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 				for i := range kvs {
-					if err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}); err != nil {
-						t.Fatalf("compactTest #%d: put kv error (%v)", i, err)
-					}
+					err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{})
+					require.NoErrorf(t, err, "compactTest #%d: put kv error", i)
 				}
 				get, err := cc.Get(ctx, "key", config.GetOptions{Revision: 3})
-				if err != nil {
-					t.Fatalf("compactTest: Get kv by revision error (%v)", err)
-				}
+				require.NoErrorf(t, err, "compactTest: Get kv by revision error")
 
 				getkvs := testutils.KeyValuesFromGetResponse(get)
 				assert.Equal(t, kvs[1:2], getkvs)
 
 				_, err = cc.Compact(ctx, 4, tc.options)
-				if err != nil {
-					t.Fatalf("compactTest: Compact error (%v)", err)
-				}
+				require.NoErrorf(t, err, "compactTest: Compact error")
 
 				_, err = cc.Get(ctx, "key", config.GetOptions{Revision: 3})
 				if err != nil {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -179,19 +180,14 @@ func TestKVDelete(t *testing.T) {
 				}
 				for _, tt := range tests {
 					for i := range kvs {
-						if err := cc.Put(ctx, kvs[i], "bar", config.PutOptions{}); err != nil {
-							t.Fatalf("count not put key %q, err: %s", kvs[i], err)
-						}
+						err := cc.Put(ctx, kvs[i], "bar", config.PutOptions{})
+						require.NoErrorf(t, err, "count not put key %q", kvs[i])
 					}
 					del, err := cc.Delete(ctx, tt.deleteKey, tt.options)
-					if err != nil {
-						t.Fatalf("count not get key %q, err: %s", tt.deleteKey, err)
-					}
+					require.NoErrorf(t, err, "count not get key %q, err", tt.deleteKey)
 					assert.Equal(t, tt.wantDeleted, int(del.Deleted))
 					get, err := cc.Get(ctx, "", config.GetOptions{Prefix: true})
-					if err != nil {
-						t.Fatalf("count not get key, err: %s", err)
-					}
+					require.NoErrorf(t, err, "count not get key")
 					kvs := testutils.KeysFromGetResponse(get)
 					assert.Equal(t, tt.wantKeys, kvs)
 				}

--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -215,14 +215,12 @@ func testMaintenanceOperationWithAuth(t *testing.T, expectConnectError, expectOp
 
 	ccWithAuth, err := clus.Client(opts...)
 	if expectConnectError {
-		if err == nil {
-			t.Fatalf("%s: expected connection error, but got successful response", t.Name())
-		}
+		require.Errorf(t, err, "%s: expected connection error, but got successful response", t.Name())
 		t.Logf("%s: connection error: %v", t.Name(), err)
 		return
 	}
 	if err != nil {
-		t.Fatalf("%s: unexpected connection error (%v)", t.Name(), err)
+		require.NoErrorf(t, err, "%s: unexpected connection error", t.Name())
 		return
 	}
 
@@ -233,15 +231,11 @@ func testMaintenanceOperationWithAuth(t *testing.T, expectConnectError, expectOp
 		err := f(ctx, ccWithAuth)
 
 		if expectOperationError {
-			if err == nil {
-				t.Fatalf("%s: expected error, but got successful response", t.Name())
-			}
+			require.Errorf(t, err, "%s: expected error, but got successful response", t.Name())
 			t.Logf("%s: operation error: %v", t.Name(), err)
 			return
 		}
 
-		if err != nil {
-			t.Fatalf("%s: unexpected operation error (%v)", t.Name(), err)
-		}
+		require.NoErrorf(t, err, "%s: unexpected operation error", t.Name())
 	})
 }

--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -42,9 +42,7 @@ func TestMemberList(t *testing.T) {
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				resp, err := cc.MemberList(ctx, false)
-				if err != nil {
-					t.Fatalf("could not get member list, err: %s", err)
-				}
+				require.NoErrorf(t, err, "could not get member list")
 				expectNum := len(clus.Members())
 				gotNum := len(resp.Members)
 				if expectNum != gotNum {

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -38,9 +40,7 @@ func TestRoleAdd_Simple(t *testing.T) {
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				_, err := cc.RoleAdd(ctx, "root")
-				if err != nil {
-					t.Fatalf("want no error, but got (%v)", err)
-				}
+				require.NoErrorf(t, err, "want no error, but got")
 			})
 		})
 	}
@@ -55,9 +55,7 @@ func TestRoleAdd_Error(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "test-role")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleAdd(ctx, "test-role")
 		if err == nil || !strings.Contains(err.Error(), rpctypes.ErrRoleAlreadyExist.Error()) {
 			t.Fatalf("want (%v) error, but got (%v)", rpctypes.ErrRoleAlreadyExist, err)
@@ -78,23 +76,15 @@ func TestRootRole(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "root")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		resp, err := cc.RoleGet(ctx, "root")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		t.Logf("get role resp %+v", resp)
 		// granting to root should be refused by server and a no-op
 		_, err = cc.RoleGrantPermission(ctx, "root", "foo", "", clientv3.PermissionType(clientv3.PermReadWrite))
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		resp2, err := cc.RoleGet(ctx, "root")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		t.Logf("get role resp %+v", resp2)
 	})
 }
@@ -108,29 +98,19 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "", clientv3.PermissionType(clientv3.PermRead))
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "", clientv3.PermissionType(clientv3.PermWrite))
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "foo", clientv3.PermissionType(clientv3.PermReadWrite))
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleRevokePermission(ctx, "role1", "foo", "")
 		if err == nil || !strings.Contains(err.Error(), rpctypes.ErrPermissionNotGranted.Error()) {
 			t.Fatalf("want error (%v), but got (%v)", rpctypes.ErrPermissionNotGranted, err)
 		}
 		_, err = cc.RoleRevokePermission(ctx, "role1", "bar", "foo")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 	})
 }
 
@@ -143,12 +123,8 @@ func TestRoleDelete(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 		_, err = cc.RoleDelete(ctx, "role1")
-		if err != nil {
-			t.Fatalf("want no error, but got (%v)", err)
-		}
+		require.NoErrorf(t, err, "want no error, but got")
 	})
 }

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -36,9 +38,7 @@ func TestStatus(t *testing.T) {
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				rs, err := cc.Status(ctx)
-				if err != nil {
-					t.Fatalf("could not get status, err: %s", err)
-				}
+				require.NoErrorf(t, err, "could not get status")
 				if len(rs) != tc.config.ClusterSize {
 					t.Fatalf("wrong number of status responses. expected:%d, got:%d ", tc.config.ClusterSize, len(rs))
 				}

--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -64,12 +65,10 @@ func TestTxnSucc(t *testing.T) {
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
-				if err := cc.Put(ctx, "key1", "value1", config.PutOptions{}); err != nil {
-					t.Fatalf("could not create key:%s, value:%s", "key1", "value1")
-				}
-				if err := cc.Put(ctx, "key2", "value2", config.PutOptions{}); err != nil {
-					t.Fatalf("could not create key:%s, value:%s", "key2", "value2")
-				}
+				err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
+				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key1", "value1")
+				err = cc.Put(ctx, "key2", "value2", config.PutOptions{})
+				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key2", "value2")
 				for _, req := range reqs {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,
@@ -108,9 +107,8 @@ func TestTxnFail(t *testing.T) {
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
-				if err := cc.Put(ctx, "key1", "value1", config.PutOptions{}); err != nil {
-					t.Fatalf("could not create key:%s, value:%s", "key1", "value1")
-				}
+				err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
+				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key1", "value1")
 				for _, req := range reqs {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,

--- a/tests/common/user_test.go
+++ b/tests/common/user_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -75,16 +76,14 @@ func TestUserAdd_Simple(t *testing.T) {
 					resp, err := cc.UserAdd(ctx, nc.username, nc.password, config.UserAddOptions{NoPassword: nc.noPassword})
 					if nc.expectedError != "" {
 						if err != nil {
-							assert.Contains(t, err.Error(), nc.expectedError)
+							assert.ErrorContains(t, err, nc.expectedError)
 							return
 						}
 
 						t.Fatalf("expected user creation to fail")
 					}
 
-					if err != nil {
-						t.Fatalf("expected no error, err: %v", err)
-					}
+					require.NoErrorf(t, err, "expected no error")
 
 					if resp == nil {
 						t.Fatalf("unexpected nil response to successful user creation")
@@ -110,14 +109,10 @@ func TestUserAdd_DuplicateUserNotAllowed(t *testing.T) {
 				password := "rhubarb"
 
 				_, err := cc.UserAdd(ctx, user, password, config.UserAddOptions{})
-				if err != nil {
-					t.Fatalf("first user creation should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "first user creation should succeed")
 
 				_, err = cc.UserAdd(ctx, user, password, config.UserAddOptions{})
-				if err == nil {
-					t.Fatalf("duplicate user creation should fail")
-				}
+				require.Errorf(t, err, "duplicate user creation should fail")
 				assert.Contains(t, err.Error(), "etcdserver: user name already exists")
 			})
 		})
@@ -137,9 +132,7 @@ func TestUserList(t *testing.T) {
 			testutils.ExecuteUntil(ctx, t, func() {
 				// No Users Yet
 				resp, err := cc.UserList(ctx)
-				if err != nil {
-					t.Fatalf("user listing should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user listing should succeed")
 				if len(resp.Users) != 0 {
 					t.Fatalf("expected no pre-existing users, found: %q", resp.Users)
 				}
@@ -148,15 +141,11 @@ func TestUserList(t *testing.T) {
 				password := "rhubarb"
 
 				_, err = cc.UserAdd(ctx, user, password, config.UserAddOptions{})
-				if err != nil {
-					t.Fatalf("user creation should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user creation should succeed")
 
 				// Users!
 				resp, err = cc.UserList(ctx)
-				if err != nil {
-					t.Fatalf("user listing should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user listing should succeed")
 				if len(resp.Users) != 1 {
 					t.Fatalf("expected one user, found: %q", resp.Users)
 				}
@@ -180,37 +169,27 @@ func TestUserDelete(t *testing.T) {
 				password := "rhubarb"
 
 				_, err := cc.UserAdd(ctx, user, password, config.UserAddOptions{})
-				if err != nil {
-					t.Fatalf("user creation should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user creation should succeed")
 
 				resp, err := cc.UserList(ctx)
-				if err != nil {
-					t.Fatalf("user listing should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user listing should succeed")
 				if len(resp.Users) != 1 {
 					t.Fatalf("expected one user, found: %q", resp.Users)
 				}
 
 				// Delete barb, sorry barb!
 				_, err = cc.UserDelete(ctx, user)
-				if err != nil {
-					t.Fatalf("user deletion should succeed at first, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user deletion should succeed at first")
 
 				resp, err = cc.UserList(ctx)
-				if err != nil {
-					t.Fatalf("user listing should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user listing should succeed")
 				if len(resp.Users) != 0 {
 					t.Fatalf("expected no users after deletion, found: %q", resp.Users)
 				}
 
 				// Try to delete barb again
 				_, err = cc.UserDelete(ctx, user)
-				if err == nil {
-					t.Fatalf("deleting a non-existent user should fail")
-				}
+				require.Errorf(t, err, "deleting a non-existent user should fail")
 				assert.Contains(t, err.Error(), "user name not found")
 			})
 		})
@@ -233,19 +212,13 @@ func TestUserChangePassword(t *testing.T) {
 				newPassword := "potato"
 
 				_, err := cc.UserAdd(ctx, user, password, config.UserAddOptions{})
-				if err != nil {
-					t.Fatalf("user creation should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user creation should succeed")
 
 				err = cc.UserChangePass(ctx, user, newPassword)
-				if err != nil {
-					t.Fatalf("user password change should succeed, err: %v", err)
-				}
+				require.NoErrorf(t, err, "user password change should succeed")
 
 				err = cc.UserChangePass(ctx, "non-existent-user", newPassword)
-				if err == nil {
-					t.Fatalf("user password change for non-existent user should fail")
-				}
+				require.Errorf(t, err, "user password change for non-existent user should fail")
 				assert.Contains(t, err.Error(), "user name not found")
 			})
 		})

--- a/tests/common/watch_test.go
+++ b/tests/common/watch_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -77,15 +78,14 @@ func TestWatch(t *testing.T) {
 					}
 
 					for j := range tt.puts {
-						if err := cc.Put(ctx, tt.puts[j].Key, tt.puts[j].Val, config.PutOptions{}); err != nil {
-							t.Fatalf("can't not put key %q, err: %s", tt.puts[j].Key, err)
-						}
+						err := cc.Put(ctx, tt.puts[j].Key, tt.puts[j].Val, config.PutOptions{})
+						require.NoErrorf(t, err, "can't not put key %q, err: %s", tt.puts[j].Key, err)
 					}
 
 					kvs, err := testutils.KeyValuesFromWatchChan(wch, len(tt.wanted), watchTimeout)
 					if err != nil {
 						wCancel()
-						t.Fatalf("failed to get key-values from watch channel %s", err)
+						require.NoErrorf(t, err, "failed to get key-values from watch channel %s", err)
 					}
 
 					wCancel()


### PR DESCRIPTION
This uses testify instead of testing for t.Fatal calls