### PR TITLE
fix: golangci-lint yamllint

### DIFF
--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -8,7 +8,7 @@ issues:
     # exclude ineffassing linter for generated files for conversion
     - path: conversion\.go
       linters: [ineffassign]
-    - text: "S1000"  # TODO: Fix me
+    - text: "S1000" # TODO: Fix me
       linters:
         - gosimple
   exclude-files:


### PR DESCRIPTION
#### Description 

Golangci-lint config file is not well formatted. This fixes it 