### PR TITLE
Set a 80% threshold for the codecov status.patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -30,6 +30,10 @@ coverage:
         # allow some coverage reductions within a threshold
         # this allows a 1% drop from the previous base commit coverage
         threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 80%
 comment:
   layout: "header, files, diff, footer"
   behavior: default # default: update, if exists. Otherwise post new; new: delete old and post new


### PR DESCRIPTION
Basically we depend on maintainers to decide whether we should add test to improve the coverage for each PR, although we set a 1% threshold for now.