### PR TITLE
Update 3.6 changelog for the fix to auto sync member in v3store

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -10,6 +10,11 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.0-rc.3 (TBD)
 
+### etcd server
+
+- [Auto sync members in v3store for the issues which have already been affected by #19557](https://github.com/etcd-io/etcd/pull/19636).
+
+
 <hr>
 
 ## v3.6.0-rc.2 (2025-03-05)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Link to
- https://github.com/etcd-io/etcd/pull/19636
- https://github.com/etcd-io/etcd/issues/19557


cc @serathius @ivanvc @fuweid 

@ivanvc once the PR https://github.com/etcd-io/etcd/pull/19636 gets merged, then we should release v3.6.0-rc.3, thx
