### PR TITLE
perf: use RLock in Demoted method for read-only access to expiry

### DIFF
--- a/server/lease/lease.go
+++ b/server/lease/lease.go
@@ -97,8 +97,8 @@ func (l *Lease) forever() {
 
 // Demoted returns true if the lease's expiry has been reset to forever.
 func (l *Lease) Demoted() bool {
-	l.expiryMu.Lock()
-	defer l.expiryMu.Unlock()
+	l.expiryMu.RLock()
+	defer l.expiryMu.RUnlock()
 	return l.expiry == forever
 }
 


### PR DESCRIPTION
Use RLock in Demoted method to improve read-only access to expiry with better concurrency.







