### PR TITLE
Fix release script prerelease GitHub template release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -364,7 +364,8 @@ main() {
     release_notes_temp_file=$(mktemp)
 
     local release_version=${RELEASE_VERSION#v} # Remove the v prefix from the release version (i.e., v3.6.1 -> 3.6.1)
-    local release_version_major_minor=${release_version%.*} # Remove the patch from the version (i.e., 3.6)
+    local release_version_major_minor
+    release_version_major_minor=$(echo "${release_version}" | cut -d. -f1-2) # Remove the patch from the version (i.e., 3.6)
     local release_version_major=${release_version_major_minor%.*} # Extract the major (i.e., 3)
     local release_version_minor=${release_version_major_minor/*./} # Extract the minor (i.e., 6)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -254,7 +254,7 @@ main() {
 
   # Upload artifacts.
   if [ "${DRY_RUN}" == "true" ] || [ "${NO_UPLOAD}" == 1 ]; then
-    log_callout "Skipping artifact upload to gs://etcd. --no-upload flat is set."
+    log_callout "Skipping artifact upload to gs://etcd. --no-upload flag is set."
   else
     read -p "Upload etcd ${RELEASE_VERSION} release artifacts to gs://etcd [y/N]? " -r confirm
     [[ "${confirm,,}" == "y" ]] || exit 1
@@ -266,7 +266,7 @@ main() {
 
   # Push images.
   if [ "${DRY_RUN}" == "true" ] || [ "${NO_DOCKER_PUSH}" == 1 ]; then
-    log_callout "Skipping docker push. --no-docker-push flat is set."
+    log_callout "Skipping docker push. --no-docker-push flag is set."
   else
     read -p "Publish etcd ${RELEASE_VERSION} docker images to quay.io [y/N]? " -r confirm
     [[ "${confirm,,}" == "y" ]] || exit 1


### PR DESCRIPTION
Follow up on https://github.com/etcd-io/etcd/issues/19334:

* Properly get the minor version from prereleases (i.e., `v3.6.0-rc.0` → `v3.6`, not `v3.6.0-rc`). I tested it on my fork, and the linked pages are as expected (note that we still have a broken link in the upgrade guide): https://github.com/ivanvc/etcd/releases/tag/v3.6.0-rc.0
* Fix a typo in "flag". It said "flat".

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
