### PR TITLE
chore: use testify instead of testing in tests/integration

### DIFF
--- a/tests/integration/clientv3/concurrency/election_test.go
+++ b/tests/integration/clientv3/concurrency/election_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
@@ -49,16 +51,12 @@ func TestResumeElection(t *testing.T) {
 	defer cancel()
 
 	// become leader
-	if err = e.Campaign(ctx, "candidate1"); err != nil {
-		t.Fatalf("Campaign() returned non nil err: %s", err)
-	}
+	require.NoErrorf(t, e.Campaign(ctx, "candidate1"), "Campaign() returned non nil err")
 
 	// get the leadership details of the current election
 	var leader *clientv3.GetResponse
 	leader, err = e.Leader(ctx)
-	if err != nil {
-		t.Fatalf("Leader() returned non nil err: %s", err)
-	}
+	require.NoErrorf(t, err, "Leader() returned non nil err")
 
 	// Recreate the election
 	e = concurrency.ResumeElection(s, prefix,
@@ -86,19 +84,13 @@ func TestResumeElection(t *testing.T) {
 	// put some random data to generate a change event, this put should be
 	// ignored by Observe() because it is not under the election prefix.
 	_, err = cli.Put(ctx, "foo", "bar")
-	if err != nil {
-		t.Fatalf("Put('foo') returned non nil err: %s", err)
-	}
+	require.NoErrorf(t, err, "Put('foo') returned non nil err")
 
 	// resign as leader
-	if err := e.Resign(ctx); err != nil {
-		t.Fatalf("Resign() returned non nil err: %s", err)
-	}
+	require.NoErrorf(t, e.Resign(ctx), "Resign() returned non nil err")
 
 	// elect a different candidate
-	if err := e.Campaign(ctx, "candidate2"); err != nil {
-		t.Fatalf("Campaign() returned non nil err: %s", err)
-	}
+	require.NoErrorf(t, e.Campaign(ctx, "candidate2"), "Campaign() returned non nil err")
 
 	// wait for observed leader change
 	resp := <-respChan

--- a/tests/integration/clientv3/connectivity/black_hole_test.go
+++ b/tests/integration/clientv3/connectivity/black_hole_test.go
@@ -67,9 +67,8 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	defer cli.Close()
 
 	wch := cli.Watch(context.Background(), "foo", clientv3.WithCreatedNotify())
-	if _, ok := <-wch; !ok {
-		t.Fatalf("watch failed on creation")
-	}
+	_, ok := <-wch
+	require.Truef(t, ok, "watch failed on creation")
 
 	// endpoint can switch to eps[1] when it detects the failure of eps[0]
 	cli.SetEndpoints(eps...)

--- a/tests/integration/clientv3/connectivity/dial_test.go
+++ b/tests/integration/clientv3/connectivity/dial_test.go
@@ -63,9 +63,7 @@ func TestDialTLSExpired(t *testing.T) {
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tls,
 	})
-	if !clientv3test.IsClientTimeout(err) {
-		t.Fatalf("expected dial timeout error, got %v", err)
-	}
+	require.Truef(t, clientv3test.IsClientTimeout(err), "expected dial timeout error")
 }
 
 // TestDialTLSNoConfig ensures the client fails to dial / times out
@@ -85,9 +83,7 @@ func TestDialTLSNoConfig(t *testing.T) {
 			c.Close()
 		}
 	}()
-	if !clientv3test.IsClientTimeout(err) {
-		t.Fatalf("expected dial timeout error, got %v", err)
-	}
+	require.Truef(t, clientv3test.IsClientTimeout(err), "expected dial timeout error")
 }
 
 // TestDialSetEndpointsBeforeFail ensures SetEndpoints can replace unavailable

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -260,9 +260,7 @@ func testBalancerUnderNetworkPartitionWatch(t *testing.T, isolateLeader bool) {
 		if len(ev.Events) != 0 {
 			t.Fatal("expected no event")
 		}
-		if err = ev.Err(); !errors.Is(err, rpctypes.ErrNoLeader) {
-			t.Fatalf("expected %v, got %v", rpctypes.ErrNoLeader, err)
-		}
+		require.ErrorIs(t, ev.Err(), rpctypes.ErrNoLeader)
 	case <-time.After(integration2.RequestWaitTimeout): // enough time to detect leader lost
 		t.Fatal("took too long to detect leader lost")
 	}
