### PR TITLE
docs(contributing): fix links and build tool list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,9 +95,17 @@ Follow the steps below to set up the environment:
 - [Clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
 - Install Go by following [installation](https://go.dev/doc/install). Please check the minimal go version in [go.mod file](./go.mod#L3).
 - Install build tools:
-  - `make`: For Debian-based distributions you can run `sudo apt-get install build-essential`
-  - `protoc`: You can download it for your os. Use version [`v3.20.3`](https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.3).
-  - `yamllint`: For Debian-based distribution you can run `sudo apt-get install yamllint`
+  - [`make`](https://www.gnu.org/software/make/): For Debian-based distributions
+    you can run `sudo apt-get install build-essential`
+  - [`protoc`](https://protobuf.dev/): You can download it for your os. Use
+    version
+    [`v3.20.3`](https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.3).
+  - [`yamllint`](https://www.yamllint.com/): For Debian-based distribution you
+    can run `sudo apt-get install yamllint`
+  - [`jq`](https://jqlang.github.io/jq/): For Debian-based distribution you can
+    run `sudo apt-get install jq`
+  - [`xz`](https://tukaani.org/xz/): For Debian-based distribution you can run
+    `sudo apt-get install xz-utils`
 - Verify that everything is installed by running `make build`
 
 Note: `make build` runs with `-v`. Other build flags can be added through env `GO_BUILD_FLAGS`, **if required**. Eg.,
@@ -124,9 +132,10 @@ A codespace will open in a web-based version of Visual Studio Code. The [dev con
 ## Implement your change
 
 etcd code should follow the coding style suggested by the Golang community.
-See the [style doc](https://github.com/golang/go/wiki/CodeReviewComments) for details.
+See the [style doc](https://go.dev/wiki/CodeReviewComments) for details.
 
-Please ensure that your change passes static analysis (requires [golangci-lint](https://golangci-lint.run/usage/install/)):
+Please ensure that your change passes static analysis (requires
+[golangci-lint](https://golangci-lint.run/welcome/install/)):
 - `make verify` to verify if all checks pass.
 - `make verify-*` to verify a single check, for example, `make verify-bom` to verify if `bill-of-materials.json` file is up-to-date.
 - `make fix` to fix all checks.


### PR DESCRIPTION
# Changelog
* Fix a couple of broken links related to code styling and linting
* Add `jq` and `xz` to the list of build tools (needed when running `make verify`)
* Add links to the website of all the listed build tools

Fixes #19110 