### PR TITLE
[3.5] tests: add TestIssue19557FixMemberDataAfterUpgrade

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -378,7 +378,7 @@
 		]
 	},
 	{
-		"project": "github.com/stretchr/testify/assert",
+		"project": "github.com/stretchr/testify",
 		"licenses": [
 			{
 				"type": "MIT License",

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -148,6 +148,7 @@ type EtcdProcessClusterConfig struct {
 	PeerProxy                    bool
 	EnvVars                      map[string]string
 	Version                      ClusterVersion
+	ExecPath                     string // NOTE: only applicable when Version is ClusterVersion
 	NextClusterVersionCompatible bool
 
 	ClusterSize int
@@ -192,6 +193,7 @@ type EtcdProcessClusterConfig struct {
 	CompactHashCheckTime       time.Duration
 	WatchProcessNotifyInterval time.Duration
 	CompactionBatchLimit       int
+	BackendBatchLimit          int
 
 	ExperimentalStopGRPCServiceOnDefrag bool
 }
@@ -377,6 +379,9 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 	if cfg.CompactionBatchLimit != 0 {
 		args = append(args, "--experimental-compaction-batch-limit", fmt.Sprintf("%d", cfg.CompactionBatchLimit))
 	}
+	if cfg.BackendBatchLimit != 0 {
+		args = append(args, "--backend-batch-limit", fmt.Sprintf("%d", cfg.BackendBatchLimit))
+	}
 
 	envVars := map[string]string{}
 	for key, value := range cfg.EnvVars {
@@ -392,6 +397,9 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 	switch cfg.Version {
 	case CurrentVersion:
 		execPath = BinPath
+		if cfg.ExecPath != "" {
+			execPath = cfg.ExecPath
+		}
 	case MinorityLastVersion:
 		if i <= cfg.ClusterSize/2 {
 			execPath = BinPath

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
+	go.etcd.io/bbolt v1.3.11
 	go.etcd.io/etcd/api/v3 v3.5.19
 	go.etcd.io/etcd/client/pkg/v3 v3.5.19
 	go.etcd.io/etcd/client/v2 v2.305.19
@@ -78,7 +79,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.20.0 // indirect


### PR DESCRIPTION
* Add downloadReleaseBinary to fetch artifact from github
* Add ExecPath in EtcdProcessClusterConfig to modify ETCD binary
* TestIssue19557FixMemberDataAfterUpgrade
  * Download old point release binary - v3.5.18
  * Start one member cluster with v3.5.18
  * Add one learner
  * Promote that learner
  * Add 10 key/values to trigger snapshot
  * Stop cluster
  * Check learner's membership information (IsLearner: true)
  * Upgrade cluster with current release
  * Stop cluster
  * Check learner's membership information (IsLearner: false)


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
