### PR TITLE
Fix release_notes.tpl.txt by adding a space between Docker image name and version

### DIFF
--- a/scripts/release_notes.tpl.txt
+++ b/scripts/release_notes.tpl.txt
@@ -82,10 +82,10 @@ rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
   --logger zap \
   --log-outputs stderr
 
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcd --version
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcdctl version
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcdutl version
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcdctl endpoint health
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcdctl put foo bar
-docker exec etcd-gcr-${ETCD_VER}/usr/local/bin/etcdctl get foo
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcd --version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdutl version
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
+docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl get foo
 ```


### PR DESCRIPTION
This PR supersedes #19122.

Add space between `${ETCD_VER}` and the path for docker commands.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
