### PR TITLE
chore: group tools/mod updates and update only direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: weekly
     allow:
-      - dependency-type: all
+      - dependency-type: direct
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
Concerning tools update it seems more appropriate to update only direct dependencies.
They can also be grouped in one PR update.