### PR TITLE
chore: enable early-return and superfluous-else from revive

### DIFF
--- a/contrib/lock/client/client.go
+++ b/contrib/lock/client/client.go
@@ -135,11 +135,10 @@ func main() {
 
 	err = write("key0", fmt.Sprintf("value from client %x", mode), int64(version))
 	if err != nil {
-		if mode == 1 {
-			log.Printf("expected fail to write to storage with old lease version: %s\n", err) // client 1 should show this message
-		} else {
+		if mode != 1 {
 			log.Fatalf("unexpected fail to write to storage: %s\n", err)
 		}
+		log.Printf("expected fail to write to storage with old lease version: %s\n", err) // client 1 should show this message
 	} else {
 		log.Printf("successfully write a key to storage using lease %x\n", int64(version))
 	}

--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -257,12 +257,11 @@ func newCheckPerfCommand(cmd *cobra.Command, args []string) {
 		fmt.Printf("PASS: Stddev is %fs\n", s.Stddev)
 	}
 
-	if ok {
-		fmt.Println("PASS")
-	} else {
+	if !ok {
 		fmt.Println("FAIL")
 		os.Exit(cobrautl.ExitError)
 	}
+	fmt.Println("PASS")
 }
 
 func attemptCleanup(client *v3.Client, autoCompact bool) {
@@ -434,7 +433,6 @@ func newCheckDatascaleCommand(cmd *cobra.Command, args []string) {
 			fmt.Printf("FAIL: ERROR(%v) -> %d\n", k, v)
 		}
 		os.Exit(cobrautl.ExitError)
-	} else {
-		fmt.Printf("PASS: Approximate system memory used : %v MB.\n", strconv.FormatFloat(mbUsed, 'f', 2, 64))
 	}
+	fmt.Printf("PASS: Approximate system memory used : %v MB.\n", strconv.FormatFloat(mbUsed, 'f', 2, 64))
 }

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -116,9 +116,8 @@ func MustStart() {
 	if err := Start(); err != nil {
 		if rootCmd.SilenceErrors {
 			cobrautl.ExitWithError(cobrautl.ExitError, err)
-		} else {
-			os.Exit(cobrautl.ExitError)
 		}
+		os.Exit(cobrautl.ExitError)
 	}
 }
 

--- a/pkg/flags/selective_string.go
+++ b/pkg/flags/selective_string.go
@@ -77,11 +77,10 @@ type SelectiveStringsValue struct {
 func (ss *SelectiveStringsValue) Set(s string) error {
 	vs := strings.Split(s, ",")
 	for i := range vs {
-		if _, ok := ss.valids[vs[i]]; ok {
-			ss.vs = append(ss.vs, vs[i])
-		} else {
+		if _, ok := ss.valids[vs[i]]; !ok {
 			return fmt.Errorf("invalid value %q", vs[i])
 		}
+		ss.vs = append(ss.vs, vs[i])
 	}
 	sort.Strings(ss.vs)
 	return nil

--- a/server/etcdserver/api/v2store/store.go
+++ b/server/etcdserver/api/v2store/store.go
@@ -603,17 +603,16 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 
 	// force will try to replace an existing file
 	if n != nil {
-		if replace {
-			if n.IsDir() {
-				return nil, v2error.NewError(v2error.EcodeNotFile, nodePath, currIndex)
-			}
-			e.PrevNode = n.Repr(false, false, s.clock)
-
-			if err := n.Remove(false, false, nil); err != nil {
-				return nil, err
-			}
-		} else {
+		if !replace {
 			return nil, v2error.NewError(v2error.EcodeNodeExist, nodePath, currIndex)
+		}
+		if n.IsDir() {
+			return nil, v2error.NewError(v2error.EcodeNotFile, nodePath, currIndex)
+		}
+		e.PrevNode = n.Repr(false, false, s.clock)
+
+		if err := n.Remove(false, false, nil); err != nil {
+			return nil, err
 		}
 	}
 

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -353,13 +353,12 @@ func getDowngradeEnabledFromRemotePeers(lg *zap.Logger, cl *membership.RaftClust
 			continue
 		}
 		enable, err := getDowngradeEnabled(lg, m, rt, timeout)
-		if err != nil {
-			lg.Warn("failed to get downgrade enabled status", zap.String("remote-member-id", m.ID.String()), zap.Error(err))
-		} else {
+		if err == nil {
 			// Since the "/downgrade/enabled" serves linearized data,
 			// this function can return once it gets a non-error response from the endpoint.
 			return enable
 		}
+		lg.Warn("failed to get downgrade enabled status", zap.String("remote-member-id", m.ID.String()), zap.Error(err))
 	}
 	return false
 }

--- a/server/proxy/grpcproxy/watcher.go
+++ b/server/proxy/grpcproxy/watcher.go
@@ -71,12 +71,11 @@ func (w *watcher) send(wr clientv3.WatchResponse) {
 		ev := (*mvccpb.Event)(wr.Events[i])
 		if ev.Kv.ModRevision < w.nextrev {
 			continue
-		} else {
-			// We cannot update w.rev here.
-			// txn can have multiple events with the same rev.
-			// If w.nextrev updates here, it would skip events in the same txn.
-			lastRev = ev.Kv.ModRevision
 		}
+		// We cannot update w.rev here.
+		// txn can have multiple events with the same rev.
+		// If w.nextrev updates here, it would skip events in the same txn.
+		lastRev = ev.Kv.ModRevision
 
 		filtered := false
 		for _, filter := range w.filters {

--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -290,15 +290,14 @@ func (s *watchableStore) moveVictims() (moved int) {
 		for w, eb := range wb {
 			// watcher has observed the store up to, but not including, w.minRev
 			rev := w.minRev - 1
-			if w.send(WatchResponse{WatchID: w.id, Events: eb.evs, Revision: rev}) {
-				pendingEventsGauge.Add(float64(len(eb.evs)))
-			} else {
+			if !w.send(WatchResponse{WatchID: w.id, Events: eb.evs, Revision: rev}) {
 				if newVictim == nil {
 					newVictim = make(watcherBatch)
 				}
 				newVictim[w] = eb
 				continue
 			}
+			pendingEventsGauge.Add(float64(len(eb.evs)))
 			moved++
 		}
 

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -1062,9 +1062,8 @@ func (epc *EtcdProcessCluster) WaitMembersForLeader(ctx context.Context, t testi
 				if strings.Contains(err.Error(), "connection refused") {
 					// if member[i] has stopped
 					continue
-				} else {
-					t.Fatal(err)
 				}
+				t.Fatal(err)
 			}
 			members[resp[0].Header.MemberId] = i
 			leaders[resp[0].Leader] = struct{}{}

--- a/tests/integration/clientv3/metrics_test.go
+++ b/tests/integration/clientv3/metrics_test.go
@@ -168,9 +168,8 @@ func getHTTPBodyAsLines(t *testing.T, url string) []string {
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
-			} else {
-				t.Fatalf("error reading: %v", err)
 			}
+			t.Fatalf("error reading: %v", err)
 		}
 		lines = append(lines, line)
 	}

--- a/tests/integration/v3_alarm_test.go
+++ b/tests/integration/v3_alarm_test.go
@@ -247,11 +247,10 @@ func TestV3CorruptAlarm(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		presp, perr := clus.Client(0).Put(context.TODO(), "abc", "aaa")
 		if perr != nil {
-			if !eqErrGRPC(perr, rpctypes.ErrCorrupt) {
-				t.Fatalf("expected %v, got %+v (%v)", rpctypes.ErrCorrupt, presp, perr)
-			} else {
+			if eqErrGRPC(perr, rpctypes.ErrCorrupt) {
 				return
 			}
+			t.Fatalf("expected %v, got %+v (%v)", rpctypes.ErrCorrupt, presp, perr)
 		}
 		time.Sleep(time.Second)
 	}
@@ -347,10 +346,9 @@ func TestV3CorruptAlarmWithLeaseCorrupted(t *testing.T) {
 	time.Sleep(time.Second)
 	presp, perr := clus.Client(0).Put(context.TODO(), "abc", "aaa")
 	if perr != nil {
-		if !eqErrGRPC(perr, rpctypes.ErrCorrupt) {
-			t.Fatalf("expected %v, got %+v (%v)", rpctypes.ErrCorrupt, presp, perr)
-		} else {
+		if eqErrGRPC(perr, rpctypes.ErrCorrupt) {
 			return
 		}
+		t.Fatalf("expected %v, got %+v (%v)", rpctypes.ErrCorrupt, presp, perr)
 	}
 }

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -124,9 +124,8 @@ func putWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 			retryCount--
 			if shouldRetry(err) {
 				continue
-			} else {
-				t.Fatal(err)
 			}
+			t.Fatal(err)
 		}
 		break
 	}
@@ -156,9 +155,8 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 			retryCount--
 			if shouldRetry(err) {
 				continue
-			} else {
-				t.Fatal(err)
 			}
+			t.Fatal(err)
 		}
 		break
 	}

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -108,12 +108,11 @@ func patchOperations(operations []porcupine.Operation, watchRevision, putReturnT
 			if !persisted {
 				// Remove non persisted operations
 				continue
+			}
+			if txnRevision != 0 {
+				op.Output = model.MaybeEtcdResponse{Persisted: true, PersistedRevision: txnRevision}
 			} else {
-				if txnRevision != 0 {
-					op.Output = model.MaybeEtcdResponse{Persisted: true, PersistedRevision: txnRevision}
-				} else {
-					op.Output = model.MaybeEtcdResponse{Persisted: true}
-				}
+				op.Output = model.MaybeEtcdResponse{Persisted: true}
 			}
 		}
 		// Leave operation as it is as we cannot discard it.

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -54,6 +54,10 @@ linters-settings: # please keep this alphabetized
         disabled: false
       - name: dot-imports
         disabled: false
+      - name: early-return
+        disabled: false
+        arguments:
+          - "preserveScope"
       - name: error-return
         disabled: false
       - name: error-naming
@@ -74,6 +78,10 @@ linters-settings: # please keep this alphabetized
         disabled: false
       - name: receiver-naming
         disabled: false
+      - name: superfluous-else
+        disabled: false
+        arguments:
+          - "preserveScope"
       - name: time-naming
         disabled: false
       - name: use-any

--- a/tools/etcd-dump-logs/raw.go
+++ b/tools/etcd-dump-logs/raw.go
@@ -75,10 +75,9 @@ func readRaw(fromIndex *uint64, waldir string, out io.Writer) {
 		} else if errors.Is(err, io.ErrUnexpectedEOF) {
 			fmt.Fprintf(out, "ErrUnexpectedEOF: The last record might be corrupted, error: %v.\n", err)
 			break
-		} else {
-			log.Printf("Error: Reading failed: %v", err)
-			break
 		}
+		log.Printf("Error: Reading failed: %v", err)
+		break
 	}
 }
 


### PR DESCRIPTION
#### Description 

[early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return): In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions.


[superfluous-else](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else): To improve the readability of code, it is recommended to reduce the indentation as much as possible. This rule highlights redundant else-blocks that can be eliminated from the code.