### PR TITLE
Remove duplicated <-s.ReadyNotify()

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -101,7 +101,6 @@ func (sctx *serveCtx) serve(
 	gopts ...grpc.ServerOption,
 ) (err error) {
 	logger := defaultLog.New(io.Discard, "etcdhttp", 0)
-	<-s.ReadyNotify()
 
 	select {
 	case <-s.StoppingNotify():


### PR DESCRIPTION
Follow up to https://github.com/etcd-io/etcd/pull/19041

It was a mistake that I made when debugging the `codecov/patch` failure in https://github.com/etcd-io/etcd/pull/19041.  Sorry. Also refer to https://github.com/etcd-io/etcd/pull/19046#issuecomment-2539373718
