### PR TITLE
Fix flaky `TestLeaseKeepAliveOneSecond`

### DIFF
--- a/tests/integration/clientv3/lease/lease_test.go
+++ b/tests/integration/clientv3/lease/lease_test.go
@@ -189,7 +189,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 	}
 }
 
-func TestLeaseKeepAliveOneSecond(t *testing.T) {
+func TestLeaseKeepAliveSeconds(t *testing.T) {
 	integration2.BeforeTest(t)
 
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
@@ -197,7 +197,7 @@ func TestLeaseKeepAliveOneSecond(t *testing.T) {
 
 	cli := clus.Client(0)
 
-	resp, err := cli.Grant(context.Background(), 1)
+	resp, err := cli.Grant(context.Background(), 3)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -208,7 +208,7 @@ func TestLeaseKeepAliveOneSecond(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		if _, ok := <-rc; !ok {
-			t.Errorf("chan is closed, want not closed")
+			t.Errorf("[%d] chan is closed, want not closed", i)
 		}
 	}
 }


### PR DESCRIPTION
Refer to https://github.com/etcd-io/etcd/actions/runs/13499481627/job/37714129702?pr=19426

```
    cluster.go:242:  - m0 -> 2f0c1931b70c09a2 (unix://localhost:m0)
    lease_test.go:211: chan is closed, want not closed
    lease_test.go:211: chan is closed, want not closed
```
