### PR TITLE
CHANGELOG: Add release date of etcd v3.4.35

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
-## v3.4.35 (TBC)
+## v3.4.36 (TBC)
+
+<hr>
+
+## v3.4.35 (2024-11-12)
 
 ### etcd server
 - Fix [watchserver related goroutine leakage](https://github.com/etcd-io/etcd/pull/18785)


### PR DESCRIPTION
Set the v3.4.35 release date to today.

Part of https://github.com/etcd-io/etcd/issues/18845.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

