### PR TITLE
fix: use testify instead of t.Fatal or t.Error in server package (part 1)

### DIFF
--- a/server/auth/jwt_test.go
+++ b/server/auth/jwt_test.go
@@ -16,7 +16,6 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"testing"
@@ -104,12 +103,8 @@ func testJWTInfo(t *testing.T, opts map[string]string) {
 		t.Fatalf("%#v", aerr)
 	}
 	ai, ok := jwt.info(ctx, token, 123)
-	if !ok {
-		t.Fatalf("failed to authenticate with token %s", token)
-	}
-	if ai.Revision != 123 {
-		t.Fatalf("expected revision 123, got %d", ai.Revision)
-	}
+	require.Truef(t, ok, "failed to authenticate with token %s", token)
+	require.Equalf(t, uint64(123), ai.Revision, "expected revision 123, got %d", ai.Revision)
 	ai, ok = jwt.info(ctx, "aaa", 120)
 	if ok || ai != nil {
 		t.Fatalf("expected aaa to fail to authenticate, got %+v", ai)
@@ -127,21 +122,15 @@ func testJWTInfo(t *testing.T, opts map[string]string) {
 			}
 
 			ai, ok := verify.info(ctx, token, 123)
-			if !ok {
-				t.Fatalf("failed to authenticate with token %s", token)
-			}
-			if ai.Revision != 123 {
-				t.Fatalf("expected revision 123, got %d", ai.Revision)
-			}
+			require.Truef(t, ok, "failed to authenticate with token %s", token)
+			require.Equalf(t, uint64(123), ai.Revision, "expected revision 123, got %d", ai.Revision)
 			ai, ok = verify.info(ctx, "aaa", 120)
 			if ok || ai != nil {
 				t.Fatalf("expected aaa to fail to authenticate, got %+v", ai)
 			}
 
 			_, aerr := verify.assign(ctx, "abc", 123)
-			if !errors.Is(aerr, ErrVerifyOnly) {
-				t.Fatalf("unexpected error when attempting to sign with public key: %v", aerr)
-			}
+			require.ErrorIsf(t, aerr, ErrVerifyOnly, "unexpected error when attempting to sign with public key: %v", aerr)
 		})
 	}
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -28,9 +29,7 @@ func mustNewURLs(t *testing.T, urls []string) []url.URL {
 		return nil
 	}
 	u, err := types.NewURLs(urls)
-	if err != nil {
-		t.Fatalf("error creating new URLs from %q: %v", urls, err)
-	}
+	require.NoErrorf(t, err, "error creating new URLs from %q: %v", urls, err)
 	return u
 }
 
