### PR TITLE
tests: address bridge unexported return issue

### DIFF
--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -113,7 +113,11 @@ func TestMemberAdd(t *testing.T) {
 		for _, quorumTc := range quorumTcs {
 			for _, clusterTc := range clusterTestCases() {
 				t.Run(learnerTc.name+"/"+quorumTc.name+"/"+clusterTc.name, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					ctxTimeout := 10 * time.Second
+					if quorumTc.waitForQuorum {
+						ctxTimeout += etcdserver.HealthInterval
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 					defer cancel()
 					c := clusterTc.config
 					c.StrictReconfigCheck = quorumTc.strictReconfigCheck

--- a/tests/framework/integration/bridge.go
+++ b/tests/framework/integration/bridge.go
@@ -24,6 +24,16 @@ type Dialer interface {
 	Dial() (net.Conn, error)
 }
 
+// Bridge interface exposing methods of the bridge
+type Bridge interface {
+	Close()
+	DropConnections()
+	PauseConnections()
+	UnpauseConnections()
+	Blackhole()
+	Unblackhole()
+}
+
 // bridge proxies connections between listener and dialer, making it possible
 // to disconnect grpc network connections without closing the logical grpc connection.
 type bridge struct {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -566,7 +566,7 @@ type Member struct {
 	GRPCServerOpts []grpc.ServerOption
 	GRPCServer     *grpc.Server
 	GRPCURL        string
-	GRPCBridge     *bridge
+	GRPCBridge     Bridge
 
 	// ServerClient is a clientv3 that directly calls the etcdserver.
 	ServerClient *clientv3.Client
@@ -819,7 +819,7 @@ func (m *Member) clientScheme() string {
 	return ""
 }
 
-func (m *Member) addBridge() (*bridge, error) {
+func (m *Member) addBridge() (Bridge, error) {
 	network, host, port := m.grpcAddr()
 	grpcAddr := net.JoinHostPort(host, m.Port)
 	bridgePort := fmt.Sprintf("%s%s", port, "0")
@@ -840,7 +840,7 @@ func (m *Member) addBridge() (*bridge, error) {
 	return m.GRPCBridge, nil
 }
 
-func (m *Member) Bridge() *bridge {
+func (m *Member) Bridge() Bridge {
 	if !m.UseBridge {
 		m.Logger.Panic("Bridge not available. Please configure using bridge before creating Cluster.")
 	}


### PR DESCRIPTION
Introducing a new `Bridge` interface to resolve bridge unexported return issue

Part of #18370.