### PR TITLE
scripts/updatebom: remove unnecessary mod override

### DIFF
--- a/scripts/updatebom.sh
+++ b/scripts/updatebom.sh
@@ -14,7 +14,7 @@ function bom_fixlet {
   # shellcheck disable=SC2207
   modules=($(modules_for_bom))
 
-  if GOFLAGS=-mod=mod run_go_tool "github.com/appscodelabs/license-bill-of-materials" \
+  if run_go_tool "github.com/appscodelabs/license-bill-of-materials" \
       --override-file ./bill-of-materials.override.json \
       "${modules[@]}" > ./bill-of-materials.json.tmp; then
     cp ./bill-of-materials.json.tmp ./bill-of-materials.json


### PR DESCRIPTION
The `GOFLAGS=-mod=mod` environment variable is not required, as that's the default mode. This code was likely copied from the tests, where `GOFLAGS` is set to `-mod=readonly`. So, executing the tool needs to override `mod`, as per the documentation, it tends to modify the `go.mod` file.

Spun off from: #19423.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
