### PR TITLE
scripts: remove receiver name check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ fuzz:
 # Static analysis
 .PHONY: verify
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
-	verify-govet verify-license-header verify-receiver-name verify-mod-tidy \
+	verify-govet verify-license-header verify-mod-tidy \
 	verify-shellws verify-proto-annotations verify-genproto verify-yamllint \
 	verify-govet-shadow verify-markdown-marker verify-go-versions
 
@@ -112,10 +112,6 @@ verify-govet:
 .PHONY: verify-license-header
 verify-license-header:
 	PASSES="license_header" ./scripts/test.sh
-
-.PHONY: verify-receiver-name
-verify-receiver-name:
-	PASSES="receiver_name" ./scripts/test.sh
 
 .PHONY: verify-mod-tidy
 verify-mod-tidy:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -433,29 +433,6 @@ function license_header_pass {
   run_for_modules generic_checker license_header_per_module
 }
 
-function receiver_name_for_package {
-  # bash 3.x compatible replacement of: mapfile -t gofiles < <(go_srcs_in_module)
-  local gofiles=()
-  while IFS= read -r line; do gofiles+=("$line"); done < <(go_srcs_in_module)
-
-  recvs=$(grep 'func ([^*]' "${gofiles[@]}"  | tr  ':' ' ' |  \
-    awk ' { print $2" "$3" "$4" "$1 }' | sed "s/[a-zA-Z\\.]*go//g" |  sort  | uniq  | \
-    grep -Ev  "(Descriptor|Proto|_)"  | awk ' { print $3" "$4 } ' | sort | uniq -c | grep -v ' 1 ' | awk ' { print $2 } ')
-  if [ -n "${recvs}" ]; then
-    # shellcheck disable=SC2206
-    recvs=($recvs)
-    for recv in "${recvs[@]}"; do
-      log_error "Mismatched receiver for $recv..."
-      grep "$recv" "${gofiles[@]}" | grep 'func ('
-    done
-    return 255
-  fi
-}
-
-function receiver_name_pass {
-  run_for_modules receiver_name_for_package
-}
-
 # goword_for_package package
 # checks spelling and comments in the 'package' in the current module
 #


### PR DESCRIPTION
This check is duplicated as the project uses revive's `receiver-naming`:
https://github.com/etcd-io/etcd/blob/b53107151a4b0404ef5edebaf11337fb3a80da66/tools/.golangci.yaml#L82-L84

Which is more robust, as the current check may have false positives.

Because `golangci-lint` runs before `verify-receiver-name` it captures the error first (refer to the [prow job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/19084/pull-etcd-verify/1869632803721711616) from the test pull request #19084), so this check is unnecessary. Moreover, the current implementation has false positives, as it doesn't detect the issue in that pull request because of a very lax regular expression:

```
make verify-receiver-name
PASSES="receiver_name" ./scripts/test.sh
Running with --race
Starting at: Wed Dec 18 10:53:16 PM PST 2024

'receiver_name' started at Wed Dec 18 10:53:16 PM PST 2024
'receiver_name' PASSED and completed at Wed Dec 18 10:53:18 PM PST 2024
SUCCESS
```

The problem is that it skips anything with an underscore in the test string. Because filenames may have underscores, it doesn't scan them. The problematic line is `grep -Ev "(Descriptor|Proto|_)"`:

https://github.com/etcd-io/etcd/blob/b53107151a4b0404ef5edebaf11337fb3a80da66/scripts/test.sh#L443

However, because this check duplicates revive's linter, it doesn't make sense to fix it. It makes more sense to remove this check.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
