### PR TITLE
Fix "make verify" failing in MacOS due to BOM file verification.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -502,7 +502,10 @@ function bom_pass {
   run cp go.sum go.sum.tmp || return 2
   run cp go.mod go.mod.tmp || return 2
 
-  output=$(GOFLAGS=-mod=mod run_go_tool github.com/appscodelabs/license-bill-of-materials \
+  # BOM file should be generated for linux. Otherwise running this command on other operating systems such as OSX
+  # results in certain dependencies being excluded from the BOM file, such as procfs. 
+  # For more info, https://github.com/etcd-io/etcd/issues/19665
+  output=$(GOOS=linux GOFLAGS=-mod=mod run_go_tool github.com/appscodelabs/license-bill-of-materials \
     --override-file ./bill-of-materials.override.json \
     "${modules[@]}")
   code="$?"

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -320,7 +320,7 @@ function tool_pkg_dir {
 # tool_get_bin [tool]
 function run_go_tool {
   local cmdbin
-  if ! cmdbin=$(GOARCH="" tool_get_bin "${1}"); then
+  if ! cmdbin=$(GOARCH="" GOOS="" tool_get_bin "${1}"); then
     log_warning "Failed to install tool '${1}'"
     return 2
   fi

--- a/scripts/updatebom.sh
+++ b/scripts/updatebom.sh
@@ -14,7 +14,10 @@ function bom_fixlet {
   # shellcheck disable=SC2207
   modules=($(modules_for_bom))
 
-  if GOFLAGS=-mod=mod run_go_tool "github.com/appscodelabs/license-bill-of-materials" \
+  # BOM file should be generated for linux. Otherwise running this command on other operating systems such as OSX
+  # results in certain dependencies being excluded from the BOM file, such as procfs. 
+  # For more info, https://github.com/etcd-io/etcd/issues/19665
+  if GOOS=linux GOFLAGS=-mod=mod run_go_tool "github.com/appscodelabs/license-bill-of-materials" \
       --override-file ./bill-of-materials.override.json \
       "${modules[@]}" > ./bill-of-materials.json.tmp; then
     cp ./bill-of-materials.json.tmp ./bill-of-materials.json


### PR DESCRIPTION
Fixes #19665

`procfs` wasn't included in BOM while building in MacOS systems because it is only available in linux based systems. It caused `make verify` command to fail and `make fix-bom` to update BOM incorrectly.

I have inspected the `license-bill-of-materials` tool, [here](https://github.com/appscodelabs/license-bill-of-materials/blob/6018e0c5287c58796f780a14f5ee3b13c4e0d0fe/license-bill-of-materials.go#L251) you will see that `go list ...` command is used to determine dependencies. I have figured passing the `GOOS=linux` environment variable to the program forces it to fetch dependencies for the linux environment, which is what we run in our CI/CD.