### PR TITLE
codecov: set commit sha for merges

### DIFF
--- a/scripts/codecov_upload.sh
+++ b/scripts/codecov_upload.sh
@@ -10,7 +10,7 @@ curl -sf -o ./bin/codecov.sh https://codecov.io/bash
 
 bash ./bin/codecov.sh -f "${COVERDIR}/all.coverprofile" \
   -cF all \
-  -C "${PULL_PULL_SHA}" \
+  -C "${PULL_PULL_SHA:-${PULL_BASE_SHA}}" \
   -r "${REPO_OWNER}/${REPO_NAME}" \
   -P "${PULL_NUMBER}" \
   -b "${BUILD_ID}" \


### PR DESCRIPTION
This is required to upload a Codecov report in a Prow post submit job.

Reference: 
* Prow documentation: https://docs.prow.k8s.io/docs/jobs/
* Codecov bash script:
   ```
   -C sha       Specify the commit sha
   ```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
