### PR TITLE
fix: use testify instead of t.Fatal or t.Error in api package

### DIFF
--- a/api/etcdserverpb/raft_internal_stringer_test.go
+++ b/api/etcdserverpb/raft_internal_stringer_test.go
@@ -17,6 +17,8 @@ package etcdserverpb_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -24,8 +26,5 @@ import (
 // panic: invalid Go type int for field k8s_io.kubernetes.vendor.go_etcd_io.etcd.etcdserver.etcdserverpb.loggablePutRequest.value_size
 // See https://github.com/kubernetes/kubernetes/issues/91937 for more details
 func TestInvalidGoTypeIntPanic(t *testing.T) {
-	result := pb.NewLoggablePutRequest(&pb.PutRequest{}).String()
-	if result != "" {
-		t.Errorf("Got result: %s, expected empty string", result)
-	}
+	assert.Empty(t, pb.NewLoggablePutRequest(&pb.PutRequest{}).String())
 }

--- a/api/v3rpc/rpctypes/error_test.go
+++ b/api/v3rpc/rpctypes/error_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -28,17 +29,13 @@ func TestConvert(t *testing.T) {
 	var e3 EtcdError
 	errors.As(ErrEmptyKey, &e3)
 
-	if e1.Error() != e2.Error() {
-		t.Fatalf("expected %q == %q", e1.Error(), e2.Error())
-	}
-	if ev1, ok := status.FromError(e1); ok && ev1.Code() != e3.Code() {
-		t.Fatalf("expected them to be equal, got %v / %v", ev1.Code(), e3.Code())
+	require.Equal(t, e1.Error(), e2.Error())
+	if ev1, ok := status.FromError(e1); ok {
+		require.Equal(t, ev1.Code(), e3.Code())
 	}
 
-	if e1.Error() == e3.Error() {
-		t.Fatalf("expected %q != %q", e1.Error(), e3.Error())
-	}
-	if ev2, ok := status.FromError(e2); ok && ev2.Code() != e3.Code() {
-		t.Fatalf("expected them to be equal, got %v / %v", ev2.Code(), e3.Code())
+	require.NotEqual(t, e1.Error(), e3.Error())
+	if ev2, ok := status.FromError(e2); ok {
+		require.Equal(t, ev2.Code(), e3.Code())
 	}
 }


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in api package

Related to #18972