### PR TITLE
Add release date for `v3.4.36` and `v3.6.0-rc.1`

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 <hr>
 
-## v3.4.36 (TBC)
+## v3.4.37 (TBC)
+
+<hr>
+
+## v3.4.36 (2025-02-25)
 
 ### etcd server
 - [Avoid deadlock in etcd.Close when stopping during bootstrapping](https://github.com/etcd-io/etcd/pull/19166)

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -8,7 +8,11 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 <hr>
 
-## v3.6.0-rc.1 (TBD)
+## v3.6.0-rc.2 (TBD)
+
+<hr>
+
+## v3.6.0-rc.1 (2025-02-25)
 
 ### etcdctl v3
 
@@ -21,6 +25,8 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 ### Dependencies
 
 - Bump [golang.org/x/crypto to v0.35.0 to address CVE-2025-22869](https://github.com/etcd-io/etcd/pull/19480).
+
+<hr>
 
 ## v3.6.0-rc.0 (2025-02-13)
 


### PR DESCRIPTION
Both releases were published successfully during today's release meeting.

cc @ivanvc, @ahrtr 