### PR TITLE
Fix the inconsistent between listen peerURL and advertise peerURL

### DIFF
--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -259,7 +259,7 @@ func (c *Cluster) ProtoMembers() []*pb.Member {
 	return ms
 }
 
-func (c *Cluster) mustNewMember(t testutil.TB) *Member {
+func (c *Cluster) MustNewMember(t testutil.TB) *Member {
 	memberNumber := c.LastMemberNum
 	c.LastMemberNum++
 
@@ -299,7 +299,7 @@ func (c *Cluster) mustNewMember(t testutil.TB) *Member {
 
 // addMember return PeerURLs of the added member.
 func (c *Cluster) addMember(t testutil.TB) types.URLs {
-	m := c.mustNewMember(t)
+	m := c.MustNewMember(t)
 
 	scheme := SchemeFromTLSInfo(c.Cfg.PeerTLS)
 
@@ -1394,7 +1394,7 @@ func NewCluster(t testutil.TB, cfg *ClusterConfig) *Cluster {
 	c := &Cluster{Cfg: cfg}
 	ms := make([]*Member, cfg.Size)
 	for i := 0; i < cfg.Size; i++ {
-		ms[i] = c.mustNewMember(t)
+		ms[i] = c.MustNewMember(t)
 	}
 	c.Members = ms
 	if err := c.fillClusterForMembers(); err != nil {
@@ -1580,7 +1580,7 @@ func (c *Cluster) GetLearnerMembers() ([]*pb.Member, error) {
 // AddAndLaunchLearnerMember creates a learner member, adds it to Cluster
 // via v3 MemberAdd API, and then launches the new member.
 func (c *Cluster) AddAndLaunchLearnerMember(t testutil.TB) {
-	m := c.mustNewMember(t)
+	m := c.MustNewMember(t)
 	m.IsLearner = true
 
 	scheme := SchemeFromTLSInfo(c.Cfg.PeerTLS)
@@ -1679,9 +1679,8 @@ func (p SortableProtoMemberSliceByPeerURLs) Less(i, j int) bool {
 }
 func (p SortableProtoMemberSliceByPeerURLs) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
-// MustNewMember creates a new member instance based on the response of V3 Member Add API.
-func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse) *Member {
-	m := c.mustNewMember(t)
+// InitializeMemberWithResponse initializes a member with the response
+func (c *Cluster) InitializeMemberWithResponse(t testutil.TB, m *Member, resp *clientv3.MemberAddResponse) {
 	m.IsLearner = resp.Member.IsLearner
 	m.NewCluster = false
 
@@ -1691,5 +1690,4 @@ func (c *Cluster) MustNewMember(t testutil.TB, resp *clientv3.MemberAddResponse)
 	}
 	m.InitialPeerURLsMap[m.Name] = types.MustNewURLs(resp.Member.PeerURLs)
 	c.Members = append(c.Members, m)
-	return m
 }

--- a/tests/integration/clientv3/cluster_test.go
+++ b/tests/integration/clientv3/cluster_test.go
@@ -230,7 +230,8 @@ func TestMemberPromote(t *testing.T) {
 	followerIdx := (leaderIdx + 1) % 3
 	capi := clus.Client(followerIdx)
 
-	urls := []string{"http://127.0.0.1:1234"}
+	learnerMember := clus.MustNewMember(t)
+	urls := learnerMember.PeerURLs.StringSlice()
 	memberAddResp, err := capi.MemberAddAsLearner(context.Background(), urls)
 	if err != nil {
 		t.Fatalf("failed to add member %v", err)
@@ -262,9 +263,9 @@ func TestMemberPromote(t *testing.T) {
 		t.Fatalf("expecting error to contain %s, got %s", expectedErrKeywords, err.Error())
 	}
 
-	// create and launch learner member based on the response of V3 Member Add API.
+	// Initialize and launch learner member based on the response of V3 Member Add API.
 	// (the response has information on peer urls of the existing members in cluster)
-	learnerMember := clus.MustNewMember(t, memberAddResp)
+	clus.InitializeMemberWithResponse(t, learnerMember, memberAddResp)
 
 	if err = learnerMember.Launch(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Symptom
```
logger.go:146: 2025-01-07T10:48:59.222Z	WARN	m1	failed to reach the peer URL	{"member": "m1", "address": "http://127.0.0.1:1234/version", "remote-member-id": "8453db59c251d047", "error": "Get \"http://127.0.0.1:1234/version\": dial tcp 127.0.0.1:1234: connect: connection refused"}

logger.go:146: 2025-01-07T10:51:09.907Z	INFO	m1	sending database snapshot	{"member": "m1", "snapshot-index": 10, "remote-peer-id": "2c0c6ac2c3d63c1e", "bytes": 108356, "size": "108 kB", "URLs": "unix://127.0.0.1:2100542460"}
logger.go:146: 2025-01-07T10:51:09.907Z	WARN	m1	failed to send database snapshot	{"member": "m1", "snapshot-index": 10, "remote-peer-id": "2c0c6ac2c3d63c1e", "bytes": 108356, "size": "108 kB", "error": "dial tcp 127.0.0.1:1234: connect: connection refused"}
```

## Root cause & solution
In test case [TestMemberPromote](https://github.com/etcd-io/etcd/blob/fce823ac2830033270f8fe03fa1b56e62bf882b8/tests/integration/clientv3/cluster_test.go#L219C6-L219C23), it sets the new learner's peerURL as `http://127.0.0.1:1234 `, see below,
https://github.com/etcd-io/etcd/blob/fce823ac2830033270f8fe03fa1b56e62bf882b8/tests/integration/clientv3/cluster_test.go#L233-L234

But actually the integration test framework doesn't use the peerURL specified by users at all; instead it generates a peerURL by itself, see below.  This PR tries to fix the inconsistency.

https://github.com/etcd-io/etcd/blob/fce823ac2830033270f8fe03fa1b56e62bf882b8/tests/framework/integration/cluster.go#L634-L636

cc @serathius @jmhbnz @ivanvc @fuweid @siyuanfoundation 