### PR TITLE
Nominate @fuweid as a new approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,11 @@
 
 approvers:
   - ahrtr            # Benjamin Wang <benjamin.ahrtr@gmail.com> <benjamin.wang@broadcom.com>
+  - fuweid           # Wei Fu <fuweid89@gmail.com>
   - jmhbnz           # James Blair <jablair@redhat.com> <mail@jamesblair.net>
   - serathius        # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
   - spzala           # Sahdev Zala <spzala@us.ibm.com>
   - wenjiaswe        # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
 reviewers:
-  - fuweid           # Wei Fu <fuweid89@gmail.com>
   - ivanvc           # Ivan Valdes <ivan@vald.es>
   - siyuanfoundation # Siyuan Zhang <sizhang@google.com> <physicsbug@gmail.com>


### PR DESCRIPTION
Fu Wei (@fuweid) has been actively contributing to etcd for the past 2–3 years. He (and also @ivanvc ) maintains a strong and effective collaboration with the community and tech leads. He not only has a deep understanding of etcd but has also played a key role in the development of v3.6.0.  His contributions have been essential to a smooth release. I propose promoting him to etcd maintainer/approver.

All Fu Wei's PR: https://github.com/etcd-io/etcd/issues?q=state%3Aclosed%20is%3Apr%20author%3Afuweid 

Proof of his expertise in etcd:
1. Resolved the missing delete event on watch: https://github.com/etcd-io/etcd/issues/19179
2. Figured out the root cause of the flaky downgrade e2e test: https://github.com/etcd-io/etcd/issues/19391#issuecomment-2652285100
3. Figured out the root cause why etcd sometimes generates a different hash when always writing exactly the same set of key/values: https://github.com/etcd-io/etcd/pull/19313#issue-2824315278
4. Figured out the root cause of the flaky lease test case: https://github.com/etcd-io/etcd/pull/19476#issue-2876365698
5. Upgraded grpc-gateway from v1 to v2 together with me: https://github.com/etcd-io/etcd/pull/16595
6. Fu Wei independently designed & implemented the bbolt [robustness test](https://github.com/etcd-io/bbolt/tree/main/tests/robustness)

BTW, Fu Wei was nominated & promoted to a reviewer on Sep 25, 2023, refer to https://github.com/etcd-io/etcd/issues/16650

cc @jmhbnz @ivanvc @serathius @spzala @wenjiaswe 