### PR TITLE
[release-3.6] Returns the string representation of the `ClusterVersion`

### DIFF
--- a/tests/framework/e2e/config.go
+++ b/tests/framework/e2e/config.go
@@ -23,6 +23,13 @@ const (
 	LastVersion         ClusterVersion = "last-version"
 )
 
+func (cv ClusterVersion) String() string {
+	if cv == CurrentVersion {
+		return "current-version"
+	}
+	return string(cv)
+}
+
 type ClusterContext struct {
 	Version ClusterVersion
 }


### PR DESCRIPTION
backport https://github.com/etcd-io/etcd/pull/19640 to 3.6

cc @fuweid 