### PR TITLE
fix: use testify instead of t.Fatal in tests/common package (part 2)

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -110,7 +110,7 @@ func TestAlarmlistOnMemberRestart(t *testing.T) {
 	testutils.ExecuteUntil(ctx, t, func() {
 		for i := 0; i < 6; i++ {
 			_, err := cc.AlarmList(ctx)
-			require.NoErrorf(t, err, "Unexpected error")
+			require.NoError(t, err)
 		}
 
 		clus.Members()[0].Stop()

--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -79,9 +79,9 @@ func TestAuthDisable(t *testing.T) {
 		// confirm put succeeded
 		resp, err := cc.Get(ctx, "hoo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "hoo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'hoo', 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'hoo', 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "hoo", string(resp.Kvs[0].Key), "want key value pair 'hoo', 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'hoo', 'bar' but got %+v", resp.Kvs)
 	})
 }
 
@@ -173,9 +173,9 @@ func TestAuthRoleUpdate(t *testing.T) {
 		// confirm put succeeded
 		resp, err := testUserAuthClient.Get(ctx, "hoo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "hoo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "hoo", string(resp.Kvs[0].Key), "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
 		// revoke the newly granted key
 		_, err = rootAuthClient.RoleRevokePermission(ctx, testRoleName, "hoo", "")
 		require.NoError(t, err)
@@ -184,9 +184,9 @@ func TestAuthRoleUpdate(t *testing.T) {
 		// confirm a key still granted can be accessed
 		resp, err = testUserAuthClient.Get(ctx, "foo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "foo", string(resp.Kvs[0].Key), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
 	})
 }
 
@@ -209,9 +209,9 @@ func TestAuthUserDeleteDuringOps(t *testing.T) {
 		// confirm put succeeded
 		resp, err := testUserAuthClient.Get(ctx, "foo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "foo", string(resp.Kvs[0].Key), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
 		// delete the user
 		_, err = rootAuthClient.UserDelete(ctx, testUserName)
 		require.NoError(t, err)
@@ -240,9 +240,9 @@ func TestAuthRoleRevokeDuringOps(t *testing.T) {
 		// confirm put succeeded
 		resp, err := testUserAuthClient.Get(ctx, "foo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "foo", string(resp.Kvs[0].Key), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
 		// create a new role
 		_, err = rootAuthClient.RoleAdd(ctx, "test-role2")
 		require.NoError(t, err)
@@ -258,9 +258,9 @@ func TestAuthRoleRevokeDuringOps(t *testing.T) {
 		// confirm put succeeded
 		resp, err = testUserAuthClient.Get(ctx, "hoo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "hoo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "hoo", string(resp.Kvs[0].Key), "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'hoo' 'bar' but got %+v", resp.Kvs)
 		// revoke a role from the user
 		_, err = rootAuthClient.UserRevokeRole(ctx, testUserName, testRoleName)
 		require.NoError(t, err)
@@ -272,9 +272,9 @@ func TestAuthRoleRevokeDuringOps(t *testing.T) {
 		// confirm put succeeded
 		resp, err = testUserAuthClient.Get(ctx, "hoo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "hoo" || string(resp.Kvs[0].Value) != "bar2" {
-			t.Fatalf("want key value pair 'hoo' 'bar2' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'hoo' 'bar2' but got %+v", resp.Kvs)
+		require.Equalf(t, "hoo", string(resp.Kvs[0].Key), "want key value pair 'hoo' 'bar2' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar2", string(resp.Kvs[0].Value), "want key value pair 'hoo' 'bar2' but got %+v", resp.Kvs)
 	})
 }
 
@@ -296,9 +296,9 @@ func TestAuthWriteKey(t *testing.T) {
 		require.NoError(t, rootAuthClient.Put(ctx, "foo", "bar", config.PutOptions{}))
 		resp, err := rootAuthClient.Get(ctx, "foo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" || string(resp.Kvs[0].Value) != "bar" {
-			t.Fatalf("want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "foo", string(resp.Kvs[0].Key), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar", string(resp.Kvs[0].Value), "want key value pair 'foo' 'bar' but got %+v", resp.Kvs)
 		// try invalid user
 		_, err = clus.Client(WithAuth("a", "b"))
 		require.ErrorContains(t, err, AuthenticationFailed)
@@ -308,9 +308,9 @@ func TestAuthWriteKey(t *testing.T) {
 		// confirm put succeeded
 		resp, err = testUserAuthClient.Get(ctx, "foo", config.GetOptions{})
 		require.NoError(t, err)
-		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" || string(resp.Kvs[0].Value) != "bar2" {
-			t.Fatalf("want key value pair 'foo' 'bar2' but got %+v", resp.Kvs)
-		}
+		require.Lenf(t, resp.Kvs, 1, "want key value pair 'foo' 'bar2' but got %+v", resp.Kvs)
+		require.Equalf(t, "foo", string(resp.Kvs[0].Key), "want key value pair 'foo' 'bar2' but got %+v", resp.Kvs)
+		require.Equalf(t, "bar2", string(resp.Kvs[0].Value), "want key value pair 'foo' 'bar2' but got %+v", resp.Kvs)
 
 		// try bad password
 		_, err = clus.Client(WithAuth(testUserName, "badpass"))
@@ -403,7 +403,7 @@ func TestAuthTxn(t *testing.T) {
 						Interactive: true,
 					})
 					if req.expectError {
-						require.Contains(t, err.Error(), req.expectResults[0])
+						require.ErrorContains(t, err, req.expectResults[0])
 					} else {
 						require.NoError(t, err)
 						require.Equal(t, req.expectResults, getRespValues(resp))
@@ -468,9 +468,9 @@ func TestAuthLeaseKeepAlive(t *testing.T) {
 
 		gresp, err := rootAuthClient.Get(ctx, "key", config.GetOptions{})
 		require.NoError(t, err)
-		if len(gresp.Kvs) != 1 || string(gresp.Kvs[0].Key) != "key" || string(gresp.Kvs[0].Value) != "value" {
-			t.Fatalf("want kv pair ('key', 'value') but got %v", gresp.Kvs)
-		}
+		require.Lenf(t, gresp.Kvs, 1, "want kv pair ('key', 'value') but got %v", gresp.Kvs)
+		require.Equalf(t, "key", string(gresp.Kvs[0].Key), "want kv pair ('key', 'value') but got %v", gresp.Kvs)
+		require.Equalf(t, "value", string(gresp.Kvs[0].Value), "want kv pair ('key', 'value') but got %v", gresp.Kvs)
 	})
 }
 
@@ -561,9 +561,8 @@ func TestAuthLeaseGrantLeases(t *testing.T) {
 				leaseID := resp.ID
 				lresp, err := rootAuthClient.Leases(ctx)
 				require.NoError(t, err)
-				if len(lresp.Leases) != 1 || lresp.Leases[0].ID != leaseID {
-					t.Fatalf("want %v leaseID but got %v leases", leaseID, lresp.Leases)
-				}
+				require.Lenf(t, lresp.Leases, 1, "want %v leaseID but got %v leases", leaseID, lresp.Leases)
+				require.Equalf(t, lresp.Leases[0].ID, leaseID, "want %v leaseID but got %v leases", leaseID, lresp.Leases)
 			})
 		})
 	}

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -34,17 +36,10 @@ func TestDefragOnline(t *testing.T) {
 		defer clus.Close()
 		kvs := []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 		for i := range kvs {
-			if err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}); err != nil {
-				t.Fatalf("compactTest #%d: put kv error (%v)", i, err)
-			}
+			require.NoErrorf(t, cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}), "compactTest #%d: put kv error", i)
 		}
 		_, err := cc.Compact(ctx, 4, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
-		if err != nil {
-			t.Fatalf("defrag_test: compact with revision error (%v)", err)
-		}
-
-		if err = cc.Defragment(ctx, options); err != nil {
-			t.Fatalf("defrag_test: defrag error (%v)", err)
-		}
+		require.NoErrorf(t, err, "defrag_test: compact with revision error (%v)", err)
+		require.NoErrorf(t, cc.Defragment(ctx, options), "defrag_test: defrag error (%v)", err)
 	})
 }

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -35,9 +35,7 @@ func TestEndpointStatus(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.Status(ctx)
-		if err != nil {
-			t.Fatalf("get endpoint status error: %v", err)
-		}
+		require.NoErrorf(t, err, "get endpoint status error: %v", err)
 	})
 }
 
