### PR TITLE
chore: use testify instead of testing in tests/e2e

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -234,13 +234,9 @@ func newCluster(t *testing.T, clusterSize int, snapshotCount uint64) *e2e.EtcdPr
 		e2e.WithSnapshotCount(snapshotCount),
 		e2e.WithKeepDataDir(true),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	t.Cleanup(func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	})
 	return epc
 }

--- a/tests/e2e/ctl_v3_auth_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_auth_no_proxy_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -60,13 +62,9 @@ func TestCtlV3AuthCertCNWithWithConcurrentOperation(t *testing.T) {
 		e2e.WithClientConnType(e2e.ClientTLS),
 		e2e.WithClientCertAuthority(true),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster")
 	defer func() {
-		if err := epc.Close(); err != nil {
-			t.Fatalf("could not close test cluster (%v)", err)
-		}
+		require.NoErrorf(t, epc.Close(), "could not close test cluster")
 	}()
 
 	epcClient := epc.Etcdctl()
@@ -74,9 +72,7 @@ func TestCtlV3AuthCertCNWithWithConcurrentOperation(t *testing.T) {
 	createUsers(ctx, t, epcClient)
 
 	t.Log("Enable auth")
-	if err := epcClient.AuthEnable(ctx); err != nil {
-		t.Fatalf("could not enable Auth: (%v)", err)
-	}
+	require.NoErrorf(t, epcClient.AuthEnable(ctx), "could not enable Auth")
 
 	// Create two goroutines, one goroutine keeps creating & deleting users,
 	// and the other goroutine keeps writing & deleting K/V entries.

--- a/tests/e2e/ctl_v3_auth_security_test.go
+++ b/tests/e2e/ctl_v3_auth_security_test.go
@@ -17,9 +17,9 @@
 package e2e
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -51,7 +51,5 @@ func authTestCVE2021_28235(cx ctlCtx) {
 	respData, err := curl(httpEndpoint, "GET", req, e2e.ClientNonTLS)
 	require.NoError(cx.t, err)
 
-	if strings.Contains(respData, rootPass) {
-		cx.t.Errorf("The root password is included in the request.\n %s", respData)
-	}
+	assert.NotContainsf(cx.t, respData, rootPass, "The root password is included in the request.\n %s", respData)
 }

--- a/tests/e2e/ctl_v3_defrag_test.go
+++ b/tests/e2e/ctl_v3_defrag_test.go
@@ -41,7 +41,5 @@ func ctlV3OfflineDefrag(cx ctlCtx) error {
 }
 
 func defragOfflineTest(cx ctlCtx) {
-	if err := ctlV3OfflineDefrag(cx); err != nil {
-		cx.t.Fatalf("defragTest ctlV3Defrag error (%v)", err)
-	}
+	require.NoErrorf(cx.t, ctlV3OfflineDefrag(cx), "defragTest ctlV3Defrag error")
 }

--- a/tests/e2e/ctl_v3_elect_test.go
+++ b/tests/e2e/ctl_v3_elect_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/pkg/v3/expect"
@@ -42,9 +43,7 @@ func testElect(cx ctlCtx) {
 	case <-time.After(2 * time.Second):
 		cx.t.Fatalf("timed out electing")
 	case l1 = <-ch:
-		if !strings.HasPrefix(l1, name) {
-			cx.t.Errorf("got %q, expected %q prefix", l1, name)
-		}
+		assert.Truef(cx.t, strings.HasPrefix(l1, name), "got %q, expected %q prefix", l1, name)
 	}
 
 	// blocked process that won't win the election
@@ -109,9 +108,7 @@ func ctlV3Elect(cx ctlCtx, name, proposal string, expectFailure bool) (*expect.E
 
 		s, xerr := proc.ExpectFunc(ctx, func(string) bool { return true })
 		if xerr != nil {
-			if !expectFailure {
-				cx.t.Errorf("expect failed (%v)", xerr)
-			}
+			assert.Truef(cx.t, expectFailure, "expect failed (%v)", xerr)
 		}
 		outc <- s
 	}()

--- a/tests/e2e/ctl_v3_grpc_test.go
+++ b/tests/e2e/ctl_v3_grpc_test.go
@@ -126,9 +126,7 @@ func TestAuthority(t *testing.T) {
 				}
 
 				epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(cfg))
-				if err != nil {
-					t.Fatalf("could not start etcd process cluster (%v)", err)
-				}
+				require.NoErrorf(t, err, "could not start etcd process cluster")
 				defer epc.Close()
 
 				endpoints := templateEndpoints(t, tc.clientURLPattern, epc)

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -44,18 +46,10 @@ func TestCtlV3LeaseKeepAlivePeerTLS(t *testing.T) {
 func leaseTestKeepAlive(cx ctlCtx) {
 	// put with TTL 10 seconds and keep-alive
 	leaseID, err := ctlV3LeaseGrant(cx, 10)
-	if err != nil {
-		cx.t.Fatalf("leaseTestKeepAlive: ctlV3LeaseGrant error (%v)", err)
-	}
-	if err := ctlV3Put(cx, "key", "val", leaseID); err != nil {
-		cx.t.Fatalf("leaseTestKeepAlive: ctlV3Put error (%v)", err)
-	}
-	if err := ctlV3LeaseKeepAlive(cx, leaseID); err != nil {
-		cx.t.Fatalf("leaseTestKeepAlive: ctlV3LeaseKeepAlive error (%v)", err)
-	}
-	if err := ctlV3Get(cx, []string{"key"}, kv{"key", "val"}); err != nil {
-		cx.t.Fatalf("leaseTestKeepAlive: ctlV3Get error (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "leaseTestKeepAlive: ctlV3LeaseGrant error")
+	require.NoErrorf(cx.t, ctlV3Put(cx, "key", "val", leaseID), "leaseTestKeepAlive: ctlV3Put error")
+	require.NoErrorf(cx.t, ctlV3LeaseKeepAlive(cx, leaseID), "leaseTestKeepAlive: ctlV3LeaseKeepAlive error")
+	require.NoErrorf(cx.t, ctlV3Get(cx, []string{"key"}, kv{"key", "val"}), "leaseTestKeepAlive: ctlV3Get error")
 }
 
 func ctlV3LeaseGrant(cx ctlCtx, ttl int) (string, error) {

--- a/tests/e2e/ctl_v3_lock_test.go
+++ b/tests/e2e/ctl_v3_lock_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/pkg/v3/expect"
@@ -47,9 +48,7 @@ func testLock(cx ctlCtx) {
 	case <-time.After(2 * time.Second):
 		cx.t.Fatalf("timed out locking")
 	case l1 = <-ch:
-		if !strings.HasPrefix(l1, name) {
-			cx.t.Errorf("got %q, expected %q prefix", l1, name)
-		}
+		assert.Truef(cx.t, strings.HasPrefix(l1, name), "got %q, expected %q prefix", l1, name)
 	}
 
 	// blocked process that won't acquire the lock

--- a/tests/e2e/ctl_v3_make_mirror_test.go
+++ b/tests/e2e/ctl_v3_make_mirror_test.go
@@ -87,15 +87,11 @@ func testMirrorCommand(cx ctlCtx, flags []string, sourcekvs []kv, destkvs []kvEx
 	}
 
 	mirrorepc, err := e2e.NewEtcdProcessCluster(context.TODO(), cx.t, e2e.WithConfig(&mirrorctx.cfg))
-	if err != nil {
-		cx.t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(cx.t, err, "could not start etcd process cluster (%v)", err)
 	mirrorctx.epc = mirrorepc
 
 	defer func() {
-		if err = mirrorctx.epc.Close(); err != nil {
-			cx.t.Fatalf("error closing etcd processes (%v)", err)
-		}
+		require.NoErrorf(cx.t, mirrorctx.epc.Close(), "error closing etcd processes")
 	}()
 
 	cmdArgs := append(cx.PrefixArgs(), "make-mirror")

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -57,9 +57,7 @@ func TestCtlV3MoveLeaderScenarios(t *testing.T) {
 func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars map[string]string) {
 	epc := setupEtcdctlTest(t, &cfg, true)
 	defer func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	}()
 
 	var tcfg *tls.Config
@@ -86,9 +84,7 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		resp, err := cli.Status(ctx, ep)
-		if err != nil {
-			t.Fatalf("failed to get status from endpoint %s: %v", ep, err)
-		}
+		require.NoErrorf(t, err, "failed to get status from endpoint %s", ep)
 		cancel()
 		cli.Close()
 
@@ -146,8 +142,6 @@ func setupEtcdctlTest(t *testing.T, cfg *e2e.EtcdProcessClusterConfig, quorum bo
 		cfg = e2e.ConfigStandalone(*cfg)
 	}
 	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(cfg))
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster")
 	return epc
 }

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -60,13 +60,9 @@ func TestClusterVersion(t *testing.T) {
 			)
 
 			epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(cfg))
-			if err != nil {
-				t.Fatalf("could not start etcd process cluster (%v)", err)
-			}
+			require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 			defer func() {
-				if errC := epc.Close(); errC != nil {
-					t.Fatalf("error closing etcd processes (%v)", errC)
-				}
+				require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 			}()
 
 			ctx := ctlCtx{
@@ -81,9 +77,7 @@ func TestClusterVersion(t *testing.T) {
 }
 
 func versionTest(cx ctlCtx) {
-	if err := ctlV3Version(cx); err != nil {
-		cx.t.Fatalf("versionTest ctlV3Version error (%v)", err)
-	}
+	require.NoErrorf(cx.t, ctlV3Version(cx), "versionTest ctlV3Version error")
 }
 
 func clusterVersionTest(cx ctlCtx, expected string) {
@@ -96,9 +90,7 @@ func clusterVersionTest(cx ctlCtx, expected string) {
 		}
 		break
 	}
-	if err != nil {
-		cx.t.Fatalf("failed cluster version test expected %v got (%v)", expected, err)
-	}
+	require.NoErrorf(cx.t, err, "failed cluster version test expected %v got (%v)", expected, err)
 }
 
 func ctlV3Version(cx ctlCtx) error {
@@ -232,9 +224,7 @@ func testCtlWithOffline(t *testing.T, testFunc func(ctlCtx), testOfflineFunc fun
 	}
 
 	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(&ret.cfg))
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	ret.epc = epc
 	ret.dataDir = epc.Procs[0].Config().DataDirPath
 

--- a/tests/e2e/ctl_v3_watch_no_cov_test.go
+++ b/tests/e2e/ctl_v3_watch_no_cov_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
@@ -115,9 +117,7 @@ func watchTest(cx ctlCtx) {
 		donec := make(chan struct{})
 		go func(i int, puts []kv) {
 			for j := range puts {
-				if err := ctlV3Put(cx, puts[j].key, puts[j].val, ""); err != nil {
-					cx.t.Errorf("watchTest #%d-%d: ctlV3Put error (%v)", i, j, err)
-				}
+				assert.NoErrorf(cx.t, ctlV3Put(cx, puts[j].key, puts[j].val, ""), "watchTest #%d-%d: ctlV3Put error", i, j)
 			}
 			close(donec)
 		}(i, tt.puts)

--- a/tests/e2e/discovery_test.go
+++ b/tests/e2e/discovery_test.go
@@ -53,9 +53,7 @@ func testClusterUsingDiscovery(t *testing.T, size int, peerTLS bool) {
 		e2e.WithClusterSize(1),
 		e2e.WithEnableV2(true),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	defer dc.Close()
 
 	dcc := MustNewHTTPClient(t, dc.EndpointsHTTP(), nil)
@@ -71,9 +69,7 @@ func testClusterUsingDiscovery(t *testing.T, size int, peerTLS bool) {
 		e2e.WithIsPeerTLS(peerTLS),
 		e2e.WithDiscovery(dc.EndpointsHTTP()[0]+"/v2/keys"),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	defer c.Close()
 
 	kubectl := []string{e2e.BinPath.Etcdctl, "--endpoints", strings.Join(c.EndpointsGRPC(), ",")}

--- a/tests/e2e/discovery_v3_test.go
+++ b/tests/e2e/discovery_v3_test.go
@@ -60,24 +60,19 @@ func testClusterUsingV3Discovery(t *testing.T, discoveryClusterSize, targetClust
 		e2e.WithClientConnType(clientTLSType),
 		e2e.WithClientAutoTLS(isClientAutoTLS),
 	)
-	if err != nil {
-		t.Fatalf("could not start discovery etcd cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start discovery etcd cluster (%v)", err)
 	defer ds.Close()
 
 	// step 2: configure the cluster size
 	discoveryToken := "8A591FAB-1D72-41FA-BDF2-A27162FDA1E0"
 	configSizeKey := fmt.Sprintf("/_etcd/registry/%s/_config/size", discoveryToken)
 	configSizeValStr := strconv.Itoa(targetClusterSize)
-	if err = ctlV3Put(ctlCtx{epc: ds}, configSizeKey, configSizeValStr, ""); err != nil {
-		t.Errorf("failed to configure cluster size to discovery serivce, error: %v", err)
-	}
+	err = ctlV3Put(ctlCtx{epc: ds}, configSizeKey, configSizeValStr, "")
+	require.NoErrorf(t, err, "failed to configure cluster size to discovery serivce, error")
 
 	// step 3: start the etcd cluster
 	epc, err := bootstrapEtcdClusterUsingV3Discovery(t, ds.EndpointsGRPC(), discoveryToken, targetClusterSize, clientTLSType, isClientAutoTLS)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	defer epc.Close()
 
 	// step 4: sanity test on the etcd cluster

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -607,9 +607,7 @@ func TestEtcdHealthyWithTinySnapshotCatchupEntries(t *testing.T) {
 	)
 	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	t.Cleanup(func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	})
 
 	// simulate 10 clients keep writing to etcd in parallel with no error

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -48,13 +48,9 @@ func TestReleaseUpgrade(t *testing.T) {
 		e2e.WithSnapshotCount(3),
 		e2e.WithBasePeerScheme("unix"), // to avoid port conflict
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	defer func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	}()
 
 	cx := ctlCtx{
@@ -69,26 +65,23 @@ func TestReleaseUpgrade(t *testing.T) {
 		kvs = append(kvs, kv{key: fmt.Sprintf("foo%d", i), val: "bar"})
 	}
 	for i := range kvs {
-		if err = ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
-			cx.t.Fatalf("#%d: ctlV3Put error (%v)", i, err)
-		}
+		err = ctlV3Put(cx, kvs[i].key, kvs[i].val, "")
+		require.NoErrorf(cx.t, err, "#%d: ctlV3Put error (%v)", i, err)
 	}
 
 	t.Log("Cluster of etcd in old version running")
 
 	for i := range epc.Procs {
 		t.Logf("Stopping node: %v", i)
-		if err = epc.Procs[i].Stop(); err != nil {
-			t.Fatalf("#%d: error closing etcd process (%v)", i, err)
-		}
+		err = epc.Procs[i].Stop()
+		require.NoErrorf(t, err, "#%d: error closing etcd process (%v)", i, err)
 		t.Logf("Stopped node: %v", i)
 		epc.Procs[i].Config().ExecPath = e2e.BinPath.Etcd
 		epc.Procs[i].Config().KeepDataDir = true
 
 		t.Logf("Restarting node in the new version: %v", i)
-		if err = epc.Procs[i].Restart(t.Context()); err != nil {
-			t.Fatalf("error restarting etcd process (%v)", err)
-		}
+		err = epc.Procs[i].Restart(t.Context())
+		require.NoErrorf(t, err, "error restarting etcd process (%v)", err)
 
 		t.Logf("Testing reads after node restarts: %v", i)
 		for j := range kvs {
@@ -110,9 +103,7 @@ func TestReleaseUpgrade(t *testing.T) {
 		}
 		break
 	}
-	if err != nil {
-		t.Fatalf("cluster version is not upgraded (%v)", err)
-	}
+	require.NoErrorf(t, err, "cluster version is not upgraded (%v)", err)
 	t.Log("TestReleaseUpgrade businessLogic DONE")
 }
 
@@ -128,13 +119,9 @@ func TestReleaseUpgradeWithRestart(t *testing.T) {
 		e2e.WithSnapshotCount(10),
 		e2e.WithBasePeerScheme("unix"),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	defer func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	}()
 
 	cx := ctlCtx{

--- a/tests/e2e/gateway_test.go
+++ b/tests/e2e/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/pkg/v3/expect"
@@ -40,9 +41,7 @@ func TestGateway(t *testing.T) {
 	}()
 
 	err = e2e.SpawnWithExpect([]string{e2e.BinPath.Etcdctl, "--endpoints=" + defaultGatewayEndpoint, "put", "foo", "bar"}, expect.ExpectedResponse{Value: "OK\r\n"})
-	if err != nil {
-		t.Errorf("failed to finish put request through gateway: %v", err)
-	}
+	assert.NoErrorf(t, err, "failed to finish put request through gateway: %v", err)
 }
 
 func startGateway(t *testing.T, endpoints string) *expect.ExpectProcess {

--- a/tests/e2e/promote_experimental_flag_test.go
+++ b/tests/e2e/promote_experimental_flag_test.go
@@ -31,13 +31,9 @@ func TestWarningApplyDuration(t *testing.T) {
 		e2e.WithClusterSize(1),
 		e2e.WithWarningUnaryRequestDuration(time.Microsecond),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	t.Cleanup(func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	})
 
 	cc := epc.Etcdctl()
@@ -58,13 +54,9 @@ func TestExperimentalWarningApplyDuration(t *testing.T) {
 		e2e.WithClusterSize(1),
 		e2e.WithExperimentalWarningUnaryRequestDuration(time.Microsecond),
 	)
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
+	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	t.Cleanup(func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	})
 
 	cc := epc.Etcdctl()
@@ -83,7 +75,5 @@ func TestBothWarningApplyDurationFlagsFail(t *testing.T) {
 		e2e.WithWarningUnaryRequestDuration(time.Second),
 		e2e.WithExperimentalWarningUnaryRequestDuration(time.Second),
 	)
-	if err == nil {
-		t.Fatal("Expected process to fail")
-	}
+	require.Errorf(t, err, "Expected process to fail")
 }

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -145,13 +145,9 @@ func TestEtctlutlMigrate(t *testing.T) {
 				// Set low SnapshotCount to ensure wal snapshot is done
 				e2e.WithSnapshotCount(1),
 			)
-			if err != nil {
-				t.Fatalf("could not start etcd process cluster (%v)", err)
-			}
+			require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 			defer func() {
-				if errC := epc.Close(); errC != nil {
-					t.Fatalf("error closing etcd processes (%v)", errC)
-				}
+				require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 			}()
 
 			dialTimeout := 10 * time.Second

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -41,12 +41,11 @@ import (
 
 func writeCustomV2Data(tb testing.TB, epc *e2e.EtcdProcessCluster, count int) {
 	for i := 0; i < count; i++ {
-		if err := e2e.CURLPut(epc, e2e.CURLReq{
+		err := e2e.CURLPut(epc, e2e.CURLReq{
 			Endpoint: "/v2/keys/foo", Value: "bar" + fmt.Sprint(i),
 			Expected: expect.ExpectedResponse{Value: `{"action":"set","node":{"key":"/foo","value":"bar` + fmt.Sprint(i)},
-		}); err != nil {
-			tb.Fatalf("failed put with curl (%v)", err)
-		}
+		})
+		require.NoErrorf(tb, err, "failed put with curl (%v)", err)
 	}
 }
 

--- a/tests/e2e/v3_curl_auth_test.go
+++ b/tests/e2e/v3_curl_auth_test.go
@@ -141,9 +141,7 @@ func testCurlV3Auth(cx ctlCtx) {
 		require.NoError(cx.t, json.Unmarshal([]byte(cURLRes), &authRes))
 
 		token, ok := authRes[rpctypes.TokenFieldNameGRPC].(string)
-		if !ok {
-			cx.t.Fatalf("failed invalid token in authenticate response using user (%v)", usernames[i])
-		}
+		require.Truef(cx.t, ok, "failed invalid token in authenticate response using user (%v)", usernames[i])
 
 		authHeader = "Authorization: " + token
 		// put with auth

--- a/tests/e2e/v3_curl_election_test.go
+++ b/tests/e2e/v3_curl_election_test.go
@@ -47,9 +47,7 @@ func testCurlV3Campaign(cx ctlCtx) {
 	})
 	lines, err := e2e.SpawnWithExpectLines(context.TODO(), cargs, cx.envMap, expect.ExpectedResponse{Value: `"leader":{"name":"`})
 	require.NoErrorf(cx.t, err, "failed post campaign request")
-	if len(lines) != 1 {
-		cx.t.Fatalf("len(lines) expected 1, got %+v", lines)
-	}
+	require.Lenf(cx.t, lines, 1, "len(lines) expected 1, got %+v", lines)
 
 	var cresp campaignResponse
 	require.NoErrorf(cx.t, json.Unmarshal([]byte(lines[0]), &cresp), "failed to unmarshal campaign response")

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -51,9 +51,8 @@ func testCurlV3MaintenanceStatus(cx ctlCtx) {
 
 	requiredFields := []string{"version", "dbSize", "leader", "raftIndex", "raftTerm", "raftAppliedIndex", "dbSizeInUse", "storageVersion"}
 	for _, field := range requiredFields {
-		if _, ok := resp[field]; !ok {
-			cx.t.Fatalf("Field %q not found in (%v)", field, resp)
-		}
+		_, ok := resp[field]
+		require.Truef(cx.t, ok, "Field %q not found in (%v)", field, resp)
 	}
 
 	require.Equal(cx.t, version.Version, resp["version"])
@@ -88,9 +87,8 @@ func testCurlV3MaintenanceHash(cx ctlCtx) {
 
 	requiredFields := []string{"header", "hash"}
 	for _, field := range requiredFields {
-		if _, ok := resp[field]; !ok {
-			cx.t.Fatalf("Field %q not found in (%v)", field, resp)
-		}
+		_, ok := resp[field]
+		require.Truef(cx.t, ok, "Field %q not found in (%v)", field, resp)
 	}
 }
 
@@ -109,9 +107,8 @@ func testCurlV3MaintenanceHashKV(cx ctlCtx) {
 
 	requiredFields := []string{"header", "hash", "compact_revision", "hash_revision"}
 	for _, field := range requiredFields {
-		if _, ok := resp[field]; !ok {
-			cx.t.Fatalf("Field %q not found in (%v)", field, resp)
-		}
+		_, ok := resp[field]
+		require.Truef(cx.t, ok, "Field %q not found in (%v)", field, resp)
 	}
 }
 

--- a/tests/e2e/zap_logging_test.go
+++ b/tests/e2e/zap_logging_test.go
@@ -38,30 +38,20 @@ func TestServerJsonLogging(t *testing.T) {
 	require.NoErrorf(t, epc.Close(), "error closing etcd processes")
 	var entry logEntry
 	lines := logs.Lines()
-	if len(lines) == 0 {
-		t.Errorf("Expected at least one log line")
-	}
+	assert.NotEmptyf(t, lines, "Expected at least one log line")
 	for _, line := range lines {
 		err := json.Unmarshal([]byte(line), &entry)
 		if err != nil {
 			t.Errorf("Failed to parse log line as json, err: %q, line: %s", err, line)
 			continue
 		}
-		if entry.Level == "" {
-			t.Errorf(`Missing "level" key, line: %s`, line)
-		}
-		if entry.Timestamp == "" {
-			t.Errorf(`Missing "ts" key, line: %s`, line)
-		}
+		assert.NotEmptyf(t, entry.Level, `Missing "level" key, line: %s`, line)
+		assert.NotEmptyf(t, entry.Timestamp, `Missing "ts" key, line: %s`, line)
 		if _, err := time.Parse("2006-01-02T15:04:05.999999Z0700", entry.Timestamp); entry.Timestamp != "" && err != nil {
 			t.Errorf(`Unexpected "ts" key format, err: %s`, err)
 		}
-		if entry.Caller == "" {
-			t.Errorf(`Missing "caller" key, line: %s`, line)
-		}
-		if entry.Message == "" {
-			t.Errorf(`Missing "message" key, line: %s`, line)
-		}
+		assert.NotEmptyf(t, entry.Caller, `Missing "caller" key, line: %s`, line)
+		assert.NotEmptyf(t, entry.Message, `Missing "message" key, line: %s`, line)
 	}
 }
 


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in tests/e2e package

Related to #18972