### PR TITLE
Robustness: Improve the documentation

### DIFF
--- a/tests/robustness/README.md
+++ b/tests/robustness/README.md
@@ -86,13 +86,13 @@ Etcd provides strict serializability for KV operations and eventual consistency 
 
 ## Running locally 
 
-1. Build etcd with failpoints
+1. Build etcd with failpoints. Please make sure that you are at the root directory of the repository before performing below steps.
     ```bash
-    make gofail-enable
+    make -f tests/robustness/makefile.mk gofail-enable 
     make build
-    make gofail-disable
+    make -f tests/robustness/makefile.mk gofail-disable 
     ```
-2. Run the tests
+2. Run the tests from the root directory of the repository only.
 
     ```bash
     make test-robustness


### PR DESCRIPTION
Included the correct path of the makefile to build the failpoints targets

Signed-off-by: Sachin Kumar <amentee@github.com>

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
