### PR TITLE
fix: enable gofumpt instead of gofmt linter in tests

### DIFF
--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -29,9 +29,11 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-var tokenTTL = time.Second * 3
-var defaultAuthToken = fmt.Sprintf("jwt,pub-key=%s,priv-key=%s,sign-method=RS256,ttl=%s",
-	mustAbsPath("../fixtures/server.crt"), mustAbsPath("../fixtures/server.key.insecure"), tokenTTL)
+var (
+	tokenTTL         = time.Second * 3
+	defaultAuthToken = fmt.Sprintf("jwt,pub-key=%s,priv-key=%s,sign-method=RS256,ttl=%s",
+		mustAbsPath("../fixtures/server.crt"), mustAbsPath("../fixtures/server.key.insecure"), tokenTTL)
+)
 
 const (
 	PermissionDenied      = "etcdserver: permission denied"

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -50,7 +50,7 @@ func TestCompact(t *testing.T) {
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
-				var kvs = []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
+				kvs := []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 				for i := range kvs {
 					err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{})
 					require.NoErrorf(t, err, "compactTest #%d: put kv error", i)

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -32,7 +32,7 @@ func TestDefragOnline(t *testing.T) {
 	cc := testutils.MustClient(clus.Client())
 	testutils.ExecuteUntil(ctx, t, func() {
 		defer clus.Close()
-		var kvs = []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
+		kvs := []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 		for i := range kvs {
 			if err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}); err != nil {
 				t.Fatalf("compactTest #%d: put kv error (%v)", i, err)

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -119,7 +119,7 @@ func TestInPlaceRecovery(t *testing.T) {
 	})
 	t.Log("old cluster started.")
 
-	//Put some data into the old cluster, so that after recovering from a blank db, the hash diverges.
+	// Put some data into the old cluster, so that after recovering from a blank db, the hash diverges.
 	t.Log("putting 10 keys...")
 	oldCc, err := e2e.NewEtcdctl(epcOld.Cfg.Client, epcOld.EndpointsGRPC())
 	require.NoError(t, err)

--- a/tests/e2e/ctl_v3_auth_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_auth_no_proxy_test.go
@@ -32,9 +32,11 @@ import (
 func TestCtlV3AuthCertCN(t *testing.T) {
 	testCtl(t, authTestCertCN, withCfg(*e2e.NewConfigClientTLSCertAuth()))
 }
+
 func TestCtlV3AuthCertCNAndUsername(t *testing.T) {
 	testCtl(t, authTestCertCNAndUsername, withCfg(*e2e.NewConfigClientTLSCertAuth()))
 }
+
 func TestCtlV3AuthCertCNAndUsernameNoPassword(t *testing.T) {
 	testCtl(t, authTestCertCNAndUsernameNoPassword, withCfg(*e2e.NewConfigClientTLSCertAuth()))
 }

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -39,6 +39,7 @@ func TestCtlV3AuthEndpointHealth(t *testing.T) {
 
 // TestCtlV3AuthSnapshot TODO fill up common/maintenance_auth_test.go when Snapshot API is added in interfaces.Client
 func TestCtlV3AuthSnapshot(t *testing.T) { testCtl(t, authTestSnapshot) }
+
 func TestCtlV3AuthSnapshotJWT(t *testing.T) {
 	testCtl(t, authTestSnapshot, withCfg(*e2e.NewConfigJWT()))
 }

--- a/tests/e2e/ctl_v3_completion_test.go
+++ b/tests/e2e/ctl_v3_completion_test.go
@@ -52,7 +52,7 @@ func testShellCompletion(t *testing.T, binPath, shellName string) {
 	require.NoError(t, completionCmd.Run())
 
 	filename := fmt.Sprintf("etcdctl-%s.completion", shellName)
-	require.NoError(t, os.WriteFile(filename, stdout.Bytes(), 0644))
+	require.NoError(t, os.WriteFile(filename, stdout.Bytes(), 0o644))
 
 	shellCmd := exec.Command(shellName, "-c", "source "+filename)
 	require.NoError(t, shellCmd.Run())

--- a/tests/e2e/ctl_v3_defrag_test.go
+++ b/tests/e2e/ctl_v3_defrag_test.go
@@ -26,7 +26,7 @@ func TestCtlV3DefragOffline(t *testing.T) {
 }
 
 func maintenanceInitKeys(cx ctlCtx) {
-	var kvs = []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
+	kvs := []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
 	for i := range kvs {
 		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
 			cx.t.Fatal(err)

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -191,9 +191,7 @@ func getFormatTest(cx ctlCtx) {
 }
 
 func getRevTest(cx ctlCtx) {
-	var (
-		kvs = []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
-	)
+	kvs := []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
 	for i := range kvs {
 		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
 			cx.t.Fatalf("getRevTest #%d: ctlV3Put error (%v)", i, err)
@@ -218,14 +216,12 @@ func getRevTest(cx ctlCtx) {
 }
 
 func getMinMaxCreateModRevTest(cx ctlCtx) {
-	var (
-		kvs = []kv{ //     revision:   store | key create | key modify
-			{"key1", "val1"}, //     2         2           2
-			{"key2", "val2"}, //     3         3           3
-			{"key1", "val3"}, //     4         2           4
-			{"key4", "val4"}, //     5         5           5
-		}
-	)
+	kvs := []kv{ //     revision:   store | key create | key modify
+		{"key1", "val1"}, //     2         2           2
+		{"key2", "val2"}, //     3         3           3
+		{"key1", "val3"}, //     4         2           4
+		{"key4", "val4"}, //     5         5           5
+	}
 	for i := range kvs {
 		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
 			cx.t.Fatalf("getRevTest #%d: ctlV3Put error (%v)", i, err)

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -28,12 +28,15 @@ func TestCtlV3LeaseKeepAlive(t *testing.T) { testCtl(t, leaseTestKeepAlive) }
 func TestCtlV3LeaseKeepAliveNoTLS(t *testing.T) {
 	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCtlV3LeaseKeepAliveClientTLS(t *testing.T) {
 	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientTLS()))
 }
+
 func TestCtlV3LeaseKeepAliveClientAutoTLS(t *testing.T) {
 	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientAutoTLS()))
 }
+
 func TestCtlV3LeaseKeepAlivePeerTLS(t *testing.T) {
 	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigPeerTLS()))
 }

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -50,12 +50,15 @@ func TestCtlV3MemberUpdate(t *testing.T) { testCtl(t, memberUpdateTest) }
 func TestCtlV3MemberUpdateNoTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCtlV3MemberUpdateClientTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(*e2e.NewConfigClientTLS()))
 }
+
 func TestCtlV3MemberUpdateClientAutoTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(*e2e.NewConfigClientAutoTLS()))
 }
+
 func TestCtlV3MemberUpdatePeerTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(*e2e.NewConfigPeerTLS()))
 }

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -224,7 +224,8 @@ func testIssue6361(t *testing.T) {
 		"--initial-cluster", epc.Procs[0].Config().InitialCluster,
 		"--initial-cluster-token", epc.Procs[0].Config().InitialToken,
 		"--initial-advertise-peer-urls", epc.Procs[0].Config().PeerURL.String(),
-		"--data-dir", newDataDir},
+		"--data-dir", newDataDir,
+	},
 		expect.ExpectedResponse{Value: "added member"})
 	if err != nil {
 		t.Fatal(err)
@@ -264,10 +265,12 @@ func testIssue6361(t *testing.T) {
 	t.Log("Starting the new member")
 	// start the new member
 	var nepc *expect.ExpectProcess
-	nepc, err = e2e.SpawnCmd([]string{epc.Procs[0].Config().ExecPath, "--name", name2,
+	nepc, err = e2e.SpawnCmd([]string{
+		epc.Procs[0].Config().ExecPath, "--name", name2,
 		"--listen-client-urls", clientURL, "--advertise-client-urls", clientURL,
 		"--listen-peer-urls", peerURL, "--initial-advertise-peer-urls", peerURL,
-		"--initial-cluster", initialCluster2, "--initial-cluster-state", "existing", "--data-dir", newDataDir2}, nil)
+		"--initial-cluster", initialCluster2, "--initial-cluster-state", "existing", "--data-dir", newDataDir2,
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/ctl_v3_watch_no_cov_test.go
+++ b/tests/e2e/ctl_v3_watch_no_cov_test.go
@@ -30,12 +30,15 @@ func TestCtlV3WatchTimeout(t *testing.T)   { testCtl(t, watchTest, withDefaultDi
 func TestCtlV3WatchInteractive(t *testing.T) {
 	testCtl(t, watchTest, withInteractive())
 }
+
 func TestCtlV3WatchInteractiveNoTLS(t *testing.T) {
 	testCtl(t, watchTest, withInteractive(), withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCtlV3WatchInteractiveClientTLS(t *testing.T) {
 	testCtl(t, watchTest, withInteractive(), withCfg(*e2e.NewConfigClientTLS()))
 }
+
 func TestCtlV3WatchInteractivePeerTLS(t *testing.T) {
 	testCtl(t, watchTest, withInteractive(), withCfg(*e2e.NewConfigPeerTLS()))
 }

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -28,9 +28,11 @@ import (
 func TestClusterOf1UsingV3Discovery_1endpoint(t *testing.T) {
 	testClusterUsingV3Discovery(t, 1, 1, e2e.ClientNonTLS, false)
 }
+
 func TestClusterOf3UsingV3Discovery_1endpoint(t *testing.T) {
 	testClusterUsingV3Discovery(t, 1, 3, e2e.ClientTLS, true)
 }
+
 func TestTLSClusterOf5UsingV3Discovery_1endpoint(t *testing.T) {
 	testClusterUsingV3Discovery(t, 1, 5, e2e.ClientTLS, false)
 }
@@ -38,9 +40,11 @@ func TestTLSClusterOf5UsingV3Discovery_1endpoint(t *testing.T) {
 func TestClusterOf1UsingV3Discovery_3endpoints(t *testing.T) {
 	testClusterUsingV3Discovery(t, 3, 1, e2e.ClientNonTLS, false)
 }
+
 func TestClusterOf3UsingV3Discovery_3endpoints(t *testing.T) {
 	testClusterUsingV3Discovery(t, 3, 3, e2e.ClientTLS, true)
 }
+
 func TestTLSClusterOf5UsingV3Discovery_3endpoints(t *testing.T) {
 	testClusterUsingV3Discovery(t, 3, 5, e2e.ClientTLS, false)
 }

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -48,7 +48,8 @@ func TestGrpcProxyAutoSync(t *testing.T) {
 	)
 
 	// Run independent grpc-proxy instance
-	proxyProc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "grpc-proxy", "start",
+	proxyProc, err := e2e.SpawnCmd([]string{
+		e2e.BinPath.Etcd, "grpc-proxy", "start",
 		"--advertise-client-url", proxyClientURL, "--listen-addr", proxyClientURL,
 		"--endpoints", node1ClientURL,
 		"--endpoints-auto-sync-interval", "1s",
@@ -107,7 +108,8 @@ func TestGrpcProxyTLSVersions(t *testing.T) {
 	)
 
 	// Run independent grpc-proxy instance
-	proxyProc, err := e2e.SpawnCmd([]string{e2e.BinPath.Etcd, "grpc-proxy", "start",
+	proxyProc, err := e2e.SpawnCmd([]string{
+		e2e.BinPath.Etcd, "grpc-proxy", "start",
 		"--advertise-client-url", proxyClientURL,
 		"--listen-addr", proxyClientURL,
 		"--endpoints", node1ClientURL,

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -123,7 +123,6 @@ func TestReleaseUpgradeWithRestart(t *testing.T) {
 		e2e.WithSnapshotCount(10),
 		e2e.WithBasePeerScheme("unix"),
 	)
-
 	if err != nil {
 		t.Fatalf("could not start etcd process cluster (%v)", err)
 	}

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -23,9 +23,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-var (
-	defaultGatewayEndpoint = "127.0.0.1:23790"
-)
+var defaultGatewayEndpoint = "127.0.0.1:23790"
 
 func TestGateway(t *testing.T) {
 	ec, err := e2e.NewEtcdProcessCluster(context.TODO(), t)

--- a/tests/e2e/http_health_check_test.go
+++ b/tests/e2e/http_health_check_test.go
@@ -172,33 +172,31 @@ func TestHTTPHealthHandler(t *testing.T) {
 	}
 }
 
-var (
-	defaultHealthCheckConfigs = []healthCheckConfig{
-		{
-			url:                    "/livez",
-			expectedStatusCode:     http.StatusOK,
-			expectedRespSubStrings: []string{`ok`},
+var defaultHealthCheckConfigs = []healthCheckConfig{
+	{
+		url:                    "/livez",
+		expectedStatusCode:     http.StatusOK,
+		expectedRespSubStrings: []string{`ok`},
+	},
+	{
+		url:                    "/readyz",
+		expectedStatusCode:     http.StatusOK,
+		expectedRespSubStrings: []string{`ok`},
+	},
+	{
+		url:                    "/livez?verbose=true",
+		expectedStatusCode:     http.StatusOK,
+		expectedRespSubStrings: []string{`[+]serializable_read ok`},
+	},
+	{
+		url:                "/readyz?verbose=true",
+		expectedStatusCode: http.StatusOK,
+		expectedRespSubStrings: []string{
+			`[+]serializable_read ok`,
+			`[+]data_corruption ok`,
 		},
-		{
-			url:                    "/readyz",
-			expectedStatusCode:     http.StatusOK,
-			expectedRespSubStrings: []string{`ok`},
-		},
-		{
-			url:                    "/livez?verbose=true",
-			expectedStatusCode:     http.StatusOK,
-			expectedRespSubStrings: []string{`[+]serializable_read ok`},
-		},
-		{
-			url:                "/readyz?verbose=true",
-			expectedStatusCode: http.StatusOK,
-			expectedRespSubStrings: []string{
-				`[+]serializable_read ok`,
-				`[+]data_corruption ok`,
-			},
-		},
-	}
-)
+	},
+}
 
 func TestHTTPLivezReadyzHandler(t *testing.T) {
 	e2e.BeforeTest(t)

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -43,7 +43,8 @@ func writeCustomV2Data(t testing.TB, epc *e2e.EtcdProcessCluster, count int) {
 	for i := 0; i < count; i++ {
 		if err := e2e.CURLPut(epc, e2e.CURLReq{
 			Endpoint: "/v2/keys/foo", Value: "bar" + fmt.Sprint(i),
-			Expected: expect.ExpectedResponse{Value: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)}}); err != nil {
+			Expected: expect.ExpectedResponse{Value: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)},
+		}); err != nil {
 			t.Fatalf("failed put with curl (%v)", err)
 		}
 	}
@@ -276,7 +277,7 @@ func assertMembershipEqual(t testing.TB, firstStore v2store.Store, secondStore v
 	rc2.SetStore(secondStore)
 	rc2.Recover(func(lg *zap.Logger, v *semver.Version) { return })
 
-	//membership should match
+	// membership should match
 	if !reflect.DeepEqual(rc1.Members(), rc2.Members()) {
 		t.Logf("memberids_from_last_version = %+v, member_ids_from_current_version = %+v", rc1.MemberIDs(), rc2.MemberIDs())
 		t.Errorf("members_from_last_version_snapshot = %+v, members_from_current_version_snapshot %+v", rc1.Members(), rc2.Members())

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -33,6 +33,7 @@ import (
 func TestCurlV3Auth(t *testing.T) {
 	testCtl(t, testCurlV3Auth)
 }
+
 func TestCurlV3AuthClientTLSCertAuth(t *testing.T) {
 	testCtl(t, testCurlV3Auth, withCfg(*e2e.NewConfigClientTLSCertAuthWithNoCN()))
 }
@@ -88,7 +89,7 @@ func testCurlV3Auth(cx ctlCtx) {
 		cx.t.Fatalf("testCurlV3Auth failed to create role (%v)", err)
 	}
 
-	//grant root role
+	// grant root role
 	for i := 0; i < len(usernames); i++ {
 		grantroleroot, merr := json.Marshal(&pb.AuthUserGrantRoleRequest{User: usernames[i], Role: "root"})
 		require.NoError(cx.t, merr)
@@ -377,9 +378,7 @@ func testCurlV3AuthRoleBasicOperations(cx ctlCtx) {
 }
 
 func testCurlV3AuthRoleManagePermission(cx ctlCtx) {
-	var (
-		rolename = "role1"
-	)
+	rolename := "role1"
 
 	// create a role
 	role, err := json.Marshal(&pb.AuthRoleAddRequest{Name: rolename})

--- a/tests/e2e/v3_curl_lease_test.go
+++ b/tests/e2e/v3_curl_lease_test.go
@@ -25,12 +25,15 @@ import (
 func TestCurlV3LeaseGrantNoTLS(t *testing.T) {
 	testCtl(t, testCurlV3LeaseGrant, withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCurlV3LeaseRevokeNoTLS(t *testing.T) {
 	testCtl(t, testCurlV3LeaseRevoke, withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCurlV3LeaseLeasesNoTLS(t *testing.T) {
 	testCtl(t, testCurlV3LeaseLeases, withCfg(*e2e.NewConfigNoTLS()))
 }
+
 func TestCurlV3LeaseKeepAliveNoTLS(t *testing.T) {
 	testCtl(t, testCurlV3LeaseKeepAlive, withCfg(*e2e.NewConfigNoTLS()))
 }

--- a/tests/framework/e2e/curl.go
+++ b/tests/framework/e2e/curl.go
@@ -59,9 +59,7 @@ func CURLPrefixArgsCluster(cfg *EtcdProcessClusterConfig, member EtcdProcess, me
 }
 
 func CURLPrefixArgs(clientURL string, cfg ClientConfig, CN bool, method string, req CURLReq) []string {
-	var (
-		cmdArgs = []string{"curl"}
-	)
+	cmdArgs := []string{"curl"}
 	if req.HTTPVersion != "" {
 		cmdArgs = append(cmdArgs, "--http"+req.HTTPVersion)
 	}

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -37,9 +37,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
-var (
-	EtcdServerReadyLines = []string{"ready to serve client requests"}
-)
+var EtcdServerReadyLines = []string{"ready to serve client requests"}
 
 // EtcdProcess is a process that serves etcd requests.
 type EtcdProcess interface {
@@ -112,7 +110,7 @@ func NewEtcdServerProcess(t testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServ
 		if err := os.RemoveAll(cfg.DataDirPath); err != nil {
 			return nil, err
 		}
-		if err := os.Mkdir(cfg.DataDirPath, 0700); err != nil {
+		if err := os.Mkdir(cfg.DataDirPath, 0o700); err != nil {
 			return nil, err
 		}
 	}

--- a/tests/framework/e2e/lazyfs.go
+++ b/tests/framework/e2e/lazyfs.go
@@ -50,12 +50,12 @@ func (fs *LazyFS) Start(ctx context.Context) (err error) {
 	if fs.ep != nil {
 		return nil
 	}
-	err = os.WriteFile(fs.configPath(), fs.config(), 0666)
+	err = os.WriteFile(fs.configPath(), fs.config(), 0o666)
 	if err != nil {
 		return err
 	}
 	dataPath := filepath.Join(fs.LazyFSDir, "data")
-	err = os.Mkdir(dataPath, 0700)
+	err = os.Mkdir(dataPath, 0o700)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (fs *LazyFS) Stop() error {
 }
 
 func (fs *LazyFS) ClearCache(ctx context.Context) error {
-	err := os.WriteFile(fs.socketPath(), []byte("lazyfs::clear-cache\n"), 0666)
+	err := os.WriteFile(fs.socketPath(), []byte("lazyfs::clear-cache\n"), 0o666)
 	if err != nil {
 		return err
 	}

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -975,9 +975,7 @@ func (m *Member) Launch() error {
 	}
 
 	if m.GRPCListener != nil {
-		var (
-			tlscfg *tls.Config
-		)
+		var tlscfg *tls.Config
 		if m.ClientTLSInfo != nil && !m.ClientTLSInfo.Empty() {
 			tlscfg, err = m.ClientTLSInfo.ServerConfig()
 			if err != nil {

--- a/tests/framework/integration/testing.go
+++ b/tests/framework/integration/testing.go
@@ -31,8 +31,10 @@ import (
 	gofail "go.etcd.io/gofail/runtime"
 )
 
-var grpcLogger grpclogsettable.SettableLoggerV2
-var insideTestContext bool
+var (
+	grpcLogger        grpclogsettable.SettableLoggerV2
+	insideTestContext bool
+)
 
 func init() {
 	grpcLogger = grpclogsettable.ReplaceGrpcLoggerV2()

--- a/tests/integration/clientv3/concurrency/session_test.go
+++ b/tests/integration/clientv3/concurrency/session_test.go
@@ -50,6 +50,7 @@ func TestSessionOptions(t *testing.T) {
 		t.Fatal("session did not get orphaned as expected")
 	}
 }
+
 func TestSessionTTLOptions(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
 	if err != nil {
@@ -57,7 +58,7 @@ func TestSessionTTLOptions(t *testing.T) {
 	}
 	defer cli.Close()
 
-	var setTTL = 90
+	setTTL := 90
 	s, err := concurrency.NewSession(cli, concurrency.WithTTL(setTTL))
 	if err != nil {
 		t.Fatal(err)

--- a/tests/integration/clientv3/examples/example_kv_test.go
+++ b/tests/integration/clientv3/examples/example_kv_test.go
@@ -322,7 +322,8 @@ func ExampleKV_do() {
 		ops := []clientv3.Op{
 			clientv3.OpPut("put-key", "123"),
 			clientv3.OpGet("put-key"),
-			clientv3.OpPut("put-key", "456")}
+			clientv3.OpPut("put-key", "456"),
+		}
 
 		for _, op := range ops {
 			if _, err := cli.Do(context.TODO(), op); err != nil {

--- a/tests/integration/clientv3/examples/example_lease_test.go
+++ b/tests/integration/clientv3/examples/example_lease_test.go
@@ -48,7 +48,7 @@ func ExampleLease_grant() {
 			log.Fatal(err)
 		}
 	})
-	//Output:
+	// Output:
 }
 
 func mockLease_revoke() {

--- a/tests/integration/clientv3/examples/main_test.go
+++ b/tests/integration/clientv3/examples/main_test.go
@@ -34,7 +34,8 @@ var lazyCluster = integration.NewLazyClusterWithConfig(
 	integration2.ClusterConfig{
 		Size:                        3,
 		WatchProgressNotifyInterval: 200 * time.Millisecond,
-		DisableStrictReconfigCheck:  true})
+		DisableStrictReconfigCheck:  true,
+	})
 
 func exampleEndpoints() []string { return lazyCluster.EndpointsGRPC() }
 

--- a/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_queue_test.go
@@ -234,6 +234,7 @@ func (q *flatPriorityQueue) Enqueue(val string) error {
 	// randomized to stress dequeuing logic; order isn't important
 	return q.PriorityQueue.Enqueue(val, uint16(rand.Intn(2)))
 }
+
 func (q *flatPriorityQueue) Dequeue() (string, error) {
 	return q.PriorityQueue.Dequeue()
 }

--- a/tests/integration/clientv3/naming/endpoints_test.go
+++ b/tests/integration/clientv3/naming/endpoints_test.go
@@ -102,7 +102,8 @@ func TestEndpointManagerAtomicity(t *testing.T) {
 
 	err = em.Update(context.TODO(), []*endpoints.UpdateWithOpts{
 		endpoints.NewAddUpdateOpts("foo/host", endpoints.Endpoint{Addr: "127.0.0.1:2000"}),
-		endpoints.NewAddUpdateOpts("foo/host2", endpoints.Endpoint{Addr: "127.0.0.1:2001"})})
+		endpoints.NewAddUpdateOpts("foo/host2", endpoints.Endpoint{Addr: "127.0.0.1:2001"}),
+	})
 	require.NoError(t, err)
 
 	ctx, watchCancel := context.WithCancel(context.Background())

--- a/tests/integration/clientv3/ordering_kv_test.go
+++ b/tests/integration/clientv3/ordering_kv_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestDetectKvOrderViolation(t *testing.T) {
-	var errOrderViolation = errors.New("DetectedOrderViolation")
+	errOrderViolation := errors.New("DetectedOrderViolation")
 
 	integration2.BeforeTest(t)
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 3, UseBridge: true})
@@ -96,7 +96,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 }
 
 func TestDetectTxnOrderViolation(t *testing.T) {
-	var errOrderViolation = errors.New("DetectedOrderViolation")
+	errOrderViolation := errors.New("DetectedOrderViolation")
 
 	integration2.BeforeTest(t)
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 3, UseBridge: true})

--- a/tests/integration/clientv3/util.go
+++ b/tests/integration/clientv3/util.go
@@ -114,7 +114,6 @@ func populateDataIntoCluster(t *testing.T, cluster *integration2.Cluster, numKey
 	for i := 0; i < numKeys; i++ {
 		_, err := cluster.RandClient().Put(ctx,
 			fmt.Sprintf("%s-%v", t.Name(), i), strings.Repeat("a", valueSize))
-
 		if err != nil {
 			t.Errorf("populating data expected no error, but got %v", err)
 		}

--- a/tests/integration/clientv3/watch_test.go
+++ b/tests/integration/clientv3/watch_test.go
@@ -576,8 +576,10 @@ func testWatchWithProgressNotify(t *testing.T, watchOnPut bool) {
 			t.Fatalf("resp.Header.Revision expected 2, got %d", resp.Header.Revision)
 		}
 		if watchOnPut { // wait for put if watch on the put key
-			ev := []*clientv3.Event{{Type: clientv3.EventTypePut,
-				Kv: &mvccpb.KeyValue{Key: []byte("foox"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}}}
+			ev := []*clientv3.Event{{
+				Type: clientv3.EventTypePut,
+				Kv:   &mvccpb.KeyValue{Key: []byte("foox"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1},
+			}}
 			if !reflect.DeepEqual(ev, resp.Events) {
 				t.Fatalf("expected %+v, got %+v", ev, resp.Events)
 			}

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -40,14 +40,12 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
-var (
-	testTLSInfo = transport.TLSInfo{
-		KeyFile:        testutils.MustAbsPath("../../fixtures/server.key.insecure"),
-		CertFile:       testutils.MustAbsPath("../../fixtures/server.crt"),
-		TrustedCAFile:  testutils.MustAbsPath("../../fixtures/ca.crt"),
-		ClientCertAuth: true,
-	}
-)
+var testTLSInfo = transport.TLSInfo{
+	KeyFile:        testutils.MustAbsPath("../../fixtures/server.key.insecure"),
+	CertFile:       testutils.MustAbsPath("../../fixtures/server.crt"),
+	TrustedCAFile:  testutils.MustAbsPath("../../fixtures/ca.crt"),
+	ClientCertAuth: true,
+}
 
 func TestEmbedEtcd(t *testing.T) {
 	testutil.SkipTestIfShortMode(t, "Cannot start embedded cluster in --short tests")

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -222,7 +222,8 @@ func TestMetricsRangeDurationSeconds(t *testing.T) {
 	client := clus.RandClient()
 
 	keys := []string{
-		"my-namespace/foobar", "my-namespace/foobar1", "namespace/foobar1"}
+		"my-namespace/foobar", "my-namespace/foobar1", "namespace/foobar1",
+	}
 	for _, key := range keys {
 		_, err := client.Put(context.Background(), key, "data")
 		require.NoError(t, err)

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -74,13 +74,13 @@ func TestClusterProxyMemberList(t *testing.T) {
 	}
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{cts.caddr}})
 
-	//test proxy member add
+	// test proxy member add
 	newMemberAddr := "127.0.0.2:6789"
 	grpcproxy.Register(lg, cts.c, prefix, newMemberAddr, 7)
 	// wait some time for proxy update members
 	time.Sleep(200 * time.Millisecond)
 
-	//check add member succ
+	// check add member succ
 	mresp, err = client.Cluster.MemberList(context.Background())
 	if err != nil {
 		t.Fatalf("err %v, want nil", err)
@@ -90,12 +90,12 @@ func TestClusterProxyMemberList(t *testing.T) {
 	}
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{newMemberAddr}})
 
-	//test proxy member delete
+	// test proxy member delete
 	deregisterMember(cts.c, prefix, newMemberAddr, t)
 	// wait some time for proxy update members
 	time.Sleep(200 * time.Millisecond)
 
-	//check delete member succ
+	// check delete member succ
 	mresp, err = client.Cluster.MemberList(context.Background())
 	if err != nil {
 		t.Fatalf("err %v, want nil", err)

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -205,7 +205,8 @@ const testClusterTkn = "tkn"
 func restoreCluster(t *testing.T, clusterN int, dbPath string) (
 	cURLs []url.URL,
 	pURLs []url.URL,
-	srvs []*embed.Etcd) {
+	srvs []*embed.Etcd,
+) {
 	urls := newEmbedURLs(t, clusterN*2)
 	cURLs, pURLs = urls[:clusterN], urls[clusterN:]
 

--- a/tests/integration/testing_test.go
+++ b/tests/integration/testing_test.go
@@ -24,6 +24,5 @@ func TestBeforeTestWithoutLeakDetection(t *testing.T) {
 	integration2.BeforeTest(t, integration2.WithoutGoLeakDetection(), integration2.WithoutSkipInShort())
 	// Intentional leak that should get ignored
 	go func() {
-
 	}()
 }

--- a/tests/integration/tracing_test.go
+++ b/tests/integration/tracing_test.go
@@ -50,7 +50,8 @@ func TestTracing(t *testing.T) {
 	srv := grpc.NewServer()
 	traceservice.RegisterTraceServiceServer(srv, &traceServer{
 		traceFound: traceFound,
-		filterFunc: containsNodeListSpan})
+		filterFunc: containsNodeListSpan,
+	})
 
 	go srv.Serve(listener)
 	defer srv.Stop()
@@ -92,7 +93,8 @@ func TestTracing(t *testing.T) {
 
 	dialOptions := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor(tracingOpts...)),
-		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor(tracingOpts...))}
+		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor(tracingOpts...)),
+	}
 	ccfg := clientv3.Config{DialOptions: dialOptions, Endpoints: []string{cfg.AdvertiseClientUrls[0].String()}}
 	cli, err := integration.NewClient(t, ccfg)
 	if err != nil {
@@ -141,7 +143,7 @@ type traceServer struct {
 }
 
 func (t *traceServer) Export(ctx context.Context, req *traceservice.ExportTraceServiceRequest) (*traceservice.ExportTraceServiceResponse, error) {
-	var emptyValue = traceservice.ExportTraceServiceResponse{}
+	emptyValue := traceservice.ExportTraceServiceResponse{}
 	if t.filterFunc(req) {
 		t.traceFound <- struct{}{}
 	}

--- a/tests/integration/v2store/main_test.go
+++ b/tests/integration/v2store/main_test.go
@@ -20,8 +20,6 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
-//var endpoints []string
-
 func TestMain(m *testing.M) {
 	//cfg := integration.ClusterConfig{Size: 1}
 	//clus := integration.NewClusterV3(nil, &cfg)

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -120,7 +120,6 @@ func putWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 			}
 			return nil
 		}()
-
 		if err != nil {
 			retryCount--
 			if shouldRetry(err) {
@@ -153,7 +152,6 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 			}
 			return nil
 		}()
-
 		if err != nil {
 			retryCount--
 			if shouldRetry(err) {

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -253,9 +253,10 @@ func TestV3TxnTooManyOps(t *testing.T) {
 		newTxn := &pb.TxnRequest{}
 		addSuccessOps(newTxn)
 		txn.Success = append(txn.Success,
-			&pb.RequestOp{Request: &pb.RequestOp_RequestTxn{
-				RequestTxn: newTxn,
-			},
+			&pb.RequestOp{
+				Request: &pb.RequestOp_RequestTxn{
+					RequestTxn: newTxn,
+				},
 			},
 		)
 	}
@@ -286,44 +287,53 @@ func TestV3TxnDuplicateKeys(t *testing.T) {
 	defer clus.Terminate(t)
 
 	putreq := &pb.RequestOp{Request: &pb.RequestOp_RequestPut{RequestPut: &pb.PutRequest{Key: []byte("abc"), Value: []byte("def")}}}
-	delKeyReq := &pb.RequestOp{Request: &pb.RequestOp_RequestDeleteRange{
-		RequestDeleteRange: &pb.DeleteRangeRequest{
-			Key: []byte("abc"),
+	delKeyReq := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestDeleteRange{
+			RequestDeleteRange: &pb.DeleteRangeRequest{
+				Key: []byte("abc"),
+			},
 		},
-	},
 	}
-	delInRangeReq := &pb.RequestOp{Request: &pb.RequestOp_RequestDeleteRange{
-		RequestDeleteRange: &pb.DeleteRangeRequest{
-			Key: []byte("a"), RangeEnd: []byte("b"),
+	delInRangeReq := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestDeleteRange{
+			RequestDeleteRange: &pb.DeleteRangeRequest{
+				Key: []byte("a"), RangeEnd: []byte("b"),
+			},
 		},
-	},
 	}
-	delOutOfRangeReq := &pb.RequestOp{Request: &pb.RequestOp_RequestDeleteRange{
-		RequestDeleteRange: &pb.DeleteRangeRequest{
-			Key: []byte("abb"), RangeEnd: []byte("abc"),
+	delOutOfRangeReq := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestDeleteRange{
+			RequestDeleteRange: &pb.DeleteRangeRequest{
+				Key: []byte("abb"), RangeEnd: []byte("abc"),
+			},
 		},
-	},
 	}
-	txnDelReq := &pb.RequestOp{Request: &pb.RequestOp_RequestTxn{
-		RequestTxn: &pb.TxnRequest{Success: []*pb.RequestOp{delInRangeReq}},
-	},
+	txnDelReq := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestTxn{
+			RequestTxn: &pb.TxnRequest{Success: []*pb.RequestOp{delInRangeReq}},
+		},
 	}
-	txnDelReqTwoSide := &pb.RequestOp{Request: &pb.RequestOp_RequestTxn{
-		RequestTxn: &pb.TxnRequest{
-			Success: []*pb.RequestOp{delInRangeReq},
-			Failure: []*pb.RequestOp{delInRangeReq}},
-	},
+	txnDelReqTwoSide := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestTxn{
+			RequestTxn: &pb.TxnRequest{
+				Success: []*pb.RequestOp{delInRangeReq},
+				Failure: []*pb.RequestOp{delInRangeReq},
+			},
+		},
 	}
 
-	txnPutReq := &pb.RequestOp{Request: &pb.RequestOp_RequestTxn{
-		RequestTxn: &pb.TxnRequest{Success: []*pb.RequestOp{putreq}},
-	},
+	txnPutReq := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestTxn{
+			RequestTxn: &pb.TxnRequest{Success: []*pb.RequestOp{putreq}},
+		},
 	}
-	txnPutReqTwoSide := &pb.RequestOp{Request: &pb.RequestOp_RequestTxn{
-		RequestTxn: &pb.TxnRequest{
-			Success: []*pb.RequestOp{putreq},
-			Failure: []*pb.RequestOp{putreq}},
-	},
+	txnPutReqTwoSide := &pb.RequestOp{
+		Request: &pb.RequestOp_RequestTxn{
+			RequestTxn: &pb.TxnRequest{
+				Success: []*pb.RequestOp{putreq},
+				Failure: []*pb.RequestOp{putreq},
+			},
+		},
 	}
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
@@ -473,7 +483,8 @@ func TestV3TxnCmpHeaderRev(t *testing.T) {
 
 		// The read-only txn uses the optimized readindex server path.
 		txnget := &pb.RequestOp{Request: &pb.RequestOp_RequestRange{
-			RequestRange: &pb.RangeRequest{Key: []byte("k")}}}
+			RequestRange: &pb.RangeRequest{Key: []byte("k")},
+		}}
 		txn := &pb.TxnRequest{Success: []*pb.RequestOp{txnget}}
 		// i = 0 /\ Succeeded => put followed txn
 		cmp := &pb.Compare{
@@ -709,7 +720,8 @@ func TestV3PutIgnoreValue(t *testing.T) {
 				preq.IgnoreValue = true
 				txn := &pb.TxnRequest{}
 				txn.Success = append(txn.Success, &pb.RequestOp{
-					Request: &pb.RequestOp_RequestPut{RequestPut: &preq}})
+					Request: &pb.RequestOp_RequestPut{RequestPut: &preq},
+				})
 				_, err := kvc.Txn(context.TODO(), txn)
 				return err
 			},
@@ -732,7 +744,8 @@ func TestV3PutIgnoreValue(t *testing.T) {
 				preq.IgnoreValue = true
 				txn := &pb.TxnRequest{}
 				txn.Success = append(txn.Success, &pb.RequestOp{
-					Request: &pb.RequestOp_RequestPut{RequestPut: &preq}})
+					Request: &pb.RequestOp_RequestPut{RequestPut: &preq},
+				})
 				_, err := kvc.Txn(context.TODO(), txn)
 				return err
 			},
@@ -844,7 +857,8 @@ func TestV3PutIgnoreLease(t *testing.T) {
 				preq.IgnoreLease = true
 				txn := &pb.TxnRequest{}
 				txn.Success = append(txn.Success, &pb.RequestOp{
-					Request: &pb.RequestOp_RequestPut{RequestPut: &preq}})
+					Request: &pb.RequestOp_RequestPut{RequestPut: &preq},
+				})
 				_, err := kvc.Txn(context.TODO(), txn)
 				return err
 			},
@@ -870,7 +884,8 @@ func TestV3PutIgnoreLease(t *testing.T) {
 				preq.IgnoreLease = true
 				txn := &pb.TxnRequest{}
 				txn.Success = append(txn.Success, &pb.RequestOp{
-					Request: &pb.RequestOp_RequestPut{RequestPut: &preq}})
+					Request: &pb.RequestOp_RequestPut{RequestPut: &preq},
+				})
 				_, err := kvc.Txn(context.TODO(), txn)
 				return err
 			},
@@ -960,7 +975,9 @@ func TestV3PutMissingLease(t *testing.T) {
 			txn := &pb.TxnRequest{}
 			txn.Success = append(txn.Success, &pb.RequestOp{
 				Request: &pb.RequestOp_RequestPut{
-					RequestPut: preq}})
+					RequestPut: preq,
+				},
+			})
 			if tresp, err := kvc.Txn(context.TODO(), txn); err == nil {
 				t.Errorf("succeeded txn success. req: %v. resp: %v", txn, tresp)
 			}
@@ -970,7 +987,9 @@ func TestV3PutMissingLease(t *testing.T) {
 			txn := &pb.TxnRequest{}
 			txn.Failure = append(txn.Failure, &pb.RequestOp{
 				Request: &pb.RequestOp_RequestPut{
-					RequestPut: preq}})
+					RequestPut: preq,
+				},
+			})
 			cmp := &pb.Compare{
 				Result: pb.Compare_GREATER,
 				Target: pb.Compare_CREATE,
@@ -987,10 +1006,14 @@ func TestV3PutMissingLease(t *testing.T) {
 			rreq := &pb.RangeRequest{Key: []byte("bar")}
 			txn.Success = append(txn.Success, &pb.RequestOp{
 				Request: &pb.RequestOp_RequestRange{
-					RequestRange: rreq}})
+					RequestRange: rreq,
+				},
+			})
 			txn.Failure = append(txn.Failure, &pb.RequestOp{
 				Request: &pb.RequestOp_RequestPut{
-					RequestPut: preq}})
+					RequestPut: preq,
+				},
+			})
 			if tresp, err := kvc.Txn(context.TODO(), txn); err != nil {
 				t.Errorf("failed good txn. req: %v. resp: %v", txn, tresp)
 			}
@@ -1028,43 +1051,50 @@ func TestV3DeleteRange(t *testing.T) {
 			"delete middle",
 			[]string{"foo", "foo/abc", "fop"},
 			"foo/", "fop", false,
-			[][]byte{[]byte("foo"), []byte("fop")}, 1,
+			[][]byte{[]byte("foo"), []byte("fop")},
+			1,
 		},
 		{
 			"no delete",
 			[]string{"foo", "foo/abc", "fop"},
 			"foo/", "foo/", false,
-			[][]byte{[]byte("foo"), []byte("foo/abc"), []byte("fop")}, 0,
+			[][]byte{[]byte("foo"), []byte("foo/abc"), []byte("fop")},
+			0,
 		},
 		{
 			"delete first",
 			[]string{"foo", "foo/abc", "fop"},
 			"fo", "fop", false,
-			[][]byte{[]byte("fop")}, 2,
+			[][]byte{[]byte("fop")},
+			2,
 		},
 		{
 			"delete tail",
 			[]string{"foo", "foo/abc", "fop"},
 			"foo/", "fos", false,
-			[][]byte{[]byte("foo")}, 2,
+			[][]byte{[]byte("foo")},
+			2,
 		},
 		{
 			"delete exact",
 			[]string{"foo", "foo/abc", "fop"},
 			"foo/abc", "", false,
-			[][]byte{[]byte("foo"), []byte("fop")}, 1,
+			[][]byte{[]byte("foo"), []byte("fop")},
+			1,
 		},
 		{
 			"delete none [x,x)",
 			[]string{"foo"},
 			"foo", "foo", false,
-			[][]byte{[]byte("foo")}, 0,
+			[][]byte{[]byte("foo")},
+			0,
 		},
 		{
 			"delete middle with preserveKVs set",
 			[]string{"foo", "foo/abc", "fop"},
 			"foo/", "fop", true,
-			[][]byte{[]byte("foo"), []byte("fop")}, 1,
+			[][]byte{[]byte("foo"), []byte("fop")},
+			1,
 		},
 	}
 
@@ -1147,12 +1177,16 @@ func TestV3TxnInvalidRange(t *testing.T) {
 	txn := &pb.TxnRequest{}
 	txn.Success = append(txn.Success, &pb.RequestOp{
 		Request: &pb.RequestOp_RequestPut{
-			RequestPut: preq}})
+			RequestPut: preq,
+		},
+	})
 
 	rreq := &pb.RangeRequest{Key: []byte("foo"), Revision: 100}
 	txn.Success = append(txn.Success, &pb.RequestOp{
 		Request: &pb.RequestOp_RequestRange{
-			RequestRange: rreq}})
+			RequestRange: rreq,
+		},
+	})
 
 	if _, err := kvc.Txn(context.TODO(), txn); !eqErrGRPC(err, rpctypes.ErrGRPCFutureRev) {
 		t.Errorf("err = %v, want %v", err, rpctypes.ErrGRPCFutureRev)
@@ -1717,7 +1751,8 @@ func testTLSReload(
 	cloneFunc func() transport.TLSInfo,
 	replaceFunc func(),
 	revertFunc func(),
-	useIP bool) {
+	useIP bool,
+) {
 	integration.BeforeTest(t)
 
 	// 1. separate copies for TLS assets modification

--- a/tests/integration/v3_kv_test.go
+++ b/tests/integration/v3_kv_test.go
@@ -64,7 +64,7 @@ func TestKVWithEmptyValue(t *testing.T) {
 		t.Log(string(kv.Key), "=", string(kv.Value))
 	}
 
-	//Remove all keys without WithFromKey/WithPrefix func
+	// Remove all keys without WithFromKey/WithPrefix func
 	_, err = client.Delete(context.Background(), "")
 	if err == nil {
 		// fatal error duo to without WithFromKey/WithPrefix func called.

--- a/tests/integration/v3_leadership_test.go
+++ b/tests/integration/v3_leadership_test.go
@@ -203,7 +203,6 @@ func TestFirstCommitNotification(t *testing.T) {
 	}
 
 	_, err := oldLeaderClient.MoveLeader(context.Background(), newLeaderID)
-
 	if err != nil {
 		t.Errorf("got error during leadership transfer: %v", err)
 	}

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -249,7 +249,9 @@ func TestV3LeaseExpire(t *testing.T) {
 
 		wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 			CreateRequest: &pb.WatchCreateRequest{
-				Key: []byte("foo"), StartRevision: 1}}}
+				Key: []byte("foo"), StartRevision: 1,
+			},
+		}}
 		if err := wStream.Send(wreq); err != nil {
 			return err
 		}

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -69,7 +69,8 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 		t.Fatal(errW)
 	}
 	if err := wStream.Send(&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 5}}}); err != nil {
+		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 5},
+	}}); err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
 	wresp, errR := wStream.Recv()

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -54,7 +54,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			[]string{"foo"},
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
-					Key: []byte("foo")}}},
+					Key: []byte("foo"),
+				},
+			}},
 
 			[]*pb.WatchResponse{
 				{
@@ -74,7 +76,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			[]string{"foo"},
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
-					Key: []byte("helloworld")}}},
+					Key: []byte("helloworld"),
+				},
+			}},
 
 			[]*pb.WatchResponse{},
 		},
