### PR TITLE
[release-3.5] [Solution 2] Auto sync members in v3store if Islearner is the only field that differs between v2store and v3store

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -277,6 +277,9 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 			return e, err
 		}
 	}
+
+	e.Server.SyncLearnerPromotionIfNeeded()
+
 	e.Server.Start()
 
 	if err = e.servePeers(); err != nil {

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -530,8 +531,22 @@ func (c *RaftCluster) PromoteMember(id types.ID, shouldApplyV3 ShouldApplyV3) {
 	if c.v2store != nil {
 		mustUpdateMemberInStore(c.lg, c.v2store, c.members[id])
 	}
-	if c.be != nil && shouldApplyV3 {
-		unsafeSaveMemberToBackend(c.lg, c.be, c.members[id])
+	if c.be != nil {
+		if shouldApplyV3 {
+			unsafeSaveMemberToBackend(c.lg, c.be, c.members[id])
+		} else {
+			// Workaround https://github.com/etcd-io/etcd/issues/19557 for the case that
+			// learner promotion hasn't been applied.
+			v3Members, _ := membersFromBackend(c.lg, c.be)
+			if m, ok := v3Members[id]; ok {
+				if m.IsLearner {
+					c.lg.Info("Forcibly apply member promotion", zap.String("member", fmt.Sprintf("%+v", *c.members[id])))
+					unsafeHackySaveMemberToBackend(c.lg, c.be, c.members[id])
+				} else {
+					c.lg.Info("Member promotion had already been correctly applied", zap.String("member", fmt.Sprintf("%+v", *c.members[id])))
+				}
+			}
+		}
 	}
 
 	c.lg.Info(
@@ -540,6 +555,53 @@ func (c *RaftCluster) PromoteMember(id types.ID, shouldApplyV3 ShouldApplyV3) {
 		zap.String("local-member-id", c.localID.String()),
 		zap.String("promoted-member-id", id.String()),
 	)
+}
+
+func (c *RaftCluster) SyncLearnerPromotionIfNeeded() {
+	c.Lock()
+	defer c.Unlock()
+
+	v2Members, _ := membersFromStore(c.lg, c.v2store)
+	v3Members, _ := membersFromBackend(c.lg, c.be)
+
+	for id, v2Member := range v2Members {
+		v3Member, ok := v3Members[id]
+
+		if !ok {
+			c.lg.Error("Detected member only in v2store but missing in v3store", zap.String("member", fmt.Sprintf("%+v", *v2Member)))
+			continue
+		}
+
+		// A peerURL list is considered the same regardless of order.
+		clonedV2Member := v2Member.Clone()
+		sort.Strings(clonedV2Member.PeerURLs)
+
+		clonedV3Member := v3Member.Clone()
+		sort.Strings(clonedV3Member.PeerURLs)
+
+		if reflect.DeepEqual(clonedV2Member.RaftAttributes, clonedV3Member.RaftAttributes) {
+			c.lg.Info("Member's RaftAttributes is consistent between v2store and v3store", zap.String("member", fmt.Sprintf("%+v", *v2Member)))
+			continue
+		}
+
+		// Sync member iff both conditions below are true,
+		//  1. IsLearner is the only field in RaftAttributes that differs between v2store and v3store.
+		//  2. v2store.IsLearner == false && v3store.IsLearner == true.
+		clonedV3Member.IsLearner = false
+		if reflect.DeepEqual(clonedV2Member.RaftAttributes, clonedV3Member.RaftAttributes) {
+			syncedV3Member := v3Member.Clone()
+			syncedV3Member.IsLearner = false
+			c.lg.Warn("Syncing member in v3store", zap.String("member", fmt.Sprintf("%+v", *syncedV3Member)))
+			unsafeHackySaveMemberToBackend(c.lg, c.be, syncedV3Member)
+			c.be.ForceCommit()
+			continue
+		}
+
+		c.lg.Error("Cannot sync member in v3store due to IsLearner not being the only field that differs between v2store amd v3store",
+			zap.String("v2member", fmt.Sprintf("%+v", *v2Member)),
+			zap.String("v3member", fmt.Sprintf("%+v", *v3Member)),
+		)
+	}
 }
 
 func (c *RaftCluster) UpdateRaftAttributes(id types.ID, raftAttr RaftAttributes, shouldApplyV3 ShouldApplyV3) {

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2931,3 +2931,15 @@ func maybeDefragBackend(cfg config.ServerConfig, be backend.Backend) error {
 func (s *EtcdServer) CorruptionChecker() CorruptionChecker {
 	return s.corruptionChecker
 }
+
+// SyncLearnerPromotionIfNeeded provides a workaround for the users who have
+// already been affected by https://github.com/etcd-io/etcd/issues/19557.
+// It automatically syncs the v3store (bbolt) from v2store iff all the
+// conditions below are true for each member,
+//  1. IsLearner is the only field that differs between v2store and v3store.
+//  2. v2store.IsLearner == false && v3store.IsLearner == true.
+func (s *EtcdServer) SyncLearnerPromotionIfNeeded() {
+	s.Logger().Info("Trying to sync the learner promotion operations for v3store if needed")
+	s.cluster.SyncLearnerPromotionIfNeeded()
+	s.Logger().Info("Finished syncing the learner promotion operations for v3store")
+}

--- a/server/mvcc/backend/verify.go
+++ b/server/mvcc/backend/verify.go
@@ -61,6 +61,14 @@ func verifyLockEnabled() bool {
 
 func insideApply() bool {
 	stackTraceStr := string(debug.Stack())
+
+	// Exclude the case of `unsafeHackySaveMemberToBackend`, which is
+	// used to workaround the situation which are already affected by
+	// https://github.com/etcd-io/etcd/issues/19557
+	if strings.Contains(stackTraceStr, "unsafeHackySaveMemberToBackend") {
+		return false
+	}
+
 	return strings.Contains(stackTraceStr, ".applyEntries")
 }
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
+	go.etcd.io/bbolt v1.3.11
 	go.etcd.io/etcd/api/v3 v3.5.19
 	go.etcd.io/etcd/client/pkg/v3 v3.5.19
 	go.etcd.io/etcd/client/v2 v2.305.19
@@ -78,7 +79,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.20.0 // indirect


### PR DESCRIPTION
Second solution to provide a fix for the users who have already been affected by https://github.com/etcd-io/etcd/issues/19557. It's based on the comment https://github.com/etcd-io/etcd/pull/19586#discussion_r1995637427,
- good side
  - Sync the v3store before the raft loop getting started, and also in appy workflow. So no any potential conflict
- bad side
  - created two exceptions
    - Forcibly apply member promotion to v3store even when `shouldApplyV3` is `false`
    - Use `LookOutsideApply` inside the apply workflow, so we have to disable the verification in e2e test case.
  - updated the apply workflow... 

The first solution is https://github.com/etcd-io/etcd/pull/19586
- good side
  - did not change the apply workflow
  - it's only executed on boostrap, it's an one-time operation
- bad side
  - It updates the backend outside apply workflow, so has potential conflict. But actually it's protected by lock, so it's still safe.


Both solutions work. If there is no strong objection or preference, let's go for solution 2 (this PR)

cc @fuweid @ivanvc @jmhbnz @serathius @siyuanfoundation 






