### PR TITLE
Update TestMemberAdd's context timeout by adding 5 more seconds

### DIFF
--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -113,7 +113,11 @@ func TestMemberAdd(t *testing.T) {
 		for _, quorumTc := range quorumTcs {
 			for _, clusterTc := range clusterTestCases() {
 				t.Run(learnerTc.name+"/"+quorumTc.name+"/"+clusterTc.name, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctxTimeout := 10 * time.Second
+					if quorumTc.waitForQuorum {
+						ctxTimeout += etcdserver.HealthInterval
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 					defer cancel()
 					c := clusterTc.config
 					c.StrictReconfigCheck = quorumTc.strictReconfigCheck


### PR DESCRIPTION
The test case will wait 5 seconds if waitForQuorum is `true`

https://github.com/etcd-io/etcd/blob/801dfc3964749a741aa3c6b7c5be07c3ef8a931c/tests/common/member_test.go#L127-L129

The context timeout is 10 seconds in total, but sometimes it may take a long time for the cluster to be ready, and the remaining time to run the test may < 5 seconds. In that case, the test will timeout for sure.

```
execute.go:47: ---> Test failed: test timed out after 4.252903074s, err: context deadline exceeded
```