### PR TITLE
Set return time to max value of int64 for failed requests during robustness test validation phase

### DIFF
--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -16,6 +16,7 @@ package validate
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/anishathalye/porcupine"
 
@@ -115,6 +116,8 @@ func patchOperations(operations []porcupine.Operation, watchRevision, putReturnT
 				op.Output = model.MaybeEtcdResponse{Persisted: true}
 			}
 		}
+		op.Return = math.MaxInt64
+
 		// Leave operation as it is as we cannot discard it.
 		newOperations = append(newOperations, op)
 	}


### PR DESCRIPTION
The failed requests will now look something like the following, extending till the end of the right.

<img width="1728" alt="Screenshot 2025-03-19 at 12 21 01 AM" src="https://github.com/user-attachments/assets/80b47d2f-eee5-4729-95ee-16e231ddeb45" />

Reference:
- https://github.com/etcd-io/etcd/issues/19579


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
