### PR TITLE
chore: enable thelper linter

### DIFF
--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -660,8 +660,8 @@ func TestNodeToMember(t *testing.T) {
 	}
 }
 
-func newTestCluster(t testing.TB, membs []*Member) *RaftCluster {
-	c := &RaftCluster{lg: zaptest.NewLogger(t), members: make(map[types.ID]*Member), removed: make(map[types.ID]bool)}
+func newTestCluster(tb testing.TB, membs []*Member) *RaftCluster {
+	c := &RaftCluster{lg: zaptest.NewLogger(tb), members: make(map[types.ID]*Member), removed: make(map[types.ID]bool)}
 	for _, m := range membs {
 		c.members[m.ID] = m
 	}

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1514,12 +1514,12 @@ func (n *nodeConfChangeCommitterRecorder) ApplyConfChange(conf raftpb.ConfChange
 	return &raftpb.ConfState{}
 }
 
-func newTestCluster(t testing.TB) *membership.RaftCluster {
-	return membership.NewCluster(zaptest.NewLogger(t))
+func newTestCluster(tb testing.TB) *membership.RaftCluster {
+	return membership.NewCluster(zaptest.NewLogger(tb))
 }
 
-func newTestClusterWithBackend(t testing.TB, membs []*membership.Member, be backend.Backend) *membership.RaftCluster {
-	lg := zaptest.NewLogger(t)
+func newTestClusterWithBackend(tb testing.TB, membs []*membership.Member, be backend.Backend) *membership.RaftCluster {
+	lg := zaptest.NewLogger(tb)
 	c := membership.NewCluster(lg)
 	c.SetBackend(schema.NewMembershipBackend(lg, be))
 	for _, m := range membs {

--- a/server/lease/lessor_bench_test.go
+++ b/server/lease/lessor_bench_test.go
@@ -60,9 +60,9 @@ func demote(le *lessor) {
 }
 
 // return new lessor and tearDown to release resource
-func setUp(t testing.TB) (le *lessor, tearDown func()) {
+func setUp(tb testing.TB) (le *lessor, tearDown func()) {
 	lg := zap.NewNop()
-	be, _ := betesting.NewDefaultTmpBackend(t)
+	be, _ := betesting.NewDefaultTmpBackend(tb)
 	// MinLeaseTTL is negative, so we can grant expired lease in benchmark.
 	// ExpiredLeasesRetryInterval should small, so benchmark of findExpired will recheck expired lease.
 	le = newLessor(lg, be, nil, LessorConfig{MinLeaseTTL: -1000, ExpiredLeasesRetryInterval: 10 * time.Microsecond})

--- a/server/storage/backend/batch_tx_test.go
+++ b/server/storage/backend/batch_tx_test.go
@@ -393,9 +393,9 @@ func checkUnsafeForEach(t *testing.T, tx backend.UnsafeReader, expectedKeys, exp
 
 // runWriteback is used test the txWriteBuffer.writeback function, which is called inside tx.Unlock().
 // The parameters are chosen based on defaultBatchLimit = 10000
-func runWriteback(t testing.TB, kss, vss [][]string, isSeq bool) {
-	b, _ := betesting.NewTmpBackend(t, time.Hour, 10000)
-	defer betesting.Close(t, b)
+func runWriteback(tb testing.TB, kss, vss [][]string, isSeq bool) {
+	b, _ := betesting.NewTmpBackend(tb, time.Hour, 10000)
+	defer betesting.Close(tb, b)
 
 	tx := b.BatchTx()
 

--- a/server/storage/backend/testing/betesting.go
+++ b/server/storage/backend/testing/betesting.go
@@ -26,28 +26,28 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/backend"
 )
 
-func NewTmpBackendFromCfg(t testing.TB, bcfg backend.BackendConfig) (backend.Backend, string) {
-	dir, err := os.MkdirTemp(t.TempDir(), "etcd_backend_test")
+func NewTmpBackendFromCfg(tb testing.TB, bcfg backend.BackendConfig) (backend.Backend, string) {
+	dir, err := os.MkdirTemp(tb.TempDir(), "etcd_backend_test")
 	if err != nil {
 		panic(err)
 	}
 	tmpPath := filepath.Join(dir, "database")
 	bcfg.Path = tmpPath
-	bcfg.Logger = zaptest.NewLogger(t)
+	bcfg.Logger = zaptest.NewLogger(tb)
 	return backend.New(bcfg), tmpPath
 }
 
 // NewTmpBackend creates a backend implementation for testing.
-func NewTmpBackend(t testing.TB, batchInterval time.Duration, batchLimit int) (backend.Backend, string) {
-	bcfg := backend.DefaultBackendConfig(zaptest.NewLogger(t))
+func NewTmpBackend(tb testing.TB, batchInterval time.Duration, batchLimit int) (backend.Backend, string) {
+	bcfg := backend.DefaultBackendConfig(zaptest.NewLogger(tb))
 	bcfg.BatchInterval, bcfg.BatchLimit = batchInterval, batchLimit
-	return NewTmpBackendFromCfg(t, bcfg)
+	return NewTmpBackendFromCfg(tb, bcfg)
 }
 
-func NewDefaultTmpBackend(t testing.TB) (backend.Backend, string) {
-	return NewTmpBackendFromCfg(t, backend.DefaultBackendConfig(zaptest.NewLogger(t)))
+func NewDefaultTmpBackend(tb testing.TB) (backend.Backend, string) {
+	return NewTmpBackendFromCfg(tb, backend.DefaultBackendConfig(zaptest.NewLogger(tb)))
 }
 
-func Close(t testing.TB, b backend.Backend) {
-	assert.NoError(t, b.Close())
+func Close(tb testing.TB, b backend.Backend) {
+	assert.NoError(tb, b.Close())
 }

--- a/server/storage/wal/testing/waltesting.go
+++ b/server/storage/wal/testing/waltesting.go
@@ -28,32 +28,32 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
-	t.Helper()
-	dir, err := os.MkdirTemp(t.TempDir(), "etcd_wal_test")
+func NewTmpWAL(tb testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL, string) {
+	tb.Helper()
+	dir, err := os.MkdirTemp(tb.TempDir(), "etcd_wal_test")
 	if err != nil {
 		panic(err)
 	}
 	tmpPath := filepath.Join(dir, "wal")
-	lg := zaptest.NewLogger(t)
+	lg := zaptest.NewLogger(tb)
 	w, err := wal.Create(lg, tmpPath, nil)
 	if err != nil {
-		t.Fatalf("Failed to create WAL: %v", err)
+		tb.Fatalf("Failed to create WAL: %v", err)
 	}
 	err = w.Close()
 	if err != nil {
-		t.Fatalf("Failed to close WAL: %v", err)
+		tb.Fatalf("Failed to close WAL: %v", err)
 	}
 	if len(reqs) != 0 {
 		w, err = wal.Open(lg, tmpPath, walpb.Snapshot{})
 		if err != nil {
-			t.Fatalf("Failed to open WAL: %v", err)
+			tb.Fatalf("Failed to open WAL: %v", err)
 		}
 
 		var state raftpb.HardState
 		_, state, _, err = w.ReadAll()
 		if err != nil {
-			t.Fatalf("Failed to read WAL: %v", err)
+			tb.Fatalf("Failed to read WAL: %v", err)
 		}
 		var entries []raftpb.Entry
 		for _, req := range reqs {
@@ -66,27 +66,27 @@ func NewTmpWAL(t testing.TB, reqs []etcdserverpb.InternalRaftRequest) (*wal.WAL,
 		}
 		err = w.Save(state, entries)
 		if err != nil {
-			t.Fatalf("Failed to save WAL: %v", err)
+			tb.Fatalf("Failed to save WAL: %v", err)
 		}
 		err = w.Close()
 		if err != nil {
-			t.Fatalf("Failed to close WAL: %v", err)
+			tb.Fatalf("Failed to close WAL: %v", err)
 		}
 	}
 
 	w, err = wal.OpenForRead(lg, tmpPath, walpb.Snapshot{})
 	if err != nil {
-		t.Fatalf("Failed to open WAL: %v", err)
+		tb.Fatalf("Failed to open WAL: %v", err)
 	}
 	return w, tmpPath
 }
 
-func Reopen(t testing.TB, walPath string) *wal.WAL {
-	t.Helper()
-	lg := zaptest.NewLogger(t)
+func Reopen(tb testing.TB, walPath string) *wal.WAL {
+	tb.Helper()
+	lg := zaptest.NewLogger(tb)
 	w, err := wal.OpenForRead(lg, walPath, walpb.Snapshot{})
 	if err != nil {
-		t.Fatalf("Failed to open WAL: %v", err)
+		tb.Fatalf("Failed to open WAL: %v", err)
 	}
 	return w
 }

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -69,13 +69,13 @@ func newClient(t *testing.T, entpoints []string, cfg e2e.ClientConfig) *clientv3
 }
 
 // tlsInfo follows the Client-to-server communication in https://etcd.io/docs/v3.6/op-guide/security/#basic-setup
-func tlsInfo(t testing.TB, cfg e2e.ClientConfig) (*transport.TLSInfo, error) {
+func tlsInfo(tb testing.TB, cfg e2e.ClientConfig) (*transport.TLSInfo, error) {
 	switch cfg.ConnectionType {
 	case e2e.ClientNonTLS, e2e.ClientTLSAndNonTLS:
 		return nil, nil
 	case e2e.ClientTLS:
 		if cfg.AutoTLS {
-			tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
+			tls, err := transport.SelfCert(zap.NewNop(), tb.TempDir(), []string{"localhost"}, 1)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate cert: %w", err)
 			}

--- a/tests/framework/e2e/cluster_direct.go
+++ b/tests/framework/e2e/cluster_direct.go
@@ -18,6 +18,6 @@ package e2e
 
 import "testing"
 
-func NewEtcdProcess(t testing.TB, cfg *EtcdServerProcessConfig) (EtcdProcess, error) {
-	return NewEtcdServerProcess(t, cfg)
+func NewEtcdProcess(tb testing.TB, cfg *EtcdServerProcessConfig) (EtcdProcess, error) {
+	return NewEtcdServerProcess(tb, cfg)
 }

--- a/tests/framework/e2e/e2e.go
+++ b/tests/framework/e2e/e2e.go
@@ -39,11 +39,11 @@ func (e e2eRunner) TestMain(m *testing.M) {
 	os.Exit(v)
 }
 
-func (e e2eRunner) BeforeTest(t testing.TB) {
-	BeforeTest(t)
+func (e e2eRunner) BeforeTest(tb testing.TB) {
+	BeforeTest(tb)
 }
 
-func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) intf.Cluster {
+func (e e2eRunner) NewCluster(ctx context.Context, tb testing.TB, opts ...config.ClusterOption) intf.Cluster {
 	cfg := config.NewClusterConfig(opts...)
 	e2eConfig := NewConfig(
 		WithClusterSize(cfg.ClusterSize),
@@ -68,7 +68,7 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.
 		e2eConfig.Client.AutoTLS = false
 		e2eConfig.Client.ConnectionType = ClientTLS
 	default:
-		t.Fatalf("ClientTLS config %q not supported", cfg.ClientTLS)
+		tb.Fatalf("ClientTLS config %q not supported", cfg.ClientTLS)
 	}
 	switch cfg.PeerTLS {
 	case config.NoTLS:
@@ -81,13 +81,13 @@ func (e e2eRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.
 		e2eConfig.IsPeerTLS = true
 		e2eConfig.IsPeerAutoTLS = false
 	default:
-		t.Fatalf("PeerTLS config %q not supported", cfg.PeerTLS)
+		tb.Fatalf("PeerTLS config %q not supported", cfg.PeerTLS)
 	}
-	epc, err := NewEtcdProcessCluster(ctx, t, WithConfig(e2eConfig))
+	epc, err := NewEtcdProcessCluster(ctx, tb, WithConfig(e2eConfig))
 	if err != nil {
-		t.Fatalf("could not start etcd integrationCluster: %s", err)
+		tb.Fatalf("could not start etcd integrationCluster: %s", err)
 	}
-	return &e2eCluster{t, *epc}
+	return &e2eCluster{tb, *epc}
 }
 
 type e2eCluster struct {

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -103,7 +103,7 @@ type EtcdServerProcessConfig struct {
 	Proxy         *proxy.ServerConfig
 }
 
-func NewEtcdServerProcess(t testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServerProcess, error) {
+func NewEtcdServerProcess(tb testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServerProcess, error) {
 	if !fileutil.Exist(cfg.ExecPath) {
 		return nil, fmt.Errorf("could not find etcd binary: %s", cfg.ExecPath)
 	}
@@ -123,7 +123,7 @@ func NewEtcdServerProcess(t testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServ
 		}
 	}
 	if cfg.LazyFSEnabled {
-		ep.lazyfs = newLazyFS(cfg.lg, cfg.DataDirPath, t)
+		ep.lazyfs = newLazyFS(cfg.lg, cfg.DataDirPath, tb)
 	}
 	return ep, nil
 }

--- a/tests/framework/e2e/testing.go
+++ b/tests/framework/e2e/testing.go
@@ -20,7 +20,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
-func BeforeTest(t testing.TB) {
-	SkipInShortMode(t)
-	testutil.BeforeTest(t)
+func BeforeTest(tb testing.TB) {
+	SkipInShortMode(tb)
+	testutil.BeforeTest(tb)
 }

--- a/tests/framework/e2e/util.go
+++ b/tests/framework/e2e/util.go
@@ -150,8 +150,8 @@ func ToTLS(s string) string {
 	return s
 }
 
-func SkipInShortMode(t testing.TB) {
-	testutil.SkipTestIfShortMode(t, "e2e tests are not running in --short mode")
+func SkipInShortMode(tb testing.TB) {
+	testutil.SkipTestIfShortMode(tb, "e2e tests are not running in --short mode")
 }
 
 func mergeEnvVariables(envVars map[string]string) []string {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -412,23 +412,23 @@ func (c *Cluster) WaitMembersMatch(t testutil.TB, membs []*pb.Member) {
 
 // WaitLeader returns index of the member in c.Members that is leader
 // or fails the test (if not established in 30s).
-func (c *Cluster) WaitLeader(t testing.TB) int {
-	return c.WaitMembersForLeader(t, c.Members)
+func (c *Cluster) WaitLeader(tb testing.TB) int {
+	return c.WaitMembersForLeader(tb, c.Members)
 }
 
 // WaitMembersForLeader waits until given members agree on the same leader,
 // and returns its 'index' in the 'membs' list
-func (c *Cluster) WaitMembersForLeader(t testing.TB, membs []*Member) int {
-	t.Logf("WaitMembersForLeader")
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+func (c *Cluster) WaitMembersForLeader(tb testing.TB, membs []*Member) int {
+	tb.Logf("WaitMembersForLeader")
+	ctx, cancel := context.WithTimeout(tb.Context(), 30*time.Second)
 	defer cancel()
 	l := 0
-	for l = c.waitMembersForLeader(ctx, t, membs); l < 0; {
+	for l = c.waitMembersForLeader(ctx, tb, membs); l < 0; {
 		if ctx.Err() != nil {
-			t.Fatalf("WaitLeader FAILED: %v", ctx.Err())
+			tb.Fatalf("WaitLeader FAILED: %v", ctx.Err())
 		}
 	}
-	t.Logf("WaitMembersForLeader succeeded. Cluster leader index: %v", l)
+	tb.Logf("WaitMembersForLeader succeeded. Cluster leader index: %v", l)
 
 	// TODO: Consider second pass check as sometimes leadership is lost
 	// soon after election:
@@ -444,15 +444,15 @@ func (c *Cluster) WaitMembersForLeader(t testing.TB, membs []*Member) int {
 
 // WaitMembersForLeader waits until given members agree on the same leader,
 // and returns its 'index' in the 'membs' list
-func (c *Cluster) waitMembersForLeader(ctx context.Context, t testing.TB, membs []*Member) int {
+func (c *Cluster) waitMembersForLeader(ctx context.Context, tb testing.TB, membs []*Member) int {
 	possibleLead := make(map[uint64]bool)
 	var lead uint64
 	for _, m := range membs {
 		possibleLead[uint64(m.Server.MemberID())] = true
 	}
-	cc, err := c.ClusterClient(t)
+	cc, err := c.ClusterClient(tb)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	// ensure leader is up via linearizable get
 	for {
@@ -483,12 +483,12 @@ func (c *Cluster) waitMembersForLeader(ctx context.Context, t testing.TB, membs 
 
 	for i, m := range membs {
 		if uint64(m.Server.MemberID()) == lead {
-			t.Logf("waitMembersForLeader found leader. Member: %v lead: %x", i, lead)
+			tb.Logf("waitMembersForLeader found leader. Member: %v lead: %x", i, lead)
 			return i
 		}
 	}
 
-	t.Logf("waitMembersForLeader failed (-1)")
+	tb.Logf("waitMembersForLeader failed (-1)")
 	return -1
 }
 
@@ -1457,7 +1457,7 @@ func (c *Cluster) Endpoints() []string {
 	return endpoints
 }
 
-func (c *Cluster) ClusterClient(t testing.TB, opts ...framecfg.ClientOption) (client *clientv3.Client, err error) {
+func (c *Cluster) ClusterClient(tb testing.TB, opts ...framecfg.ClientOption) (client *clientv3.Client, err error) {
 	cfg, err := c.newClientCfg()
 	if err != nil {
 		return nil, err
@@ -1469,7 +1469,7 @@ func (c *Cluster) ClusterClient(t testing.TB, opts ...framecfg.ClientOption) (cl
 	if err != nil {
 		return nil, err
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		client.Close()
 	})
 	return client, nil

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -41,11 +41,11 @@ func (e integrationRunner) TestMain(m *testing.M) {
 	testutil.MustTestMainWithLeakDetection(m)
 }
 
-func (e integrationRunner) BeforeTest(t testing.TB) {
-	BeforeTest(t)
+func (e integrationRunner) BeforeTest(tb testing.TB) {
+	BeforeTest(tb)
 }
 
-func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) intf.Cluster {
+func (e integrationRunner) NewCluster(ctx context.Context, tb testing.TB, opts ...config.ClusterOption) intf.Cluster {
 	var err error
 	cfg := config.NewClusterConfig(opts...)
 	integrationCfg := ClusterConfig{
@@ -55,27 +55,27 @@ func (e integrationRunner) NewCluster(ctx context.Context, t testing.TB, opts ..
 		AuthToken:                  cfg.AuthToken,
 		SnapshotCount:              cfg.SnapshotCount,
 	}
-	integrationCfg.ClientTLS, err = tlsInfo(t, cfg.ClientTLS)
+	integrationCfg.ClientTLS, err = tlsInfo(tb, cfg.ClientTLS)
 	if err != nil {
-		t.Fatalf("ClientTLS: %s", err)
+		tb.Fatalf("ClientTLS: %s", err)
 	}
-	integrationCfg.PeerTLS, err = tlsInfo(t, cfg.PeerTLS)
+	integrationCfg.PeerTLS, err = tlsInfo(tb, cfg.PeerTLS)
 	if err != nil {
-		t.Fatalf("PeerTLS: %s", err)
+		tb.Fatalf("PeerTLS: %s", err)
 	}
 	return &integrationCluster{
-		Cluster: NewCluster(t, &integrationCfg),
-		t:       t,
+		Cluster: NewCluster(tb, &integrationCfg),
+		t:       tb,
 		ctx:     ctx,
 	}
 }
 
-func tlsInfo(t testing.TB, cfg config.TLSConfig) (*transport.TLSInfo, error) {
+func tlsInfo(tb testing.TB, cfg config.TLSConfig) (*transport.TLSInfo, error) {
 	switch cfg {
 	case config.NoTLS:
 		return nil, nil
 	case config.AutoTLS:
-		tls, err := transport.SelfCert(zap.NewNop(), t.TempDir(), []string{"localhost"}, 1)
+		tls, err := transport.SelfCert(zap.NewNop(), tb.TempDir(), []string{"localhost"}, 1)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate cert: %w", err)
 		}

--- a/tests/framework/integration/testing.go
+++ b/tests/framework/integration/testing.go
@@ -138,18 +138,18 @@ func assertInTestContext(t testutil.TB) {
 	}
 }
 
-func NewEmbedConfig(t testing.TB, name string) *embed.Config {
+func NewEmbedConfig(tb testing.TB, name string) *embed.Config {
 	cfg := embed.NewConfig()
 	cfg.Name = name
-	lg := zaptest.NewLogger(t, zaptest.Level(zapcore.InfoLevel)).Named(cfg.Name)
+	lg := zaptest.NewLogger(tb, zaptest.Level(zapcore.InfoLevel)).Named(cfg.Name)
 	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(lg)
-	cfg.Dir = t.TempDir()
+	cfg.Dir = tb.TempDir()
 	return cfg
 }
 
-func NewClient(t testing.TB, cfg clientv3.Config) (*clientv3.Client, error) {
+func NewClient(tb testing.TB, cfg clientv3.Config) (*clientv3.Client, error) {
 	if cfg.Logger == nil {
-		cfg.Logger = zaptest.NewLogger(t).Named("client")
+		cfg.Logger = zaptest.NewLogger(tb).Named("client")
 	}
 	return clientv3.New(cfg)
 }

--- a/tests/framework/unit/unit.go
+++ b/tests/framework/unit/unit.go
@@ -42,10 +42,10 @@ func (e unitRunner) TestMain(m *testing.M) {
 	}
 }
 
-func (e unitRunner) BeforeTest(t testing.TB) {
+func (e unitRunner) BeforeTest(tb testing.TB) {
 }
 
-func (e unitRunner) NewCluster(ctx context.Context, t testing.TB, opts ...config.ClusterOption) intf.Cluster {
-	testutil.SkipTestIfShortMode(t, "Cannot create clusters in --short tests")
+func (e unitRunner) NewCluster(ctx context.Context, tb testing.TB, opts ...config.ClusterOption) intf.Cluster {
+	testutil.SkipTestIfShortMode(tb, "Cannot create clusters in --short tests")
 	return nil
 }

--- a/tests/integration/v3_leadership_test.go
+++ b/tests/integration/v3_leadership_test.go
@@ -236,14 +236,14 @@ func TestFirstCommitNotification(t *testing.T) {
 
 func checkFirstCommitNotification(
 	ctx context.Context,
-	t testing.TB,
+	tb testing.TB,
 	member *integration.Member,
 	leaderAppliedIndex uint64,
 	notifier <-chan struct{},
 ) error {
 	// wait until server applies all the changes of leader
 	for member.Server.AppliedIndex() < leaderAppliedIndex {
-		t.Logf("member.Server.AppliedIndex():%v <= leaderAppliedIndex:%v", member.Server.AppliedIndex(), leaderAppliedIndex)
+		tb.Logf("member.Server.AppliedIndex():%v <= leaderAppliedIndex:%v", member.Server.AppliedIndex(), leaderAppliedIndex)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -261,7 +261,7 @@ func checkFirstCommitNotification(
 			)
 		}
 	default:
-		t.Logf("member.Server.AppliedIndex():%v >= leaderAppliedIndex:%v", member.Server.AppliedIndex(), leaderAppliedIndex)
+		tb.Logf("member.Server.AppliedIndex():%v >= leaderAppliedIndex:%v", member.Server.AppliedIndex(), leaderAppliedIndex)
 		return fmt.Errorf(
 			"notification was not triggered, member ID: %d",
 			member.ID(),

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
     - staticcheck
     - stylecheck
     - testifylint
+    - thelper
     - unconvert # Remove unnecessary type conversions
     - unparam
     - unused
@@ -102,5 +103,18 @@ linters-settings: # please keep this alphabetized
       # to always require f-functions for stretchr/testify, but not for golang standard lib.
       # Also refer to https://github.com/etcd-io/etcd/pull/18741#issuecomment-2422395914
       require-f-funcs: true
+  thelper:
+    test:
+      first: false
+      begin: false
+    benchmark:
+      first: false
+      begin: false
+    tb:
+      first: false
+      begin: false
+    fuzz:
+      first: false
+      begin: false
   usetesting:
     os-mkdir-temp: false


### PR DESCRIPTION
#### Description

enables and fixes [thelper](https://golangci-lint.run/usage/linters/#thelper) linter issues.

Notice that only naming rules are activated here.

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->