### PR TITLE
tests: use high burst value in limiter.

### DIFF
--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -59,7 +59,8 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 
 	lm := identity.NewLeaseIDStorage()
 	reports := []report.ClientReport{}
-	limiter := rate.NewLimiter(rate.Limit(profile.MaximalQPS), 200)
+	// Use the highest MaximalQPS of all traffic profiles as burst otherwise actual traffic may be accidentally limited
+	limiter := rate.NewLimiter(rate.Limit(profile.MaximalQPS), 1000)
 
 	cc, err := client.NewRecordingClient(endpoints, ids, baseTime)
 	require.NoError(t, err)


### PR DESCRIPTION
Use the highest MaximalQPS of all traffic profiles as burst otherwise actual traffic may be accidentally limited. For example, if burst is set to 200 it is unlikely traffic can achieve higher than 200.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
