### PR TITLE
release: Allow "v" prefix when specifying release version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,8 +48,9 @@ help() {
 }
 
 main() {
-  VERSION=$1
-  if [[ ! "${VERSION}" =~ [0-9]+.[0-9]+.[0-9]+ ]]; then
+  # Allow to receive the version with the "v" prefix, i.e. v3.6.0.
+  VERSION=${1#v}
+  if [[ ! "${VERSION}" =~ ^[0-9]+.[0-9]+.[0-9]+ ]]; then
     log_error "Expected 'version' param of the form '<major-version>.<minor-version>.<patch-version>' but got '${VERSION}'"
     exit 1
   fi


### PR DESCRIPTION
This pull requests:

1. Allows to specify the release version with either the "v" prefix or not (i.e., `v3.6.0` or `3.6.0`)
~2. Sets the `BRANCH` to main if the minor version is `3.6`.~

~Technically, this is not needed if we pass the environment variable `BRANCH` set to `main` with every pre-release. So, another "fix" would be to document this in the release guide. I'm open to reverting and doing the documentation this way.~

Part of #19010. 