### PR TITLE
add MemberDowngradeUpgrade failpoint

### DIFF
--- a/tests/framework/e2e/curl.go
+++ b/tests/framework/e2e/curl.go
@@ -123,10 +123,8 @@ func CURLPut(clus *EtcdProcessCluster, req CURLReq) error {
 }
 
 func CURLGet(clus *EtcdProcessCluster, req CURLReq) error {
-	ctx, cancel := context.WithTimeout(context.Background(), req.timeoutDuration())
-	defer cancel()
-
-	return SpawnWithExpectsContext(ctx, CURLPrefixArgsCluster(clus.Cfg, clus.Procs[rand.Intn(clus.Cfg.ClusterSize)], "GET", req), nil, req.Expected)
+	member := clus.Procs[rand.Intn(clus.Cfg.ClusterSize)]
+	return CURLGetFromMember(clus, member, req)
 }
 
 func CURLGetFromMember(clus *EtcdProcessCluster, member EtcdProcess, req CURLReq) error {

--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -1,0 +1,176 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/server/v3/etcdserver"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+func DowngradeEnable(t *testing.T, epc *EtcdProcessCluster, ver *semver.Version) {
+	t.Logf("etcdctl downgrade enable %s", ver.String())
+	c := epc.Etcdctl()
+	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
+		err := c.DowngradeEnable(context.TODO(), ver.String())
+		require.NoError(t, err)
+	})
+
+	t.Log("Downgrade enabled, validating if cluster is ready for downgrade")
+	for i := 0; i < len(epc.Procs); i++ {
+		ValidateVersion(t, epc.Cfg, epc.Procs[i], version.Versions{
+			Cluster: ver.String(),
+			Server:  offsetMinor(ver, 1).String(),
+			Storage: ver.String(),
+		})
+		AssertProcessLogs(t, epc.Procs[i], "The server is ready to downgrade")
+	}
+
+	t.Log("Cluster is ready for downgrade")
+}
+
+func DowngradeUpgradeMembers(t *testing.T, lg *zap.Logger, clus *EtcdProcessCluster, numberOfMembersToChange int, currentVersion, targetVersion *semver.Version) error {
+	if lg == nil {
+		lg = clus.lg
+	}
+	isDowngrade := targetVersion.LessThan(*currentVersion)
+	opString := "upgrading"
+	newExecPath := BinPath.Etcd
+	if isDowngrade {
+		opString = "downgrading"
+		newExecPath = BinPath.EtcdLastRelease
+	}
+	membersToChange := rand.Perm(len(clus.Procs))[:numberOfMembersToChange]
+	lg.Info(fmt.Sprintf("Test %s members", opString), zap.Any("members", membersToChange))
+
+	// Need to wait health interval for cluster to prepare for downgrade/upgrade
+	time.Sleep(etcdserver.HealthInterval)
+
+	for _, memberID := range membersToChange {
+		member := clus.Procs[memberID]
+		if member.Config().ExecPath == newExecPath {
+			return fmt.Errorf("member:%s is already running with the %s target binary - %s", member.Config().Name, opString, member.Config().ExecPath)
+		}
+		lg.Info(fmt.Sprintf("%s member", opString), zap.String("member", member.Config().Name))
+		if err := member.Stop(); err != nil {
+			return err
+		}
+		member.Config().ExecPath = newExecPath
+		lg.Info("Restarting member", zap.String("member", member.Config().Name))
+		err := member.Start(context.TODO())
+		if err != nil {
+			return err
+		}
+	}
+	lg.Info("Validating versions")
+	for _, memberID := range membersToChange {
+		member := clus.Procs[memberID]
+		if isDowngrade || numberOfMembersToChange == len(clus.Procs) {
+			ValidateVersion(t, clus.Cfg, member, version.Versions{
+				Cluster: targetVersion.String(),
+				Server:  targetVersion.String(),
+			})
+		} else {
+			ValidateVersion(t, clus.Cfg, member, version.Versions{
+				Cluster: currentVersion.String(),
+				Server:  targetVersion.String(),
+			})
+		}
+	}
+	return nil
+}
+
+func ValidateVersion(t *testing.T, cfg *EtcdProcessClusterConfig, member EtcdProcess, expect version.Versions) {
+	testutils.ExecuteWithTimeout(t, 30*time.Second, func() {
+		for {
+			result, err := getMemberVersionByCurl(cfg, member)
+			if err != nil {
+				cfg.Logger.Warn("failed to get member version and retrying", zap.Error(err), zap.String("member", member.Config().Name))
+				time.Sleep(time.Second)
+				continue
+			}
+			cfg.Logger.Info("Comparing versions", zap.String("member", member.Config().Name), zap.Any("got", result), zap.Any("want", expect))
+			if err := compareMemberVersion(expect, result); err != nil {
+				cfg.Logger.Warn("Versions didn't match retrying", zap.Error(err), zap.String("member", member.Config().Name))
+				time.Sleep(time.Second)
+				continue
+			}
+			cfg.Logger.Info("Versions match", zap.String("member", member.Config().Name))
+			break
+		}
+	})
+}
+
+// offsetMinor returns the version with offset from the original minor, with the same major.
+func offsetMinor(v *semver.Version, offset int) *semver.Version {
+	var minor int64
+	if offset >= 0 {
+		minor = v.Minor + int64(offset)
+	} else {
+		diff := int64(-offset)
+		if diff < v.Minor {
+			minor = v.Minor - diff
+		}
+	}
+	return &semver.Version{Major: v.Major, Minor: minor}
+}
+
+func majorMinorVersionsEqual(v1, v2 string) bool {
+	ver1 := semver.New(v1)
+	ver2 := semver.New(v2)
+	return ver1.Major == ver2.Major && ver1.Minor == ver2.Minor
+}
+
+func compareMemberVersion(expect version.Versions, target version.Versions) error {
+	if expect.Server != "" && !majorMinorVersionsEqual(expect.Server, target.Server) {
+		return fmt.Errorf("expect etcdserver version %v, but got %v", expect.Server, target.Server)
+	}
+
+	if expect.Cluster != "" && !majorMinorVersionsEqual(expect.Cluster, target.Cluster) {
+		return fmt.Errorf("expect etcdcluster version %v, but got %v", expect.Cluster, target.Cluster)
+	}
+
+	if expect.Storage != "" && !majorMinorVersionsEqual(expect.Storage, target.Storage) {
+		return fmt.Errorf("expect storage version %v, but got %v", expect.Storage, target.Storage)
+	}
+	return nil
+}
+
+func getMemberVersionByCurl(cfg *EtcdProcessClusterConfig, member EtcdProcess) (version.Versions, error) {
+	args := CURLPrefixArgsCluster(cfg, member, "GET", CURLReq{Endpoint: "/version"})
+	lines, err := RunUtilCompletion(args, nil)
+	if err != nil {
+		return version.Versions{}, err
+	}
+
+	data := strings.Join(lines, "\n")
+	result := version.Versions{}
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		return version.Versions{}, fmt.Errorf("failed to unmarshal (%v): %w", data, err)
+	}
+	return result, nil
+}

