### PR TITLE
migrate experimental-compaction-sleep-interval flag to compaction-sleep interval

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -148,6 +148,7 @@ var (
 		"experimental-bootstrap-defrag-threshold-megabytes": "bootstrap-defrag-threshold-megabytes",
 		"experimental-max-learners":                         "max-learners",
 		"experimental-memory-mlock":                         "memory-mlock",
+		"experimental-compaction-sleep-interval":            "compaction-sleep-interval",
 		"experimental-downgrade-check-time":                 "downgrade-check-time",
 	}
 )
@@ -407,7 +408,11 @@ type Config struct {
 	ExperimentalCompactionBatchLimit int `json:"experimental-compaction-batch-limit"`
 	CompactionBatchLimit             int `json:"compaction-batch-limit"`
 	// ExperimentalCompactionSleepInterval is the sleep interval between every etcd compaction loop.
+	// Deprecated in v3.6 and will be decommissioned in v3.7.
+	// TODO: Delete in v3.7
 	ExperimentalCompactionSleepInterval time.Duration `json:"experimental-compaction-sleep-interval"`
+	// CompactionSleepInterval is the sleep interval between every etcd compaction loop.
+	CompactionSleepInterval time.Duration `json:"compaction-sleep-interval"`
 	// ExperimentalWatchProgressNotifyInterval is the time duration of periodic watch progress notifications.
 	// Deprecated in v3.6 and will be decommissioned in v3.7.
 	// TODO: Delete in v3.7
@@ -847,7 +852,8 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	// TODO: delete in v3.7
 	fs.IntVar(&cfg.ExperimentalCompactionBatchLimit, "experimental-compaction-batch-limit", cfg.ExperimentalCompactionBatchLimit, "Sets the maximum revisions deleted in each compaction batch. Deprecated in v3.6 and will be decommissioned in v3.7. Use --compaction-batch-limit instead.")
 	fs.IntVar(&cfg.CompactionBatchLimit, "compaction-batch-limit", cfg.CompactionBatchLimit, "Sets the maximum revisions deleted in each compaction batch.")
-	fs.DurationVar(&cfg.ExperimentalCompactionSleepInterval, "experimental-compaction-sleep-interval", cfg.ExperimentalCompactionSleepInterval, "Sets the sleep interval between each compaction batch.")
+	fs.DurationVar(&cfg.ExperimentalCompactionSleepInterval, "experimental-compaction-sleep-interval", cfg.ExperimentalCompactionSleepInterval, "Sets the sleep interval between each compaction batch. Deprecated in v3.6 and will be decommissioned in v3.7. Use --compaction-sleep-interval instead.")
+	fs.DurationVar(&cfg.CompactionSleepInterval, "compaction-sleep-interval", cfg.CompactionSleepInterval, "Sets the sleep interval between each compaction batch.")
 	// TODO: delete in v3.7
 	fs.DurationVar(&cfg.ExperimentalWatchProgressNotifyInterval, "experimental-watch-progress-notify-interval", cfg.ExperimentalWatchProgressNotifyInterval, "Duration of periodic watch progress notifications. Deprecated in v3.6 and will be decommissioned in v3.7. Use --watch-progress-notify-interval instead.")
 	fs.DurationVar(&cfg.WatchProgressNotifyInterval, "watch-progress-notify-interval", cfg.WatchProgressNotifyInterval, "Duration of periodic watch progress notifications.")

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -227,7 +227,7 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		EnableLeaseCheckpoint:                cfg.ExperimentalEnableLeaseCheckpoint,
 		LeaseCheckpointPersist:               cfg.ExperimentalEnableLeaseCheckpointPersist,
 		CompactionBatchLimit:                 cfg.CompactionBatchLimit,
-		CompactionSleepInterval:              cfg.ExperimentalCompactionSleepInterval,
+		CompactionSleepInterval:              cfg.CompactionSleepInterval,
 		WatchProgressNotifyInterval:          cfg.WatchProgressNotifyInterval,
 		DowngradeCheckTime:                   cfg.DowngradeCheckTime,
 		WarningApplyDuration:                 cfg.WarningApplyDuration,

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -72,6 +72,7 @@ var (
 		"experimental-bootstrap-defrag-threshold-megabytes": "--experimental-bootstrap-defrag-threshold-megabytes is deprecated in v3.6 and will be decommissioned in v3.7. Use '--bootstrap-defrag-threshold-megabytes' instead.",
 		"experimental-max-learners":                         "--experimental-max-learners is deprecated in v3.6 and will be decommissioned in v3.7. Use '--max-learners' instead.",
 		"experimental-memory-mlock":                         "--experimental-memory-mlock is deprecated in v3.6 and will be decommissioned in v3.7. Use '--memory-mlock' instead.",
+		"experimental-compaction-sleep-interval":            "--experimental-compaction-sleep-interval is deprecated in v3.6 and will be decommissioned in v3.7. Use 'compaction-sleep-interval' instead.",
 		"experimental-downgrade-check-time":                 "--experimental-downgrade-check-time is deprecated in v3.6 and will be decommissioned in v3.7. Use '--downgrade-check-time' instead.",
 	}
 )
@@ -208,6 +209,10 @@ func (cfg *config) parse(arguments []string) error {
 
 	if cfg.ec.FlagsExplicitlySet["experimental-memory-mlock"] {
 		cfg.ec.MemoryMlock = cfg.ec.ExperimentalMemoryMlock
+	}
+
+	if cfg.ec.FlagsExplicitlySet["experimental-compaction-sleep-interval"] {
+		cfg.ec.CompactionSleepInterval = cfg.ec.ExperimentalCompactionSleepInterval
 	}
 
 	if cfg.ec.FlagsExplicitlySet["experimental-downgrade-check-time"] {

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -318,6 +318,8 @@ Experimental feature:
   --experimental-snapshot-catch-up-entries '5000'
     Number of entries for a slow follower to catch up after compacting the raft storage entries.
   --experimental-compaction-sleep-interval
+    Sets the sleep interval between each compaction batch.  Deprecated in v3.6 and will be decommissioned in v3.7. Use 'compaction-sleep-interval' instead.
+  --compaction-sleep-interval
     Sets the sleep interval between each compaction batch.
   --experimental-downgrade-check-time
     Duration of time between two downgrade status checks. Deprecated in v3.6 and will be decommissioned in v3.7. Use "downgrade-check-time" instead.


### PR DESCRIPTION
Migrate `experimental-compaction-sleep-interval` flag to `compaction-sleep-interval`

Sub task from https://github.com/etcd-io/etcd/issues/19141