### PR TITLE
markdown lint job: set ETCD_ROOT_DIR to root directory of git repository

### DIFF
--- a/scripts/markdown_diff_lint.sh
+++ b/scripts/markdown_diff_lint.sh
@@ -2,6 +2,7 @@
 # This script runs markdownlint-cli2 on changed files.
 # Usage: ./markdown_lint.sh
 
+ETCD_ROOT_DIR=$(git rev-parse --show-toplevel)
 
 # We source ./scripts/test_utils.sh, it sets the log functions and color variables.
 source ./scripts/test_utils.sh
@@ -66,6 +67,7 @@ for file in "${changed_files[@]}"; do
   markdownlint-cli2 "${file}" --config "${ETCD_ROOT_DIR}/tools/.markdownlint.jsonc" 2>/dev/null || true
   while IFS= read -r line; do
     line_number=$(echo "${line}" | awk -F: '{print $2}' | awk '{print $1}')
+
     while [ "${i}" -lt "${#end_ranges[@]}" ] && [ "${line_number}" -gt "${end_ranges["${i}"]}" ]; do
       i=$((1 + i))
     done

--- a/tools/.markdownlint.jsonc
+++ b/tools/.markdownlint.jsonc
@@ -64,25 +64,7 @@
       "maximum": 1
     },
   
-    // MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md013.md
-    "MD013": {
-      // Number of characters
-      "line_length": 80,
-      // Number of characters for headings
-      "heading_line_length": 80,
-      // Number of characters for code blocks
-      "code_block_line_length": 80,
-      // Include code blocks
-      "code_blocks": true,
-      // Include tables
-      "tables": true,
-      // Include headings
-      "headings": true,
-      // Strict length checking
-      "strict": false,
-      // Stern length checking
-      "stern": false
-    },
+    "MD013": false,
   
     // MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md014.md
     "MD014": true,


### PR DESCRIPTION
Add `ETCD_ROOT_DIR="$(git rev-parse --show-toplevel)"` in `markdown_diff_lint.sh`. 
Solves #18059 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