--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -27,10 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/robustness/identity"
@@ -39,8 +37,9 @@ import (
 )
 
 var (
-	MemberReplace   Failpoint = memberReplace{}
-	MemberDowngrade Failpoint = memberDowngrade{}
+	MemberReplace          Failpoint = memberReplace{}
+	MemberDowngrade        Failpoint = memberDowngrade{}
+	MemberDowngradeUpgrade Failpoint = memberDowngradeUpgrade{}
 )
 
 type memberReplace struct{}
@@ -148,14 +147,15 @@ func (f memberReplace) Available(config e2e.EtcdProcessClusterConfig, member e2e
 type memberDowngrade struct{}
 
 func (f memberDowngrade) Inject(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster, baseTime time.Time, ids identity.Provider) ([]report.ClientReport, error) {
-	v, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
+	currentVersion, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
 	if err != nil {
 		return nil, err
 	}
-	targetVersion := semver.Version{Major: v.Major, Minor: v.Minor - 1}
+	lastVersion, err := e2e.GetVersionFromBinary(e2e.BinPath.EtcdLastRelease)
+	if err != nil {
+		return nil, err
+	}
 	numberOfMembersToDowngrade := rand.Int()%len(clus.Procs) + 1
-	membersToDowngrade := rand.Perm(len(clus.Procs))[:numberOfMembersToDowngrade]
-	lg.Info("Test downgrading members", zap.Any("members", membersToDowngrade))
 
 	member := clus.Procs[0]
 	endpoints := []string{member.EndpointsGRPC()[0]}
@@ -172,28 +172,9 @@ func (f memberDowngrade) Inject(ctx context.Context, t *testing.T, lg *zap.Logge
 
 	// Need to wait health interval for cluster to accept changes
 	time.Sleep(etcdserver.HealthInterval)
-	lg.Info("Enable downgrade")
-	err = enableDowngrade(ctx, cc, &targetVersion)
-	if err != nil {
-		return nil, err
-	}
-	// Need to wait health interval for cluster to prepare for downgrade
-	time.Sleep(etcdserver.HealthInterval)
+	e2e.DowngradeEnable(t, clus, lastVersion)
 
-	for _, memberID := range membersToDowngrade {
-		member = clus.Procs[memberID]
-		lg.Info("Downgrading member", zap.String("member", member.Config().Name))
-		if err = member.Stop(); err != nil {
-			return nil, err
-		}
-		member.Config().ExecPath = e2e.BinPath.EtcdLastRelease
-		lg.Info("Restarting member", zap.String("member", member.Config().Name))
-		err = member.Start(ctx)
-		if err != nil {
-			return nil, err
-		}
-		err = verifyVersion(t, clus, member, targetVersion)
-	}
+	err = e2e.DowngradeUpgradeMembers(t, lg, clus, numberOfMembersToDowngrade, currentVersion, lastVersion)
 	time.Sleep(etcdserver.HealthInterval)
 	return nil, err
 }
@@ -203,6 +184,68 @@ func (f memberDowngrade) Name() string {
 }
 
 func (f memberDowngrade) Available(config e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess, profile traffic.Profile) bool {
+	if !fileutil.Exist(e2e.BinPath.EtcdLastRelease) {
+		return false
+	}
+	// only run memberDowngrade test if no snapshot would be sent between members.
+	// see https://github.com/etcd-io/etcd/issues/19147 for context.
+	if config.ServerConfig.SnapshotCatchUpEntries < etcdserver.DefaultSnapshotCatchUpEntries {
+		return false
+	}
+	v, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
+	if err != nil {
+		panic("Failed checking etcd version binary")
+	}
+	v3_6 := semver.Version{Major: 3, Minor: 6}
+	// only current version cluster can be downgraded.
+	return v.Compare(v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
+}
+
+type memberDowngradeUpgrade struct{}
+
+func (f memberDowngradeUpgrade) Inject(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster, baseTime time.Time, ids identity.Provider) ([]report.ClientReport, error) {
+	currentVersion, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
+	if err != nil {
+		return nil, err
+	}
+	lastVersion, err := e2e.GetVersionFromBinary(e2e.BinPath.EtcdLastRelease)
+	if err != nil {
+		return nil, err
+	}
+
+	member := clus.Procs[0]
+	endpoints := []string{member.EndpointsGRPC()[0]}
+	cc, err := clientv3.New(clientv3.Config{
+		Endpoints:            endpoints,
+		Logger:               zap.NewNop(),
+		DialKeepAliveTime:    10 * time.Second,
+		DialKeepAliveTimeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer cc.Close()
+
+	// Need to wait health interval for cluster to accept changes
+	time.Sleep(etcdserver.HealthInterval)
+	e2e.DowngradeEnable(t, clus, lastVersion)
+	// downgrade all members first
+	err = e2e.DowngradeUpgradeMembers(t, lg, clus, len(clus.Procs), currentVersion, lastVersion)
+	if err != nil {
+		return nil, err
+	}
+	// partial upgrade the cluster
+	numberOfMembersToUpgrade := rand.Int()%len(clus.Procs) + 1
+	err = e2e.DowngradeUpgradeMembers(t, lg, clus, numberOfMembersToUpgrade, lastVersion, currentVersion)
+	time.Sleep(etcdserver.HealthInterval)
+	return nil, err
+}
+
+func (f memberDowngradeUpgrade) Name() string {
+	return "MemberDowngradeUpgrade"
+}
+
+func (f memberDowngradeUpgrade) Available(config e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess, profile traffic.Profile) bool {
 	if !fileutil.Exist(e2e.BinPath.EtcdLastRelease) {
 		return false
 	}
@@ -251,30 +294,4 @@ func patchArgs(args []string, flag, newValue string) error {
 		}
 	}
 	return fmt.Errorf("--%s flag not found", flag)
-}
-
-func enableDowngrade(ctx context.Context, cc *clientv3.Client, targetVersion *semver.Version) error {
-	_, err := cc.Maintenance.Downgrade(ctx, clientv3.DowngradeAction(pb.DowngradeRequest_VALIDATE), targetVersion.String())
-	if err != nil {
-		return err
-	}
-	_, err = cc.Maintenance.Downgrade(ctx, clientv3.DowngradeAction(pb.DowngradeRequest_ENABLE), targetVersion.String())
-	return err
-}
-
-func verifyVersion(t *testing.T, clus *e2e.EtcdProcessCluster, member e2e.EtcdProcess, expectedVersion semver.Version) error {
-	var err error
-	expected := fmt.Sprintf(`"etcdserver":"%d.%d\..*"etcdcluster":"%d\.%d\.`, expectedVersion.Major, expectedVersion.Minor, expectedVersion.Major, expectedVersion.Minor)
-	for i := 0; i < 35; i++ {
-		if err = e2e.CURLGetFromMember(clus, member, e2e.CURLReq{Endpoint: "/version", Expected: expect.ExpectedResponse{Value: expected, IsRegularExpr: true}}); err != nil {
-			t.Logf("#%d: v3 is not ready yet (%v)", i, err)
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		break
-	}
-	if err != nil {
-		return fmt.Errorf("failed to verify version, expected %v got (%w)", expected, err)
-	}
-	return nil
 }

--- a/tests/robustness/failpoint/failpoint.go
+++ b/tests/robustness/failpoint/failpoint.go
@@ -47,6 +47,7 @@ var allFailpoints = []Failpoint{
 	BeforeApplyOneConfChangeSleep,
 	MemberReplace,
 	MemberDowngrade,
+	MemberDowngradeUpgrade,
 	DropPeerNetwork,
 	RaftBeforeSaveSleep,
 	RaftAfterSaveSleep,


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

https://github.com/etcd-io/etcd/issues/17118

The MemberDowngradeUpgrade failpoint first downgrades all members, and upgrades some members. This is to test no robustness issue during the whole downgrade-upgrade process, which can be stopped at any point.

Tested locally with 
```
go test -run TestRobustnessExploratory -v --count 100 --failfast --timeout 5h
```
There is a little flakiness due to reasons unrelated to what the test wants to do, like a server fails to start. But that's mainly because we are stopping and restarting the servers many times. I think <5% is probably acceptable. 