### PR TITLE
fix: enable gofumpt instead of gofmt linter in tools

### DIFF
--- a/tools/benchmark/cmd/lease.go
+++ b/tools/benchmark/cmd/lease.go
@@ -33,9 +33,7 @@ var leaseKeepaliveCmd = &cobra.Command{
 	Run: leaseKeepaliveFunc,
 }
 
-var (
-	leaseKeepaliveTotal int
-)
+var leaseKeepaliveTotal int
 
 func init() {
 	RootCmd.AddCommand(leaseKeepaliveCmd)

--- a/tools/etcd-dump-db/backend.go
+++ b/tools/etcd-dump-db/backend.go
@@ -35,7 +35,7 @@ func snapDir(dataDir string) string {
 }
 
 func getBuckets(dbPath string) (buckets []string, err error) {
-	db, derr := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: flockTimeout})
+	db, derr := bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: flockTimeout})
 	if derr != nil {
 		return nil, fmt.Errorf("failed to open bolt DB %w", derr)
 	}
@@ -132,7 +132,7 @@ func metaDecoder(k, v []byte) {
 }
 
 func iterateBucket(dbPath, bucket string, limit uint64, decode bool) (err error) {
-	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: flockTimeout})
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: flockTimeout})
 	if err != nil {
 		return fmt.Errorf("failed to open bolt DB %w", err)
 	}

--- a/tools/etcd-dump-db/main.go
+++ b/tools/etcd-dump-db/main.go
@@ -53,9 +53,11 @@ var (
 	}
 )
 
