### PR TITLE
[3.5] release: properly change working dir if tmp location already exists

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -86,10 +86,12 @@ main() {
   # Set up release directory.
   local reldir="/tmp/etcd-release-${VERSION}"
   log_callout "Preparing temporary directory: ${reldir}"
-  if [ ! -d "${reldir}/etcd" ] && [ "${IN_PLACE}" == 0 ]; then
-    mkdir -p "${reldir}"
-    cd "${reldir}"
-    run git clone "${REPOSITORY}" --branch "${BRANCH}" --depth 1
+  if [ "${IN_PLACE}" == 0 ]; then
+    if [ ! -d "${reldir}/etcd" ]; then
+      mkdir -p "${reldir}"
+      cd "${reldir}"
+      run git clone "${REPOSITORY}" --branch "${BRANCH}" --depth 1
+    fi
     run cd "${reldir}/etcd" || exit 2
     run git checkout "${BRANCH}" || exit 2
     run git pull origin


### PR DESCRIPTION
Backport of https://github.com/etcd-io/etcd/pull/18812 to 3.5 according to the release plan of 3.5.17 (https://github.com/etcd-io/etcd/issues/18846)

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
