### PR TITLE
Remove explicit random seed in robustness tests

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
 	testRunner.TestMain(m)
 }
 


### PR DESCRIPTION
Starting with Go 1.20 calling rand.Seed explicitly is no longer needed. 

I'm guessing the deprecated functionality is not needed particularly for robustness testing.

There was an earlier etcd issue https://github.com/etcd-io/etcd/issues/16428 and PR for this in August 2023 https://github.com/etcd-io/etcd/pull/16447.


