### PR TITLE
Run a separate in memory snapshot to reduce number of entries stored in raft memory storage

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -899,7 +899,7 @@ func (c *RaftCluster) Store(store v2store.Store) {
 		if m.ClientURLs != nil {
 			mustUpdateMemberAttrInStore(c.lg, store, m)
 		}
-		c.lg.Info(
+		c.lg.Debug(
 			"snapshot storing member",
 			zap.String("id", m.ID.String()),
 			zap.Strings("peer-urls", m.PeerURLs),

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -679,12 +679,13 @@ func TestSnapshot(t *testing.T) {
 			t.Errorf("action = %s, want Release", gaction[1])
 		}
 	}()
-
-	srv.snapshot(1, raftpb.ConfState{Voters: []uint64{1}})
+	ep := etcdProgress{appliedi: 1, confState: raftpb.ConfState{Voters: []uint64{1}}}
+	srv.snapshot(&ep)
 	<-ch
 	if len(st.Action()) != 0 {
 		t.Errorf("no action expected on v2store. Got %d actions", len(st.Action()))
 	}
+	assert.Equal(t, uint64(1), ep.diskSnapshotIndex)
 }
 
 // TestSnapshotOrdering ensures raft persists snapshot onto disk before

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -686,6 +686,7 @@ func TestSnapshot(t *testing.T) {
 		t.Errorf("no action expected on v2store. Got %d actions", len(st.Action()))
 	}
 	assert.Equal(t, uint64(1), ep.diskSnapshotIndex)
+	assert.Equal(t, uint64(1), ep.memorySnapshotIndex)
 }
 
 // TestSnapshotOrdering ensures raft persists snapshot onto disk before

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -667,24 +667,14 @@ func TestSnapshotDisk(t *testing.T) {
 		gaction, _ := p.Wait(2)
 		defer func() { ch <- struct{}{} }()
 
-		if len(gaction) != 2 {
-			t.Errorf("len(action) = %d, want 2", len(gaction))
-			return
-		}
-		if !reflect.DeepEqual(gaction[0], testutil.Action{Name: "SaveSnap"}) {
-			t.Errorf("action = %s, want SaveSnap", gaction[0])
-		}
-
-		if !reflect.DeepEqual(gaction[1], testutil.Action{Name: "Release"}) {
-			t.Errorf("action = %s, want Release", gaction[1])
-		}
+		assert.Len(t, gaction, 2)
+		assert.Equal(t, testutil.Action{Name: "SaveSnap"}, gaction[0])
+		assert.Equal(t, testutil.Action{Name: "Release"}, gaction[1])
 	}()
 	ep := etcdProgress{appliedi: 1, confState: raftpb.ConfState{Voters: []uint64{1}}}
 	srv.snapshot(&ep, true)
 	<-ch
-	if len(st.Action()) != 0 {
-		t.Errorf("no action expected on v2store. Got %d actions", len(st.Action()))
-	}
+	assert.Empty(t, st.Action())
 	assert.Equal(t, uint64(1), ep.diskSnapshotIndex)
 	assert.Equal(t, uint64(1), ep.memorySnapshotIndex)
 }
@@ -728,17 +718,12 @@ func TestSnapshotMemory(t *testing.T) {
 		gaction, _ := p.Wait(1)
 		defer func() { ch <- struct{}{} }()
 
-		if len(gaction) != 0 {
-			t.Errorf("len(action) = %d, want 0", len(gaction))
-			return
-		}
+		assert.Empty(t, gaction)
 	}()
 	ep := etcdProgress{appliedi: 1, confState: raftpb.ConfState{Voters: []uint64{1}}}
 	srv.snapshot(&ep, false)
 	<-ch
-	if len(st.Action()) != 0 {
-		t.Errorf("no action expected on v2store. Got %d actions", len(st.Action()))
-	}
+	assert.Empty(t, st.Action())
 	assert.Equal(t, uint64(0), ep.diskSnapshotIndex)
 	assert.Equal(t, uint64(1), ep.memorySnapshotIndex)
 }

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -111,7 +111,9 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	//
 	// Since there is no way to confirm server has compacted the log, we
 	// use log monitor to watch and expect "compacted Raft logs" content.
-	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "compacted Raft logs", 2)
+	// In v3.6 we no longer generates "compacted Raft logs" log as raft compaction happens independently to snapshot.
+	// For now let's use snapshot log which should be equivalent to compaction.
+	expectMemberLog(t, clus.Members[initialLead], 5*time.Second, "saved snapshot to disk", 2)
 
 	// After RecoverPartition, leader L will send snapshot to slow F_m0
 	// follower, because F_m0(index:8) is 'out of date' compared to


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/17098

Alternative to https://github.com/etcd-io/etcd/pull/18635

Goal: Reduce number of raft entries stored in memory

Context:
* Etcd maintains 2 different independently updates storages. V2 - stored as snapshots every X entries (100`000 by default), V3 - memory mapped bbolt storage, flushed every 5 seconds to disk
* Etcd maintains guarantee for the data stored on disk. V3 storage needs to be always fresher than V2 snapshot. Meaning V3 consistent index is >= index of last snapshot.
* This guarantee requires that before writing any V2 snapshots etcd needs to flush V3 storage which is costly.
* In etcd v3.6 no longer uses v2 storage as source of truth, however it maintains periodic snapshot generation for backward compatibility.
* Raft in memory store needs to store last snapshot and all entries since. However, this snapshot doesn't need to be persisted to disk.

Proposal:
* Separate disk and memory snapshotting.
* Disk snapshotting will be used for backward compatibility. Done every --snapshot-count. 
* Memory snapshots would no longer be bound by disk overhead.


Benchmark results `./bin/tools/benchmark put --total=15000 --val-size=100000`

| Scenario           | Snapshot count | Memory snapshot count | CPU[%] | Memory[MB] | PUTs per second |
| ------------------ | -------------- | --------------------- | ------ | ---------- | --------------- |
| Base               | 10000          | n/a                   | 49.4   | 1954.5     | 1029.2          |
| Snapshot in memory | 10000          | 1                     | 51.1   | 1330.4     | 1006.1          |
| Snapshot in memory | 10000          | 10                    | 48.9   | 1264.2     | 1046.3          |
| Snapshot in memory | 10000          | 100                   | 48.1   | 1210.4     | 1051.8          |
| Snapshot in memory | 10000          | 1000                  | 48.2   | 1360.0     | 1047.2          |
| Snapshot in memory | 10000          | 10000                 | 49.4   | 2040.3     | 1027.4          |