@@ -302,9 +300,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	_, err = kvc.Get(ctx, "a")
 	cancel()
-	if !errors.Is(err, rpctypes.ErrLeaderChanged) {
-		t.Fatalf("expected %v, got %v", rpctypes.ErrLeaderChanged, err)
-	}
+	require.ErrorIsf(t, err, rpctypes.ErrLeaderChanged, "expected %v, got %v", rpctypes.ErrLeaderChanged, err)
 
 	for i := 0; i < 5; i++ {
 		ctx, cancel = context.WithTimeout(context.TODO(), 10*time.Second)

--- a/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
@@ -73,9 +73,7 @@ func TestDoubleBarrier(t *testing.T) {
 	default:
 	}
 
-	if err := b.Enter(); err != nil {
-		t.Fatalf("could not enter last barrier (%v)", err)
-	}
+	require.NoErrorf(t, b.Enter(), "could not enter last barrier")
 
 	timerC := time.After(time.Duration(waiters*100) * time.Millisecond)
 	for i := 0; i < waiters-1; i++ {

--- a/tests/integration/clientv3/naming/endpoints_test.go
+++ b/tests/integration/clientv3/naming/endpoints_test.go
@@ -61,14 +61,10 @@ func TestEndpointManager(t *testing.T) {
 		Endpoint: e1,
 	}
 
-	if !reflect.DeepEqual(us[0], wu) {
-		t.Fatalf("up = %#v, want %#v", us[0], wu)
-	}
+	require.Truef(t, reflect.DeepEqual(us[0], wu), "up = %#v, want %#v", us[0], wu)
 
 	err = em.DeleteEndpoint(context.TODO(), "foo/a1")
-	if err != nil {
-		t.Fatalf("failed to udpate %v", err)
-	}
+	require.NoErrorf(t, err, "failed to udpate %v", err)
 
 	us = <-w
 	if us == nil {
@@ -80,9 +76,7 @@ func TestEndpointManager(t *testing.T) {
 		Key: "foo/a1",
 	}
 
-	if !reflect.DeepEqual(us[0], wu) {
-		t.Fatalf("up = %#v, want %#v", us[1], wu)
-	}
+	require.Truef(t, reflect.DeepEqual(us[0], wu), "up = %#v, want %#v", us[0], wu)
 }
 
 // TestEndpointManagerAtomicity ensures the resolver will initialize
@@ -112,9 +106,7 @@ func TestEndpointManagerAtomicity(t *testing.T) {
 	require.NoError(t, err)
 
 	updates := <-w
-	if len(updates) != 2 {
-		t.Fatalf("expected two updates, got %+v", updates)
-	}
+	require.Lenf(t, updates, 2, "expected two updates, got %+v", updates)
 
 	_, err = c.Txn(context.TODO()).Then(etcd.OpDelete("foo/host"), etcd.OpDelete("foo/host2")).Commit()
 	require.NoError(t, err)
@@ -155,15 +147,9 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}
-	if len(eps) != 2 {
-		t.Fatalf("unexpected the number of endpoints: %d", len(eps))
-	}
-	if !reflect.DeepEqual(eps[k1], e1) {
-		t.Fatalf("unexpected endpoints: %s", k1)
-	}
-	if !reflect.DeepEqual(eps[k2], e2) {
-		t.Fatalf("unexpected endpoints: %s", k2)
-	}
+	require.Lenf(t, eps, 2, "unexpected the number of endpoints: %d", len(eps))
+	require.Truef(t, reflect.DeepEqual(eps[k1], e1), "unexpected endpoints: %s", k1)
+	require.Truef(t, reflect.DeepEqual(eps[k2], e2), "unexpected endpoints: %s", k2)
 
 	// Delete
 	err = em.DeleteEndpoint(context.TODO(), k1)
@@ -175,12 +161,8 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}
-	if len(eps) != 1 {
-		t.Fatalf("unexpected the number of endpoints: %d", len(eps))
-	}
-	if !reflect.DeepEqual(eps[k2], e2) {
-		t.Fatalf("unexpected endpoints: %s", k2)
-	}
+	require.Lenf(t, eps, 1, "unexpected the number of endpoints: %d", len(eps))
+	require.Truef(t, reflect.DeepEqual(eps[k2], e2), "unexpected endpoints: %s", k2)
 
 	// Update
 	k3 := "foo/a3"
@@ -198,10 +180,6 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to list foo")
 	}
