### PR TITLE
Update 3.6 changelog to cover the etcdutl status command change

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -43,6 +43,7 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Add [optional --bump-revision and --mark-compacted flag to etcdutl snapshot restore operation](https://github.com/etcd-io/etcd/pull/16029).
 - Add [hashkv](https://github.com/etcd-io/etcd/pull/15965) command to print hash of keys and values up to given revision
 - Removed [legacy etcdutl backup](https://github.com/etcd-io/etcd/pull/16662)
+- [Count the number of keys from users perspective](https://github.com/etcd-io/etcd/pull/19344)
 
 ### Package `clientv3`
 


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/19344
