### PR TITLE
Dynamically assign pipeline buffer size

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -577,6 +577,11 @@ type Config struct {
 	// be refined to mlock in-use area of bbolt only.
 	MemoryMlock bool `json:"memory-mlock"`
 
+	// PipelineBufferSize is the size of the pipeline buffer for each peer.
+	// It helps hold temporary network latency and prevents message drops.
+	// Default value is 64 messages.
+	PipelineBufferSize int `json:"pipeline-buffer-size"`
+
 	// ExperimentalMemoryMlock enables mlocking of etcd owned memory pages.
 	// TODO: Delete in v3.7
 	// Deprecated: Use MemoryMlock instad. To be decommissioned in v3.7.
@@ -660,6 +665,8 @@ func NewConfig() *Config {
 		MaxRequestBytes:      DefaultMaxRequestBytes,
 		MaxConcurrentStreams: DefaultMaxConcurrentStreams,
 		WarningApplyDuration: DefaultWarningApplyDuration,
+
+		PipelineBufferSize: 64,
 
 		GRPCKeepAliveMinTime:  DefaultGRPCKeepAliveMinTime,
 		GRPCKeepAliveInterval: DefaultGRPCKeepAliveInterval,
@@ -962,6 +969,9 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 
 	// featuregate
 	cfg.ServerFeatureGate.(featuregate.MutableFeatureGate).AddFlag(fs, ServerFeatureGateFlagName)
+
+	fs.IntVar(&cfg.PipelineBufferSize, "pipeline-buffer-size", 64,
+		"The size of the pipeline buffer for each peer. Default value is 64 messages.")
 }
 
 func ConfigFromFile(path string) (*Config, error) {

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -1708,3 +1708,57 @@ func TestDistributedTracingFlagsMigration(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigParsingPipelineBufferSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		expectedSize int
+		expectErr    bool
+	}{
+		{
+			name:         "default value",
+			args:         []string{},
+			expectedSize: 64,
+			expectErr:    false,
+		},
+		{
+			name:         "custom value",
+			args:         []string{"--pipeline-buffer-size=128"},
+			expectedSize: 128,
+			expectErr:    false,
+		},
+		{
+			name:         "zero value",
+			args:         []string{"--pipeline-buffer-size=0"},
+			expectedSize: 0,
+			expectErr:    true,
+		},
+		{
+			name:         "negative value",
+			args:         []string{"--pipeline-buffer-size=-1"},
+			expectedSize: 0,
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newConfig()
+			err := cfg.parse(tc.args)
+			if tc.expectErr {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if cfg.ec.PipelineBufferSize != tc.expectedSize {
+				t.Errorf("expected PipelineBufferSize=%d, got %d", tc.expectedSize, cfg.ec.PipelineBufferSize)
+			}
+		})
+	}
+}

--- a/server/etcdserver/api/rafthttp/transport.go
+++ b/server/etcdserver/api/rafthttp/transport.go
@@ -119,6 +119,11 @@ type Transport struct {
 	// machine and thus stop the Transport.
 	ErrorC chan error
 
+	// PipelineBufferSize is the size of the pipeline buffer for each peer.
+	// It helps hold temporary network latency and prevents message drops.
+	// Default value is 64 messages.
+	PipelineBufferSize int
+
 	streamRt   http.RoundTripper // roundTripper used by streams
 	pipelineRt http.RoundTripper // roundTripper used by pipelines
 
@@ -151,6 +156,12 @@ func (t *Transport) Start() error {
 	if t.DialRetryFrequency == 0 {
 		t.DialRetryFrequency = rate.Every(100 * time.Millisecond)
 	}
+
+	// If PipelineBufferSize is not set, use the default value
+	if t.PipelineBufferSize <= 0 {
+		t.PipelineBufferSize = defaultPipelineBufSize
+	}
+
 	return nil
 }
 

--- a/tests/e2e/pipeline_test.go
+++ b/tests/e2e/pipeline_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestPipelineBufferSize(t *testing.T) {
+	ctx := context.Background()
+
+	// First cluster with buffer size 128
+	epc1, err := e2e.NewEtcdProcessCluster(ctx, t,
+		e2e.WithClusterSize(3),
+		e2e.WithPipelineBufferSize(128),
+		e2e.WithBasePort(20000),
+	)
+	if err != nil {
+		t.Fatalf("could not start etcd process cluster: %v", err)
+	}
+	defer epc1.Close()
+
+	// Wait for the cluster to be ready
+	time.Sleep(time.Second)
+
+	// Verify the first cluster has the correct buffer size
+	for _, proc := range epc1.Procs {
+		args := proc.Config().Args
+		found := false
+		for _, arg := range args {
+			if arg == "--pipeline-buffer-size=128" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("member %s does not have pipeline-buffer-size=128 in args %v", proc.Config().Name, args)
+		}
+	}
+
+	// Second cluster with buffer size 256
+	epc2, err := e2e.NewEtcdProcessCluster(ctx, t,
+		e2e.WithClusterSize(3),
+		e2e.WithPipelineBufferSize(256),
+		e2e.WithBasePort(21000),
+	)
+	if err != nil {
+		t.Fatalf("could not start etcd process cluster: %v", err)
+	}
+	defer epc2.Close()
+
+	// Wait for the cluster to be ready
+	time.Sleep(time.Second)
+
+	// Verify the second cluster has the correct buffer size
+	for _, proc := range epc2.Procs {
+		args := proc.Config().Args
+		found := false
+		for _, arg := range args {
+			if arg == "--pipeline-buffer-size=256" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("member %s does not have pipeline-buffer-size=256 in args %v", proc.Config().Name, args)
+		}
+	}
+}

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -146,6 +146,7 @@ type EtcdProcessClusterConfig struct {
 	GoFailClientTimeout time.Duration
 	LazyFSEnabled       bool
 	PeerProxy           bool
+	PipelineBufferSize  int
 
 	// Process config
 
@@ -423,6 +424,10 @@ func WithExtensiveMetrics() EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.ServerConfig.Metrics = "extensive" }
 }
 
+func WithPipelineBufferSize(size int) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.PipelineBufferSize = size }
+}
+
 // NewEtcdProcessCluster launches a new cluster from etcd processes, returning
 // a new EtcdProcessCluster once all nodes are ready to accept client requests.
 func NewEtcdProcessCluster(ctx context.Context, t testing.TB, opts ...EPClusterOption) (*EtcdProcessCluster, error) {
@@ -656,6 +661,11 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 		}
 		args = append(args, fmt.Sprintf("--%s=%s", flag, value))
 	}
+
+	if cfg.PipelineBufferSize > 0 {
+		args = append(args, fmt.Sprintf("--pipeline-buffer-size=%d", cfg.PipelineBufferSize))
+	}
+
 	envVars := map[string]string{}
 	maps.Copy(envVars, cfg.EnvVars)
 	var gofailPort int

--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -175,6 +175,13 @@ func TestEtcdServerProcessConfig(t *testing.T) {
 			},
 		},
 		{
+			name:   "PipelineBufferSize",
+			config: NewConfig(WithPipelineBufferSize(128)),
+			expectArgsContain: []string{
+				"--pipeline-buffer-size=128",
+			},
+		},
+		{
 			name:   "PeerTLS",
 			config: NewConfig(WithIsPeerTLS(true)),
 			expectArgsContain: []string{


### PR DESCRIPTION
Attempts to resolve issue https://github.com/etcd-io/etcd/issues/19635.

Dynamically set the configuration `pipeline-buffer-size`, instead of using
hard-coded value 64.
Fallback to default value of 64 if configuration isn't provided.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
