### PR TITLE
[release-3.6] minor refactor DowngradeUpgradeMembersByID to not block on waiting fo…

### DIFF
--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/version"
@@ -146,6 +147,7 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 		opString = "downgrading"
 		newExecPath = BinPath.EtcdLastRelease
 	}
+	g := new(errgroup.Group)
 	for _, memberID := range membersToChange {
 		member := clus.Procs[memberID]
 		if member.Config().ExecPath == newExecPath {
@@ -157,10 +159,15 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 		}
 		member.Config().ExecPath = newExecPath
 		lg.Info("Restarting member", zap.String("member", member.Config().Name))
-		err := member.Start(context.TODO())
-		if err != nil {
-			return err
-		}
+		// We shouldn't block on waiting for the member to be ready,
+		// otherwise it will be blocked forever if other members are
+		// not started yet.
+		g.Go(func() error {
+			return member.Start(context.TODO())
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	t.Log("Waiting health interval to make sure the leader propagates version to new processes")


### PR DESCRIPTION
…r member to be ready

backport to 3.6

cc @fuweid 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
