### PR TITLE
Update 3.4 changelog to cover the goroutine leakage issue

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,9 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.35 (TBC)
 
+### etcd server
+- Fix [watchserver related goroutine leakage](https://github.com/etcd-io/etcd/pull/18785)
+
 ### Dependencies
 - Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18670).
 


### PR DESCRIPTION
Previous PR forgot to update 3.4 changelog.