@@ -48,9 +47,7 @@ func TestConfigVerifyBootstrapWithoutClusterAndDiscoveryURLFail(t *testing.T) {
 
 func TestConfigVerifyExistingWithDiscoveryURLFail(t *testing.T) {
 	cluster, err := types.NewURLsMap("node1=http://127.0.0.1:2380")
-	if err != nil {
-		t.Fatalf("NewCluster error: %v", err)
-	}
+	require.NoErrorf(t, err, "NewCluster error: %v", err)
 	c := &ServerConfig{
 		Name:               "node1",
 		DiscoveryURL:       "http://127.0.0.1:2379/abcdefg",
@@ -139,9 +136,7 @@ func TestConfigVerifyLocalMember(t *testing.T) {
 
 	for i, tt := range tests {
 		cluster, err := types.NewURLsMap(tt.clusterSetting)
-		if err != nil {
-			t.Fatalf("#%d: Got unexpected error: %v", i, err)
-		}
+		require.NoErrorf(t, err, "#%d: Got unexpected error: %v", i, err)
 		cfg := ServerConfig{
 			Name:               "node1",
 			InitialPeerURLsMap: cluster,

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -347,9 +347,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 
 			cfg, err := ConfigFromFile(tmpfile.Name())
 			if tc.expectErr {
-				if err == nil {
-					t.Fatal("expect parse error")
-				}
+				require.Errorf(t, err, "expect parse error")
 				return
 			}
 			if err != nil {
@@ -378,17 +376,11 @@ func TestUpdateDefaultClusterFromName(t *testing.T) {
 	// in case of 'etcd --name=abc'
 	exp := fmt.Sprintf("%s=%s://localhost:%s", cfg.Name, oldscheme, lpport)
 	_, _ = cfg.UpdateDefaultClusterFromName(defaultInitialCluster)
-	if exp != cfg.InitialCluster {
-		t.Fatalf("initial-cluster expected %q, got %q", exp, cfg.InitialCluster)
-	}
+	require.Equalf(t, exp, cfg.InitialCluster, "initial-cluster expected %q, got %q", exp, cfg.InitialCluster)
 	// advertise peer URL should not be affected
-	if origpeer != cfg.AdvertisePeerUrls[0].String() {
-		t.Fatalf("advertise peer url expected %q, got %q", origadvc, cfg.AdvertisePeerUrls[0].String())
-	}
+	require.Equalf(t, origpeer, cfg.AdvertisePeerUrls[0].String(), "advertise peer url expected %q, got %q", origadvc, cfg.AdvertisePeerUrls[0].String())
 	// advertise client URL should not be affected
-	if origadvc != cfg.AdvertiseClientUrls[0].String() {
-		t.Fatalf("advertise client url expected %q, got %q", origadvc, cfg.AdvertiseClientUrls[0].String())
-	}
+	require.Equalf(t, origadvc, cfg.AdvertiseClientUrls[0].String(), "advertise client url expected %q, got %q", origadvc, cfg.AdvertiseClientUrls[0].String())
 }
 
 // TestUpdateDefaultClusterFromNameOverwrite ensures that machine's default host is only used
@@ -407,25 +399,15 @@ func TestUpdateDefaultClusterFromNameOverwrite(t *testing.T) {
 	lpport := cfg.ListenPeerUrls[0].Port()
 	cfg.ListenPeerUrls[0] = url.URL{Scheme: cfg.ListenPeerUrls[0].Scheme, Host: fmt.Sprintf("0.0.0.0:%s", lpport)}
 	dhost, _ := cfg.UpdateDefaultClusterFromName(defaultInitialCluster)
-	if dhost != defaultHostname {
-		t.Fatalf("expected default host %q, got %q", defaultHostname, dhost)
-	}
+	require.Equalf(t, dhost, defaultHostname, "expected default host %q, got %q", defaultHostname, dhost)
 	aphost, apport := cfg.AdvertisePeerUrls[0].Hostname(), cfg.AdvertisePeerUrls[0].Port()
-	if apport != lpport {
-		t.Fatalf("advertise peer url got different port %s, expected %s", apport, lpport)
-	}
-	if aphost != defaultHostname {
-		t.Fatalf("advertise peer url expected machine default host %q, got %q", defaultHostname, aphost)
-	}
+	require.Equalf(t, apport, lpport, "advertise peer url got different port %s, expected %s", apport, lpport)
+	require.Equalf(t, aphost, defaultHostname, "advertise peer url expected machine default host %q, got %q", defaultHostname, aphost)
 	expected := fmt.Sprintf("%s=%s://%s:%s", cfg.Name, oldscheme, defaultHostname, lpport)
-	if expected != cfg.InitialCluster {
-		t.Fatalf("initial-cluster expected %q, got %q", expected, cfg.InitialCluster)
-	}
+	require.Equalf(t, expected, cfg.InitialCluster, "initial-cluster expected %q, got %q", expected, cfg.InitialCluster)
 
 	// advertise client URL should not be affected
-	if origadvc != cfg.AdvertiseClientUrls[0].String() {
-		t.Fatalf("advertise-client-url expected %q, got %q", origadvc, cfg.AdvertiseClientUrls[0].String())
-	}
+	require.Equalf(t, origadvc, cfg.AdvertiseClientUrls[0].String(), "advertise-client-url expected %q, got %q", origadvc, cfg.AdvertiseClientUrls[0].String())
 }
 
 func TestInferLocalAddr(t *testing.T) {

--- a/server/embed/etcd_test.go
+++ b/server/embed/etcd_test.go
@@ -15,9 +15,10 @@
 package embed
 
 import (
-	"errors"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 )
@@ -33,7 +34,6 @@ func TestEmptyClientTLSInfo_createMetricsListener(t *testing.T) {
 		Scheme: "https",
 		Host:   "localhost:8080",
 	}
-	if _, err := e.createMetricsListener(murl); !errors.Is(err, ErrMissingClientTLSInfoForMetricsURL) {
-		t.Fatalf("expected error %v, got %v", ErrMissingClientTLSInfoForMetricsURL, err)
-	}
+	_, err := e.createMetricsListener(murl)
+	require.ErrorIsf(t, err, ErrMissingClientTLSInfoForMetricsURL, "expected error %v, got %v", ErrMissingClientTLSInfoForMetricsURL, err)
 }

--- a/server/embed/serve_test.go
+++ b/server/embed/serve_test.go
@@ -15,11 +15,12 @@
 package embed
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/server/v3/auth"
 )
@@ -44,9 +45,8 @@ func TestStartEtcdWrongToken(t *testing.T) {
 	cfg.Dir = tdir
 	cfg.AuthToken = "wrong-token"
 
-	if _, err := StartEtcd(cfg); !errors.Is(err, auth.ErrInvalidAuthOpts) {
-		t.Fatalf("expected %v, got %v", auth.ErrInvalidAuthOpts, err)
-	}
+	_, err := StartEtcd(cfg)
+	require.ErrorIsf(t, err, auth.ErrInvalidAuthOpts, "expected %v, got %v", auth.ErrInvalidAuthOpts, err)
 }
 
 func newEmbedURLs(n int) (urls []url.URL) {

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"go.etcd.io/etcd/pkg/v3/featuregate"
@@ -330,9 +331,8 @@ func TestConfigIsNewCluster(t *testing.T) {
 	for i, tt := range tests {
 		cfg := newConfig()
 		args := []string{"--initial-cluster-state", tests[i].state}
-		if err := cfg.parse(args); err != nil {
-			t.Fatalf("#%d: unexpected clusterState.Set error: %v", i, err)
-		}
+		err := cfg.parse(args)
+		require.NoErrorf(t, err, "#%d: unexpected clusterState.Set error: %v", i, err)
 		if g := cfg.ec.IsNewCluster(); g != tt.wIsNew {
 			t.Errorf("#%d: isNewCluster = %v, want %v", i, g, tt.wIsNew)
 		}
@@ -460,9 +460,7 @@ func TestParseFeatureGateFlags(t *testing.T) {
 			cfg := newConfig()
 			err := cfg.parse(tc.args)
 			if tc.expectErr {
-				if err == nil {
-					t.Fatal("expect parse error")
-				}
+				require.Errorf(t, err, "expect parse error")
 				return
 			}
 			if err != nil {

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -137,13 +137,10 @@ func TestApplyRepeat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(act) == 0 {
-		t.Fatalf("expected len(act)=0, got %d", len(act))
-	}
+	require.NotEmptyf(t, act, "expected len(act)=0, got %d", len(act))
 
-	if err = <-stopc; err != nil {
-		t.Fatalf("error on stop (%v)", err)
-	}
+	err = <-stopc
+	require.NoErrorf(t, err, "error on stop (%v)", err)
 }
 
 type uberApplierMock struct{}

--- a/server/storage/schema/actions_test.go
+++ b/server/storage/schema/actions_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -71,9 +72,7 @@ func TestActionIsReversible(t *testing.T) {
 			be, _ := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			defer be.Close()
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			defer tx.Unlock()
 			UnsafeCreateMetaBucket(tx)
@@ -128,9 +127,7 @@ func TestActionListRevert(t *testing.T) {
 			be, _ := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			defer be.Close()
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			defer tx.Unlock()
 

--- a/server/storage/schema/changes_test.go
+++ b/server/storage/schema/changes_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
 )
 
@@ -39,9 +41,7 @@ func TestUpgradeDowngrade(t *testing.T) {
 			be, _ := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			defer be.Close()
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			defer tx.Unlock()
 			UnsafeCreateMetaBucket(tx)

--- a/server/storage/schema/migration_test.go
+++ b/server/storage/schema/migration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -168,9 +169,7 @@ func TestMigrationStepExecute(t *testing.T) {
 			be, _ := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			defer be.Close()
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			defer tx.Unlock()
 

--- a/server/storage/schema/schema_test.go
+++ b/server/storage/schema/schema_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -299,9 +300,7 @@ func setupBackendData(t *testing.T, ver semver.Version, overrideKeys func(tx bac
 	t.Helper()
 	be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 	tx := be.BatchTx()
-	if tx == nil {
-		t.Fatal("batch tx is nil")
-	}
+	require.NotNilf(t, tx, "batch tx is nil")
 	tx.Lock()
 	UnsafeCreateMetaBucket(tx)
 	if overrideKeys != nil {

--- a/server/storage/schema/version_test.go
+++ b/server/storage/schema/version_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/bbolt"
@@ -59,9 +60,7 @@ func TestVersion(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(Meta)
 			UnsafeSetStorageVersion(tx, semver.New(tc.version))
@@ -105,9 +104,7 @@ func TestVersionSnapshot(t *testing.T) {
 		t.Run(tc.version, func(t *testing.T) {
 			be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(Meta)
 			UnsafeSetStorageVersion(tx, semver.New(tc.version))

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -15,7 +15,6 @@
 package wal
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -203,13 +202,9 @@ func TestRepairFailDeleteDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, _, _, err = w.ReadAll()
-	if !errors.Is(err, io.ErrUnexpectedEOF) {
-		t.Fatalf("err = %v, want error %v", err, io.ErrUnexpectedEOF)
-	}
+	require.ErrorIsf(t, err, io.ErrUnexpectedEOF, "err = %v, want error %v", err, io.ErrUnexpectedEOF)
 	w.Close()
 
 	os.RemoveAll(p)
-	if Repair(zaptest.NewLogger(t), p) {
-		t.Fatal("expect 'Repair' fail on unexpected directory deletion")
-	}
+	require.Falsef(t, Repair(zaptest.NewLogger(t), p), "expect 'Repair' fail on unexpected directory deletion")
 }

--- a/server/storage/wal/wal_bench_test.go
+++ b/server/storage/wal/wal_bench_test.go
@@ -17,6 +17,7 @@ package wal
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/raft/v3/raftpb"
@@ -38,9 +39,7 @@ func benchmarkWriteEntry(b *testing.B, size int, batch int) {
 	p := b.TempDir()
 
 	w, err := Create(zaptest.NewLogger(b), p, []byte("somedata"))
-	if err != nil {
-		b.Fatalf("err = %v, want nil", err)
-	}
+	require.NoErrorf(b, err, "err = %v, want nil", err)
 	data := make([]byte, size)
 	for i := 0; i < size; i++ {
 		data[i] = byte(i)


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in server package

Related to #18972