### PR TITLE
client/pkg: address Go 1.24 usetesting issues

### DIFF
--- a/client/pkg/testutil/before.go
+++ b/client/pkg/testutil/before.go
@@ -19,9 +19,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
@@ -31,15 +28,12 @@ func BeforeTest(tb testing.TB) {
 
 	revertVerifyFunc := verify.EnableAllVerifications()
 
-	path, err := os.Getwd()
-	require.NoError(tb, err)
 	tempDir := tb.TempDir()
-	require.NoError(tb, os.Chdir(tempDir))
+	tb.Chdir(tempDir)
 	tb.Logf("Changing working directory to: %s", tempDir)
 
 	tb.Cleanup(func() {
 		revertVerifyFunc()
-		assert.NoError(tb, os.Chdir(path))
 	})
 }
 


### PR DESCRIPTION
Follow up on: https://github.com/etcd-io/etcd/pull/19440#issuecomment-2691945198

Use the test package's provided Chdir function. Therefore, it's not required to evaluate an error (it doesn't return one) or change directories at the end.

References:
* https://pkg.go.dev/testing#T.Chdir
* https://pkg.go.dev/testing#T.TempDir

Part of #19581

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
