### PR TITLE
chore: enable unnecessary-stmt rule from revive

### DIFF
--- a/client/pkg/types/urls.go
+++ b/client/pkg/types/urls.go
@@ -47,7 +47,6 @@ func NewURLs(strs []string) (URLs, error) {
 				return nil, fmt.Errorf("URL must not contain a path: %s", in)
 			}
 		case "unix", "unixs":
-			break
 		default:
 			return nil, fmt.Errorf("URL scheme must be http, https, unix, or unixs: %s", in)
 		}

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -64,8 +64,7 @@ func startEtcdOrProxyV2(args []string) {
 	lg.Info("Running: ", zap.Strings("args", args))
 	if err != nil {
 		lg.Warn("failed to verify flags", zap.Error(err))
-		switch {
-		case errorspkg.Is(err, embed.ErrUnsetAdvertiseClientURLsFlag):
+		if errorspkg.Is(err, embed.ErrUnsetAdvertiseClientURLsFlag) {
 			lg.Warn("advertise client URLs are not set", zap.Error(err))
 		}
 		os.Exit(1)

--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -49,8 +49,7 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 		switch {
 		case err == nil:
 			// update crc of the decoder when necessary
-			switch rec.Type {
-			case CrcType:
+			if rec.Type == CrcType {
 				crc := decoder.LastCRC()
 				// current crc of decoder must match the crc of the record.
 				// do no need to match 0 crc, since the decoder is a new one at this case.

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -48,49 +48,30 @@ linters-settings: # please keep this alphabetized
     confidence: 0.8
     rules:
       - name: blank-imports
-        disabled: false
       - name: context-as-argument
-        disabled: false
       - name: context-keys-type
-        disabled: false
       - name: dot-imports
-        disabled: false
       - name: early-return
-        disabled: false
         arguments:
           - "preserveScope"
       - name: error-return
-        disabled: false
       - name: error-naming
-        disabled: false
       - name: error-strings
-        disabled: false
       - name: errorf
-        disabled: false
       - name: if-return
-        disabled: false
       - name: increment-decrement
-        disabled: false
       - name: indent-error-flow
-        disabled: false
       - name: package-comments
-        disabled: false
       - name: range
-        disabled: false
       - name: receiver-naming
-        disabled: false
       - name: superfluous-else
-        disabled: false
         arguments:
           - "preserveScope"
       - name: time-naming
-        disabled: false
+      - name: unnecessary-stmt
       - name: use-any
-        disabled: false
       - name: var-declaration
-        disabled: false
       - name: var-naming
-        disabled: false
         arguments:
           # The following is the configuration for var-naming rule, the first element is the allow list and the second element is the deny list.
           - [] # AllowList: leave it empty to use the default (empty, too). This means that we're not relaxing the rule in any way, i.e. elementId will raise a violation, it should be elementID, refer to the next line to see the list of denied initialisms.


### PR DESCRIPTION
#### Description 

[unnecessary-stmt](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt): This rule suggests to remove redundant statements like a break at the end of a case block, for improving the code's readability.