### PR TITLE
[release-3.5] Fix the learner promotion changes not being persisted into v3store (bbolt)

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -696,6 +696,10 @@ func (c *RaftCluster) IsReadyToPromoteMember(id uint64) bool {
 	return true
 }
 
+func (c *RaftCluster) MembersFromStore() (map[types.ID]*Member, map[types.ID]bool) {
+	return membersFromStore(c.lg, c.v2store)
+}
+
 func membersFromStore(lg *zap.Logger, st v2store.Store) (map[types.ID]*Member, map[types.ID]bool) {
 	members := make(map[types.ID]*Member)
 	removed := make(map[types.ID]bool)
@@ -730,6 +734,10 @@ func membersFromStore(lg *zap.Logger, st v2store.Store) (map[types.ID]*Member, m
 		removed[MustParseMemberIDFromKey(lg, n.Key)] = true
 	}
 	return members, removed
+}
+
+func (c *RaftCluster) MembersFromBackend() (map[types.ID]*Member, map[types.ID]bool) {
+	return membersFromBackend(c.lg, c.be)
 }
 
 func membersFromBackend(lg *zap.Logger, be backend.Backend) (map[types.ID]*Member, map[types.ID]bool) {

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -1049,12 +1049,6 @@ func TestAddMemberSyncsBackendAndStoreV2(t *testing.T) {
 			backendMembers: []*Member{alice},
 		},
 		{
-			name:           "Adding member should fail if it exists in both",
-			storeV2Members: []*Member{alice},
-			backendMembers: []*Member{alice},
-			expectPanics:   true,
-		},
-		{
 			name:           "Adding member should fail if it exists in storeV2 and backend is nil",
 			storeV2Members: []*Member{alice},
 			backendNil:     true,

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -1049,6 +1049,11 @@ func TestAddMemberSyncsBackendAndStoreV2(t *testing.T) {
 			backendMembers: []*Member{alice},
 		},
 		{
+			name:           "Adding member should success if it exists in both",
+			storeV2Members: []*Member{alice},
+			backendMembers: []*Member{alice},
+		},
+		{
 			name:           "Adding member should fail if it exists in storeV2 and backend is nil",
 			storeV2Members: []*Member{alice},
 			backendNil:     true,

--- a/server/etcdserver/api/membership/store.go
+++ b/server/etcdserver/api/membership/store.go
@@ -54,9 +54,6 @@ func unsafeSaveMemberToBackend(lg *zap.Logger, be backend.Backend, m *Member) er
 	tx := be.BatchTx()
 	tx.LockInsideApply()
 	defer tx.Unlock()
-	if unsafeMemberExists(tx, mkey) {
-		return errMemberAlreadyExist
-	}
 	tx.UnsafePut(buckets.Members, mkey, mvalue)
 	return nil
 }

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2490,9 +2490,9 @@ func (s *EtcdServer) verifyV3StoreInSyncWithV2Store(shouldApplyV3 membership.Sho
 		v3Data, v3Err := json.Marshal(processedV3Members)
 
 		if v2Err != nil || v3Err != nil {
-			panic("members in v2store doesn't members in v3store")
+			panic("members in v2store doesn't match v3store")
 		}
-		panic(fmt.Sprintf("members in v2store doesn't v3store, v2store: %s, v3store: %s", string(v2Data), string(v3Data)))
+		panic(fmt.Sprintf("members in v2store doesn't match v3store, v2store: %s, v3store: %s", string(v2Data), string(v3Data)))
 	}
 }
 

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -655,6 +655,7 @@ func TestApplyConfigChangeUpdatesConsistIndex(t *testing.T) {
 
 	be, _ := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, be)
+	cl.SetBackend(be)
 	cindex.CreateMetaBucket(be.BatchTx())
 
 	cl.AddMember(&membership.Member{ID: types.ID(1)}, true)

--- a/server/verify/verify.go
+++ b/server/verify/verify.go
@@ -90,10 +90,35 @@ func Verify(cfg Config) error {
 // VerifyIfEnabled performs verification according to ETCD_VERIFY env settings.
 // See Verify for more information.
 func VerifyIfEnabled(cfg Config) error {
-	if os.Getenv(ENV_VERIFY) == ENV_VERIFY_ALL_VALUE {
+	if VerifyEnabled() {
 		return Verify(cfg)
 	}
 	return nil
+}
+
+// VerifyEnabled returns `true` if verification is enabled.
+func VerifyEnabled() bool {
+	return os.Getenv(ENV_VERIFY) == ENV_VERIFY_ALL_VALUE
+}
+
+// EnableVerification enables the verification and returns a function that
+// can be used to bring the original settings.
+func EnableVerification() func() {
+	previousEnv := os.Getenv(ENV_VERIFY)
+	os.Setenv(ENV_VERIFY, ENV_VERIFY_ALL_VALUE)
+	return func() {
+		os.Setenv(ENV_VERIFY, previousEnv)
+	}
+}
+
+// DisableVerification disables the verification and returns a function that
+// can be used to bring the original settings.
+func DisableVerification() func() {
+	previousEnv := os.Getenv(ENV_VERIFY)
+	os.Unsetenv(ENV_VERIFY)
+	return func() {
+		os.Setenv(ENV_VERIFY, previousEnv)
+	}
 }
 
 // MustVerifyIfEnabled performs verification according to ETCD_VERIFY env settings

--- a/tests/e2e/ctl_v2_test.go
+++ b/tests/e2e/ctl_v2_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"go.etcd.io/etcd/server/v3/verify"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -228,6 +229,10 @@ func TestUtlCtlV2Backup(t *testing.T) {
 
 func testUtlCtlV2Backup(t *testing.T, snapCount int, v3 bool, utl bool) {
 	BeforeTestV2(t)
+
+	// disable the verification because this case updated the db offline
+	revertFunc := verify.DisableVerification()
+	defer revertFunc()
 
 	backupDir, err := ioutil.TempDir(t.TempDir(), "testbackup0.etcd")
 	if err != nil {


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/issues/19557

Also added a generic verification on ensure the membership data in v3store is always in sync with v2store.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
