### PR TITLE
Wait for cluster version to non-default value to remove errors when cluster is bootstrapping.

### DIFF
--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -106,7 +106,7 @@ func (m *Monitor) decideClusterVersion() (*semver.Version, error) {
 // UpdateStorageVersionIfNeeded updates the storage version if it differs from cluster version.
 func (m *Monitor) UpdateStorageVersionIfNeeded() {
 	cv := m.s.GetClusterVersion()
-	if cv == nil {
+	if cv == nil || cv.String() == version.MinClusterVersion {
 		return
 	}
 	sv := m.s.GetStorageVersion()


### PR DESCRIPTION
Don't think those errors are useful or understandable. Function `UpdateStorageVersionIfNeeded` was supposed to wait until cluster version is set, however it missed case that cluster version is set to "3.0.0" temporarily before all members join.

```
{"level":"warn","ts":"2024-12-16T13:21:15.690381+0100","caller":"rafthttp/probing_status.go:68","msg":"prober detected unhealthy status","round-tripper-name":"ROUND_TRIPPER_SNAPSHOT","remote-peer-id":"fd422379fda50e48","rtt":"0s","error":"dial tcp 127.0.0.1:32380: connect: connection refused"}
{"level":"warn","ts":"2024-12-16T13:21:15.690398+0100","caller":"rafthttp/probing_status.go:68","msg":"prober detected unhealthy status","round-tripper-name":"ROUND_TRIPPER_RAFT_MESSAGE","remote-peer-id":"fd422379fda50e48","rtt":"0s","error":"dial tcp 127.0.0.1:32380: connect: connection refused"}
{"level":"info","ts":"2024-12-16T13:21:16.082165+0100","caller":"version/monitor.go:116","msg":"cluster version differs from storage version.","cluster-version":"3.0.0","storage-version":"3.5.0"}
{"level":"error","ts":"2024-12-16T13:21:16.082221+0100","caller":"version/monitor.go:120","msg":"failed to update storage version","cluster-version":"3.0.0","error":"cannot create migration plan: version \"3.5.0\" is not supported","stacktrace":"go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).UpdateStorageVersionIfNeeded\n\tgo.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:120\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).monitorStorageVersion\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2295\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach.func1\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2476"}
{"level":"info","ts":"2024-12-16T13:21:20.083213+0100","caller":"version/monitor.go:116","msg":"cluster version differs from storage version.","cluster-version":"3.0.0","storage-version":"3.5.0"}
{"level":"error","ts":"2024-12-16T13:21:20.083282+0100","caller":"version/monitor.go:120","msg":"failed to update storage version","cluster-version":"3.0.0","error":"cannot create migration plan: version \"3.5.0\" is not supported","stacktrace":"go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).UpdateStorageVersionIfNeeded\n\tgo.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:120\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).monitorStorageVersion\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2295\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach.func1\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2476"}
{"level":"warn","ts":"2024-12-16T13:21:20.691121+0100","caller":"rafthttp/probing_status.go:68","msg":"prober detected unhealthy status","round-tripper-name":"ROUND_TRIPPER_RAFT_MESSAGE","remote-peer-id":"fd422379fda50e48","rtt":"0s","error":"dial tcp 127.0.0.1:32380: connect: connection refused"}
{"level":"warn","ts":"2024-12-16T13:21:20.691137+0100","caller":"rafthttp/probing_status.go:68","msg":"prober detected unhealthy status","round-tripper-name":"ROUND_TRIPPER_SNAPSHOT","remote-peer-id":"fd422379fda50e48","rtt":"0s","error":"dial tcp 127.0.0.1:32380: connect: connection refused"}
```
/cc @ahrtr 