### PR TITLE
fix runtime error: comparing uncomparable type

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -264,6 +264,12 @@ func (l *lessor) Leases(ctx context.Context) (*LeaseLeasesResponse, error) {
 	return nil, ContextError(ctx, err)
 }
 
+// To identify the context passed to `KeepAlive`, a key/value pair is
+// attached to the context. The key is a `keepAliveCtxKey` object, and
+// the value is the pointer to the context object itself, ensuring
+// uniqueness as each context has a unique memory address.
+type keepAliveCtxKey struct{}
+
 func (l *lessor) KeepAlive(ctx context.Context, id LeaseID) (<-chan *LeaseKeepAliveResponse, error) {
 	ch := make(chan *LeaseKeepAliveResponse, LeaseResponseChSize)
 
@@ -278,6 +284,10 @@ func (l *lessor) KeepAlive(ctx context.Context, id LeaseID) (<-chan *LeaseKeepAl
 	default:
 	}
 	ka, ok := l.keepAlives[id]
+
+	if ctx.Done() != nil {
+		ctx = context.WithValue(ctx, keepAliveCtxKey{}, &ctx)
+	}
 	if !ok {
 		// create fresh keep alive
 		ka = &keepAlive{
@@ -348,7 +358,7 @@ func (l *lessor) keepAliveCtxCloser(ctx context.Context, id LeaseID, donec <-cha
 
 	// close channel and remove context if still associated with keep alive
 	for i, c := range ka.ctxs {
-		if c == ctx {
+		if c.Value(keepAliveCtxKey{}) == ctx.Value(keepAliveCtxKey{}) {
 			close(ka.chs[i])
 			ka.ctxs = append(ka.ctxs[:i], ka.ctxs[i+1:]...)
 			ka.chs = append(ka.chs[:i], ka.chs[i+1:]...)


### PR DESCRIPTION
Fixes a runtime panic that occurs when KeepAlive is called with a Context implemented by an uncomparable type, which is later canceled. The panic message is:

```
panic: runtime error: comparing uncomparable type lease_test.uncomparableCtx

goroutine 380 [running]:
go.etcd.io/etcd/client/v3.(*lessor).keepAliveCtxCloser(0xc000327720, {0x13416c8, 0xc00011b9b0}, 0x14c4932ade455905, 0xc002291420)
    /home/kevin/IdeaProjects/etcd/client/v3/lease.go:351 +0x1d6
created by go.etcd.io/etcd/client/v3.(*lessor).KeepAlive in goroutine 156
    /home/kevin/IdeaProjects/etcd/client/v3/lease.go:299 +0x554
```

To reproduce the issue, the existing test has been updated to include a custom uncomparable Context implementation. Previously, this test consistently caused a panic due to the uncomparable Context type. The updated implementation modifies keepAliveCtxCloser to properly handle such cases.