### PR TITLE
fix: use testify instead of t.Fatal or t.Error in pkg package (part 1)

### DIFF
--- a/pkg/crc/crc_test.go
+++ b/pkg/crc/crc_test.go
@@ -8,15 +8,16 @@ import (
 	"hash/crc32"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestHash32 tests that Hash32 provided by this package can take an initial
 // crc and behaves exactly the same as the standard one in the following calls.
 func TestHash32(t *testing.T) {
 	stdhash := crc32.New(crc32.IEEETable)
-	if _, err := stdhash.Write([]byte("test data")); err != nil {
-		t.Fatalf("unexpected write error: %v", err)
-	}
+	_, err := stdhash.Write([]byte("test data"))
+	require.NoErrorf(t, err, "unexpected write error: %v", err)
 	// create a new hash with stdhash.Sum32() as initial crc
 	hash := New(stdhash.Sum32(), crc32.IEEETable)
 
@@ -38,12 +39,10 @@ func TestHash32(t *testing.T) {
 	}
 
 	// write something
-	if _, err := stdhash.Write([]byte("test data")); err != nil {
-		t.Fatalf("unexpected write error: %v", err)
-	}
-	if _, err := hash.Write([]byte("test data")); err != nil {
-		t.Fatalf("unexpected write error: %v", err)
-	}
+	_, err = stdhash.Write([]byte("test data"))
+	require.NoErrorf(t, err, "unexpected write error: %v", err)
+	_, err = hash.Write([]byte("test data"))
+	require.NoErrorf(t, err, "unexpected write error: %v", err)
 	wsum32 = stdhash.Sum32()
 	if g := hash.Sum32(); g != wsum32 {
 		t.Errorf("Sum32 after write = %d, want %d", g, wsum32)

--- a/pkg/flags/flag_test.go
+++ b/pkg/flags/flag_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -41,9 +42,8 @@ func TestSetFlagsFromEnv(t *testing.T) {
 		"a": "",
 		"b": "bar",
 	} {
-		if got := fs.Lookup(f).Value.String(); got != want {
-			t.Fatalf("flag %q=%q, want %q", f, got, want)
-		}
+		got := fs.Lookup(f).Value.String()
+		require.Equalf(t, want, got, "flag %q=%q, want %q", f, got, want)
 	}
 
 	// now read the env and verify flags were updated as expected
@@ -85,7 +85,5 @@ func TestSetFlagsFromEnvParsingError(t *testing.T) {
 			break
 		}
 	}
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected error %v", err)
 }

--- a/pkg/flags/strings_test.go
+++ b/pkg/flags/strings_test.go
@@ -17,6 +17,8 @@ package flags
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringsValue(t *testing.T) {
@@ -30,8 +32,6 @@ func TestStringsValue(t *testing.T) {
 	}
 	for i := range tests {
 		ss := []string(*NewStringsValue(tests[i].s))
-		if !reflect.DeepEqual(tests[i].exp, ss) {
-			t.Fatalf("#%d: expected %q, got %q", i, tests[i].exp, ss)
-		}
+		require.Truef(t, reflect.DeepEqual(tests[i].exp, ss), "#%d: expected %q, got %q", i, tests[i].exp, ss)
 	}
 }

--- a/pkg/flags/uint32_test.go
+++ b/pkg/flags/uint32_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUint32Value(t *testing.T) {
@@ -101,9 +102,7 @@ func TestUint32FromFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := flag.NewFlagSet("etcd", flag.ContinueOnError)
 			fs.Var(NewUint32Value(tc.defaultVal), flagName, "Maximum concurrent streams that each client can open at a time.")
-			if err := fs.Parse(tc.arguments); err != nil {
-				t.Fatalf("Unexpected error: %v\n", err)
-			}
+			require.NoError(t, fs.Parse(tc.arguments))
 			actualMaxStream := Uint32FromFlag(fs, flagName)
 			assert.Equal(t, tc.expectedVal, actualMaxStream)
 		})

