### PR TITLE
etcdutl: use map to count unique user keys in snapshot status

### DIFF
--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -126,6 +126,7 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 	defer db.Close()
 
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	seenKeys := make(map[string]struct{})
 
 	if err = db.View(func(tx *bolt.Tx) error {
 		// check snapshot file integrity first
@@ -175,8 +176,14 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 					if err != nil {
 						return fmt.Errorf("cannot unmarshal value, key: %q value: %q err: %w", k, v, err)
 					}
+					key := string(kv.Key)
+					// refer to https://etcd.io/docs/v3.5/learning/data_model/
+					if !mvcc.IsTombstone(k) {
+						seenKeys[key] = struct{}{}
+					} else {
+						delete(seenKeys, key)
+					}
 				}
-				ds.TotalKey++
 				return nil
 			}); err != nil {
 				return fmt.Errorf("error during bucket key iteration, name: %q err: %w", string(next), err)
@@ -187,6 +194,7 @@ func (s *v3Manager) Status(dbPath string) (ds Status, err error) {
 		return ds, err
 	}
 
+	ds.TotalKey = len(seenKeys)
 	ds.Hash = h.Sum32()
 	return ds, nil
 }

--- a/server/storage/mvcc/revision.go
+++ b/server/storage/mvcc/revision.go
@@ -120,3 +120,7 @@ func BytesToBucketKey(bytes []byte) BucketKey {
 func isTombstone(b []byte) bool {
 	return len(b) == markedRevBytesLen && b[markBytePosition] == markTombstone
 }
+
+func IsTombstone(b []byte) bool {
+	return isTombstone(b)
+}

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -279,8 +279,8 @@ func authTestSnapshot(cx ctlCtx) {
 	if st.Revision != 4 {
 		cx.t.Fatalf("expected 4, got %d", st.Revision)
 	}
-	if st.TotalKey < 3 {
-		cx.t.Fatalf("expected at least 3, got %d", st.TotalKey)
+	if st.TotalKey < 1 {
+		cx.t.Fatalf("expected at least 1, got %d", st.TotalKey)
 	}
 }
 

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -65,8 +65,8 @@ func snapshotTest(cx ctlCtx) {
 	if st.Revision != 5 {
 		cx.t.Fatalf("expected 4, got %d", st.Revision)
 	}
-	if st.TotalKey < 4 {
-		cx.t.Fatalf("expected at least 4, got %d", st.TotalKey)
+	if st.TotalKey < 2 {
+		cx.t.Fatalf("expected at least 2, got %d", st.TotalKey)
 	}
 }
 


### PR DESCRIPTION
The new implementation:
- Uses map to track unique keys for accurate counting
- Excludes internal built-in keys from total count
- Improves code maintainability

Although this approach uses additional memory for the map, the trade-off is acceptable since:
- Status() is not in hot path
- Correctness takes priority over performance optimization
- Simpler code is easier to maintain

Fixes #19253


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
