### PR TITLE
concurrency: early termination if session key is deleted

### DIFF
--- a/client/v3/concurrency/election.go
+++ b/client/v3/concurrency/election.go
@@ -90,7 +90,7 @@ func (e *Election) Campaign(ctx context.Context, val string) error {
 		}
 	}
 
-	err = waitDeletes(ctx, client, e.keyPrefix, e.leaderRev-1)
+	err = waitDeletes(ctx, client, e.keyPrefix, e.leaderKey, e.leaderRev-1)
 	if err != nil {
 		// clean up in case of context cancel
 		select {

--- a/client/v3/concurrency/key.go
+++ b/client/v3/concurrency/key.go
@@ -32,15 +32,12 @@ func waitDelete(ctx context.Context, client *v3.Client, key, leaseKey string, re
 	defer cancel()
 
 	wch := client.Watch(cctx, key, v3.WithRev(rev))
-	lch := client.Watch(cctx, leaseKey)
+	lch := client.Watch(cctx, leaseKey, v3.WithRev(rev))
 
 	for {
 		select {
 		case wr, ok := <-wch:
 			if !ok {
-				if err := wr.Err(); err != nil {
-					return err
-				}
 				return ErrLostWatcher
 			}
 
@@ -55,9 +52,6 @@ func waitDelete(ctx context.Context, client *v3.Client, key, leaseKey string, re
 			}
 		case sr, ok := <-lch:
 			if !ok {
-				if err := sr.Err(); err != nil {
-					return err
-				}
 				return ErrLostWatcher
 			}
 

--- a/client/v3/concurrency/mutex.go
+++ b/client/v3/concurrency/mutex.go
@@ -85,8 +85,7 @@ func (m *Mutex) Lock(ctx context.Context) error {
 	}
 	client := m.s.Client()
 	// wait for deletion revisions prior to myKey
-	// TODO: early termination if the session key is deleted before other session keys with smaller revisions.
-	werr := waitDeletes(ctx, client, m.pfx, m.myRev-1)
+	werr := waitDeletes(ctx, client, m.pfx, m.myKey, m.myRev-1)
 	// release lock key if wait failed
 	if werr != nil {
 		m.Unlock(client.Ctx())

--- a/tests/integration/clientv3/concurrency/mutex_test.go
+++ b/tests/integration/clientv3/concurrency/mutex_test.go
@@ -17,6 +17,7 @@ package concurrency_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -83,6 +84,15 @@ func TestMutexLockEarlyTerminationOnSessionExpired(t *testing.T) {
 	go func() {
 		m2Done <- m2.Lock(t.Context())
 	}()
+
+	// wait until m2's key appears in etcd
+	require.Eventually(t, func() bool {
+		resp, err := cli.Get(t.Context(), "/my-lock/", clientv3.WithPrefix())
+		if err != nil {
+			return false
+		}
+		return len(resp.Kvs) >= 2
+	}, 5*time.Second, 50*time.Millisecond)
 
 	// revoke s2's session while m1 still holds the lock,
 	// this should trigger early termination,

--- a/tests/integration/v3_election_test.go
+++ b/tests/integration/v3_election_test.go
@@ -365,7 +365,7 @@ func TestElectionWithAuthEnabled(t *testing.T) {
 			if serr != nil {
 				errC <- fmt.Errorf("[NewSession] %s: %w", campaign.name, serr)
 			}
-			s.Orphan()
+			defer s.Close()
 
 			e := concurrency.NewElection(s, campaign.pfx)
 			eerr := e.Campaign(t.Context(), "whatever")


### PR DESCRIPTION
fix #19597

---

### Affected Components

This fix benefits both `Mutex` and `Election`:

- **Mutex:** When a waiting client's session expires, it returns `ErrLeaseExpiredDuringWait` immediately instead of waiting for all preceding keys to be deleted.
- **Election:** Same early termination behavior for candidates waiting in the election queue.

Both components share the same `waitDeletes` implementation, so fixing it in `key.go` benefits both.
