### PR TITLE
Fix race condition (also a regression of the PR 19139)

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -84,7 +84,6 @@ type Etcd struct {
 	errc  chan error
 
 	closeOnce sync.Once
-	wg        sync.WaitGroup
 }
 
 type peerListener struct {
@@ -457,7 +456,6 @@ func (e *Etcd) Close() {
 		}
 	}
 	if e.errc != nil {
-		e.wg.Wait()
 		close(e.errc)
 	}
 }
@@ -872,9 +870,6 @@ func (e *Etcd) serveMetrics() (err error) {
 }
 
 func (e *Etcd) errHandler(err error) {
-	e.wg.Add(1)
-	defer e.wg.Done()
-
 	if err != nil {
 		e.GetLogger().Error("setting up serving from embedded etcd failed.", zap.Error(err))
 	}


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/19172, which is a regression caused by https://github.com/etcd-io/etcd/pull/19139

I decided to partially rollback 19139 to fix https://github.com/etcd-io/etcd/issues/19172. We need to backport the fix to 3.5, so let's keep it as simple as possible.

We can do any further enhance in 3.6 only.

cc @fuweid @ivanvc @jmhbnz @serathius 
