### PR TITLE
Fix a log formatting bug in the e2e downgrade tests

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
@@ -160,7 +159,7 @@ func testDowngradeUpgrade(t *testing.T, numberOfMembersToDowngrade int, clusterS
 	}
 
 	membersToChange := rand.Perm(len(epc.Procs))[:numberOfMembersToDowngrade]
-	t.Logf(fmt.Sprintln("Elect members for operations"), zap.Any("members", membersToChange))
+	t.Logf("Elect members for operations on members: %v", membersToChange)
 
 	t.Logf("Starting downgrade process to %q", lastVersionStr)
 	err = e2e.DowngradeUpgradeMembersByID(t, nil, epc, membersToChange, currentVersion, lastClusterVersion)

--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -84,7 +84,7 @@ func DowngradeCancel(t *testing.T, epc *EtcdProcessCluster) {
 
 func DowngradeUpgradeMembers(t *testing.T, lg *zap.Logger, clus *EtcdProcessCluster, numberOfMembersToChange int, currentVersion, targetVersion *semver.Version) error {
 	membersToChange := rand.Perm(len(clus.Procs))[:numberOfMembersToChange]
-	t.Logf(fmt.Sprintln("Elect members for operations"), zap.Any("members", membersToChange))
+	t.Logf("Elect members for operations on members: %v", membersToChange)
 
 	return DowngradeUpgradeMembersByID(t, lg, clus, membersToChange, currentVersion, targetVersion)
 }


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

The log message was of the following format before fixing
```
cluster_downgrade_test.go:163: Elect members for operations
        %!(EXTRA zapcore.Field={members 1 0  [2 1]})
```

After
```
 cluster_downgrade_test.go:163: Elect members for operations zapcore.Field{Key:"members", Type:0x1, Integer:0, String:"", Interface:zap.ints{1}}
```