### PR TITLE
[3.4] Backport updating release script to use ssh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,7 +41,7 @@ main() {
       REPOSITORY=$(pwd)
       BRANCH=$(git rev-parse --abbrev-ref HEAD)
   else
-      REPOSITORY=${REPOSITORY:-"https://github.com/etcd-io/etcd.git"}
+      REPOSITORY=${REPOSITORY:-"git@github.com:etcd-io/etcd.git"}
       BRANCH=${BRANCH:-"release-${MINOR_VERSION}"}
   fi
 


### PR DESCRIPTION
Backports commit: b82f882c3d9011bab9da05a6159f701e979b4348 to `release-3.4`.

We encountered the issue of needing to amend this script manually with this commit diff during release today in order to carry out the release. We originally discussed not backporting this change to `release-3.4` because we were not confident how well the script was performing (https://github.com/etcd-io/etcd/pull/17677#discussion_r1545789197). We have now performed several releases with the script carrying out the full release process including pushing tags etc, so I think we should now complete the backport.

cc @ahrtr, @ivanvc  