### PR TITLE
grpcproxy: use metadata instead of context withvalue in with client auth token

### DIFF
--- a/server/proxy/grpcproxy/util_test.go
+++ b/server/proxy/grpcproxy/util_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+)
+
+func TestWithClientAuthToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		initContext func() context.Context
+		want        string
+	}{
+		{
+			name: "with valid token",
+			initContext: func() context.Context {
+				md := metadata.Pairs(rpctypes.TokenFieldNameGRPC, "test-token-123")
+				return metadata.NewIncomingContext(t.Context(), md)
+			},
+			want: "test-token-123",
+		},
+		{
+			name: "without token",
+			initContext: func() context.Context {
+				return t.Context()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			ctxWithToken := tt.initContext()
+
+			got := withClientAuthToken(ctx, ctxWithToken)
+
+			if tt.want == "" {
+				assert.Equal(t, ctx, got)
+				return
+			}
+
+			md, ok := metadata.FromOutgoingContext(got)
+			assert.True(t, ok)
+			tokens := md[rpctypes.TokenFieldNameGRPC]
+			assert.Len(t, tokens, 1)
+			assert.Equal(t, tt.want, tokens[0])
+		})
+	}
+}

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -17,6 +17,8 @@ package e2e
 import (
 	"context"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/expect"
+	v3electionpb "go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -141,4 +144,165 @@ func waitForEndpointInLog(ctx context.Context, proxyProc *expect.ExpectProcess, 
 	})
 
 	return err
+}
+
+func TestGRPCProxyWatchersAfterTokenExpiry(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cluster, err := e2e.NewEtcdProcessCluster(ctx, t,
+		e2e.WithClusterSize(1),
+		e2e.WithAuthTokenOpts("simple"),
+		e2e.WithAuthTokenTTL(1),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cluster.Stop()) })
+
+	cli := cluster.Etcdctl()
+
+	createUsers(ctx, t, cli)
+
+	require.NoError(t, cli.AuthEnable(ctx))
+
+	var (
+		node1ClientURL = cluster.Procs[0].Config().ClientURL
+		proxyClientURL = "127.0.0.1:42379"
+	)
+
+	proxyProc, err := e2e.SpawnCmd([]string{
+		e2e.BinPath.Etcd, "grpc-proxy", "start",
+		"--advertise-client-url", proxyClientURL,
+		"--listen-addr", proxyClientURL,
+		"--endpoints", node1ClientURL,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyProc.Stop()) })
+
+	var totalEventsCount int64
+
+	handler := func(events clientv3.WatchChan) {
+		for {
+			select {
+			case ev, open := <-events:
+				if !open {
+					return
+				}
+				if ev.Err() != nil {
+					t.Logf("watch response error: %s", ev.Err())
+					continue
+				}
+				atomic.AddInt64(&totalEventsCount, 1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	withAuth := e2e.WithAuth("root", "rootPassword")
+	withEndpoint := e2e.WithEndpoints([]string{proxyClientURL})
+
+	events := cluster.Etcdctl(withAuth, withEndpoint).Watch(ctx, "/test", config.WatchOptions{Prefix: true, Revision: 1})
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handler(events)
+	}()
+
+	clusterCli := cluster.Etcdctl(withAuth)
+	_, err = clusterCli.Put(ctx, "/test/1", "test", config.PutOptions{})
+	require.NoError(t, err)
+	require.NoError(t, err)
+
+	time.Sleep(time.Second * 2)
+
+	events2 := cluster.Etcdctl(withAuth, withEndpoint).Watch(ctx, "/test", config.WatchOptions{Prefix: true, Revision: 1})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handler(events2)
+	}()
+
+	events3 := cluster.Etcdctl(withAuth, withEndpoint).Watch(ctx, "/test", config.WatchOptions{Prefix: true, Revision: 1})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handler(events3)
+	}()
+
+	time.Sleep(time.Second)
+
+	cancel()
+	wg.Wait()
+
+	assert.Equal(t, int64(3), atomic.LoadInt64(&totalEventsCount))
+}
+
+func TestGRPCProxyStreamAuthTokenForwarding(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	cluster, err := e2e.NewEtcdProcessCluster(ctx, t,
+		e2e.WithClusterSize(1),
+		e2e.WithAuthTokenOpts("simple"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cluster.Stop()) })
+
+	cli := cluster.Etcdctl()
+	createUsers(ctx, t, cli)
+	require.NoError(t, cli.AuthEnable(ctx))
+
+	var (
+		proxyClientURL = "127.0.0.1:52379"
+	)
+
+	proxyProc, err := e2e.SpawnCmd([]string{
+		e2e.BinPath.Etcd, "grpc-proxy", "start",
+		"--advertise-client-url", proxyClientURL,
+		"--listen-addr", proxyClientURL,
+		"--endpoints", cluster.Procs[0].Config().ClientURL,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyProc.Stop()) })
+
+	_, err = proxyProc.ExpectFunc(ctx, func(s string) bool {
+		return strings.Contains(s, "started gRPC proxy")
+	})
+	require.NoError(t, err)
+
+	proxyClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{proxyClientURL},
+		DialTimeout: 5 * time.Second,
+		Username:    "root",
+		Password:    "rootPassword",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyClient.Close()) })
+
+	electionClient := v3electionpb.NewElectionClient(proxyClient.ActiveConnection())
+
+	cctx, ccancel := context.WithTimeout(ctx, 10*time.Second)
+	defer ccancel()
+
+	const electionName = "test-election"
+	const proposal = "test-proposal"
+
+	_, err = electionClient.Campaign(cctx, &v3electionpb.CampaignRequest{
+		Name:  []byte(electionName),
+		Value: []byte(proposal),
+	})
+	require.NoError(t, err)
+
+	obs, err := electionClient.Observe(cctx, &v3electionpb.LeaderRequest{Name: []byte(electionName)})
+	require.NoError(t, err)
+
+	leader, err := obs.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, leader)
+	require.NotNil(t, leader.Kv)
+	assert.Equal(t, proposal, string(leader.Kv.Value))
 }

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -285,6 +285,10 @@ func WithAuthTokenOpts(token string) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.ServerConfig.AuthToken = token }
 }
 
+func WithAuthTokenTTL(ttl uint) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.ServerConfig.AuthTokenTTL = ttl }
+}
+
 func WithRollingStart(rolling bool) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.RollingStart = rolling }
 }


### PR DESCRIPTION
Change to use metadata instead of `context.WithValue` to ensure each proxy watcher client has a new stream created with its token. 
Previously context.WithValue resulted in `streamKeyFromCtx` returning an empty string in the clientv3 watcher, causing stream reuse.
When new clients connected to proxy after the token expired (token for the initial client which connected) the reused stream's context would still contain the expired token.                                                                                                                           This caused auth failures when `isWatchPermitted` on cluster checked the stream's context resulting in hanging proxy watcher clients.

Issue can be reproduced by setting a low `--auth-token-ttl` on cluster and connect 1 client first to proxy and then connect a second one after token expired.