### PR TITLE
fix: use testify instead of t.Fatal or t.Error in pkg package

### DIFF
--- a/pkg/crc/crc_test.go
+++ b/pkg/crc/crc_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,38 +22,22 @@ func TestHash32(t *testing.T) {
 	// create a new hash with stdhash.Sum32() as initial crc
 	hash := New(stdhash.Sum32(), crc32.IEEETable)
 
-	wsize := stdhash.Size()
-	if g := hash.Size(); g != wsize {
-		t.Errorf("size = %d, want %d", g, wsize)
-	}
-	wbsize := stdhash.BlockSize()
-	if g := hash.BlockSize(); g != wbsize {
-		t.Errorf("block size = %d, want %d", g, wbsize)
-	}
-	wsum32 := stdhash.Sum32()
-	if g := hash.Sum32(); g != wsum32 {
-		t.Errorf("Sum32 = %d, want %d", g, wsum32)
-	}
+	assert.Equalf(t, hash.Size(), stdhash.Size(), "size")
+	assert.Equalf(t, hash.BlockSize(), stdhash.BlockSize(), "block size")
+	assert.Equalf(t, hash.Sum32(), stdhash.Sum32(), "Sum32")
 	wsum := stdhash.Sum(make([]byte, 32))
-	if g := hash.Sum(make([]byte, 32)); !reflect.DeepEqual(g, wsum) {
-		t.Errorf("sum = %v, want %v", g, wsum)
-	}
+	g := hash.Sum(make([]byte, 32))
+	assert.Truef(t, reflect.DeepEqual(g, wsum), "sum")
 
 	// write something
 	_, err = stdhash.Write([]byte("test data"))
 	require.NoErrorf(t, err, "unexpected write error: %v", err)
 	_, err = hash.Write([]byte("test data"))
 	require.NoErrorf(t, err, "unexpected write error: %v", err)
-	wsum32 = stdhash.Sum32()
-	if g := hash.Sum32(); g != wsum32 {
-		t.Errorf("Sum32 after write = %d, want %d", g, wsum32)
-	}
+	assert.Equalf(t, hash.Sum32(), stdhash.Sum32(), "Sum32 after write")
 
 	// reset
 	stdhash.Reset()
 	hash.Reset()
-	wsum32 = stdhash.Sum32()
-	if g := hash.Sum32(); g != wsum32 {
-		t.Errorf("Sum32 after reset = %d, want %d", g, wsum32)
-	}
+	assert.Equalf(t, hash.Sum32(), stdhash.Sum32(), "Sum32 after reset")
 }

--- a/pkg/flags/selective_string_test.go
+++ b/pkg/flags/selective_string_test.go
@@ -16,6 +16,8 @@ package flags
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSelectiveStringValue(t *testing.T) {
@@ -35,13 +37,9 @@ func TestSelectiveStringValue(t *testing.T) {
 	}
 	for i, tt := range tests {
 		sf := NewSelectiveStringValue(tt.vals...)
-		if sf.v != tt.vals[0] {
-			t.Errorf("#%d: want default val=%v,but got %v", i, tt.vals[0], sf.v)
-		}
+		assert.Equalf(t, sf.v, tt.vals[0], "#%d: want default val=%v,but got %v", i, tt.vals[0], sf.v)
 		err := sf.Set(tt.val)
-		if tt.pass != (err == nil) {
-			t.Errorf("#%d: want pass=%t, but got err=%v", i, tt.pass, err)
-		}
+		assert.Equalf(t, tt.pass, (err == nil), "#%d: want pass=%t, but got err=%v", i, tt.pass, err)
 	}
 }
 
@@ -63,8 +61,6 @@ func TestSelectiveStringsValue(t *testing.T) {
 	for i, tt := range tests {
 		sf := NewSelectiveStringsValue(tt.vals...)
 		err := sf.Set(tt.val)
-		if tt.pass != (err == nil) {
-			t.Errorf("#%d: want pass=%t, but got err=%v", i, tt.pass, err)
-		}
+		assert.Equalf(t, tt.pass, (err == nil), "#%d: want pass=%t, but got err=%v", i, tt.pass, err)
 	}
 }

