### PR TITLE
fix: use testify instead of t.Fatal or t.Error in client package (part 1)

### DIFF
--- a/client/internal/v2/keys_bench_test.go
+++ b/client/internal/v2/keys_bench_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func createTestNode(size int) *Node {
@@ -54,9 +56,7 @@ func benchmarkResponseUnmarshalling(b *testing.B, children, size int) {
 	header.Add("X-Etcd-Index", "123456")
 	response := createTestResponse(children, size)
 	body, err := json.Marshal(response)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	newResponse := new(Response)

--- a/client/internal/v2/members_test.go
+++ b/client/internal/v2/members_test.go
@@ -154,9 +154,7 @@ func TestV2MembersURL(t *testing.T) {
 		Path:   "/pants/v2/members",
 	}
 
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("v2MembersURL got %#v, want %#v", got, want)
-	}
+	require.Truef(t, reflect.DeepEqual(want, got), "v2MembersURL got %#v, want %#v", got, want)
 }
 
 func TestMemberUnmarshal(t *testing.T) {
@@ -316,9 +314,7 @@ func TestMemberCreateRequestMarshal(t *testing.T) {
 	got, err := json.Marshal(&req)
 	require.NoErrorf(t, err, "Marshal returned unexpected err")
 
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("Failed to marshal memberCreateRequest: want=%s, got=%s", want, got)
-	}
+	require.Truef(t, reflect.DeepEqual(want, got), "Failed to marshal memberCreateRequest: want=%s, got=%s", want, got)
 }
 
 func TestHTTPMembersAPIAddSuccess(t *testing.T) {

--- a/client/pkg/fileutil/dir_windows.go
+++ b/client/pkg/fileutil/dir_windows.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// PrivateDirMode grants owner to make/remove files inside the directory.
-	PrivateDirMode = 0777
+	PrivateDirMode = 0o777
 )
 
 // OpenDir opens a directory in windows with write access for syncing.

--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -47,9 +47,7 @@ func TestIsDirWriteable(t *testing.T) {
 		// Chmod is not supported under windows.
 		t.Skipf("running as a superuser or in windows")
 	}
