### PR TITLE
chore: use testify instead of testing in tests/integration

### DIFF
--- a/tests/integration/clientv3/cluster_test.go
+++ b/tests/integration/clientv3/cluster_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 )
@@ -267,9 +269,7 @@ func TestMemberPromote(t *testing.T) {
 	// (the response has information on peer urls of the existing members in cluster)
 	clus.InitializeMemberWithResponse(t, learnerMember, memberAddResp)
 
-	if err = learnerMember.Launch(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, learnerMember.Launch())
 
 	// retry until promote succeed or timeout
 	timeout := time.After(5 * time.Second)

--- a/tests/integration/clientv3/concurrency/session_test.go
+++ b/tests/integration/clientv3/concurrency/session_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -28,18 +29,12 @@ import (
 
 func TestSessionOptions(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 	lease, err := cli.Grant(context.Background(), 100)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s, err := concurrency.NewSession(cli, concurrency.WithLease(lease.ID))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer s.Close()
 	assert.Equal(t, s.Lease(), lease.ID)
 
@@ -53,16 +48,12 @@ func TestSessionOptions(t *testing.T) {
 
 func TestSessionTTLOptions(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	setTTL := 90
 	s, err := concurrency.NewSession(cli, concurrency.WithTTL(setTTL))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer s.Close()
 
 	leaseID := s.Lease()
@@ -84,18 +75,12 @@ func TestSessionTTLOptions(t *testing.T) {
 
 func TestSessionCtx(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 	lease, err := cli.Grant(context.Background(), 100)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s, err := concurrency.NewSession(cli, concurrency.WithLease(lease.ID))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer s.Close()
 	assert.Equal(t, s.Lease(), lease.ID)
 

--- a/tests/integration/clientv3/connectivity/black_hole_test.go
+++ b/tests/integration/clientv3/connectivity/black_hole_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -62,9 +63,7 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	timeout := pingInterval + integration2.RequestWaitTimeout
 
 	cli, err := integration2.NewClient(t, ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	wch := cli.Watch(context.Background(), "foo", clientv3.WithCreatedNotify())
@@ -80,9 +79,8 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 
 	clus.Members[0].Bridge().Blackhole()
 
-	if _, err = clus.Client(1).Put(context.TODO(), "foo", "bar"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(1).Put(context.TODO(), "foo", "bar")
+	require.NoError(t, err)
 	select {
 	case <-wch:
 	case <-time.After(timeout):
@@ -97,12 +95,10 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	clus.Members[1].Bridge().Blackhole()
 
 	// make sure client[0] can connect to eps[0] after remove the blackhole.
-	if _, err = clus.Client(0).Get(context.TODO(), "foo"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err = clus.Client(0).Put(context.TODO(), "foo", "bar1"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Get(context.TODO(), "foo")
+	require.NoError(t, err)
+	_, err = clus.Client(0).Put(context.TODO(), "foo", "bar1")
+	require.NoError(t, err)
 
 	select {
 	case <-wch:
@@ -183,9 +179,7 @@ func testBalancerUnderBlackholeNoKeepAlive(t *testing.T, op func(*clientv3.Clien
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 	cli, err := integration2.NewClient(t, ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	// wait for eps[0] to be pinned
@@ -214,7 +208,5 @@ func testBalancerUnderBlackholeNoKeepAlive(t *testing.T, op func(*clientv3.Clien
 			t.Errorf("#%d: failed with error %v", i, err)
 		}
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -124,9 +125,7 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 	cli, err := integration2.NewClient(t, ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 	// wait for eps[0] to be pinned
 	clientv3test.MustWaitPinReady(t, cli)
@@ -180,9 +179,7 @@ func TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection(t *testing.T
 		DialTimeout: 2 * time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	// add all eps to list, so that when the original pined one fails
@@ -201,9 +198,7 @@ func TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection(t *testing.T
 			break
 		}
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestBalancerUnderNetworkPartitionWatchLeader(t *testing.T) {
@@ -233,9 +228,7 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 
 	// pin eps[target]
 	watchCli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[target]}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("watchCli created to: %v", target)
 	defer watchCli.Close()
 
@@ -291,9 +284,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 	cli, err := integration2.NewClient(t, ccfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	// wait for eps[0] to be pinned
@@ -303,9 +294,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 	cli.SetEndpoints(eps...)
 	time.Sleep(time.Second * 2)
 	conn, err := cli.Dial(clus.Members[(leaderIndex+1)%3].GRPCURL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer conn.Close()
 
 	clus.Members[leaderIndex].InjectPartition(t, clus.Members[(leaderIndex+1)%3], clus.Members[(leaderIndex+2)%3])

--- a/tests/integration/clientv3/connectivity/server_shutdown_test.go
+++ b/tests/integration/clientv3/connectivity/server_shutdown_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
@@ -45,9 +47,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 
 	// pin eps[lead]
 	watchCli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[lead]}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer watchCli.Close()
 
 	// wait for eps[lead] to be pinned
@@ -91,9 +91,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 
 	// writes to eps[lead+1]
 	putCli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[(lead+1)%3]}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer putCli.Close()
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -154,9 +152,7 @@ func testBalancerUnderServerShutdownMutable(t *testing.T, op func(*clientv3.Clie
 
 	// pin eps[0]
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: []string{eps[0]}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 
 	// wait for eps[0] to be pinned
@@ -177,9 +173,7 @@ func testBalancerUnderServerShutdownMutable(t *testing.T, op func(*clientv3.Clie
 	cctx, ccancel := context.WithTimeout(context.Background(), time.Second)
 	err = op(cli, cctx)
 	ccancel()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestBalancerUnderServerShutdownGetLinearizable(t *testing.T) {

--- a/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -216,9 +217,7 @@ func TestDoubleBarrierFailover(t *testing.T) {
 		}
 	}
 
-	if err = s0.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s0.Close())
 	// join on rest of waiters
 	for i := 0; i < waiters-1; i++ {
 		select {

--- a/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -182,14 +184,10 @@ func TestMutexSessionRelock(t *testing.T) {
 	}
 
 	m := concurrency.NewMutex(session, "test-mutex")
-	if err := m.Lock(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, m.Lock(context.TODO()))
 
 	m2 := concurrency.NewMutex(session, "test-mutex")
-	if err := m2.Lock(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, m2.Lock(context.TODO()))
 }
 
 // TestMutexWaitsOnCurrentHolder ensures a mutex is only acquired once all
@@ -211,9 +209,7 @@ func TestMutexWaitsOnCurrentHolder(t *testing.T) {
 	}
 	defer firstOwnerSession.Close()
 	firstOwnerMutex := concurrency.NewMutex(firstOwnerSession, "test-mutex")
-	if err = firstOwnerMutex.Lock(cctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, firstOwnerMutex.Lock(cctx))
 
 	victimSession, err := concurrency.NewSession(cli)
 	if err != nil {
@@ -286,9 +282,7 @@ func TestMutexWaitsOnCurrentHolder(t *testing.T) {
 	default:
 	}
 
-	if err := firstOwnerMutex.Unlock(cctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, firstOwnerMutex.Unlock(cctx))
 
 	select {
 	case <-newOwnerDonec:

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -61,9 +61,7 @@ func TestMaintenanceHashKV(t *testing.T) {
 		_, err := cli.Get(context.TODO(), "foo")
 		require.NoError(t, err)
 		hresp, err := cli.HashKV(context.Background(), clus.Members[i].GRPCURL, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if hv == 0 {
 			hv = hresp.Hash
 			continue
@@ -83,9 +81,7 @@ func TestCompactionHash(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cc, err := clus.ClusterClient(t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL}, 1000)
 }
@@ -140,9 +136,7 @@ func TestMaintenanceMoveLeader(t *testing.T) {
 
 	cli = clus.Client(oldLeadIdx)
 	_, err = cli.MoveLeader(context.Background(), target)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	leadIdx := clus.WaitLeader(t)
 	lead := uint64(clus.Members[leadIdx].ID())
@@ -172,9 +166,7 @@ func TestMaintenanceSnapshotCancel(t *testing.T) {
 	populateDataIntoCluster(t, clus, 3, 1024*1024)
 
 	rc1, err := clus.RandClient().Snapshot(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer rc1.Close()
 
 	// read 16 bytes to ensure that server opens snapshot
@@ -232,9 +224,7 @@ func testMaintenanceSnapshotTimeout(t *testing.T, snapshot func(context.Context,
 	populateDataIntoCluster(t, clus, 3, 1024*1024)
 
 	rc2, err := snapshot(ctx, clus.RandClient())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer rc2.Close()
 
 	time.Sleep(2 * time.Second)
@@ -290,9 +280,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 	// reading snapshot with canceled context should error out
 	ctx, cancel := context.WithCancel(context.Background())
 	rc1, err := snapshot(ctx, clus.RandClient())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer rc1.Close()
 
 	donec := make(chan struct{})
@@ -311,9 +299,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	rc2, err := snapshot(ctx, clus.RandClient())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer rc2.Close()
 
 	// 300ms left and expect timeout while snapshot reading is in progress
@@ -339,9 +325,7 @@ func TestMaintenanceSnapshotWithVersionVersion(t *testing.T) {
 
 	// reading snapshot with canceled context should error out
 	resp, err := clus.RandClient().SnapshotWithVersion(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer resp.Snapshot.Close()
 	if resp.Version != "3.6.0" {
 		t.Errorf("unexpected version, expected %q, got %q", version.Version, resp.Version)
@@ -411,18 +395,14 @@ func TestMaintenanceStatus(t *testing.T) {
 
 	t.Logf("Creating client...")
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: eps, DialOptions: []grpc.DialOption{grpc.WithBlock()}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer cli.Close()
 	t.Logf("Creating client [DONE]")
 
 	prevID, leaderFound := uint64(0), false
 	for i := 0; i < 3; i++ {
 		resp, err := cli.Status(context.TODO(), eps[i])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		t.Logf("Response from %v: %v", i, resp)
 		if resp.DbSizeQuota != storage.DefaultQuotaBytes {
 			t.Errorf("unexpected backend default quota returned: %d, expected %d", resp.DbSizeQuota, storage.DefaultQuotaBytes)

--- a/tests/integration/clientv3/metrics_test.go
+++ b/tests/integration/clientv3/metrics_test.go
@@ -30,6 +30,7 @@ import (
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"go.etcd.io/etcd/client/pkg/v3/transport"
@@ -86,9 +87,7 @@ func TestV3ClientMetrics(t *testing.T) {
 		},
 	}
 	cli, cerr := integration2.NewClient(t, cfg)
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer cli.Close()
 
 	wc := cli.Watch(context.Background(), "foo")

--- a/tests/integration/clientv3/mirror_auth_test.go
+++ b/tests/integration/clientv3/mirror_auth_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -45,9 +46,7 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 
 	// Seed /syncpath with some initial data
 	_, err := initialClient.KV.Put(context.TODO(), "/syncpath/foo", "bar")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Require authentication
 	authSetupRoot(t, initialClient.Auth)
@@ -61,9 +60,7 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 		Password:    "syncfoo",
 	}
 	syncClient, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer syncClient.Close()
 
 	// Now run the sync process, create changes, and get the initial sync state
@@ -86,9 +83,7 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 
 	// Update state
 	_, err = syncClient.KV.Put(context.TODO(), "/syncpath/foo", "baz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Wait for the updated state to sync
 	select {

--- a/tests/integration/clientv3/mirror_test.go
+++ b/tests/integration/clientv3/mirror_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/client/v3/mirror"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
@@ -35,9 +37,7 @@ func TestMirrorSync(t *testing.T) {
 
 	c := clus.Client(0)
 	_, err := c.KV.Put(context.TODO(), "foo", "bar")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	syncer := mirror.NewSyncer(c, "", 0)
 	gch, ech := syncer.SyncBase(context.TODO())
@@ -56,9 +56,7 @@ func TestMirrorSync(t *testing.T) {
 	wch := syncer.SyncUpdates(context.TODO())
 
 	_, err = c.KV.Put(context.TODO(), "foo", "bar")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	select {
 	case r := <-wch:

--- a/tests/integration/clientv3/namespace_test.go
+++ b/tests/integration/clientv3/namespace_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/namespace"
@@ -34,21 +36,16 @@ func TestNamespacePutGet(t *testing.T) {
 	c := clus.Client(0)
 	nsKV := namespace.NewKV(c.KV, "foo/")
 
-	if _, err := nsKV.Put(context.TODO(), "abc", "bar"); err != nil {
-		t.Fatal(err)
-	}
+	_, err := nsKV.Put(context.TODO(), "abc", "bar")
+	require.NoError(t, err)
 	resp, err := nsKV.Get(context.TODO(), "abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if string(resp.Kvs[0].Key) != "abc" {
 		t.Errorf("expected key=%q, got key=%q", "abc", resp.Kvs[0].Key)
 	}
 
 	resp, err = c.Get(context.TODO(), "foo/abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if string(resp.Kvs[0].Value) != "bar" {
 		t.Errorf("expected value=%q, got value=%q", "bar", resp.Kvs[0].Value)
 	}
@@ -64,9 +61,8 @@ func TestNamespaceWatch(t *testing.T) {
 	nsKV := namespace.NewKV(c.KV, "foo/")
 	nsWatcher := namespace.NewWatcher(c.Watcher, "foo/")
 
-	if _, err := nsKV.Put(context.TODO(), "abc", "bar"); err != nil {
-		t.Fatal(err)
-	}
+	_, err := nsKV.Put(context.TODO(), "abc", "bar")
+	require.NoError(t, err)
 
 	nsWch := nsWatcher.Watch(context.TODO(), "abc", clientv3.WithRev(1))
 	wkv := &mvccpb.KeyValue{Key: []byte("abc"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}

--- a/tests/integration/clientv3/ordering_kv_test.go
+++ b/tests/integration/clientv3/ordering_kv_test.go
@@ -43,27 +43,21 @@ func TestDetectKvOrderViolation(t *testing.T) {
 		},
 	}
 	cli, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { assert.NoError(t, cli.Close()) }()
 	ctx := context.TODO()
 
-	if _, err = clus.Client(0).Put(ctx, "foo", "bar"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Put(ctx, "foo", "bar")
+	require.NoError(t, err)
 	// ensure that the second member has the current revision for the key foo
-	if _, err = clus.Client(1).Get(ctx, "foo"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(1).Get(ctx, "foo")
+	require.NoError(t, err)
 
 	// stop third member in order to force the member to have an outdated revision
 	clus.Members[2].Stop(t)
 	time.Sleep(1 * time.Second) // give enough time for operation
 	_, err = cli.Put(ctx, "foo", "buzz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// perform get request against the first member, in order to
 	// set up kvOrdering to expect "foo" revisions greater than that of
@@ -73,9 +67,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 			return errOrderViolation
 		})
 	v, err := orderingKv.Get(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("Read from the first member: v:%v err:%v", v, err)
 	assert.Equal(t, []byte("buzz"), v.Kvs[0].Value)
 
@@ -110,26 +102,21 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 		},
 	}
 	cli, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { assert.NoError(t, cli.Close()) }()
 	ctx := context.TODO()
 
-	if _, err = clus.Client(0).Put(ctx, "foo", "bar"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(0).Put(ctx, "foo", "bar")
+	require.NoError(t, err)
 	// ensure that the second member has the current revision for the key foo
-	if _, err = clus.Client(1).Get(ctx, "foo"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(1).Get(ctx, "foo")
+	require.NoError(t, err)
 
 	// stop third member in order to force the member to have an outdated revision
 	clus.Members[2].Stop(t)
 	time.Sleep(1 * time.Second) // give enough time for operation
-	if _, err = clus.Client(1).Put(ctx, "foo", "buzz"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = clus.Client(1).Put(ctx, "foo", "buzz")
+	require.NoError(t, err)
 
 	// perform get request against the first member, in order to
 	// set up kvOrdering to expect "foo" revisions greater than that of
@@ -144,9 +131,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	).Then(
 		clientv3.OpGet("foo"),
 	).Commit()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// ensure that only the third member is queried during requests
 	clus.Members[0].Stop(t)

--- a/tests/integration/clientv3/txn_test.go
+++ b/tests/integration/clientv3/txn_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -150,14 +152,10 @@ func TestTxnSuccess(t *testing.T) {
 	ctx := context.TODO()
 
 	_, err := kv.Txn(ctx).Then(clientv3.OpPut("foo", "bar")).Commit()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	resp, err := kv.Get(ctx, "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(resp.Kvs) != 1 || string(resp.Kvs[0].Key) != "foo" {
 		t.Fatalf("unexpected Get response %v", resp)
 	}
@@ -171,20 +169,15 @@ func TestTxnCompareRange(t *testing.T) {
 
 	kv := clus.Client(0)
 	fooResp, err := kv.Put(context.TODO(), "foo/", "bar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err = kv.Put(context.TODO(), "foo/a", "baz"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	_, err = kv.Put(context.TODO(), "foo/a", "baz")
+	require.NoError(t, err)
 	tresp, terr := kv.Txn(context.TODO()).If(
 		clientv3.Compare(
 			clientv3.CreateRevision("foo/"), "=", fooResp.Header.Revision).
 			WithPrefix(),
 	).Commit()
-	if terr != nil {
-		t.Fatal(terr)
-	}
+	require.NoError(t, terr)
 	if tresp.Succeeded {
 		t.Fatal("expected prefix compare to false, got compares as true")
 	}
@@ -204,25 +197,19 @@ func TestTxnNested(t *testing.T) {
 			clientv3.OpPut("foo", "bar"),
 			clientv3.OpTxn(nil, []clientv3.Op{clientv3.OpPut("abc", "123")}, nil)).
 		Else(clientv3.OpPut("foo", "baz")).Commit()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(tresp.Responses) != 2 {
 		t.Errorf("expected 2 top-level txn responses, got %+v", tresp.Responses)
 	}
 
 	// check txn writes were applied
 	resp, err := kv.Get(context.TODO(), "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(resp.Kvs) != 1 || string(resp.Kvs[0].Value) != "bar" {
 		t.Errorf("unexpected Get response %+v", resp)
 	}
 	resp, err = kv.Get(context.TODO(), "abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(resp.Kvs) != 1 || string(resp.Kvs[0].Value) != "123" {
 		t.Errorf("unexpected Get response %+v", resp)
 	}

--- a/tests/integration/clientv3/user_test.go
+++ b/tests/integration/clientv3/user_test.go
@@ -37,9 +37,7 @@ func TestUserError(t *testing.T) {
 	authapi := clus.RandClient()
 
 	_, err := authapi.UserAdd(context.TODO(), "foo", "bar")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = authapi.UserAdd(context.TODO(), "foo", "bar")
 	if !errors.Is(err, rpctypes.ErrUserAlreadyExist) {
@@ -138,29 +136,22 @@ func TestUserErrorAuth(t *testing.T) {
 
 	cfg.Username, cfg.Password = "root", "123"
 	authed, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer authed.Close()
 
-	if _, err := authed.UserList(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	_, err = authed.UserList(context.TODO())
+	require.NoError(t, err)
 }
 
 func authSetupRoot(t *testing.T, auth clientv3.Auth) {
-	if _, err := auth.UserAdd(context.TODO(), "root", "123"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := auth.RoleAdd(context.TODO(), "root"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := auth.UserGrantRole(context.TODO(), "root", "root"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := auth.AuthEnable(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	_, err := auth.UserAdd(context.TODO(), "root", "123")
+	require.NoError(t, err)
+	_, err = auth.RoleAdd(context.TODO(), "root")
+	require.NoError(t, err)
+	_, err = auth.UserGrantRole(context.TODO(), "root", "root")
+	require.NoError(t, err)
+	_, err = auth.AuthEnable(context.TODO())
+	require.NoError(t, err)
 }
 
 // TestGetTokenWithoutAuth is when Client can connect to etcd even if they
@@ -177,9 +168,8 @@ func TestGetTokenWithoutAuth(t *testing.T) {
 	var client *clientv3.Client
 
 	// make sure "auth" was disabled
-	if _, err = authapi.AuthDisable(context.TODO()); err != nil {
-		t.Fatal(err)
-	}
+	_, err = authapi.AuthDisable(context.TODO())
+	require.NoError(t, err)
 
 	// "Username" and "Password" must be used
 	cfg := clientv3.Config{

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -98,13 +98,9 @@ func testMetricDbSizeDefrag(t *testing.T, name string) {
 		time.Sleep(500 * time.Millisecond)
 
 		afterCompactionInUse, verr := clus.Members[0].Metric("etcd_mvcc_db_total_size_in_use_in_bytes")
-		if verr != nil {
-			t.Fatal(verr)
-		}
+		require.NoError(t, verr)
 		aciu, verr := strconv.Atoi(afterCompactionInUse)
-		if verr != nil {
-			t.Fatal(verr)
-		}
+		require.NoError(t, verr)
 		if biu <= aciu {
 			return fmt.Errorf("expected less than %d, got %d after compaction", biu, aciu)
 		}

--- a/tests/integration/v3_alarm_test.go
+++ b/tests/integration/v3_alarm_test.go
@@ -57,9 +57,7 @@ func TestV3StorageQuotaApply(t *testing.T) {
 	// test small put still works
 	smallbuf := make([]byte, 1024)
 	_, serr := kvc0.Put(context.TODO(), &pb.PutRequest{Key: key, Value: smallbuf})
-	if serr != nil {
-		t.Fatal(serr)
-	}
+	require.NoError(t, serr)
 
 	// test big put
 	bigbuf := make([]byte, quotasize)
@@ -75,9 +73,7 @@ func TestV3StorageQuotaApply(t *testing.T) {
 	for {
 		req := &pb.AlarmRequest{Action: pb.AlarmRequest_GET}
 		resp, aerr := clus.Members[0].Server.Alarm(context.TODO(), req)
-		if aerr != nil {
-			t.Fatal(aerr)
-		}
+		require.NoError(t, aerr)
 		if len(resp.Alarms) != 0 {
 			break
 		}

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -86,9 +86,7 @@ func TestV3AuthTokenWithDisable(t *testing.T) {
 	authSetupRoot(t, integration.ToGRPC(clus.Client(0)).Auth)
 
 	c, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer c.Close()
 
 	rctx, cancel := context.WithCancel(context.TODO())
@@ -119,17 +117,13 @@ func TestV3AuthRevision(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	presp, perr := api.KV.Put(ctx, &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	cancel()
-	if perr != nil {
-		t.Fatal(perr)
-	}
+	require.NoError(t, perr)
 	rev := presp.Header.Revision
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	aresp, aerr := api.Auth.UserAdd(ctx, &pb.AuthUserAddRequest{Name: "root", Password: "123", Options: &authpb.UserAddOptions{NoPassword: false}})
 	cancel()
-	if aerr != nil {
-		t.Fatal(aerr)
-	}
+	require.NoError(t, aerr)
 	if aresp.Header.Revision != rev {
 		t.Fatalf("revision expected %d, got %d", rev, aresp.Header.Revision)
 	}
@@ -161,9 +155,7 @@ func testV3AuthWithLeaseRevokeWithRoot(t *testing.T, ccfg integration.ClusterCon
 		Username:  "root",
 		Password:  "123",
 	})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer rootc.Close()
 
 	leaseResp, err := rootc.Grant(context.TODO(), 2)
@@ -219,9 +211,7 @@ func TestV3AuthWithLeaseRevoke(t *testing.T) {
 	authSetupRoot(t, integration.ToGRPC(clus.Client(0)).Auth)
 
 	rootc, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "root", Password: "123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer rootc.Close()
 
 	leaseResp, err := rootc.Grant(context.TODO(), 90)
@@ -232,9 +222,7 @@ func TestV3AuthWithLeaseRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	userc, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer userc.Close()
 	_, err = userc.Revoke(context.TODO(), leaseID)
 	if err == nil {
@@ -268,15 +256,11 @@ func TestV3AuthWithLeaseAttach(t *testing.T) {
 	authSetupRoot(t, integration.ToGRPC(clus.Client(0)).Auth)
 
 	user1c, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer user1c.Close()
 
 	user2c, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user2", Password: "user2-123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer user2c.Close()
 
 	leaseResp, err := user1c.Grant(context.TODO(), 90)
@@ -421,9 +405,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 	authSetupRoot(t, integration.ToGRPC(clus.Client(0)).Auth)
 
 	c, cerr := integration.NewClient(t, clientv3.Config{Endpoints: clus.Client(0).Endpoints(), Username: "user1", Password: "user1-123"})
-	if cerr != nil {
-		t.Fatal(cerr)
-	}
+	require.NoError(t, cerr)
 	defer c.Close()
 
 	watchStartCh, watchEndCh := make(chan any), make(chan any)

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -671,9 +671,7 @@ func TestV3PutIgnoreValue(t *testing.T) {
 	lc := integration.ToGRPC(clus.RandClient()).Lease
 	lresp, err := lc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 
 	tests := []struct {
 		putFunc  func() error
@@ -802,9 +800,7 @@ func TestV3PutIgnoreLease(t *testing.T) {
 	lc := integration.ToGRPC(clus.RandClient()).Lease
 	lresp, err := lc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 
 	key, val, val1 := []byte("zoo"), []byte("bar"), []byte("bar1")
 	putReq := pb.PutRequest{Key: key, Value: val}
@@ -1644,9 +1640,7 @@ func TestTLSReloadAtomicReplace(t *testing.T) {
 
 	cloneFunc := func() transport.TLSInfo {
 		tlsInfo, terr := copyTLSFiles(integration.TestTLSInfo, certsDir)
-		if terr != nil {
-			t.Fatal(terr)
-		}
+		require.NoError(t, terr)
 		_, err := copyTLSFiles(integration.TestTLSInfoExpired, certsDirExp)
 		require.NoError(t, err)
 		return tlsInfo
@@ -1680,9 +1674,7 @@ func TestTLSReloadCopy(t *testing.T) {
 
 	cloneFunc := func() transport.TLSInfo {
 		tlsInfo, terr := copyTLSFiles(integration.TestTLSInfo, certsDir)
-		if terr != nil {
-			t.Fatal(terr)
-		}
+		require.NoError(t, terr)
 		return tlsInfo
 	}
 	replaceFunc := func() {
@@ -1704,9 +1696,7 @@ func TestTLSReloadCopyIPOnly(t *testing.T) {
 
 	cloneFunc := func() transport.TLSInfo {
 		tlsInfo, terr := copyTLSFiles(integration.TestTLSInfoIP, certsDir)
-		if terr != nil {
-			t.Fatal(terr)
-		}
+		require.NoError(t, terr)
 		return tlsInfo
 	}
 	replaceFunc := func() {
@@ -1787,9 +1777,7 @@ func testTLSReload(
 
 	// 7. new requests should trigger listener to reload valid certs
 	tls, terr := tlsInfo.ClientConfig()
-	if terr != nil {
-		t.Fatal(terr)
-	}
+	require.NoError(t, terr)
 	cl, cerr := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 5 * time.Second,

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -52,9 +52,7 @@ func TestV3LeasePromote(t *testing.T) {
 	ttl := time.Duration(lresp.TTL) * time.Second
 	afterGrant := time.Now()
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 
 	// wait until the lease is going to expire.
 	time.Sleep(time.Until(afterGrant.Add(ttl - time.Second)))
@@ -436,9 +434,7 @@ func TestV3LeaseExists(t *testing.T) {
 		ctx0,
 		&pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 
 	if !leaseExist(t, clus, lresp.ID) {
 		t.Error("unexpected lease not exists")
@@ -461,9 +457,7 @@ func TestV3LeaseLeases(t *testing.T) {
 			ctx0,
 			&pb.LeaseGrantRequest{TTL: 30})
 		require.NoError(t, err)
-		if lresp.Error != "" {
-			t.Fatal(lresp.Error)
-		}
+		require.Empty(t, lresp.Error)
 		ids = append(ids, lresp.ID)
 	}
 
@@ -696,9 +690,7 @@ func TestV3LeaseFailover(t *testing.T) {
 	// create lease
 	lresp, err := lc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 5})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 
 	// isolate the current leader with its followers.
 	clus.Members[toIsolate].Pause()
@@ -789,9 +781,7 @@ func TestV3LeaseRecoverAndRevoke(t *testing.T) {
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
 	require.NoError(t, err)
 
@@ -830,9 +820,7 @@ func TestV3LeaseRevokeAndRecover(t *testing.T) {
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
 	require.NoError(t, err)
 
@@ -872,9 +860,7 @@ func TestV3LeaseRecoverKeyWithDetachedLease(t *testing.T) {
 
 	lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
 	require.NoError(t, err)
-	if lresp.Error != "" {
-		t.Fatal(lresp.Error)
-	}
+	require.Empty(t, lresp.Error)
 	_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})
 	require.NoError(t, err)
 
@@ -918,9 +904,7 @@ func TestV3LeaseRecoverKeyWithMutipleLease(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		lresp, err := lsc.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: fiveMinTTL})
 		require.NoError(t, err)
-		if lresp.Error != "" {
-			t.Fatal(lresp.Error)
-		}
+		require.Empty(t, lresp.Error)
 		leaseIDs = append(leaseIDs, lresp.ID)
 
 		_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar"), Lease: lresp.ID})

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -586,9 +586,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
-	if werr != nil {
-		t.Fatal(werr)
-	}
+	require.NoError(t, werr)
 	req := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
 			Key: []byte("foo"),
@@ -606,9 +604,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 
 	// check received PUT
 	resp, rerr := ws.Recv()
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
+	require.NoError(t, rerr)
 	wevs := []*mvccpb.Event{
 		{
 			Type: mvccpb.PUT,
@@ -1227,9 +1223,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
-	if werr != nil {
-		t.Fatal(werr)
-	}
+	require.NoError(t, werr)
 	req := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 		CreateRequest: &pb.WatchCreateRequest{
 			Key:     []byte("foo"),
@@ -1309,9 +1303,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 		require.NoError(t, err)
 
 		ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(wctx)
-		if werr != nil {
-			t.Fatal(werr)
-		}
+		require.NoError(t, werr)
 
 		req := &pb.WatchRequest{RequestUnion: &pb.WatchRequest_CreateRequest{
 			CreateRequest: &pb.WatchCreateRequest{

--- a/tests/integration/v3election_grpc_test.go
+++ b/tests/integration/v3election_grpc_test.go
@@ -42,9 +42,7 @@ func TestV3ElectionCampaign(t *testing.T) {
 	lc := integration.ToGRPC(clus.Client(0)).Election
 	req1 := &epb.CampaignRequest{Name: []byte("foo"), Lease: lease1.ID, Value: []byte("abc")}
 	l1, lerr1 := lc.Campaign(context.TODO(), req1)
-	if lerr1 != nil {
-		t.Fatal(lerr1)
-	}
+	require.NoError(t, lerr1)
 
 	campaignc := make(chan struct{})
 	go func() {
@@ -65,9 +63,8 @@ func TestV3ElectionCampaign(t *testing.T) {
 		t.Fatalf("got leadership before resign")
 	}
 
-	if _, uerr := lc.Resign(context.TODO(), &epb.ResignRequest{Leader: l1.Leader}); uerr != nil {
-		t.Fatal(uerr)
-	}
+	_, uerr := lc.Resign(context.TODO(), &epb.ResignRequest{Leader: l1.Leader})
+	require.NoError(t, uerr)
 
 	select {
 	case <-time.After(200 * time.Millisecond):
@@ -76,9 +73,7 @@ func TestV3ElectionCampaign(t *testing.T) {
 	}
 
 	lval, lverr := lc.Leader(context.TODO(), &epb.LeaderRequest{Name: []byte("foo")})
-	if lverr != nil {
-		t.Fatal(lverr)
-	}
+	require.NoError(t, lverr)
 
 	if string(lval.Kv.Value) != "def" {
 		t.Fatalf("got election value %q, expected %q", string(lval.Kv.Value), "def")

--- a/tests/integration/v3lock_grpc_test.go
+++ b/tests/integration/v3lock_grpc_test.go
@@ -40,9 +40,7 @@ func TestV3LockLockWaiter(t *testing.T) {
 
 	lc := integration.ToGRPC(clus.Client(0)).Lock
 	l1, lerr1 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})
-	if lerr1 != nil {
-		t.Fatal(lerr1)
-	}
+	require.NoError(t, lerr1)
 
 	lockc := make(chan struct{})
 	go func() {
@@ -62,9 +60,8 @@ func TestV3LockLockWaiter(t *testing.T) {
 		t.Fatalf("locked before unlock")
 	}
 
-	if _, uerr := lc.Unlock(context.TODO(), &lockpb.UnlockRequest{Key: l1.Key}); uerr != nil {
-		t.Fatal(uerr)
-	}
+	_, uerr := lc.Unlock(context.TODO(), &lockpb.UnlockRequest{Key: l1.Key})
+	require.NoError(t, uerr)
 
 	select {
 	case <-time.After(200 * time.Millisecond):


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal calls in tests/integration package.

@ahrtr, I’m sorry that this is so big but it’s only t.Fatal on errors replacements.

Related to #18972