### PR TITLE
Split `scripts/test_lib.sh`

### DIFF
--- a/scripts/markdown_diff_lint.sh
+++ b/scripts/markdown_diff_lint.sh
@@ -3,10 +3,10 @@
 # Usage: ./markdown_lint.sh
 
 
-# We source ./scripts/test_lib.sh, it sets the log functions and color variables.
-source ./scripts/test_lib.sh
+# We source ./scripts/test_utils.sh, it sets the log functions and color variables.
+source ./scripts/test_utils.sh
 
-# When we source ./scripts/test_lib.sh, it has the line set -u which treats unset variables as errors.
+# When we source ./scripts/test_utils.sh, it has the line set -u which treats unset variables as errors.
 # We need to unset the variable to avoid the error.
 set +u -eo pipefail
 

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source ./scripts/test_utils.sh
+
 ROOT_MODULE="go.etcd.io/etcd"
 
 if [[ "$(go list)" != "${ROOT_MODULE}/v3" ]]; then
@@ -14,96 +16,6 @@ function set_root_dir {
 }
 
 set_root_dir
-
-####   Convenient IO methods #####
-
-COLOR_RED='\033[0;31m'
-COLOR_ORANGE='\033[0;33m'
-COLOR_GREEN='\033[0;32m'
-COLOR_LIGHTCYAN='\033[0;36m'
-COLOR_BLUE='\033[0;94m'
-COLOR_MAGENTA='\033[95m'
-COLOR_BOLD='\033[1m'
-COLOR_NONE='\033[0m' # No Color
-
-
-function log_error {
-  >&2 echo -n -e "${COLOR_BOLD}${COLOR_RED}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-function log_warning {
-  >&2 echo -n -e "${COLOR_ORANGE}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-function log_callout {
-  >&2 echo -n -e "${COLOR_LIGHTCYAN}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-function log_cmd {
-  >&2 echo -n -e "${COLOR_BLUE}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-function log_success {
-  >&2 echo -n -e "${COLOR_GREEN}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-function log_info {
-  >&2 echo -n -e "${COLOR_NONE}"
-  >&2 echo "$@"
-  >&2 echo -n -e "${COLOR_NONE}"
-}
-
-# From http://stackoverflow.com/a/12498485
-function relativePath {
-  # both $1 and $2 are absolute paths beginning with /
-  # returns relative path to $2 from $1
-  local source=$1
-  local target=$2
-
-  local commonPart=$source
-  local result=""
-
-  while [[ "${target#"$commonPart"}" == "${target}" ]]; do
-    # no match, means that candidate common part is not correct
-    # go up one level (reduce common part)
-    commonPart="$(dirname "$commonPart")"
-    # and record that we went back, with correct / handling
-    if [[ -z $result ]]; then
-      result=".."
-    else
-      result="../$result"
-    fi
-  done
-
-  if [[ $commonPart == "/" ]]; then
-    # special case for root (no common path)
-    result="$result/"
-  fi
-
-  # since we now have identified the common part,
-  # compute the non-common part
-  local forwardPart="${target#"$commonPart"}"
-
-  # and now stick all parts together
-  if [[ -n $result ]] && [[ -n $forwardPart ]]; then
-    result="$result$forwardPart"
-  elif [[ -n $forwardPart ]]; then
-    # extra slash removal
-    result="${forwardPart:1}"
-  fi
-
-  echo "$result"
-}
 
 ####   Discovery of files/packages within a go module #####
 

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+####   Convenient IO methods #####
+
+export COLOR_RED='\033[0;31m'
+export COLOR_ORANGE='\033[0;33m'
+export COLOR_GREEN='\033[0;32m'
+export COLOR_LIGHTCYAN='\033[0;36m'
+export COLOR_BLUE='\033[0;94m'
+export COLOR_BOLD='\033[1m'
+export COLOR_MAGENTA='\033[95m'
+export COLOR_NONE='\033[0m' # No Color
+
+
+function log_error {
+  >&2 echo -n -e "${COLOR_BOLD}${COLOR_RED}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+function log_warning {
+  >&2 echo -n -e "${COLOR_ORANGE}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+function log_callout {
+  >&2 echo -n -e "${COLOR_LIGHTCYAN}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+function log_cmd {
+  >&2 echo -n -e "${COLOR_BLUE}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+function log_success {
+  >&2 echo -n -e "${COLOR_GREEN}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+function log_info {
+  >&2 echo -n -e "${COLOR_NONE}"
+  >&2 echo "$@"
+  >&2 echo -n -e "${COLOR_NONE}"
+}
+
+# From http://stackoverflow.com/a/12498485
+function relativePath {
+  # both $1 and $2 are absolute paths beginning with /
+  # returns relative path to $2 from $1
+  local source=$1
+  local target=$2
+
+  local commonPart=$source
+  local result=""
+
+  while [[ "${target#"$commonPart"}" == "${target}" ]]; do
+    # no match, means that candidate common part is not correct
+    # go up one level (reduce common part)
+    commonPart="$(dirname "$commonPart")"
+    # and record that we went back, with correct / handling
+    if [[ -z $result ]]; then
+      result=".."
+    else
+      result="../$result"
+    fi
+  done
+
+  if [[ $commonPart == "/" ]]; then
+    # special case for root (no common path)
+    result="$result/"
+  fi
+
+  # since we now have identified the common part,
+  # compute the non-common part
+  local forwardPart="${target#"$commonPart"}"
+
+  # and now stick all parts together
+  if [[ -n $result ]] && [[ -n $forwardPart ]]; then
+    result="$result$forwardPart"
+  elif [[ -n $forwardPart ]]; then
+    # extra slash removal
+    result="${forwardPart:1}"
+  fi
+
+  echo "$result"
+}


### PR DESCRIPTION
From #19604 , the `markdown_diff_lint.sh` fails because of:

```bash
if [[ "$(go list)" != "${ROOT_MODULE}/v3" ]]; then
  echo "must be run from '${ROOT_MODULE}/v3' module directory"
  exit 255
fi
```

While the `markdown_diff_lint.sh` does not require `go`. The idea is to break `test_lib.sh` into another file that only contains basic functionalities like logging and getting relative path (i.e. `test_utils.sh`). Both `test_lib.sh` and `markdown_diff_lint.sh` will `source` from `test_utils.sh`. 

Solves #18059 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
