### PR TITLE
tests/robustness: address Go 1.24 usetesting issues

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -55,7 +55,7 @@ func TestRobustnessExploratory(t *testing.T) {
 		t.Run(s.Name, func(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			s.Cluster.Logger = lg
-			ctx := context.Background()
+			ctx := t.Context()
 			c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.Cluster))
 			require.NoError(t, err)
 			defer forcestopCluster(c)
@@ -74,7 +74,7 @@ func TestRobustnessRegression(t *testing.T) {
 		t.Run(s.Name, func(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			s.Cluster.Logger = lg
-			ctx := context.Background()
+			ctx := t.Context()
 			c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.Cluster))
 			require.NoError(t, err)
 			defer forcestopCluster(c)


### PR DESCRIPTION
#### Description

Apply `usetesting --fix ./...` on tests/robustness packages

Part of https://github.com/etcd-io/etcd/issues/19581

