### PR TITLE
Fix goword errors

### DIFF
--- a/tests/integration/embed/embed_proxy_test.go
+++ b/tests/integration/embed/embed_proxy_test.go
@@ -14,6 +14,6 @@
 
 //go:build cluster_proxy
 
-// The purpose of this (empty) package is too keep following test working:
+// Package embed_test is an empty package that exists to keep the following test working:
 // #  go test -tags=cluster_proxy ./integration/embed
 package embed_test


### PR DESCRIPTION
For some reason, the goword check has passed while the file `tests/integration/embed/embed_proxy_test.go` has an error in the godoc. Update it so it doesn't show the error anymore.

Running `goword` against this file returns:

```bash
$ goword ./tests/integration/embed/embed_proxy_test.go
./tests/integration/embed/embed_proxy_test.go.17: // The purpose of this (empty) package is too keep following test working: (godoc-export: The -> // Package embed_test?)
```

I found this while working on another related task.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