@@ -84,7 +88,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
 					Key:      []byte("foo"),
-					RangeEnd: []byte("fop")}}},
+					RangeEnd: []byte("fop"),
+				},
+			}},
 
 			[]*pb.WatchResponse{
 				{
@@ -105,7 +111,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
 					Key:      []byte("helloworld"),
-					RangeEnd: []byte("helloworle")}}},
+					RangeEnd: []byte("helloworle"),
+				},
+			}},
 
 			[]*pb.WatchResponse{},
 		},
@@ -115,7 +123,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
 					Key:      []byte(""),
-					RangeEnd: []byte("\x00")}}},
+					RangeEnd: []byte("\x00"),
+				},
+			}},
 
 			[]*pb.WatchResponse{
 				{
@@ -135,7 +145,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			[]string{"foo", "foo", "foo"},
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
-					Key: []byte("foo")}}},
+					Key: []byte("foo"),
+				},
+			}},
 
 			[]*pb.WatchResponse{
 				{
@@ -176,7 +188,9 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
 					Key:      []byte("foo"),
-					RangeEnd: []byte("fop")}}},
+					RangeEnd: []byte("fop"),
+				},
+			}},
 
 			[]*pb.WatchResponse{
 				{
@@ -316,7 +330,8 @@ func TestV3WatchFutureRevision(t *testing.T) {
 	wkey := []byte("foo")
 	wrev := int64(10)
 	req := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-		CreateRequest: &pb.WatchCreateRequest{Key: wkey, StartRevision: wrev}}}
+		CreateRequest: &pb.WatchCreateRequest{Key: wkey, StartRevision: wrev},
+	}}
 	err = wStream.Send(req)
 	if err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
