### PR TITLE
Fix addMemberAsLearnerAndPromote to avoid error 'etcdserver: can only…

### DIFF
--- a/tests/e2e/runtime_reconfiguration_test.go
+++ b/tests/e2e/runtime_reconfiguration_test.go
@@ -178,7 +178,6 @@ func addMemberAsLearnerAndPromote(ctx context.Context, t *testing.T, epc *e2e.Et
 
 	id, err := epc.StartNewProc(ctx, nil, t, true /* addAsLearner */)
 	require.NoError(t, err)
-	_, err = epc.Etcdctl(e2e.WithEndpoints(endpoints)).MemberPromote(ctx, id)
 
 	attempt := 0
 	for attempt < 3 {


### PR DESCRIPTION
… promote a learner member'

Fix a test regression caused by https://github.com/etcd-io/etcd/pull/19272

This is another example of regression caused by "ok-to-test" label wasn't added.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
