### PR TITLE
fileutil: removes redundant continue statement in RemoveMatchFile

### DIFF
--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -160,7 +160,6 @@ func RemoveMatchFile(lg *zap.Logger, dir string, matchFunc func(fileName string)
 				lg.Error("remove file failed",
 					zap.String("file", file),
 					zap.Error(err))
-				continue
 			}
 		}
 	}


### PR DESCRIPTION
Looks to my eyes that the `continue` statement in `RemoveMatchFile` is redundant? I see no logic below it in the enclosing for loop.


