### PR TITLE
chore: use testify instead of testing in server/etcdserver

### DIFF
--- a/server/etcdserver/api/etcdhttp/types/errors_test.go
+++ b/server/etcdserver/api/etcdhttp/types/errors_test.go
@@ -19,14 +19,16 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPErrorWriteTo(t *testing.T) {
 	err := NewHTTPError(http.StatusBadRequest, "what a bad request you made!")
 	rr := httptest.NewRecorder()
-	if e := err.WriteTo(rr); e != nil {
-		t.Fatalf("HTTPError.WriteTo error (%v)", e)
-	}
+	e := err.WriteTo(rr)
+	require.NoErrorf(t, e, "HTTPError.WriteTo error (%v)", e)
 
 	wcode := http.StatusBadRequest
 	wheader := http.Header(map[string][]string{
@@ -34,16 +36,10 @@ func TestHTTPErrorWriteTo(t *testing.T) {
 	})
 	wbody := `{"message":"what a bad request you made!"}`
 
-	if wcode != rr.Code {
-		t.Errorf("HTTP status code %d, want %d", rr.Code, wcode)
-	}
+	assert.Equalf(t, wcode, rr.Code, "HTTP status code %d, want %d", rr.Code, wcode)
 
-	if !reflect.DeepEqual(wheader, rr.HeaderMap) {
-		t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader)
-	}
+	assert.Truef(t, reflect.DeepEqual(wheader, rr.HeaderMap), "HTTP headers %v, want %v", rr.HeaderMap, wheader)
 
 	gbody := rr.Body.String()
-	if wbody != gbody {
-		t.Errorf("HTTP body %q, want %q", gbody, wbody)
-	}
+	assert.Equalf(t, wbody, gbody, "HTTP body %q, want %q", gbody, wbody)
 }

--- a/server/etcdserver/api/etcdhttp/version_test.go
+++ b/server/etcdserver/api/etcdhttp/version_test.go
@@ -20,34 +20,29 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/api/v3/version"
 )
 
 func TestServeVersion(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "", nil)
-	if err != nil {
-		t.Fatalf("error creating request: %v", err)
-	}
+	require.NoErrorf(t, err, "error creating request: %v", err)
 	rw := httptest.NewRecorder()
 	serveVersion(rw, req, "3.6.0", "3.5.2")
-	if rw.Code != http.StatusOK {
-		t.Errorf("code=%d, want %d", rw.Code, http.StatusOK)
-	}
+	assert.Equalf(t, http.StatusOK, rw.Code, "code=%d, want %d", rw.Code, http.StatusOK)
 	vs := version.Versions{
 		Server:  version.Version,
 		Cluster: "3.6.0",
 		Storage: "3.5.2",
 	}
 	w, err := json.Marshal(&vs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if g := rw.Body.String(); g != string(w) {
-		t.Fatalf("body = %q, want %q", g, string(w))
-	}
-	if ct := rw.HeaderMap.Get("Content-Type"); ct != "application/json" {
-		t.Errorf("contet-type header = %s, want %s", ct, "application/json")
-	}
+	require.NoError(t, err)
+	g := rw.Body.String()
+	require.Equalf(t, g, string(w), "body = %q, want %q", g, string(w))
+	ct := rw.HeaderMap.Get("Content-Type")
+	assert.Equalf(t, "application/json", ct, "contet-type header = %s, want %s", ct, "application/json")
 }
 
 func TestServeVersionFails(t *testing.T) {
@@ -56,14 +51,10 @@ func TestServeVersionFails(t *testing.T) {
 	} {
 		t.Run(m, func(t *testing.T) {
 			req, err := http.NewRequest(m, "", nil)
-			if err != nil {
-				t.Fatalf("error creating request: %v", err)
-			}
+			require.NoErrorf(t, err, "error creating request: %v", err)
 			rw := httptest.NewRecorder()
 			serveVersion(rw, req, "3.6.0", "3.5.2")
-			if rw.Code != http.StatusMethodNotAllowed {
-				t.Errorf("method %s: code=%d, want %d", m, rw.Code, http.StatusMethodNotAllowed)
-			}
+			assert.Equalf(t, http.StatusMethodNotAllowed, rw.Code, "method %s: code=%d, want %d", m, rw.Code, http.StatusMethodNotAllowed)
 		})
 	}
 }

--- a/server/etcdserver/api/membership/member_test.go
+++ b/server/etcdserver/api/membership/member_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/client/pkg/v3/types"
 )
 
@@ -49,9 +51,7 @@ func TestMemberTime(t *testing.T) {
 		{NewMember("mem1", []url.URL{{Scheme: "http", Host: "10.0.0.2:2379"}, {Scheme: "http", Host: "10.0.0.1:2379"}}, "", nil), 16552244735972308939},
 	}
 	for i, tt := range tests {
-		if tt.mem.ID != tt.id {
-			t.Errorf("#%d: mem.ID = %v, want %v", i, tt.mem.ID, tt.id)
-		}
+		assert.Equalf(t, tt.mem.ID, tt.id, "#%d: mem.ID = %v, want %v", i, tt.mem.ID, tt.id)
 	}
 }
 
@@ -64,12 +64,8 @@ func TestMemberClone(t *testing.T) {
 	}
 	for i, tt := range tests {
 		nm := tt.Clone()
-		if nm == tt {
-			t.Errorf("#%d: the pointers are the same, and clone doesn't happen", i)
-		}
-		if !reflect.DeepEqual(nm, tt) {
-			t.Errorf("#%d: member = %+v, want %+v", i, nm, tt)
-		}
+		assert.NotSamef(t, nm, tt, "#%d: the pointers are the same, and clone doesn't happen", i)
+		assert.Truef(t, reflect.DeepEqual(nm, tt), "#%d: member = %+v, want %+v", i, nm, tt)
 	}
 }
 

--- a/server/etcdserver/api/rafthttp/msg_codec_test.go
+++ b/server/etcdserver/api/rafthttp/msg_codec_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -89,9 +91,7 @@ func TestMessage(t *testing.T) {
 			continue
 		}
 		if err == nil {
-			if !reflect.DeepEqual(m, tt.msg) {
-				t.Errorf("#%d: message = %+v, want %+v", i, m, tt.msg)
-			}
+			assert.Truef(t, reflect.DeepEqual(m, tt.msg), "#%d: message = %+v, want %+v", i, m, tt.msg)
 		}
 	}
 }

--- a/server/etcdserver/api/rafthttp/msgappv2_codec_test.go
+++ b/server/etcdserver/api/rafthttp/msgappv2_codec_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	stats "go.etcd.io/etcd/server/v3/etcdserver/api/v2stats"
 	"go.etcd.io/raft/v3/raftpb"
@@ -116,8 +118,6 @@ func TestMsgAppV2(t *testing.T) {
 			t.Errorf("#%d: unexpected decode message error: %v", i, err)
 			continue
 		}
