### PR TITLE
development: fix 'make verify' errors in OSX

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -67,6 +67,18 @@ if [ -z "${GOARCH:-}" ]; then
   GOARCH=$(go env GOARCH);
 fi
 
+if [ -z "${OS:-}" ]; then
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+fi
+
+if [ -z "${ARCH:-}" ]; then
+  ARCH=$(uname -m)
+
+  if [ "$ARCH" = "arm64" ]; then
+    ARCH="aarch64"
+  fi
+fi
+
 # determine whether target supports race detection
 if [ -z "${RACE:-}" ] ; then
   if [ "$GOARCH" == "amd64" ] || [ "$GOARCH" == "arm64" ]; then
@@ -331,7 +343,7 @@ function shellcheck_pass {
   SHELLCHECK=shellcheck
   if ! tool_exists "shellcheck" "https://github.com/koalaman/shellcheck#installing"; then
     log_callout "Installing shellcheck $SHELLCHECK_VERSION"
-    wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv -C /tmp/ --strip-components=1
+    wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.${OS}.${ARCH}.tar.xz" | tar -xJv -C /tmp/ --strip-components=1
     mkdir -p ./bin
     mv /tmp/shellcheck ./bin/
     SHELLCHECK=./bin/shellcheck
@@ -356,7 +368,14 @@ function markdown_marker_pass {
   # TODO: check other markdown files when marker handles headers with '[]'
   if ! tool_exists "$marker" "https://crates.io/crates/marker"; then
     log_callout "Installing markdown marker $MARKDOWN_MARKER_VERSION"
-    wget -qO- "https://github.com/crawford/marker/releases/download/${MARKDOWN_MARKER_VERSION}/marker-${MARKDOWN_MARKER_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar -xzv -C /tmp/ --strip-components=1 >/dev/null
+    MARKER_OS=$OS
+    if [ "$OS" = "darwin" ]; then
+      MARKER_OS="apple-darwin"
+    elif [ "$OS" = "linux" ]; then
+      MARKER_OS="unknown-linux-musl"
+    fi
+
+    wget -qO- "https://github.com/crawford/marker/releases/download/${MARKDOWN_MARKER_VERSION}/marker-${MARKDOWN_MARKER_VERSION}-${ARCH}-${MARKER_OS}.tar.gz" | tar -xzv -C /tmp/ --strip-components=1 >/dev/null
     mkdir -p ./bin
     mv /tmp/marker ./bin/
     marker=./bin/marker


### PR DESCRIPTION
Hi folks 👋

I am a newbie and I was excited about contributing to etcd. Currently local development workflow suggests running 'make verify' to verify all checks pass before committing. However, currently this check fails in the main branch. 

Two errors have been faced and fixed. 
- Firstly, updated check for "github.com/prometheus/procfs" in "bill-of-materials.json" to be skipped in OSX.
- Secondly, updated "scripts/test.sh" to download tools "crawford/marker" and "koalaman/shellcheck" for the host OS and architecture. Previously ARM MacOS devices were having errors while running make verify because downloaded version of shellcheck was for linux x86_64 architecture.

For reference, here are the errors faced during local setup.

1. Error before updating `bill-if-materials.json`,

```
381,389d380
<               "project": "github.com/prometheus/procfs",
<               "licenses": [
<                       {
<                               "type": "Apache License 2.0",
<                               "confidence": 1
<                       }
<               ]
<       },
<       {
modularized licenses do not match given bill of materials
FAIL: 'bom' FAILED at Fri Mar 14 00:02:01 CDT 2025
```


2. Error before updating shellcheck download,

```
stderr: ./scripts/test_lib.sh: line 148: ./bin/shellcheck: cannot execute binary file: Exec format error
FAIL: (code:126):
  % './bin/shellcheck' '-fgcc' 'scripts/build-binary.sh' 'scripts/build-docker.sh' 'scripts/build-release.sh' 'scripts/build.sh' 'scripts/build_lib.sh' 'scripts/build_tools.sh' 'scripts/codecov_upload.sh' 'scripts/fix.sh' 'scripts/fuzzing.sh' 'scripts/genproto.sh' 'scripts/markdown_diff_lint.sh' 'scripts/measure-testgrid-flakiness.sh' 'scripts/release.sh' 'scripts/release_mod.sh' 'scripts/sync_go_toolchain_directive.sh' 'scripts/test.sh' 'scripts/test_images.sh' 'scripts/test_lib.sh' 'scripts/update_dep.sh' 'scripts/update_proto_annotations.sh' 'scripts/updatebom.sh' 'scripts/verify_genproto.sh' 'scripts/verify_go_versions.sh' 'scripts/verify_proto_annotations.sh'

FAIL: 'run ./bin/shellcheck -fgcc scripts/build-binary.sh scripts/build-docker.sh scripts/build-release.sh scripts/build.sh scripts/build_lib.sh scripts/build_tools.sh scripts/codecov_upload.sh scripts/fix.sh scripts/fuzzing.sh scripts/genproto.sh scripts/markdown_diff_lint.sh scripts/measure-testgrid-flakiness.sh scripts/release.sh scripts/release_mod.sh scripts/sync_go_toolchain_directive.sh scripts/test.sh scripts/test_images.sh scripts/test_lib.sh scripts/update_dep.sh scripts/update_proto_annotations.sh scripts/updatebom.sh scripts/verify_genproto.sh scripts/verify_go_versions.sh scripts/verify_proto_annotations.sh' checking failed (!=0 return code)
FAIL: 'shellcheck' FAILED at Fri Mar 14 00:03:03 CDT 2025
```