### PR TITLE
etcdserver: Fixing minor typos in v3election.proto and rpc.proto

### DIFF
--- a/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
@@ -2847,7 +2847,7 @@
         },
         "storageVersion": {
           "type": "string",
-          "description": "storageVersion is the version of the db file. It might be get updated with delay in relationship to the target cluster version."
+          "description": "storageVersion is the version of the db file. It might be updated with delay in relationship to the target cluster version."
         },
         "dbSizeQuota": {
           "type": "string",

--- a/Documentation/dev-guide/apispec/swagger/v3election.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/v3election.swagger.json
@@ -318,7 +318,7 @@
         "name": {
           "type": "string",
           "format": "byte",
-          "description": "name is the election identifier that correponds to the leadership key."
+          "description": "name is the election identifier that corresponds to the leadership key."
         },
         "key": {
           "type": "string",

--- a/api/etcdserverpb/rpc.pb.go
+++ b/api/etcdserverpb/rpc.pb.go
@@ -4301,7 +4301,7 @@ type StatusResponse struct {
 	DbSizeInUse int64 `protobuf:"varint,9,opt,name=dbSizeInUse,proto3" json:"dbSizeInUse,omitempty"`
 	// isLearner indicates if the member is raft learner.
 	IsLearner bool `protobuf:"varint,10,opt,name=isLearner,proto3" json:"isLearner,omitempty"`
-	// storageVersion is the version of the db file. It might be get updated with delay in relationship to the target cluster version.
+	// storageVersion is the version of the db file. It might be updated with delay in relationship to the target cluster version.
 	StorageVersion string `protobuf:"bytes,11,opt,name=storageVersion,proto3" json:"storageVersion,omitempty"`
 	// dbSizeQuota is the configured etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes)
 	DbSizeQuota int64 `protobuf:"varint,12,opt,name=dbSizeQuota,proto3" json:"dbSizeQuota,omitempty"`

--- a/api/etcdserverpb/rpc.proto
+++ b/api/etcdserverpb/rpc.proto
@@ -1196,7 +1196,7 @@ message StatusResponse {
   int64 dbSizeInUse = 9 [(versionpb.etcd_version_field)="3.4"];
   // isLearner indicates if the member is raft learner.
   bool isLearner = 10 [(versionpb.etcd_version_field)="3.4"];
-  // storageVersion is the version of the db file. It might be get updated with delay in relationship to the target cluster version.
+  // storageVersion is the version of the db file. It might be updated with delay in relationship to the target cluster version.
   string storageVersion = 11 [(versionpb.etcd_version_field)="3.6"];
   // dbSizeQuota is the configured etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes)
   int64 dbSizeQuota = 12 [(versionpb.etcd_version_field)="3.6"];

--- a/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go
+++ b/server/etcdserver/api/v3election/v3electionpb/v3election.pb.go
@@ -157,7 +157,7 @@ func (m *CampaignResponse) GetLeader() *LeaderKey {
 }
 
 type LeaderKey struct {
-	// name is the election identifier that correponds to the leadership key.
+	// name is the election identifier that corresponds to the leadership key.
 	Name []byte `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// key is an opaque key representing the ownership of the election. If the key
 	// is deleted, then leadership is lost.

--- a/server/etcdserver/api/v3election/v3electionpb/v3election.proto
+++ b/server/etcdserver/api/v3election/v3electionpb/v3election.proto
@@ -76,7 +76,7 @@ message CampaignResponse {
 }
 
 message LeaderKey {
-  // name is the election identifier that correponds to the leadership key.
+  // name is the election identifier that corresponds to the leadership key.
   bytes name = 1;
   // key is an opaque key representing the ownership of the election. If the key
   // is deleted, then leadership is lost.


### PR DESCRIPTION
Fixing minor typos in the proto files.