### PR TITLE
Fix displaying etcd logo in README on a dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@
 
 **Note**: The `main` branch may be in an *unstable or even broken state* during development. For stable versions, see [releases][github-release].
 
-![etcd Logo](logos/etcd-horizontal-color.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/cncf/artwork/9870640f123303a355611065195c43ac3f27aa19/projects/etcd/horizontal/white/etcd-horizontal-white.png">
+  <source media="(prefers-color-scheme: light)" srcset="logos/etcd-horizontal-color.svg">
+  <img alt="etcd logo" src="logos/etcd-horizontal-color.svg" width=269 />
+</picture>
 
 etcd is a distributed reliable key-value store for the most critical data of a distributed system, with a focus on being:
 


### PR DESCRIPTION
This PR fixes displaying the etcd logo in README.md on a GitHub dark theme.

<details><summary>Before/after screenshots</summary>
<p>

Before (dark):

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/05114fee-b215-4176-89ec-f56189c631d2">

After (dark):

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/3347709b-8337-44d5-8c0a-849bca596138">

Before (light):

<img width="1167" alt="image" src="https://github.com/user-attachments/assets/d5f61b6a-43e7-450c-88d9-febca04bede2">

After (light):

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/0232de7f-f1e5-4b29-9bbe-cd0b924f3e84">

</p>
</details> 

See [this doc](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) for implementation details.