### PR TITLE
[release-3.6] Auto sync members in v3store is IsLearner differs between v2 and v3 store

### DIFF
--- a/server/etcdserver/api/membership/membership_test.go
+++ b/server/etcdserver/api/membership/membership_test.go
@@ -85,6 +85,10 @@ func (b *backendMock) MustSaveMemberToBackend(m *Member) {
 	b.members[m.ID] = m
 }
 
+func (b *backendMock) MustHackySaveMemberToBackend(m *Member) {
+	b.members[m.ID] = m
+}
+
 func (b *backendMock) TrimMembershipFromBackend() error {
 	b.members = make(map[types.ID]*Member)
 	b.removed = make(map[types.ID]bool)

--- a/server/etcdserver/api/membership/store.go
+++ b/server/etcdserver/api/membership/store.go
@@ -39,6 +39,7 @@ type ClusterVersionBackend interface {
 type MemberBackend interface {
 	MustReadMembersFromBackend() (map[types.ID]*Member, map[types.ID]bool)
 	MustSaveMemberToBackend(*Member)
+	MustHackySaveMemberToBackend(*Member)
 	TrimMembershipFromBackend() error
 	MustDeleteMemberFromBackend(types.ID)
 }

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -448,6 +448,11 @@ func (c *bootstrappedCluster) Finalize(cfg config.ServerConfig, s *bootstrappedS
 	}
 	c.cl.SetStore(s.st)
 	c.cl.SetBackend(schema.NewMembershipBackend(cfg.Logger, s.backend.be))
+
+	// Workaround the issues which have already been affected
+	// by https://github.com/etcd-io/etcd/issues/19557.
+	c.cl.SyncLearnerPromotionIfNeeded()
+
 	if s.wal.haveWAL {
 		c.cl.Recover(api.UpdateCapability)
 		if c.databaseFileMissing(s) {

--- a/server/storage/backend/verify.go
+++ b/server/storage/backend/verify.go
@@ -62,6 +62,14 @@ func verifyLockEnabled() bool {
 
 func insideApply() bool {
 	stackTraceStr := string(debug.Stack())
+
+	// Exclude the case of `MustHackySaveMemberToBackend`, which is
+	// used to workaround the situations which are already affected
+	// by https://github.com/etcd-io/etcd/issues/19557.
+	if strings.Contains(stackTraceStr, "MustHackySaveMemberToBackend") {
+		return false
+	}
+
 	return strings.Contains(stackTraceStr, ".applyEntries")
 }
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.10.0
+	go.etcd.io/bbolt v1.4.0
 	go.etcd.io/etcd/api/v3 v3.6.0-rc.2
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-rc.2
 	go.etcd.io/etcd/client/v2 v2.306.0-rc.2
@@ -88,7 +89,6 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	go.etcd.io/bbolt v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect


### PR DESCRIPTION
release-3.6 isn't able to automatically fix the issues which have already been affected by https://github.com/etcd-io/etcd/issues/19557.

Also adding the validation has flaws as mentioned in https://github.com/etcd-io/etcd/issues/19557#issuecomment-2741425899

Eventually I tried to add similar auto sync in 3.6 as what we did for 3.5 in https://github.com/etcd-io/etcd/pull/19606 

This is the only way to avoid all confusion and reduce of user experience.

cc @fuweid @serathius @siyuanfoundation 

