### PR TITLE
fix: enable gofumpt instead of gofmt linter globally

### DIFF
--- a/pkg/expect/expect.go
+++ b/pkg/expect/expect.go
@@ -34,9 +34,7 @@ import (
 
 const debugLinesTail = 40
 
-var (
-	ErrProcessRunning = fmt.Errorf("process is still running")
-)
+var ErrProcessRunning = fmt.Errorf("process is still running")
 
 type ExpectedResponse struct {
 	Value         string

--- a/pkg/featuregate/feature_gate_test.go
+++ b/pkg/featuregate/feature_gate_test.go
@@ -233,7 +233,7 @@ func TestFeatureGateOverride(t *testing.T) {
 	const testBetaGate Feature = "TestBeta"
 
 	// Don't parse the flag, assert defaults are used.
-	var f = New("test", zaptest.NewLogger(t))
+	f := New("test", zaptest.NewLogger(t))
 	f.Add(map[Feature]FeatureSpec{
 		testAlphaGate: {Default: false, PreRelease: Alpha},
 		testBetaGate:  {Default: false, PreRelease: Beta},
@@ -262,7 +262,7 @@ func TestFeatureGateFlagDefaults(t *testing.T) {
 	const testBetaGate Feature = "TestBeta"
 
 	// Don't parse the flag, assert defaults are used.
-	var f = New("test", zaptest.NewLogger(t))
+	f := New("test", zaptest.NewLogger(t))
 	f.Add(map[Feature]FeatureSpec{
 		testAlphaGate: {Default: false, PreRelease: Alpha},
 		testBetaGate:  {Default: true, PreRelease: Beta},
@@ -286,7 +286,7 @@ func TestFeatureGateKnownFeatures(t *testing.T) {
 	)
 
 	// Don't parse the flag, assert defaults are used.
-	var f = New("test", zaptest.NewLogger(t))
+	f := New("test", zaptest.NewLogger(t))
 	f.Add(map[Feature]FeatureSpec{
 		testAlphaGate:      {Default: false, PreRelease: Alpha},
 		testBetaGate:       {Default: true, PreRelease: Beta},

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -318,6 +318,7 @@ func TestURLsEqual(t *testing.T) {
 		}
 	}
 }
+
 func TestURLStringsEqual(t *testing.T) {
 	defer func() { resolveTCPAddr = resolveTCPAddrDefault }()
 	errOnResolve := func(ctx context.Context, addr string) (*net.TCPAddr, error) {

--- a/pkg/netutil/routes_linux.go
+++ b/pkg/netutil/routes_linux.go
@@ -27,9 +27,11 @@ import (
 	"go.etcd.io/etcd/pkg/v3/cpuutil"
 )
 
-var errNoDefaultRoute = fmt.Errorf("could not find default route")
-var errNoDefaultHost = fmt.Errorf("could not find default host")
-var errNoDefaultInterface = fmt.Errorf("could not find default interface")
+var (
+	errNoDefaultRoute     = fmt.Errorf("could not find default route")
+	errNoDefaultHost      = fmt.Errorf("could not find default host")
+	errNoDefaultInterface = fmt.Errorf("could not find default interface")
+)
 
 // GetDefaultHost obtains the first IP address of machine from the routing table and returns the IP address as string.
 // An IPv4 address is preferred to an IPv6 address for backward compatibility.

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -15,7 +15,5 @@
 // Package osutil implements operating system-related utility functions.
 package osutil
 
-var (
-	// support to override setting SIG_DFL so tests don't terminate early
-	setDflSignal = dflSignal
-)
+// support to override setting SIG_DFL so tests don't terminate early
+var setDflSignal = dflSignal

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -211,12 +211,14 @@ func (t *Trace) logInfo(threshold time.Duration) (string, []zap.Field) {
 		lastStepTime = tstep.time
 	}
 
-	fs := []zap.Field{zap.String("detail", writeFields(t.fields)),
+	fs := []zap.Field{
+		zap.String("detail", writeFields(t.fields)),
 		zap.Duration("duration", totalDuration),
 		zap.Time("start", t.startTime),
 		zap.Time("end", endTime),
 		zap.Strings("steps", steps),
-		zap.Int("step_count", len(steps))}
+		zap.Int("step_count", len(steps)),
+	}
 	return msg, fs
 }
 

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -19,7 +19,7 @@ linters:
     # - structcheck
     # - varcheck
     - errorlint
-    - gofmt
+    - gofumpt
     - goimports
     - ineffassign
     - nakedret


### PR DESCRIPTION
#### Description

enables and fixes [gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) linter issues globally

Closes #18955