### PR TITLE
etcdserver: add ErrRootRoleNotGranted error code

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -68,6 +68,7 @@ var (
 	ErrGRPCPermissionNotGiven   = status.Error(codes.InvalidArgument, "etcdserver: permission not given")
 	ErrGRPCPermissionDenied     = status.Error(codes.PermissionDenied, "etcdserver: permission denied")
 	ErrGRPCRoleNotGranted       = status.Error(codes.FailedPrecondition, "etcdserver: role is not granted to the user")
+	ErrGRPCRootRoleNotGranted   = status.Error(codes.FailedPrecondition, "etcdserver: permission denied, root role is not granted to current user")
 	ErrGRPCPermissionNotGranted = status.Error(codes.FailedPrecondition, "etcdserver: permission is not granted to the role")
 	ErrGRPCAuthNotEnabled       = status.Error(codes.FailedPrecondition, "etcdserver: authentication is not enabled")
 	ErrGRPCInvalidAuthToken     = status.Error(codes.Unauthenticated, "etcdserver: invalid auth token")
@@ -138,6 +139,7 @@ var (
 		ErrorDesc(ErrGRPCAuthFailed):           ErrGRPCAuthFailed,
 		ErrorDesc(ErrGRPCPermissionDenied):     ErrGRPCPermissionDenied,
 		ErrorDesc(ErrGRPCRoleNotGranted):       ErrGRPCRoleNotGranted,
+		ErrorDesc(ErrGRPCRootRoleNotGranted):   ErrGRPCRootRoleNotGranted,
 		ErrorDesc(ErrGRPCPermissionNotGranted): ErrGRPCPermissionNotGranted,
 		ErrorDesc(ErrGRPCAuthNotEnabled):       ErrGRPCAuthNotEnabled,
 		ErrorDesc(ErrGRPCInvalidAuthToken):     ErrGRPCInvalidAuthToken,
@@ -205,6 +207,7 @@ var (
 	ErrAuthFailed           = Error(ErrGRPCAuthFailed)
 	ErrPermissionDenied     = Error(ErrGRPCPermissionDenied)
 	ErrRoleNotGranted       = Error(ErrGRPCRoleNotGranted)
+	ErrRootRoleNotGranted   = Error(ErrGRPCRootRoleNotGranted)
 	ErrPermissionNotGranted = Error(ErrGRPCPermissionNotGranted)
 	ErrAuthNotEnabled       = Error(ErrGRPCAuthNotEnabled)
 	ErrInvalidAuthToken     = Error(ErrGRPCInvalidAuthToken)

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -54,6 +54,7 @@ var (
 	ErrNoPasswordUser       = errors.New("auth: authentication failed, password was given for no password user")
 	ErrPermissionDenied     = errors.New("auth: permission denied")
 	ErrRoleNotGranted       = errors.New("auth: role is not granted to the user")
+	ErrRootRoleNotGranted   = errors.New("auth: permission denied, root role is not granted to current user")
 	ErrPermissionNotGranted = errors.New("auth: permission is not granted to the role")
 	ErrAuthNotEnabled       = errors.New("auth: authentication is not enabled")
 	ErrAuthOldRevision      = errors.New("auth: revision in header is old")
@@ -927,7 +928,7 @@ func (as *authStore) IsAdminPermitted(authInfo *AuthInfo) error {
 	}
 
 	if !hasRootRole(u) {
-		return ErrPermissionDenied
+		return ErrRootRoleNotGranted
 	}
 
 	return nil

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -83,6 +83,7 @@ var toGRPCErrorMap = map[error]error{
 	auth.ErrPermissionNotGiven:   rpctypes.ErrGRPCPermissionNotGiven,
 	auth.ErrPermissionDenied:     rpctypes.ErrGRPCPermissionDenied,
 	auth.ErrRoleNotGranted:       rpctypes.ErrGRPCRoleNotGranted,
+	auth.ErrRootRoleNotGranted:   rpctypes.ErrGRPCRootRoleNotGranted,
 	auth.ErrPermissionNotGranted: rpctypes.ErrGRPCPermissionNotGranted,
 	auth.ErrAuthNotEnabled:       rpctypes.ErrGRPCAuthNotEnabled,
 	auth.ErrInvalidAuthToken:     rpctypes.ErrGRPCInvalidAuthToken,


### PR DESCRIPTION
etcdserver: add ErrRootRoleNotGranted to better prompt users to grant root privileges to current call etcd's client user.

before:

```
./etcdctl --user="test1" role list
Password:
{"level":"warn","ts":"2025-02-26T23:05:11.856813+0800","logger":"etcd-client","caller":"v3@v3.6.0-alpha.0/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0000ce000/127.0.0.1:2379","method":"/etcdserverpb.Auth/RoleList","attempt":0,"error":"rpc error: code = PermissionDenied desc = etcdserver: permission denied"}
Error: etcdserver: permission denied
```

after change:

```
 /etcdctl --user="test1" role list
Password:
{"level":"warn","ts":"2025-02-26T22:58:17.949208+0800","logger":"etcd-client","caller":"v3@v3.6.0-alpha.0/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000277a40/127.0.0.1:2379","method":"/etcdserverpb.Auth/RoleList","attempt":0,"error":"rpc error: code = FailedPrecondition desc = etcdserver: permission denied, root role is not granted to current user"}
Error: etcdserver: permission denied, root role is not granted to current user
```