### PR TITLE
server: remove ExperimentalMaxLearners

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -154,7 +154,6 @@ var (
 		"experimental-watch-progress-notify-interval":       "watch-progress-notify-interval",
 		"experimental-warning-apply-duration":               "warning-apply-duration",
 		"experimental-bootstrap-defrag-threshold-megabytes": "bootstrap-defrag-threshold-megabytes",
-		"experimental-max-learners":                         "max-learners",
 		"experimental-memory-mlock":                         "memory-mlock",
 		"experimental-snapshot-catchup-entries":             "snapshot-catchup-entries",
 		"experimental-compaction-sleep-interval":            "compaction-sleep-interval",
@@ -469,10 +468,6 @@ type Config struct {
 	// TODO: Delete in v3.7
 	// Deprecated: Use WarningUnaryRequestDuration. Will be decommissioned in v3.7.
 	ExperimentalWarningUnaryRequestDuration time.Duration `json:"experimental-warning-unary-request-duration"`
-	// ExperimentalMaxLearners sets a limit to the number of learner members that can exist in the cluster membership.
-	// TODO: Delete in v3.7
-	// Deprecated: Use MaxLearners instead. Will be decommissioned in v3.7.
-	ExperimentalMaxLearners int `json:"experimental-max-learners"`
 	// MaxLearners sets a limit to the number of learner members that can exist in the cluster membership.
 	MaxLearners int `json:"max-learners"`
 
@@ -718,8 +713,6 @@ func NewConfig() *Config {
 		ExperimentalMemoryMlock:             false,
 		ExperimentalStopGRPCServiceOnDefrag: false,
 		MaxLearners:                         membership.DefaultMaxLearners,
-		// TODO: delete in v3.7
-		ExperimentalMaxLearners: membership.DefaultMaxLearners,
 
 		ExperimentalTxnModeWriteWithSharedBuffer:  DefaultExperimentalTxnModeWriteWithSharedBuffer,
 		ExperimentalDistributedTracingAddress:     DefaultDistributedTracingAddress,
@@ -959,7 +952,6 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	fs.UintVar(&cfg.ExperimentalBootstrapDefragThresholdMegabytes, "experimental-bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect. It's deprecated, and will be decommissioned in v3.7. Use --bootstrap-defrag-threshold-megabytes instead.")
 	fs.UintVar(&cfg.BootstrapDefragThresholdMegabytes, "bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
 	// TODO: delete in v3.7
-	fs.IntVar(&cfg.ExperimentalMaxLearners, "experimental-max-learners", membership.DefaultMaxLearners, "Sets the maximum number of learners that can be available in the cluster membership. Deprecated in v3.6 and will be decommissioned in v3.7. Use --max-learners instead.")
 	fs.IntVar(&cfg.MaxLearners, "max-learners", membership.DefaultMaxLearners, "Sets the maximum number of learners that can be available in the cluster membership.")
 	fs.Uint64Var(&cfg.ExperimentalSnapshotCatchUpEntries, "experimental-snapshot-catchup-entries", cfg.ExperimentalSnapshotCatchUpEntries, "Number of entries for a slow follower to catch up after compacting the raft storage entries. Deprecated in v3.6 and will be decommissioned in v3.7. Use --snapshot-catchup-entries instead.")
 	fs.Uint64Var(&cfg.SnapshotCatchUpEntries, "snapshot-catchup-entries", cfg.SnapshotCatchUpEntries, "Number of entries for a slow follower to catch up after compacting the raft storage entries.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -70,7 +70,6 @@ var (
 		"experimental-watch-progress-notify-interval":       "--experimental-watch-progress-notify-interval is deprecated in v3.6 and will be decommissioned in v3.7. Use '--watch-progress-notify-interval' instead.",
 		"experimental-warning-apply-duration":               "--experimental-warning-apply-duration is deprecated in v3.6 and will be decommissioned in v3.7. Use '--warning-apply-duration' instead.",
 		"experimental-bootstrap-defrag-threshold-megabytes": "--experimental-bootstrap-defrag-threshold-megabytes is deprecated in v3.6 and will be decommissioned in v3.7. Use '--bootstrap-defrag-threshold-megabytes' instead.",
-		"experimental-max-learners":                         "--experimental-max-learners is deprecated in v3.6 and will be decommissioned in v3.7. Use '--max-learners' instead.",
 		"experimental-memory-mlock":                         "--experimental-memory-mlock is deprecated in v3.6 and will be decommissioned in v3.7. Use '--memory-mlock' instead.",
 		"experimental-snapshot-catchup-entries":             "--experimental-snapshot-catchup-entries is deprecated in v3.6 and will be decommissioned in v3.7. Use '--snapshot-catchup-entries' instead.",
 		"experimental-compaction-sleep-interval":            "--experimental-compaction-sleep-interval is deprecated in v3.6 and will be decommissioned in v3.7. Use 'compaction-sleep-interval' instead.",
@@ -210,10 +209,6 @@ func (cfg *config) parse(arguments []string) error {
 	}
 	if cfg.ec.FlagsExplicitlySet["experimental-peer-skip-client-san-verification"] {
 		cfg.ec.PeerTLSInfo.SkipClientSANVerify = cfg.ec.ExperimentalPeerSkipClientSanVerification
-	}
-
-	if cfg.ec.FlagsExplicitlySet["experimental-max-learners"] {
-		cfg.ec.MaxLearners = cfg.ec.ExperimentalMaxLearners
 	}
 
 	if cfg.ec.FlagsExplicitlySet["experimental-memory-mlock"] {

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -1090,70 +1090,6 @@ func TestBootstrapDefragThresholdMegabytesFlagMigration(t *testing.T) {
 	}
 }
 
-// TestMaxLearnersFlagMigration tests the migration from
-// --experimental-max-learners to --max-learners
-// TODO: delete in v3.7
-func TestMaxLearnersFlagMigration(t *testing.T) {
-	testCases := []struct {
-		name                    string
-		maxLearners             int
-		experimentalMaxLearners int
-		expectErr               bool
-		expectedMaxLearners     int
-	}{
-		{
-			name:                    "cannot set both experimental flag and non experimental flag",
-			maxLearners:             1,
-			experimentalMaxLearners: 2,
-			expectErr:               true,
-		},
-		{
-			name:                    "can set experimental flag",
-			experimentalMaxLearners: 2,
-			expectedMaxLearners:     2,
-		},
-		{
-			name:                "can set non experimental flag",
-			maxLearners:         1,
-			expectedMaxLearners: 1,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cmdLineArgs := []string{}
-			yc := struct {
-				ExperimentalMaxLearners int `json:"experimental-max-learners,omitempty"`
-				MaxLearners             int `json:"max-learners,omitempty"`
-			}{}
-
-			if tc.maxLearners != 0 {
-				cmdLineArgs = append(cmdLineArgs, fmt.Sprintf("--max-learners=%d", tc.maxLearners))
-				yc.MaxLearners = tc.maxLearners
-			}
-
-			if tc.experimentalMaxLearners != 0 {
-				cmdLineArgs = append(cmdLineArgs, fmt.Sprintf("--experimental-max-learners=%d", tc.experimentalMaxLearners))
-				yc.ExperimentalMaxLearners = tc.experimentalMaxLearners
-			}
-
-			cfgFromCmdLine, errFromCmdLine, cfgFromFile, errFromFile := generateCfgsFromFileAndCmdLine(t, yc, cmdLineArgs)
-
-			if tc.expectErr {
-				if errFromCmdLine == nil || errFromFile == nil {
-					t.Fatal("expect parse error")
-				}
-				return
-			}
-			if errFromCmdLine != nil || errFromFile != nil {
-				t.Fatal("error parsing config")
-			}
-
-			require.Equal(t, tc.expectedMaxLearners, cfgFromCmdLine.ec.MaxLearners)
-			require.Equal(t, tc.expectedMaxLearners, cfgFromFile.ec.MaxLearners)
-		})
-	}
-}
-
 // TestMemoryMlockFlagMigration tests the migration from
 // --experimental-memory-mlock to --memory-mlock
 // TODO: delete in v3.7
@@ -1341,7 +1277,6 @@ func TestConfigFileDeprecatedOptions(t *testing.T) {
 		ExperimentalWatchProgressNotifyInterval       time.Duration `json:"experimental-watch-progress-notify-interval,omitempty"`
 		ExperimentalWarningApplyDuration              time.Duration `json:"experimental-warning-apply-duration,omitempty"`
 		ExperimentalBootstrapDefragThresholdMegabytes uint          `json:"experimental-bootstrap-defrag-threshold-megabytes,omitempty"`
-		ExperimentalMaxLearners                       int           `json:"experimental-max-learners,omitempty"`
 		ExperimentalSnapshotCatchUpEntries            uint64        `json:"experimental-snapshot-catch-up-entries,omitempty"`
 		ExperimentalCompactionSleepInterval           time.Duration `json:"experimental-compaction-sleep-interval,omitempty"`
 		ExperimentalDowngradeCheckTime                time.Duration `json:"experimental-downgrade-check-time,omitempty"`
@@ -1368,7 +1303,6 @@ func TestConfigFileDeprecatedOptions(t *testing.T) {
 				ExperimentalWatchProgressNotifyInterval:       3 * time.Minute,
 				ExperimentalWarningApplyDuration:              3 * time.Minute,
 				ExperimentalBootstrapDefragThresholdMegabytes: 100,
-				ExperimentalMaxLearners:                       1,
 				ExperimentalSnapshotCatchUpEntries:            1000,
 				ExperimentalCompactionSleepInterval:           30 * time.Second,
 				ExperimentalDowngradeCheckTime:                1 * time.Minute,
@@ -1381,7 +1315,6 @@ func TestConfigFileDeprecatedOptions(t *testing.T) {
 				"experimental-watch-progress-notify-interval":       {},
 				"experimental-warning-apply-duration":               {},
 				"experimental-bootstrap-defrag-threshold-megabytes": {},
-				"experimental-max-learners":                         {},
 				"experimental-snapshot-catchup-entries":             {},
 				"experimental-compaction-sleep-interval":            {},
 				"experimental-downgrade-check-time":                 {},

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -321,8 +321,6 @@ Experimental feature:
     Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.
   --experimental-warning-unary-request-duration '300ms'
     Set time duration after which a warning is generated if a unary request takes more than this duration. Deprecated in v3.6 and will be decommissioned in v3.7. Use '--warning-unary-request-duration' instead.
-  --experimental-max-learners '1'
-    Set the max number of learner members allowed in the cluster membership. Deprecated in v3.6 and will be decommissioned in v3.7. Use '--max-learners' instead.
   --max-learners '1'
     Set the max number of learner members allowed in the cluster membership.
   --experimental-snapshot-catch-up-entries '5000'


### PR DESCRIPTION
ExperimentalMaxLearners was introduced in v3.6, so there's no need to worry about deprecating, it can be migrated straight into a FeatureGate.

Follow up on https://github.com/kubernetes/kubernetes/pull/130583#issuecomment-2707218268.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