@@ -385,7 +400,8 @@ func TestV3WatchWrongRange(t *testing.T) {
 	}
 	for i, tt := range tests {
 		if err := wStream.Send(&pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-			CreateRequest: &pb.WatchCreateRequest{Key: tt.key, RangeEnd: tt.end, StartRevision: 1}}}); err != nil {
+			CreateRequest: &pb.WatchCreateRequest{Key: tt.key, RangeEnd: tt.end, StartRevision: 1},
+		}}); err != nil {
 			t.Fatalf("#%d: wStream.Send error: %v", i, err)
 		}
 		cresp, err := wStream.Recv()
@@ -429,7 +445,9 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 
 	wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
-			Key: []byte("foo"), StartRevision: startRev}}}
+			Key: []byte("foo"), StartRevision: startRev,
+		},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
@@ -444,7 +462,9 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 
 	creq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CancelRequest{
 		CancelRequest: &pb.WatchCancelRequest{
-			WatchId: wresp.WatchId}}}
+			WatchId: wresp.WatchId,
+		},
+	}}
 	if err := wStream.Send(creq); err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
@@ -503,7 +523,8 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 	progress := make(map[int64]int64)
 
 	wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), RangeEnd: []byte("fop")}}}
+		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), RangeEnd: []byte("fop")},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("first watch request failed (%v)", err)
 	}
