### PR TITLE
Patch the return time with MaxInt64 in robustness test

### DIFF
--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -291,7 +292,7 @@ func (h *AppendableHistory) appendFailed(request EtcdRequest, start, end time.Du
 	isRead := request.IsRead()
 	if !isRead {
 		// Failed writes can still be persisted, setting -1 for now as don't know when request has took effect.
-		op.Return = -1
+		op.Return = math.MaxInt64
 		// Operations of single client needs to be sequential.
 		// As we don't know return time of failed operations, all new writes need to be done with new stream id.
 		h.streamID = h.idProvider.NewStreamID()
@@ -300,10 +301,11 @@ func (h *AppendableHistory) appendFailed(request EtcdRequest, start, end time.Du
 }
 
 func (h *AppendableHistory) append(op porcupine.Operation) {
-	if op.Return != -1 && op.Call >= op.Return {
+	if op.Return != math.MaxInt64 && op.Call >= op.Return {
 		panic(fmt.Sprintf("Invalid operation, call(%d) >= return(%d)", op.Call, op.Return))
 	}
-	if len(h.operations) > 0 {
+
+	if len(h.operations) > 0 && op.ClientId == h.operations[len(h.operations)-1].ClientId {
 		prev := h.operations[len(h.operations)-1]
 		if op.Call <= prev.Call {
 			panic(fmt.Sprintf("Out of order append, new.call(%d) <= prev.call(%d)", op.Call, prev.Call))
@@ -488,34 +490,8 @@ func (h History) Len() int {
 
 func (h History) Operations() []porcupine.Operation {
 	operations := make([]porcupine.Operation, 0, len(h.operations))
-	maxTime := h.lastObservedTime()
-	for _, op := range h.operations {
-		// Failed requests don't have a known return time.
-		if op.Return == -1 {
-			// Simulate Infinity by using last observed time.
-			op.Return = maxTime + time.Second.Nanoseconds()
-		}
-		operations = append(operations, op)
-	}
-	return operations
-}
 
-func (h History) lastObservedTime() int64 {
-	var maxTime int64
-	for _, op := range h.operations {
-		if op.Return == -1 {
-			// Collect call time from failed operations
-			if op.Call > maxTime {
-				maxTime = op.Call
-			}
-		} else {
-			// Collect return time from successful operations
-			if op.Return > maxTime {
-				maxTime = op.Return
-			}
-		}
-	}
-	return maxTime
+	return append(operations, h.operations...)
 }
 
 func (h History) MaxRevision() int64 {

--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -16,6 +16,7 @@ package validate
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/anishathalye/porcupine"
 
@@ -214,7 +215,9 @@ func uniquePutReturnTime(allOperations []porcupine.Operation, reports []report.C
 		request := persistedRequests[i]
 		switch request.Type {
 		case model.Txn:
-			lastReturnTime--
+			if lastReturnTime != math.MaxInt64 {
+				lastReturnTime--
+			}
 			for _, op := range request.Txn.OperationsOnSuccess {
 				if op.Type != model.PutOperation {
 					continue

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -17,6 +17,7 @@ package validate
 
 import (
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/report"
 )
 
-const infinite = 1000000000
+const infinite = math.MaxInt64
 
 func TestPatchHistory(t *testing.T) {
 	for _, tc := range []struct {
@@ -70,7 +71,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 99, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -113,7 +114,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 			watchOperations: watchResponse(3, putEvent("key", "value", 2), putEvent("key", "value", 3)),
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000004, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -152,7 +153,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequestWithLease("key", "value", 123),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 99, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -195,7 +196,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 			watchOperations: watchResponse(3, putEvent("key", "value", 2), putEvent("key", "value", 3)),
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: 1000000004, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 				{Return: 4, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -233,7 +234,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 			watchOperations: watchResponse(3, deleteEvent("key", 2)),
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 400, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 				{Return: 400, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -260,7 +261,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 99, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -269,7 +270,7 @@ func TestPatchHistory(t *testing.T) {
 				h.AppendTxn(nil, []clientv3.Op{clientv3.OpDelete("key")}, []clientv3.Op{}, 100, infinite, nil, errors.New("failed"))
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 100, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 			},
 		},
 		{
@@ -287,7 +288,7 @@ func TestPatchHistory(t *testing.T) {
 				h.AppendTxn(nil, []clientv3.Op{clientv3.OpPut("key", "value")}, []clientv3.Op{clientv3.OpDelete("key")}, 100, infinite, nil, errors.New("failed"))
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 100, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 			},
 		},
 		{
@@ -296,7 +297,7 @@ func TestPatchHistory(t *testing.T) {
 				h.AppendTxn(nil, []clientv3.Op{clientv3.OpDelete("key")}, []clientv3.Op{clientv3.OpPut("key", "value")}, 100, infinite, nil, errors.New("failed"))
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 100, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 			},
 		},
 		{
@@ -315,7 +316,7 @@ func TestPatchHistory(t *testing.T) {
 				putRequest("key", "value"),
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 99, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Persisted: true}},
 			},
 		},
 		{
@@ -347,7 +348,7 @@ func TestPatchHistory(t *testing.T) {
 			},
 			expectedRemainingOperations: []porcupine.Operation{
 				{Return: 200, Output: putResponse(model.EtcdOperationResult{})},
-				{Return: infinite + 600, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 				{Return: 600, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -366,7 +367,7 @@ func TestPatchHistory(t *testing.T) {
 			expectedRemainingOperations: []porcupine.Operation{
 				{Return: 200, Output: putResponse(model.EtcdOperationResult{})},
 				// TODO: We can infer that failed operation finished before last operation matching following.
-				{Return: infinite + 598, Output: model.MaybeEtcdResponse{Persisted: true}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Persisted: true}},
 				{Return: 600, Output: putResponse(model.EtcdOperationResult{})},
 			},
 		},
@@ -376,7 +377,7 @@ func TestPatchHistory(t *testing.T) {
 				h.AppendTxn(nil, []clientv3.Op{}, []clientv3.Op{clientv3.OpDelete("key")}, 100, infinite, nil, errors.New("failed"))
 			},
 			expectedRemainingOperations: []porcupine.Operation{
-				{Return: infinite + 100, Output: model.MaybeEtcdResponse{Error: "failed"}},
+				{Return: infinite, Output: model.MaybeEtcdResponse{Error: "failed"}},
 			},
 		},
 		{


### PR DESCRIPTION
Reference:
- https://github.com/etcd-io/etcd/issues/19579


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