-	if len(eps) != 1 {
-		t.Fatalf("unexpected the number of endpoints: %d", len(eps))
-	}
-	if !reflect.DeepEqual(eps[k3], e3) {
-		t.Fatalf("unexpected endpoints: %s", k3)
-	}
+	require.Lenf(t, eps, 1, "unexpected the number of endpoints: %d", len(eps))
+	require.Truef(t, reflect.DeepEqual(eps[k3], e3), "unexpected endpoints: %s", k3)
 }

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -104,26 +104,20 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 
 		t.Logf("Response: %v", string(resp.GetPayload().GetBody()))
 
-		if resp.GetPayload() == nil {
-			t.Fatalf("unexpected response from foo: %s", resp.GetPayload().GetBody())
-		}
+		require.NotNilf(t, resp.GetPayload(), "unexpected response from foo: %s", resp.GetPayload().GetBody())
 		lastResponse = resp.GetPayload().GetBody()
 	}
 
 	// If the load balancing policy is pick first then return payload should equal number of requests
 	t.Logf("Last response: %v", string(lastResponse))
 	if lbPolicy == "pick_first" {
-		if string(lastResponse) != "3500" {
-			t.Fatalf("unexpected total responses from foo: %s", lastResponse)
-		}
+		require.Equalf(t, "3500", string(lastResponse), "unexpected total responses from foo: %s", lastResponse)
 	}
 
 	// If the load balancing policy is round robin we should see roughly half total requests served by each server
 	if lbPolicy == "round_robin" {
 		responses, err := strconv.Atoi(string(lastResponse))
-		if err != nil {
-			t.Fatalf("couldn't convert to int: %s", lastResponse)
-		}
+		require.NoErrorf(t, err, "couldn't convert to int: %s", lastResponse)
 
 		// Allow 25% tolerance as round robin is not perfect and we don't want the test to flake
 		expected := float64(totalRequests) * 0.5

--- a/tests/integration/clientv3/ordering_util_test.go
+++ b/tests/integration/clientv3/ordering_util_test.go
@@ -138,7 +138,5 @@ func TestUnresolvableOrderViolation(t *testing.T) {
 	time.Sleep(1 * time.Second) // give enough time for operation
 
 	_, err = OrderingKv.Get(ctx, "foo", clientv3.WithSerializable())
-	if !errors.Is(err, ordering.ErrNoGreaterRev) {
-		t.Fatalf("expected %v, got %v", ordering.ErrNoGreaterRev, err)
-	}
+	require.ErrorIsf(t, err, ordering.ErrNoGreaterRev, "expected %v, got %v", ordering.ErrNoGreaterRev, err)
 }

--- a/tests/integration/clientv3/snapshot/v3_snapshot_test.go
+++ b/tests/integration/clientv3/snapshot/v3_snapshot_test.go
@@ -44,14 +44,10 @@ func TestSaveSnapshotFilePermissions(t *testing.T) {
 	defer os.RemoveAll(dbPath)
 
 	dbInfo, err := os.Stat(dbPath)
-	if err != nil {
-		t.Fatalf("failed to get test snapshot file status: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to get test snapshot file status: %v", err)
 	actualFileMode := dbInfo.Mode()
 
-	if expectedFileMode != actualFileMode {
-		t.Fatalf("expected test snapshot file mode %s, got %s:", expectedFileMode, actualFileMode)
-	}
+	require.Equalf(t, expectedFileMode, actualFileMode, "expected test snapshot file mode %s, got %s:", expectedFileMode, actualFileMode)
 }
 
 // TestSaveSnapshotVersion ensures that the snapshot returns proper storage version.
@@ -67,9 +63,7 @@ func TestSaveSnapshotVersion(t *testing.T) {
 	ver, dbPath := createSnapshotFile(t, cfg, kvs)
 	defer os.RemoveAll(dbPath)
 
-	if ver != "3.6.0" {
-		t.Fatalf("expected snapshot version %s, got %s:", "3.6.0", ver)
-	}
+	require.Equalf(t, "3.6.0", ver, "expected snapshot version %s, got %s:", "3.6.0", ver)
 }
 
 type kv struct {

--- a/tests/integration/member_test.go
+++ b/tests/integration/member_test.go
@@ -94,9 +94,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		_, err = m.Client.Put(ctx, "/"+key, "bar")
-		if err != nil {
-			t.Fatalf("#%d: create on %s error: %v", i, m.URL(), err)
-		}
+		require.NoErrorf(t, err, "#%d: create on %s error", i, m.URL())
 		cancel()
 	}
 	m.Stop(t)
@@ -107,9 +105,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		resp, err := m.Client.Get(ctx, "/"+key)
-		if err != nil {
-			t.Fatalf("#%d: get on %s error: %v", i, m.URL(), err)
-		}
+		require.NoErrorf(t, err, "#%d: get on %s error", i, m.URL())
 		cancel()
 
 		if len(resp.Kvs) != 1 || string(resp.Kvs[0].Value) != "bar" {

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -40,9 +40,7 @@ func TestMetricDbSizeBoot(t *testing.T) {
 	v, err := clus.Members[0].Metric("etcd_debugging_mvcc_db_total_size_in_bytes")
 	require.NoError(t, err)
 
-	if v == "0" {
-		t.Fatalf("expected non-zero, got %q", v)
-	}
+	require.NotEqualf(t, "0", v, "expected non-zero, got %q", v)
 }
 
 func TestMetricDbSizeDefrag(t *testing.T) {
@@ -75,16 +73,12 @@ func testMetricDbSizeDefrag(t *testing.T, name string) {
 	require.NoError(t, err)
 	bv, err := strconv.Atoi(beforeDefrag)
 	require.NoError(t, err)
-	if bv < expected {
-		t.Fatalf("expected db size greater than %d, got %d", expected, bv)
-	}
+	require.GreaterOrEqualf(t, bv, expected, "expected db size greater than %d, got %d", expected, bv)
 	beforeDefragInUse, err := clus.Members[0].Metric("etcd_mvcc_db_total_size_in_use_in_bytes")
 	require.NoError(t, err)
 	biu, err := strconv.Atoi(beforeDefragInUse)
 	require.NoError(t, err)
-	if biu < expected {
-		t.Fatalf("expected db size in use is greater than %d, got %d", expected, biu)
-	}
+	require.GreaterOrEqualf(t, biu, expected, "expected db size in use is greater than %d, got %d", expected, biu)
 
 	// clear out historical keys, in use bytes should free pages
 	creq := &pb.CompactionRequest{Revision: int64(numPuts), Physical: true}
@@ -116,9 +110,7 @@ func testMetricDbSizeDefrag(t *testing.T, name string) {
 			break
 		}
 		retry++
-		if retry >= maxRetry {
-			t.Fatalf("%v", err.Error())
-		}
+		require.Lessf(t, retry, maxRetry, "%v", err.Error())
 	}
 
 	// defrag should give freed space back to fs
@@ -128,17 +120,13 @@ func testMetricDbSizeDefrag(t *testing.T, name string) {
 	require.NoError(t, err)
 	av, err := strconv.Atoi(afterDefrag)
 	require.NoError(t, err)
-	if bv <= av {
-		t.Fatalf("expected less than %d, got %d after defrag", bv, av)
-	}
+	require.Greaterf(t, bv, av, "expected less than %d, got %d after defrag", bv, av)
 
 	afterDefragInUse, err := clus.Members[0].Metric("etcd_mvcc_db_total_size_in_use_in_bytes")
 	require.NoError(t, err)
 	adiu, err := strconv.Atoi(afterDefragInUse)
 	require.NoError(t, err)
-	if adiu > av {
-		t.Fatalf("db size in use (%d) is expected less than db size (%d) after defrag", adiu, av)
-	}
+	require.LessOrEqualf(t, adiu, av, "db size in use (%d) is expected less than db size (%d) after defrag", adiu, av)
 }
 
 func TestMetricQuotaBackendBytes(t *testing.T) {
@@ -150,9 +138,7 @@ func TestMetricQuotaBackendBytes(t *testing.T) {
 	require.NoError(t, err)
 	qv, err := strconv.ParseFloat(qs, 64)
 	require.NoError(t, err)
-	if int64(qv) != storage.DefaultQuotaBytes {
-		t.Fatalf("expected %d, got %f", storage.DefaultQuotaBytes, qv)
-	}
+	require.Equalf(t, storage.DefaultQuotaBytes, int64(qv), "expected %d, got %f", storage.DefaultQuotaBytes, qv)
 }
 
 func TestMetricsHealth(t *testing.T) {
@@ -174,9 +160,7 @@ func TestMetricsHealth(t *testing.T) {
 
 	hv, err := clus.Members[0].Metric("etcd_server_health_failures")
 	require.NoError(t, err)
-	if hv != "0" {
-		t.Fatalf("expected '0' from etcd_server_health_failures, got %q", hv)
-	}
+	require.Equalf(t, "0", hv, "expected '0' from etcd_server_health_failures, got %q", hv)
 }
 
 func TestMetricsRangeDurationSeconds(t *testing.T) {

--- a/tests/integration/network_partition_test.go
+++ b/tests/integration/network_partition_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
@@ -65,9 +67,7 @@ func TestNetworkPartition5MembersLeaderInMajority(t *testing.T) {
 		}
 		t.Logf("[%d] got %v", i, err)
 	}
-	if err != nil {
-		t.Fatalf("failed after 3 tries (%v)", err)
-	}
+	require.NoErrorf(t, err, "failed after 3 tries (%v)", err)
 }
 
 func testNetworkPartition5MembersLeaderInMajority(t *testing.T) error {

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -52,9 +52,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 		DialTimeout: 5 * time.Second,
 	}
 	client, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatalf("err %v, want nil", err)
-	}
+	require.NoErrorf(t, err, "err %v, want nil", err)
 	defer client.Close()
 
 	// wait some time for register-loop to write keys
@@ -62,16 +60,10 @@ func TestClusterProxyMemberList(t *testing.T) {
 
 	var mresp *clientv3.MemberListResponse
 	mresp, err = client.Cluster.MemberList(context.Background())
-	if err != nil {
-		t.Fatalf("err %v, want nil", err)
-	}
+	require.NoErrorf(t, err, "err %v, want nil", err)
 
-	if len(mresp.Members) != 1 {
-		t.Fatalf("len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
-	}
-	if len(mresp.Members[0].ClientURLs) != 1 {
-		t.Fatalf("len(mresp.Members[0].ClientURLs) expected 1, got %d (%+v)", len(mresp.Members[0].ClientURLs), mresp.Members[0].ClientURLs[0])
-	}
+	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
+	require.Lenf(t, mresp.Members[0].ClientURLs, 1, "len(mresp.Members[0].ClientURLs) expected 1, got %d (%+v)", len(mresp.Members[0].ClientURLs), mresp.Members[0].ClientURLs[0])
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{cts.caddr}})
 
 	// test proxy member add
@@ -82,12 +74,8 @@ func TestClusterProxyMemberList(t *testing.T) {
 
 	// check add member succ
 	mresp, err = client.Cluster.MemberList(context.Background())
-	if err != nil {
-		t.Fatalf("err %v, want nil", err)
-	}
-	if len(mresp.Members) != 2 {
-		t.Fatalf("len(mresp.Members) expected 2, got %d (%+v)", len(mresp.Members), mresp.Members)
-	}
+	require.NoErrorf(t, err, "err %v, want nil", err)
+	require.Lenf(t, mresp.Members, 2, "len(mresp.Members) expected 2, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{newMemberAddr}})
 
 	// test proxy member delete
@@ -97,12 +85,8 @@ func TestClusterProxyMemberList(t *testing.T) {
 
 	// check delete member succ
 	mresp, err = client.Cluster.MemberList(context.Background())
-	if err != nil {
-		t.Fatalf("err %v, want nil", err)
-	}
-	if len(mresp.Members) != 1 {
-		t.Fatalf("len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
-	}
+	require.NoErrorf(t, err, "err %v, want nil", err)
+	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{cts.caddr}})
 }
 
@@ -162,10 +146,7 @@ func newClusterProxyServer(lg *zap.Logger, endpoints []string, prefix string, t 
 
 func deregisterMember(c *clientv3.Client, prefix, addr string, t *testing.T) {
 	em, err := endpoints.NewManager(c, prefix)
-	if err != nil {
-		t.Fatalf("new endpoint manager failed, err %v", err)
-	}
-	if err = em.DeleteEndpoint(c.Ctx(), prefix+"/"+addr); err != nil {
-		t.Fatalf("delete endpoint failed, err %v", err)
-	}
+	require.NoErrorf(t, err, "new endpoint manager failed, err")
+	err = em.DeleteEndpoint(c.Ctx(), prefix+"/"+addr)
+	require.NoErrorf(t, err, "delete endpoint failed, err")
 }

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -44,13 +44,9 @@ func TestKVProxyRange(t *testing.T) {
 		DialTimeout: 5 * time.Second,
 	}
 	client, err := integration2.NewClient(t, cfg)
-	if err != nil {
-		t.Fatalf("err = %v, want nil", err)
-	}
+	require.NoErrorf(t, err, "err = %v, want nil", err)
 	_, err = client.Get(context.Background(), "foo")
-	if err != nil {
-		t.Fatalf("err = %v, want nil", err)
-	}
+	require.NoErrorf(t, err, "err = %v, want nil", err)
 	client.Close()
 }
 

--- a/tests/integration/proxy/grpcproxy/register_test.go
+++ b/tests/integration/proxy/grpcproxy/register_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -40,12 +41,8 @@ func TestRegister(t *testing.T) {
 	donec := grpcproxy.Register(zaptest.NewLogger(t), cli, testPrefix, paddr, 5)
 
 	ups := <-wa
-	if len(ups) != 1 {
-		t.Fatalf("len(ups) expected 1, got %d (%v)", len(ups), ups)
-	}
-	if ups[0].Endpoint.Addr != paddr {
-		t.Fatalf("ups[0].Addr expected %q, got %q", paddr, ups[0].Endpoint.Addr)
-	}
+	require.Lenf(t, ups, 1, "len(ups) expected 1, got %d (%v)", len(ups), ups)
+	require.Equalf(t, ups[0].Endpoint.Addr, paddr, "ups[0].Addr expected %q, got %q", paddr, ups[0].Endpoint.Addr)
 
 	cli.Close()
 	clus.TakeClient(0)
@@ -58,12 +55,8 @@ func TestRegister(t *testing.T) {
 
 func mustCreateWatcher(t *testing.T, c *clientv3.Client, prefix string) endpoints.WatchChannel {
 	em, err := endpoints.NewManager(c, prefix)
-	if err != nil {
-		t.Fatalf("failed to create endpoints.Manager: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to create endpoints.Manager")
 	wc, err := em.NewWatchChannel(c.Ctx())
-	if err != nil {
-		t.Fatalf("failed to resolve %q (%v)", prefix, err)
-	}
+	require.NoErrorf(t, err, "failed to resolve %q", prefix)
 	return wc
 }

--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -132,9 +132,7 @@ func getWorker(ctx context.Context, t *testing.T, clus *integration.Cluster) {
 		if resp == nil {
 			continue
 		}
-		if prevRev > resp.Header.Revision {
-			t.Fatalf("rev is less than previously observed revision, rev: %d, prevRev: %d", resp.Header.Revision, prevRev)
-		}
+		require.LessOrEqualf(t, prevRev, resp.Header.Revision, "rev is less than previously observed revision, rev: %d, prevRev: %d", resp.Header.Revision, prevRev)
 		prevRev = resp.Header.Revision
 	}
 }

--- a/tests/integration/snapshot/member_test.go
+++ b/tests/integration/snapshot/member_test.go
@@ -93,9 +93,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 	mresp, err := cli2.MemberList(ctx)
 	cancel()
 	require.NoError(t, err)
-	if len(mresp.Members) != 4 {
-		t.Fatalf("expected 4 members, got %+v", mresp)
-	}
+	require.Lenf(t, mresp.Members, 4, "expected 4 members, got %+v", mresp)
 
 	// make sure restored cluster has kept all data on recovery
 	var gresp *clientv3.GetResponse
@@ -104,11 +102,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 	for i := range gresp.Kvs {
-		if string(gresp.Kvs[i].Key) != kvs[i].k {
-			t.Fatalf("#%d: key expected %s, got %s", i, kvs[i].k, gresp.Kvs[i].Key)
-		}
-		if string(gresp.Kvs[i].Value) != kvs[i].v {
-			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[i].Value)
-		}
+		require.Equalf(t, string(gresp.Kvs[i].Key), kvs[i].k, "#%d: key expected %s, got %s", i, kvs[i].k, gresp.Kvs[i].Key)
+		require.Equalf(t, string(gresp.Kvs[i].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[i].Value)
 	}
 }

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -88,9 +88,7 @@ func TestSnapshotV3RestoreSingle(t *testing.T) {
 		var gresp *clientv3.GetResponse
 		gresp, err = cli.Get(context.Background(), kvs[i].k)
 		require.NoError(t, err)
-		if string(gresp.Kvs[0].Value) != kvs[i].v {
-			t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
-		}
+		require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 	}
 }
 
@@ -121,9 +119,7 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 			var gresp *clientv3.GetResponse
 			gresp, err = cli.Get(context.Background(), kvs[i].k)
 			require.NoError(t, err)
-			if string(gresp.Kvs[0].Value) != kvs[i].v {
-				t.Fatalf("#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
-			}
+			require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 		}
 	}
 }
@@ -132,12 +128,11 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 func TestCorruptedBackupFileCheck(t *testing.T) {
 	dbPath := testutils.MustAbsPath("testdata/corrupted_backup.db")
 	integration2.BeforeTest(t)
-	if _, err := os.Stat(dbPath); err != nil {
-		t.Fatalf("test file [%s] does not exist: %v", dbPath, err)
-	}
+	_, err := os.Stat(dbPath)
+	require.NoErrorf(t, err, "test file [%s] does not exist: %v", dbPath, err)
 
 	sp := snapshot.NewV3(zaptest.NewLogger(t))
-	_, err := sp.Status(dbPath)
+	_, err = sp.Status(dbPath)
 	expectedErrKeywords := "snapshot file integrity check failed"
 	/* example error message:
 	snapshot file integrity check failed. 2 errors found.

--- a/tests/integration/v2store/store_test.go
+++ b/tests/integration/v2store/store_test.go
@@ -101,7 +101,7 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, "set", e.Action)
 	assert.Equal(t, "/foo", e.Node.Key)
 	assert.False(t, e.Node.Dir)
-	assert.Equal(t, "", *e.Node.Value)
+	assert.Empty(t, *e.Node.Value)
 	assert.Nil(t, e.Node.Nodes)
 	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, int64(0), e.Node.TTL)
@@ -123,7 +123,7 @@ func TestSet(t *testing.T) {
 	// check prevNode
 	require.NotNil(t, e.PrevNode)
 	assert.Equal(t, "/foo", e.PrevNode.Key)
-	assert.Equal(t, "", *e.PrevNode.Value)
+	assert.Empty(t, *e.PrevNode.Value)
 	assert.Equal(t, uint64(1), e.PrevNode.ModifiedIndex)
 	// Set /foo="baz" (for testing prevNode)
 	eidx = 3
@@ -198,7 +198,7 @@ func TestStoreCreateValue(t *testing.T) {
 	assert.Equal(t, "create", e.Action)
 	assert.Equal(t, "/empty", e.Node.Key)
 	assert.False(t, e.Node.Dir)
-	assert.Equal(t, "", *e.Node.Value)
+	assert.Empty(t, *e.Node.Value)
 	assert.Nil(t, e.Node.Nodes)
 	assert.Nil(t, e.Node.Expiration)
 	assert.Equal(t, int64(0), e.Node.TTL)
@@ -271,7 +271,7 @@ func TestStoreUpdateValue(t *testing.T) {
 	assert.Equal(t, "update", e.Action)
 	assert.Equal(t, "/foo", e.Node.Key)
 	assert.False(t, e.Node.Dir)
-	assert.Equal(t, "", *e.Node.Value)
+	assert.Empty(t, *e.Node.Value)
 	assert.Equal(t, int64(0), e.Node.TTL)
 	assert.Equal(t, uint64(3), e.Node.ModifiedIndex)
 	// check prevNode
@@ -282,7 +282,7 @@ func TestStoreUpdateValue(t *testing.T) {
 
 	e, _ = s.Get("/foo", false, false)
 	assert.Equal(t, eidx, e.EtcdIndex)
-	assert.Equal(t, "", *e.Node.Value)
+	assert.Empty(t, *e.Node.Value)
 }
 
 // TestStoreUpdateFailsIfDirectory ensures that the store cannot update a directory.

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -44,9 +44,7 @@ func TestV3AuthEmptyUserGet(t *testing.T) {
 	authSetupRoot(t, api.Auth)
 
 	_, err := api.KV.Range(ctx, &pb.RangeRequest{Key: []byte("abc")})
-	if !eqErrGRPC(err, rpctypes.ErrUserEmpty) {
-		t.Fatalf("got %v, expected %v", err, rpctypes.ErrUserEmpty)
-	}
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrUserEmpty), "got %v, expected %v", err, rpctypes.ErrUserEmpty)
 }
 
 // TestV3AuthEmptyUserPut ensures that a put with an empty user will return an empty user error,
@@ -70,9 +68,7 @@ func TestV3AuthEmptyUserPut(t *testing.T) {
 	// cluster terminating.
 	for i := 0; i < 10; i++ {
 		_, err := api.KV.Put(ctx, &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
-		if !eqErrGRPC(err, rpctypes.ErrUserEmpty) {
-			t.Fatalf("got %v, expected %v", err, rpctypes.ErrUserEmpty)
-		}
+		require.Truef(t, eqErrGRPC(err, rpctypes.ErrUserEmpty), "got %v, expected %v", err, rpctypes.ErrUserEmpty)
 	}
 }
 
@@ -124,9 +120,7 @@ func TestV3AuthRevision(t *testing.T) {
 	aresp, aerr := api.Auth.UserAdd(ctx, &pb.AuthUserAddRequest{Name: "root", Password: "123", Options: &authpb.UserAddOptions{NoPassword: false}})
 	cancel()
 	require.NoError(t, aerr)
-	if aresp.Header.Revision != rev {
-		t.Fatalf("revision expected %d, got %d", rev, aresp.Header.Revision)
-	}
+	require.Equalf(t, aresp.Header.Revision, rev, "revision expected %d, got %d", rev, aresp.Header.Revision)
 }
 
 // TestV3AuthWithLeaseRevokeWithRoot ensures that granted leases
@@ -333,16 +327,12 @@ func TestV3AuthNonAuthorizedRPCs(t *testing.T) {
 	key := "foo"
 	val := "bar"
 	_, err := nonAuthedKV.Put(context.TODO(), key, val)
-	if err != nil {
-		t.Fatalf("couldn't put key (%v)", err)
-	}
+	require.NoErrorf(t, err, "couldn't put key (%v)", err)
 
 	authSetupRoot(t, integration.ToGRPC(clus.Client(0)).Auth)
 
 	respput, err := nonAuthedKV.Put(context.TODO(), key, val)
-	if !eqErrGRPC(err, rpctypes.ErrGRPCUserEmpty) {
-		t.Fatalf("could put key (%v), it should cause an error of permission denied", respput)
-	}
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCUserEmpty), "could put key (%v), it should cause an error of permission denied", respput)
 }
 
 func TestV3AuthOldRevConcurrent(t *testing.T) {
@@ -428,9 +418,7 @@ func TestV3AuthWatchErrorAndWatchId0(t *testing.T) {
 	require.Error(t, watchResponse.Err()) // permission denied
 
 	_, err := c.Put(ctx, "k1", "val")
-	if err != nil {
-		t.Fatalf("Unexpected error from Put: %v", err)
-	}
+	require.NoErrorf(t, err, "Unexpected error from Put: %v", err)
 
 	<-watchEndCh
 }

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -61,9 +61,7 @@ func TestFailover(t *testing.T) {
 			// Create an etcd client before or after first server down
 			t.Logf("Creating an etcd client [%s]", tc.name)
 			cli, err := tc.testFunc(t, cc, clus)
-			if err != nil {
-				t.Fatalf("Failed to create client: %v", err)
-			}
+			require.NoErrorf(t, err, "Failed to create client")
 			defer cli.Close()
 
 			// Sanity test
@@ -142,12 +140,8 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 				t.Logf("Failed to get key (%v)", getErr)
 				return getErr
 			}
-			if len(resp.Kvs) != 1 {
-				t.Fatalf("Expected 1 key, got %d", len(resp.Kvs))
-			}
-			if !bytes.Equal([]byte(val), resp.Kvs[0].Value) {
-				t.Fatalf("Unexpected value, expected: %s, got: %s", val, resp.Kvs[0].Value)
-			}
+			require.Lenf(t, resp.Kvs, 1, "Expected 1 key, got %d", len(resp.Kvs))
+			require.Truef(t, bytes.Equal([]byte(val), resp.Kvs[0].Value), "Unexpected value, expected: %s, got: %s", val, resp.Kvs[0].Value)
 			return nil
 		}()
 		if err != nil {


### PR DESCRIPTION
#### Description

This uses testify instead of testing for t.Fatal or t.Error calls in tests/integration package

Related to #18972