### PR TITLE
Enable client side gRPC health check by default

### DIFF
--- a/client/v3/internal/resolver/resolver.go
+++ b/client/v3/internal/resolver/resolver.go
@@ -15,6 +15,8 @@
 package resolver
 
 import (
+	// import grpc/health to enable transparent client side checking
+	_ "google.golang.org/grpc/health"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/serviceconfig"
@@ -41,7 +43,7 @@ func New(endpoints ...string) *EtcdManualResolver {
 
 // Build returns itself for Resolver, because it's both a builder and a resolver.
 func (r *EtcdManualResolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	r.serviceConfig = cc.ParseServiceConfig(`{"loadBalancingPolicy": "round_robin"}`)
+	r.serviceConfig = cc.ParseServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`)
 	if r.serviceConfig.Err != nil {
 		return nil, r.serviceConfig.Err
 	}

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -39,6 +39,8 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -508,6 +510,10 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 	pb.RegisterAuthServer(server, authp)
 	v3electionpb.RegisterElectionServer(server, electionp)
 	v3lockpb.RegisterLockServer(server, lockp)
+
+	hsrv := health.NewServer()
+	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(server, hsrv)
 
 	return server
 }


### PR DESCRIPTION
Followup to https://github.com/etcd-io/etcd/pull/16278

Previously the default gRPC service config for the resolver is `{"loadBalancingPolicy": "round_robin"}`. 

https://github.com/etcd-io/etcd/blob/7ab761246cc449ddfc630001fb2caff160eb4ee3/client/v3/internal/resolver/resolver.go#L44

Now I propose to change the default service config to `{"loadBalancingPolicy": "round_robin"}, "healthCheckConfig": {"serviceName": ""}`. The benefit is that 
- any applications which depend on etcd client sdk don't need to care about the low level grpc service config.
- Is it also a best practice to always enable client side health check if the `loadBalancingPolicy` is `round_robin`? @dfawley But I am not whether is there any performance penalty? Probably we need to run [rw-heatmaps](https://github.com/etcd-io/etcd/tree/main/tools/rw-heatmaps) to double confirm.