### PR TITLE
Update 3.6 changelog to cover the membership validation update

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -10,6 +10,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.0-rc.4 (TBC)
 
+### etcd server
+
+- [Switch to validating v3 when v2 and v3 are synchronized](https://github.com/etcd-io/etcd/pull/19703).
+
 <hr>
 
 ## v3.6.0-rc.3 (2025-03-27)


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/19703 , which is backport of https://github.com/etcd-io/etcd/pull/19694

I will also add the verification in release-3.6 as mentioned in https://github.com/etcd-io/etcd/pull/19694#issuecomment-2768913482 

After that, we should be ready to release `v3.6.0-rc.4`. 

cc @ivanvc @jmhbnz @serathius 