### PR TITLE
Add change log 3.7

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -1,0 +1,11 @@
+
+
+Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md).
+
+<hr>
+
+## v3.7.0 (TBD)
+
+### Deprecations
+
+- Deprecated [UsageFunc in pkg/cobrautl](https://github.com/etcd-io/etcd/pull/18356).


### PR DESCRIPTION
Follow up on pull request https://github.com/etcd-io/etcd/pull/18356

Added changelog file for version 3.7.
Added `UsageFunc` to deprecations section of changelog version 3.6.

/cc @ahrtr @ivanvc 