### PR TITLE
[Robustness test] Preserve return time for failed requests

### DIFF
--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -294,8 +293,6 @@ func (h *AppendableHistory) appendFailed(request EtcdRequest, start, end time.Du
 	}
 	isRead := request.IsRead()
 	if !isRead {
-		// Failed writes can still be persisted, setting -1 for now as don't know when request has took effect.
-		op.Return = math.MaxInt64
 		// Operations of single client needs to be sequential.
 		// As we don't know return time of failed operations, all new writes need to be done with new stream id.
 		h.streamID = h.idProvider.NewStreamID()
@@ -304,7 +301,7 @@ func (h *AppendableHistory) appendFailed(request EtcdRequest, start, end time.Du
 }
 
 func (h *AppendableHistory) append(op porcupine.Operation) {
-	if op.Return != math.MaxInt64 && op.Call >= op.Return {
+	if op.Call >= op.Return {
 		panic(fmt.Sprintf("Invalid operation, call(%d) >= return(%d)", op.Call, op.Return))
 	}
 

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/tests/v3/robustness/model"
-	"go.etcd.io/etcd/tests/v3/robustness/report"
 )
 
 var (
@@ -86,19 +85,6 @@ func validateSerializableOperations(lg *zap.Logger, operations []porcupine.Opera
 		}
 	}
 	return lastErr
-}
-
-func filterSerializableOperations(clients []report.ClientReport) []porcupine.Operation {
-	resp := []porcupine.Operation{}
-	for _, client := range clients {
-		for _, op := range client.KeyValue {
-			request := op.Input.(model.EtcdRequest)
-			if request.Type == model.Range && request.Range.Revision != 0 {
-				resp = append(resp, op)
-			}
-		}
-	}
-	return resp
 }
 
 func validateSerializableRead(lg *zap.Logger, replay *model.EtcdReplay, request model.EtcdRequest, response model.MaybeEtcdResponse) error {

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -405,13 +405,14 @@ func TestPatchHistory(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			history := model.NewAppendableHistory(identity.NewIDProvider())
 			tc.historyFunc(history)
-			operations := patchLinearizableOperations([]report.ClientReport{
+			reports := []report.ClientReport{
 				{
 					ClientID: 0,
 					KeyValue: history.History.Operations(),
 					Watch:    tc.watchOperations,
 				},
-			}, tc.persistedRequest)
+			}
+			operations := patchLinearizableOperations(relevantOperations(patchFailedRequestWithInfiniteReturnTime(reports)), reports, tc.persistedRequest)
 			if diff := cmp.Diff(tc.expectedRemainingOperations, operations,
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(porcupine.Operation{}, "Input", "Call", "ClientId"),


### PR DESCRIPTION
In the current implementation, we patch the return time of failed requests to infinite and save it in the report, so we lose the original return time. 

With the change in this PR, we would now save the return time as-is, and during validation, we patch it to infinite. 

Reference:
- https://github.com/etcd-io/etcd/issues/19579
- https://github.com/etcd-io/etcd/pull/19651#discussion_r2011549432

Closes https://github.com/etcd-io/etcd/issues/19579

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

