### PR TITLE
increase timeout for MemberDowngradeUpgrade test

### DIFF
--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -261,6 +261,10 @@ func (f memberDowngradeUpgrade) Available(config e2e.EtcdProcessClusterConfig, m
 	return v.Compare(v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
 }
 
+func (f memberDowngradeUpgrade) Timeout() time.Duration {
+	return 120 * time.Second
+}
+
 func getID(ctx context.Context, cc *clientv3.Client, name string) (id uint64, found bool, err error) {
 	// Ensure linearized MemberList by first making a linearized Get request from the same member.
 	// This is required for v3.4 support as it doesn't support linearized MemberList https://github.com/etcd-io/etcd/issues/18929

--- a/tests/robustness/failpoint/failpoint.go
+++ b/tests/robustness/failpoint/failpoint.go
@@ -80,7 +80,11 @@ func Validate(clus *e2e.EtcdProcessCluster, failpoint Failpoint, profile traffic
 }
 
 func Inject(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster, failpoint Failpoint, baseTime time.Time, ids identity.Provider) (*report.FailpointReport, error) {
-	ctx, cancel := context.WithTimeout(ctx, triggerTimeout)
+	timeout := triggerTimeout
+	if timeoutObj, ok := failpoint.(TimeoutInterface); ok {
+		timeout = timeoutObj.Timeout()
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	var err error
 
@@ -146,4 +150,8 @@ type Failpoint interface {
 
 type AvailabilityChecker interface {
 	Available(e2e.EtcdProcessClusterConfig, e2e.EtcdProcess, traffic.Profile) bool
+}
+
+type TimeoutInterface interface {
+	Timeout() time.Duration
 }


### PR DESCRIPTION
fix https://github.com/etcd-io/etcd/issues/19306

After increasing timeout of DowngradeUpgrade context, test passed
```
--- PASS: TestRobustnessExploratory (247.49s)
    --- PASS: TestRobustnessExploratory/EtcdHighTraffic/ClusterOfSize3 (111.99s)
        --- PASS: TestRobustnessExploratory/EtcdHighTraffic/ClusterOfSize3/MemberDowngradeUpgrade (109.36s)
    --- PASS: TestRobustnessExploratory/EtcdTrafficDeleteLeases/ClusterOfSize3 (61.07s)
        --- PASS: TestRobustnessExploratory/EtcdTrafficDeleteLeases/ClusterOfSize3/MemberDowngradeUpgrade (58.64s)
    --- PASS: TestRobustnessExploratory/KubernetesHighTraffic/ClusterOfSize3 (71.66s)
        --- PASS: TestRobustnessExploratory/KubernetesHighTraffic/ClusterOfSize3/MemberDowngradeUpgrade (69.18s)
    --- PASS: TestRobustnessExploratory/KubernetesLowTraffic/ClusterOfSize3 (2.75s)
PASS
ok      go.etcd.io/etcd/tests/v3/robustness     3385.637s
```
