### PR TITLE
chore: use testify instead of testing in server/storage

### DIFF
--- a/server/storage/backend/batch_tx_test.go
+++ b/server/storage/backend/batch_tx_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
 	bolt "go.etcd.io/bbolt"
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -51,9 +52,7 @@ func TestBatchTxPut(t *testing.T) {
 		tx.Lock()
 		_, gv := tx.UnsafeRange(schema.Test, []byte("foo"), nil, 0)
 		tx.Unlock()
-		if !reflect.DeepEqual(gv[0], v) {
-			t.Errorf("v = %s, want %s", gv[0], v)
-		}
+		assert.Truef(t, reflect.DeepEqual(gv[0], v), "v = %s, want %s", gv[0], v)
 		tx.Commit()
 	}
 }
@@ -120,12 +119,8 @@ func TestBatchTxRange(t *testing.T) {
 	}
 	for i, tt := range tests {
 		keys, vals := tx.UnsafeRange(schema.Test, tt.key, tt.endKey, tt.limit)
-		if !reflect.DeepEqual(keys, tt.wkeys) {
-			t.Errorf("#%d: keys = %+v, want %+v", i, keys, tt.wkeys)
-		}
-		if !reflect.DeepEqual(vals, tt.wvals) {
-			t.Errorf("#%d: vals = %+v, want %+v", i, vals, tt.wvals)
-		}
+		assert.Truef(t, reflect.DeepEqual(keys, tt.wkeys), "#%d: keys = %+v, want %+v", i, keys, tt.wkeys)
+		assert.Truef(t, reflect.DeepEqual(vals, tt.wvals), "#%d: vals = %+v, want %+v", i, vals, tt.wvals)
 	}
 }
 
@@ -148,9 +143,7 @@ func TestBatchTxDelete(t *testing.T) {
 		tx.Lock()
 		ks, _ := tx.UnsafeRange(schema.Test, []byte("foo"), nil, 0)
 		tx.Unlock()
-		if len(ks) != 0 {
-			t.Errorf("keys on foo = %v, want nil", ks)
-		}
+		assert.Emptyf(t, ks, "keys on foo = %v, want nil", ks)
 		tx.Commit()
 	}
 }
@@ -174,10 +167,7 @@ func TestBatchTxCommit(t *testing.T) {
 			t.Errorf("bucket test does not exit")
 			return nil
 		}
-		v := bucket.Get([]byte("foo"))
-		if v == nil {
-			t.Errorf("foo key failed to written in backend")
-		}
+		assert.NotNilf(t, bucket.Get([]byte("foo")), "foo key failed to written in backend")
 		return nil
 	})
 }
@@ -202,10 +192,7 @@ func TestBatchTxBatchLimitCommit(t *testing.T) {
 			t.Errorf("bucket test does not exit")
 			return nil
 		}
-		v := bucket.Get([]byte("foo"))
-		if v == nil {
-			t.Errorf("foo key failed to written in backend")
-		}
+		assert.NotNilf(t, bucket.Get([]byte("foo")), "foo key failed to written in backend")
 		return nil
 	})
 }

--- a/server/storage/backend/verify_test.go
+++ b/server/storage/backend/verify_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/client/pkg/v3/verify"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
@@ -83,9 +85,7 @@ func TestLockVerify(t *testing.T) {
 					tc.lock(be.BatchTx())
 				}
 			}) != nil
-			if hasPaniced != tc.expectPanic {
-				t.Errorf("%v != %v", hasPaniced, tc.expectPanic)
-			}
+			assert.Equalf(t, hasPaniced, tc.expectPanic, "%v != %v", hasPaniced, tc.expectPanic)
 		})
 	}
 }

