### PR TITLE
fix test.sh to download correct binary for mac os

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -576,7 +576,13 @@ function release_pass {
     log_warning "fallback to" ${UPGRADE_VER}
   fi
 
-  local file="etcd-$UPGRADE_VER-linux-$GOARCH.tar.gz"
+  local file
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    file="etcd-$UPGRADE_VER-darwin-$GOARCH.zip"
+  else
+    file="etcd-$UPGRADE_VER-linux-$GOARCH.tar.gz"
+  fi
+
   log_callout "Downloading $file"
 
   set +e


### PR DESCRIPTION
When testing on mac os, the script downloads incorrect binary, `ELF 64-bit LSB executable, x86-64, version 1 (SYSV)`, which is not executable on MAC OS. 

With this change, the script downloads executable binary, `Mach-O 64-bit executable x86_64`