### PR TITLE
fix: enable go-require rule from testifylint

### DIFF
--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -110,7 +111,7 @@ func TestAuthGracefulDisable(t *testing.T) {
 				return
 			}
 			// the watcher should still work after reconnecting
-			require.NoErrorf(t, rootAuthClient.Put(ctx, "key", "value", config.PutOptions{}), "failed to put key value")
+			assert.NoErrorf(t, rootAuthClient.Put(ctx, "key", "value", config.PutOptions{}), "failed to put key value")
 		}()
 
 		wCtx, wCancel := context.WithCancel(ctx)

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -424,7 +424,7 @@ func testCtlV3ReadAfterWrite(t *testing.T, ops ...clientv3.OpOption) {
 			}
 
 			count++
-			require.Equal(t, "bar2", string(resp.Kvs[0].Value))
+			assert.Equal(t, "bar2", string(resp.Kvs[0].Value))
 		}
 	}()
 

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -107,7 +107,7 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 			}
 
 			merr := epc.Procs[0].Restart(ctx)
-			require.NoError(t, merr)
+			assert.NoError(t, merr)
 			epc.WaitLeader(t)
 
 			time.Sleep(100 * time.Millisecond)
@@ -135,7 +135,7 @@ func TestCtlV3ConsistentMemberList(t *testing.T) {
 			}
 
 			count++
-			require.Len(t, mresp.Members, 1)
+			assert.Len(t, mresp.Members, 1)
 		}
 	}()
 

--- a/tests/e2e/v3_lease_no_proxy_test.go
+++ b/tests/e2e/v3_lease_no_proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -106,7 +107,7 @@ func testLeaseRevokeIssue(t *testing.T, clusterSize int, connectToOneFollower bo
 		defer close(doneC)
 
 		respC, kerr := clientForKeepAlive.KeepAlive(ctx, leaseRsp.ID)
-		require.NoError(t, kerr)
+		assert.NoError(t, kerr)
 		// ensure we have received the first response from the server
 		<-respC
 		startC <- struct{}{}

--- a/tests/e2e/watch_test.go
+++ b/tests/e2e/watch_test.go
@@ -387,7 +387,7 @@ func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombsto
 				t.Logf("DELETE key=%s", key)
 
 				resp, derr := c.KV.Delete(ctx, key)
-				require.NoError(t, derr)
+				assert.NoError(t, derr)
 				respHeader = resp.Header
 
 				requestedValues = append(requestedValues, valueEvent{value: "", typ: mvccpb.DELETE})
@@ -396,7 +396,7 @@ func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombsto
 
 				t.Logf("PUT key=%s, val=%s", key, value)
 				resp, perr := c.KV.Put(ctx, key, value)
-				require.NoError(t, perr)
+				assert.NoError(t, perr)
 				respHeader = resp.Header
 
 				requestedValues = append(requestedValues, valueEvent{value: value, typ: mvccpb.PUT})
@@ -409,7 +409,7 @@ func testStartWatcherFromCompactedRevision(t *testing.T, performCompactOnTombsto
 
 				t.Logf("COMPACT rev=%d", lastRevision)
 				_, err = c.KV.Compact(ctx, lastRevision, clientv3.WithCompactPhysical())
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}
 	}()

--- a/tests/e2e/zap_logging_test.go
+++ b/tests/e2e/zap_logging_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -130,7 +131,7 @@ func TestConnectionRejectMessage(t *testing.T) {
 			go func() {
 				startedCh <- struct{}{}
 				verr := e2e.WaitReadyExpectProc(context.TODO(), p, []string{tc.expectedErrMsg})
-				require.NoError(t, verr)
+				assert.NoError(t, verr)
 				doneCh <- struct{}{}
 			}()
 

--- a/tests/framework/testutils/log_observer_test.go
+++ b/tests/framework/testutils/log_observer_test.go
@@ -53,7 +53,7 @@ func TestLogObserver_Expect(t *testing.T) {
 		defer close(resCh)
 
 		res, err := logOb.Expect(ctx, t.Name(), 2)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		resCh <- res
 	}()
 

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -112,8 +112,6 @@ linters-settings: # please keep this alphabetized
     checks:
       - ST1019 # Importing the same package multiple times.
   testifylint:
-    disable:
-      - go-require
     enable-all: true
     formatter:
       # Require f-assertions (e.g. assert.Equalf) if a message is passed to the assertion, even if


### PR DESCRIPTION
This fixes [go-require](https://github.com/Antonboom/testifylint?tab=readme-ov-file#go-require) rule from [testifylint](https://github.com/Antonboom/testifylint)

Closes #18719

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->