-		if !reflect.DeepEqual(m, tt) {
-			t.Errorf("#%d: message = %+v, want %+v", i, m, tt)
-		}
+		assert.Truef(t, reflect.DeepEqual(m, tt), "#%d: message = %+v, want %+v", i, m, tt)
 	}
 }

--- a/server/etcdserver/api/rafthttp/peer_test.go
+++ b/server/etcdserver/api/rafthttp/peer_test.go
@@ -17,6 +17,8 @@ package rafthttp
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -80,8 +82,6 @@ func TestPeerPick(t *testing.T) {
 			pipeline:       &pipeline{},
 		}
 		_, picked := peer.pick(tt.m)
-		if picked != tt.wpicked {
-			t.Errorf("#%d: picked = %v, want %v", i, picked, tt.wpicked)
-		}
+		assert.Equalf(t, picked, tt.wpicked, "#%d: picked = %v, want %v", i, picked, tt.wpicked)
 	}
 }

--- a/server/etcdserver/api/rafthttp/snapshot_test.go
+++ b/server/etcdserver/api/rafthttp/snapshot_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -84,12 +86,8 @@ func TestSnapshotSend(t *testing.T) {
 
 	for i, tt := range tests {
 		sent, files := testSnapshotSend(t, snap.NewMessage(tt.m, tt.rc, tt.size))
-		if tt.wsent != sent {
-			t.Errorf("#%d: snapshot expected %v, got %v", i, tt.wsent, sent)
-		}
-		if tt.wfiles != len(files) {
-			t.Fatalf("#%d: expected %d files, got %d files", i, tt.wfiles, len(files))
-		}
+		assert.Equalf(t, tt.wsent, sent, "#%d: snapshot expected %v, got %v", i, tt.wsent, sent)
+		require.Lenf(t, files, tt.wfiles, "#%d: expected %d files, got %d files", i, tt.wfiles, len(files))
 	}
 }
 
@@ -120,9 +118,7 @@ func testSnapshotSend(t *testing.T, sm *snap.Message) (bool, []os.DirEntry) {
 	<-ch
 
 	files, rerr := os.ReadDir(d)
-	if rerr != nil {
-		t.Fatal(rerr)
-	}
+	require.NoError(t, rerr)
 	return sent, files
 }
 

--- a/server/etcdserver/api/rafthttp/urlpick_test.go
+++ b/server/etcdserver/api/rafthttp/urlpick_test.go
@@ -18,6 +18,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 )
 
@@ -31,15 +33,11 @@ func TestURLPickerPickTwice(t *testing.T) {
 		{Scheme: "http", Host: "127.0.0.1:2380"}: true,
 		{Scheme: "http", Host: "127.0.0.1:7001"}: true,
 	}
-	if !urlmap[u] {
-		t.Errorf("url picked = %+v, want a possible url in %+v", u, urlmap)
-	}
+	assert.Truef(t, urlmap[u], "url picked = %+v, want a possible url in %+v", u, urlmap)
 
 	// pick out the same url when calling pick again
 	uu := picker.pick()
-	if u != uu {
-		t.Errorf("url picked = %+v, want %+v", uu, u)
-	}
+	assert.Equalf(t, u, uu, "url picked = %+v, want %+v", uu, u)
 }
 
 func TestURLPickerUpdate(t *testing.T) {
@@ -51,9 +49,7 @@ func TestURLPickerUpdate(t *testing.T) {
 		{Scheme: "http", Host: "localhost:2380"}: true,
 		{Scheme: "http", Host: "localhost:7001"}: true,
 	}
-	if !urlmap[u] {
-		t.Errorf("url picked = %+v, want a possible url in %+v", u, urlmap)
-	}
+	assert.Truef(t, urlmap[u], "url picked = %+v, want a possible url in %+v", u, urlmap)
 }
 
 func TestURLPickerUnreachable(t *testing.T) {
@@ -62,9 +58,7 @@ func TestURLPickerUnreachable(t *testing.T) {
 	picker.unreachable(u)
 
 	uu := picker.pick()
-	if u == uu {
-		t.Errorf("url picked = %+v, want other possible urls", uu)
-	}
+	assert.NotEqualf(t, u, uu, "url picked = %+v, want other possible urls", uu)
 }
 
 func mustNewURLPicker(t *testing.T, us []string) *urlPicker {

--- a/server/etcdserver/api/rafthttp/util_test.go
+++ b/server/etcdserver/api/rafthttp/util_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/raft/v3/raftpb"
@@ -45,9 +46,7 @@ func TestEntry(t *testing.T) {
 			t.Errorf("#%d: unexpected read ents error: %v", i, err)
 			continue
 		}
-		if !reflect.DeepEqual(ent, tt) {
-			t.Errorf("#%d: ent = %+v, want %+v", i, ent, tt)
-		}
+		assert.Truef(t, reflect.DeepEqual(ent, tt), "#%d: ent = %+v, want %+v", i, ent, tt)
 	}
 }
 
@@ -88,9 +87,8 @@ func TestCompareMajorMinorVersion(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		if g := compareMajorMinorVersion(tt.va, tt.vb); g != tt.w {
-			t.Errorf("#%d: compare = %d, want %d", i, g, tt.w)
-		}
+		g := compareMajorMinorVersion(tt.va, tt.vb)
+		assert.Equalf(t, g, tt.w, "#%d: compare = %d, want %d", i, g, tt.w)
 	}
 }
 
@@ -115,9 +113,7 @@ func TestServerVersion(t *testing.T) {
 	}
 	for i, tt := range tests {
 		v := serverVersion(tt.h)
-		if v.String() != tt.wv.String() {
-			t.Errorf("#%d: version = %s, want %s", i, v, tt.wv)
-		}
+		assert.Equalf(t, v.String(), tt.wv.String(), "#%d: version = %s, want %s", i, v, tt.wv)
 	}
 }
 
@@ -142,9 +138,7 @@ func TestMinClusterVersion(t *testing.T) {
 	}
 	for i, tt := range tests {
 		v := minClusterVersion(tt.h)
-		if v.String() != tt.wv.String() {
-			t.Errorf("#%d: version = %s, want %s", i, v, tt.wv)
-		}
+		assert.Equalf(t, v.String(), tt.wv.String(), "#%d: version = %s, want %s", i, v, tt.wv)
 	}
 }
 
@@ -189,9 +183,8 @@ func TestCheckVersionCompatibility(t *testing.T) {
 	}
 	for i, tt := range tests {
 		_, _, err := checkVersionCompatibility("", tt.server, tt.minCluster)
-		if ok := err == nil; ok != tt.wok {
-			t.Errorf("#%d: ok = %v, want %v", i, ok, tt.wok)
-		}
+		ok := err == nil
+		assert.Equalf(t, ok, tt.wok, "#%d: ok = %v, want %v", i, ok, tt.wok)
 	}
 }
 

