### PR TITLE
Delay the monitorStorageVersion goroutine until the server is fully ready

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -16,6 +16,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	defaultLog "log"
@@ -100,7 +101,12 @@ func (sctx *serveCtx) serve(
 	gopts ...grpc.ServerOption,
 ) (err error) {
 	logger := defaultLog.New(io.Discard, "etcdhttp", 0)
-	<-s.ReadyNotify()
+
+	select {
+	case <-s.StoppingNotify():
+		return errors.New("server is stopping")
+	case <-s.ReadyNotify():
+	}
 
 	sctx.lg.Info("ready to serve client requests")
 


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/18978

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.


```
	// The field "storageVersion" in Meta bucket was introduced in 3.6.
	// It doesn't exist in 3.5 and older versions. We depend on fields
	// "confState" and "term" to identify 3.5, as the two fields were
	// introduced in 3.5.
	// But the field "confState" is only guaranteed to be populated
	// after the member fully bootstraps itself. So we need to wait
	// for the etcdserver ready for serve client requests here.
```