-var flockTimeout time.Duration
-var iterateBucketLimit uint64
-var iterateBucketDecode bool
+var (
+	flockTimeout        time.Duration
+	iterateBucketLimit  uint64
+	iterateBucketDecode bool
+)
 
 func init() {
 	rootCommand.PersistentFlags().DurationVar(&flockTimeout, "timeout", 10*time.Second, "time to wait to obtain a file lock on db file, 0 to block indefinitely")

--- a/tools/etcd-dump-db/page.go
+++ b/tools/etcd-dump-db/page.go
@@ -16,9 +16,11 @@ package main
 
 import "unsafe"
 
-const pageHeaderSize = unsafe.Sizeof(page{})
-const leafPageElementSize = unsafe.Sizeof(leafPageElement{})
-const pageMaxAllocSize = 0xFFFFFFF
+const (
+	pageHeaderSize      = unsafe.Sizeof(page{})
+	leafPageElementSize = unsafe.Sizeof(leafPageElement{})
+	pageMaxAllocSize    = 0xFFFFFFF
+)
 
 const (
 	leafPageFlag = 0x02

--- a/tools/etcd-dump-logs/etcd-dump-log_test.go
+++ b/tools/etcd-dump-logs/etcd-dump-log_test.go
@@ -92,7 +92,7 @@ func TestEtcdDumpLogEntryType(t *testing.T) {
 
 func mustCreateWALLog(t *testing.T, path string) {
 	memberdir := filepath.Join(path, "member")
-	err := os.Mkdir(memberdir, 0744)
+	err := os.Mkdir(memberdir, 0o744)
 	require.NoError(t, err)
 	waldir := walDir(path)
 	snapdir := snapDir(path)
@@ -100,7 +100,7 @@ func mustCreateWALLog(t *testing.T, path string) {
 	w, err := wal.Create(zaptest.NewLogger(t), waldir, nil)
 	require.NoError(t, err)
 
-	err = os.Mkdir(snapdir, 0744)
+	err = os.Mkdir(snapdir, 0o744)
 	require.NoError(t, err)
 
 	ents := make([]raftpb.Entry, 0)
@@ -162,11 +162,12 @@ func appendNormalIRREnts(ents *[]raftpb.Entry) {
 
 	irrdeleterange := &etcdserverpb.DeleteRangeRequest{Key: []byte("0"), RangeEnd: []byte("9"), PrevKv: true}
 
-	delInRangeReq := &etcdserverpb.RequestOp{Request: &etcdserverpb.RequestOp_RequestDeleteRange{
-		RequestDeleteRange: &etcdserverpb.DeleteRangeRequest{
-			Key: []byte("a"), RangeEnd: []byte("b"),
+	delInRangeReq := &etcdserverpb.RequestOp{
+		Request: &etcdserverpb.RequestOp_RequestDeleteRange{
+			RequestDeleteRange: &etcdserverpb.DeleteRangeRequest{
+				Key: []byte("a"), RangeEnd: []byte("b"),
+			},
 		},
-	},
 	}
 
 	irrtxn := &etcdserverpb.TxnRequest{Success: []*etcdserverpb.RequestOp{delInRangeReq}, Failure: []*etcdserverpb.RequestOp{delInRangeReq}}

--- a/tools/etcd-dump-logs/main.go
+++ b/tools/etcd-dump-logs/main.go
@@ -314,7 +314,8 @@ func evaluateEntrytypeFlag(entrytype string) []EntryFilter {
 		entrytypelist = strings.Split(entrytype, ",")
 	}
 
-	validRequest := map[string][]EntryFilter{"ConfigChange": {passConfChange},
+	validRequest := map[string][]EntryFilter{
+		"ConfigChange":        {passConfChange},
 		"Normal":              {passInternalRaftRequest, passRequest, passUnknownNormal},
 		"Request":             {passRequest},
 		"InternalRaftRequest": {passInternalRaftRequest},
@@ -346,10 +347,12 @@ IRRCompaction, IRRLeaseGrant, IRRLeaseRevoke, IRRLeaseCheckpoint`, et)
 // listEntriesType filters and prints entries based on the entry-type flag,
 func listEntriesType(entrytype string, streamdecoder string, ents []raftpb.Entry) {
 	entryFilters := evaluateEntrytypeFlag(entrytype)
-	printerMap := map[string]EntryPrinter{"InternalRaftRequest": printInternalRaftRequest,
-		"Request":       printRequest,
-		"ConfigChange":  printConfChange,
-		"UnknownNormal": printUnknownNormal}
+	printerMap := map[string]EntryPrinter{
+		"InternalRaftRequest": printInternalRaftRequest,
+		"Request":             printRequest,
+		"ConfigChange":        printConfChange,
+		"UnknownNormal":       printUnknownNormal,
+	}
 	var stderr strings.Builder
 	args := strings.Split(streamdecoder, " ")
 	cmd := exec.Command(args[0], args[1:]...)

--- a/tools/local-tester/bridge/bridge.go
+++ b/tools/local-tester/bridge/bridge.go
@@ -186,8 +186,10 @@ type config struct {
 	rxDelay string
 }
 
-type acceptFaultFunc func()
-type connFaultFunc func(*bridgeConn)
+type (
+	acceptFaultFunc func()
+	connFaultFunc   func(*bridgeConn)
+)
 
 func main() {
 	var cfg config

--- a/tools/proto-annotations/cmd/etcd_version.go
+++ b/tools/proto-annotations/cmd/etcd_version.go
@@ -27,19 +27,17 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/wal"
 )
 
-var (
-	// externalPackages that are not expected to have etcd version annotation.
-	externalPackages = []string{
-		"io.prometheus.client",
-		"grpc.binarylog.v1",
-		"google.protobuf",
-		"google.rpc",
-		"google.api",
-		"raftpb",
-		"grpc.gateway.protoc_gen_swagger.options",
-		"grpc.gateway.protoc_gen_openapiv2.options",
-	}
-)
+// externalPackages that are not expected to have etcd version annotation.
+var externalPackages = []string{
+	"io.prometheus.client",
+	"grpc.binarylog.v1",
+	"google.protobuf",
+	"google.rpc",
+	"google.api",
+	"raftpb",
+	"grpc.gateway.protoc_gen_swagger.options",
+	"grpc.gateway.protoc_gen_openapiv2.options",
+}
 
 // printEtcdVersion writes etcd_version proto annotation to stdout and returns any errors encountered when reading annotation.
 func printEtcdVersion() []error {


### PR DESCRIPTION
enables and fixes [gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) linter issues in tools directory