### PR TITLE
[3.5] add tls min/max version to grpc proxy

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -78,13 +78,16 @@ var (
 
 	// tls for clients connecting to proxy
 
-	grpcProxyListenCA           string
-	grpcProxyListenCert         string
-	grpcProxyListenKey          string
-	grpcProxyListenCipherSuites []string
-	grpcProxyListenAutoTLS      bool
-	grpcProxyListenCRL          string
-	selfSignedCertValidity      uint
+	grpcProxyListenCA            string
+	grpcProxyListenCert          string
+	grpcProxyListenKey           string
+	grpcProxyListenCipherSuites  []string
+	grpcProxyListenAutoTLS       bool
+	grpcProxyListenCRL           string
+	grpcProxyListenTLSMinVersion string
+	grpcProxyListenTLSMaxVersion string
+
+	selfSignedCertValidity uint
 
 	grpcProxyAdvertiseClientURL string
 	grpcProxyResolverPrefix     string
@@ -166,6 +169,8 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&grpcProxyListenAutoTLS, "auto-tls", false, "proxy TLS using generated certificates")
 	cmd.Flags().StringVar(&grpcProxyListenCRL, "client-crl-file", "", "proxy client certificate revocation list file.")
 	cmd.Flags().UintVar(&selfSignedCertValidity, "self-signed-cert-validity", 1, "The validity period of the proxy certificates, unit is year")
+	cmd.Flags().StringVar(&grpcProxyListenTLSMinVersion, "tls-min-version", string(tlsutil.TLSVersion12), "Minimum TLS version supported by grpc proxy. Possible values: TLS1.2, TLS1.3.")
+	cmd.Flags().StringVar(&grpcProxyListenTLSMaxVersion, "tls-max-version", string(tlsutil.TLSVersionDefault), "Maximum TLS version supported by grpc proxy. Possible values: TLS1.2, TLS1.3 (empty defers to Go).")
 
 	// experimental flags
 	cmd.Flags().BoolVar(&grpcProxyEnableOrdering, "experimental-serializable-ordering", false, "Ensure serializable reads have monotonically increasing store revisions across endpoints.")
@@ -197,13 +202,6 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 	// The empty CN is required for grpcProxyCert.
 	// Please see https://github.com/etcd-io/etcd/issues/11970#issuecomment-687875315  for more context.
 	tlsInfo := newTLS(grpcProxyListenCA, grpcProxyListenCert, grpcProxyListenKey, false)
-	if len(grpcProxyListenCipherSuites) > 0 {
-		cs, err := tlsutil.GetCipherSuites(grpcProxyListenCipherSuites)
-		if err != nil {
-			log.Fatal(err)
-		}
-		tlsInfo.CipherSuites = cs
-	}
 	if tlsInfo == nil && grpcProxyListenAutoTLS {
 		host := []string{"https://" + grpcProxyListenAddr}
 		dir := filepath.Join(grpcProxyDataDir, "fixtures", "proxy")
@@ -213,10 +211,32 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 		}
 		tlsInfo = &autoTLS
 	}
-
 	if tlsInfo != nil {
+		if len(grpcProxyListenCipherSuites) > 0 {
+			cs, err := tlsutil.GetCipherSuites(grpcProxyListenCipherSuites)
+			if err != nil {
+				log.Fatal(err)
+			}
+			tlsInfo.CipherSuites = cs
+		}
+		if grpcProxyListenTLSMinVersion != "" {
+			version, err := tlsutil.GetTLSVersion(grpcProxyListenTLSMinVersion)
+			if err != nil {
+				log.Fatal(err)
+			}
+			tlsInfo.MinVersion = version
+		}
+		if grpcProxyListenTLSMaxVersion != "" {
+			version, err := tlsutil.GetTLSVersion(grpcProxyListenTLSMaxVersion)
+			if err != nil {
+				log.Fatal(err)
+			}
+			tlsInfo.MaxVersion = version
+		}
+
 		lg.Info("gRPC proxy server TLS", zap.String("tls-info", fmt.Sprintf("%+v", tlsInfo)))
 	}
+
 	m := mustListenCMux(lg, tlsInfo)
 	grpcl := m.Match(cmux.HTTP2())
 	defer func() {
@@ -288,6 +308,29 @@ func checkArgs() {
 	}
 	if grpcProxyListenAutoTLS && selfSignedCertValidity == 0 {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("selfSignedCertValidity is invalid,it should be greater than 0"))
+		os.Exit(1)
+	}
+
+	minVersion, err := tlsutil.GetTLSVersion(grpcProxyListenTLSMinVersion)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("tls-min-version is invalid: %w", err))
+		os.Exit(1)
+	}
+	maxVersion, err := tlsutil.GetTLSVersion(grpcProxyListenTLSMaxVersion)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("tls-max-version is invalid: %w", err))
+		os.Exit(1)
+	}
+
+	// maxVersion == 0 means that Go selects the highest available version.
+	if maxVersion != 0 && minVersion > maxVersion {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("min version (%s) is greater than max version (%s)", grpcProxyListenTLSMinVersion, grpcProxyListenTLSMaxVersion))
+		os.Exit(1)
+	}
+
+	// Check if user attempted to configure ciphers for TLS1.3 only: Go does not support that currently.
+	if minVersion == tls.VersionTLS13 && len(grpcProxyListenCipherSuites) > 0 {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("cipher suites cannot be configured when only TLS1.3 is enabled"))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This adds the min and max TLS version support from #13506 and #15156 to the grpc proxy.

Fixes #13506
Backport of #18816

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
