### PR TITLE
scripts: remove duplicate bom fix in fix make target

### DIFF
--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -33,7 +33,6 @@ log_callout -e "\\nFixing etcd code for you...\n"
 
 run_for_modules mod_tidy_fix || exit 2
 run_for_modules run ${GO_CMD} fmt || exit 2
-run_for_module tests bom_fix || exit 2
 bash_ws_fix || exit 2
 
 log_success -e "\\nSUCCESS: etcd code is fixed :)"


### PR DESCRIPTION
The BOM fix is called from the `fix-bom` target, which is also a prerequisite for the `fix` target:
https://github.com/etcd-io/etcd/blob/b5c620a75d70380d8117979995e1915d6f16d620/Makefile#L73

Therefore, running `make fix` runs the BOM fix twice.

This is the clipped output from running `make fix`:

```
generating bill-of-materials.json                                                                                                                                                  
% (cd tools/mod && 'go' 'install' 'github.com/appscodelabs/license-bill-of-materials')                                                                                             
% '/home/ivan/.local/share/asdf/installs/golang/1.22.9/packages/bin/license-bill-of-materials' '--override-file' './bill-of-materials.override.json' 'go.etcd.io/etcd/api/v3/...' '
go.etcd.io/etcd/pkg/v3/...' 'go.etcd.io/etcd/client/pkg/v3/...' 'go.etcd.io/etcd/client/v2/...' 'go.etcd.io/etcd/client/v3/...' 'go.etcd.io/etcd/server/v3/...' 'go.etcd.io/etcd/et
cdutl/v3/...' 'go.etcd.io/etcd/etcdctl/v3/...' 'go.etcd.io/etcd/tests/v3/...' 'go.etcd.io/etcd/v3/...'                                                                             
bom refreshed                               
...
                                              
./scripts/fix.sh                                                                                                                                                                   
                                                                                                                                                                                   
Fixing etcd code for you...                                                                                                                                                        
                                                                                         
...

generating bill-of-materials.json                                                        
% (cd tools/mod && 'go' 'install' 'github.com/appscodelabs/license-bill-of-materials')   
% '/home/ivan/.local/share/asdf/installs/golang/1.22.9/packages/bin/license-bill-of-materials' '--override-file' './bill-of-materials.override.json' 'go.etcd.io/etcd/api/v3/...' '
go.etcd.io/etcd/pkg/v3/...' 'go.etcd.io/etcd/client/pkg/v3/...' 'go.etcd.io/etcd/client/v2/...' 'go.etcd.io/etcd/client/v3/...' 'go.etcd.io/etcd/server/v3/...' 'go.etcd.io/etcd/et
cdutl/v3/...' 'go.etcd.io/etcd/etcdctl/v3/...' 'go.etcd.io/etcd/tests/v3/...' 'go.etcd.io/etcd/v3/...'                                                                             
bom refreshed                                                                                                                                                                      
Fixing whitespaces in the bash scripts                                                                                                                                             
find ./ -name '*.sh' -print0 | xargs -0 sed -i.bak 's|  |  |g'                                                                                                                     
                                                                                                                                                                                   
SUCCESS: etcd code is fixed :)      
```



Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
