### PR TITLE
server: Remove deprecated NewZapCoreLoggerBuilder

### DIFF
--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -216,12 +216,6 @@ func NewZapLoggerBuilder(lg *zap.Logger) func(*Config) error {
 	}
 }
 
-// NewZapCoreLoggerBuilder - is a deprecated setter for the logger.
-// Deprecated: Use simpler NewZapLoggerBuilder. To be removed in etcd-3.6.
-func NewZapCoreLoggerBuilder(lg *zap.Logger, _ zapcore.Core, _ zapcore.WriteSyncer) func(*Config) error {
-	return NewZapLoggerBuilder(lg)
-}
-
 // SetupGlobalLoggers configures 'global' loggers (grpc, zapGlobal) based on the cfg.
 //
 // The method is not executed by embed server by default (since 3.5) to


### PR DESCRIPTION
This pull request removes the deprecated `NewZapCoreLoggerBuilder` function.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
