### PR TITLE
Fix lease expiration check

### DIFF
--- a/client/v3/concurrency/session.go
+++ b/client/v3/concurrency/session.go
@@ -155,8 +155,7 @@ func WithContext(ctx context.Context) SessionOption {
 	}
 }
 
-// Unexpired returns true iff the session was unexpired at some point during the
-// Unexpired() call.
-func (s *Session) Unexpired() bool {
-	return s.client.Unexpired(s.id)
+// Expired returns true iff the session is expired.
+func (s *Session) Expired() bool {
+	return s.client.Expired(s.id)
 }

--- a/client/v3/concurrency/session.go
+++ b/client/v3/concurrency/session.go
@@ -154,3 +154,9 @@ func WithContext(ctx context.Context) SessionOption {
 		so.ctx = ctx
 	}
 }
+
+// Unexpired returns true iff the session was unexpired at some point during the
+// Unexpired() call.
+func (s *Session) Unexpired() bool {
+	return s.client.Unexpired(s.id)
+}

--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -136,6 +136,10 @@ type Lease interface {
 	// (see https://github.com/etcd-io/etcd/pull/7866)
 	KeepAlive(ctx context.Context, id LeaseID) (<-chan *LeaseKeepAliveResponse, error)
 
+	// Unexpired returns true iff the lease is unexpired (more precisely: iff the
+	// lease was unexpired during the execution of the Unexpired() call).
+	Unexpired(id LeaseID) bool
+
 	// KeepAliveOnce renews the lease once. The response corresponds to the
 	// first message from calling KeepAlive. If the response has a recoverable
 	// error, KeepAliveOnce will retry the RPC with a new keep alive message.
@@ -623,4 +627,14 @@ func (ka *keepAlive) close() {
 	for _, ch := range ka.chs {
 		close(ch)
 	}
+}
+
+func (l *lessor) Unexpired(id LeaseID) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	ka, ok := l.keepAlives[id]
+	if !ok {
+		return false
+	}
+	return ka.deadline.After(time.Now())
 }

--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -136,9 +136,9 @@ type Lease interface {
 	// (see https://github.com/etcd-io/etcd/pull/7866)
 	KeepAlive(ctx context.Context, id LeaseID) (<-chan *LeaseKeepAliveResponse, error)
 
-	// Unexpired returns true iff the lease is unexpired (more precisely: iff the
-	// lease was unexpired during the execution of the Unexpired() call).
-	Unexpired(id LeaseID) bool
+	// Expired returns true iff the lease is expired (more precisely: iff the
+	// lease was expired during the execution of the Expired() call).
+	Expired(id LeaseID) bool
 
 	// KeepAliveOnce renews the lease once. The response corresponds to the
 	// first message from calling KeepAlive. If the response has a recoverable
@@ -629,12 +629,12 @@ func (ka *keepAlive) close() {
 	}
 }
 
-func (l *lessor) Unexpired(id LeaseID) bool {
+func (l *lessor) Expired(id LeaseID) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	ka, ok := l.keepAlives[id]
 	if !ok {
-		return false
+		return true
 	}
-	return ka.deadline.After(time.Now())
+	return ka.deadline.Before(time.Now())
 }

--- a/client/v3/leasing/kv.go
+++ b/client/v3/leasing/kv.go
@@ -466,12 +466,7 @@ func (lkv *leasingKV) readySession() bool {
 	if lkv.session == nil {
 		return false
 	}
-	select {
-	case <-lkv.session.Done():
-	default:
-		return true
-	}
-	return false
+	return lkv.session.Unexpired()
 }
 
 func (lkv *leasingKV) leaseID() v3.LeaseID {

--- a/client/v3/leasing/kv.go
+++ b/client/v3/leasing/kv.go
@@ -466,7 +466,7 @@ func (lkv *leasingKV) readySession() bool {
 	if lkv.session == nil {
 		return false
 	}
-	return lkv.session.Unexpired()
+	return !lkv.session.Expired()
 }
 
 func (lkv *leasingKV) leaseID() v3.LeaseID {


### PR DESCRIPTION
Fixes #19091.

This PR adds and uses a client-side `Unexpired()` method that determines if a lease is valid by checking if its expiration time is after the current time. This helps fix a bug in the client `leasing` library, and provides a general API to check if a lease is valid, which was not previously exposed to users.

This adds a new test for `leasing` which does a few Puts and Gets with delays and with a client that gets network partitioned. The test fails often on the old `leasing` implementation. The bug within `leasing` was here:
https://github.com/etcd-io/etcd/blob/9fa35e53f429ca8f21b0d6b26f24e1848f2652a6/client/v3/leasing/kv.go#L469-L473
This code tries to determine if a session is "ready" by checking if an non-blocking receive on `lkv.session.Done()` fails. However, failing to immediately receive on a `chan` does not guarantee anything: the other side's send or `close` may just have been delayed by a bit.

Fortunately for reproducing the problem, there's a delay already present in the code: the `Done()` channel is closed by a background loop that sleeps and periodically checks whether the lease is expired. If the lease expires while this loop is sleeping, there is a delay between the true expiration time and when the `Done()` channel is closed, which seems to make the test fail relatively reliably (it still sometimes takes a few tries to get a failure).

Using `Unexpired()`, the test always appears to pass.

I couldn't find other places using etcd leases with the problematic pattern from the `leasing` library, but I'm admittedly not sure how the `Lease` library is used by others.