### PR TITLE
Reduce QPS requirement to 100

### DIFF
--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -46,7 +46,7 @@ var (
 		CompactPeriod:                  200 * time.Millisecond,
 	}
 	HighTrafficProfile = Profile{
-		MinimalQPS:                     200,
+		MinimalQPS:                     100,
 		MaximalQPS:                     1000,
 		ClientCount:                    8,
 		MaxNonUniqueRequestConcurrency: 3,


### PR DESCRIPTION
In last robustness meeting Nov 20 https://docs.google.com/document/d/1idZ_7tV6F18v223LyQ0WVUn9gXLSKyeLwYTdAgbjxpw/edit?usp=sharing, we identified that reducing QPS would reduce number of flakes from 10->2

We need a better way to monitor and track qps accross tests