--- a/pkg/flags/unique_strings_test.go
+++ b/pkg/flags/unique_strings_test.go
@@ -17,6 +17,8 @@ package flags
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUniqueStrings(t *testing.T) {
@@ -58,11 +60,7 @@ func TestNewUniqueStrings(t *testing.T) {
 	}
 	for i := range tests {
 		uv := NewUniqueStringsValue(tests[i].s)
-		if !reflect.DeepEqual(tests[i].exp, uv.Values) {
-			t.Fatalf("#%d: expected %+v, got %+v", i, tests[i].exp, uv.Values)
-		}
-		if uv.String() != tests[i].rs {
-			t.Fatalf("#%d: expected %q, got %q", i, tests[i].rs, uv.String())
-		}
+		require.Truef(t, reflect.DeepEqual(tests[i].exp, uv.Values), "#%d: expected %+v, got %+v", i, tests[i].exp, uv.Values)
+		require.Equalf(t, uv.String(), tests[i].rs, "#%d: expected %q, got %q", i, tests[i].rs, uv.String())
 	}
 }

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -18,6 +18,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateURLsValueBad(t *testing.T) {
@@ -66,8 +68,6 @@ func TestNewURLsValue(t *testing.T) {
 	}
 	for i := range tests {
 		uu := []url.URL(*NewURLsValue(tests[i].s))
-		if !reflect.DeepEqual(tests[i].exp, uu) {
-			t.Fatalf("#%d: expected %+v, got %+v", i, tests[i].exp, uu)
-		}
+		require.Truef(t, reflect.DeepEqual(tests[i].exp, uu), "#%d: expected %+v, got %+v", i, tests[i].exp, uu)
 	}
 }

--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPageWriterRandom(t *testing.T) {
@@ -36,12 +37,9 @@ func TestPageWriterRandom(t *testing.T) {
 		}
 		n += c
 	}
-	if cw.writeBytes > n {
-		t.Fatalf("wrote %d bytes to io.Writer, but only wrote %d bytes", cw.writeBytes, n)
-	}
-	if maxPendingBytes := pageBytes + defaultBufferBytes; n-cw.writeBytes > maxPendingBytes {
-		t.Fatalf("got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, maxPendingBytes)
-	}
+	require.LessOrEqualf(t, cw.writeBytes, n, "wrote %d bytes to io.Writer, but only wrote %d bytes", cw.writeBytes, n)
+	maxPendingBytes := pageBytes + defaultBufferBytes
+	require.LessOrEqualf(t, n-cw.writeBytes, maxPendingBytes, "got %d bytes pending, expected less than %d bytes", n-cw.writeBytes, maxPendingBytes)
 	t.Logf("total writes: %d", cw.writes)
 	t.Logf("total write bytes: %d (of %d)", cw.writeBytes, n)
 }
