### PR TITLE
robustness-test: Migrate `experimental-compaction-batch-limit` flag

### DIFF
--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -25,6 +25,11 @@ import (
 func TestEtcdServerProcessConfig(t *testing.T) {
 	v3_5_12 := semver.Version{Major: 3, Minor: 5, Patch: 12}
 	v3_5_14 := semver.Version{Major: 3, Minor: 5, Patch: 14}
+
+	v3_4 := semver.Version{Major: 3, Minor: 4}
+	v3_5 := semver.Version{Major: 3, Minor: 5}
+	v3_6 := semver.Version{Major: 3, Minor: 6}
+
 	tcs := []struct {
 		name                 string
 		config               *EtcdProcessClusterConfig
@@ -106,6 +111,30 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			expectArgsContain: []string{
 				"--listen-client-http-urls=http://localhost:4",
 			},
+		},
+		{
+			name:   "CompactionBatchLimit_v3.6",
+			config: NewConfig(WithCompactionBatchLimit(10)),
+			expectArgsContain: []string{
+				"--compaction-batch-limit",
+			},
+			mockBinaryVersion: &v3_6,
+		},
+		{
+			name:   "CompactionBatchLimit_v3.5",
+			config: NewConfig(WithCompactionBatchLimit(10)),
+			expectArgsContain: []string{
+				"--experimental-compaction-batch-limit",
+			},
+			mockBinaryVersion: &v3_5,
+		},
+		{
+			name:   "CompactionBatchLimit_v3.4",
+			config: NewConfig(WithCompactionBatchLimit(10)),
+			expectArgsContain: []string{
+				"--experimental-compaction-batch-limit",
+			},
+			mockBinaryVersion: &v3_4,
 		},
 		{
 			name:   "ForceNewCluster",


### PR DESCRIPTION
Related: https://github.com/etcd-io/etcd/issues/19354

Robustness tests run different versions of binaries. This flag is experimental in v3.4 and v3.5. But non-experimental in v3.6+. This PR adds ability to run different binaries with it's canonical flag name.

In robustness tests we pass these config via `embed.ServerConfig` struct and get converted into CLI flags before spawning the etcd server binary. This PR maps into right canonical flag based on versions. So even when the experimental field is removed from the struct (in v3.7), the flags will be correctly mapped.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
