### PR TITLE
[3.5] *: support custom content check online in v2store

### DIFF
--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -41,6 +41,14 @@ func createV2store(t testing.TB, dataDirPath string) {
 			t.Fatalf("failed put with curl (%v)", err)
 		}
 	}
+
+	t.Log("Verify keys in v2store memory")
+	epURL := epc.Procs[0].EndpointsV3()[0]
+	proc, err := e2e.SpawnCmd([]string{e2e.BinDir + "/etcdctl", "--endpoints=" + epURL, "check", "v2store"}, nil)
+	assert.NoError(t, err)
+
+	_, err = proc.Expect("detected custom content in v2store memory")
+	assert.NoError(t, err)
 }
 
 func assertVerifyCanStartV2deprecationNotYet(t testing.TB, dataDirPath string) {


### PR DESCRIPTION
It's to use v2 API to list all keys in v2store. If there is any active key in v2store, `etcdctl check v2store` returns error. However, the last snapshot might still contain custom content. The end-user still needs to check that content offline by `etcdutl check v2store`.

Part of #18993


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