--- a/server/storage/mvcc/hash_test.go
+++ b/server/storage/mvcc/hash_test.go
@@ -192,18 +192,10 @@ func TestHasherStore(t *testing.T) {
 
 	for _, want := range hashes {
 		got, _, err := s.HashByRev(want.Revision)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if want.Hash != got.Hash {
-			t.Errorf("Expected stored hash to match, got: %d, expected: %d", want.Hash, got.Hash)
-		}
-		if want.Revision != got.Revision {
-			t.Errorf("Expected stored revision to match, got: %d, expected: %d", want.Revision, got.Revision)
-		}
-		if want.CompactRevision != got.CompactRevision {
-			t.Errorf("Expected stored compact revision to match, got: %d, expected: %d", want.CompactRevision, got.CompactRevision)
-		}
+		require.NoError(t, err)
+		assert.Equalf(t, want.Hash, got.Hash, "Expected stored hash to match, got: %d, expected: %d", want.Hash, got.Hash)
+		assert.Equalf(t, want.Revision, got.Revision, "Expected stored revision to match, got: %d, expected: %d", want.Revision, got.Revision)
+		assert.Equalf(t, want.CompactRevision, got.CompactRevision, "Expected stored compact revision to match, got: %d, expected: %d", want.CompactRevision, got.CompactRevision)
 	}
 }
 
@@ -222,13 +214,9 @@ func TestHasherStoreFull(t *testing.T) {
 	// Hash for old revision should be discarded as storage is already full
 	s.Store(KeyValueHash{Revision: minRevision - 1})
 	hash, _, err := s.HashByRev(minRevision - 1)
-	if err == nil {
-		t.Errorf("Expected an error as old revision should be discarded, got: %v", hash)
-	}
+	require.Errorf(t, err, "Expected an error as old revision should be discarded, got: %v", hash)
 	// Hash for new revision should be stored even when storage is full
 	s.Store(KeyValueHash{Revision: maxRevision + 1})
 	_, _, err = s.HashByRev(maxRevision + 1)
-	if err != nil {
-		t.Errorf("Didn't expect error for new revision, err: %v", err)
-	}
+	assert.NoErrorf(t, err, "Didn't expect error for new revision, err: %v", err)
 }

--- a/server/storage/mvcc/store_test.go
+++ b/server/storage/mvcc/store_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -48,9 +49,7 @@ func TestScheduledCompact(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(schema.Meta)
 			UnsafeSetScheduledCompact(tx, tc.value)
@@ -87,9 +86,7 @@ func TestFinishedCompact(t *testing.T) {
 			lg := zaptest.NewLogger(t)
 			be, tmpPath := betesting.NewTmpBackend(t, time.Microsecond, 10)
 			tx := be.BatchTx()
-			if tx == nil {
-				t.Fatal("batch tx is nil")
-			}
+			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(schema.Meta)
 			UnsafeSetFinishedCompact(tx, tc.value)

--- a/server/storage/schema/actions_test.go
+++ b/server/storage/schema/actions_test.go
@@ -15,7 +15,6 @@
 package schema
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -80,13 +79,9 @@ func TestActionIsReversible(t *testing.T) {
 
 			assertBucketState(t, tx, Meta, tc.state)
 			reverse, err := tc.action.unsafeDo(tx)
-			if err != nil {
-				t.Errorf("Failed to upgrade, err: %v", err)
-			}
+			require.NoErrorf(t, err, "Failed to upgrade, err: %v", err)
 			_, err = reverse.unsafeDo(tx)
-			if err != nil {
-				t.Errorf("Failed to downgrade, err: %v", err)
-			}
+			require.NoErrorf(t, err, "Failed to downgrade, err: %v", err)
 			assertBucketState(t, tx, Meta, tc.state)
 		})
 	}
@@ -132,10 +127,7 @@ func TestActionListRevert(t *testing.T) {
 			defer tx.Unlock()
 
 			UnsafeCreateMetaBucket(tx)
-			err := tc.actions.unsafeExecute(lg, tx)
-			if !errors.Is(err, tc.expectError) {
-				t.Errorf("Unexpected error or lack thereof, expected: %v, got: %v", tc.expectError, err)
-			}
+			require.ErrorIs(t, tc.actions.unsafeExecute(lg, tx), tc.expectError)
 			assertBucketState(t, tx, Meta, tc.expectState)
 		})
 	}

