### PR TITLE
Mark --max-snapshots as deprecated in 3.6 and will be decommissioned …

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -169,6 +169,8 @@ type Config struct {
 	// follower to catch up.
 	SnapshotCatchUpEntries uint64 `json:"experimental-snapshot-catch-up-entries"`
 
+	// MaxSnapFiles is deprecated in v3.6 and will be decommissioned in v3.7.
+	// TODO: remove it in 3.7.
 	MaxSnapFiles uint `json:"max-snapshots"`
 	//revive:disable-next-line:var-naming
 	MaxWalFiles uint `json:"max-wals"`
@@ -617,7 +619,7 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 		"listen-metrics-urls",
 		"List of URLs to listen on for the metrics and health endpoints.",
 	)
-	fs.UintVar(&cfg.MaxSnapFiles, "max-snapshots", cfg.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited).")
+	fs.UintVar(&cfg.MaxSnapFiles, "max-snapshots", cfg.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.7.")
 	fs.UintVar(&cfg.MaxWalFiles, "max-wals", cfg.MaxWalFiles, "Maximum number of wal files to retain (0 is unlimited).")
 	fs.StringVar(&cfg.Name, "name", cfg.Name, "Human-readable name for this member.")
 	fs.Uint64Var(&cfg.SnapshotCount, "snapshot-count", cfg.SnapshotCount, "Number of committed transactions to trigger a snapshot to disk. Deprecated in v3.6 and will be decommissioned in v3.7.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -60,6 +60,7 @@ var (
 	deprecatedFlags = map[string]string{
 		// TODO: remove in 3.7.
 		"snapshot-count": "--snapshot-count is deprecated in 3.6 and will be decommissioned in 3.7.",
+		"max-snapshots":  "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.7.",
 		"v2-deprecation": "--v2-deprecation is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input.",
 	}
 )

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -72,7 +72,7 @@ Member:
   --listen-client-http-urls ''
     List of URLs to listen on for http only client traffic. Enabling this flag removes http services from --listen-client-urls.
   --max-snapshots '` + strconv.Itoa(embed.DefaultMaxSnapshots) + `'
-    Maximum number of snapshot files to retain (0 is unlimited).
+    Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.7.
   --max-wals '` + strconv.Itoa(embed.DefaultMaxWALs) + `'
     Maximum number of wal files to retain (0 is unlimited).
   --quota-backend-bytes '0'

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -682,6 +682,11 @@ func TestEtcdDeprecatedFlags(t *testing.T) {
 			expectedMsg: "--snapshot-count is deprecated in 3.6 and will be decommissioned in 3.7",
 		},
 		{
+			name:        "max-snapshots",
+			args:        append(commonArgs, "--max-snapshots=10"),
+			expectedMsg: "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.7",
+		},
+		{
 			name:        "v2-deprecation",
 			args:        append(commonArgs, "--v2-deprecation", "write-only-drop-data"),
 			expectedMsg: "--v2-deprecation is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input",


### PR DESCRIPTION
…in 3.7


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
