### PR TITLE
migrate experimental-downgrade-checktime to downgrade-checktime

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -141,6 +141,7 @@ var (
 		"experimental-bootstrap-defrag-threshold-megabytes": "bootstrap-defrag-threshold-megabytes",
 		"experimental-max-learners":                         "max-learners",
 		"experimental-memory-mlock":                         "memory-mlock",
+		"experimental-downgrade-check-time":                 "downgrade-check-time",
 	}
 )
 
@@ -487,7 +488,12 @@ type Config struct {
 	// Setting this is unsafe and will cause data loss.
 	UnsafeNoFsync bool `json:"unsafe-no-fsync"`
 
+	// ExperimentalDowngradeCheckTime is the duration between two downgrade status checks (in seconds).
+	// Deprecated in v3.6 and scheduled to be removed in v3.7.
+	// TODO: Delete `ExperimentalDowngradeCheckTime` in v3.7.
 	ExperimentalDowngradeCheckTime time.Duration `json:"experimental-downgrade-check-time"`
+	// DowngradeCheckTime is the duration between two downgrade status checks (in seconds).
+	DowngradeCheckTime time.Duration `json:"downgrade-check-time"`
 
 	// MemoryMlock enables mlocking of etcd owned memory pages.
 	// The setting improves etcd tail latency in environments were:
@@ -617,6 +623,7 @@ func NewConfig() *Config {
 		EnableGRPCGateway:     true,
 
 		ExperimentalDowngradeCheckTime: DefaultDowngradeCheckTime,
+		DowngradeCheckTime:             DefaultDowngradeCheckTime,
 		MemoryMlock:                    false,
 		// TODO: delete in v3.7
 		ExperimentalMemoryMlock:             false,
@@ -827,7 +834,9 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	// TODO: delete in v3.7
 	fs.DurationVar(&cfg.ExperimentalWatchProgressNotifyInterval, "experimental-watch-progress-notify-interval", cfg.ExperimentalWatchProgressNotifyInterval, "Duration of periodic watch progress notifications. Deprecated in v3.6 and will be decommissioned in v3.7. Use --watch-progress-notify-interval instead.")
 	fs.DurationVar(&cfg.WatchProgressNotifyInterval, "watch-progress-notify-interval", cfg.WatchProgressNotifyInterval, "Duration of periodic watch progress notifications.")
-	fs.DurationVar(&cfg.ExperimentalDowngradeCheckTime, "experimental-downgrade-check-time", cfg.ExperimentalDowngradeCheckTime, "Duration of time between two downgrade status checks.")
+	fs.DurationVar(&cfg.DowngradeCheckTime, "downgrade-check-time", cfg.DowngradeCheckTime, "Duration of time between two downgrade status checks.")
+	// TODO: delete in v3.7
+	fs.DurationVar(&cfg.ExperimentalDowngradeCheckTime, "experimental-downgrade-check-time", cfg.ExperimentalDowngradeCheckTime, "Duration of time between two downgrade status checks. Deprecated in v3.6 and will be decommissioned in v3.7. Use --downgrade-check-time instead.")
 	// TODO: delete in v3.7
 	fs.DurationVar(&cfg.ExperimentalWarningApplyDuration, "experimental-warning-apply-duration", cfg.ExperimentalWarningApplyDuration, "Time duration after which a warning is generated if request takes more time. Deprecated in v3.6 and will be decommissioned in v3.7. Use --warning-watch-progress-duration instead.")
 	fs.DurationVar(&cfg.WarningApplyDuration, "warning-apply-duration", cfg.WarningApplyDuration, "Time duration after which a warning is generated if watch progress takes more time.")

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -229,7 +229,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		CompactionBatchLimit:                 cfg.CompactionBatchLimit,
 		CompactionSleepInterval:              cfg.ExperimentalCompactionSleepInterval,
 		WatchProgressNotifyInterval:          cfg.WatchProgressNotifyInterval,
-		DowngradeCheckTime:                   cfg.ExperimentalDowngradeCheckTime,
+		DowngradeCheckTime:                   cfg.DowngradeCheckTime,
 		WarningApplyDuration:                 cfg.WarningApplyDuration,
 		WarningUnaryRequestDuration:          cfg.WarningUnaryRequestDuration,
 		MemoryMlock:                          cfg.MemoryMlock,

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -72,6 +72,7 @@ var (
 		"experimental-bootstrap-defrag-threshold-megabytes": "--experimental-bootstrap-defrag-threshold-megabytes is deprecated in v3.6 and will be decommissioned in v3.7. Use '--bootstrap-defrag-threshold-megabytes' instead.",
 		"experimental-max-learners":                         "--experimental-max-learners is deprecated in v3.6 and will be decommissioned in v3.7. Use '--max-learners' instead.",
 		"experimental-memory-mlock":                         "--experimental-memory-mlock is deprecated in v3.6 and will be decommissioned in v3.7. Use '--memory-mlock' instead.",
+		"experimental-downgrade-check-time":                 "--experimental-downgrade-check-time is deprecated in v3.6 and will be decommissioned in v3.7. Use '--downgrade-check-time' instead.",
 	}
 )
 
@@ -207,6 +208,10 @@ func (cfg *config) parse(arguments []string) error {
 
 	if cfg.ec.FlagsExplicitlySet["experimental-memory-mlock"] {
 		cfg.ec.MemoryMlock = cfg.ec.ExperimentalMemoryMlock
+	}
+
+	if cfg.ec.FlagsExplicitlySet["experimental-downgrade-check-time"] {
+		cfg.ec.DowngradeCheckTime = cfg.ec.ExperimentalDowngradeCheckTime
 	}
 
 	// `V2Deprecation` (--v2-deprecation) is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input.

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -320,6 +320,8 @@ Experimental feature:
   --experimental-compaction-sleep-interval
     Sets the sleep interval between each compaction batch.
   --experimental-downgrade-check-time
+    Duration of time between two downgrade status checks. Deprecated in v3.6 and will be decommissioned in v3.7. Use "downgrade-check-time" instead.
+  --downgrade-check-time
     Duration of time between two downgrade status checks.
   --experimental-enable-lease-checkpoint-persist 'false'
     Enable persisting remainingTTL to prevent indefinite auto-renewal of long lived leases. Always enabled in v3.6. Should be used to ensure smooth upgrade from v3.5 clusters with this feature enabled. Requires experimental-enable-lease-checkpoint to be enabled.


### PR DESCRIPTION
Migrate flag `experimental-downgrade-check-time` to `downgrade-check-time`.

Sub task from https://github.com/etcd-io/etcd/issues/19141

