### PR TITLE
Update scripts/release.sh to push to artifact registry

### DIFF
--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -62,6 +62,7 @@ which don't need to be executed before releasing each version.
 4. Authenticate the image registry, refer to [Authentication methods](https://cloud.google.com/container-registry/docs/advanced-authentication).
    - `gcloud auth login`
    - `gcloud auth configure-docker`
+   - `gcloud auth configure-docker us-docker.pkg.dev`
 5. Install gh, refer to [GitHub's documentation](https://github.com/cli/cli#installation). Ensure that running
    `gh auth login` succeeds for the GitHub account you use to contribute to etcd,
    and that `gh auth status` has a clean exit and doesn't show any issues.
@@ -73,6 +74,7 @@ which don't need to be executed before releasing each version.
 3. Once permissions are elevated, temporarily relax [branch protections](https://github.com/etcd-io/etcd/settings/branches) to allow pushing changes directly to `release-*` branches in GitHub.
 4. Verify you can pass the authentication to the image registries,
    - `docker login gcr.io`
+   - `docker login us-docker.pkg.dev`
    - `docker login quay.io`
      - If the release person doesn't have access to 1password, one of the owners (@ahrtr, @ivanvc, @jmhbnz, @serathius) needs to share the password with them per [this guide](https://support.1password.com/share-items/). See rough steps below,
        - [Sign in](https://team-etcd.1password.com/home) to your account on 1password.com.

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -45,6 +45,7 @@ if [ -z "${TAG:-}" ]; then
     # From https://stackoverflow.com/q/72144329/
     DOCKER_BUILDKIT=1 docker build --build-arg="ARCH=${ARCH}" -t "gcr.io/etcd-development/etcd:${VERSION}" "${IMAGEDIR}"
     DOCKER_BUILDKIT=1 docker build --build-arg="ARCH=${ARCH}" -t "quay.io/coreos/etcd:${VERSION}" "${IMAGEDIR}"
+    DOCKER_BUILDKIT=1 docker build --build-arg="ARCH=${ARCH}" -t "us-docker.pkg.dev/etcd-development/etcd/etcd:${VERSION}" "${IMAGEDIR}"
 else
     docker build -t "${TAG}:${VERSION}" "${IMAGEDIR}"
 fi

--- a/scripts/release_notes.tpl.txt
+++ b/scripts/release_notes.tpl.txt
@@ -55,19 +55,19 @@ mv /tmp/etcd-${ETCD_VER}-darwin-amd64/* /tmp/etcd-download-test && rm -rf mv /tm
 
 ###### Docker
 
-etcd uses [`gcr.io/etcd-development/etcd`](https://gcr.io/etcd-development/etcd) as a primary container registry, and [`quay.io/coreos/etcd`](https://quay.io/coreos/etcd) as secondary.
+etcd uses [`us-docker.pkg.dev/etcd-development/etcd/etcd`](https://console.cloud.google.com/artifacts/docker/etcd-development/us/etcd) as a primary container registry, and [`quay.io/coreos/etcd`](https://quay.io/coreos/etcd) as secondary.
 
 ```sh
 ETCD_VER=${RELEASE_VERSION}
 
 rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
-  docker rmi gcr.io/etcd-development/etcd:${ETCD_VER} || true && \
+  docker rmi us-docker.pkg.dev/etcd-development/etcd/etcd:${ETCD_VER} || true && \
   docker run \
   -p 2379:2379 \
   -p 2380:2380 \
   --mount type=bind,source=/tmp/etcd-data.tmp,destination=/etcd-data \
-  --name etcd-gcr-${ETCD_VER} \
-  gcr.io/etcd-development/etcd:${ETCD_VER} \
+  --name etcd-${ETCD_VER} \
+  us-docker.pkg.dev/etcd-development/etcd/etcd:${ETCD_VER} \
   /usr/local/bin/etcd \
   --name s1 \
   --data-dir /etcd-data \
@@ -82,10 +82,10 @@ rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
   --logger zap \
   --log-outputs stderr
 
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcd --version
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl version
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdutl version
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
-docker exec etcd-gcr-${ETCD_VER} /usr/local/bin/etcdctl get foo
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcd --version
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcdctl version
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcdutl version
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcdctl endpoint health
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcdctl put foo bar
+docker exec etcd-${ETCD_VER} /usr/local/bin/etcdctl get foo
 ```

--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -38,7 +38,7 @@ fi
 
 # Pick defaults based on release workflow
 ARCH=$(go env GOARCH)
-REPOSITARY=${REPOSITARY:-"gcr.io/etcd-development/etcd"}
+REPOSITARY=${REPOSITARY:-"us-docker.pkg.dev/etcd-development/etcd/etcd"}
 if [ -n "$VERSION" ]; then
     # Expected Format: v3.6.99-amd64
     TAG=v"${VERSION}"-"${ARCH}"


### PR DESCRIPTION
This pr addresses https://github.com/etcd-io/etcd/issues/15199. On March 18, 2025, Container Registry will be replaced by Artifact Registry and no longer available.

There are wider discussions ongoing about how etcd will adopt/re-use existing k8s etcd image build pipeline. In the short term lets ensure our upcoming releases will push to artifact registry.

A new registry has been created in our `etcd-development` gcp project: https://console.cloud.google.com/artifacts/docker/etcd-development/us/etcd?project=etcd-development

I have verified push permissions work as expected by pushing a `v3.5.17` image to the new repository and granted push permissions to our `etcd-release-team` custom gcp role. Public read only access has been granted to the repository so users can pull our images. 

I've also verified the release script is working as expecting, producing the following images after being run in dry run mode:

```bash
 ~  Documents  etcd   main ↑1  last: 0m 6s  docker images
REPOSITORY                                    TAG              IMAGE ID      CREATED             SIZE
gcr.io/etcd-development/etcd                  v3.6.99-s390x    0955597f3106  35 seconds ago      64.4 MB
quay.io/coreos/etcd                           v3.6.99-s390x    0955597f3106  35 seconds ago      64.4 MB
us-docker.pkg.dev/etcd-development/etcd/etcd  v3.6.99-s390x    0955597f3106  35 seconds ago      64.4 MB
gcr.io/distroless/static-debian12             <none>           4d0de7b4ef96  37 seconds ago      5.73 MB
us-docker.pkg.dev/etcd-development/etcd/etcd  v3.6.99-ppc64le  28c366e5d9ad  50 seconds ago      60.5 MB
quay.io/coreos/etcd                           v3.6.99-ppc64le  28c366e5d9ad  50 seconds ago      60.5 MB
gcr.io/etcd-development/etcd                  v3.6.99-ppc64le  28c366e5d9ad  50 seconds ago      60.5 MB
gcr.io/etcd-development/etcd                  v3.6.99-arm64    619e0640fca5  About a minute ago  59 MB
quay.io/coreos/etcd                           v3.6.99-arm64    619e0640fca5  About a minute ago  59 MB
us-docker.pkg.dev/etcd-development/etcd/etcd  v3.6.99-arm64    619e0640fca5  About a minute ago  59 MB
us-docker.pkg.dev/etcd-development/etcd/etcd  v3.6.99-amd64    5cc288184af8  About a minute ago  60.9 MB
gcr.io/etcd-development/etcd                  v3.6.99-amd64    5cc288184af8  About a minute ago  60.9 MB
quay.io/coreos/etcd                           v3.6.99-amd64    5cc288184af8  About a minute ago  60.9 MB

```

cc @ahrtr, @serathius, @ivanvc 