### PR TITLE
fix(defrag): close temp file in case of error

### DIFF
--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -499,6 +499,15 @@ func (b *backend) defrag() error {
 	tdbp := temp.Name()
 	tmpdb, err := bolt.Open(tdbp, 0600, &options)
 	if err != nil {
+		temp.Close()
+		if err := os.Remove(temp.Name()); err != nil && b.lg != nil {
+			b.lg.Error(
+				"failed to remove temporary file",
+				zap.String("path", temp.Name()),
+				zap.Error(err),
+			)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
See issue https://github.com/etcd-io/etcd/issues/18841 and the discussion https://github.com/etcd-io/etcd/pull/18822#discussion_r1830692111 for details.

As written in the issue the temp file is closed if the defragmentation works as expected. The only case where it is left open is when the `bolt.Open` call fails. I think it is enough to simply include the close there, in my opinion there is no need to complicate this more.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