@@ -570,7 +591,9 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	}
 	req := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
-			Key: []byte("foo")}}}
+			Key: []byte("foo"),
+		},
+	}}
 	if err := ws.Send(req); err != nil {
 		t.Fatal(err)
 	}
@@ -634,11 +657,15 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 		if i < watchKeyN {
 			wreq = &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
-					Key: []byte("foo"), StartRevision: startRev}}}
+					Key: []byte("foo"), StartRevision: startRev,
+				},
+			}}
 		} else {
 			wreq = &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 				CreateRequest: &pb.WatchCreateRequest{
-					Key: []byte("fo"), RangeEnd: []byte("fp"), StartRevision: startRev}}}
+					Key: []byte("fo"), RangeEnd: []byte("fp"), StartRevision: startRev,
+				},
+			}}
 		}
 		if err := wStream.Send(wreq); err != nil {
 			t.Fatalf("wStream.Send error: %v", err)
@@ -730,7 +757,9 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 
 	wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
-			Key: []byte("foo"), RangeEnd: []byte("fop"), StartRevision: startRev}}}
+			Key: []byte("foo"), RangeEnd: []byte("fop"), StartRevision: startRev,
+		},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
@@ -744,7 +773,9 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 		ru := &pb.RequestOp{}
 		ru.Request = &pb.RequestOp_RequestPut{
 			RequestPut: &pb.PutRequest{
-				Key: []byte(fmt.Sprintf("foo%d", i)), Value: []byte("bar")}}
+				Key: []byte(fmt.Sprintf("foo%d", i)), Value: []byte("bar"),
+			},
+		}
 		txn.Success = append(txn.Success, ru)
 	}
 