@@ -61,9 +59,7 @@ func TestPageWriterPartialSlack(t *testing.T) {
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if cw.writes != 1 {
-		t.Fatalf("got %d writes, expected 1", cw.writes)
-	}
+	require.Equalf(t, 1, cw.writes, "got %d writes, expected 1", cw.writes)
 	// nearly fill buffer
 	if _, err := w.Write(buf[:1022]); err != nil {
 		t.Fatal(err)
@@ -72,16 +68,12 @@ func TestPageWriterPartialSlack(t *testing.T) {
 	if _, err := w.Write(buf[:8]); err != nil {
 		t.Fatal(err)
 	}
-	if cw.writes != 1 {
-		t.Fatalf("got %d writes, expected 1", cw.writes)
-	}
+	require.Equalf(t, 1, cw.writes, "got %d writes, expected 1", cw.writes)
 	// finish writing slack space
 	if _, err := w.Write(buf[:128]); err != nil {
 		t.Fatal(err)
 	}
-	if cw.writes != 2 {
-		t.Fatalf("got %d writes, expected 2", cw.writes)
-	}
+	require.Equalf(t, 2, cw.writes, "got %d writes, expected 2", cw.writes)
 }
 
 // TestPageWriterOffset tests if page writer correctly repositions when offset is given.
@@ -97,9 +89,7 @@ func TestPageWriterOffset(t *testing.T) {
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if w.pageOffset != 64 {
-		t.Fatalf("w.pageOffset expected 64, got %d", w.pageOffset)
-	}
+	require.Equalf(t, 64, w.pageOffset, "w.pageOffset expected 64, got %d", w.pageOffset)
 
 	w = NewPageWriter(cw, w.pageOffset, pageBytes)
 	if _, err := w.Write(buf[:64]); err != nil {
@@ -108,9 +98,7 @@ func TestPageWriterOffset(t *testing.T) {
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if w.pageOffset != 0 {
-		t.Fatalf("w.pageOffset expected 0, got %d", w.pageOffset)
-	}
+	require.Equalf(t, 0, w.pageOffset, "w.pageOffset expected 0, got %d", w.pageOffset)
 }
 
 func TestPageWriterPageBytes(t *testing.T) {
@@ -161,9 +149,7 @@ type checkPageWriter struct {
 }
 
 func (cw *checkPageWriter) Write(p []byte) (int, error) {
-	if len(p)%cw.pageBytes != 0 {
-		cw.t.Fatalf("got write len(p) = %d, expected len(p) == k*cw.pageBytes", len(p))
-	}
+	require.Equalf(cw.t, 0, len(p)%cw.pageBytes, "got write len(p) = %d, expected len(p) == k*cw.pageBytes", len(p))
 	cw.writes++
 	cw.writeBytes += len(p)
 	return len(p), nil

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPercentiles(t *testing.T) {
@@ -64,9 +66,7 @@ func TestReport(t *testing.T) {
 		ErrorDist: map[string]int{"oops": 1},
 		Lats:      []float64{1.0, 1.0, 1.0, 1.0, 1.0},
 	}
-	if !reflect.DeepEqual(stats, wStats) {
-		t.Fatalf("got %+v, want %+v", stats, wStats)
-	}
+	require.Truef(t, reflect.DeepEqual(stats, wStats), "got %+v, want %+v", stats, wStats)
 
 	wstrs := []string{
 		"Stddev:\t0",
@@ -108,7 +108,5 @@ func TestWeightedReport(t *testing.T) {
 		ErrorDist: map[string]int{"oops": 1},
 		Lats:      []float64{0.5, 0.5, 0.5, 0.5, 0.5},
 	}
-	if !reflect.DeepEqual(stats, wStats) {
-		t.Fatalf("got %+v, want %+v", stats, wStats)
-	}
+	require.Truef(t, reflect.DeepEqual(stats, wStats), "got %+v, want %+v", stats, wStats)
 }

--- a/pkg/report/timeseries_test.go
+++ b/pkg/report/timeseries_test.go
@@ -17,6 +17,8 @@ package report
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTimeseries(t *testing.T) {
@@ -25,20 +27,12 @@ func TestGetTimeseries(t *testing.T) {
 	sp.Add(now, time.Second)
 	sp.Add(now.Add(5*time.Second), time.Second)
 	n := sp.getTimeSeries().Len()
-	if n < 3 {
-		t.Fatalf("expected at 6 points of time series, got %s", sp.getTimeSeries())
-	}
+	require.GreaterOrEqualf(t, n, 3, "expected at 6 points of time series, got %s", sp.getTimeSeries())
 
 	// add a point with duplicate timestamp
 	sp.Add(now, 3*time.Second)
 	ts := sp.getTimeSeries()
-	if ts[0].MinLatency != time.Second {
-		t.Fatalf("ts[0] min latency expected %v, got %s", time.Second, ts[0].MinLatency)
-	}
-	if ts[0].AvgLatency != 2*time.Second {
-		t.Fatalf("ts[0] average latency expected %v, got %s", 2*time.Second, ts[0].AvgLatency)
-	}
-	if ts[0].MaxLatency != 3*time.Second {
-		t.Fatalf("ts[0] max latency expected %v, got %s", 3*time.Second, ts[0].MaxLatency)
-	}
+	require.Equalf(t, time.Second, ts[0].MinLatency, "ts[0] min latency expected %v, got %s", time.Second, ts[0].MinLatency)
+	require.Equalf(t, 2*time.Second, ts[0].AvgLatency, "ts[0] average latency expected %v, got %s", 2*time.Second, ts[0].AvgLatency)
+	require.Equalf(t, 3*time.Second, ts[0].MaxLatency, "ts[0] max latency expected %v, got %s", 3*time.Second, ts[0].MaxLatency)
 }

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -34,9 +35,7 @@ func TestFIFOSchedule(t *testing.T) {
 					fmt.Println("err: ", err)
 				}
 			}()
-			if next != i {
-				t.Fatalf("job#%d: got %d, want %d", i, next, i)
-			}
+			require.Equalf(t, next, i, "job#%d: got %d, want %d", i, next, i)
 			next = i + 1
 			if next%3 == 0 {
 				panic("fifo panic")

--- a/pkg/stringutil/rand_test.go
+++ b/pkg/stringutil/rand_test.go
@@ -17,14 +17,14 @@ package stringutil
 import (
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUniqueStrings(t *testing.T) {
 	ss := UniqueStrings(10, 50)
 	sort.Strings(ss)
 	for i := 1; i < len(ss); i++ {
-		if ss[i-1] == ss[i] {
-			t.Fatalf("ss[i-1] %q == ss[i] %q", ss[i-1], ss[i])
-		}
+		require.NotEqualf(t, ss[i-1], ss[i], "ss[i-1] %q == ss[i] %q", ss[i-1], ss[i])
 	}
 }

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 )
 
@@ -215,9 +217,7 @@ func TestLog(t *testing.T) {
 			tt.trace.lg = lg
 			tt.trace.Log()
 			data, err := os.ReadFile(logPath)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			for _, msg := range tt.expectedMsg {
 				if !bytes.Contains(data, []byte(msg)) {
@@ -293,9 +293,7 @@ func TestLogIfLong(t *testing.T) {
 			tt.trace.lg = lg
 			tt.trace.LogIfLong(tt.threshold)
 			data, err := os.ReadFile(logPath)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			for _, msg := range tt.expectedMsg {
 				if !bytes.Contains(data, []byte(msg)) {
 					t.Errorf("Expected to find %v in log", msg)


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in pkg package

Related to #18972