--- a/server/etcdserver/api/v2error/error_test.go
+++ b/server/etcdserver/api/v2error/error_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestErrorWriteTo(t *testing.T) {
@@ -28,22 +30,16 @@ func TestErrorWriteTo(t *testing.T) {
 		rr := httptest.NewRecorder()
 		err.WriteTo(rr)
 
-		if err.StatusCode() != rr.Code {
-			t.Errorf("HTTP status code %d, want %d", rr.Code, err.StatusCode())
-		}
+		assert.Equalf(t, err.StatusCode(), rr.Code, "HTTP status code %d, want %d", rr.Code, err.StatusCode())
 
 		gbody := strings.TrimSuffix(rr.Body.String(), "\n")
-		if err.toJSONString() != gbody {
-			t.Errorf("HTTP body %q, want %q", gbody, err.toJSONString())
-		}
+		assert.Equalf(t, err.toJSONString(), gbody, "HTTP body %q, want %q", gbody, err.toJSONString())
 
 		wheader := http.Header(map[string][]string{
 			"Content-Type": {"application/json"},
 			"X-Etcd-Index": {"1"},
 		})
 
-		if !reflect.DeepEqual(wheader, rr.HeaderMap) {
-			t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader)
-		}
+		assert.Truef(t, reflect.DeepEqual(wheader, rr.HeaderMap), "HTTP headers %v, want %v", rr.HeaderMap, wheader)
 	}
 }

--- a/server/etcdserver/api/v2store/event_test.go
+++ b/server/etcdserver/api/v2store/event_test.go
@@ -17,6 +17,8 @@ package v2store
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v2error"
 )
 
@@ -38,9 +40,7 @@ func TestEventQueue(t *testing.T) {
 	n := eh.Queue.Size
 	for ; n > 0; n-- {
 		e := eh.Queue.Events[i]
-		if e.Index() != uint64(j) {
-			t.Fatalf("queue error!")
-		}
+		require.Equalf(t, e.Index(), uint64(j), "queue error!")
 		j++
 		i = (i + 1) % eh.Queue.Capacity
 	}
@@ -84,9 +84,7 @@ func TestScanHistory(t *testing.T) {
 	}
 
 	e, _ = eh.scan("/foo/bar", true, 7)
-	if e != nil {
-		t.Fatalf("bad index shoud reuturn nil")
-	}
+	require.Nilf(t, e, "bad index shoud reuturn nil")
 }
 
 func TestEventIndexHistoryCleared(t *testing.T) {
@@ -136,25 +134,13 @@ func TestCloneEvent(t *testing.T) {
 		PrevNode:  nil,
 	}
 	e2 := e1.Clone()
-	if e2.Action != Create {
-		t.Fatalf("Action=%q, want %q", e2.Action, Create)
-	}
-	if e2.EtcdIndex != e1.EtcdIndex {
-		t.Fatalf("EtcdIndex=%d, want %d", e2.EtcdIndex, e1.EtcdIndex)
-	}
+	require.Equalf(t, Create, e2.Action, "Action=%q, want %q", e2.Action, Create)
+	require.Equalf(t, e2.EtcdIndex, e1.EtcdIndex, "EtcdIndex=%d, want %d", e2.EtcdIndex, e1.EtcdIndex)
 	// Changing the cloned node should not affect the original
 	e2.Action = Delete
 	e2.EtcdIndex = uint64(5)
-	if e1.Action != Create {
-		t.Fatalf("Action=%q, want %q", e1.Action, Create)
-	}
-	if e1.EtcdIndex != uint64(1) {
-		t.Fatalf("EtcdIndex=%d, want %d", e1.EtcdIndex, uint64(1))
-	}
-	if e2.Action != Delete {
-		t.Fatalf("Action=%q, want %q", e2.Action, Delete)
-	}
-	if e2.EtcdIndex != uint64(5) {
-		t.Fatalf("EtcdIndex=%d, want %d", e2.EtcdIndex, uint64(5))
-	}
+	require.Equalf(t, Create, e1.Action, "Action=%q, want %q", e1.Action, Create)
+	require.Equalf(t, uint64(1), e1.EtcdIndex, "EtcdIndex=%d, want %d", e1.EtcdIndex, uint64(1))
+	require.Equalf(t, Delete, e2.Action, "Action=%q, want %q", e2.Action, Delete)
+	require.Equalf(t, uint64(5), e2.EtcdIndex, "EtcdIndex=%d, want %d", e2.EtcdIndex, uint64(5))
 }

--- a/server/etcdserver/api/v2store/heap_test.go
+++ b/server/etcdserver/api/v2store/heap_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHeapPushPop(t *testing.T) {
@@ -36,9 +38,7 @@ func TestHeapPushPop(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		node := h.pop()
-		if node.ExpireTime.Before(min) {
-			t.Fatal("heap sort wrong!")
-		}
+		require.Falsef(t, node.ExpireTime.Before(min), "heap sort wrong!")
 		min = node.ExpireTime
 	}
 }
@@ -71,21 +71,15 @@ func TestHeapUpdate(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		node := h.pop()
-		if node.ExpireTime.Before(min) {
-			t.Fatal("heap sort wrong!")
-		}
+		require.Falsef(t, node.ExpireTime.Before(min), "heap sort wrong!")
 		min = node.ExpireTime
 
 		if i == 8 {
-			if node.Path != "7" {
-				t.Fatal("heap sort wrong!", node.Path)
-			}
+			require.Equalf(t, "7", node.Path, "heap sort wrong!")
 		}
 
 		if i == 9 {
-			if node.Path != "5" {
-				t.Fatal("heap sort wrong!")
-			}
+			require.Equalf(t, "5", node.Path, "heap sort wrong!")
 		}
 	}
 }

