### PR TITLE
Assume v2 store is always not nil

### DIFF
--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -666,6 +666,7 @@ func newTestCluster(tb testing.TB, membs []*Member) *RaftCluster {
 		members: make(map[types.ID]*Member),
 		removed: make(map[types.ID]bool),
 		be:      newMembershipBackend(),
+		v2store: v2store.New(),
 	}
 	for _, m := range membs {
 		c.members[m.ID] = m

--- a/server/etcdserver/api/membership/membership_test.go
+++ b/server/etcdserver/api/membership/membership_test.go
@@ -34,10 +34,6 @@ func TestAddRemoveMember(t *testing.T) {
 	c.AddMember(newTestMember(18, nil, "node18", nil), true)
 	c.RemoveMember(18, true)
 
-	// Skipping removal of already removed member
-	c.RemoveMember(17, true)
-	c.RemoveMember(18, true)
-
 	c.AddMember(newTestMember(19, nil, "node19", nil), true)
 
 	// Recover from backend

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1510,6 +1510,7 @@ func newTestCluster(tb testing.TB) *membership.RaftCluster {
 func newTestClusterWithBackend(tb testing.TB, membs []*membership.Member, be backend.Backend) *membership.RaftCluster {
 	lg := zaptest.NewLogger(tb)
 	c := membership.NewCluster(lg)
+	c.SetStore(v2store.New())
 	c.SetBackend(schema.NewMembershipBackend(lg, be))
 	for _, m := range membs {
 		c.AddMember(m, true)


### PR DESCRIPTION
I didn't find know any case where during server lifecycle v2store would be nil. I have a sad suspicion that this condition was introduced just for testing.

Would like to introduce hard assumption to v2 not being nil to ensure that it is properly tested and we are 100% sure that when we move to v3 storage the v2 is not used.