### PR TITLE
changelog: update Go entry to reflect 1.22.11 update

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -13,8 +13,8 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [runtime panic that occurs when KeepAlive is called with a Context implemented by an uncomparable type](https://github.com/etcd-io/etcd/pull/18936)
 
 ### Dependencies
-- Compile binaries using [go 1.22.10](https://github.com/etcd-io/etcd/pull/19005)
-  
+- Compile binaries using [go 1.22.11](https://github.com/etcd-io/etcd/pull/19212)
+
 <hr>
 
 ## v3.4.35 (2024-11-12)

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -20,7 +20,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Dependencies
 - Bump [golang-jwt/jwt to 4.5.1 to address GO-2024-3250](https://github.com/etcd-io/etcd/pull/18899).
-- Compile binaries using [go 1.22.10](https://github.com/etcd-io/etcd/pull/19004).
+- Compile binaries using [go 1.22.11](https://github.com/etcd-io/etcd/pull/19211).
 
 <hr>
 


### PR DESCRIPTION
Update 3.4.36 and 3.5.18 Go entries to reflect the 1.22.11 update.

Part of #19210.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
