### PR TITLE
chore: fix the output of `etcdctl watch -i`

### DIFF
--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -105,13 +105,13 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 
 		args := Argify(l)
 		if len(args) < 1 {
-			fmt.Fprintf(os.Stderr, "Invalid command: %s (watch and progress supported)\n", l)
+			fmt.Fprintf(os.Stderr, "Invalid command: '%s' (only `watch` and `progress` are supported)\n", l)
 			continue
 		}
 		switch args[0] {
 		case "watch":
 			if len(args) < 2 && envKey == "" {
-				fmt.Fprintf(os.Stderr, "Invalid command %s (command type or key is not provided)\n", l)
+				fmt.Fprintf(os.Stderr, "Invalid command: '%s' (the key/prefix is not provided)\n", l)
 				continue
 			}
 			watchArgs, execArgs, perr := parseWatchArgs(osArgs, args, envKey, envRange, true)
@@ -121,7 +121,7 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 
 			ch, err := getWatchChan(c, watchArgs)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Invalid command %s (%v)\n", l, err)
+				fmt.Fprintf(os.Stderr, "Invalid command: '%s' (%v)\n", l, err)
 				continue
 			}
 			go printWatchCh(c, ch, execArgs)
@@ -131,7 +131,7 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 				cobrautl.ExitWithError(cobrautl.ExitError, err)
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "Invalid command %s (only support watch)\n", l)
+			fmt.Fprintf(os.Stderr, "Invalid command: '%s' (only `watch` and `progress` are supported)\n", l)
 			continue
 		}
 	}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
![image](https://github.com/user-attachments/assets/2bd83dc4-d635-4cb0-bfb5-a569858d21bd)
Although the interactive mode of `etcdctl watch` supports `progress` command now, the output is a little bit out-of-date :(