@@ -53,9 +51,7 @@ func TestEndpointHashKV(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
-		if err := cc.Put(ctx, key, value, config.PutOptions{}); err != nil {
-			t.Fatalf("count not put key %q, err: %s", key, err)
-		}
+		require.NoErrorf(t, cc.Put(ctx, key, value, config.PutOptions{}), "count not put key %q", key)
 	}
 
 	t.Log("Check all members' Hash and HashRevision")
@@ -82,8 +78,6 @@ func TestEndpointHealth(t *testing.T) {
 	defer clus.Close()
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
-		if err := cc.Health(ctx); err != nil {
-			t.Fatalf("get endpoint health error: %v", err)
-		}
+		require.NoErrorf(t, cc.Health(ctx), "get endpoint health error")
 	})
 }

--- a/tests/common/role_test.go
+++ b/tests/common/role_test.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -40,7 +39,7 @@ func TestRoleAdd_Simple(t *testing.T) {
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				_, err := cc.RoleAdd(ctx, "root")
-				require.NoErrorf(t, err, "want no error, but got")
+				require.NoError(t, err)
 			})
 		})
 	}
@@ -55,15 +54,11 @@ func TestRoleAdd_Error(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "test-role")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleAdd(ctx, "test-role")
-		if err == nil || !strings.Contains(err.Error(), rpctypes.ErrRoleAlreadyExist.Error()) {
-			t.Fatalf("want (%v) error, but got (%v)", rpctypes.ErrRoleAlreadyExist, err)
-		}
+		require.ErrorContainsf(t, err, rpctypes.ErrRoleAlreadyExist.Error(), "want (%v) error, but got (%v)", rpctypes.ErrRoleAlreadyExist, err)
 		_, err = cc.RoleAdd(ctx, "")
