### PR TITLE
migrate experimental-snapshot-catchup-entries flag to snapshot-catchup-entries

### DIFF
--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -72,6 +72,7 @@ var (
 		"experimental-bootstrap-defrag-threshold-megabytes": "--experimental-bootstrap-defrag-threshold-megabytes is deprecated in v3.6 and will be decommissioned in v3.7. Use '--bootstrap-defrag-threshold-megabytes' instead.",
 		"experimental-max-learners":                         "--experimental-max-learners is deprecated in v3.6 and will be decommissioned in v3.7. Use '--max-learners' instead.",
 		"experimental-memory-mlock":                         "--experimental-memory-mlock is deprecated in v3.6 and will be decommissioned in v3.7. Use '--memory-mlock' instead.",
+		"experimental-snapshot-catchup-entries":             "--experimental-snapshot-catchup-entries is deprecated in v3.6 and will be decommissioned in v3.7. Use '--snapshot-catchup-entries' instead.",
 		"experimental-compaction-sleep-interval":            "--experimental-compaction-sleep-interval is deprecated in v3.6 and will be decommissioned in v3.7. Use 'compaction-sleep-interval' instead.",
 		"experimental-downgrade-check-time":                 "--experimental-downgrade-check-time is deprecated in v3.6 and will be decommissioned in v3.7. Use '--downgrade-check-time' instead.",
 		"experimental-enable-distributed-tracing":           "--experimental-enable-distributed-tracing is deprecated in 3.6 and will be decommissioned in 3.7. Use --enable-distributed-tracing instead.",
@@ -217,6 +218,10 @@ func (cfg *config) parse(arguments []string) error {
 
 	if cfg.ec.FlagsExplicitlySet["experimental-memory-mlock"] {
 		cfg.ec.MemoryMlock = cfg.ec.ExperimentalMemoryMlock
+	}
+
+	if cfg.ec.FlagsExplicitlySet["experimental-snapshot-catchup-entries"] {
+		cfg.ec.SnapshotCatchUpEntries = cfg.ec.ExperimentalSnapshotCatchUpEntries
 	}
 
 	if cfg.ec.FlagsExplicitlySet["experimental-compaction-sleep-interval"] {

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -342,6 +342,8 @@ Experimental feature:
   --experimental-memory-mlock
     Enable to enforce etcd pages (in particular bbolt) to stay in RAM. Deprecated in v3.6 and will be decommissioned in v3.7. Use '--memory-mlock' instead.
   --experimental-snapshot-catchup-entries
+    Number of entries for a slow follower to catch up after compacting the raft storage entries. Deprecated in v3.6 and will be decommissioned in v3.7. Use '--snapshot-catchup-entries' instead.
+  --snapshot-catchup-entries
     Number of entries for a slow follower to catch up after compacting the raft storage entries.
   --experimental-stop-grpc-service-on-defrag
     Enable etcd gRPC service to stop serving client requests on defragmentation. It's deprecated, and will be decommissioned in v3.7. Use '--feature-gates=StopGRPCServiceOnDefrag=true' instead.

--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -81,7 +81,7 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			name:   "CatchUpEntries",
 			config: NewConfig(WithSnapshotCatchUpEntries(100)),
 			expectArgsContain: []string{
-				"--experimental-snapshot-catchup-entries=100",
+				"--snapshot-catchup-entries=100",
 			},
 			mockBinaryVersion: &v3_5_14,
 		},
@@ -89,14 +89,14 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			name:   "CatchUpEntriesNoVersion",
 			config: NewConfig(WithSnapshotCatchUpEntries(100), WithVersion(LastVersion)),
 			expectArgsNotContain: []string{
-				"--experimental-snapshot-catchup-entries=100",
+				"--snapshot-catchup-entries=100",
 			},
 		},
 		{
 			name:   "CatchUpEntriesOldVersion",
 			config: NewConfig(WithSnapshotCatchUpEntries(100), WithVersion(LastVersion)),
 			expectArgsNotContain: []string{
-				"--experimental-snapshot-catchup-entries=100",
+				"--snapshot-catchup-entries=100",
 			},
 			mockBinaryVersion: &v3_5_12,
 		},

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -531,3 +531,12 @@ func CouldSetSnapshotCatchupEntries(execPath string) bool {
 	v3_5_14 := semver.Version{Major: 3, Minor: 5, Patch: 14}
 	return v.Compare(v3_5_14) >= 0
 }
+
+func UsesExperimentalSnapshotCatchupEntriesFlag(execPath string) bool {
+	v, err := GetVersionFromBinary(execPath)
+	if err != nil {
+		return false
+	}
+	v3_6 := semver.Version{Major: 3, Minor: 6}
+	return v.LessThan(v3_6)
+}


### PR DESCRIPTION
Migrate `experimental-snapshot-catchup-entries` flag to `snapshot-catchup-entries`

Sub task from https://github.com/etcd-io/etcd/issues/19141

__Note:__
1. This PR also handles a fix to an unintended bug from [this feature PR](https://github.com/etcd-io/etcd/pull/15033), where the field-name was set as `experimental-snapshot-catch-up-entries` when cmd-line flag `experimental-snapshot-catchup-entries` was used.
2. YAML field `experimental-snapshot-catch-up-entries` will set flag `experimental-snapshot-catchup-entries` correctly at `FlagsExplicitlySet`. This is required to mark / identify the field if used from 'config-file' as a deprecated flag usage.
3. `experimental-snapshot-catch-up-entries` YAML field usage is maintained the same field-name for backward compability.
