### PR TITLE
Add a threshold for codecov failure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,13 @@ coverage:
   range: 60..80
   round: down
   precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        # allow some coverage reductions within a threshold
+        # this allows a 1% drop from the previous base commit coverage
+        threshold: 1%
 comment:
   layout: "header, files, diff, footer"
   behavior: default # default: update, if exists. Otherwise post new; new: delete old and post new


### PR DESCRIPTION
Now that we have enabled proper codecov integration in https://github.com/kubernetes/org/issues/5231 we have noticed pr's being failed for coverage reductions that are trivial, i.e. < .1%.

Let's try and introduce some configuration to make codecov only fail when a meaningful reduction in coverage has occurred.

cc @serathius 