### PR TITLE
Remove some HealthInterval to reduce the time to run DowngradeUpgradeMembers

### DIFF
--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
-	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -77,9 +76,6 @@ func DowngradeUpgradeMembers(t *testing.T, lg *zap.Logger, clus *EtcdProcessClus
 	}
 	membersToChange := rand.Perm(len(clus.Procs))[:numberOfMembersToChange]
 	lg.Info(fmt.Sprintf("Test %s members", opString), zap.Any("members", membersToChange))
-
-	// Need to wait health interval for cluster to prepare for downgrade/upgrade
-	time.Sleep(etcdserver.HealthInterval)
 
 	for _, memberID := range membersToChange {
 		member := clus.Procs[memberID]

--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -226,8 +226,6 @@ func (f memberDowngradeUpgrade) Inject(ctx context.Context, t *testing.T, lg *za
 	}
 	defer cc.Close()
 
-	// Need to wait health interval for cluster to accept changes
-	time.Sleep(etcdserver.HealthInterval)
 	e2e.DowngradeEnable(t, clus, lastVersion)
 	// downgrade all members first
 	err = e2e.DowngradeUpgradeMembers(t, lg, clus, len(clus.Procs), currentVersion, lastVersion)


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/19306.

This would reduce the time to run DowngradeUpgradeMembers. But it still would not complete in 1min (still needs about 90s with this change for downgrading and upgrading all 3 members).

@gangli113 is working on changing the failpoint timeout for the `MemberDowngradeUpgrade` failpoint. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
