### PR TITLE
server: fix unexported-return lint issue

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -36,6 +36,8 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
+var _ AuthStore = (*authStore)(nil)
+
 var (
 	rootPerm = authpb.Permission{PermType: authpb.READWRITE, Key: []byte{}, RangeEnd: []byte{0}}
 
@@ -938,7 +940,7 @@ func (as *authStore) IsAuthEnabled() bool {
 }
 
 // NewAuthStore creates a new AuthStore.
-func NewAuthStore(lg *zap.Logger, be AuthBackend, tp TokenProvider, bcryptCost int) *authStore {
+func NewAuthStore(lg *zap.Logger, be AuthBackend, tp TokenProvider, bcryptCost int) AuthStore {
 	if lg == nil {
 		lg = zap.NewNop()
 	}

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -113,12 +113,14 @@ func setupAuthStore(t *testing.T) (store *authStore, teardownfunc func(t *testin
 
 	// The UserAdd function cannot generate old etcd version user data (user's option is nil)
 	// add special users through the underlying interface
-	addUserWithNoOption(as)
+	asImpl, ok := as.(*authStore)
+	require.Truef(t, ok, "addUserWithNoOption: needs an AuthStore implementation")
+	addUserWithNoOption(asImpl)
 
 	tearDown := func(_ *testing.T) {
 		as.Close()
 	}
-	return as, tearDown
+	return asImpl, tearDown
 }
 
 func addUserWithNoOption(as *authStore) {
@@ -133,7 +135,7 @@ func addUserWithNoOption(as *authStore) {
 	as.refreshRangePermCache(tx)
 }
 
-func enableAuthAndCreateRoot(as *authStore) error {
+func enableAuthAndCreateRoot(as AuthStore) error {
 	_, err := as.UserAdd(&pb.AuthUserAddRequest{Name: "root", HashedPassword: encodePassword("root"), Options: &authpb.UserAddOptions{NoPassword: false}})
 	if err != nil {
 		return err

--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -33,7 +33,7 @@ type serverVersionAdapter struct {
 	*EtcdServer
 }
 
-func NewServerVersionAdapter(s *EtcdServer) *serverVersionAdapter {
+func NewServerVersionAdapter(s *EtcdServer) serverversion.Server {
 	return &serverVersionAdapter{
 		EtcdServer: s,
 	}

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -82,6 +82,7 @@ type store struct {
 
 // NewStore returns a new store. It is useful to create a store inside
 // mvcc pkg. It should only be used for testing externally.
+// revive:disable-next-line:unexported-return this is used internally in the mvcc pkg
 func NewStore(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfig) *store {
 	if lg == nil {
 		lg = zap.NewNop()

--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -76,7 +76,7 @@ var _ WatchableKV = (*watchableStore)(nil)
 // cancel operations.
 type cancelFunc func()
 
-func New(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfig) *watchableStore {
+func New(lg *zap.Logger, b backend.Backend, le lease.Lessor, cfg StoreConfig) WatchableKV {
 	s := newWatchableStore(lg, b, le, cfg)
 	s.wg.Add(2)
 	go s.syncWatchersLoop()

--- a/server/storage/schema/auth.go
+++ b/server/storage/schema/auth.go
@@ -40,7 +40,7 @@ type authBackend struct {
 
 var _ auth.AuthBackend = (*authBackend)(nil)
 
-func NewAuthBackend(lg *zap.Logger, be backend.Backend) *authBackend {
+func NewAuthBackend(lg *zap.Logger, be backend.Backend) auth.AuthBackend {
 	return &authBackend{
 		be: be,
 		lg: lg,


### PR DESCRIPTION
PR to fix `unexported-return` lint issues under the `server` folder as mentioned in [Issue 18370](https://github.com/etcd-io/etcd/issues/18370). 

This PR:
- uses existing interfaces to fix

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
