### PR TITLE
tests/integration: address Go 1.24 usetesting issues

### DIFF
--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -199,7 +199,7 @@ func TestClusterUpgradeAfterPromotingMembers(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			epc, _ := mustCreateNewClusterByPromotingMembers(t, e2e.LastVersion, clusterSize,
 				e2e.WithSnapshotCount(uint64(tc.snapshot)))
@@ -220,7 +220,7 @@ func TestClusterUpgradeAfterPromotingMembers(t *testing.T) {
 
 			t.Logf("Checking all members are ready to serve client requests")
 			for i := 0; i < clusterSize; i++ {
-				err = epc.Procs[i].Etcdctl().Put(context.Background(), "foo", "bar", config.PutOptions{})
+				err = epc.Procs[i].Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
 				require.NoError(t, err)
 			}
 		})
@@ -230,7 +230,7 @@ func TestClusterUpgradeAfterPromotingMembers(t *testing.T) {
 func mustCreateNewClusterByPromotingMembers(t *testing.T, clusterVersion e2e.ClusterVersion, clusterSize int, opts ...e2e.EPClusterOption) (*e2e.EtcdProcessCluster, []*etcdserverpb.Member) {
 	require.GreaterOrEqualf(t, clusterSize, 1, "clusterSize must be at least 1")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Logf("Creating new etcd cluster - version: %s, clusterSize: %v", clusterVersion, clusterSize)
 	opts = append(opts, e2e.WithVersion(clusterVersion), e2e.WithClusterSize(1))
@@ -284,7 +284,7 @@ func mustCreateNewClusterByPromotingMembers(t *testing.T, clusterVersion e2e.Clu
 }
 
 func ensureAllMembersAreVotingMembers(t *testing.T, epc *e2e.EtcdProcessCluster) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	resp, err := epc.Etcdctl().MemberList(ctx, false)

--- a/tests/integration/clientv3/cluster_test.go
+++ b/tests/integration/clientv3/cluster_test.go
@@ -37,7 +37,7 @@ func TestMemberList(t *testing.T) {
 
 	capi := clus.RandClient()
 
-	resp, err := capi.MemberList(context.Background())
+	resp, err := capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -56,7 +56,7 @@ func TestMemberAdd(t *testing.T) {
 	capi := clus.RandClient()
 
 	urls := []string{"http://127.0.0.1:1234"}
-	resp, err := capi.MemberAdd(context.Background(), urls)
+	resp, err := capi.MemberAdd(t.Context(), urls)
 	if err != nil {
 		t.Fatalf("failed to add member %v", err)
 	}
@@ -74,13 +74,13 @@ func TestMemberAddWithExistingURLs(t *testing.T) {
 
 	capi := clus.RandClient()
 
-	resp, err := capi.MemberList(context.Background())
+	resp, err := capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
 
 	existingURL := resp.Members[0].PeerURLs[0]
-	_, err = capi.MemberAdd(context.Background(), []string{existingURL})
+	_, err = capi.MemberAdd(t.Context(), []string{existingURL})
 	expectedErrKeywords := "Peer URLs already exists"
 	if err == nil {
 		t.Fatalf("expecting add member to fail, got no error")
@@ -97,7 +97,7 @@ func TestMemberRemove(t *testing.T) {
 	defer clus.Terminate(t)
 
 	capi := clus.Client(1)
-	resp, err := capi.MemberList(context.Background())
+	resp, err := capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -113,12 +113,12 @@ func TestMemberRemove(t *testing.T) {
 		}
 	}
 
-	_, err = capi.MemberRemove(context.Background(), rmvID)
+	_, err = capi.MemberRemove(t.Context(), rmvID)
 	if err != nil {
 		t.Fatalf("failed to remove member %v", err)
 	}
 
-	resp, err = capi.MemberList(context.Background())
+	resp, err = capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -135,18 +135,18 @@ func TestMemberUpdate(t *testing.T) {
 	defer clus.Terminate(t)
 
 	capi := clus.RandClient()
-	resp, err := capi.MemberList(context.Background())
+	resp, err := capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
 
 	urls := []string{"http://127.0.0.1:1234"}
-	_, err = capi.MemberUpdate(context.Background(), resp.Members[0].ID, urls)
+	_, err = capi.MemberUpdate(t.Context(), resp.Members[0].ID, urls)
 	if err != nil {
 		t.Fatalf("failed to update member %v", err)
 	}
 
-	resp, err = capi.MemberList(context.Background())
+	resp, err = capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -178,11 +178,11 @@ func TestMemberAddUpdateWrongURLs(t *testing.T) {
 		{"localhost:1234"},
 	}
 	for i := range tt {
-		_, err := capi.MemberAdd(context.Background(), tt[i])
+		_, err := capi.MemberAdd(t.Context(), tt[i])
 		if err == nil {
 			t.Errorf("#%d: MemberAdd err = nil, but error", i)
 		}
-		_, err = capi.MemberUpdate(context.Background(), 0, tt[i])
+		_, err = capi.MemberUpdate(t.Context(), 0, tt[i])
 		if err == nil {
 			t.Errorf("#%d: MemberUpdate err = nil, but error", i)
 		}
@@ -198,7 +198,7 @@ func TestMemberAddForLearner(t *testing.T) {
 	capi := clus.RandClient()
 
 	urls := []string{"http://127.0.0.1:1234"}
-	resp, err := capi.MemberAddAsLearner(context.Background(), urls)
+	resp, err := capi.MemberAddAsLearner(t.Context(), urls)
 	if err != nil {
 		t.Fatalf("failed to add member %v", err)
 	}
@@ -234,7 +234,7 @@ func TestMemberPromote(t *testing.T) {
 
 	learnerMember := clus.MustNewMember(t)
 	urls := learnerMember.PeerURLs.StringSlice()
-	memberAddResp, err := capi.MemberAddAsLearner(context.Background(), urls)
+	memberAddResp, err := capi.MemberAddAsLearner(t.Context(), urls)
 	if err != nil {
 		t.Fatalf("failed to add member %v", err)
 	}
@@ -256,7 +256,7 @@ func TestMemberPromote(t *testing.T) {
 
 	// learner is not started yet. Expect learner progress check to fail.
 	// As the result, member promote request will fail.
-	_, err = capi.MemberPromote(context.Background(), learnerID)
+	_, err = capi.MemberPromote(t.Context(), learnerID)
 	expectedErrKeywords := "can only promote a learner member which is in sync with leader"
 	if err == nil {
 		t.Fatalf("expecting promote not ready learner to fail, got no error")
@@ -280,7 +280,7 @@ func TestMemberPromote(t *testing.T) {
 			t.Fatalf("failed all attempts to promote learner member, last error: %v", err)
 		}
 
-		_, err = capi.MemberPromote(context.Background(), learnerID)
+		_, err = capi.MemberPromote(t.Context(), learnerID)
 		// successfully promoted learner
 		if err == nil {
 			break
@@ -308,7 +308,7 @@ func TestMemberPromoteMemberNotLearner(t *testing.T) {
 	followerIdx := (leaderIdx + 1) % 3
 	cli := clus.Client(followerIdx)
 
-	resp, err := cli.MemberList(context.Background())
+	resp, err := cli.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -319,7 +319,7 @@ func TestMemberPromoteMemberNotLearner(t *testing.T) {
 	// promoting any of the voting members in cluster should fail
 	expectedErrKeywords := "can only promote a learner member"
 	for _, m := range resp.Members {
-		_, err = cli.MemberPromote(context.Background(), m.ID)
+		_, err = cli.MemberPromote(t.Context(), m.ID)
 		if err == nil {
 			t.Fatalf("expect promoting voting member to fail, got no error")
 		}
@@ -344,7 +344,7 @@ func TestMemberPromoteMemberNotExist(t *testing.T) {
 	followerIdx := (leaderIdx + 1) % 3
 	cli := clus.Client(followerIdx)
 
-	resp, err := cli.MemberList(context.Background())
+	resp, err := cli.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to list member %v", err)
 	}
@@ -369,7 +369,7 @@ func TestMemberPromoteMemberNotExist(t *testing.T) {
 	}
 
 	expectedErrKeywords := "member not found"
-	_, err = cli.MemberPromote(context.Background(), randID)
+	_, err = cli.MemberPromote(t.Context(), randID)
 	if err == nil {
 		t.Fatalf("expect promoting voting member to fail, got no error")
 	}
@@ -388,7 +388,7 @@ func TestMaxLearnerInCluster(t *testing.T) {
 
 	// 2. adding 2 learner members should succeed
 	for i := 0; i < 2; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		_, err := clus.Client(0).MemberAddAsLearner(ctx, []string{fmt.Sprintf("http://127.0.0.1:123%d", i)})
 		cancel()
 		if err != nil {
@@ -399,7 +399,7 @@ func TestMaxLearnerInCluster(t *testing.T) {
 	// ensure client endpoint is voting member
 	leaderIdx := clus.WaitLeader(t)
 	capi := clus.Client(leaderIdx)
-	resp1, err := capi.MemberList(context.Background())
+	resp1, err := capi.MemberList(t.Context())
 	if err != nil {
 		t.Fatalf("failed to get member list")
 	}
@@ -414,7 +414,7 @@ func TestMaxLearnerInCluster(t *testing.T) {
 	}
 
 	// 3. cluster has 3 voting member and 2 learner, adding another learner should fail
-	_, err = clus.Client(0).MemberAddAsLearner(context.Background(), []string{"http://127.0.0.1:2342"})
+	_, err = clus.Client(0).MemberAddAsLearner(t.Context(), []string{"http://127.0.0.1:2342"})
 	if err == nil {
 		t.Fatalf("expect member add to fail, got no error")
 	}
@@ -424,7 +424,7 @@ func TestMaxLearnerInCluster(t *testing.T) {
 	}
 
 	// 4. cluster has 3 voting member and 1 learner, adding a voting member should succeed
-	_, err = clus.Client(0).MemberAdd(context.Background(), []string{"http://127.0.0.1:3453"})
+	_, err = clus.Client(0).MemberAdd(t.Context(), []string{"http://127.0.0.1:3453"})
 	if err != nil {
 		t.Errorf("failed to add member %v", err)
 	}

--- a/tests/integration/clientv3/concurrency/election_test.go
+++ b/tests/integration/clientv3/concurrency/election_test.go
@@ -47,7 +47,7 @@ func TestResumeElection(t *testing.T) {
 	e := concurrency.NewElection(s, prefix)
 
 	// entire test should never take more than 10 seconds
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
 	defer cancel()
 
 	// become leader

--- a/tests/integration/clientv3/concurrency/session_test.go
+++ b/tests/integration/clientv3/concurrency/session_test.go
@@ -31,7 +31,7 @@ func TestSessionOptions(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
 	require.NoError(t, err)
 	defer cli.Close()
-	lease, err := cli.Grant(context.Background(), 100)
+	lease, err := cli.Grant(t.Context(), 100)
 	require.NoError(t, err)
 	s, err := concurrency.NewSession(cli, concurrency.WithLease(lease.ID))
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestSessionTTLOptions(t *testing.T) {
 
 	leaseID := s.Lease()
 	// TTL retrieved should be less than the set TTL, but not equal to default:60 or exprired:-1
-	resp, err := cli.Lease.TimeToLive(context.Background(), leaseID)
+	resp, err := cli.Lease.TimeToLive(t.Context(), leaseID)
 	if err != nil {
 		t.Log(err)
 	}
@@ -77,7 +77,7 @@ func TestSessionCtx(t *testing.T) {
 	cli, err := integration2.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
 	require.NoError(t, err)
 	defer cli.Close()
-	lease, err := cli.Grant(context.Background(), 100)
+	lease, err := cli.Grant(t.Context(), 100)
 	require.NoError(t, err)
 	s, err := concurrency.NewSession(cli, concurrency.WithLease(lease.ID))
 	require.NoError(t, err)

--- a/tests/integration/clientv3/connectivity/black_hole_test.go
+++ b/tests/integration/clientv3/connectivity/black_hole_test.go
@@ -66,7 +66,7 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	require.NoError(t, err)
 	defer cli.Close()
 
-	wch := cli.Watch(context.Background(), "foo", clientv3.WithCreatedNotify())
+	wch := cli.Watch(t.Context(), "foo", clientv3.WithCreatedNotify())
 	_, ok := <-wch
 	require.Truef(t, ok, "watch failed on creation")
 
@@ -78,7 +78,7 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 
 	clus.Members[0].Bridge().Blackhole()
 
-	_, err = clus.Client(1).Put(context.TODO(), "foo", "bar")
+	_, err = clus.Client(1).Put(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 	select {
 	case <-wch:
@@ -94,9 +94,9 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	clus.Members[1].Bridge().Blackhole()
 
 	// make sure client[0] can connect to eps[0] after remove the blackhole.
-	_, err = clus.Client(0).Get(context.TODO(), "foo")
+	_, err = clus.Client(0).Get(t.Context(), "foo")
 	require.NoError(t, err)
-	_, err = clus.Client(0).Put(context.TODO(), "foo", "bar1")
+	_, err = clus.Client(0).Put(t.Context(), "foo", "bar1")
 	require.NoError(t, err)
 
 	select {
@@ -196,7 +196,7 @@ func testBalancerUnderBlackholeNoKeepAlive(t *testing.T, op func(*clientv3.Clien
 	// TODO: first operation can succeed
 	// when gRPC supports better retry on non-delivered request
 	for i := 0; i < 5; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
 		err = op(cli, ctx)
 		cancel()
 		if err == nil {

--- a/tests/integration/clientv3/connectivity/dial_test.go
+++ b/tests/integration/clientv3/connectivity/dial_test.go
@@ -129,7 +129,7 @@ func testDialSetEndpoints(t *testing.T, setBefore bool) {
 		cli.SetEndpoints(eps[toKill%3], eps[(toKill+1)%3])
 	}
 	time.Sleep(time.Second * 2)
-	ctx, cancel := context.WithTimeout(context.Background(), integration2.RequestWaitTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration2.RequestWaitTimeout)
 	_, err = cli.Get(ctx, "foo", clientv3.WithSerializable())
 	require.NoError(t, err)
 	cancel()
@@ -150,7 +150,7 @@ func TestSwitchSetEndpoints(t *testing.T) {
 
 	cli.SetEndpoints(eps...)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	_, err := cli.Get(ctx, "foo")
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestDialForeignEndpoint(t *testing.T) {
 	// grpc can return a lazy connection that's not connected yet; confirm
 	// that it can communicate with the cluster.
 	kvc := clientv3.NewKVFromKVClient(pb.NewKVClient(conn), clus.Client(0))
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	_, gerr := kvc.Get(ctx, "abc")
 	require.NoError(t, gerr)
@@ -201,7 +201,7 @@ func TestSetEndpointAndPut(t *testing.T) {
 	defer clus.Terminate(t)
 
 	clus.Client(1).SetEndpoints(clus.Members[0].GRPCURL)
-	_, err := clus.Client(1).Put(context.TODO(), "foo", "bar")
+	_, err := clus.Client(1).Put(t.Context(), "foo", "bar")
 	if err != nil && !strings.Contains(err.Error(), "closing") {
 		t.Fatal(err)
 	}

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -136,7 +136,7 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 	clus.Members[0].InjectPartition(t, clus.Members[1:]...)
 
 	for i := 0; i < 5; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 		err = op(cli, ctx)
 		t.Logf("Op returned error: %v", err)
 		t.Log("Cancelling...")
@@ -191,7 +191,7 @@ func TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection(t *testing.T
 
 	// expects balancer to round robin to leader within two attempts
 	for i := 0; i < 2; i++ {
-		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		ctx, cancel := context.WithTimeout(t.Context(), timeout)
 		_, err = cli.Get(ctx, "a")
 		cancel()
 		if err == nil {
@@ -240,7 +240,7 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 	// under the cover to other available eps, but expose the failure to the
 	// caller (test assertion).
 
-	wch := watchCli.Watch(clientv3.WithRequireLeader(context.Background()), "foo", clientv3.WithCreatedNotify())
+	wch := watchCli.Watch(clientv3.WithRequireLeader(t.Context()), "foo", clientv3.WithCreatedNotify())
 	select {
 	case <-wch:
 	case <-time.After(integration2.RequestWaitTimeout):
@@ -297,13 +297,13 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 
 	clus.Members[leaderIndex].InjectPartition(t, clus.Members[(leaderIndex+1)%3], clus.Members[(leaderIndex+2)%3])
 	kvc := clientv3.NewKVFromKVClient(pb.NewKVClient(conn), nil)
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	_, err = kvc.Get(ctx, "a")
 	cancel()
 	require.ErrorIsf(t, err, rpctypes.ErrLeaderChanged, "expected %v, got %v", rpctypes.ErrLeaderChanged, err)
 
 	for i := 0; i < 5; i++ {
-		ctx, cancel = context.WithTimeout(context.TODO(), 10*time.Second)
+		ctx, cancel = context.WithTimeout(t.Context(), 10*time.Second)
 		_, err = kvc.Get(ctx, "a")
 		cancel()
 		if err != nil {

--- a/tests/integration/clientv3/connectivity/server_shutdown_test.go
+++ b/tests/integration/clientv3/connectivity/server_shutdown_test.go
@@ -58,7 +58,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 	watchCli.SetEndpoints(eps...)
 
 	key, val := "foo", "bar"
-	wch := watchCli.Watch(context.Background(), key, clientv3.WithCreatedNotify())
+	wch := watchCli.Watch(t.Context(), key, clientv3.WithCreatedNotify())
 	select {
 	case <-wch:
 	case <-time.After(integration2.RequestWaitTimeout):
@@ -94,7 +94,7 @@ func TestBalancerUnderServerShutdownWatch(t *testing.T) {
 	require.NoError(t, err)
 	defer putCli.Close()
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		_, err = putCli.Put(ctx, key, val)
 		cancel()
 		if err == nil {
@@ -170,7 +170,7 @@ func testBalancerUnderServerShutdownMutable(t *testing.T, op func(*clientv3.Clie
 	// TODO: remove this (expose client connection state?)
 	time.Sleep(time.Second)
 
-	cctx, ccancel := context.WithTimeout(context.Background(), time.Second)
+	cctx, ccancel := context.WithTimeout(t.Context(), time.Second)
 	err = op(cli, cctx)
 	ccancel()
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func testBalancerUnderServerShutdownImmutable(t *testing.T, op func(*clientv3.Cl
 
 	// switched to others when eps[0] was explicitly shut down
 	// and following request should succeed
-	cctx, ccancel := context.WithTimeout(context.Background(), timeout)
+	cctx, ccancel := context.WithTimeout(t.Context(), timeout)
 	err = op(cli, cctx)
 	ccancel()
 	if err != nil {
@@ -329,7 +329,7 @@ func testBalancerUnderServerStopInflightRangeOnRestart(t *testing.T, linearizabl
 	donec, readyc := make(chan struct{}), make(chan struct{}, 1)
 	go func() {
 		defer close(donec)
-		ctx, cancel := context.WithTimeout(context.TODO(), clientTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), clientTimeout)
 		readyc <- struct{}{}
 
 		// TODO: The new grpc load balancer will not pin to an endpoint

--- a/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_barrier_test.go
@@ -15,7 +15,6 @@
 package recipes_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -46,7 +45,7 @@ func testBarrier(t *testing.T, waiters int, chooseClient func() *clientv3.Client
 	require.Errorf(t, b.Hold(), "able to double-hold barrier")
 
 	// put a random key to move the revision forward
-	if _, err := chooseClient().Put(context.Background(), "x", ""); err != nil {
+	if _, err := chooseClient().Put(t.Context(), "x", ""); err != nil {
 		t.Errorf("could not put x (%v)", err)
 	}
 

--- a/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
@@ -15,7 +15,6 @@
 package recipes_test
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -153,7 +152,7 @@ func TestDoubleBarrierTooManyClients(t *testing.T) {
 		t.Errorf("Unexcepted error, expected: ErrTooManyClients, got: %v", err)
 	}
 
-	resp, err := clus.RandClient().Get(context.TODO(), "test-barrier/waiters", clientv3.WithPrefix())
+	resp, err := clus.RandClient().Get(t.Context(), "test-barrier/waiters", clientv3.WithPrefix())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_lock_test.go
@@ -71,7 +71,7 @@ func testMutexLock(t *testing.T, waiters int, chooseClient func() *clientv3.Clie
 				return
 			}
 			m := concurrency.NewMutex(session, "test-mutex")
-			if err := m.Lock(context.TODO()); err != nil {
+			if err := m.Lock(t.Context()); err != nil {
 				errC <- fmt.Errorf("#%d: failed to wait on lock: %w", i, err)
 				return
 			}
@@ -93,7 +93,7 @@ func testMutexLock(t *testing.T, waiters int, chooseClient func() *clientv3.Clie
 				t.Fatalf("lock %d followers did not wait", i)
 			default:
 			}
-			require.NoErrorf(t, m.Unlock(context.TODO()), "could not release lock")
+			require.NoErrorf(t, m.Unlock(t.Context()), "could not release lock")
 		}
 	}
 	wg.Wait()
@@ -120,7 +120,7 @@ func TestMutexTryLockMultiNode(t *testing.T) {
 }
 
 func testMutexTryLock(t *testing.T, lockers int, chooseClient func() *clientv3.Client) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	lockedC := make(chan *concurrency.Mutex)
@@ -182,10 +182,10 @@ func TestMutexSessionRelock(t *testing.T) {
 	}
 
 	m := concurrency.NewMutex(session, "test-mutex")
-	require.NoError(t, m.Lock(context.TODO()))
+	require.NoError(t, m.Lock(t.Context()))
 
 	m2 := concurrency.NewMutex(session, "test-mutex")
-	require.NoError(t, m2.Lock(context.TODO()))
+	require.NoError(t, m2.Lock(t.Context()))
 }
 
 // TestMutexWaitsOnCurrentHolder ensures a mutex is only acquired once all
@@ -197,7 +197,7 @@ func TestMutexWaitsOnCurrentHolder(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	cctx := context.Background()
+	cctx := t.Context()
 
 	cli := clus.Client(0)
 

--- a/tests/integration/clientv3/lease/lease_test.go
+++ b/tests/integration/clientv3/lease/lease_test.go
@@ -40,7 +40,7 @@ func TestLeaseNotFoundError(t *testing.T) {
 
 	kv := clus.RandClient()
 
-	_, err := kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(clientv3.LeaseID(500)))
+	_, err := kv.Put(t.Context(), "foo", "bar", clientv3.WithLease(clientv3.LeaseID(500)))
 	require.ErrorIsf(t, err, rpctypes.ErrLeaseNotFound, "expected %v, got %v", rpctypes.ErrLeaseNotFound, err)
 }
 
@@ -54,15 +54,15 @@ func TestLeaseGrant(t *testing.T) {
 
 	kv := clus.RandClient()
 
-	_, merr := lapi.Grant(context.Background(), clientv3.MaxLeaseTTL+1)
+	_, merr := lapi.Grant(t.Context(), clientv3.MaxLeaseTTL+1)
 	require.ErrorIsf(t, merr, rpctypes.ErrLeaseTTLTooLarge, "err = %v, want %v", merr, rpctypes.ErrLeaseTTLTooLarge)
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(resp.ID))
+	_, err = kv.Put(t.Context(), "foo", "bar", clientv3.WithLease(resp.ID))
 	require.NoErrorf(t, err, "failed to create key with lease %v", err)
 }
 
@@ -76,17 +76,17 @@ func TestLeaseRevoke(t *testing.T) {
 
 	kv := clus.RandClient()
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	_, err = lapi.Revoke(context.Background(), resp.ID)
+	_, err = lapi.Revoke(t.Context(), resp.ID)
 	if err != nil {
 		t.Errorf("failed to revoke lease %v", err)
 	}
 
-	_, err = kv.Put(context.TODO(), "foo", "bar", clientv3.WithLease(resp.ID))
+	_, err = kv.Put(t.Context(), "foo", "bar", clientv3.WithLease(resp.ID))
 	require.ErrorIsf(t, err, rpctypes.ErrLeaseNotFound, "err = %v, want %v", err, rpctypes.ErrLeaseNotFound)
 }
 
@@ -98,17 +98,17 @@ func TestLeaseKeepAliveOnce(t *testing.T) {
 
 	lapi := clus.RandClient()
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	_, err = lapi.KeepAliveOnce(context.Background(), resp.ID)
+	_, err = lapi.KeepAliveOnce(t.Context(), resp.ID)
 	if err != nil {
 		t.Errorf("failed to keepalive lease %v", err)
 	}
 
-	_, err = lapi.KeepAliveOnce(context.Background(), clientv3.LeaseID(0))
+	_, err = lapi.KeepAliveOnce(t.Context(), clientv3.LeaseID(0))
 	if !errors.Is(err, rpctypes.ErrLeaseNotFound) {
 		t.Errorf("expected %v, got %v", rpctypes.ErrLeaseNotFound, err)
 	}
@@ -123,7 +123,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 	lapi := clus.Client(0)
 	clus.TakeClient(0)
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -133,7 +133,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 		_ func()
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	rc, kerr := lapi.KeepAlive(uncomparableCtx{Context: ctx}, resp.ID)
 	if kerr != nil {
@@ -151,7 +151,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 		t.Errorf("ID = %x, want %x", kresp.ID, resp.ID)
 	}
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(t.Context())
 	rc2, kerr2 := lapi.KeepAlive(uncomparableCtx{Context: ctx2}, resp.ID)
 	if kerr2 != nil {
 		t.Errorf("failed to keepalive lease %v", kerr2)
@@ -187,11 +187,11 @@ func TestLeaseKeepAliveSeconds(t *testing.T) {
 
 	cli := clus.Client(0)
 
-	resp, err := cli.Grant(context.Background(), 3)
+	resp, err := cli.Grant(t.Context(), 3)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
-	rc, kerr := cli.KeepAlive(context.Background(), resp.ID)
+	rc, kerr := cli.KeepAlive(t.Context(), resp.ID)
 	if kerr != nil {
 		t.Errorf("failed to keepalive lease %v", kerr)
 	}
@@ -217,12 +217,12 @@ func TestLeaseKeepAliveHandleFailure(t *testing.T) {
 	// TODO: change this line to get a cluster client
 	lapi := clus.RandClient()
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
 
-	rc, kerr := lapi.KeepAlive(context.Background(), resp.ID)
+	rc, kerr := lapi.KeepAlive(t.Context(), resp.ID)
 	if kerr != nil {
 		t.Errorf("failed to keepalive lease %v", kerr)
 	}
@@ -272,14 +272,14 @@ func TestLeaseKeepAliveNotFound(t *testing.T) {
 	cli := clus.RandClient()
 	var lchs []leaseCh
 	for i := 0; i < 3; i++ {
-		resp, rerr := cli.Grant(context.TODO(), 5)
+		resp, rerr := cli.Grant(t.Context(), 5)
 		require.NoError(t, rerr)
-		kach, kaerr := cli.KeepAlive(context.Background(), resp.ID)
+		kach, kaerr := cli.KeepAlive(t.Context(), resp.ID)
 		require.NoError(t, kaerr)
 		lchs = append(lchs, leaseCh{resp.ID, kach})
 	}
 
-	_, err := cli.Revoke(context.TODO(), lchs[1].lid)
+	_, err := cli.Revoke(t.Context(), lchs[1].lid)
 	require.NoError(t, err)
 
 	<-lchs[0].ch
@@ -304,7 +304,7 @@ func TestLeaseGrantErrConnClosed(t *testing.T) {
 	donec := make(chan struct{})
 	go func() {
 		defer close(donec)
-		_, err := cli.Grant(context.TODO(), 5)
+		_, err := cli.Grant(t.Context(), 5)
 		if !clientv3.IsConnCanceled(err) {
 			// context.Canceled if grpc-go balancer calls 'Get' with an inflight client.Close.
 			t.Errorf("expected %v, or server unavailable, got %v", context.Canceled, err)
@@ -330,7 +330,7 @@ func TestLeaseKeepAliveFullResponseQueue(t *testing.T) {
 	lapi := clus.Client(0)
 
 	// expect lease keepalive every 10-second
-	lresp, err := lapi.Grant(context.Background(), 30)
+	lresp, err := lapi.Grant(t.Context(), 30)
 	require.NoErrorf(t, err, "failed to create lease %v", err)
 	id := lresp.ID
 
@@ -341,14 +341,14 @@ func TestLeaseKeepAliveFullResponseQueue(t *testing.T) {
 	clientv3.LeaseResponseChSize = 0
 
 	// never fetch from response queue, and let it become full
-	_, err = lapi.KeepAlive(context.Background(), id)
+	_, err = lapi.KeepAlive(t.Context(), id)
 	require.NoErrorf(t, err, "failed to keepalive lease %v", err)
 
 	// TTL should not be refreshed after 3 seconds
 	// expect keepalive to be triggered after TTL/3
 	time.Sleep(3 * time.Second)
 
-	tr, terr := lapi.TimeToLive(context.Background(), id)
+	tr, terr := lapi.TimeToLive(t.Context(), id)
 	require.NoErrorf(t, terr, "failed to get lease information %v", terr)
 	if tr.TTL >= 29 {
 		t.Errorf("unexpected kept-alive lease TTL %d", tr.TTL)
@@ -367,7 +367,7 @@ func TestLeaseGrantNewAfterClose(t *testing.T) {
 
 	donec := make(chan struct{})
 	go func() {
-		_, err := cli.Grant(context.TODO(), 5)
+		_, err := cli.Grant(t.Context(), 5)
 		if !clientv3.IsConnCanceled(err) {
 			t.Errorf("expected %v or server unavailable, got %v", context.Canceled, err)
 		}
@@ -387,7 +387,7 @@ func TestLeaseRevokeNewAfterClose(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cli := clus.Client(0)
-	resp, err := cli.Grant(context.TODO(), 5)
+	resp, err := cli.Grant(t.Context(), 5)
 	require.NoError(t, err)
 	leaseID := resp.ID
 
@@ -396,7 +396,7 @@ func TestLeaseRevokeNewAfterClose(t *testing.T) {
 
 	errMsgCh := make(chan string, 1)
 	go func() {
-		_, err := cli.Revoke(context.TODO(), leaseID)
+		_, err := cli.Revoke(t.Context(), leaseID)
 		if !clientv3.IsConnCanceled(err) {
 			errMsgCh <- fmt.Sprintf("expected %v or server unavailable, got %v", context.Canceled, err)
 		} else {
@@ -422,9 +422,9 @@ func TestLeaseKeepAliveCloseAfterDisconnectRevoke(t *testing.T) {
 	cli := clus.Client(0)
 
 	// setup lease and do a keepalive
-	resp, err := cli.Grant(context.Background(), 10)
+	resp, err := cli.Grant(t.Context(), 10)
 	require.NoError(t, err)
-	rc, kerr := cli.KeepAlive(context.Background(), resp.ID)
+	rc, kerr := cli.KeepAlive(t.Context(), resp.ID)
 	require.NoError(t, kerr)
 	kresp := <-rc
 	require.Equalf(t, kresp.ID, resp.ID, "ID = %x, want %x", kresp.ID, resp.ID)
@@ -434,7 +434,7 @@ func TestLeaseKeepAliveCloseAfterDisconnectRevoke(t *testing.T) {
 	time.Sleep(time.Second)
 	clus.WaitLeader(t)
 
-	_, err = clus.Client(1).Revoke(context.TODO(), resp.ID)
+	_, err = clus.Client(1).Revoke(t.Context(), resp.ID)
 	require.NoError(t, err)
 
 	clus.Members[0].Restart(t)
@@ -461,11 +461,11 @@ func TestLeaseKeepAliveInitTimeout(t *testing.T) {
 	cli := clus.Client(0)
 
 	// setup lease and do a keepalive
-	resp, err := cli.Grant(context.Background(), 5)
+	resp, err := cli.Grant(t.Context(), 5)
 	require.NoError(t, err)
 	// keep client disconnected
 	clus.Members[0].Stop(t)
-	rc, kerr := cli.KeepAlive(context.Background(), resp.ID)
+	rc, kerr := cli.KeepAlive(t.Context(), resp.ID)
 	require.NoError(t, kerr)
 	select {
 	case ka, ok := <-rc:
@@ -488,9 +488,9 @@ func TestLeaseKeepAliveTTLTimeout(t *testing.T) {
 	cli := clus.Client(0)
 
 	// setup lease and do a keepalive
-	resp, err := cli.Grant(context.Background(), 5)
+	resp, err := cli.Grant(t.Context(), 5)
 	require.NoError(t, err)
-	rc, kerr := cli.KeepAlive(context.Background(), resp.ID)
+	rc, kerr := cli.KeepAlive(t.Context(), resp.ID)
 	require.NoError(t, kerr)
 	kresp := <-rc
 	require.Equalf(t, kresp.ID, resp.ID, "ID = %x, want %x", kresp.ID, resp.ID)
@@ -516,7 +516,7 @@ func TestLeaseTimeToLive(t *testing.T) {
 	c := clus.RandClient()
 	lapi := c
 
-	resp, err := lapi.Grant(context.Background(), 10)
+	resp, err := lapi.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
@@ -524,15 +524,15 @@ func TestLeaseTimeToLive(t *testing.T) {
 	kv := clus.RandClient()
 	keys := []string{"foo1", "foo2"}
 	for i := range keys {
-		_, err = kv.Put(context.TODO(), keys[i], "bar", clientv3.WithLease(resp.ID))
+		_, err = kv.Put(t.Context(), keys[i], "bar", clientv3.WithLease(resp.ID))
 		require.NoError(t, err)
 	}
 
 	// linearized read to ensure Puts propagated to server backing lapi
-	_, err = c.Get(context.TODO(), "abc")
+	_, err = c.Get(t.Context(), "abc")
 	require.NoError(t, err)
 
-	lresp, lerr := lapi.TimeToLive(context.Background(), resp.ID, clientv3.WithAttachedKeys())
+	lresp, lerr := lapi.TimeToLive(t.Context(), resp.ID, clientv3.WithAttachedKeys())
 	require.NoError(t, lerr)
 	require.Equalf(t, lresp.ID, resp.ID, "leaseID expected %d, got %d", resp.ID, lresp.ID)
 	require.Equalf(t, int64(10), lresp.GrantedTTL, "GrantedTTL expected %d, got %d", 10, lresp.GrantedTTL)
@@ -546,7 +546,7 @@ func TestLeaseTimeToLive(t *testing.T) {
 	sort.Strings(ks)
 	require.Truef(t, reflect.DeepEqual(ks, keys), "keys expected %v, got %v", keys, ks)
 
-	lresp, lerr = lapi.TimeToLive(context.Background(), resp.ID)
+	lresp, lerr = lapi.TimeToLive(t.Context(), resp.ID)
 	require.NoError(t, lerr)
 	require.Emptyf(t, lresp.Keys, "unexpected keys %+v", lresp.Keys)
 }
@@ -558,16 +558,16 @@ func TestLeaseTimeToLiveLeaseNotFound(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cli := clus.RandClient()
-	resp, err := cli.Grant(context.Background(), 10)
+	resp, err := cli.Grant(t.Context(), 10)
 	if err != nil {
 		t.Errorf("failed to create lease %v", err)
 	}
-	_, err = cli.Revoke(context.Background(), resp.ID)
+	_, err = cli.Revoke(t.Context(), resp.ID)
 	if err != nil {
 		t.Errorf("failed to Revoke lease %v", err)
 	}
 
-	lresp, err := cli.TimeToLive(context.Background(), resp.ID)
+	lresp, err := cli.TimeToLive(t.Context(), resp.ID)
 	// TimeToLive() should return a response with TTL=-1.
 	require.NoErrorf(t, err, "expected err to be nil")
 	require.NotNilf(t, lresp, "expected lresp not to be nil")
@@ -586,14 +586,14 @@ func TestLeaseLeases(t *testing.T) {
 
 	var ids []clientv3.LeaseID
 	for i := 0; i < 5; i++ {
-		resp, err := cli.Grant(context.Background(), 10)
+		resp, err := cli.Grant(t.Context(), 10)
 		if err != nil {
 			t.Errorf("failed to create lease %v", err)
 		}
 		ids = append(ids, resp.ID)
 	}
 
-	resp, err := cli.Leases(context.Background())
+	resp, err := cli.Leases(t.Context())
 	require.NoError(t, err)
 	require.Lenf(t, resp.Leases, 5, "len(resp.Leases) expected 5, got %d", len(resp.Leases))
 	for i := range resp.Leases {
@@ -610,10 +610,10 @@ func TestLeaseRenewLostQuorum(t *testing.T) {
 	defer clus.Terminate(t)
 
 	cli := clus.Client(0)
-	r, err := cli.Grant(context.TODO(), 4)
+	r, err := cli.Grant(t.Context(), 4)
 	require.NoError(t, err)
 
-	kctx, kcancel := context.WithCancel(context.Background())
+	kctx, kcancel := context.WithCancel(t.Context())
 	defer kcancel()
 	ka, err := cli.KeepAlive(kctx, r.ID)
 	require.NoError(t, err)
@@ -651,7 +651,7 @@ func TestLeaseKeepAliveLoopExit(t *testing.T) {
 	clus := integration2.NewCluster(t, &integration2.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cli := clus.Client(0)
 	clus.TakeClient(0)
 
@@ -727,15 +727,15 @@ func TestLeaseWithRequireLeader(t *testing.T) {
 	defer clus.Terminate(t)
 
 	c := clus.Client(0)
-	lid1, err1 := c.Grant(context.TODO(), 60)
+	lid1, err1 := c.Grant(t.Context(), 60)
 	require.NoError(t, err1)
-	lid2, err2 := c.Grant(context.TODO(), 60)
+	lid2, err2 := c.Grant(t.Context(), 60)
 	require.NoError(t, err2)
 	// kaReqLeader close if the leader is lost
-	kaReqLeader, kerr1 := c.KeepAlive(clientv3.WithRequireLeader(context.TODO()), lid1.ID)
+	kaReqLeader, kerr1 := c.KeepAlive(clientv3.WithRequireLeader(t.Context()), lid1.ID)
 	require.NoError(t, kerr1)
 	// kaWait will wait even if the leader is lost
-	kaWait, kerr2 := c.KeepAlive(context.TODO(), lid2.ID)
+	kaWait, kerr2 := c.KeepAlive(t.Context(), lid2.ID)
 	require.NoError(t, kerr2)
 
 	select {

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -50,7 +50,7 @@ func TestMaintenanceHashKV(t *testing.T) {
 	defer clus.Terminate(t)
 
 	for i := 0; i < 3; i++ {
-		_, err := clus.RandClient().Put(context.Background(), "foo", "bar")
+		_, err := clus.RandClient().Put(t.Context(), "foo", "bar")
 		require.NoError(t, err)
 	}
 
@@ -58,9 +58,9 @@ func TestMaintenanceHashKV(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		cli := clus.Client(i)
 		// ensure writes are replicated
-		_, err := cli.Get(context.TODO(), "foo")
+		_, err := cli.Get(t.Context(), "foo")
 		require.NoError(t, err)
-		hresp, err := cli.HashKV(context.Background(), clus.Members[i].GRPCURL, 0)
+		hresp, err := cli.HashKV(t.Context(), clus.Members[i].GRPCURL, 0)
 		require.NoError(t, err)
 		if hv == 0 {
 			hv = hresp.Hash
@@ -83,7 +83,7 @@ func TestCompactionHash(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL}, 1000)
+	testutil.TestCompactionHash(t.Context(), t, hashTestCase{cc, clus.Members[0].GRPCURL}, 1000)
 }
 
 type hashTestCase struct {
@@ -129,13 +129,13 @@ func TestMaintenanceMoveLeader(t *testing.T) {
 	target := uint64(clus.Members[targetIdx].ID())
 
 	cli := clus.Client(targetIdx)
-	_, err := cli.MoveLeader(context.Background(), target)
+	_, err := cli.MoveLeader(t.Context(), target)
 	if !errors.Is(err, rpctypes.ErrNotLeader) {
 		t.Fatalf("error expected %v, got %v", rpctypes.ErrNotLeader, err)
 	}
 
 	cli = clus.Client(oldLeadIdx)
-	_, err = cli.MoveLeader(context.Background(), target)
+	_, err = cli.MoveLeader(t.Context(), target)
 	require.NoError(t, err)
 
 	leadIdx := clus.WaitLeader(t)
@@ -154,7 +154,7 @@ func TestMaintenanceSnapshotCancel(t *testing.T) {
 	defer clus.Terminate(t)
 
 	// reading snapshot with canceled context should error out
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Since http2 spec defines the receive windows's size and max size of
 	// frame in the stream, the underlayer - gRPC client can pre-read data
@@ -211,7 +211,7 @@ func testMaintenanceSnapshotTimeout(t *testing.T, snapshot func(context.Context,
 	defer clus.Terminate(t)
 
 	// reading snapshot with deadline exceeded should error out
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	// Since http2 spec defines the receive windows's size and max size of
@@ -278,7 +278,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 	clus.Members[0].Restart(t)
 
 	// reading snapshot with canceled context should error out
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	rc1, err := snapshot(ctx, clus.RandClient())
 	require.NoError(t, err)
 	defer rc1.Close()
@@ -296,7 +296,7 @@ func testMaintenanceSnapshotErrorInflight(t *testing.T, snapshot func(context.Co
 	<-donec
 
 	// reading snapshot with deadline exceeded should error out
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel = context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 	rc2, err := snapshot(ctx, clus.RandClient())
 	require.NoError(t, err)
@@ -320,11 +320,11 @@ func TestMaintenanceSnapshotWithVersionVersion(t *testing.T) {
 
 	// Put some keys to ensure that wal snapshot is triggered
 	for i := 0; i < 10; i++ {
-		clus.RandClient().Put(context.Background(), fmt.Sprintf("%d", i), "1")
+		clus.RandClient().Put(t.Context(), fmt.Sprintf("%d", i), "1")
 	}
 
 	// reading snapshot with canceled context should error out
-	resp, err := clus.RandClient().SnapshotWithVersion(context.Background())
+	resp, err := clus.RandClient().SnapshotWithVersion(t.Context())
 	require.NoError(t, err)
 	defer resp.Snapshot.Close()
 	if resp.Version != "3.6.0" {
@@ -341,7 +341,7 @@ func TestMaintenanceSnapshotContentDigest(t *testing.T) {
 	populateDataIntoCluster(t, clus, 3, 1024*1024)
 
 	// reading snapshot with canceled context should error out
-	resp, err := clus.RandClient().SnapshotWithVersion(context.Background())
+	resp, err := clus.RandClient().SnapshotWithVersion(t.Context())
 	require.NoError(t, err)
 	defer resp.Snapshot.Close()
 
@@ -401,7 +401,7 @@ func TestMaintenanceStatus(t *testing.T) {
 
 	prevID, leaderFound := uint64(0), false
 	for i := 0; i < 3; i++ {
-		resp, err := cli.Status(context.TODO(), eps[i])
+		resp, err := cli.Status(t.Context(), eps[i])
 		require.NoError(t, err)
 		t.Logf("Response from %v: %v", i, resp)
 		if resp.DbSizeQuota != storage.DefaultQuotaBytes {

--- a/tests/integration/clientv3/metrics_test.go
+++ b/tests/integration/clientv3/metrics_test.go
@@ -17,7 +17,6 @@ package clientv3test
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"net"
@@ -90,13 +89,13 @@ func TestV3ClientMetrics(t *testing.T) {
 	require.NoError(t, cerr)
 	defer cli.Close()
 
-	wc := cli.Watch(context.Background(), "foo")
+	wc := cli.Watch(t.Context(), "foo")
 
 	wBefore := sumCountersForMetricAndLabels(t, url, "grpc_client_msg_received_total", "Watch", "bidi_stream")
 
 	pBefore := sumCountersForMetricAndLabels(t, url, "grpc_client_started_total", "Put", "unary")
 
-	_, err = cli.Put(context.Background(), "foo", "bar")
+	_, err = cli.Put(t.Context(), "foo", "bar")
 	if err != nil {
 		t.Errorf("Error putting value in key store")
 	}

--- a/tests/integration/clientv3/mirror_auth_test.go
+++ b/tests/integration/clientv3/mirror_auth_test.go
@@ -17,7 +17,6 @@
 package clientv3test
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -39,13 +38,13 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 	initialClient := clus.Client(0)
 
 	// Create a user to run the mirror process that only has access to /syncpath
-	initialClient.RoleAdd(context.Background(), "syncer")
-	initialClient.RoleGrantPermission(context.Background(), "syncer", "/syncpath", clientv3.GetPrefixRangeEnd("/syncpath"), clientv3.PermissionType(clientv3.PermReadWrite))
-	initialClient.UserAdd(context.Background(), "syncer", "syncfoo")
-	initialClient.UserGrantRole(context.Background(), "syncer", "syncer")
+	initialClient.RoleAdd(t.Context(), "syncer")
+	initialClient.RoleGrantPermission(t.Context(), "syncer", "/syncpath", clientv3.GetPrefixRangeEnd("/syncpath"), clientv3.PermissionType(clientv3.PermReadWrite))
+	initialClient.UserAdd(t.Context(), "syncer", "syncfoo")
+	initialClient.UserGrantRole(t.Context(), "syncer", "syncer")
 
 	// Seed /syncpath with some initial data
-	_, err := initialClient.KV.Put(context.TODO(), "/syncpath/foo", "bar")
+	_, err := initialClient.KV.Put(t.Context(), "/syncpath/foo", "bar")
 	require.NoError(t, err)
 
 	// Require authentication
@@ -65,7 +64,7 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 
 	// Now run the sync process, create changes, and get the initial sync state
 	syncer := mirror.NewSyncer(syncClient, "/syncpath", 0)
-	gch, ech := syncer.SyncBase(context.TODO())
+	gch, ech := syncer.SyncBase(t.Context())
 	wkvs := []*mvccpb.KeyValue{{Key: []byte("/syncpath/foo"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}}
 
 	for g := range gch {
@@ -79,10 +78,10 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 	}
 
 	// Start a continuous sync
-	wch := syncer.SyncUpdates(context.TODO())
+	wch := syncer.SyncUpdates(t.Context())
 
 	// Update state
-	_, err = syncClient.KV.Put(context.TODO(), "/syncpath/foo", "baz")
+	_, err = syncClient.KV.Put(t.Context(), "/syncpath/foo", "baz")
 	require.NoError(t, err)
 
 	// Wait for the updated state to sync

--- a/tests/integration/clientv3/mirror_test.go
+++ b/tests/integration/clientv3/mirror_test.go
@@ -15,7 +15,6 @@
 package clientv3test
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -36,11 +35,11 @@ func TestMirrorSync(t *testing.T) {
 	defer clus.Terminate(t)
 
 	c := clus.Client(0)
-	_, err := c.KV.Put(context.TODO(), "foo", "bar")
+	_, err := c.KV.Put(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 
 	syncer := mirror.NewSyncer(c, "", 0)
-	gch, ech := syncer.SyncBase(context.TODO())
+	gch, ech := syncer.SyncBase(t.Context())
 	wkvs := []*mvccpb.KeyValue{{Key: []byte("foo"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}}
 
 	for g := range gch {
@@ -53,9 +52,9 @@ func TestMirrorSync(t *testing.T) {
 		t.Fatalf("unexpected error %v", e)
 	}
 
-	wch := syncer.SyncUpdates(context.TODO())
+	wch := syncer.SyncUpdates(t.Context())
 
-	_, err = c.KV.Put(context.TODO(), "foo", "bar")
+	_, err = c.KV.Put(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 
 	select {
@@ -76,7 +75,7 @@ func TestMirrorSyncBase(t *testing.T) {
 	defer cluster.Terminate(t)
 
 	cli := cluster.Client(0)
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	keyCh := make(chan string)
 	var wg sync.WaitGroup

--- a/tests/integration/clientv3/namespace_test.go
+++ b/tests/integration/clientv3/namespace_test.go
@@ -15,7 +15,6 @@
 package clientv3test
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -36,15 +35,15 @@ func TestNamespacePutGet(t *testing.T) {
 	c := clus.Client(0)
 	nsKV := namespace.NewKV(c.KV, "foo/")
 
-	_, err := nsKV.Put(context.TODO(), "abc", "bar")
+	_, err := nsKV.Put(t.Context(), "abc", "bar")
 	require.NoError(t, err)
-	resp, err := nsKV.Get(context.TODO(), "abc")
+	resp, err := nsKV.Get(t.Context(), "abc")
 	require.NoError(t, err)
 	if string(resp.Kvs[0].Key) != "abc" {
 		t.Errorf("expected key=%q, got key=%q", "abc", resp.Kvs[0].Key)
 	}
 
-	resp, err = c.Get(context.TODO(), "foo/abc")
+	resp, err = c.Get(t.Context(), "foo/abc")
 	require.NoError(t, err)
 	if string(resp.Kvs[0].Value) != "bar" {
 		t.Errorf("expected value=%q, got value=%q", "bar", resp.Kvs[0].Value)
@@ -61,16 +60,16 @@ func TestNamespaceWatch(t *testing.T) {
 	nsKV := namespace.NewKV(c.KV, "foo/")
 	nsWatcher := namespace.NewWatcher(c.Watcher, "foo/")
 
-	_, err := nsKV.Put(context.TODO(), "abc", "bar")
+	_, err := nsKV.Put(t.Context(), "abc", "bar")
 	require.NoError(t, err)
 
-	nsWch := nsWatcher.Watch(context.TODO(), "abc", clientv3.WithRev(1))
+	nsWch := nsWatcher.Watch(t.Context(), "abc", clientv3.WithRev(1))
 	wkv := &mvccpb.KeyValue{Key: []byte("abc"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}
 	if wr := <-nsWch; len(wr.Events) != 1 || !reflect.DeepEqual(wr.Events[0].Kv, wkv) {
 		t.Errorf("expected namespaced event %+v, got %+v", wkv, wr.Events[0].Kv)
 	}
 
-	wch := c.Watch(context.TODO(), "foo/abc", clientv3.WithRev(1))
+	wch := c.Watch(t.Context(), "foo/abc", clientv3.WithRev(1))
 	wkv = &mvccpb.KeyValue{Key: []byte("foo/abc"), Value: []byte("bar"), CreateRevision: 2, ModRevision: 2, Version: 1}
 	if wr := <-wch; len(wr.Events) != 1 || !reflect.DeepEqual(wr.Events[0].Kv, wkv) {
 		t.Errorf("expected unnamespaced event %+v, got %+v", wkv, wr)

--- a/tests/integration/clientv3/naming/endpoints_test.go
+++ b/tests/integration/clientv3/naming/endpoints_test.go
@@ -36,7 +36,7 @@ func TestEndpointManager(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create EndpointManager", err)
 	}
-	ctx, watchCancel := context.WithCancel(context.Background())
+	ctx, watchCancel := context.WithCancel(t.Context())
 	defer watchCancel()
 	w, err := em.NewWatchChannel(ctx)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestEndpointManager(t *testing.T) {
 	}
 
 	e1 := endpoints.Endpoint{Addr: "127.0.0.1", Metadata: "metadata"}
-	err = em.AddEndpoint(context.TODO(), "foo/a1", e1)
+	err = em.AddEndpoint(t.Context(), "foo/a1", e1)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
 	}
@@ -63,7 +63,7 @@ func TestEndpointManager(t *testing.T) {
 
 	require.Truef(t, reflect.DeepEqual(us[0], wu), "up = %#v, want %#v", us[0], wu)
 
-	err = em.DeleteEndpoint(context.TODO(), "foo/a1")
+	err = em.DeleteEndpoint(t.Context(), "foo/a1")
 	require.NoErrorf(t, err, "failed to udpate %v", err)
 
 	us = <-w
@@ -94,13 +94,13 @@ func TestEndpointManagerAtomicity(t *testing.T) {
 		t.Fatal("failed to create EndpointManager", err)
 	}
 
-	err = em.Update(context.TODO(), []*endpoints.UpdateWithOpts{
+	err = em.Update(t.Context(), []*endpoints.UpdateWithOpts{
 		endpoints.NewAddUpdateOpts("foo/host", endpoints.Endpoint{Addr: "127.0.0.1:2000"}),
 		endpoints.NewAddUpdateOpts("foo/host2", endpoints.Endpoint{Addr: "127.0.0.1:2001"}),
 	})
 	require.NoError(t, err)
 
-	ctx, watchCancel := context.WithCancel(context.Background())
+	ctx, watchCancel := context.WithCancel(t.Context())
 	defer watchCancel()
 	w, err := em.NewWatchChannel(ctx)
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestEndpointManagerAtomicity(t *testing.T) {
 	updates := <-w
 	require.Lenf(t, updates, 2, "expected two updates, got %+v", updates)
 
-	_, err = c.Txn(context.TODO()).Then(etcd.OpDelete("foo/host"), etcd.OpDelete("foo/host2")).Commit()
+	_, err = c.Txn(t.Context()).Then(etcd.OpDelete("foo/host"), etcd.OpDelete("foo/host2")).Commit()
 	require.NoError(t, err)
 
 	updates = <-w
@@ -131,19 +131,19 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	// Add
 	k1 := "foo/a1"
 	e1 := endpoints.Endpoint{Addr: "127.0.0.1", Metadata: "metadata1"}
-	err = em.AddEndpoint(context.TODO(), k1, e1)
+	err = em.AddEndpoint(t.Context(), k1, e1)
 	if err != nil {
 		t.Fatal("failed to add", k1, err)
 	}
 
 	k2 := "foo/a2"
 	e2 := endpoints.Endpoint{Addr: "127.0.0.2", Metadata: "metadata2"}
-	err = em.AddEndpoint(context.TODO(), k2, e2)
+	err = em.AddEndpoint(t.Context(), k2, e2)
 	if err != nil {
 		t.Fatal("failed to add", k2, err)
 	}
 
-	eps, err := em.List(context.TODO())
+	eps, err := em.List(t.Context())
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}
@@ -152,12 +152,12 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	require.Truef(t, reflect.DeepEqual(eps[k2], e2), "unexpected endpoints: %s", k2)
 
 	// Delete
-	err = em.DeleteEndpoint(context.TODO(), k1)
+	err = em.DeleteEndpoint(t.Context(), k1)
 	if err != nil {
 		t.Fatal("failed to delete", k2, err)
 	}
 
-	eps, err = em.List(context.TODO())
+	eps, err = em.List(t.Context())
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}
@@ -171,12 +171,12 @@ func TestEndpointManagerCRUD(t *testing.T) {
 		{Update: endpoints.Update{Op: endpoints.Add, Key: k3, Endpoint: e3}},
 		{Update: endpoints.Update{Op: endpoints.Delete, Key: k2}},
 	}
-	err = em.Update(context.TODO(), updates)
+	err = em.Update(t.Context(), updates)
 	if err != nil {
 		t.Fatal("failed to update", err)
 	}
 
-	eps, err = em.List(context.TODO())
+	eps, err = em.List(t.Context())
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -16,7 +16,6 @@ package naming_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -60,12 +59,12 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 	e1 := endpoints.Endpoint{Addr: s1.Addr()}
 	e2 := endpoints.Endpoint{Addr: s2.Addr()}
 
-	err = em.AddEndpoint(context.TODO(), "foo/e1", e1)
+	err = em.AddEndpoint(t.Context(), "foo/e1", e1)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
 	}
 
-	err = em.AddEndpoint(context.TODO(), "foo/e2", e2)
+	err = em.AddEndpoint(t.Context(), "foo/e2", e2)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
 	}
@@ -85,7 +84,7 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 
 	// Send an initial request that should go to e1
 	c := testpb.NewTestServiceClient(conn)
-	resp, err := c.UnaryCall(context.TODO(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
+	resp, err := c.UnaryCall(t.Context(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		t.Fatal("failed to invoke rpc to foo (e1)", err)
 	}
@@ -97,7 +96,7 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 	lastResponse := []byte{'1'}
 	totalRequests := 3500
 	for i := 1; i < totalRequests; i++ {
-		resp, err := c.UnaryCall(context.TODO(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
+		resp, err := c.UnaryCall(t.Context(), &testpb.SimpleRequest{}, grpc.WaitForReady(true))
 		if err != nil {
 			t.Fatal("failed to invoke rpc to foo", err)
 		}
@@ -168,12 +167,12 @@ func TestEtcdEndpointManager(t *testing.T) {
 	e1 := endpoints.Endpoint{Addr: s1.Addr()}
 	e2 := endpoints.Endpoint{Addr: s2.Addr()}
 
-	em.AddEndpoint(context.Background(), "foo/e1", e1)
-	emOther.AddEndpoint(context.Background(), "foo_other/e2", e2)
+	em.AddEndpoint(t.Context(), "foo/e1", e1)
+	emOther.AddEndpoint(t.Context(), "foo_other/e2", e2)
 
-	epts, err := em.List(context.Background())
+	epts, err := em.List(t.Context())
 	require.NoError(t, err)
-	eptsOther, err := emOther.List(context.Background())
+	eptsOther, err := emOther.List(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, epts, 1)
 	assert.Len(t, eptsOther, 1)

--- a/tests/integration/clientv3/ordering_kv_test.go
+++ b/tests/integration/clientv3/ordering_kv_test.go
@@ -15,7 +15,6 @@
 package clientv3test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ func TestDetectKvOrderViolation(t *testing.T) {
 	cli, err := integration2.NewClient(t, cfg)
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, cli.Close()) }()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	_, err = clus.Client(0).Put(ctx, "foo", "bar")
 	require.NoError(t, err)
@@ -104,7 +103,7 @@ func TestDetectTxnOrderViolation(t *testing.T) {
 	cli, err := integration2.NewClient(t, cfg)
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, cli.Close()) }()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	_, err = clus.Client(0).Put(ctx, "foo", "bar")
 	require.NoError(t, err)

--- a/tests/integration/clientv3/ordering_util_test.go
+++ b/tests/integration/clientv3/ordering_util_test.go
@@ -15,7 +15,6 @@
 package clientv3test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -44,7 +43,7 @@ func TestEndpointSwitchResolvesViolation(t *testing.T) {
 	require.NoError(t, err)
 	defer cli.Close()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	_, err = clus.Client(0).Put(ctx, "foo", "bar")
 	require.NoError(t, err)
@@ -104,7 +103,7 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 	require.NoError(t, err)
 	defer cli.Close()
 	eps := cli.Endpoints()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cli.SetEndpoints(clus.Members[0].GRPCURL)
 	time.Sleep(1 * time.Second)

--- a/tests/integration/clientv3/snapshot/v3_snapshot_test.go
+++ b/tests/integration/clientv3/snapshot/v3_snapshot_test.go
@@ -103,14 +103,14 @@ func createSnapshotFile(t *testing.T, cfg *embed.Config, kvs []kv) (version stri
 	require.NoError(t, err)
 	defer cli.Close()
 	for i := range kvs {
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 		_, err = cli.Put(ctx, kvs[i].k, kvs[i].v)
 		cancel()
 		require.NoError(t, err)
 	}
 
 	dbPath = filepath.Join(t.TempDir(), fmt.Sprintf("snapshot%d.db", time.Now().Nanosecond()))
-	version, err = snapshot.SaveWithVersion(context.Background(), zaptest.NewLogger(t), ccfg, dbPath)
+	version, err = snapshot.SaveWithVersion(t.Context(), zaptest.NewLogger(t), ccfg, dbPath)
 	require.NoError(t, err)
 	return version, dbPath
 }

--- a/tests/integration/clientv3/user_test.go
+++ b/tests/integration/clientv3/user_test.go
@@ -36,16 +36,16 @@ func TestUserError(t *testing.T) {
 
 	authapi := clus.RandClient()
 
-	_, err := authapi.UserAdd(context.TODO(), "foo", "bar")
+	_, err := authapi.UserAdd(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 
-	_, err = authapi.UserAdd(context.TODO(), "foo", "bar")
+	_, err = authapi.UserAdd(t.Context(), "foo", "bar")
 	require.ErrorIsf(t, err, rpctypes.ErrUserAlreadyExist, "expected %v, got %v", rpctypes.ErrUserAlreadyExist, err)
 
-	_, err = authapi.UserDelete(context.TODO(), "not-exist-user")
+	_, err = authapi.UserDelete(t.Context(), "not-exist-user")
 	require.ErrorIsf(t, err, rpctypes.ErrUserNotFound, "expected %v, got %v", rpctypes.ErrUserNotFound, err)
 
-	_, err = authapi.UserGrantRole(context.TODO(), "foo", "test-role-does-not-exist")
+	_, err = authapi.UserGrantRole(t.Context(), "foo", "test-role-does-not-exist")
 	require.ErrorIsf(t, err, rpctypes.ErrRoleNotFound, "expected %v, got %v", rpctypes.ErrRoleNotFound, err)
 }
 
@@ -68,34 +68,34 @@ func TestAddUserAfterDelete(t *testing.T) {
 	defer authed.Close()
 
 	// add user
-	_, err = authed.UserAdd(context.TODO(), "foo", "bar")
+	_, err = authed.UserAdd(t.Context(), "foo", "bar")
 	require.NoError(t, err)
-	_, err = authapi.Authenticate(context.TODO(), "foo", "bar")
+	_, err = authapi.Authenticate(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 	// delete user
-	_, err = authed.UserDelete(context.TODO(), "foo")
+	_, err = authed.UserDelete(t.Context(), "foo")
 	require.NoError(t, err)
-	if _, err = authed.Authenticate(context.TODO(), "foo", "bar"); err == nil {
+	if _, err = authed.Authenticate(t.Context(), "foo", "bar"); err == nil {
 		t.Errorf("expect Authenticate error for old password")
 	}
 	// add user back
-	_, err = authed.UserAdd(context.TODO(), "foo", "bar")
+	_, err = authed.UserAdd(t.Context(), "foo", "bar")
 	require.NoError(t, err)
-	_, err = authed.Authenticate(context.TODO(), "foo", "bar")
+	_, err = authed.Authenticate(t.Context(), "foo", "bar")
 	require.NoError(t, err)
 	// change password
-	_, err = authed.UserChangePassword(context.TODO(), "foo", "bar2")
+	_, err = authed.UserChangePassword(t.Context(), "foo", "bar2")
 	require.NoError(t, err)
-	_, err = authed.UserChangePassword(context.TODO(), "foo", "bar1")
+	_, err = authed.UserChangePassword(t.Context(), "foo", "bar1")
 	require.NoError(t, err)
 
-	if _, err = authed.Authenticate(context.TODO(), "foo", "bar"); err == nil {
+	if _, err = authed.Authenticate(t.Context(), "foo", "bar"); err == nil {
 		t.Errorf("expect Authenticate error for old password")
 	}
-	if _, err = authed.Authenticate(context.TODO(), "foo", "bar2"); err == nil {
+	if _, err = authed.Authenticate(t.Context(), "foo", "bar2"); err == nil {
 		t.Errorf("expect Authenticate error for old password")
 	}
-	_, err = authed.Authenticate(context.TODO(), "foo", "bar1")
+	_, err = authed.Authenticate(t.Context(), "foo", "bar1")
 	require.NoError(t, err)
 }
 
@@ -109,7 +109,7 @@ func TestUserErrorAuth(t *testing.T) {
 	authSetupRoot(t, authapi.Auth)
 
 	// unauthenticated client
-	_, err := authapi.UserAdd(context.TODO(), "foo", "bar")
+	_, err := authapi.UserAdd(t.Context(), "foo", "bar")
 	require.ErrorIsf(t, err, rpctypes.ErrUserEmpty, "expected %v, got %v", rpctypes.ErrUserEmpty, err)
 
 	// wrong id or password
@@ -130,18 +130,18 @@ func TestUserErrorAuth(t *testing.T) {
 	require.NoError(t, err)
 	defer authed.Close()
 
-	_, err = authed.UserList(context.TODO())
+	_, err = authed.UserList(t.Context())
 	require.NoError(t, err)
 }
 
 func authSetupRoot(t *testing.T, auth clientv3.Auth) {
-	_, err := auth.UserAdd(context.TODO(), "root", "123")
+	_, err := auth.UserAdd(t.Context(), "root", "123")
 	require.NoError(t, err)
-	_, err = auth.RoleAdd(context.TODO(), "root")
+	_, err = auth.RoleAdd(t.Context(), "root")
 	require.NoError(t, err)
-	_, err = auth.UserGrantRole(context.TODO(), "root", "root")
+	_, err = auth.UserGrantRole(t.Context(), "root", "root")
 	require.NoError(t, err)
-	_, err = auth.AuthEnable(context.TODO())
+	_, err = auth.AuthEnable(t.Context())
 	require.NoError(t, err)
 }
 
@@ -159,7 +159,7 @@ func TestGetTokenWithoutAuth(t *testing.T) {
 	var client *clientv3.Client
 
 	// make sure "auth" was disabled
-	_, err = authapi.AuthDisable(context.TODO())
+	_, err = authapi.AuthDisable(t.Context())
 	require.NoError(t, err)
 
 	// "Username" and "Password" must be used

--- a/tests/integration/clientv3/util.go
+++ b/tests/integration/clientv3/util.go
@@ -33,7 +33,7 @@ import (
 // Fatal on time-out.
 func MustWaitPinReady(t *testing.T, cli *clientv3.Client) {
 	// TODO: decrease timeout after balancer rewrite!!!
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	_, err := cli.Get(ctx, "foo")
 	cancel()
 	if err != nil {
@@ -109,7 +109,7 @@ func IsUnavailable(err error) bool {
 // populateDataIntoCluster populates the key-value pairs into cluster and the
 // key will be named by testing.T.Name()-index.
 func populateDataIntoCluster(t *testing.T, cluster *integration2.Cluster, numKeys int, valueSize int) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < numKeys; i++ {
 		_, err := cluster.RandClient().Put(ctx,

--- a/tests/integration/clientv3/watch_fragment_test.go
+++ b/tests/integration/clientv3/watch_fragment_test.go
@@ -17,7 +17,6 @@
 package clientv3test
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -81,7 +80,7 @@ func testWatchFragment(t *testing.T, fragment, exceedRecvLimit bool) {
 	errc := make(chan error)
 	for i := 0; i < 10; i++ {
 		go func(i int) {
-			_, err := cli.Put(context.TODO(),
+			_, err := cli.Put(t.Context(),
 				fmt.Sprint("foo", i),
 				strings.Repeat("a", 1024*1024),
 			)
@@ -97,7 +96,7 @@ func testWatchFragment(t *testing.T, fragment, exceedRecvLimit bool) {
 	if fragment {
 		opts = append(opts, clientv3.WithFragment())
 	}
-	wch := cli.Watch(context.TODO(), "foo", opts...)
+	wch := cli.Watch(t.Context(), "foo", opts...)
 
 	// expect 10 MiB watch response
 	select {

--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -130,12 +130,12 @@ func TestForceNewCluster(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
 	defer c.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	resp, err := c.Members[0].Client.Put(ctx, "/foo", "bar")
 	require.NoErrorf(t, err, "unexpected create error")
 	cancel()
 	// ensure create has been applied in this machine
-	ctx, cancel = context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), integration.RequestTimeout)
 	watch := c.Members[0].Client.Watcher.Watch(ctx, "/foo", clientv3.WithRev(resp.Header.Revision-1))
 	for resp := range watch {
 		if len(resp.Events) != 0 {
@@ -156,7 +156,7 @@ func TestForceNewCluster(t *testing.T) {
 
 	// use new http client to init new connection
 	// ensure force restart keep the old data, and new Cluster can make progress
-	ctx, cancel = context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), integration.RequestTimeout)
 	watch = c.Members[0].Client.Watcher.Watch(ctx, "/foo", clientv3.WithRev(resp.Header.Revision-1))
 	for resp := range watch {
 		if len(resp.Events) != 0 {
@@ -240,7 +240,7 @@ func TestIssue2904(t *testing.T) {
 	c.Members[2].Stop(t)
 
 	// send remove member-1 request to the Cluster.
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	// the proposal is not committed because member 1 is stopped, but the
 	// proposal is appended to leader'Server raft log.
 	c.Members[0].Client.MemberRemove(ctx, uint64(c.Members[2].Server.MemberID()))
@@ -312,7 +312,7 @@ func TestIssue3699(t *testing.T) {
 
 	t.Logf("Expecting successful put...")
 	// try to participate in Cluster
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	_, err := c.Members[0].Client.Put(ctx, "/foo", "bar")
 	require.NoErrorf(t, err, "unexpected error on Put")
 	cancel()
@@ -441,7 +441,7 @@ func clusterMustProgress(t *testing.T, members []*integration.Member) {
 	)
 	// retry in case of leader loss induced by slow CI
 	for i := 0; i < 3; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		resp, err = members[0].Client.Put(ctx, key, "bar")
 		cancel()
 		if err == nil {
@@ -452,7 +452,7 @@ func clusterMustProgress(t *testing.T, members []*integration.Member) {
 	require.NoErrorf(t, err, "create on #0 error")
 
 	for i, m := range members {
-		mctx, mcancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		mctx, mcancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		watch := m.Client.Watcher.Watch(mctx, key, clientv3.WithRev(resp.Header.Revision-1))
 		for resp := range watch {
 			if len(resp.Events) != 0 {
@@ -494,16 +494,16 @@ func TestConcurrentRemoveMember(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer c.Terminate(t)
 
-	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
+	addResp, err := c.Members[0].Client.MemberAddAsLearner(t.Context(), []string{"http://localhost:123"})
 	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second / 2)
-		c.Members[0].Client.MemberRemove(context.Background(), removeID)
+		c.Members[0].Client.MemberRemove(t.Context(), removeID)
 		close(done)
 	}()
-	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	_, err = c.Members[0].Client.MemberRemove(t.Context(), removeID)
 	require.NoError(t, err)
 	<-done
 }
@@ -513,16 +513,16 @@ func TestConcurrentMoveLeader(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer c.Terminate(t)
 
-	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
+	addResp, err := c.Members[0].Client.MemberAddAsLearner(t.Context(), []string{"http://localhost:123"})
 	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second / 2)
-		c.Members[0].Client.MoveLeader(context.Background(), removeID)
+		c.Members[0].Client.MoveLeader(t.Context(), removeID)
 		close(done)
 	}()
-	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	_, err = c.Members[0].Client.MemberRemove(t.Context(), removeID)
 	require.NoError(t, err)
 	<-done
 }

--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -38,7 +38,7 @@ func TestPeriodicCheck(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var totalRevisions int64 = 1210
 	var rev int64
@@ -74,7 +74,7 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
@@ -112,7 +112,7 @@ func TestCompactHashCheck(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var totalRevisions int64 = 1210
 	var rev int64
@@ -149,7 +149,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
@@ -186,7 +186,7 @@ func TestCompactHashCheckDetectMultipleCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -20,7 +20,6 @@
 package embed_test
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	defer cli.Close()
 
 	// open watch connection
-	cli.Watch(context.Background(), "foo")
+	cli.Watch(t.Context(), "foo")
 
 	donec := make(chan struct{})
 	go func() {

--- a/tests/integration/grpc_test.go
+++ b/tests/integration/grpc_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	tls "crypto/tls"
 	"fmt"
 	"strings"
@@ -105,7 +104,7 @@ func TestAuthority(t *testing.T) {
 
 				putRequestMethod := "/etcdserverpb.KV/Put"
 				for i := 0; i < 100; i++ {
-					_, err := kv.Put(context.TODO(), "foo", "bar")
+					_, err := kv.Put(t.Context(), "foo", "bar")
 					require.NoError(t, err)
 				}
 

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -46,7 +46,7 @@ func TestCompactionHash(t *testing.T) {
 		},
 	}
 
-	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL, client, clus.Members[0].Server}, 1000)
+	testutil.TestCompactionHash(t.Context(), t, hashTestCase{cc, clus.Members[0].GRPCURL, client, clus.Members[0].Server}, 1000)
 }
 
 type hashTestCase struct {

--- a/tests/integration/member_test.go
+++ b/tests/integration/member_test.go
@@ -91,7 +91,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 
 	var err error
 	for i := 0; i < 120; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		_, err = m.Client.Put(ctx, "/"+key, "bar")
 		require.NoErrorf(t, err, "#%d: create on %s error", i, m.URL())
@@ -102,7 +102,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 
 	m.WaitOK(t)
 	for i := 0; i < 120; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		resp, err := m.Client.Get(ctx, "/"+key)
 		require.NoErrorf(t, err, "#%d: get on %s error", i, m.URL())
@@ -134,7 +134,7 @@ func checkMemberCount(t *testing.T, m *integration.Member, expectedMemberCount i
 	if len(membersFromBackend) != expectedMemberCount {
 		t.Errorf("Expect member count read from backend=%d, got %d", expectedMemberCount, len(membersFromBackend))
 	}
-	membersResp, err := m.Client.MemberList(context.Background())
+	membersResp, err := m.Client.MemberList(t.Context())
 	require.NoError(t, err)
 	if len(membersResp.Members) != expectedMemberCount {
 		t.Errorf("Expect len(MemberList)=%d, got %d", expectedMemberCount, len(membersResp.Members))

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -15,7 +15,6 @@
 package grpcproxy
 
 import (
-	"context"
 	"net"
 	"os"
 	"testing"
@@ -59,7 +58,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	var mresp *clientv3.MemberListResponse
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 
 	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
@@ -73,7 +72,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// check add member succ
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 	require.Lenf(t, mresp.Members, 2, "len(mresp.Members) expected 2, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{newMemberAddr}})
@@ -84,7 +83,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// check delete member succ
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{cts.caddr}})

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -15,7 +15,6 @@
 package grpcproxy
 
 import (
-	"context"
 	"net"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ func TestKVProxyRange(t *testing.T) {
 	}
 	client, err := integration2.NewClient(t, cfg)
 	require.NoErrorf(t, err, "err = %v, want nil", err)
-	_, err = client.Get(context.Background(), "foo")
+	_, err = client.Get(t.Context(), "foo")
 	require.NoErrorf(t, err, "err = %v, want nil", err)
 	client.Close()
 }

--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -81,7 +81,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
 	defer cancel()
 
 	wg := sync.WaitGroup{}
@@ -104,7 +104,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 	injectFailures(clus)
 	wg.Wait()
 	kv := clus.Client(0)
-	resp, err := kv.Get(context.Background(), "foo")
+	resp, err := kv.Get(t.Context(), "foo")
 	require.NoError(t, err)
 	t.Logf("Revision %d", resp.Header.Revision)
 }

--- a/tests/integration/snapshot/member_test.go
+++ b/tests/integration/snapshot/member_test.go
@@ -56,7 +56,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 
 	urls := newEmbedURLs(t, 2)
 	newCURLs, newPURLs := urls[:1], urls[1:]
-	_, err = cli.MemberAdd(context.Background(), []string{newPURLs[0].String()})
+	_, err = cli.MemberAdd(t.Context(), []string{newPURLs[0].String()})
 	require.NoError(t, err)
 
 	// wait for membership reconfiguration apply
@@ -89,7 +89,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 	require.NoError(t, err)
 	defer cli2.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	mresp, err := cli2.MemberList(ctx)
 	cancel()
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 
 	// make sure restored cluster has kept all data on recovery
 	var gresp *clientv3.GetResponse
-	ctx, cancel = context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	gresp, err = cli2.Get(ctx, "foo", clientv3.WithPrefix())
 	cancel()
 	require.NoError(t, err)

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -86,7 +86,7 @@ func TestSnapshotV3RestoreSingle(t *testing.T) {
 	defer cli.Close()
 	for i := range kvs {
 		var gresp *clientv3.GetResponse
-		gresp, err = cli.Get(context.Background(), kvs[i].k)
+		gresp, err = cli.Get(t.Context(), kvs[i].k)
 		require.NoError(t, err)
 		require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 	}
@@ -117,7 +117,7 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 		defer cli.Close()
 		for i := range kvs {
 			var gresp *clientv3.GetResponse
-			gresp, err = cli.Get(context.Background(), kvs[i].k)
+			gresp, err = cli.Get(t.Context(), kvs[i].k)
 			require.NoError(t, err)
 			require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 		}
@@ -182,7 +182,7 @@ func createSnapshotFile(t *testing.T, kvs []kv) string {
 	require.NoError(t, err)
 	defer cli.Close()
 	for i := range kvs {
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 		_, err = cli.Put(ctx, kvs[i].k, kvs[i].v)
 		cancel()
 		require.NoError(t, err)
@@ -190,7 +190,7 @@ func createSnapshotFile(t *testing.T, kvs []kv) string {
 
 	sp := snapshot.NewV3(zaptest.NewLogger(t))
 	dpPath := filepath.Join(t.TempDir(), fmt.Sprintf("snapshot%d.db", time.Now().Nanosecond()))
-	_, err = sp.Save(context.Background(), ccfg, dpPath)
+	_, err = sp.Save(t.Context(), ccfg, dpPath)
 	require.NoError(t, err)
 	return dpPath
 }

--- a/tests/integration/tracing_test.go
+++ b/tests/integration/tracing_test.go
@@ -76,7 +76,7 @@ func TestTracing(t *testing.T) {
 
 	// create a client that has tracing enabled
 	tracer := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
-	defer tracer.Shutdown(context.TODO())
+	defer tracer.Shutdown(t.Context())
 	tp := trace.TracerProvider(tracer)
 
 	tracingOpts := []otelgrpc.Option{
@@ -101,7 +101,7 @@ func TestTracing(t *testing.T) {
 	defer cli.Close()
 
 	// make a request with the instrumented client
-	resp, err := cli.Get(context.TODO(), "key")
+	resp, err := cli.Get(t.Context(), "key")
 	require.NoError(t, err)
 	require.Empty(t, resp.Kvs)
 

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -63,7 +63,7 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 
 	// Once the cluster version has been updated, any entity's storage
 	// version should be align with cluster version.
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	_, err = cli.AuthStatus(ctx)
 	cancel()
 	if err != nil {

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -108,7 +108,7 @@ func putWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 		// put data test
 		err := func() error {
 			t.Log("Sanity test, putting data")
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 
 			if _, putErr := cli.Put(ctx, key, val); putErr != nil {
@@ -133,7 +133,7 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 		// get data test
 		err := func() error {
 			t.Log("Sanity test, getting data")
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 			resp, getErr := cli.Get(ctx, key)
 			if getErr != nil {

--- a/tests/integration/v3_grpc_inflight_test.go
+++ b/tests/integration/v3_grpc_inflight_test.go
@@ -39,10 +39,10 @@ func TestV3MaintenanceDefragmentInflightRange(t *testing.T) {
 
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
-	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	donec := make(chan struct{})
 	go func() {
@@ -51,7 +51,7 @@ func TestV3MaintenanceDefragmentInflightRange(t *testing.T) {
 	}()
 
 	mvc := integration.ToGRPC(cli).Maintenance
-	mvc.Defragment(context.Background(), &pb.DefragmentRequest{})
+	mvc.Defragment(t.Context(), &pb.DefragmentRequest{})
 	cancel()
 
 	<-donec
@@ -69,10 +69,10 @@ func TestV3KVInflightRangeRequests(t *testing.T) {
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
 
-	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 
 	reqN := 10 // use 500+ for fast machine
 	var wg sync.WaitGroup

--- a/tests/integration/v3_kv_test.go
+++ b/tests/integration/v3_kv_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,15 +33,15 @@ func TestKVWithEmptyValue(t *testing.T) {
 
 	client := clus.RandClient()
 
-	_, err := client.Put(context.Background(), "my-namespace/foobar", "data")
+	_, err := client.Put(t.Context(), "my-namespace/foobar", "data")
 	require.NoError(t, err)
-	_, err = client.Put(context.Background(), "my-namespace/foobar1", "data")
+	_, err = client.Put(t.Context(), "my-namespace/foobar1", "data")
 	require.NoError(t, err)
-	_, err = client.Put(context.Background(), "namespace/foobar1", "data")
+	_, err = client.Put(t.Context(), "namespace/foobar1", "data")
 	require.NoError(t, err)
 
 	// Range over all keys.
-	resp, err := client.Get(context.Background(), "", clientv3.WithFromKey())
+	resp, err := client.Get(t.Context(), "", clientv3.WithFromKey())
 	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
@@ -50,18 +49,18 @@ func TestKVWithEmptyValue(t *testing.T) {
 
 	// Range over all keys in a namespace.
 	client.KV = namespace.NewKV(client.KV, "my-namespace/")
-	resp, err = client.Get(context.Background(), "", clientv3.WithFromKey())
+	resp, err = client.Get(t.Context(), "", clientv3.WithFromKey())
 	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
 	}
 
 	// Remove all keys without WithFromKey/WithPrefix func
-	_, err = client.Delete(context.Background(), "")
+	_, err = client.Delete(t.Context(), "")
 	// fatal error duo to without WithFromKey/WithPrefix func called.
 	require.Error(t, err)
 
-	respDel, err := client.Delete(context.Background(), "", clientv3.WithFromKey())
+	respDel, err := client.Delete(t.Context(), "", clientv3.WithFromKey())
 	// fatal error duo to with WithFromKey/WithPrefix func called.
 	require.NoError(t, err)
 	t.Logf("delete keys:%d", respDel.Deleted)

--- a/tests/integration/v3_leadership_test.go
+++ b/tests/integration/v3_leadership_test.go
@@ -63,7 +63,7 @@ func testMoveLeader(t *testing.T, auto bool) {
 		require.NoError(t, err)
 	} else {
 		mvc := integration.ToGRPC(clus.Client(oldLeadIdx)).Maintenance
-		_, err := mvc.MoveLeader(context.TODO(), &pb.MoveLeaderRequest{TargetID: target})
+		_, err := mvc.MoveLeader(t.Context(), &pb.MoveLeaderRequest{TargetID: target})
 		require.NoError(t, err)
 	}
 
@@ -108,7 +108,7 @@ func TestMoveLeaderError(t *testing.T) {
 	target := uint64(clus.Members[(oldLeadIdx+2)%3].Server.MemberID())
 
 	mvc := integration.ToGRPC(clus.Client(followerIdx)).Maintenance
-	_, err := mvc.MoveLeader(context.TODO(), &pb.MoveLeaderRequest{TargetID: target})
+	_, err := mvc.MoveLeader(t.Context(), &pb.MoveLeaderRequest{TargetID: target})
 	if !eqErrGRPC(err, rpctypes.ErrGRPCNotLeader) {
 		t.Errorf("err = %v, want %v", err, rpctypes.ErrGRPCNotLeader)
 	}
@@ -136,7 +136,7 @@ func TestMoveLeaderToLearnerError(t *testing.T) {
 	learnerID := learners[0].ID
 	leaderIdx := clus.WaitLeader(t)
 	cli := clus.Client(leaderIdx)
-	_, err = cli.MoveLeader(context.Background(), learnerID)
+	_, err = cli.MoveLeader(t.Context(), learnerID)
 	if err == nil {
 		t.Fatalf("expecting leader transfer to learner to fail, got no error")
 	}
@@ -183,7 +183,7 @@ func TestTransferLeadershipWithLearner(t *testing.T) {
 
 func TestFirstCommitNotification(t *testing.T) {
 	integration.BeforeTest(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	clusterSize := 3
 	cluster := integration.NewCluster(t, &integration.ClusterConfig{Size: clusterSize})
 	defer cluster.Terminate(t)
@@ -199,7 +199,7 @@ func TestFirstCommitNotification(t *testing.T) {
 		notifiers[i] = clusterMember.Server.FirstCommitInTermNotify()
 	}
 
-	_, err := oldLeaderClient.MoveLeader(context.Background(), newLeaderID)
+	_, err := oldLeaderClient.MoveLeader(t.Context(), newLeaderID)
 	if err != nil {
 		t.Errorf("got error during leadership transfer: %v", err)
 	}

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -64,7 +64,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	defer clus.Terminate(t)
 
 	// spawn a watcher before shutdown, and put it in synced watcher
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.Client(0)).Watch.Watch(ctx)
 	require.NoError(t, errW)
@@ -92,7 +92,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 
 	// to trigger snapshot from the leader to the stopped follower
 	for i := 0; i < 15; i++ {
-		_, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+		_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 		if err != nil {
 			t.Errorf("#%d: couldn't put key (%v)", i, err)
 		}
@@ -177,7 +177,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 }
 
 func expectMemberLog(t *testing.T, m *integration.Member, timeout time.Duration, s string, count int) {
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	lines, err := m.LogObserver.Expect(ctx, s, count)

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -233,7 +233,7 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			defer clus.Terminate(t)
 
 			wAPI := integration.ToGRPC(clus.RandClient()).Watch
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 			wStream, err := wAPI.Watch(ctx)
 			if err != nil {
@@ -268,7 +268,7 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 				for _, k := range tt.putKeys {
 					kvc := integration.ToGRPC(clus.RandClient()).KV
 					req := &pb.PutRequest{Key: []byte(k), Value: []byte("bar")}
-					if _, err := kvc.Put(context.TODO(), req); err != nil {
+					if _, err := kvc.Put(t.Context(), req); err != nil {
 						t.Errorf("#%d: couldn't put key (%v)", i, err)
 					}
 				}
@@ -320,7 +320,7 @@ func TestV3WatchFutureRevision(t *testing.T) {
 	defer clus.Terminate(t)
 
 	wAPI := integration.ToGRPC(clus.RandClient()).Watch
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, err := wAPI.Watch(ctx)
 	if err != nil {
@@ -349,7 +349,7 @@ func TestV3WatchFutureRevision(t *testing.T) {
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	for {
 		req := &pb.PutRequest{Key: wkey, Value: []byte("bar")}
-		resp, rerr := kvc.Put(context.TODO(), req)
+		resp, rerr := kvc.Put(t.Context(), req)
 		if rerr != nil {
 			t.Fatalf("couldn't put key (%v)", rerr)
 		}
@@ -382,7 +382,7 @@ func TestV3WatchWrongRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	wAPI := integration.ToGRPC(clus.RandClient()).Watch
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, err := wAPI.Watch(ctx)
 	if err != nil {
@@ -436,7 +436,7 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if errW != nil {
@@ -478,7 +478,7 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 	}
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Errorf("couldn't put key (%v)", err)
 	}
 
@@ -496,7 +496,7 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -513,7 +513,7 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 			defer wg.Done()
 			kvc := integration.ToGRPC(clus.RandClient()).KV
 			req := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
-			if _, err := kvc.Put(context.TODO(), req); err != nil {
+			if _, err := kvc.Put(t.Context(), req); err != nil {
 				t.Errorf("couldn't put key (%v)", err)
 			}
 		}()
@@ -582,7 +582,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
@@ -599,7 +599,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	_, err = kvc.Put(context.TODO(), preq)
+	_, err = kvc.Put(t.Context(), preq)
 	require.NoError(t, err)
 
 	// check received PUT
@@ -636,7 +636,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if errW != nil {
@@ -676,7 +676,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 		ids[wresp.WatchId] = struct{}{}
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -704,7 +704,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 	}
 
 	// now put one key that has only one matching watcher
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("fo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("fo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 	wresp, err := wStream.Recv()
@@ -740,7 +740,7 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -771,7 +771,7 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 		txn.Success = append(txn.Success, ru)
 	}
 
-	tresp, err := kvc.Txn(context.Background(), &txn)
+	tresp, err := kvc.Txn(t.Context(), &txn)
 	if err != nil {
 		t.Fatalf("kvc.Txn error: %v", err)
 	}
@@ -829,14 +829,14 @@ func TestV3WatchMultipleEventsPutUnsynced(t *testing.T) {
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -852,10 +852,10 @@ func TestV3WatchMultipleEventsPutUnsynced(t *testing.T) {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -916,7 +916,7 @@ func TestV3WatchProgressOnMemberRestart(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	errC := make(chan error, 1)
@@ -1029,7 +1029,7 @@ func testV3WatchMultipleStreams(t *testing.T, startRev int64) {
 
 	streams := make([]pb.Watch_WatchClient, 5)
 	for i := range streams {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 		defer cancel()
 		wStream, errW := wAPI.Watch(ctx)
 		if errW != nil {
@@ -1056,7 +1056,7 @@ func testV3WatchMultipleStreams(t *testing.T, startRev int64) {
 		}
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -1129,7 +1129,7 @@ func TestWatchWithProgressNotify(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -1188,7 +1188,7 @@ func TestV3WatchClose(t *testing.T) {
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		go func() {
-			ctx, cancel := context.WithCancel(context.TODO())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer func() {
 				wg.Done()
 				cancel()
@@ -1219,7 +1219,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
@@ -1247,7 +1247,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	_, err = kvc.Put(context.TODO(), preq)
+	_, err = kvc.Put(t.Context(), preq)
 	require.NoError(t, err)
 
 	select {
@@ -1257,7 +1257,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	}
 
 	dreq := &pb.DeleteRangeRequest{Key: []byte("foo")}
-	_, err = kvc.DeleteRange(context.TODO(), dreq)
+	_, err = kvc.DeleteRange(t.Context(), dreq)
 	require.NoError(t, err)
 
 	select {
@@ -1281,7 +1281,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	wctx, wcancel := context.WithCancel(context.Background())
+	wctx, wcancel := context.WithCancel(t.Context())
 	defer wcancel()
 
 	tests := []struct {
@@ -1299,7 +1299,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 	}}
 	for i, tt := range tests {
 		kvc := integration.ToGRPC(clus.RandClient()).KV
-		_, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])})
+		_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])})
 		require.NoError(t, err)
 
 		ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(wctx)
@@ -1317,7 +1317,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 		_, err = ws.Recv()
 		require.NoError(t, err)
 
-		_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])})
+		_, err = kvc.Put(t.Context(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])})
 		require.NoError(t, err)
 
 		recv := make(chan *pb.WatchResponse, 1)
@@ -1351,7 +1351,7 @@ func TestV3WatchCancellation(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	cli := clus.RandClient()
@@ -1391,7 +1391,7 @@ func TestV3WatchCloseCancelRace(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	cli := clus.RandClient()
@@ -1436,7 +1436,7 @@ func TestV3WatchProgressWaitsForSync(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	// Write a couple values into key to make sure there's a
@@ -1499,7 +1499,7 @@ func TestV3WatchProgressWaitsForSyncNoEvents(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	resp, err := client.Put(ctx, "bar", "1")
@@ -1547,7 +1547,7 @@ func TestV3NoEventsLostOnCompact(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// sendLoop throughput is rate-limited to 1 event per second

--- a/tests/integration/v3lock_grpc_test.go
+++ b/tests/integration/v3lock_grpc_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -33,18 +32,18 @@ func TestV3LockLockWaiter(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
+	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err1)
-	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
+	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err2)
 
 	lc := integration.ToGRPC(clus.Client(0)).Lock
-	l1, lerr1 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})
+	l1, lerr1 := lc.Lock(t.Context(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})
 	require.NoError(t, lerr1)
 
 	lockc := make(chan struct{})
 	go func() {
-		l2, lerr2 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease2.ID})
+		l2, lerr2 := lc.Lock(t.Context(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease2.ID})
 		if lerr2 != nil {
 			t.Error(lerr2)
 		}
@@ -60,7 +59,7 @@ func TestV3LockLockWaiter(t *testing.T) {
 		t.Fatalf("locked before unlock")
 	}
 
-	_, uerr := lc.Unlock(context.TODO(), &lockpb.UnlockRequest{Key: l1.Key})
+	_, uerr := lc.Unlock(t.Context(), &lockpb.UnlockRequest{Key: l1.Key})
 	require.NoError(t, uerr)
 
 	select {

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -35,8 +35,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    # Disabled in the meanwhile, it raises several issues with new Go 1.24 functions
-    # - usetesting
+    - usetesting
     - whitespace
 linters-settings: # please keep this alphabetized
   goimports:


### PR DESCRIPTION
#### Description

Apply `usetesting --fix ./...` on tests/integration packages and enable usetesting.

Closes #19581
