### PR TITLE
Migrate WALVersion to fix unexported-return of walVersion

### DIFF
--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -97,7 +97,7 @@ func (o *migrateOptions) Config() (*migrateConfig, error) {
 type migrateConfig struct {
 	lg            *zap.Logger
 	targetVersion *semver.Version
-	walVersion    schema.WALVersion
+	walVersion    wal.Version
 	dataDir       string
 	force         bool
 }

--- a/server/storage/wal/version.go
+++ b/server/storage/wal/version.go
@@ -29,9 +29,15 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
+// Version defines the wal version interface.
+type Version interface {
+	// MinimalEtcdVersion returns minimal etcd version able to interpret WAL log.
+	MinimalEtcdVersion() *semver.Version
+}
+
 // ReadWALVersion reads remaining entries from opened WAL and returns struct
 // that implements schema.WAL interface.
-func ReadWALVersion(w *WAL) (*walVersion, error) {
+func ReadWALVersion(w *WAL) (Version, error) {
 	_, _, ents, err := w.ReadAll()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes WALVersion for [issue](https://github.com/etcd-io/etcd/issues/18370)
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
