### PR TITLE
fix: use testify instead of t.Fatal or t.Error in contrib package

### DIFF
--- a/contrib/raftexample/kvstore_test.go
+++ b/contrib/raftexample/kvstore_test.go
@@ -26,9 +26,7 @@ func Test_kvstore_snapshot(t *testing.T) {
 	s := &kvstore{kvStore: tm}
 
 	v, _ := s.Lookup("foo")
-	if v != "bar" {
-		t.Fatalf("foo has unexpected value, got %s", v)
-	}
+	require.Equalf(t, "bar", v, "foo has unexpected value, got %s", v)
 
 	data, err := s.getSnapshot()
 	require.NoError(t, err)
@@ -37,10 +35,6 @@ func Test_kvstore_snapshot(t *testing.T) {
 	err = s.recoverFromSnapshot(data)
 	require.NoError(t, err)
 	v, _ = s.Lookup("foo")
-	if v != "bar" {
-		t.Fatalf("foo has unexpected value, got %s", v)
-	}
-	if !reflect.DeepEqual(s.kvStore, tm) {
-		t.Fatalf("store expected %+v, got %+v", tm, s.kvStore)
-	}
+	require.Equalf(t, "bar", v, "foo has unexpected value, got %s", v)
+	require.Truef(t, reflect.DeepEqual(s.kvStore, tm), "store expected %+v, got %+v", tm, s.kvStore)
 }

--- a/contrib/raftexample/raft_test.go
+++ b/contrib/raftexample/raft_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -121,10 +123,7 @@ func TestProcessMessages(t *testing.T) {
 			}
 
 			outputMessages := rn.processMessages(tc.InputMessages)
-
-			if !reflect.DeepEqual(outputMessages, tc.ExpectedMessages) {
-				t.Fatalf("Unexpected messages, expected: %v, got %v", tc.ExpectedMessages, outputMessages)
-			}
+			require.Truef(t, reflect.DeepEqual(outputMessages, tc.ExpectedMessages), "Unexpected messages, expected: %v, got %v", tc.ExpectedMessages, outputMessages)
 		})
 	}
 }

--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -217,9 +217,8 @@ func TestPutAndGetKeyValue(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	if gotValue := string(data); wantValue != gotValue {
-		t.Fatalf("expect %s, got %s", wantValue, gotValue)
-	}
+	gotValue := string(data)
+	require.Equalf(t, wantValue, gotValue, "expect %s, got %s", wantValue, gotValue)
 }
 
 // TestAddNewNode tests adding new node to the existing cluster.


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in contrib package

Related to #18972