### PR TITLE
changelog: update go version for 3.4.35 and 3.5.17

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -11,7 +11,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [panicking occurred due to improper error handling during defragmentation](https://github.com/etcd-io/etcd/pull/18843)
 
 ### Dependencies
-- Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18670).
+- Compile binaries using [go 1.22.9](https://github.com/etcd-io/etcd/pull/18850).
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -11,7 +11,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [panicking occurred due to improper error handling during defragmentation](https://github.com/etcd-io/etcd/pull/18842)
 
 ### Dependencies
-- Compile binaries using [go 1.22.8](https://github.com/etcd-io/etcd/pull/18669).
+- Compile binaries using [go 1.22.9](https://github.com/etcd-io/etcd/pull/18849).
 
 <hr>
 


### PR DESCRIPTION
Part of #18847.

Add a note in 3.4.35 and 3.5.17 about compiling with Go 1.22.9.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