--- a/pkg/flags/uint32_test.go
+++ b/pkg/flags/uint32_test.go
@@ -56,13 +56,9 @@ func TestUint32Value(t *testing.T) {
 			err := val.Set(tc.s)
 
 			if tc.expectError {
-				if err == nil {
-					t.Errorf("Expected failure on parsing uint32 value from %s", tc.s)
-				}
+				assert.Errorf(t, err, "Expected failure on parsing uint32 value from %s", tc.s)
 			} else {
-				if err != nil {
-					t.Errorf("Unexpected error when parsing %s: %v", tc.s, err)
-				}
+				require.NoErrorf(t, err, "Unexpected error when parsing %s: %v", tc.s, err)
 				assert.Equal(t, tc.expectedVal, uint32(val))
 			}
 		})

--- a/pkg/flags/unique_urls_test.go
+++ b/pkg/flags/unique_urls_test.go
@@ -104,7 +104,7 @@ func TestUniqueURLsFromFlag(t *testing.T) {
 	fs.Var(u, name, "usage")
 	uss := UniqueURLsFromFlag(fs, name)
 
-	require.Equal(t, len(u.Values), len(uss))
+	require.Len(t, uss, len(u.Values))
 
 	um := make(map[string]struct{})
 	for _, x := range uss {

--- a/pkg/flags/urls_test.go
+++ b/pkg/flags/urls_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,9 +41,7 @@ func TestValidateURLsValueBad(t *testing.T) {
 	}
 	for i, in := range tests {
 		u := URLsValue{}
-		if err := u.Set(in); err == nil {
-			t.Errorf(`#%d: unexpected nil error for in=%q`, i, in)
-		}
+		assert.Errorf(t, u.Set(in), `#%d: unexpected nil error for in=%q`, i, in)
 	}
 }
 

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -17,6 +17,8 @@ package httputil
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetHostname(t *testing.T) {
@@ -43,8 +45,6 @@ func TestGetHostname(t *testing.T) {
 	}
 	for i := range tt {
 		hv := GetHostname(tt[i].req)
-		if hv != tt[i].host {
-			t.Errorf("#%d: %q expected host %q, got '%v'", i, tt[i].req.Host, tt[i].host, hv)
-		}
+		assert.Equalf(t, hv, tt[i].host, "#%d: %q expected host %q, got '%v'", i, tt[i].req.Host, tt[i].host, hv)
 	}
 }

--- a/pkg/idutil/id_test.go
+++ b/pkg/idutil/id_test.go
@@ -17,30 +17,24 @@ package idutil
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewGenerator(t *testing.T) {
 	g := NewGenerator(0x12, time.Unix(0, 0).Add(0x3456*time.Millisecond))
 	id := g.Next()
 	wid := uint64(0x12000000345601)
-	if id != wid {
-		t.Errorf("id = %x, want %x", id, wid)
-	}
+	assert.Equalf(t, id, wid, "id = %x, want %x", id, wid)
 }
 
 func TestNewGeneratorUnique(t *testing.T) {
 	g := NewGenerator(0, time.Time{})
 	id := g.Next()
 	// different server generates different ID
-	g1 := NewGenerator(1, time.Time{})
-	if gid := g1.Next(); id == gid {
-		t.Errorf("generate the same id %x using different server ID", id)
-	}
+	assert.NotEqualf(t, id, NewGenerator(1, time.Time{}).Next(), "generate the same id %x using different server ID", id)
 	// restarted server generates different ID
-	g2 := NewGenerator(0, time.Now())
-	if gid := g2.Next(); id == gid {
-		t.Errorf("generate the same id %x after restart", id)
-	}
+	assert.NotEqualf(t, id, NewGenerator(0, time.Now()).Next(), "generate the same id %x after restart", id)
 }
 
 func TestNext(t *testing.T) {
@@ -48,9 +42,7 @@ func TestNext(t *testing.T) {
 	wid := uint64(0x12000000345601)
 	for i := 0; i < 1000; i++ {
 		id := g.Next()
-		if id != wid+uint64(i) {
-			t.Errorf("id = %x, want %x", id, wid+uint64(i))
-		}
+		assert.Equalf(t, id, wid+uint64(i), "id = %x, want %x", id, wid+uint64(i))
 	}
 }
 

--- a/pkg/ioutil/pagewriter_test.go
+++ b/pkg/ioutil/pagewriter_test.go
@@ -32,9 +32,7 @@ func TestPageWriterRandom(t *testing.T) {
 	n := 0
 	for i := 0; i < 4096; i++ {
 		c, err := w.Write(buf[:rand.Intn(len(buf))])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		n += c
 	}
 	require.LessOrEqualf(t, cw.writeBytes, n, "wrote %d bytes to io.Writer, but only wrote %d bytes", cw.writeBytes, n)
@@ -53,26 +51,20 @@ func TestPageWriterPartialSlack(t *testing.T) {
 	cw := &checkPageWriter{pageBytes: 64, t: t}
 	w := NewPageWriter(cw, pageBytes, 0)
 	// put writer in non-zero page offset
-	if _, err := w.Write(buf[:64]); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	_, err := w.Write(buf[:64])
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
 	require.Equalf(t, 1, cw.writes, "got %d writes, expected 1", cw.writes)
 	// nearly fill buffer
-	if _, err := w.Write(buf[:1022]); err != nil {
-		t.Fatal(err)
-	}
+	_, err = w.Write(buf[:1022])
+	require.NoError(t, err)
 	// overflow buffer, but without enough to write as aligned
-	if _, err := w.Write(buf[:8]); err != nil {
-		t.Fatal(err)
-	}
+	_, err = w.Write(buf[:8])
+	require.NoError(t, err)
 	require.Equalf(t, 1, cw.writes, "got %d writes, expected 1", cw.writes)
 	// finish writing slack space
-	if _, err := w.Write(buf[:128]); err != nil {
-		t.Fatal(err)
-	}
+	_, err = w.Write(buf[:128])
+	require.NoError(t, err)
 	require.Equalf(t, 2, cw.writes, "got %d writes, expected 2", cw.writes)
 }
 
@@ -83,21 +75,15 @@ func TestPageWriterOffset(t *testing.T) {
 	buf := make([]byte, defaultBufferBytes)
 	cw := &checkPageWriter{pageBytes: 64, t: t}
 	w := NewPageWriter(cw, pageBytes, 0)
-	if _, err := w.Write(buf[:64]); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	_, err := w.Write(buf[:64])
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
 	require.Equalf(t, 64, w.pageOffset, "w.pageOffset expected 64, got %d", w.pageOffset)
 
 	w = NewPageWriter(cw, w.pageOffset, pageBytes)
-	if _, err := w.Write(buf[:64]); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
+	_, err = w.Write(buf[:64])
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
 	require.Equalf(t, 0, w.pageOffset, "w.pageOffset expected 0, got %d", w.pageOffset)
 }
 

--- a/pkg/ioutil/reader_test.go
+++ b/pkg/ioutil/reader_test.go
@@ -17,6 +17,9 @@ package ioutil
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLimitedBufferReaderRead(t *testing.T) {
@@ -24,10 +27,6 @@ func TestLimitedBufferReaderRead(t *testing.T) {
 	ln := 1
 	lr := NewLimitedBufferReader(buf, ln)
 	n, err := lr.Read(make([]byte, 10))
-	if err != nil {
-		t.Fatalf("unexpected read error: %v", err)
-	}
-	if n != ln {
-		t.Errorf("len(data read) = %d, want %d", n, ln)
-	}
+	require.NoErrorf(t, err, "unexpected read error: %v", err)
+	assert.Equalf(t, n, ln, "len(data read) = %d, want %d", n, ln)
 }

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -136,14 +138,10 @@ func TestResolveTCPAddrs(t *testing.T) {
 		urls, err := resolveTCPAddrs(ctx, zaptest.NewLogger(t), tt.urls)
 		cancel()
 		if tt.hasError {
-			if err == nil {
-				t.Errorf("expected error")
-			}
+			require.Errorf(t, err, "expected error")
 			continue
 		}
-		if !reflect.DeepEqual(urls, tt.expected) {
-			t.Errorf("expected: %v, got %v", tt.expected, urls)
-		}
+		assert.Truef(t, reflect.DeepEqual(urls, tt.expected), "expected: %v, got %v", tt.expected, urls)
 	}
 }
 
@@ -308,9 +306,7 @@ func TestURLsEqual(t *testing.T) {
 
 	for i, test := range tests {
 		result, err := urlsEqual(context.TODO(), zaptest.NewLogger(t), test.a, test.b)
-		if result != test.expect {
-			t.Errorf("idx=%d #%d: a:%v b:%v, expected %v but %v", i, test.n, test.a, test.b, test.expect, result)
-		}
+		assert.Equalf(t, result, test.expect, "idx=%d #%d: a:%v b:%v, expected %v but %v", i, test.n, test.a, test.b, test.expect, result)
 		if test.err != nil {
 			if err.Error() != test.err.Error() {
 				t.Errorf("idx=%d #%d: err expected %v but %v", i, test.n, test.err, err)
@@ -347,11 +343,7 @@ func TestURLStringsEqual(t *testing.T) {
 		t.Logf("TestURLStringsEqual, case #%d", idx)
 		resolveTCPAddr = c.resolver
 		result, err := URLStringsEqual(context.TODO(), zaptest.NewLogger(t), c.urlsA, c.urlsB)
-		if !result {
-			t.Errorf("unexpected result %v", result)
-		}
-		if err != nil {
-			t.Errorf("unexpected error %v", err)
-		}
+		assert.Truef(t, result, "unexpected result %v", result)
+		assert.NoErrorf(t, err, "unexpected error %v", err)
 	}
 }

--- a/pkg/netutil/routes_linux_test.go
+++ b/pkg/netutil/routes_linux_test.go
@@ -16,20 +16,20 @@
 
 package netutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestGetDefaultInterface(t *testing.T) {
 	ifc, err := GetDefaultInterfaces()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("default network interfaces: %+v\n", ifc)
 }
 
 func TestGetDefaultHost(t *testing.T) {
 	ip, err := GetDefaultHost()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("default ip: %v", ip)
 }

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -29,9 +30,7 @@ func init() { setDflSignal = func(syscall.Signal) {} }
 func waitSig(t *testing.T, c <-chan os.Signal, sig os.Signal) {
 	select {
 	case s := <-c:
-		if s != sig {
-			t.Fatalf("signal was %v, want %v", s, sig)
-		}
+		require.Equalf(t, s, sig, "signal was %v, want %v", s, sig)
 	case <-time.After(1 * time.Second):
 		t.Fatalf("timeout waiting for %v", sig)
 	}
@@ -54,12 +53,8 @@ func TestHandleInterrupts(t *testing.T) {
 		waitSig(t, c, sig)
 		waitSig(t, c, sig)
 
-		if n == 3 {
-			t.Fatalf("interrupt handlers were called in wrong order")
-		}
-		if n != 4 {
-			t.Fatalf("interrupt handlers were not called properly")
-		}
+		require.NotEqualf(t, 3, n, "interrupt handlers were called in wrong order")
+		require.Equalf(t, 4, n, "interrupt handlers were not called properly")
 		// reset interrupt handlers
 		interruptHandlers = interruptHandlers[:0]
 		interruptExitMu.Unlock()

--- a/pkg/pbutil/pbutil_test.go
+++ b/pkg/pbutil/pbutil_test.go
@@ -18,21 +18,20 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshaler(t *testing.T) {
 	data := []byte("test data")
 	m := &fakeMarshaler{data: data}
-	if g := MustMarshal(m); !reflect.DeepEqual(g, data) {
-		t.Errorf("data = %s, want %s", g, m.data)
-	}
+	g := MustMarshal(m)
+	assert.Truef(t, reflect.DeepEqual(g, data), "data = %s, want %s", g, m.data)
 }
 
 func TestMarshalerPanic(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("recover = nil, want error")
-		}
+		assert.NotNilf(t, recover(), "recover = nil, want error")
 	}()
 	m := &fakeMarshaler{err: errors.New("blah")}
 	MustMarshal(m)
@@ -42,16 +41,12 @@ func TestUnmarshaler(t *testing.T) {
 	data := []byte("test data")
 	m := &fakeUnmarshaler{}
 	MustUnmarshal(m, data)
-	if !reflect.DeepEqual(m.data, data) {
-		t.Errorf("data = %s, want %s", m.data, data)
-	}
+	assert.Truef(t, reflect.DeepEqual(m.data, data), "data = %s, want %s", m.data, data)
 }
 
 func TestUnmarshalerPanic(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("recover = nil, want error")
-		}
+		assert.NotNilf(t, recover(), "recover = nil, want error")
 	}()
 	m := &fakeUnmarshaler{err: errors.New("blah")}
 	MustUnmarshal(m, nil)
@@ -69,12 +64,8 @@ func TestGetBool(t *testing.T) {
 	}
 	for i, tt := range tests {
 		b, set := GetBool(tt.b)
-		if b != tt.wb {
-			t.Errorf("#%d: value = %v, want %v", i, b, tt.wb)
-		}
-		if set != tt.wset {
-			t.Errorf("#%d: set = %v, want %v", i, set, tt.wset)
-		}
+		assert.Equalf(t, b, tt.wb, "#%d: value = %v, want %v", i, b, tt.wb)
+		assert.Equalf(t, set, tt.wset, "#%d: set = %v, want %v", i, set, tt.wset)
 	}
 }
 

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -17,10 +17,10 @@ package report
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,16 +28,12 @@ func TestPercentiles(t *testing.T) {
 	nums := make([]float64, 100)
 	nums[99] = 1 // 99-percentile (1 out of 100)
 	data := percentiles(nums)
-	if data[len(pctls)-2] != 1 {
-		t.Fatalf("99-percentile expected 1, got %f", data[len(pctls)-2])
-	}
+	require.InDeltaf(t, 1, data[len(pctls)-2], 0.0, "99-percentile expected 1, got %f", data[len(pctls)-2])
 
 	nums = make([]float64, 1000)
 	nums[999] = 1 // 99.9-percentile (1 out of 1000)
 	data = percentiles(nums)
-	if data[len(pctls)-1] != 1 {
-		t.Fatalf("99.9-percentile expected 1, got %f", data[len(pctls)-1])
-	}
+	require.InDeltaf(t, 1, data[len(pctls)-1], 0.0, "99.9-percentile expected 1, got %f", data[len(pctls)-1])
 }
 
 func TestReport(t *testing.T) {
@@ -76,9 +72,7 @@ func TestReport(t *testing.T) {
 	}
 	ss := <-r.Run()
 	for i, ws := range wstrs {
-		if !strings.Contains(ss, ws) {
-			t.Errorf("#%d: stats string missing %s", i, ws)
-		}
+		assert.Containsf(t, ss, ws, "#%d: stats string missing %s", i, ws)
 	}
 }
 

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
@@ -53,7 +54,5 @@ func TestFIFOSchedule(t *testing.T) {
 	}
 
 	s.WaitFinish(100)
-	if s.Finished() != 100 {
-		t.Errorf("finished = %d, want %d", s.Finished(), 100)
-	}
+	assert.Equalf(t, 100, s.Finished(), "finished = %d, want %d", s.Finished(), 100)
 }

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -50,9 +51,7 @@ func TestGet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trace := Get(tt.inputCtx)
-			if trace == nil {
-				t.Errorf("Expected %v; Got nil", tt.outputTrace)
-			}
+			assert.NotNilf(t, trace, "Expected %v; Got nil", tt.outputTrace)
 			if tt.outputTrace == nil || trace.operation != tt.outputTrace.operation {
 				t.Errorf("Expected %v; Got %v", tt.outputTrace, trace)
 			}
@@ -75,16 +74,10 @@ func TestCreate(t *testing.T) {
 	)
 
 	trace := New(op, nil, fields[0], fields[1])
-	if trace.operation != op {
-		t.Errorf("Expected %v; Got %v", op, trace.operation)
-	}
+	assert.Equalf(t, trace.operation, op, "Expected %v; Got %v", op, trace.operation)
 	for i, f := range trace.fields {
-		if f.Key != fields[i].Key {
-			t.Errorf("Expected %v; Got %v", fields[i].Key, f.Key)
-		}
-		if f.Value != fields[i].Value {
-			t.Errorf("Expected %v; Got %v", fields[i].Value, f.Value)
-		}
+		assert.Equalf(t, f.Key, fields[i].Key, "Expected %v; Got %v", fields[i].Key, f.Key)
+		assert.Equalf(t, f.Value, fields[i].Value, "Expected %v; Got %v", fields[i].Value, f.Value)
 	}
 
 	for i, v := range steps {
@@ -92,15 +85,9 @@ func TestCreate(t *testing.T) {
 	}
 
 	for i, v := range trace.steps {
-		if steps[i] != v.msg {
-			t.Errorf("Expected %v; Got %v", steps[i], v.msg)
-		}
-		if stepFields[i].Key != v.fields[0].Key {
-			t.Errorf("Expected %v; Got %v", stepFields[i].Key, v.fields[0].Key)
-		}
-		if stepFields[i].Value != v.fields[0].Value {
-			t.Errorf("Expected %v; Got %v", stepFields[i].Value, v.fields[0].Value)
-		}
+		assert.Equalf(t, steps[i], v.msg, "Expected %v; Got %v", steps[i], v.msg)
+		assert.Equalf(t, stepFields[i].Key, v.fields[0].Key, "Expected %v; Got %v", stepFields[i].Key, v.fields[0].Key)
+		assert.Equalf(t, stepFields[i].Value, v.fields[0].Value, "Expected %v; Got %v", stepFields[i].Value, v.fields[0].Value)
 	}
 }
 
@@ -220,9 +207,7 @@ func TestLog(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, msg := range tt.expectedMsg {
-				if !bytes.Contains(data, []byte(msg)) {
-					t.Errorf("Expected to find %v in log", msg)
-				}
+				assert.Truef(t, bytes.Contains(data, []byte(msg)), "Expected to find %v in log", msg)
 			}
 		})
 	}
@@ -295,9 +280,7 @@ func TestLogIfLong(t *testing.T) {
 			data, err := os.ReadFile(logPath)
 			require.NoError(t, err)
 			for _, msg := range tt.expectedMsg {
-				if !bytes.Contains(data, []byte(msg)) {
-					t.Errorf("Expected to find %v in log", msg)
-				}
+				assert.Truef(t, bytes.Contains(data, []byte(msg)), "Expected to find %v in log", msg)
 			}
 		})
 	}

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWait(t *testing.T) {
@@ -26,9 +28,8 @@ func TestWait(t *testing.T) {
 	ch := wt.Register(eid)
 	wt.Trigger(eid, "foo")
 	v := <-ch
-	if g, w := fmt.Sprintf("%v (%T)", v, v), "foo (string)"; g != w {
-		t.Errorf("<-ch = %v, want %v", g, w)
-	}
+	g, w := fmt.Sprintf("%v (%T)", v, v), "foo (string)"
+	assert.Equalf(t, g, w, "<-ch = %v, want %v", g, w)
 
 	if g := <-ch; g != nil {
 		t.Errorf("unexpected non-nil value: %v (%T)", g, g)
@@ -69,9 +70,8 @@ func TestTriggerDupSuppression(t *testing.T) {
 	wt.Trigger(eid, "bar")
 
 	v := <-ch
-	if g, w := fmt.Sprintf("%v (%T)", v, v), "foo (string)"; g != w {
-		t.Errorf("<-ch = %v, want %v", g, w)
-	}
+	g, w := fmt.Sprintf("%v (%T)", v, v), "foo (string)"
+	assert.Equalf(t, g, w, "<-ch = %v, want %v", g, w)
 
 	if g := <-ch; g != nil {
 		t.Errorf("unexpected non-nil value: %v (%T)", g, g)
@@ -86,17 +86,11 @@ func TestIsRegistered(t *testing.T) {
 	wt.Register(2)
 
 	for i := uint64(0); i < 3; i++ {
-		if !wt.IsRegistered(i) {
-			t.Errorf("event ID %d isn't registered", i)
-		}
+		assert.Truef(t, wt.IsRegistered(i), "event ID %d isn't registered", i)
 	}
 
-	if wt.IsRegistered(4) {
-		t.Errorf("event ID 4 shouldn't be registered")
-	}
+	assert.Falsef(t, wt.IsRegistered(4), "event ID 4 shouldn't be registered")
 
 	wt.Trigger(0, "foo")
-	if wt.IsRegistered(0) {
-		t.Errorf("event ID 0 is already triggered, shouldn't be registered")
-	}
+	assert.Falsef(t, wt.IsRegistered(0), "event ID 0 is already triggered, shouldn't be registered")
 }


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in pkg package

Related to #18972