### PR TITLE
chore: use testify instead of testing in tests/robustness

### DIFF
--- a/tests/robustness/options/cluster_options_test.go
+++ b/tests/robustness/options/cluster_options_test.go
@@ -18,6 +18,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -52,18 +54,10 @@ func TestWithClusterOptionGroups(t *testing.T) {
 	}
 	for i, tt := range expectedServerConfigs {
 		cluster := *e2e.NewConfig(opts...)
-		if cluster.ServerConfig.SnapshotCount != tt.SnapshotCount {
-			t.Errorf("Test case %d: SnapshotCount = %v, want %v\n", i, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount)
-		}
-		if cluster.ServerConfig.SnapshotCatchUpEntries != tt.SnapshotCatchUpEntries {
-			t.Errorf("Test case %d: SnapshotCatchUpEntries = %v, want %v\n", i, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries)
-		}
-		if cluster.ServerConfig.TickMs != tt.TickMs {
-			t.Errorf("Test case %d: TickMs = %v, want %v\n", i, cluster.ServerConfig.TickMs, tt.TickMs)
-		}
-		if cluster.ServerConfig.ElectionMs != tt.ElectionMs {
-			t.Errorf("Test case %d: ElectionMs = %v, want %v\n", i, cluster.ServerConfig.ElectionMs, tt.ElectionMs)
-		}
+		assert.Equalf(t, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount, "Test case %d: SnapshotCount = %v, want %v\n", i, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount)
+		assert.Equalf(t, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries, "Test case %d: SnapshotCatchUpEntries = %v, want %v\n", i, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries)
+		assert.Equalf(t, cluster.ServerConfig.TickMs, tt.TickMs, "Test case %d: TickMs = %v, want %v\n", i, cluster.ServerConfig.TickMs, tt.TickMs)
+		assert.Equalf(t, cluster.ServerConfig.ElectionMs, tt.ElectionMs, "Test case %d: ElectionMs = %v, want %v\n", i, cluster.ServerConfig.ElectionMs, tt.ElectionMs)
 	}
 }
 
@@ -94,17 +88,9 @@ func TestWithOptionsSubset(t *testing.T) {
 	}
 	for i, tt := range expectedServerConfigs {
 		cluster := *e2e.NewConfig(opts...)
-		if cluster.ServerConfig.SnapshotCount != tt.SnapshotCount {
-			t.Errorf("Test case %d: SnapshotCount = %v, want %v\n", i, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount)
-		}
-		if cluster.ServerConfig.SnapshotCatchUpEntries != tt.SnapshotCatchUpEntries {
-			t.Errorf("Test case %d: SnapshotCatchUpEntries = %v, want %v\n", i, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries)
-		}
-		if cluster.ServerConfig.TickMs != tt.TickMs {
-			t.Errorf("Test case %d: TickMs = %v, want %v\n", i, cluster.ServerConfig.TickMs, tt.TickMs)
-		}
-		if cluster.ServerConfig.ElectionMs != tt.ElectionMs {
-			t.Errorf("Test case %d: ElectionMs = %v, want %v\n", i, cluster.ServerConfig.ElectionMs, tt.ElectionMs)
-		}
+		assert.Equalf(t, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount, "Test case %d: SnapshotCount = %v, want %v\n", i, cluster.ServerConfig.SnapshotCount, tt.SnapshotCount)
+		assert.Equalf(t, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries, "Test case %d: SnapshotCatchUpEntries = %v, want %v\n", i, cluster.ServerConfig.SnapshotCatchUpEntries, tt.SnapshotCatchUpEntries)
+		assert.Equalf(t, cluster.ServerConfig.TickMs, tt.TickMs, "Test case %d: TickMs = %v, want %v\n", i, cluster.ServerConfig.TickMs, tt.TickMs)
+		assert.Equalf(t, cluster.ServerConfig.ElectionMs, tt.ElectionMs, "Test case %d: ElectionMs = %v, want %v\n", i, cluster.ServerConfig.ElectionMs, tt.ElectionMs)
 	}
 }

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/anishathalye/porcupine"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/tests/v3/robustness/model"
@@ -243,9 +244,7 @@ func TestValidateSerializableOperations(t *testing.T) {
 			if err != nil {
 				errStr = err.Error()
 			}
-			if errStr != tc.expectError {
-				t.Errorf("validateSerializableOperations(...), got: %q, want: %q", err, tc.expectError)
-			}
+			assert.Equalf(t, errStr, tc.expectError, "validateSerializableOperations(...), got: %q, want: %q", err, tc.expectError)
 		})
 	}
 }

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -1844,9 +1845,7 @@ func TestValidateWatch(t *testing.T) {
 			if err != nil {
 				errStr = err.Error()
 			}
-			if errStr != tc.expectError {
-				t.Errorf("validateWatch(...), got: %q, want: %q", err, tc.expectError)
-			}
+			assert.Equalf(t, errStr, tc.expectError, "validateWatch(...), got: %q, want: %q", err, tc.expectError)
 		})
 	}
 }


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in tests/robustness package

Related to #18972