### PR TITLE
Do not wait for ready notify if the server is stopping

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -16,6 +16,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	defaultLog "log"
@@ -101,6 +102,12 @@ func (sctx *serveCtx) serve(
 ) (err error) {
 	logger := defaultLog.New(io.Discard, "etcdhttp", 0)
 	<-s.ReadyNotify()
+
+	select {
+	case <-s.StoppingNotify():
+		return errors.New("server is stopping")
+	case <-s.ReadyNotify():
+	}
 
 	sctx.lg.Info("ready to serve client requests")
 


### PR DESCRIPTION
Extracted from https://github.com/etcd-io/etcd/pull/19040, so as to be reviewed & merged separately.

When server is stopping for whatever reason, the member may fail to publish itself.  In that case, it won't close the ready notify channel, accordingly the etcdserver will get blocked on the ready notification (see below). 

https://github.com/etcd-io/etcd/blob/3cf550d3a47ecee743eaadec1ebd183a0fa88383/server/embed/serve.go#L103