-		if err == nil || !strings.Contains(err.Error(), rpctypes.ErrRoleEmpty.Error()) {
-			t.Fatalf("want (%v) error, but got (%v)", rpctypes.ErrRoleEmpty, err)
-		}
+		require.ErrorContainsf(t, err, rpctypes.ErrRoleEmpty.Error(), "want (%v) error, but got (%v)", rpctypes.ErrRoleEmpty, err)
 	})
 }
 
@@ -76,15 +71,15 @@ func TestRootRole(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "root")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		resp, err := cc.RoleGet(ctx, "root")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		t.Logf("get role resp %+v", resp)
 		// granting to root should be refused by server and a no-op
 		_, err = cc.RoleGrantPermission(ctx, "root", "foo", "", clientv3.PermissionType(clientv3.PermReadWrite))
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		resp2, err := cc.RoleGet(ctx, "root")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		t.Logf("get role resp %+v", resp2)
 	})
 }
@@ -98,19 +93,17 @@ func TestRoleGrantRevokePermission(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "", clientv3.PermissionType(clientv3.PermRead))
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "", clientv3.PermissionType(clientv3.PermWrite))
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleGrantPermission(ctx, "role1", "bar", "foo", clientv3.PermissionType(clientv3.PermReadWrite))
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleRevokePermission(ctx, "role1", "foo", "")
-		if err == nil || !strings.Contains(err.Error(), rpctypes.ErrPermissionNotGranted.Error()) {
-			t.Fatalf("want error (%v), but got (%v)", rpctypes.ErrPermissionNotGranted, err)
-		}
+		require.ErrorContainsf(t, err, rpctypes.ErrPermissionNotGranted.Error(), "want error (%v), but got (%v)", rpctypes.ErrPermissionNotGranted, err)
 		_, err = cc.RoleRevokePermission(ctx, "role1", "bar", "foo")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 	})
 }
 
@@ -123,8 +116,8 @@ func TestRoleDelete(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		_, err := cc.RoleAdd(ctx, "role1")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 		_, err = cc.RoleDelete(ctx, "role1")
-		require.NoErrorf(t, err, "want no error, but got")
+		require.NoError(t, err)
 	})
 }