--- a/server/etcdserver/api/v2store/node_extern_test.go
+++ b/server/etcdserver/api/v2store/node_extern_test.go
@@ -20,13 +20,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeExternClone(t *testing.T) {
 	var eNode *NodeExtern
-	if g := eNode.Clone(); g != nil {
-		t.Fatalf("nil.Clone=%v, want nil", g)
-	}
+	g := eNode.Clone()
+	require.Nilf(t, g, "nil.Clone=%v, want nil", g)
 
 	const (
 		key string = "/foo/bar"
@@ -66,15 +66,9 @@ func TestNodeExternClone(t *testing.T) {
 	assert.Len(t, gNode.Nodes, len(childs))
 	assert.Equal(t, child, *gNode.Nodes[0])
 	// but pointers should differ
-	if gNode.Value == eNode.Value {
-		t.Fatalf("expected value pointers to differ, but got same!")
-	}
-	if gNode.Expiration == eNode.Expiration {
-		t.Fatalf("expected expiration pointers to differ, but got same!")
-	}
-	if sameSlice(gNode.Nodes, eNode.Nodes) {
-		t.Fatalf("expected nodes pointers to differ, but got same!")
-	}
+	require.NotSamef(t, gNode.Value, eNode.Value, "expected value pointers to differ, but got same!")
+	require.NotSamef(t, gNode.Expiration, eNode.Expiration, "expected expiration pointers to differ, but got same!")
+	require.Falsef(t, sameSlice(gNode.Nodes, eNode.Nodes), "expected nodes pointers to differ, but got same!")
 	// Original should be the same
 	assert.Equal(t, key, eNode.Key)
 	assert.Equal(t, ttl, eNode.TTL)
@@ -82,9 +76,7 @@ func TestNodeExternClone(t *testing.T) {
 	assert.Equal(t, mi, eNode.ModifiedIndex)
 	assert.Equal(t, valp, eNode.Value)
 	assert.Equal(t, expp, eNode.Expiration)
-	if !sameSlice(eNode.Nodes, childs) {
-		t.Fatalf("expected nodes pointer to same, but got different!")
-	}
+	require.Truef(t, sameSlice(eNode.Nodes, childs), "expected nodes pointer to same, but got different!")
 	// Change the clone and ensure the original is not affected
 	gNode.Key = "/baz"
 	gNode.TTL = 0

--- a/server/etcdserver/api/v2store/node_test.go
+++ b/server/etcdserver/api/v2store/node_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -30,17 +31,11 @@ var (
 func TestNewKVIs(t *testing.T) {
 	nd := newTestNode()
 
-	if nd.IsHidden() {
-		t.Errorf("nd.Hidden() = %v, want = false", nd.IsHidden())
-	}
+	assert.Falsef(t, nd.IsHidden(), "nd.Hidden() = %v, want = false", nd.IsHidden())
 
-	if nd.IsPermanent() {
-		t.Errorf("nd.IsPermanent() = %v, want = false", nd.IsPermanent())
-	}
+	assert.Falsef(t, nd.IsPermanent(), "nd.IsPermanent() = %v, want = false", nd.IsPermanent())
 
-	if nd.IsDir() {
-		t.Errorf("nd.IsDir() = %v, want = false", nd.IsDir())
-	}
+	assert.Falsef(t, nd.IsDir(), "nd.IsDir() = %v, want = false", nd.IsDir())
 }
 
 func TestNewKVReadWriteCompare(t *testing.T) {
@@ -73,26 +68,20 @@ func TestNewKVReadWriteCompare(t *testing.T) {
 func TestNewKVExpiration(t *testing.T) {
 	nd := newTestNode()
 
-	if _, ttl := nd.expirationAndTTL(clockwork.NewFakeClock()); ttl > expiration.Nanoseconds() {
-		t.Errorf("ttl = %d, want %d < %d", ttl, ttl, expiration.Nanoseconds())
-	}
+	_, ttl := nd.expirationAndTTL(clockwork.NewFakeClock())
+	assert.LessOrEqualf(t, ttl, expiration.Nanoseconds(), "ttl = %d, want %d < %d", ttl, ttl, expiration.Nanoseconds())
 
 	newExpiration := time.Hour
 	nd.UpdateTTL(time.Now().Add(newExpiration))
-	if _, ttl := nd.expirationAndTTL(clockwork.NewFakeClock()); ttl > newExpiration.Nanoseconds() {
-		t.Errorf("ttl = %d, want %d < %d", ttl, ttl, newExpiration.Nanoseconds())
-	}
+	_, ttl = nd.expirationAndTTL(clockwork.NewFakeClock())
+	assert.LessOrEqualf(t, ttl, newExpiration.Nanoseconds(), "ttl = %d, want %d < %d", ttl, ttl, newExpiration.Nanoseconds())
 	if ns, err := nd.List(); ns != nil || err == nil {
 		t.Errorf("nodes = %v and err = %v, want nodes = nil and err != nil", ns, err)
 	}
 
 	en := nd.Repr(false, false, clockwork.NewFakeClock())
-	if en.Key != nd.Path {
-		t.Errorf("en.Key = %s, want = %s", en.Key, nd.Path)
-	}
-	if *(en.Value) != nd.Value {
-		t.Errorf("*(en.Key) = %s, want = %s", *(en.Value), nd.Value)
-	}
+	assert.Equalf(t, en.Key, nd.Path, "en.Key = %s, want = %s", en.Key, nd.Path)
+	assert.Equalf(t, *(en.Value), nd.Value, "*(en.Key) = %s, want = %s", *(en.Value), nd.Value)
 }
 
 func TestNewKVListReprCompareClone(t *testing.T) {
@@ -103,20 +92,12 @@ func TestNewKVListReprCompareClone(t *testing.T) {
 	}
 
 	en := nd.Repr(false, false, clockwork.NewFakeClock())
-	if en.Key != nd.Path {
-		t.Errorf("en.Key = %s, want = %s", en.Key, nd.Path)
-	}
-	if *(en.Value) != nd.Value {
-		t.Errorf("*(en.Key) = %s, want = %s", *(en.Value), nd.Value)
-	}
+	assert.Equalf(t, en.Key, nd.Path, "en.Key = %s, want = %s", en.Key, nd.Path)
+	assert.Equalf(t, *(en.Value), nd.Value, "*(en.Key) = %s, want = %s", *(en.Value), nd.Value)
 
 	cn := nd.Clone()
-	if cn.Path != nd.Path {
-		t.Errorf("cn.Path = %s, want = %s", cn.Path, nd.Path)
-	}
-	if cn.Value != nd.Value {
-		t.Errorf("cn.Value = %s, want = %s", cn.Value, nd.Value)
-	}
+	assert.Equalf(t, cn.Path, nd.Path, "cn.Path = %s, want = %s", cn.Path, nd.Path)
+	assert.Equalf(t, cn.Value, nd.Value, "cn.Value = %s, want = %s", cn.Value, nd.Value)
 }
 
 func TestNewKVRemove(t *testing.T) {
@@ -140,96 +121,67 @@ func TestNewKVRemove(t *testing.T) {
 			t.Errorf("value = %s and err = %v, want value = %s and err = nil", v, err, val2)
 		}
 	}
-
-	if err := nd.Remove(false, false, nil); err != nil {
-		t.Errorf("nd.Remove err = %v, want = nil", err)
-	} else {
-		// still readable
-		if v, err := nd.Read(); v != val2 || err != nil {
-			t.Errorf("value = %s and err = %v, want value = %s and err = nil", v, err, val2)
-		}
-		if len(nd.store.ttlKeyHeap.array) != 0 {
-			t.Errorf("len(nd.store.ttlKeyHeap.array) = %d, want = 0", len(nd.store.ttlKeyHeap.array))
-		}
-		if len(nd.store.ttlKeyHeap.keyMap) != 0 {
-			t.Errorf("len(nd.store.ttlKeyHeap.keyMap) = %d, want = 0", len(nd.store.ttlKeyHeap.keyMap))
-		}
+	err := nd.Remove(false, false, nil)
+	assert.Nilf(t, err, "nd.Remove err = %v, want = nil", err)
+	// still readable
+	v, err := nd.Read()
+	if v != val2 || err != nil {
+		t.Errorf("value = %s and err = %v, want value = %s and err = nil", v, err, val2)
 	}
+	assert.Emptyf(t, nd.store.ttlKeyHeap.array, "len(nd.store.ttlKeyHeap.array) = %d, want = 0", len(nd.store.ttlKeyHeap.array))
+	assert.Emptyf(t, nd.store.ttlKeyHeap.keyMap, "len(nd.store.ttlKeyHeap.keyMap) = %d, want = 0", len(nd.store.ttlKeyHeap.keyMap))
 }
 
 func TestNewDirIs(t *testing.T) {
 	nd, _ := newTestNodeDir()
-	if nd.IsHidden() {
-		t.Errorf("nd.Hidden() = %v, want = false", nd.IsHidden())
-	}
+	assert.Falsef(t, nd.IsHidden(), "nd.Hidden() = %v, want = false", nd.IsHidden())
 
-	if nd.IsPermanent() {
-		t.Errorf("nd.IsPermanent() = %v, want = false", nd.IsPermanent())
-	}
+	assert.Falsef(t, nd.IsPermanent(), "nd.IsPermanent() = %v, want = false", nd.IsPermanent())
 
-	if !nd.IsDir() {
-		t.Errorf("nd.IsDir() = %v, want = true", nd.IsDir())
-	}
+	assert.Truef(t, nd.IsDir(), "nd.IsDir() = %v, want = true", nd.IsDir())
 }
 
 func TestNewDirReadWriteListReprClone(t *testing.T) {
 	nd, _ := newTestNodeDir()
 
-	if _, err := nd.Read(); err == nil {
-		t.Errorf("err = %v, want err != nil", err)
-	}
+	_, err := nd.Read()
+	assert.NotNilf(t, err, "err = %v, want err != nil", err)
 
-	if err := nd.Write(val, nd.CreatedIndex+1); err == nil {
-		t.Errorf("err = %v, want err != nil", err)
-	}
+	err = nd.Write(val, nd.CreatedIndex+1)
+	assert.NotNilf(t, err, "err = %v, want err != nil", err)
 
 	if ns, err := nd.List(); ns == nil && err != nil {
 		t.Errorf("nodes = %v and err = %v, want nodes = nil and err == nil", ns, err)
 	}
 
 	en := nd.Repr(false, false, clockwork.NewFakeClock())
-	if en.Key != nd.Path {
-		t.Errorf("en.Key = %s, want = %s", en.Key, nd.Path)
-	}
+	assert.Equalf(t, en.Key, nd.Path, "en.Key = %s, want = %s", en.Key, nd.Path)
 
 	cn := nd.Clone()
-	if cn.Path != nd.Path {
-		t.Errorf("cn.Path = %s, want = %s", cn.Path, nd.Path)
-	}
+	assert.Equalf(t, cn.Path, nd.Path, "cn.Path = %s, want = %s", cn.Path, nd.Path)
 }
 
 func TestNewDirExpirationTTL(t *testing.T) {
 	nd, _ := newTestNodeDir()
 
-	if _, ttl := nd.expirationAndTTL(clockwork.NewFakeClock()); ttl > expiration.Nanoseconds() {
-		t.Errorf("ttl = %d, want %d < %d", ttl, ttl, expiration.Nanoseconds())
-	}
+	_, ttl := nd.expirationAndTTL(clockwork.NewFakeClock())
+	assert.LessOrEqualf(t, ttl, expiration.Nanoseconds(), "ttl = %d, want %d < %d", ttl, ttl, expiration.Nanoseconds())
 
 	newExpiration := time.Hour
 	nd.UpdateTTL(time.Now().Add(newExpiration))
-	if _, ttl := nd.expirationAndTTL(clockwork.NewFakeClock()); ttl > newExpiration.Nanoseconds() {
-		t.Errorf("ttl = %d, want %d < %d", ttl, ttl, newExpiration.Nanoseconds())
-	}
+	_, ttl = nd.expirationAndTTL(clockwork.NewFakeClock())
+	assert.LessOrEqualf(t, ttl, newExpiration.Nanoseconds(), "ttl = %d, want %d < %d", ttl, ttl, newExpiration.Nanoseconds())
 }
 
 func TestNewDirChild(t *testing.T) {
 	nd, child := newTestNodeDir()
 
-	if err := nd.Add(child); err != nil {
-		t.Errorf("nd.Add(child) err = %v, want = nil", err)
-	} else {
-		if len(nd.Children) == 0 {
-			t.Errorf("len(nd.Children) = %d, want = 1", len(nd.Children))
-		}
-	}
-
-	if err := child.Remove(true, true, nil); err != nil {
-		t.Errorf("child.Remove err = %v, want = nil", err)
-	} else {
-		if len(nd.Children) != 0 {
-			t.Errorf("len(nd.Children) = %d, want = 0", len(nd.Children))
-		}
-	}
+	err := nd.Add(child)
+	assert.Nilf(t, err, "nd.Add(child) err = %v, want = nil", err)
+	assert.NotEmptyf(t, nd.Children, "len(nd.Children) = %d, want = 1", len(nd.Children))
+	err = child.Remove(true, true, nil)
+	assert.Nilf(t, err, "child.Remove err = %v, want = nil", err)
+	assert.Emptyf(t, nd.Children, "len(nd.Children) = %d, want = 0", len(nd.Children))
 }
 
 func newTestNode() *node {

--- a/server/etcdserver/api/v2store/watcher_hub_test.go
+++ b/server/etcdserver/api/v2store/watcher_hub_test.go
@@ -14,7 +14,11 @@
 
 package v2store
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 // TestIsHidden tests isHidden functions.
 func TestIsHidden(t *testing.T) {
@@ -24,41 +28,31 @@ func TestIsHidden(t *testing.T) {
 	watch := "/"
 	key := "/_foo"
 	hidden := isHidden(watch, key)
-	if !hidden {
-		t.Fatalf("%v should be hidden to %v\n", key, watch)
-	}
+	require.Truef(t, hidden, "%v should be hidden to %v\n", key, watch)
 
 	// watch at "/_foo"
 	// key is "/_foo", not hidden to "/_foo"
 	// expected: hidden = false
 	watch = "/_foo"
 	hidden = isHidden(watch, key)
-	if hidden {
-		t.Fatalf("%v should not be hidden to %v\n", key, watch)
-	}
+	require.Falsef(t, hidden, "%v should not be hidden to %v\n", key, watch)
 
 	// watch at "/_foo/"
 	// key is "/_foo/foo", not hidden to "/_foo"
 	key = "/_foo/foo"
 	hidden = isHidden(watch, key)
-	if hidden {
-		t.Fatalf("%v should not be hidden to %v\n", key, watch)
-	}
+	require.Falsef(t, hidden, "%v should not be hidden to %v\n", key, watch)
 
 	// watch at "/_foo/"
 	// key is "/_foo/_foo", hidden to "/_foo"
 	key = "/_foo/_foo"
 	hidden = isHidden(watch, key)
-	if !hidden {
-		t.Fatalf("%v should be hidden to %v\n", key, watch)
-	}
+	require.Truef(t, hidden, "%v should be hidden to %v\n", key, watch)
 
 	// watch at "/_foo/foo"
 	// key is "/_foo"
 	watch = "_foo/foo"
 	key = "/_foo/"
 	hidden = isHidden(watch, key)
-	if hidden {
-		t.Fatalf("%v should not be hidden to %v\n", key, watch)
-	}
+	require.Falsef(t, hidden, "%v should not be hidden to %v\n", key, watch)
 }

--- a/server/etcdserver/api/v2store/watcher_test.go
+++ b/server/etcdserver/api/v2store/watcher_test.go
@@ -14,15 +14,17 @@
 
 package v2store
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestWatcher(t *testing.T) {
 	s := newStore()
 	wh := s.WatcherHub
 	w, err := wh.watch("/foo", true, false, 1, 1)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
+	require.Nil(t, err)
 	c := w.EventChan()
 
 	select {
@@ -38,9 +40,7 @@ func TestWatcher(t *testing.T) {
 
 	re := <-c
 
-	if e != re {
-		t.Fatal("recv != send")
-	}
+	require.Samef(t, e, re, "recv != send")
 
 	w, _ = wh.watch("/foo", false, false, 2, 1)
 	c = w.EventChan()
@@ -62,9 +62,7 @@ func TestWatcher(t *testing.T) {
 
 	re = <-c
 
-	if e != re {
-		t.Fatal("recv != send")
-	}
+	require.Samef(t, e, re, "recv != send")
 
 	// ensure we are doing exact matching rather than prefix matching
 	w, _ = wh.watch("/fo", true, false, 1, 1)
@@ -83,7 +81,5 @@ func TestWatcher(t *testing.T) {
 
 	re = <-c
 
-	if e != re {
-		t.Fatal("recv != send")
-	}
+	require.Samef(t, e, re, "recv != send")
 }

--- a/server/etcdserver/api/v3compactor/revision_test.go
+++ b/server/etcdserver/api/v3compactor/revision_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -44,12 +46,8 @@ func TestRevision(t *testing.T) {
 	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err := compactable.Wait(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}) {
-		t.Errorf("compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
-	}
+	require.NoError(t, err)
+	assert.Truef(t, reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}), "compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
 
 	// skip the same revision
 	rg.SetRev(99) // will be 100
@@ -61,12 +59,8 @@ func TestRevision(t *testing.T) {
 	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err = compactable.Wait(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}) {
-		t.Errorf("compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
-	}
+	require.NoError(t, err)
+	assert.Truef(t, reflect.DeepEqual(a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision}), "compact request = %v, want %v", a[0].Params[0], &pb.CompactionRequest{Revision: expectedRevision})
 }
 
 func TestRevisionPause(t *testing.T) {
@@ -98,11 +92,7 @@ func TestRevisionPause(t *testing.T) {
 	fc.Advance(revInterval)
 	rg.Wait(1)
 	a, err := compactable.Wait(1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	wreq := &pb.CompactionRequest{Revision: int64(90)}
-	if !reflect.DeepEqual(a[0].Params[0], wreq) {
-		t.Errorf("compact request = %v, want %v", a[0].Params[0], wreq.Revision)
-	}
+	assert.Truef(t, reflect.DeepEqual(a[0].Params[0], wreq), "compact request = %v, want %v", a[0].Params[0], wreq.Revision)
 }

--- a/server/etcdserver/api/v3rpc/key_test.go
+++ b/server/etcdserver/api/v3rpc/key_test.go
@@ -17,6 +17,8 @@ package v3rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
@@ -52,10 +54,8 @@ func TestCheckRangeRequest(t *testing.T) {
 		}
 
 		actualRet := checkRangeRequest(&rangeReq)
-		if getError(actualRet) != getError(req.expectedError) {
-			t.Errorf("expected sortOrder (%d) and sortTarget (%d) to be %q, but got %q",
-				req.sortOrder, req.sortTarget, getError(req.expectedError), getError(actualRet))
-		}
+		assert.Equalf(t, getError(actualRet), getError(req.expectedError), "expected sortOrder (%d) and sortTarget (%d) to be %q, but got %q",
+			req.sortOrder, req.sortTarget, getError(req.expectedError), getError(actualRet))
 	}
 }
 

--- a/server/etcdserver/api/v3rpc/watch_test.go
+++ b/server/etcdserver/api/v3rpc/watch_test.go
@@ -16,9 +16,11 @@ package v3rpc
 
 import (
 	"bytes"
-	"errors"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -70,13 +72,9 @@ func TestSendFragment(t *testing.T) {
 			return nil
 		}
 		err := sendFragments(tt[i].wr, tt[i].maxRequestBytes, testSend)
-		if !errors.Is(err, tt[i].werr) {
-			t.Errorf("#%d: expected error %v, got %v", i, tt[i].werr, err)
-		}
+		require.ErrorIsf(t, err, tt[i].werr, "#%d: expected error %v, got %v", i, tt[i].werr, err)
 		got := len(fragmentedResp)
-		if got != tt[i].fragments {
-			t.Errorf("#%d: expected response number %d, got %d", i, tt[i].fragments, got)
-		}
+		assert.Equalf(t, got, tt[i].fragments, "#%d: expected response number %d, got %d", i, tt[i].fragments, got)
 		if got > 0 && fragmentedResp[got-1].Fragment {
 			t.Errorf("#%d: expected fragment=false in last response, got %+v", i, fragmentedResp[got-1])
 		}

--- a/server/etcdserver/bootstrap_test.go
+++ b/server/etcdserver/bootstrap_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -100,9 +101,7 @@ func TestBootstrapExistingClusterNoWALMaxLearner(t *testing.T) {
 			}
 			_, err = bootstrapExistingClusterNoWAL(cfg, mockBootstrapRoundTrip(tt.members))
 			hasError := err != nil
-			if hasError != tt.hasError {
-				t.Errorf("expected error: %v got: %v", tt.hasError, err)
-			}
+			assert.Equalf(t, hasError, tt.hasError, "expected error: %v got: %v", tt.hasError, err)
 			if hasError {
 				require.Containsf(t, err.Error(), tt.expectedError.Error(), "expected error to contain: %q, got: %q", tt.expectedError.Error(), err.Error())
 			}
@@ -200,16 +199,12 @@ func TestBootstrapBackend(t *testing.T) {
 
 			hasError := err != nil
 			expectedHasError := tt.expectedError != nil
-			if hasError != expectedHasError {
-				t.Errorf("expected error: %v got: %v", expectedHasError, err)
-			}
+			assert.Equalf(t, expectedHasError, hasError, "expected error: %v got: %v", expectedHasError, err)
 			if hasError {
 				require.Containsf(t, err.Error(), tt.expectedError.Error(), "expected error to contain: %q, got: %q", tt.expectedError.Error(), err.Error())
 			}
 
-			if backend.ci.ConsistentIndex() != tt.expectedConsistentIdx {
-				t.Errorf("expected consistent index: %d, got: %d", tt.expectedConsistentIdx, backend.ci.ConsistentIndex())
-			}
+			assert.Equalf(t, tt.expectedConsistentIdx, backend.ci.ConsistentIndex(), "expected consistent index: %d, got: %d", tt.expectedConsistentIdx, backend.ci.ConsistentIndex())
 		})
 	}
 }

--- a/server/etcdserver/cindex/cindex_test.go
+++ b/server/etcdserver/cindex/cindex_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
@@ -34,9 +35,7 @@ func TestConsistentIndex(t *testing.T) {
 	ci := NewConsistentIndex(be)
 
 	tx := be.BatchTx()
-	if tx == nil {
-		t.Fatal("batch tx is nil")
-	}
+	require.NotNilf(t, tx, "batch tx is nil")
 	tx.Lock()
 
 	schema.UnsafeCreateMetaBucket(tx)
@@ -46,9 +45,7 @@ func TestConsistentIndex(t *testing.T) {
 	term := uint64(234)
 	ci.SetConsistentIndex(r, term)
 	index := ci.ConsistentIndex()
-	if index != r {
-		t.Errorf("expected %d,got %d", r, index)
-	}
+	assert.Equalf(t, index, r, "expected %d,got %d", r, index)
 	tx.Lock()
 	ci.UnsafeSave(tx)
 	tx.Unlock()
@@ -135,13 +132,9 @@ func TestFakeConsistentIndex(t *testing.T) {
 	r := rand.Uint64()
 	ci := NewFakeConsistentIndex(r)
 	index := ci.ConsistentIndex()
-	if index != r {
-		t.Errorf("expected %d,got %d", r, index)
-	}
+	assert.Equalf(t, index, r, "expected %d,got %d", r, index)
 	r = rand.Uint64()
 	ci.SetConsistentIndex(r, 5)
 	index = ci.ConsistentIndex()
-	if index != r {
-		t.Errorf("expected %d,got %d", r, index)
-	}
+	assert.Equalf(t, index, r, "expected %d,got %d", r, index)
 }

--- a/server/etcdserver/cluster_util_test.go
+++ b/server/etcdserver/cluster_util_test.go
@@ -21,6 +21,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/types"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -89,9 +90,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 
 	for i, tt := range tests {
 		ok := isCompatibleWithVers(zaptest.NewLogger(t), tt.vers, tt.local, tt.minV, tt.maxV)
-		if ok != tt.wok {
-			t.Errorf("#%d: ok = %+v, want %+v", i, ok, tt.wok)
-		}
+		assert.Equalf(t, ok, tt.wok, "#%d: ok = %+v, want %+v", i, ok, tt.wok)
 	}
 }
 
@@ -125,9 +124,7 @@ func TestConvertToClusterVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ver, err := convertToClusterVersion(tt.inputVerStr)
 			hasError := err != nil
-			if hasError != tt.hasError {
-				t.Errorf("Expected error status is %v; Got %v", tt.hasError, err)
-			}
+			assert.Equalf(t, hasError, tt.hasError, "Expected error status is %v; Got %v", tt.hasError, err)
 			if tt.hasError {
 				return
 			}
@@ -166,13 +163,9 @@ func TestDecideAllowedVersionRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			minV, maxV := allowedVersionRange(tt.downgradeEnabled)
-			if !minV.Equal(*tt.expectedMinV) {
-				t.Errorf("Expected minV is %v; Got %v", tt.expectedMinV.String(), minV.String())
-			}
+			assert.Truef(t, minV.Equal(*tt.expectedMinV), "Expected minV is %v; Got %v", tt.expectedMinV.String(), minV.String())
 
-			if !maxV.Equal(*tt.expectedMaxV) {
-				t.Errorf("Expected maxV is %v; Got %v", tt.expectedMaxV.String(), maxV.String())
-			}
+			assert.Truef(t, maxV.Equal(*tt.expectedMaxV), "Expected maxV is %v; Got %v", tt.expectedMaxV.String(), maxV.String())
 		})
 	}
 }

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -115,9 +114,7 @@ func TestInitialCheck(t *testing.T) {
 			if gotError := err != nil; gotError != tc.expectError {
 				t.Errorf("Unexpected error, got: %v, expected?: %v", err, tc.expectError)
 			}
-			if tc.hasher.alarmTriggered != tc.expectCorrupt {
-				t.Errorf("Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
-			}
+			assert.Equalf(t, tc.hasher.alarmTriggered, tc.expectCorrupt, "Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
 			assert.Equal(t, tc.expectActions, tc.hasher.actions)
 		})
 	}
@@ -239,9 +236,7 @@ func TestPeriodicCheck(t *testing.T) {
 			if gotError := err != nil; gotError != tc.expectError {
 				t.Errorf("Unexpected error, got: %v, expected?: %v", err, tc.expectError)
 			}
-			if tc.hasher.alarmTriggered != tc.expectCorrupt {
-				t.Errorf("Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
-			}
+			assert.Equalf(t, tc.hasher.alarmTriggered, tc.expectCorrupt, "Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
 			assert.Equal(t, tc.expectActions, tc.hasher.actions)
 		})
 	}
@@ -430,12 +425,8 @@ func TestCompactHashCheck(t *testing.T) {
 				hasher:                &tc.hasher,
 			}
 			monitor.CompactHashCheck()
-			if tc.hasher.alarmTriggered != tc.expectCorrupt {
-				t.Errorf("Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
-			}
-			if tc.expectLastRevisionChecked != monitor.latestRevisionChecked {
-				t.Errorf("Unexpected last revision checked, got: %v, expected?: %v", monitor.latestRevisionChecked, tc.expectLastRevisionChecked)
-			}
+			assert.Equalf(t, tc.hasher.alarmTriggered, tc.expectCorrupt, "Unexpected corrupt triggered, got: %v, expected?: %v", tc.hasher.alarmTriggered, tc.expectCorrupt)
+			assert.Equalf(t, tc.expectLastRevisionChecked, monitor.latestRevisionChecked, "Unexpected last revision checked, got: %v, expected?: %v", monitor.latestRevisionChecked, tc.expectLastRevisionChecked)
 			assert.Equal(t, tc.expectActions, tc.hasher.actions)
 		})
 	}
@@ -563,9 +554,7 @@ func TestHashKVHandler(t *testing.T) {
 			require.NoErrorf(t, err, "unexpected io.ReadAll error: %v", err)
 			require.Equalf(t, resp.StatusCode, tt.wcode, "#%d: code = %d, want %d", i, resp.StatusCode, tt.wcode)
 			if resp.StatusCode != http.StatusOK {
-				if !strings.Contains(string(body), tt.wKeyWords) {
-					t.Errorf("#%d: body: %s, want body to contain keywords: %s", i, body, tt.wKeyWords)
-				}
+				assert.Containsf(t, string(body), tt.wKeyWords, "#%d: body: %s, want body to contain keywords: %s", i, body, tt.wKeyWords)
 				return
 			}
 

--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/sha256"
 	"io"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -234,9 +233,7 @@ func TestCheckTxn(t *testing.T) {
 			if err != nil {
 				gotErr = err.Error()
 			}
-			if gotErr != tc.expectError {
-				t.Errorf("Error not matching, got %q, expected %q", gotErr, tc.expectError)
-			}
+			assert.Equalf(t, gotErr, tc.expectError, "Error not matching, got %q, expected %q", gotErr, tc.expectError)
 		})
 	}
 }
@@ -254,9 +251,7 @@ func TestCheckPut(t *testing.T) {
 			if err != nil {
 				gotErr = err.Error()
 			}
-			if gotErr != tc.expectError {
-				t.Errorf("Error not matching, got %q, expected %q", gotErr, tc.expectError)
-			}
+			assert.Equalf(t, gotErr, tc.expectError, "Error not matching, got %q, expected %q", gotErr, tc.expectError)
 		})
 	}
 }
