### PR TITLE
changelog: update GO entry to reflect 1.22.12 update

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -14,7 +14,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 - Fix [runtime panic that occurs when KeepAlive is called with a Context implemented by an uncomparable type](https://github.com/etcd-io/etcd/pull/18936)
 
 ### Dependencies
-- Compile binaries using [go 1.22.11](https://github.com/etcd-io/etcd/pull/19212)
+- Compile binaries using [go 1.22.12](https://github.com/etcd-io/etcd/pull/19337)
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -11,6 +11,9 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### `tools/benchmark`
 - Backport [add mixed read-write performance evaluation scripts](https://github.com/etcd-io/etcd/pull/19275).
 
+### Dependencies
+- Compile binaries using [go 1.22.12](https://github.com/etcd-io/etcd/pull/19336).
+
 <hr>
 
 ## v3.5.18 (2025-01-24)


### PR DESCRIPTION
Update 3.4.36 and 3.5.18 to reflect the go 1.22.12 Update

Subtask of https://github.com/etcd-io/etcd/issues/19333