--- a/server/storage/schema/changes_test.go
+++ b/server/storage/schema/changes_test.go
@@ -47,14 +47,10 @@ func TestUpgradeDowngrade(t *testing.T) {
 			UnsafeCreateMetaBucket(tx)
 
 			_, err := tc.change.upgradeAction().unsafeDo(tx)
-			if err != nil {
-				t.Errorf("Failed to upgrade, err: %v", err)
-			}
+			require.NoErrorf(t, err, "Failed to upgrade, err: %v", err)
 			assertBucketState(t, tx, Meta, tc.expectStateAfterUpgrade)
 			_, err = tc.change.downgradeAction().unsafeDo(tx)
-			if err != nil {
-				t.Errorf("Failed to downgrade, err: %v", err)
-			}
+			require.NoErrorf(t, err, "Failed to downgrade, err: %v", err)
 			assertBucketState(t, tx, Meta, tc.expectStateAfterDowngrade)
 		})
 	}

--- a/server/storage/schema/migration_test.go
+++ b/server/storage/schema/migration_test.go
@@ -15,7 +15,6 @@
 package schema
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -177,12 +176,8 @@ func TestMigrationStepExecute(t *testing.T) {
 			UnsafeSetStorageVersion(tx, &tc.currentVersion)
 
 			step := newMigrationStep(tc.currentVersion, tc.isUpgrade, tc.changes)
-			err := step.unsafeExecute(lg, tx)
-			if !errors.Is(err, tc.expectError) {
-				t.Errorf("Unexpected error or lack thereof, expected: %v, got: %v", tc.expectError, err)
-			}
-			v := UnsafeReadStorageVersion(tx)
-			assert.Equal(t, tc.expectVersion, v)
+			require.ErrorIs(t, step.unsafeExecute(lg, tx), tc.expectError)
+			assert.Equal(t, tc.expectVersion, UnsafeReadStorageVersion(tx))
 			assert.Equal(t, tc.expectRecordedActions, recorder.actions)
 		})
 	}