--- a/tests/common/status_test.go
+++ b/tests/common/status_test.go
@@ -39,19 +39,13 @@ func TestStatus(t *testing.T) {
 			testutils.ExecuteUntil(ctx, t, func() {
 				rs, err := cc.Status(ctx)
 				require.NoErrorf(t, err, "could not get status")
-				if len(rs) != tc.config.ClusterSize {
-					t.Fatalf("wrong number of status responses. expected:%d, got:%d ", tc.config.ClusterSize, len(rs))
-				}
+				require.Lenf(t, rs, tc.config.ClusterSize, "wrong number of status responses. expected:%d, got:%d ", tc.config.ClusterSize, len(rs))
 				memberIDs := make(map[uint64]struct{})
 				for _, r := range rs {
-					if r == nil {
-						t.Fatalf("status response is nil")
-					}
+					require.NotNilf(t, r, "status response is nil")
 					memberIDs[r.Header.MemberId] = struct{}{}
 				}
-				if len(rs) != len(memberIDs) {
-					t.Fatalf("found duplicated members")
-				}
+				require.Lenf(t, rs, len(memberIDs), "found duplicated members")
 			})
 		})
 	}

--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -73,9 +73,7 @@ func TestTxnSucc(t *testing.T) {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,
 					})
-					if err != nil {
-						t.Errorf("Txn returned error: %s", err)
-					}
+					require.NoErrorf(t, err, "Txn returned error: %s", err)
 					assert.Equal(t, req.expectResults, getRespValues(resp))
 				}
 			})
@@ -113,9 +111,7 @@ func TestTxnFail(t *testing.T) {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
 						Interactive: true,
 					})
-					if err != nil {
-						t.Errorf("Txn returned error: %s", err)
-					}
+					require.NoErrorf(t, err, "Txn returned error: %s", err)
 					assert.Equal(t, req.expectResults, getRespValues(resp))
 				}
 			})

--- a/tests/common/wait_leader_test.go
+++ b/tests/common/wait_leader_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
@@ -33,9 +35,8 @@ func TestWaitLeader(t *testing.T) {
 			defer clus.Close()
 
 			leader := clus.WaitLeader(t)
-			if leader < 0 || leader >= len(clus.Members()) {
-				t.Fatalf("WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", leader, len(clus.Members()))
-			}
+			require.GreaterOrEqualf(t, leader, 0, "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", leader, len(clus.Members()))
+			require.Lessf(t, leader, len(clus.Members()), "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", leader, len(clus.Members()))
 		})
 	}
 }
@@ -61,19 +62,15 @@ func TestWaitLeader_MemberStop(t *testing.T) {
 			defer clus.Close()
 
 			lead1 := clus.WaitLeader(t)
-			if lead1 < 0 || lead1 >= len(clus.Members()) {
-				t.Fatalf("WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead1, len(clus.Members()))
-			}
+			require.GreaterOrEqualf(t, lead1, 0, "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead1, len(clus.Members()))
+			require.Lessf(t, lead1, len(clus.Members()), "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead1, len(clus.Members()))
 
 			clus.Members()[lead1].Stop()
 			lead2 := clus.WaitLeader(t)
-			if lead2 < 0 || lead2 >= len(clus.Members()) {
-				t.Fatalf("WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead2, len(clus.Members()))
-			}
+			require.GreaterOrEqualf(t, lead2, 0, "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead2, len(clus.Members()))
+			require.Lessf(t, lead2, len(clus.Members()), "WaitLeader failed for the leader index (%d) is out of range, cluster member count: %d", lead2, len(clus.Members()))
 
-			if lead1 == lead2 {
-				t.Fatalf("WaitLeader failed for the leader(index=%d) did not change as expected after a member stopped", lead1)
-			}
+			require.NotEqualf(t, lead1, lead2, "WaitLeader failed for the leader(index=%d) did not change as expected after a member stopped", lead1)
 		})
 	}
 }

--- a/tests/common/watch_test.go
+++ b/tests/common/watch_test.go
@@ -73,9 +73,7 @@ func TestWatch(t *testing.T) {
 				for _, tt := range tests {
 					wCtx, wCancel := context.WithCancel(ctx)
 					wch := cc.Watch(wCtx, tt.watchKey, tt.opts)
-					if wch == nil {
-						t.Fatalf("failed to watch %s", tt.watchKey)
-					}
+					require.NotNilf(t, wch, "failed to watch %s", tt.watchKey)
 
 					for j := range tt.puts {
 						err := cc.Put(ctx, tt.puts[j].Key, tt.puts[j].Val, config.PutOptions{})


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal calls

Related to #18972