### PR TITLE
Mark etcd-local-tester as deprecated so we can remove it in future

### DIFF
--- a/tools/local-tester/README.md
+++ b/tools/local-tester/README.md
@@ -1,5 +1,8 @@
 # etcd local-tester
 
+> [!WARNING]
+> etcd-local-tester is now deprecated in favor of our much more comprehensive [robustness testing suite](https://github.com/etcd-io/etcd/tree/main/tests/robustness). In a future etcd release this historic tool will be removed as it is no longer maintained.
+
 The etcd local-tester runs a fault injected cluster using local processes. It sets up an etcd cluster with unreliable network bridges on its peer and client interfaces. The cluster runs with a constant stream of `Put` requests to simulate client usage. A fault injection script periodically kills cluster members and disrupts bridge connectivity.
 
 # Requirements

--- a/tools/local-tester/bridge.sh
+++ b/tools/local-tester/bridge.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+echo "Warning: etcd-local-tester is now deprecated in favor of our robustness testing suite and will be removed in a future release."
+
 exec tools/local-tester/bridge/bridge \
   -delay-accept    \
   -reset-listen    \

--- a/tools/local-tester/bridge/bridge.go
+++ b/tools/local-tester/bridge/bridge.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // Package main is the entry point for the local tester network bridge.
+// Deprecated: etcd local tester is now deprecated. Use the etcd robustness
+// testing suite instead to validate etcd behaviour under failure conditions.
 package main
 
 import (

--- a/tools/local-tester/bridge/dispatch.go
+++ b/tools/local-tester/bridge/dispatch.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: etcd local tester is now deprecated. Use the etcd robustness
+// testing suite instead to validate etcd behaviour under failure conditions.
 package main
 
 import (


### PR DESCRIPTION
While looking at something else in our `tools/` directory the other day I stumbled into the `local-tester` directory and taking a brief look it seemed to me like it was something we no longer used as we have the massively more comprehensive robustness testing suite now.  The last meaningful update to the tool looked to be about eight years ago.

I propose we mark this old utility as deprecated and remove it in future so we don't confuse anyone with what tool they should be using to validate etcd behaviour under failure conditions.

cc @serathius, @ahrtr 