--- a/server/storage/schema/schema_test.go
+++ b/server/storage/schema/schema_test.go
@@ -208,9 +208,7 @@ func TestMigrate(t *testing.T) {
 			w, _ := waltesting.NewTmpWAL(t, tc.walEntries)
 			defer w.Close()
 			walVersion, err := wal.ReadWALVersion(w)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			b := backend.NewDefaultBackend(lg, dataPath)
 			defer b.Close()
@@ -264,16 +262,12 @@ func TestMigrateIsReversible(t *testing.T) {
 			assertBucketState(t, tx, Meta, tc.state)
 			w, walPath := waltesting.NewTmpWAL(t, nil)
 			walVersion, err := wal.ReadWALVersion(w)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			// Upgrade to current version
 			ver := localBinaryVersion()
 			err = UnsafeMigrate(lg, tx, walVersion, ver)
-			if err != nil {
-				t.Errorf("Migrate(lg, tx, %q) returned error %+v", ver, err)
-			}
+			require.NoErrorf(t, err, "Migrate(lg, tx, %q) returned error %+v", ver, err)
 			assert.Equal(t, &ver, UnsafeReadStorageVersion(tx))
 
 			// Downgrade back to initial version
@@ -281,13 +275,9 @@ func TestMigrateIsReversible(t *testing.T) {
 			w = waltesting.Reopen(t, walPath)
 			defer w.Close()
 			walVersion, err = wal.ReadWALVersion(w)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			err = UnsafeMigrate(lg, tx, walVersion, tc.initialVersion)
-			if err != nil {
-				t.Errorf("Migrate(lg, tx, %q) returned error %+v", tc.initialVersion, err)
-			}
+			require.NoErrorf(t, err, "Migrate(lg, tx, %q) returned error %+v", tc.initialVersion, err)
 
 			// Assert that all changes were revered
 			assertBucketState(t, tx, Meta, tc.state)

--- a/server/storage/schema/version_test.go
+++ b/server/storage/schema/version_test.go
@@ -112,18 +112,15 @@ func TestVersionSnapshot(t *testing.T) {
 			be.ForceCommit()
 			be.Close()
 			db, err := bbolt.Open(tmpPath, 0o400, &bbolt.Options{ReadOnly: true})
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer db.Close()
 
 			var ver *semver.Version
-			if err = db.View(func(tx *bbolt.Tx) error {
+			err = db.View(func(tx *bbolt.Tx) error {
 				ver = ReadStorageVersionFromSnapshot(tx)
 				return nil
-			}); err != nil {
-				t.Fatal(err)
-			}
+			})
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectVersion, ver.String())
 		})

--- a/server/storage/wal/file_pipeline_test.go
+++ b/server/storage/wal/file_pipeline_test.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -28,9 +29,7 @@ func TestFilePipeline(t *testing.T) {
 	defer fp.Close()
 
 	f, ferr := fp.Open()
-	if ferr != nil {
-		t.Fatal(ferr)
-	}
+	require.NoError(t, ferr)
 	f.Close()
 }
 

--- a/server/storage/wal/repair_test.go
+++ b/server/storage/wal/repair_test.go
@@ -167,9 +167,7 @@ func TestRepairFailDeleteDir(t *testing.T) {
 	p := t.TempDir()
 
 	w, err := Create(zaptest.NewLogger(t), p, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	oldSegmentSizeBytes := SegmentSizeBytes
 	SegmentSizeBytes = 64
@@ -177,30 +175,20 @@ func TestRepairFailDeleteDir(t *testing.T) {
 		SegmentSizeBytes = oldSegmentSizeBytes
 	}()
 	for _, es := range makeEnts(50) {
-		if err = w.Save(raftpb.HardState{}, es); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, w.Save(raftpb.HardState{}, es))
 	}
 
 	_, serr := w.tail().Seek(0, io.SeekCurrent)
-	if serr != nil {
-		t.Fatal(serr)
-	}
+	require.NoError(t, serr)
 	w.Close()
 
 	f, err := openLast(zaptest.NewLogger(t), p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if terr := f.Truncate(20); terr != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(20))
 	f.Close()
 
 	w, err = Open(zaptest.NewLogger(t), p, walpb.Snapshot{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, _, err = w.ReadAll()
 	require.ErrorIsf(t, err, io.ErrUnexpectedEOF, "err = %v, want error %v", err, io.ErrUnexpectedEOF)
 	w.Close()

--- a/server/storage/wal/walpb/record_test.go
+++ b/server/storage/wal/walpb/record_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/descriptor"
+	"github.com/stretchr/testify/assert"
 
 	"go.etcd.io/raft/v3/raftpb"
 )
@@ -25,10 +26,8 @@ import (
 func TestSnapshotMetadataCompatibility(t *testing.T) {
 	_, snapshotMetadataMd := descriptor.ForMessage(&raftpb.SnapshotMetadata{})
 	_, snapshotMd := descriptor.ForMessage(&Snapshot{})
-	if len(snapshotMetadataMd.GetField()) != len(snapshotMd.GetField()) {
-		t.Errorf("Different number of fields in raftpb.SnapshotMetadata vs. walpb.Snapshot. " +
-			"They are supposed to be in sync.")
-	}
+	assert.Lenf(t, snapshotMd.GetField(), len(snapshotMetadataMd.GetField()), "Different number of fields in raftpb.SnapshotMetadata vs. walpb.Snapshot. "+
+		"They are supposed to be in sync.")
 }
 
 func TestValidateSnapshot(t *testing.T) {


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in server/storage package

Related to #18972