### PR TITLE
Add ivanvc as approver for .github, scripts and tools/rw-heatmaps

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
   - ivanvc           # Ivan Valdes <ivan@vald.es>
-
-labels:
-  - area/performance

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
   - ivanvc           # Ivan Valdes <ivan@vald.es>
-
-labels:
-  - area/performance


### PR DESCRIPTION
Let's recognize the fantastic work @ivanvc has been doing recently. 

Of particular note was the recent rework of `scripts/release.sh` to [use `gh` cli to automate creating GitHub releases](https://github.com/etcd-io/etcd/pull/18649). This saved us significant toil last release cycle earlier this week.

Given the excellent work Ivan has been doing in the areas of ci / tooling and his earlier efforts to rewrite `tools/rw-heatmaps` in golang I think it makes perfect sense for him to be an `approver` for these areas.

cc @etcd-io/maintainers-etcd 