### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/client/v3/kv.go
+++ b/client/v3/kv.go
@@ -134,7 +134,7 @@ func (kv *kv) Compact(ctx context.Context, rev int64, opts ...CompactOption) (*C
 	if err != nil {
 		return nil, ContextError(ctx, err)
 	}
-	return (*CompactResponse)(resp), err
+	return (*CompactResponse)(resp), nil
 }
 
 func (kv *kv) Txn(ctx context.Context) Txn {

--- a/server/auth/jwt.go
+++ b/server/auth/jwt.go
@@ -121,7 +121,7 @@ func (t *tokenJWT) assign(ctx context.Context, username string, revision uint64)
 		zap.Uint64("revision", revision),
 		zap.String("token", token),
 	)
-	return token, err
+	return token, nil
 }
 
 func newTokenProviderJWT(lg *zap.Logger, optMap map[string]string) (*tokenJWT, error) {


### PR DESCRIPTION
use a more straightforward return value