@@ -822,7 +853,9 @@ func TestV3WatchMultipleEventsPutUnsynced(t *testing.T) {
 
 	wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
-			Key: []byte("foo"), RangeEnd: []byte("fop"), StartRevision: 1}}}
+			Key: []byte("foo"), RangeEnd: []byte("fop"), StartRevision: 1,
+		},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
@@ -1012,7 +1045,9 @@ func testV3WatchMultipleStreams(t *testing.T, startRev int64) {
 		}
 		wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 			CreateRequest: &pb.WatchCreateRequest{
-				Key: []byte("foo"), StartRevision: startRev}}}
+				Key: []byte("foo"), StartRevision: startRev,
+			},
+		}}
 		if err := wStream.Send(wreq); err != nil {
 			t.Fatalf("wStream.Send error: %v", err)
 		}
@@ -1111,12 +1146,14 @@ func TestWatchWithProgressNotify(t *testing.T) {
 
 	// create two watchers, one with progressNotify set.
 	wreq := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 1, ProgressNotify: true}}}
+		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 1, ProgressNotify: true},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("watch request failed (%v)", err)
 	}
 	wreq = &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
-		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 1}}}
+		CreateRequest: &pb.WatchCreateRequest{Key: []byte("foo"), StartRevision: 1},
+	}}
 	if err := wStream.Send(wreq); err != nil {
 		t.Fatalf("watch request failed (%v)", err)
 	}
