### PR TITLE
[test] Correct the expected version in downgrade test case

### DIFF
--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -120,17 +120,10 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 	lg.Info("Validating versions")
 	for _, memberID := range membersToChange {
 		member := clus.Procs[memberID]
-		if isDowngrade || len(membersToChange) == len(clus.Procs) {
-			ValidateVersion(t, clus.Cfg, member, version.Versions{
-				Cluster: targetVersion.String(),
-				Server:  targetVersion.String(),
-			})
-		} else {
-			ValidateVersion(t, clus.Cfg, member, version.Versions{
-				Cluster: currentVersion.String(),
-				Server:  targetVersion.String(),
-			})
-		}
+		ValidateVersion(t, clus.Cfg, member, version.Versions{
+			Cluster: targetVersion.String(),
+			Server:  targetVersion.String(),
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
Fix https://github.com/etcd-io/etcd/issues/19391

There are two issues in the existing downgrade e2e test cases:
- as long as it's downgrade is enabled, then we should expect a lower cluster version.
- after we upgrade all member to its original version, we should expect a higher cluster version.

Thanks @fuweid for the analysis.

cc @siyuanfoundation @serathius @henrybear327 

