### PR TITLE
Move interface `AlarmBackend` from `server/etcdserver/api/v3alarm` to `server/storage/schema` to fix the `unexported-return` lint error

### DIFF
--- a/server/etcdserver/api/v3alarm/alarms.go
+++ b/server/etcdserver/api/v3alarm/alarms.go
@@ -23,18 +23,11 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/schema"
 )
 
 type BackendGetter interface {
 	Backend() backend.Backend
-}
-
-type AlarmBackend interface {
-	CreateAlarmBucket()
-	MustPutAlarm(member *pb.AlarmMember)
-	MustDeleteAlarm(alarm *pb.AlarmMember)
-	GetAllAlarms() ([]*pb.AlarmMember, error)
-	ForceCommit()
 }
 
 type alarmSet map[types.ID]*pb.AlarmMember
@@ -45,10 +38,10 @@ type AlarmStore struct {
 	mu    sync.Mutex
 	types map[pb.AlarmType]alarmSet
 
-	be AlarmBackend
+	be schema.AlarmBackend
 }
 
-func NewAlarmStore(lg *zap.Logger, be AlarmBackend) (*AlarmStore, error) {
+func NewAlarmStore(lg *zap.Logger, be schema.AlarmBackend) (*AlarmStore, error) {
 	if lg == nil {
 		lg = zap.NewNop()
 	}

--- a/server/storage/schema/alarm.go
+++ b/server/storage/schema/alarm.go
@@ -21,12 +21,20 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/backend"
 )
 
+type AlarmBackend interface {
+	CreateAlarmBucket()
+	MustPutAlarm(member *etcdserverpb.AlarmMember)
+	MustDeleteAlarm(alarm *etcdserverpb.AlarmMember)
+	GetAllAlarms() ([]*etcdserverpb.AlarmMember, error)
+	ForceCommit()
+}
+
 type alarmBackend struct {
 	lg *zap.Logger
 	be backend.Backend
 }
 
-func NewAlarmBackend(lg *zap.Logger, be backend.Backend) *alarmBackend {
+func NewAlarmBackend(lg *zap.Logger, be backend.Backend) AlarmBackend {
 	return &alarmBackend{
 		lg: lg,
 		be: be,


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
