### PR TITLE
 Fix passing compaction-batch-limit to etcd v3.4 and v3.5

### DIFF
--- a/tests/robustness/failpoint/trigger.go
+++ b/tests/robustness/failpoint/trigger.go
@@ -75,7 +75,7 @@ func (t triggerCompact) Trigger(ctx context.Context, _ *testing.T, member e2e.Et
 		}
 		rev = resp.Header.Revision
 
-		if !t.multiBatchCompaction || rev > int64(clus.Cfg.ServerConfig.CompactionBatchLimit) {
+		if !t.multiBatchCompaction || rev > int64(clus.Cfg.ServerConfig.ExperimentalCompactionBatchLimit) {
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -99,7 +99,7 @@ func (t triggerCompact) Available(config e2e.EtcdProcessClusterConfig, _ e2e.Etc
 	// For multiBatchCompaction we need to guarantee that there are enough revisions between two compaction requests.
 	// With addition of compaction requests to traffic this might be hard if experimental-compaction-batch-limit is too high.
 	if t.multiBatchCompaction {
-		return config.ServerConfig.CompactionBatchLimit <= 10
+		return config.ServerConfig.ExperimentalCompactionBatchLimit <= 10
 	}
 	return true
 }

--- a/tests/robustness/options/server_config_options.go
+++ b/tests/robustness/options/server_config_options.go
@@ -26,9 +26,9 @@ func WithSnapshotCount(input ...uint64) e2e.EPClusterOption {
 	}
 }
 
-func WithCompactionBatchLimit(input ...int) e2e.EPClusterOption {
+func WithExperimentalCompactionBatchLimit(input ...int) e2e.EPClusterOption {
 	return func(c *e2e.EtcdProcessClusterConfig) {
-		c.ServerConfig.CompactionBatchLimit = input[internalRand.Intn(len(input))]
+		c.ServerConfig.ExperimentalCompactionBatchLimit = input[internalRand.Intn(len(input))]
 	}
 }
 

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -97,7 +97,7 @@ func Exploratory(_ *testing.T) []TestScenario {
 		options.WithSubsetOptions(randomizableOptions...),
 		e2e.WithGoFailEnabled(true),
 		// Set low minimal compaction batch limit to allow for triggering multi batch compaction failpoints.
-		options.WithCompactionBatchLimit(10, 100, 1000),
+		options.WithExperimentalCompactionBatchLimit(10, 100, 1000),
 		e2e.WithWatchProcessNotifyInterval(100 * time.Millisecond),
 	}
 
@@ -219,7 +219,7 @@ func Regression(t *testing.T) []TestScenario {
 		Traffic:   traffic.Kubernetes,
 		Cluster: *e2e.NewConfig(
 			e2e.WithClusterSize(1),
-			e2e.WithCompactionBatchLimit(300),
+			e2e.WithExperimentalCompactionBatchLimit(300),
 			e2e.WithSnapshotCount(1000),
 			e2e.WithGoFailEnabled(true),
 		),


### PR DESCRIPTION
PR https://github.com/etcd-io/etcd/pull/19196 broke robustness test periodics.

/cc @ahrtr @siyuanfoundation @gangli113 