-	if err := IsDirWriteable(tmpdir); err == nil {
-		t.Fatalf("expected IsDirWriteable to error")
-	}
+	require.Errorf(t, IsDirWriteable(tmpdir), "expected IsDirWriteable to error")
 }
 
 func TestCreateDirAll(t *testing.T) {
@@ -72,9 +70,7 @@ func TestExist(t *testing.T) {
 		t.Skip(err)
 	}
 	defer os.RemoveAll(fdir)
-	if !Exist(fdir) {
-		t.Fatalf("expected Exist true, got %v", Exist(fdir))
-	}
+	require.Truef(t, Exist(fdir), "expected Exist true, got %v", Exist(fdir))
 
 	f, err := os.CreateTemp(os.TempDir(), "fileutil")
 	require.NoError(t, err)
@@ -93,20 +89,14 @@ func TestExist(t *testing.T) {
 func TestDirEmpty(t *testing.T) {
 	dir := t.TempDir()
 
-	if !DirEmpty(dir) {
-		t.Fatalf("expected DirEmpty true, got %v", DirEmpty(dir))
-	}
+	require.Truef(t, DirEmpty(dir), "expected DirEmpty true, got %v", DirEmpty(dir))
 
 	file, err := os.CreateTemp(dir, "new_file")
 	require.NoError(t, err)
 	file.Close()
 
-	if DirEmpty(dir) {
-		t.Fatalf("expected DirEmpty false, got %v", DirEmpty(dir))
-	}
-	if DirEmpty(file.Name()) {
-		t.Fatalf("expected DirEmpty false, got %v", DirEmpty(file.Name()))
-	}
+	require.Falsef(t, DirEmpty(dir), "expected DirEmpty false, got %v", DirEmpty(dir))
+	require.Falsef(t, DirEmpty(file.Name()), "expected DirEmpty false, got %v", DirEmpty(file.Name()))
 }
 
 func TestZeroToEnd(t *testing.T) {
@@ -129,9 +119,7 @@ func TestZeroToEnd(t *testing.T) {
 	require.NoError(t, ZeroToEnd(f))
 	off, serr := f.Seek(0, io.SeekCurrent)
 	require.NoError(t, serr)
-	if off != 512 {
-		t.Fatalf("expected offset 512, got %d", off)
-	}
+	require.Equalf(t, int64(512), off, "expected offset 512, got %d", off)
 
 	b = make([]byte, 512)
 	_, err = f.Read(b)

--- a/client/pkg/fileutil/read_dir_test.go
+++ b/client/pkg/fileutil/read_dir_test.go
@@ -34,9 +34,7 @@ func TestReadDir(t *testing.T) {
 	fs, err := ReadDir(tmpdir)
 	require.NoErrorf(t, err, "error calling ReadDir")
 	wfs := []string{"abc", "def", "ghi", "xyz"}
-	if !reflect.DeepEqual(fs, wfs) {
-		t.Fatalf("ReadDir: got %v, want %v", fs, wfs)
-	}
+	require.Truef(t, reflect.DeepEqual(fs, wfs), "ReadDir: got %v, want %v", fs, wfs)
 
 	files = []string{"def.wal", "abc.wal", "xyz.wal", "ghi.wal"}
 	for _, f := range files {
@@ -45,9 +43,7 @@ func TestReadDir(t *testing.T) {
 	fs, err = ReadDir(tmpdir, WithExt(".wal"))
 	require.NoErrorf(t, err, "error calling ReadDir")
 	wfs = []string{"abc.wal", "def.wal", "ghi.wal", "xyz.wal"}
-	if !reflect.DeepEqual(fs, wfs) {
-		t.Fatalf("ReadDir: got %v, want %v", fs, wfs)
-	}
+	require.Truef(t, reflect.DeepEqual(fs, wfs), "ReadDir: got %v, want %v", fs, wfs)
 }
 
 func writeFunc(t *testing.T, path string) {

--- a/client/pkg/srv/srv_test.go
+++ b/client/pkg/srv/srv_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
@@ -152,12 +154,8 @@ func TestSRVGetCluster(t *testing.T) {
 		urls := testutil.MustNewURLs(t, tt.urls)
 		str, err := GetCluster(tt.scheme, tt.service, name, "example.com", urls)
 
-		if hasErr(err) != tt.werr {
-			t.Fatalf("%d: err = %#v, want = %#v", i, err, tt.werr)
-		}
-		if strings.Join(str, ",") != tt.expected {
-			t.Errorf("#%d: cluster = %s, want %s", i, str, tt.expected)
-		}
+		require.Equalf(t, hasErr(err), tt.werr, "%d: err = %#v, want = %#v", i, err, tt.werr)
+		require.Equalf(t, tt.expected, strings.Join(str, ","), "#%d: cluster = %s, want %s", i, str, tt.expected)
 	}
 }
 
@@ -255,9 +253,7 @@ func TestSRVDiscover(t *testing.T) {
 
 		srvs, err := GetClient("etcd-client", "example.com", "")
 
-		if hasErr(err) != tt.werr {
-			t.Fatalf("%d: err = %#v, want = %#v", i, err, tt.werr)
-		}
+		require.Equalf(t, hasErr(err), tt.werr, "%d: err = %#v, want = %#v", i, err, tt.werr)
 		if srvs == nil {
 			if len(tt.expected) > 0 {
 				t.Errorf("#%d: srvs = nil, want non-nil", i)

--- a/client/pkg/tlsutil/cipher_suites_test.go
+++ b/client/pkg/tlsutil/cipher_suites_test.go
@@ -17,13 +17,13 @@ package tlsutil
 import (
 	"crypto/tls"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCipherSuite_not_existing(t *testing.T) {
 	_, ok := GetCipherSuite("not_existing")
-	if ok {
-		t.Fatal("Expected not ok")
-	}
+	require.Falsef(t, ok, "Expected not ok")
 }
 
 func CipherSuiteExpectedToExist(tb testing.TB, cipher string, expectedID uint16) {

--- a/client/pkg/transport/keepalive_listener_test.go
+++ b/client/pkg/transport/keepalive_listener_test.go
@@ -36,9 +36,8 @@ func TestNewKeepAliveListener(t *testing.T) {
 	go http.Get("http://" + ln.Addr().String())
 	conn, err := ln.Accept()
 	require.NoErrorf(t, err, "unexpected Accept error")
-	if _, ok := conn.(*keepAliveConn); !ok {
-		t.Fatalf("Unexpected conn type: %T, wanted *keepAliveConn", conn)
-	}
+	_, ok := conn.(*keepAliveConn)
+	require.Truef(t, ok, "Unexpected conn type: %T, wanted *keepAliveConn", conn)
 	conn.Close()
 	ln.Close()
 

--- a/client/pkg/transport/timeout_transport_test.go
+++ b/client/pkg/transport/timeout_transport_test.go
@@ -42,9 +42,7 @@ func TestNewTimeoutTransport(t *testing.T) {
 	defer conn.Close()
 
 	tconn, ok := conn.(*timeoutConn)
-	if !ok {
-		t.Fatalf("failed to dial out *timeoutConn")
-	}
+	require.Truef(t, ok, "failed to dial out *timeoutConn")
 	if tconn.readTimeout != time.Hour {
 		t.Errorf("read timeout = %s, want %s", tconn.readTimeout, time.Hour)
 	}

--- a/client/pkg/types/set_test.go
+++ b/client/pkg/types/set_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnsafeSet(t *testing.T) {
@@ -41,16 +43,11 @@ func driveSetTests(t *testing.T, s Set) {
 	t.Helper()
 	// Verify operations on an empty set
 	values := s.Values()
-	if len(values) != 0 {
-		t.Fatalf("Expect values=%v got %v", []string{}, values)
-	}
-	if l := s.Length(); l != 0 {
-		t.Fatalf("Expected length=0, got %d", l)
-	}
+	require.Emptyf(t, values, "Expect values=%v got %v", []string{}, values)
+	l := s.Length()
+	require.Equalf(t, 0, l, "Expected length=0, got %d", l)
 	for _, v := range []string{"foo", "bar", "baz"} {
-		if s.Contains(v) {
-			t.Fatalf("Expect s.Contains(%q) to be fale, got true", v)
-		}
+		require.Falsef(t, s.Contains(v), "Expect s.Contains(%q) to be fale, got true", v)
 	}
 
 	// Add three items, ensure they show up
@@ -60,30 +57,22 @@ func driveSetTests(t *testing.T, s Set) {
 
 	eValues := []string{"foo", "bar", "baz"}
 	values = s.Values()
-	if !equal(values, eValues) {
-		t.Fatalf("Expect values=%v got %v", eValues, values)
-	}
+	require.Truef(t, equal(values, eValues), "Expect values=%v got %v", eValues, values)
 
 	for _, v := range eValues {
-		if !s.Contains(v) {
-			t.Fatalf("Expect s.Contains(%q) to be true, got false", v)
-		}
+		require.Truef(t, s.Contains(v), "Expect s.Contains(%q) to be true, got false", v)
 	}
 
-	if l := s.Length(); l != 3 {
-		t.Fatalf("Expected length=3, got %d", l)
-	}
+	l = s.Length()
+	require.Equalf(t, 3, l, "Expected length=3, got %d", l)
 
 	// Add the same item a second time, ensuring it is not duplicated
 	s.Add("foo")
 
 	values = s.Values()
-	if !equal(values, eValues) {
-		t.Fatalf("Expect values=%v got %v", eValues, values)
-	}
-	if l := s.Length(); l != 3 {
-		t.Fatalf("Expected length=3, got %d", l)
-	}
+	require.Truef(t, equal(values, eValues), "Expect values=%v got %v", eValues, values)
+	l = s.Length()
+	require.Equalf(t, 3, l, "Expected length=3, got %d", l)
 
 	// Remove all items, ensure they are gone
 	s.Remove("foo")
@@ -92,13 +81,10 @@ func driveSetTests(t *testing.T, s Set) {
 
 	eValues = []string{}
 	values = s.Values()
-	if !equal(values, eValues) {
-		t.Fatalf("Expect values=%v got %v", eValues, values)
-	}
+	require.Truef(t, equal(values, eValues), "Expect values=%v got %v", eValues, values)
 
-	if l := s.Length(); l != 0 {
-		t.Fatalf("Expected length=0, got %d", l)
-	}
+	l = s.Length()
+	require.Equalf(t, 0, l, "Expected length=0, got %d", l)
 
 	// Create new copies of the set, and ensure they are unlinked to the
 	// original Set by making modifications
@@ -119,9 +105,7 @@ func driveSetTests(t *testing.T, s Set) {
 		{[]string{"foo", "bar"}, cp2.Values()},
 		{[]string{"bar"}, cp3.Values()},
 	} {
-		if !equal(tt.want, tt.got) {
-			t.Fatalf("case %d: expect values=%v got %v", i, tt.want, tt.got)
-		}
+		require.Truef(t, equal(tt.want, tt.got), "case %d: expect values=%v got %v", i, tt.want, tt.got)
 	}
 
 	for i, tt := range []struct {
@@ -136,9 +120,7 @@ func driveSetTests(t *testing.T, s Set) {
 		{false, cp2.Equals(s)},
 		{false, cp2.Equals(cp1)},
 	} {
-		if tt.got != tt.want {
-			t.Fatalf("case %d: want %t, got %t", i, tt.want, tt.got)
-		}
+		require.Equalf(t, tt.want, tt.got, "case %d: want %t, got %t", i, tt.want, tt.got)
 	}
 
 	// Subtract values from a Set, ensuring a new Set is created and
@@ -156,9 +138,7 @@ func driveSetTests(t *testing.T, s Set) {
 		{[]string{"foo", "baz"}, sub1.Values()},
 		{[]string{}, sub2.Values()},
 	} {
-		if !equal(tt.want, tt.got) {
-			t.Fatalf("case %d: expect values=%v got %v", i, tt.want, tt.got)
-		}
+		require.Truef(t, equal(tt.want, tt.got), "case %d: expect values=%v got %v", i, tt.want, tt.got)
 	}
 }
 

--- a/client/pkg/types/urlsmap_test.go
+++ b/client/pkg/types/urlsmap_test.go
@@ -63,9 +63,8 @@ func TestNameURLPairsString(t *testing.T) {
 		"five": testutil.MustNewURLs(t, nil),
 	})
 	w := "abc=http://0.0.0.0:0000,abc=http://1.1.1.1:1111,def=http://2.2.2.2:2222,ghi=http://127.0.0.1:2380,ghi=http://3.3.3.3:1234"
-	if g := cls.String(); g != w {
-		t.Fatalf("NameURLPairs.String():\ngot  %#v\nwant %#v", g, w)
-	}
+	g := cls.String()
+	require.Equalf(t, g, w, "NameURLPairs.String():\ngot  %#v\nwant %#v", g, w)
 }
 
 func TestParse(t *testing.T) {

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -147,9 +147,7 @@ func TestDialTimeout(t *testing.T) {
 func TestDialNoTimeout(t *testing.T) {
 	cfg := Config{Endpoints: []string{"127.0.0.1:12345"}}
 	c, err := NewClient(t, cfg)
-	if c == nil {
-		t.Fatalf("new client with DialNoWait should succeed, got %v", err)
-	}
+	require.NotNilf(t, c, "new client with DialNoWait should succeed, got %v", err)
 	require.NoErrorf(t, err, "new client with DialNoWait should succeed")
 	c.Close()
 }

--- a/client/v3/compact_op_test.go
+++ b/client/v3/compact_op_test.go
@@ -18,13 +18,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 func TestCompactOp(t *testing.T) {
 	req1 := OpCompact(100, WithCompactPhysical()).toRequest()
 	req2 := &etcdserverpb.CompactionRequest{Revision: 100, Physical: true}
-	if !reflect.DeepEqual(req1, req2) {
-		t.Fatalf("expected %+v, got %+v", req2, req1)
-	}
+	require.Truef(t, reflect.DeepEqual(req1, req2), "expected %+v, got %+v", req2, req1)
 }

--- a/client/v3/ctx_test.go
+++ b/client/v3/ctx_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -28,9 +29,7 @@ import (
 func TestMetadataWithRequireLeader(t *testing.T) {
 	ctx := context.TODO()
 	_, ok := metadata.FromOutgoingContext(ctx)
-	if ok {
-		t.Fatal("expected no outgoing metadata ctx key")
-	}
+	require.Falsef(t, ok, "expected no outgoing metadata ctx key")
 
 	// add a conflicting key with some other value
 	md := metadata.Pairs(rpctypes.MetadataRequireLeaderKey, "invalid")
@@ -41,28 +40,20 @@ func TestMetadataWithRequireLeader(t *testing.T) {
 	// expect overwrites but still keep other keys
 	ctx = WithRequireLeader(ctx)
 	md, ok = metadata.FromOutgoingContext(ctx)
-	if !ok {
-		t.Fatal("expected outgoing metadata ctx key")
-	}
-	if ss := md.Get(rpctypes.MetadataRequireLeaderKey); !reflect.DeepEqual(ss, []string{rpctypes.MetadataHasLeader}) {
-		t.Fatalf("unexpected metadata for %q %v", rpctypes.MetadataRequireLeaderKey, ss)
-	}
-	if ss := md.Get("hello"); !reflect.DeepEqual(ss, []string{"1", "2"}) {
-		t.Fatalf("unexpected metadata for 'hello' %v", ss)
-	}
+	require.Truef(t, ok, "expected outgoing metadata ctx key")
+	ss := md.Get(rpctypes.MetadataRequireLeaderKey)
+	require.Truef(t, reflect.DeepEqual(ss, []string{rpctypes.MetadataHasLeader}), "unexpected metadata for %q %v", rpctypes.MetadataRequireLeaderKey, ss)
+	ss = md.Get("hello")
+	require.Truef(t, reflect.DeepEqual(ss, []string{"1", "2"}), "unexpected metadata for 'hello' %v", ss)
 }
 
 func TestMetadataWithClientAPIVersion(t *testing.T) {
 	ctx := withVersion(WithRequireLeader(context.TODO()))
 
 	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		t.Fatal("expected outgoing metadata ctx key")
-	}
-	if ss := md.Get(rpctypes.MetadataRequireLeaderKey); !reflect.DeepEqual(ss, []string{rpctypes.MetadataHasLeader}) {
-		t.Fatalf("unexpected metadata for %q %v", rpctypes.MetadataRequireLeaderKey, ss)
-	}
-	if ss := md.Get(rpctypes.MetadataClientAPIVersionKey); !reflect.DeepEqual(ss, []string{version.APIVersion}) {
-		t.Fatalf("unexpected metadata for %q %v", rpctypes.MetadataClientAPIVersionKey, ss)
-	}
+	require.Truef(t, ok, "expected outgoing metadata ctx key")
+	ss := md.Get(rpctypes.MetadataRequireLeaderKey)
+	require.Truef(t, reflect.DeepEqual(ss, []string{rpctypes.MetadataHasLeader}), "unexpected metadata for %q %v", rpctypes.MetadataRequireLeaderKey, ss)
+	ss = md.Get(rpctypes.MetadataClientAPIVersionKey)
+	require.Truef(t, reflect.DeepEqual(ss, []string{version.APIVersion}), "unexpected metadata for %q %v", rpctypes.MetadataClientAPIVersionKey, ss)
 }


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in client package

Related to #18972