### PR TITLE
codecov: improve coverage upload

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,7 +25,7 @@ jobs:
           mkdir "${TARGET}"
           case "${TARGET}" in
             linux-amd64-coverage)
-              GOARCH=amd64 ./scripts/codecov_upload.sh
+              GOARCH=amd64 make upload-coverage-report
               ;;
             *)
               echo "Failed to find target"

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,14 @@ test-e2e-release: build
 test-robustness:
 	PASSES="robustness" ./scripts/test.sh $(GO_TEST_FLAGS)
 
+.PHONY: test-coverage
+test-coverage:
+	COVERDIR=covdir PASSES="build cov" ./scripts/test.sh $(GO_TEST_FLAGS)
+
+.PHONY: upload-coverage-report
+upload-coverage-report: test-coverage
+	./scripts/codecov_upload.sh
+
 .PHONY: fuzz
 fuzz: 
 	./scripts/fuzzing.sh

--- a/scripts/codecov_upload.sh
+++ b/scripts/codecov_upload.sh
@@ -5,14 +5,5 @@
 
 set -o pipefail
 
-LOG_FILE=${1:-test-coverage.log}
-
-# We collect the coverage
-COVERDIR=covdir PASSES='build cov' ./scripts/test.sh 2>&1 | tee "${LOG_FILE}"
-test_success="$?"
-
 # We try to upload whatever we have:
-bash <(curl -s https://codecov.io/bash) -f ./covdir/all.coverprofile -cF all || exit 2
-
-# Expose the original status of the test coverage execution.
-exit ${test_success}
+bash <(curl -s https://codecov.io/bash) -f ./covdir/all.coverprofile -cF all


### PR DESCRIPTION
Align running the code coverage upload with other workflows by executing it from a Makefile target.

Update the current GitHub workflow to call this new target.

I identified this improvement while migrating this workflow to a Prow job.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