@@ -1171,7 +1208,9 @@ func TestV3WatchClose(t *testing.T) {
 			cr := &pb.WatchCreateRequest{Key: []byte("a")}
 			req := &pb.WatchRequest{
 				RequestUnion: &pb.WatchRequest_CreateRequest{
-					CreateRequest: cr}}
+					CreateRequest: cr,
+				},
+			}
 			ws.Send(req)
 			ws.Recv()
 		}()
@@ -1199,7 +1238,8 @@ func TestV3WatchWithFilter(t *testing.T) {
 		CreateRequest: &pb.WatchCreateRequest{
 			Key:     []byte("foo"),
 			Filters: []pb.WatchCreateRequest_FilterType{pb.WatchCreateRequest_NOPUT},
-		}}}
+		},
+	}}
 	if err := ws.Send(req); err != nil {
 		t.Fatal(err)
 	}
@@ -1287,7 +1327,8 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 				Key:      []byte(tt.key),
 				RangeEnd: []byte(tt.end),
 				PrevKv:   true,
-			}}}
+			},
+		}}
 		err = ws.Send(req)
 		require.NoError(t, err)
 		_, err = ws.Recv()
@@ -1434,7 +1475,7 @@ func TestV3WatchProgressWaitsForSync(t *testing.T) {
 
 	// Immediately request a progress notification. As the client
 	// is unsynchronised, the server will not sent any notification,
-	//as client can infer progress from events.
+	// as client can infer progress from events.
 	err := client.RequestProgress(ctx)
 	require.NoError(t, err)
 

--- a/tests/robustness/client/watch.go
+++ b/tests/robustness/client/watch.go
@@ -124,7 +124,7 @@ resetWatch:
 }
 
 func ValidateGotAtLeastOneProgressNotify(t *testing.T, reports []report.ClientReport, expectProgressNotify bool) {
-	var gotProgressNotify = false
+	gotProgressNotify := false
 external:
 	for _, r := range reports {
 		for _, op := range r.Watch {

--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -35,9 +35,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/traffic"
 )
 
-var (
-	MemberReplace Failpoint = memberReplace{}
-)
+var MemberReplace Failpoint = memberReplace{}
 
 type memberReplace struct{}
 

--- a/tests/robustness/failpoint/failpoint.go
+++ b/tests/robustness/failpoint/failpoint.go
@@ -35,25 +35,23 @@ const (
 	triggerTimeout = time.Minute
 )
 
-var (
-	allFailpoints = []Failpoint{
-		KillFailpoint, BeforeCommitPanic, AfterCommitPanic, RaftBeforeSavePanic, RaftAfterSavePanic,
-		DefragBeforeCopyPanic, DefragBeforeRenamePanic, BackendBeforePreCommitHookPanic, BackendAfterPreCommitHookPanic,
-		BackendBeforeStartDBTxnPanic, BackendAfterStartDBTxnPanic, BackendBeforeWritebackBufPanic,
-		BackendAfterWritebackBufPanic, CompactBeforeCommitScheduledCompactPanic, CompactAfterCommitScheduledCompactPanic,
-		CompactBeforeSetFinishedCompactPanic, CompactAfterSetFinishedCompactPanic, CompactBeforeCommitBatchPanic,
-		CompactAfterCommitBatchPanic, RaftBeforeLeaderSendPanic, BlackholePeerNetwork, DelayPeerNetwork,
-		RaftBeforeFollowerSendPanic, RaftBeforeApplySnapPanic, RaftAfterApplySnapPanic, RaftAfterWALReleasePanic,
-		RaftBeforeSaveSnapPanic, RaftAfterSaveSnapPanic, BlackholeUntilSnapshot,
-		BeforeApplyOneConfChangeSleep,
-		MemberReplace,
-		DropPeerNetwork,
-		RaftBeforeSaveSleep,
-		RaftAfterSaveSleep,
-		ApplyBeforeOpenSnapshot,
-		SleepBeforeSendWatchResponse,
-	}
-)
+var allFailpoints = []Failpoint{
+	KillFailpoint, BeforeCommitPanic, AfterCommitPanic, RaftBeforeSavePanic, RaftAfterSavePanic,
+	DefragBeforeCopyPanic, DefragBeforeRenamePanic, BackendBeforePreCommitHookPanic, BackendAfterPreCommitHookPanic,
+	BackendBeforeStartDBTxnPanic, BackendAfterStartDBTxnPanic, BackendBeforeWritebackBufPanic,
+	BackendAfterWritebackBufPanic, CompactBeforeCommitScheduledCompactPanic, CompactAfterCommitScheduledCompactPanic,
+	CompactBeforeSetFinishedCompactPanic, CompactAfterSetFinishedCompactPanic, CompactBeforeCommitBatchPanic,
+	CompactAfterCommitBatchPanic, RaftBeforeLeaderSendPanic, BlackholePeerNetwork, DelayPeerNetwork,
+	RaftBeforeFollowerSendPanic, RaftBeforeApplySnapPanic, RaftAfterApplySnapPanic, RaftAfterWALReleasePanic,
+	RaftBeforeSaveSnapPanic, RaftAfterSaveSnapPanic, BlackholeUntilSnapshot,
+	BeforeApplyOneConfChangeSleep,
+	MemberReplace,
+	DropPeerNetwork,
+	RaftBeforeSaveSleep,
+	RaftAfterSaveSleep,
+	ApplyBeforeOpenSnapshot,
+	SleepBeforeSendWatchResponse,
+}
 
 func PickRandom(clus *e2e.EtcdProcessCluster, profile traffic.Profile) (Failpoint, error) {
 	availableFailpoints := make([]Failpoint, 0, len(allFailpoints))

--- a/tests/robustness/failpoint/kill.go
+++ b/tests/robustness/failpoint/kill.go
@@ -30,9 +30,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/traffic"
 )
 
-var (
-	KillFailpoint Failpoint = killFailpoint{}
-)
+var KillFailpoint Failpoint = killFailpoint{}
 
 type killFailpoint struct{}
 

--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -181,10 +181,10 @@ func (s EtcdState) Step(request EtcdRequest) (EtcdState, MaybeEtcdResponse) {
 		newState.Leases[request.LeaseGrant.LeaseID] = lease
 		return newState, MaybeEtcdResponse{EtcdResponse: EtcdResponse{Revision: newState.Revision, LeaseGrant: &LeaseGrantReponse{}}}
 	case LeaseRevoke:
-		//Delete the keys attached to the lease
+		// Delete the keys attached to the lease
 		keyDeleted := false
 		for key := range newState.Leases[request.LeaseRevoke.LeaseID].Keys {
-			//same as delete.
+			// same as delete.
 			if _, ok := newState.KeyValues[key]; ok {
 				if !keyDeleted {
 					keyDeleted = true
@@ -193,7 +193,7 @@ func (s EtcdState) Step(request EtcdRequest) (EtcdState, MaybeEtcdResponse) {
 				delete(newState.KeyLeases, key)
 			}
 		}
-		//delete the lease
+		// delete the lease
 		delete(newState.Leases, request.LeaseRevoke.LeaseID)
 		if keyDeleted {
 			newState.Revision++
@@ -402,8 +402,10 @@ type RangeResponse struct {
 type LeaseGrantReponse struct {
 	LeaseID int64
 }
-type LeaseRevokeResponse struct{}
-type DefragmentResponse struct{}
+type (
+	LeaseRevokeResponse struct{}
+	DefragmentResponse  struct{}
+)
 
 type EtcdOperationResult struct {
 	RangeResponse
@@ -451,8 +453,7 @@ func ToValueOrHash(value string) ValueOrHash {
 	return v
 }
 
-type CompactResponse struct {
-}
+type CompactResponse struct{}
 
 type CompactRequest struct {
 	Revision int64

--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -481,7 +481,7 @@ func (h History) Len() int {
 
 func (h History) Operations() []porcupine.Operation {
 	operations := make([]porcupine.Operation, 0, len(h.operations))
-	var maxTime = h.lastObservedTime()
+	maxTime := h.lastObservedTime()
 	for _, op := range h.operations {
 		// Failed requests don't have a known return time.
 		if op.Return == -1 {

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -53,7 +53,7 @@ func persistClientReports(t *testing.T, lg *zap.Logger, path string, reports []C
 	})
 	for _, r := range reports {
 		clientDir := filepath.Join(path, fmt.Sprintf("client-%d", r.ClientID))
-		err := os.MkdirAll(clientDir, 0700)
+		err := os.MkdirAll(clientDir, 0o700)
 		require.NoError(t, err)
 		if len(r.Watch) != 0 {
 			persistWatchOperations(t, lg, filepath.Join(clientDir, "watch.json"), r.Watch)
@@ -115,7 +115,7 @@ func loadWatchOperations(path string) (operations []model.WatchOperation, err er
 		}
 		return nil, fmt.Errorf("failed to open watch operation file: %q, err: %w", path, err)
 	}
-	file, err := os.OpenFile(path, os.O_RDONLY, 0755)
+	file, err := os.OpenFile(path, os.O_RDONLY, 0o755)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open watch operation file: %q, err: %w", path, err)
 	}
@@ -140,7 +140,7 @@ func loadKeyValueOperations(path string) (operations []porcupine.Operation, err 
 		}
 		return nil, fmt.Errorf("failed to open watch operation file: %q, err: %w", path, err)
 	}
-	file, err := os.OpenFile(path, os.O_RDONLY, 0755)
+	file, err := os.OpenFile(path, os.O_RDONLY, 0o755)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open watch operation file: %q, err: %w", path, err)
 	}
@@ -171,7 +171,7 @@ func loadKeyValueOperations(path string) (operations []porcupine.Operation, err 
 
 func persistWatchOperations(t *testing.T, lg *zap.Logger, path string, responses []model.WatchOperation) {
 	lg.Info("Saving watch operations", zap.String("path", path))
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
 		t.Errorf("Failed to save watch operations: %v", err)
 		return
@@ -188,7 +188,7 @@ func persistWatchOperations(t *testing.T, lg *zap.Logger, path string, responses
 
 func persistKeyValueOperations(t *testing.T, lg *zap.Logger, path string, operations []porcupine.Operation) {
 	lg.Info("Saving operation history", zap.String("path", path))
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
 		t.Errorf("Failed to save operation history: %v", err)
 		return

--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -49,7 +49,7 @@ func testResultsDirectory(t *testing.T) string {
 	require.NoError(t, err)
 	err = os.RemoveAll(path)
 	require.NoError(t, err)
-	err = os.MkdirAll(path, 0700)
+	err = os.MkdirAll(path, 0o700)
 	require.NoError(t, err)
 	return path
 }

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -255,7 +255,7 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 		if leaseID != 0 {
 			var resp *clientv3.LeaseRevokeResponse
 			resp, err = c.client.LeaseRevoke(opCtx, leaseID)
-			//if LeaseRevoke has failed, do not remove the mapping.
+			// if LeaseRevoke has failed, do not remove the mapping.
 			if err == nil {
 				c.leaseStorage.RemoveLeaseID(c.client.ID)
 			}

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -32,19 +32,17 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/random"
 )
 
-var (
-	Kubernetes Traffic = kubernetesTraffic{
-		averageKeyCount: 10,
-		resource:        "pods",
-		namespace:       "default",
-		// Please keep the sum of weights equal 1000.
-		writeChoices: []random.ChoiceWeight[KubernetesRequestType]{
-			{Choice: KubernetesUpdate, Weight: 90},
-			{Choice: KubernetesDelete, Weight: 5},
-			{Choice: KubernetesCreate, Weight: 5},
-		},
-	}
-)
+var Kubernetes Traffic = kubernetesTraffic{
+	averageKeyCount: 10,
+	resource:        "pods",
+	namespace:       "default",
+	// Please keep the sum of weights equal 1000.
+	writeChoices: []random.ChoiceWeight[KubernetesRequestType]{
+		{Choice: KubernetesUpdate, Weight: 90},
+		{Choice: KubernetesDelete, Weight: 5},
+		{Choice: KubernetesCreate, Weight: 5},
+	},
+}
 
 type kubernetesTraffic struct {
 	averageKeyCount int


### PR DESCRIPTION
#### Description

enables and fixes [gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) linter issues in tests directory

Related to #18955