### PR TITLE
Update 3.6 changelog to cover the revert client/v2 change

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -13,6 +13,7 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 ### etcd server
 
 - [Auto sync members in v3store for the issues which have already been affected by #19557](https://github.com/etcd-io/etcd/pull/19636).
+- [Move `client/internal/v2` into `server/internel/clientv2`](https://github.com/etcd-io/etcd/pull/19673).
 
 ### Dependencies
 


### PR DESCRIPTION
Link to 
- https://github.com/etcd-io/etcd/pull/19671
- https://github.com/etcd-io/etcd/issues/19670
- https://github.com/etcd-io/etcd/pull/19673

cc @fuweid @ivanvc @serathius @liggitt 