### PR TITLE
deflaky: TestSnapshotStatus

### DIFF
--- a/etcdutl/snapshot/v3_snapshot_test.go
+++ b/etcdutl/snapshot/v3_snapshot_test.go
@@ -141,6 +141,7 @@ func createDB(t *testing.T, generateContent func(*etcdserver.EtcdServer)) string
 	t.Helper()
 
 	cfg := embed.NewConfig()
+	cfg.BackendBatchLimit = 1
 	cfg.LogLevel = "fatal"
 	cfg.Dir = t.TempDir()
 


### PR DESCRIPTION
## Root Cause

The backend commits pending changes into boltdb per 100 ms by default. When brand-new member starts, that member will save member into backend by `MustSaveMemberToBackend`. However, it doesn't force change into boltdb. It depends on backend's auto-commit per 100ms.

If auto-commit happens after `UpdateStorageVersion`, the `UpdateStorageVersion`
will fail on `missing confstate information`. The confstate information is handled by commit-prehook. Once `UpdateStorageVersion` fails, `TestSnapshotStatus` won't have another chance to do that because that
server has been closed. So without storage version information, hash of boltdb data is not expected.

## How to reproduce it?

```diff
diff --git a/etcdutl/snapshot/v3_snapshot_test.go b/etcdutl/snapshot/v3_snapshot_test.go
index c2b3d5202..cd88ff995 100644
--- a/etcdutl/snapshot/v3_snapshot_test.go
+++ b/etcdutl/snapshot/v3_snapshot_test.go
@@ -141,6 +141,7 @@ func createDB(t *testing.T, generateContent func(*etcdserver.EtcdServer)) string
        t.Helper()

        cfg := embed.NewConfig()
+       cfg.BackendBatchInterval = 5 * time.Second
        cfg.LogLevel = "fatal"
        cfg.Dir = t.TempDir()
```

```bash
➜  snapshot git:(deflaky-TestSnapshotStatus) ✗ go test -v -run "^TestSnapshotStatus$" -count 1 ./
=== RUN   TestSnapshotStatus
    v3_snapshot_test.go:47:
                Error Trace:    /home/weifu/workspace/etcd/etcdutl/snapshot/v3_snapshot_test.go:47
                Error:          Not equal:
                                expected: 0x62132b4d
                                actual  : 0x6bf96324
                Test:           TestSnapshotStatus
--- FAIL: TestSnapshotStatus (0.14s)
FAIL
FAIL    go.etcd.io/etcd/etcdutl/v3/snapshot     0.154s
FAIL
```

## How to fix?

Change `BackendBatchLimit` to `1` so that we can force-commit during `MustSaveMemberToBackend`.

Fixes: #19228

cc @ahrtr @serathius 


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