@@ -274,9 +269,7 @@ func TestCheckRange(t *testing.T) {
 			if err != nil {
 				gotErr = err.Error()
 			}
-			if gotErr != tc.expectError {
-				t.Errorf("Error not matching, got %q, expected %q", gotErr, tc.expectError)
-			}
+			assert.Equalf(t, gotErr, tc.expectError, "Error not matching, got %q, expected %q", gotErr, tc.expectError)
 		})
 	}
 }
@@ -334,9 +327,7 @@ func TestReadonlyTxnError(t *testing.T) {
 	}
 
 	_, _, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{})
-	if err == nil || !strings.Contains(err.Error(), "applyTxn: failed Range: rangeKeys: context cancelled: context canceled") {
-		t.Fatalf("Expected context canceled error, got %v", err)
-	}
+	require.Containsf(t, err.Error(), "applyTxn: failed Range: rangeKeys: context cancelled: context canceled", "Expected context canceled error, got %v", err)
 }
 
 func TestWriteTxnPanicWithoutApply(t *testing.T) {

--- a/server/etcdserver/version/downgrade_test.go
+++ b/server/etcdserver/version/downgrade_test.go
@@ -113,9 +113,7 @@ func TestIsValidDowngrade(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res := isValidDowngrade(
 				semver.Must(semver.NewVersion(tt.verFrom)), semver.Must(semver.NewVersion(tt.verTo)))
-			if res != tt.result {
-				t.Errorf("Expected downgrade valid is %v; Got %v", tt.result, res)
-			}
+			assert.Equalf(t, res, tt.result, "Expected downgrade valid is %v; Got %v", tt.result, res)
 		})
 	}
 }

