### PR TITLE
Add verify release assets GitHub workflow

### DIFF
--- a/.github/workflows/verify-released-assets.yaml
+++ b/.github/workflows/verify-released-assets.yaml
@@ -1,0 +1,44 @@
+---
+name: Verify released binary assets
+permissions: read-all
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  verify-assets:
+    name: Verify released binary assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify binary assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE: ${{ github.event.release.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir github-assets
+          pushd github-assets
+          gh --repo "${REPOSITORY}" release download "${RELEASE}"
+
+          test_assets() {
+            if [ "$(wc -l <SHA256SUMS)" != "$(find . -name 'etcd-*' | wc -l)" ]; then
+              echo "::error:: Invalid number of assets"
+              exit 1
+            fi
+            sha256sum -c SHA256SUMS
+          }
+          test_assets
+          popd
+
+          mkdir google-assets
+          for file in github-assets/*; do
+            file=$(basename "${file}")
+            echo "Downloading ${file} from Google..."
+            curl "https://storage.googleapis.com/etcd/${RELEASE}/${file}" \
+            --fail \
+            -o "google-assets/${file}"
+          done
+          pushd google-assets
+
+          test_assets


### PR DESCRIPTION
This pull request may seem counter-intuitive, as we're trying to move away from GitHub actions. However, there's no current way of running a CI check like this in Prow. It doesn't support running when the repository has a new tag.

This change:

* Verifies that the `SHA256SUMS` file exists and has the same number of lines as uploaded assets.
* Verifies that the uploaded files match the checksum from the `SHA256SUMS` file

For both GitHub and Google Cloud assets.

I tested this in my fork:

* Successful run: https://github.com/ivanvc/etcd/actions/runs/13648835540
* Failure run: https://github.com/ivanvc/etcd/actions/runs/13648892616

If the workflow fails, the release lead will get an email from GitHub with the failure.

With this check, we should have more confidence when we enable the automatic undrafting of the release. This addresses issues with corrupted uploads like #19270.

Part of: #18604.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
