### PR TITLE
release: add prompt to draft GitHub release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -337,6 +337,9 @@ main() {
     log_warning "WARNING: If not running on DRY_MODE, please do the GitHub release manually."
     log_warning ""
   else
+    read -p "Create GitHub draft release in ${REPOSITORY} [y/N]? " -r confirm
+    [[ "${confirm,,}" == "y" ]] || exit 1
+
     local gh_repo
     local release_notes_temp_file
     local release_url


### PR DESCRIPTION
This is a cherry-pick from #18886. This pull request can be merged soon without adding the automated step to undraft/release the GitHub release.

We identified the potential improvement while doing the 3.5.17 / 3.4.35 releases.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