--- a/server/etcdserver/version/monitor_test.go
+++ b/server/etcdserver/version/monitor_test.go
@@ -60,9 +60,7 @@ func TestMemberMinimalVersion(t *testing.T) {
 			memberVersions: tt.memberVersions,
 		})
 		minV := monitor.membersMinimalServerVersion()
-		if !reflect.DeepEqual(minV, tt.wantVersion) {
-			t.Errorf("#%d: ver = %+v, want %+v", i, minV, tt.wantVersion)
-		}
+		assert.Truef(t, reflect.DeepEqual(minV, tt.wantVersion), "#%d: ver = %+v, want %+v", i, minV, tt.wantVersion)
 	}
 }
 
@@ -108,9 +106,7 @@ func TestDecideStorageVersion(t *testing.T) {
 			}
 			monitor := NewMonitor(zaptest.NewLogger(t), s)
 			monitor.UpdateStorageVersionIfNeeded()
-			if !reflect.DeepEqual(s.storageVersion, tt.expectStorageVersion) {
-				t.Errorf("Unexpected storage version value, got = %+v, want %+v", s.storageVersion, tt.expectStorageVersion)
-			}
+			assert.Truef(t, reflect.DeepEqual(s.storageVersion, tt.expectStorageVersion), "Unexpected storage version value, got = %+v, want %+v", s.storageVersion, tt.expectStorageVersion)
 		})
 	}
 }
