### PR TITLE
server/proxy/tcpproxy: reuse addr in TCPProxy.Run

### DIFF
--- a/server/proxy/tcpproxy/userspace.go
+++ b/server/proxy/tcpproxy/userspace.go
@@ -74,14 +74,12 @@ func (tp *TCPProxy) Run() error {
 	if tp.MonitorInterval == 0 {
 		tp.MonitorInterval = 5 * time.Minute
 	}
+
+	var eps []string // for logging
 	for _, srv := range tp.Endpoints {
 		addr := net.JoinHostPort(srv.Target, fmt.Sprintf("%d", srv.Port))
 		tp.remotes = append(tp.remotes, &remote{srv: srv, addr: addr})
-	}
-
-	var eps []string
-	for _, ep := range tp.Endpoints {
-		eps = append(eps, fmt.Sprintf("%s:%d", ep.Target, ep.Port))
+		eps = append(eps, addr)
 	}
 	if tp.Logger != nil {
 		tp.Logger.Info("ready to proxy client requests", zap.Strings("endpoints", eps))


### PR DESCRIPTION
"addr" is the result of net.JoinHostPort which supports IPv6 address.

Rather than ranging "tp.Endpoints" again, it's better to reuse "addr" in the first loop to collect "eps".

See #7942 and #7943 for context.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
