### PR TITLE
*: deflake MemberDowngradeUpdate robustness case

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2392,9 +2392,12 @@ func (s *EtcdServer) updateClusterVersionV3(ver string) {
 
 // monitorDowngrade every DowngradeCheckTime checks if it's the leader and cancels downgrade if needed.
 func (s *EtcdServer) monitorDowngrade() {
+	lg := s.Logger()
+
 	monitor := serverversion.NewMonitor(s.Logger(), NewServerVersionAdapter(s))
 	t := s.Cfg.DowngradeCheckTime
 	if t == 0 {
+		lg.Info("downgrade monitor has been disabled")
 		return
 	}
 	for {


### PR DESCRIPTION
### 1. Update DowngradeUpgradeMembersByID Interface

By default, the leader cancels the downgrade process once all members reach the target version. However, this behavior is unpredictable and may cause unexpected errors.

Example 1: Single-Member Cluster

  T0: Set up a single-member cluster.
  T1: Enable the downgrade process.
  T2: Downgrade the member from v3.6.0 to v3.5.0.
  T3: Upgrade the member from v3.5.0 to v3.6.0.

If the leader cancels the downgrade process between T2 and T3, the cluster should end up at v3.6.0; otherwise, it remains at v3.5.0.

Example 2: Three-Member Cluster

  T0: Set up a three-member cluster.
  T1: Enable the downgrade process.
  T2: Downgrade two members from v3.6.0 to v3.5.0.
  T3: Upgrade those two members back to v3.6.0.

Since the downgrade process is incomplete, after T3, the cluster should remain at v3.5.0 instead of v3.6.0.

Key Takeaways

  * The binary version alone should not determine the cluster version.
  * The caller must explicitly track and manage the expected version.

### 2. Manually cancels the downgrade process after a successful downgrade in MemberDowngradeUpdate failpoint

As demonstrated in Example 1, canceling downgrade process can reduce flakiness.

### 3. Remove AssertProcessLogs from DowngradeEnable

The log message "The server is ready to downgrade" appears only when the storage version monitor detects a mismatch between the cluster and storage versions.

If traffic is insufficient to trigger a commit or if an auto-commit occurs right after reading the storage version, the monitor may fail to update it, leading to errors like:

```bash
"msg":"failed to update storage version","cluster-version":"3.6.0",
"error":"cannot detect storage schema version: missing confstate information"
```

Given this, we should remove the AssertProcessLogs statement because we won't receive log 'The server is ready to downgrade'.

Similar to #19313

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @serathius @ahrtr @henrybear327 @siyuanfoundation 

Fixes: https://github.com/etcd-io/etcd/issues/19306