@@ -160,9 +156,7 @@ func TestVersionMatchTarget(t *testing.T) {
 				memberVersions: tt.versionMap,
 			})
 			actual := monitor.versionsMatchTarget(tt.targetVersion)
-			if actual != tt.expectedFinished {
-				t.Errorf("expected downgrade finished is %v; got %v", tt.expectedFinished, actual)
-			}
+			assert.Equalf(t, tt.expectedFinished, actual, "expected downgrade finished is %v; got %v", tt.expectedFinished, actual)
 		})
 	}
 }

--- a/server/etcdserver/zap_raft_test.go
+++ b/server/etcdserver/zap_raft_test.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -46,30 +46,18 @@ func TestNewRaftLogger(t *testing.T) {
 		ErrorOutputPaths: []string{logPath},
 	}
 	gl, err := NewRaftLogger(lcfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	gl.Info("etcd-logutil-1")
 	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Contains(data, []byte("etcd-logutil-1")) {
-		t.Fatalf("can't find data in log %q", string(data))
-	}
+	require.NoError(t, err)
+	require.Truef(t, bytes.Contains(data, []byte("etcd-logutil-1")), "can't find data in log %q", string(data))
 
 	gl.Warning("etcd-logutil-2")
 	data, err = os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Contains(data, []byte("etcd-logutil-2")) {
-		t.Fatalf("can't find data in log %q", string(data))
-	}
-	if !bytes.Contains(data, []byte("zap_raft_test.go:")) {
-		t.Fatalf("unexpected caller; %q", string(data))
-	}
+	require.NoError(t, err)
+	require.Truef(t, bytes.Contains(data, []byte("etcd-logutil-2")), "can't find data in log %q", string(data))
+	require.Truef(t, bytes.Contains(data, []byte("zap_raft_test.go:")), "unexpected caller; %q", string(data))
 }
 
 func TestNewRaftLoggerFromZapCore(t *testing.T) {
@@ -84,7 +72,5 @@ func TestNewRaftLoggerFromZapCore(t *testing.T) {
 	lg := NewRaftLoggerFromZapCore(cr, syncer)
 	lg.Info("TestNewRaftLoggerFromZapCore")
 	txt := buf.String()
-	if !strings.Contains(txt, "TestNewRaftLoggerFromZapCore") {
-		t.Fatalf("unexpected log %q", txt)
-	}
+	require.Containsf(t, txt, "TestNewRaftLoggerFromZapCore", "unexpected log %q", txt)
 }


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in server/etcdserver package

Related to #18972