### PR TITLE
flags: optimise memory allocation

### DIFF
--- a/pkg/flags/selective_string.go
+++ b/pkg/flags/selective_string.go
@@ -59,7 +59,7 @@ func (ss *SelectiveStringValue) Valids() []string {
 // valids[0] will be default value. Caller must be sure
 // len(valids) != 0 or it will panic.
 func NewSelectiveStringValue(valids ...string) *SelectiveStringValue {
-	vm := make(map[string]struct{})
+	vm := make(map[string]struct{}, len(valids))
 	for _, v := range valids {
 		vm[v] = struct{}{}
 	}
@@ -106,7 +106,7 @@ func (ss *SelectiveStringsValue) Valids() []string {
 // for which any one of the given strings is a valid value,
 // and any other value is an error.
 func NewSelectiveStringsValue(valids ...string) *SelectiveStringsValue {
-	vm := make(map[string]struct{})
+	vm := make(map[string]struct{}, len(valids))
 	for _, v := range valids {
 		vm[v] = struct{}{}
 	}

--- a/pkg/flags/unique_strings.go
+++ b/pkg/flags/unique_strings.go
@@ -31,8 +31,9 @@ type UniqueStringsValue struct {
 // Implements "flag.Value" interface.
 // The values are set in order.
 func (us *UniqueStringsValue) Set(s string) error {
-	us.Values = make(map[string]struct{})
-	for _, v := range strings.Split(s, ",") {
+	values := strings.Split(s, ",")
+	us.Values = make(map[string]struct{}, len(values))
+	for _, v := range values {
 		us.Values[v] = struct{}{}
 	}
 	return nil


### PR DESCRIPTION
This PR introduces tiny optimizations by specifying `len` in `make(map...)` statements