### PR TITLE
scripts: Use go mod instead of go list to get dependencies

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -508,7 +508,7 @@ function bom_pass {
 
 function dump_deps_of_module() {
   local module
-  if ! module=$(run go list -m); then
+  if ! module=$(run go mod edit -json | jq -r .Module.Path); then
     return 255
   fi
   run go mod edit -json | jq -r '.Require[] | .Path+","+.Version+","+if .Indirect then " (indirect)" else "" end+",'"${module}"'"'


### PR DESCRIPTION
Replace `go list -m` with `go mod edit -json`, as the latter can return the same information. This will be helpful when the project migrates to using a Go workspace, as it will return the current module defined in go.mod rather than all the modules from the current directory (using a workspace, the top-level go.mod will return all the child modules from the repository).

Spun off from #19423.
Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
