### PR TITLE
fix: enable int-conversion rule of perfsprint

### DIFF
--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -15,13 +15,13 @@
 package fileutil
 
 import (
-	"fmt"
 	"io"
 	"math/rand"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -64,7 +64,7 @@ func TestCreateDirAll(t *testing.T) {
 }
 
 func TestExist(t *testing.T) {
-	fdir := filepath.Join(os.TempDir(), fmt.Sprint(time.Now().UnixNano()+rand.Int63n(1000)))
+	fdir := filepath.Join(os.TempDir(), strconv.FormatInt(time.Now().UnixNano()+rand.Int63n(1000), 10))
 	os.RemoveAll(fdir)
 	if err := os.Mkdir(fdir, 0o666); err != nil {
 		t.Skip(err)

--- a/client/pkg/srv/srv.go
+++ b/client/pkg/srv/srv.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -54,7 +55,7 @@ func GetCluster(serviceScheme, service, name, dns string, apurls types.URLs) ([]
 			return err
 		}
 		for _, srv := range addrs {
-			port := fmt.Sprintf("%d", srv.Port)
+			port := strconv.FormatUint(uint64(srv.Port), 10)
 			host := net.JoinHostPort(srv.Target, port)
 			tcpAddr, terr := resolveTCPAddr("tcp", host)
 			if terr != nil {
@@ -67,7 +68,7 @@ func GetCluster(serviceScheme, service, name, dns string, apurls types.URLs) ([]
 				n = name
 			}
 			if n == "" {
-				n = fmt.Sprintf("%d", tempName)
+				n = strconv.Itoa(tempName)
 				tempName++
 			}
 			// SRV records have a trailing dot but URL shouldn't.
@@ -112,7 +113,7 @@ func GetClient(service, domain string, serviceName string) (*SRVClients, error) 
 		for _, srv := range addrs {
 			urls = append(urls, &url.URL{
 				Scheme: scheme,
-				Host:   net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port)),
+				Host:   net.JoinHostPort(srv.Target, strconv.FormatUint(uint64(srv.Port), 10)),
 			})
 		}
 		srvs = append(srvs, addrs...)

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -194,7 +194,7 @@ func makeMemberListTable(r v3.MemberListResponse) (hdr []string, rows [][]string
 			isLearner = "true"
 		}
 		rows = append(rows, []string{
-			fmt.Sprintf("%x", m.ID),
+			strconv.FormatUint(m.ID, 16),
 			status,
 			m.Name,
 			strings.Join(m.PeerURLs, ","),
@@ -210,7 +210,7 @@ func makeEndpointHealthTable(healthList []epHealth) (hdr []string, rows [][]stri
 	for _, h := range healthList {
 		rows = append(rows, []string{
 			h.Ep,
-			fmt.Sprintf("%v", h.Health),
+			strconv.FormatBool(h.Health),
 			h.Took,
 			h.Error,
 		})
@@ -226,19 +226,19 @@ func makeEndpointStatusTable(statusList []epStatus) (hdr []string, rows [][]stri
 	for _, status := range statusList {
 		rows = append(rows, []string{
 			status.Ep,
-			fmt.Sprintf("%x", status.Resp.Header.MemberId),
+			strconv.FormatUint(status.Resp.Header.MemberId, 16),
 			status.Resp.Version,
 			status.Resp.StorageVersion,
 			humanize.Bytes(uint64(status.Resp.DbSize)),
 			humanize.Bytes(uint64(status.Resp.DbSizeInUse)),
 			fmt.Sprintf("%d%%", int(float64(100-(status.Resp.DbSizeInUse*100/status.Resp.DbSize)))),
 			humanize.Bytes(uint64(status.Resp.DbSizeQuota)),
-			fmt.Sprint(status.Resp.Leader == status.Resp.Header.MemberId),
-			fmt.Sprint(status.Resp.IsLearner),
-			fmt.Sprint(status.Resp.RaftTerm),
-			fmt.Sprint(status.Resp.RaftIndex),
-			fmt.Sprint(status.Resp.RaftAppliedIndex),
-			fmt.Sprint(strings.Join(status.Resp.Errors, ", ")),
+			strconv.FormatBool(status.Resp.Leader == status.Resp.Header.MemberId),
+			strconv.FormatBool(status.Resp.IsLearner),
+			strconv.FormatUint(status.Resp.RaftTerm, 10),
+			strconv.FormatUint(status.Resp.RaftIndex, 10),
+			strconv.FormatUint(status.Resp.RaftAppliedIndex, 10),
+			strings.Join(status.Resp.Errors, ", "),
 			status.Resp.DowngradeInfo.GetTargetVersion(),
 			strconv.FormatBool(status.Resp.DowngradeInfo.GetEnabled()),
 		})
@@ -251,8 +251,8 @@ func makeEndpointHashKVTable(hashList []epHashKV) (hdr []string, rows [][]string
 	for _, h := range hashList {
 		rows = append(rows, []string{
 			h.Ep,
-			fmt.Sprint(h.Resp.Hash),
-			fmt.Sprint(h.Resp.HashRevision),
+			strconv.FormatUint(uint64(h.Resp.Hash), 10),
+			strconv.FormatInt(h.Resp.HashRevision, 10),
 		})
 	}
 	return hdr, rows

--- a/etcdutl/etcdutl/printer.go
+++ b/etcdutl/etcdutl/printer.go
@@ -16,7 +16,7 @@ package etcdutl
 
 import (
 	"errors"
-	"fmt"
+	"strconv"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -68,9 +68,9 @@ func (p *printerUnsupported) DBHashKV(HashKV)          { p.p(nil) }
 func makeDBStatusTable(ds snapshot.Status) (hdr []string, rows [][]string) {
 	hdr = []string{"hash", "revision", "total keys", "total size", "version"}
 	rows = append(rows, []string{
-		fmt.Sprintf("%x", ds.Hash),
-		fmt.Sprint(ds.Revision),
-		fmt.Sprint(ds.TotalKey),
+		strconv.FormatUint(uint64(ds.Hash), 16),
+		strconv.FormatInt(ds.Revision, 10),
+		strconv.Itoa(ds.TotalKey),
 		humanize.Bytes(uint64(ds.TotalSize)),
 		ds.Version,
 	})
@@ -80,9 +80,9 @@ func makeDBStatusTable(ds snapshot.Status) (hdr []string, rows [][]string) {
 func makeDBHashKVTable(ds HashKV) (hdr []string, rows [][]string) {
 	hdr = []string{"hash", "hash revision", "compact revision"}
 	rows = append(rows, []string{
-		fmt.Sprint(ds.Hash),
-		fmt.Sprint(ds.HashRevision),
-		fmt.Sprint(ds.CompactRevision),
+		strconv.FormatUint(uint64(ds.Hash), 10),
+		strconv.FormatInt(ds.HashRevision, 10),
+		strconv.FormatInt(ds.CompactRevision, 10),
 	})
 	return hdr, rows
 }

--- a/pkg/report/timeseries.go
+++ b/pkg/report/timeseries.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -127,11 +128,11 @@ func (t TimeSeries) String() string {
 	var rows [][]string
 	for i := range t {
 		row := []string{
-			fmt.Sprintf("%d", t[i].Timestamp),
+			strconv.FormatInt(t[i].Timestamp, 10),
 			t[i].MinLatency.String(),
 			t[i].AvgLatency.String(),
 			t[i].MaxLatency.String(),
-			fmt.Sprintf("%d", t[i].ThroughPut),
+			strconv.FormatInt(t[i].ThroughPut, 10),
 		}
 		rows = append(rows, row)
 	}

--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -56,7 +57,7 @@ func watchGetFunc(_ *cobra.Command, _ []string) {
 	// setup keys for watchers
 	watchRev := int64(0)
 	for i := 0; i < watchEvents; i++ {
-		v := fmt.Sprintf("%d", i)
+		v := strconv.Itoa(i)
 		resp, err := clients[0].Put(context.TODO(), "watchkey", v)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
This fixes int-conversion rule from [perfsprint](https://github.com/catenacyber/perfsprint)

This helps avoid unnecessary memory allocations.
It doesn't include server and tests folder as they have a lot of impacted files

<!--
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
-->