### PR TITLE
*: introduce (*Op) Limit() interface for robustness

### DIFF
--- a/client/v3/op.go
+++ b/client/v3/op.go
@@ -106,6 +106,9 @@ func (op Op) RangeBytes() []byte { return op.end }
 // Rev returns the requested revision, if any.
 func (op Op) Rev() int64 { return op.rev }
 
+// Limit returns limit of the result, if any.
+func (op Op) Limit() int64 { return op.limit }
+
 // IsPut returns true iff the operation is a Put.
 func (op Op) IsPut() bool { return op.t == tPut }
 

--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -88,8 +88,8 @@ func (c *RecordingClient) Do(ctx context.Context, op clientv3.Op) (clientv3.OpRe
 }
 
 func (c *RecordingClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-	revision := clientv3.OpGet(key, opts...).Rev()
-	return c.Range(ctx, key, "", revision, 0)
+	op := clientv3.OpGet(key, opts...)
+	return c.Range(ctx, key, string(op.RangeBytes()), op.Rev(), op.Limit())
 }
 
 func (c *RecordingClient) Range(ctx context.Context, start, end string, revision, limit int64) (*clientv3.GetResponse, error) {


### PR DESCRIPTION
Since #19137, kubernetes traffic profile is unable to send List request with page size, because limit in option is not accessable. To fix it, this fix is to introduce Limit() interface.

Fixes: #19292


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
