### PR TITLE
tests/framework: address Go 1.24 usetesting issues

### DIFF
--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -1079,7 +1079,7 @@ func findMemberIDByEndpoint(members []*etcdserverpb.Member, endpoint string) (ui
 // WaitLeader returns index of the member in c.Members() that is leader
 // or fails the test (if not established in 30s).
 func (epc *EtcdProcessCluster) WaitLeader(t testing.TB) int {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	return epc.WaitMembersForLeader(ctx, t, epc.Procs)
 }

--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -37,7 +36,7 @@ func DowngradeEnable(t *testing.T, epc *EtcdProcessCluster, ver *semver.Version)
 	t.Logf("etcdctl downgrade enable %s", ver.String())
 	c := epc.Etcdctl()
 	testutils.ExecuteWithTimeout(t, 20*time.Second, func() {
-		err := c.DowngradeEnable(context.TODO(), ver.String())
+		err := c.DowngradeEnable(t.Context(), ver.String())
 		require.NoError(t, err)
 	})
 
@@ -60,7 +59,7 @@ func DowngradeCancel(t *testing.T, epc *EtcdProcessCluster) {
 	testutils.ExecuteWithTimeout(t, 1*time.Minute, func() {
 		for {
 			t.Logf("etcdctl downgrade cancel")
-			err = c.DowngradeCancel(context.TODO())
+			err = c.DowngradeCancel(t.Context())
 			if err != nil {
 				if strings.Contains(err.Error(), "no inflight downgrade job") {
 					// cancellation has been performed successfully
@@ -93,7 +92,7 @@ func ValidateDowngradeInfo(t *testing.T, clus *EtcdProcessCluster, expected *pb.
 
 		testutils.ExecuteWithTimeout(t, 1*time.Minute, func() {
 			for {
-				statuses, err := mc.Status(context.Background())
+				statuses, err := mc.Status(t.Context())
 				if err != nil {
 					cfg.Logger.Warn("failed to get member status and retrying",
 						zap.Error(err),
@@ -157,7 +156,7 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 		}
 		member.Config().ExecPath = newExecPath
 		lg.Info("Restarting member", zap.String("member", member.Config().Name))
-		err := member.Start(context.TODO())
+		err := member.Start(t.Context())
 		if err != nil {
 			return err
 		}

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -321,7 +321,7 @@ func (ep *EtcdServerProcess) IsRunning() bool {
 func AssertProcessLogs(t *testing.T, ep EtcdProcess, expectLog string) {
 	t.Helper()
 	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	_, err = ep.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: expectLog})
 	if err != nil {

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -420,7 +420,7 @@ func (c *Cluster) WaitLeader(t testing.TB) int {
 // and returns its 'index' in the 'membs' list
 func (c *Cluster) WaitMembersForLeader(t testing.TB, membs []*Member) int {
 	t.Logf("WaitMembersForLeader")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	l := 0
 	for l = c.waitMembersForLeader(ctx, t, membs); l < 0; {

--- a/tests/framework/testutils/execute.go
+++ b/tests/framework/testutils/execute.go
@@ -24,7 +24,7 @@ import (
 )
 
 func ExecuteWithTimeout(t *testing.T, timeout time.Duration, f func()) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 	ExecuteUntil(ctx, t, f)
 }

--- a/tests/framework/testutils/log_observer_test.go
+++ b/tests/framework/testutils/log_observer_test.go
@@ -32,7 +32,7 @@ func TestLogObserver_Timeout(t *testing.T) {
 	logger := zap.New(logCore)
 	logger.Info(t.Name())
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	_, err := logOb.Expect(ctx, "unknown", 1)
 	cancel()
 	require.ErrorIs(t, err, context.DeadlineExceeded)
@@ -45,7 +45,7 @@ func TestLogObserver_Expect(t *testing.T) {
 
 	logger := zap.New(logCore)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	resCh := make(chan []string, 1)


### PR DESCRIPTION
#### Description

Apply `usetesting --fix ./...` on tests/framework packages

Part of https://github.com/etcd-io/etcd/issues/19581

