### PR TITLE
Reproduce TestDowngradeCancellationAfterDowngrading2InClusterOf3 failure consistently

### DIFF
--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -127,6 +127,12 @@ func (m *Monitor) UpdateStorageVersionIfNeeded() {
 				zap.String("target-version", d.TargetVersion),
 				zap.String("server-version", version.Version),
 			)
+		} else if d != nil && !d.Enabled {
+			m.lg.Info(
+				"The server is in downgrade cancellation state",
+				zap.String("target-version", d.TargetVersion),
+				zap.String("server-version", version.Version),
+			)
 		}
 	}
 }

--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -117,6 +117,9 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 			return err
 		}
 	}
+
+	time.Sleep(5 * time.Second)
+
 	lg.Info("Validating versions")
 	for _, memberID := range membersToChange {
 		member := clus.Procs[memberID]


### PR DESCRIPTION
Implemented findings from Fu Wei. See https://github.com/etcd-io/etcd/issues/19391#issuecomment-2652285100

Execute locally by using the following command: 
`clear; PASSES="release e2e" PKG=./tests/e2e TESTCASE="TestDowngradeCancellationAfterDowngrading2InClusterOf3" TIMEOUT=20m ./scripts/test.sh -v -failfast`

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
