### PR TITLE
Address Go 1.24 govet errors

### DIFF
--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -351,11 +351,11 @@ func isContextError(err error) bool {
 func contextErrToGRPCErr(err error) error {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
-		return status.Errorf(codes.DeadlineExceeded, err.Error())
+		return status.Error(codes.DeadlineExceeded, err.Error())
 	case errors.Is(err, context.Canceled):
-		return status.Errorf(codes.Canceled, err.Error())
+		return status.Error(codes.Canceled, err.Error())
 	default:
-		return status.Errorf(codes.Unknown, err.Error())
+		return status.Error(codes.Unknown, err.Error())
 	}
 }
 

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -1031,7 +1031,7 @@ func acquireLeaseAndKey(clus *integration.Cluster, key string) (int64, error) {
 		return 0, err
 	}
 	if lresp.Error != "" {
-		return 0, fmt.Errorf(lresp.Error)
+		return 0, errors.New(lresp.Error)
 	}
 	// attach to key
 	put := &pb.PutRequest{Key: []byte(key), Lease: lresp.ID}


### PR DESCRIPTION
With Go v1.24.0 being more strict on the errors usage, it raises some issues in the current codebase.

```bash
% (cd client/v3 && 'go' 'vet' './...')
stderr: # go.etcd.io/etcd/client/v3
stderr: # [go.etcd.io/etcd/client/v3]
stderr: ./retry_interceptor.go:354:48: non-constant format string in call to google.golang.org/grpc/status.Errorf
stderr: ./retry_interceptor.go:356:40: non-constant format string in call to google.golang.org/grpc/status.Errorf
stderr: ./retry_interceptor.go:358:39: non-constant format string in call to google.golang.org/grpc/status.Errorf

% (cd tests && 'go' 'vet' './...')
stderr: # go.etcd.io/etcd/tests/v3/integration
stderr: # [go.etcd.io/etcd/tests/v3/integration]
stderr: integration/v3_lease_test.go:1034:24: non-constant format string in call to fmt.Errorf
FAIL: (code:1):
  % (cd tests && 'go' 'vet' './...')

FAIL: 'run go vet ./...' checking failed (!=0 return code)
There was a Failure in module tests, aborting...
FAIL: 'govet' FAILED at Tue Feb 25 05:04:55 PM PST 2025
```

Ultimately, addressing these issues shouldn't have any impact on Go 1.23.

Part of #19417 / #19440

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
