### PR TITLE
robustness: only run MemberDowngrade test for high SnapshotCatchUpEntries

### DIFF
--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -206,6 +206,11 @@ func (f memberDowngrade) Available(config e2e.EtcdProcessClusterConfig, member e
 	if !fileutil.Exist(e2e.BinPath.EtcdLastRelease) {
 		return false
 	}
+	// only run memberDowngrade test if no snapshot would be sent between members.
+	// see https://github.com/etcd-io/etcd/issues/19147 for context.
+	if config.ServerConfig.SnapshotCatchUpEntries < etcdserver.DefaultSnapshotCatchUpEntries {
+		return false
+	}
 	v, err := e2e.GetVersionFromBinary(e2e.BinPath.Etcd)
 	if err != nil {
 		panic("Failed checking etcd version binary")

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -23,6 +23,7 @@ import (
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 	"go.etcd.io/etcd/tests/v3/robustness/client"
 	"go.etcd.io/etcd/tests/v3/robustness/failpoint"
@@ -101,7 +102,7 @@ func Exploratory(_ *testing.T) []TestScenario {
 	}
 
 	if e2e.CouldSetSnapshotCatchupEntries(e2e.BinPath.Etcd) {
-		baseOptions = append(baseOptions, e2e.WithSnapshotCatchUpEntries(100))
+		baseOptions = append(baseOptions, options.WithSnapshotCatchUpEntries(100, etcdserver.DefaultSnapshotCatchUpEntries))
 	}
 	scenarios := []TestScenario{}
 	for _, tp := range trafficProfiles {


### PR DESCRIPTION
This should prevent snapshot from being sent in the test.
Tested locally for 100 times, did not see any flakiness.

https://github.com/etcd-io/etcd/issues/19147 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
