### PR TITLE
Add Robustness test to reproduce issue 18089

### DIFF
--- a/tests/robustness/README.md
+++ b/tests/robustness/README.md
@@ -19,7 +19,7 @@ The purpose of these tests is to rigorously validate that etcd maintains its [KV
 | Duplicated watch event due to bug in TXN caching [#17247]       | Jan 2024 | main branch     | Robustness    | Yes, prevented regression in v3.6               |                                   |
 | Watch events lost during stream starvation [#17529]             | Mar 2024 | v3.4 or earlier | User          | Yes, after covering of slow watch               | `make test-robustness-issue17529` |
 | Revision decreasing caused by crash during compaction [#17780]  | Apr 2024 | v3.4 or earlier | Robustness    | Yes, after covering compaction                  |                                   |
-| Watch dropping an event when compacting on delete [#18089]      | May 2024 | v3.4 or earlier | Robustness    | Yes, after covering of compaction               |                                   |
+| Watch dropping an event when compacting on delete [#18089]      | May 2024 | v3.4 or earlier | Robustness    | Yes, after covering of compaction               | `make test-robustness-issue18089` |
 | Inconsistency when reading compacted revision in TXN [#18667]   | Oct 2024 | v3.4 or earlier | User          |                                                 |                                   |
 
 [#13766]: https://github.com/etcd-io/etcd/issues/13766

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -41,7 +41,7 @@ var testRunner = framework.E2eTestRunner
 
 var (
 	WaitBeforeFailpoint = time.Second
-	WaitJitter          = traffic.CompactionPeriod
+	WaitJitter          = traffic.DefaultCompactionPeriod
 	WaitAfterFailpoint  = time.Second
 )
 

--- a/tests/robustness/makefile.mk
+++ b/tests/robustness/makefile.mk
@@ -49,6 +49,11 @@ test-robustness-issue17780: /tmp/etcd-v3.5.13-compactBeforeSetFinishedCompact/bi
 	GO_TEST_FLAGS='-v --run=TestRobustnessRegression/Issue17780 --count 200 --failfast --bin-dir=/tmp/etcd-v3.5.13-compactBeforeSetFinishedCompact/bin' make test-robustness && \
 	  echo "Failed to reproduce" || echo "Successful reproduction"
 
+.PHONY: test-robustness-issue18089
+test-robustness-issue18089: /tmp/etcd-v3.5.12-beforeSendWatchResponse/bin
+	GO_TEST_FLAGS='-v -run=TestRobustnessRegression/Issue18089 -count 100 -failfast --bin-dir=/tmp/etcd-v3.5.12-beforeSendWatchResponse/bin' make test-robustness && \
+	  echo "Failed to reproduce" || echo "Successful reproduction"
+
 # Failpoints
 
 GOPATH = $(shell go env GOPATH)

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -223,6 +223,16 @@ func Regression(t *testing.T) []TestScenario {
 			e2e.WithGoFailEnabled(true),
 		),
 	})
+	scenarios = append(scenarios, TestScenario{
+		Name:      "Issue18089",
+		Profile:   traffic.LowTraffic.WithCompactionPeriod(100 * time.Millisecond), // Use frequent compaction for high reproduce rate
+		Failpoint: failpoint.SleepBeforeSendWatchResponse,
+		Traffic:   traffic.EtcdDelete,
+		Cluster: *e2e.NewConfig(
+			e2e.WithClusterSize(1),
+			e2e.WithGoFailEnabled(true),
+		),
+	})
 	if v.Compare(version.V3_5) >= 0 {
 		opts := []e2e.EPClusterOption{
 			e2e.WithSnapshotCount(100),

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -64,6 +64,16 @@ var (
 			{Choice: Put, Weight: 40},
 		},
 	}
+	EtcdDelete Traffic = etcdTraffic{
+		keyCount:     10,
+		largePutSize: 32769,
+		leaseTTL:     DefaultLeaseTTL,
+		// Please keep the sum of weights equal 100.
+		requests: []random.ChoiceWeight[etcdRequestType]{
+			{Choice: Put, Weight: 50},
+			{Choice: Delete, Weight: 50},
+		},
+	}
 )
 
 type etcdTraffic struct {


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

This is just an idea about how to reproduce issue 18089 using robustness tests.

With a few tweaks I was able to reproduce the issue by 
* issuing more Delete requests
* running frequent compact
* simulating a slow watch

In my local environment it usually takes 2 to 10 runs (< 1min) to reproduce the issue.

```
make test-robustness-issue18089
...
logger.go:146: 2025-01-11T00:36:07.292Z     ERROR   Broke watch guarantee   {"guarantee": "resumable", "client": 9, "request": {"Key":"/registry/pods/","Revision":539,"WithPrefix":true,"WithProgressNotify":true,"WithPrevKV":true}, "got-event": {"Type":"put-operation","Key":"/registry/pods/default/jzIW7","Value":{"Value":"563","Hash":0},"Revision":540,"IsCreate":false,"PrevValue":{"Value":{"Value":"560","Hash":0},"ModRevision":537}}, "want-event": {"Type":"delete-operation","Key":"/registry/pods/default/DOj8f","Value":{"Value":"","Hash":0},"Revision":539,"IsCreate":false}}
    validate.go:48: Failed validating watch history, err: broke Resumable - A broken watch can be resumed by establishing a new watch starting after the last revision received in a watch event before the break, so long as the revision is in the history window
    logger.go:146: 2025-01-11T00:36:07.292Z     INFO    Validating serializable operations
    logger.go:146: 2025-01-11T00:36:07.292Z     INFO    Saving robustness test report   {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721"}
    logger.go:146: 2025-01-11T00:36:07.292Z     INFO    Saving member data dir  {"member": "TestRobustnessRegressionIssue18089-test-0", "path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/server-TestRobustnessRegressionIssue18089-test-0"}
    logger.go:146: 2025-01-11T00:36:07.292Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-1/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.293Z     INFO    no KV operations for client, skip persisting    {"client-id": 1}
    logger.go:146: 2025-01-11T00:36:07.294Z     INFO    no watch operations for client, skip persisting {"client-id": 2}
    logger.go:146: 2025-01-11T00:36:07.294Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-2/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.294Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-3/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.294Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-3/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.294Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-4/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.295Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-4/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.295Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-5/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.296Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-5/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.296Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-6/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.297Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-6/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.297Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-7/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.297Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-7/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.298Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-8/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.298Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-8/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.299Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-9/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.299Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-9/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.299Z     INFO    Saving watch operations {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-10/watch.json"}
    logger.go:146: 2025-01-11T00:36:07.300Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-10/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.301Z     INFO    no watch operations for client, skip persisting {"client-id": 11}
    logger.go:146: 2025-01-11T00:36:07.301Z     INFO    Saving operation history        {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/client-11/operations.json"}
    logger.go:146: 2025-01-11T00:36:07.301Z     INFO    Saving visualization    {"path": "/tmp/TestRobustnessRegression_Issue18089/1736555767292791721/history.html"}
    logger.go:146: 2025-01-11T00:36:08.015Z     INFO    killing server...       {"name": "TestRobustnessRegressionIssue18089-test-0"}
    logger.go:146: 2025-01-11T00:36:08.015Z     INFO    stopping server...      {"name": "TestRobustnessRegressionIssue18089-test-0"}
    logger.go:146: 2025-01-11T00:36:08.018Z     INFO    stopped server. {"name": "TestRobustnessRegressionIssue18089-test-0"}
--- FAIL: TestRobustnessRegression (6.24s)
    --- FAIL: TestRobustnessRegression/Issue18089 (6.21s)
FAIL
FAIL    go.etcd.io/etcd/tests/v3/robustness     54.537s
FAIL
FAIL: (code:1):
  % (cd tests && 'env' 'ETCD_VERIFY=all' 'go' 'test' 'go.etcd.io/etcd/tests/v3/robustness' '-timeout=30m' '-v' '--run=TestRobustnessRegression/Issue18089' '--count' '100' '--failfast' '--bin-dir=/tmp/etcd-v3.5.15-failpoints/bin')
ERROR: Tests for following packages failed:
   go.etcd.io/etcd/tests/v3/robustness
FAIL: 'robustness' FAILED at Sat 11 Jan 2025 12:36:08 AM UTC
make[1]: *** [Makefile:59: test-robustness] Error 255
make[1]: Leaving directory '/home/---/jmao/etcd'
Successful reproduction
```
