### PR TITLE
Update the allowedErrors in TestNoErrorLogsDuringNormalOperations

### DIFF
--- a/tests/e2e/logging_test.go
+++ b/tests/e2e/logging_test.go
@@ -39,9 +39,6 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			},
 			allowedErrors: map[string]bool{
 				"setting up serving from embedded etcd failed.": true,
-				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
-				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
 			},
 		},
 		{
@@ -52,9 +49,6 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			},
 			allowedErrors: map[string]bool{
 				"setting up serving from embedded etcd failed.": true,
-				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
-				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
 			},
 		},
 		{
@@ -69,9 +63,6 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			},
 			allowedErrors: map[string]bool{
 				"setting up serving from embedded etcd failed.": true,
-				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
-				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
 			},
 		},
 		{
@@ -84,9 +75,6 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			},
 			allowedErrors: map[string]bool{
 				"setting up serving from embedded etcd failed.": true,
-				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
-				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
 			},
 		},
 		{
@@ -99,9 +87,6 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 			},
 			allowedErrors: map[string]bool{
 				"setting up serving from embedded etcd failed.": true,
-				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
-				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
 			},
 		},
 	}


### PR DESCRIPTION
Revert https://github.com/etcd-io/etcd/pull/19060.

After https://github.com/etcd-io/etcd/pull/19068 is merged, we shouldn't see the following error anymore,

```
Messages:   	error level log message found: {"level":"error","ts":"2024-11-16T20:58:00.500222Z","caller":"version/monitor.go:120","msg":"failed to update storage version","cluster-version":"3.6.0","error":"cannot detect storage schema version: missing confstate information","stacktrace":"go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).UpdateStorageVersionIfNeeded\n\tgo.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:120\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).monitorStorageVersion\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2286\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach.func1\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2467"}
```
