### PR TITLE
fix: grpcproxy can get stuck in and endless loop causing high cpu usage

### DIFF
--- a/server/proxy/grpcproxy/cluster.go
+++ b/server/proxy/grpcproxy/cluster.go
@@ -107,7 +107,11 @@ func (cp *clusterProxy) monitor(wa endpoints.WatchChannel) {
 		case <-cp.ctx.Done():
 			cp.lg.Info("watching endpoints interrupted", zap.Error(cp.ctx.Err()))
 			return
-		case updates := <-wa:
+		case updates, ok := <-wa:
+			if !ok {
+				cp.lg.Info("endpoints watch channel closed")
+				return
+			}
 			cp.umu.Lock()
 			for _, up := range updates {
 				switch up.Op {


### PR DESCRIPTION
Fixes: #19553

When a watch channel gets closed, the monitor() function gets stuck in an endless loop, locking and unlocking mutexes and heavily impacting CPU usage

CPU profile data captured during an instance of this issue:

```
File: etcd
Type: cpu
Time: 2025-03-07 10:01:07 GMT
Duration: 10.15s, Total samples = 9.94s (97.90%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) web
(pprof) top
Showing nodes accounting for 8560ms, 86.12% of 9940ms total
Dropped 78 nodes (cum <= 49.70ms)
Showing top 10 nodes out of 31
      flat  flat%   sum%        cum   cum%
    2490ms 25.05% 25.05%     7210ms 72.54%  runtime.selectgo
    1390ms 13.98% 39.03%     1630ms 16.40%  runtime.unlock2
    1200ms 12.07% 51.11%     1200ms 12.07%  runtime.lock2
     810ms  8.15% 59.26%      820ms  8.25%  sync/atomic.(*Int32).Add (inline)
     590ms  5.94% 65.19%     1030ms 10.36%  sync.(*RWMutex).Lock
     530ms  5.33% 70.52%     1730ms 17.40%  runtime.sellock
     490ms  4.93% 75.45%     2120ms 21.33%  runtime.selunlock
     440ms  4.43% 79.88%      440ms  4.43%  sync.(*Mutex).Unlock (inline)
     370ms  3.72% 83.60%     9800ms 98.59%  go.etcd.io/etcd/server/v3/proxy/grpcproxy.(*clusterProxy).monitor
     250ms  2.52% 86.12%      250ms  2.52%  runtime.cheaprand (inline)
```
