### PR TITLE
Update release note for bumping Go to 1.23.8/1.24.2

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -8,7 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### Dependencies
 - Bump [golang.org/x/net to v0.36.0 to address CVE-2025-22870](https://github.com/etcd-io/etcd/pull/19529).
-- Compile binaries using [go 1.23.7](https://github.com/etcd-io/etcd/pull/19533)
+- Compile binaries using [go 1.23.8](https://github.com/etcd-io/etcd/pull/19726)
 
 <hr>
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -5,6 +5,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.22 (TBC)
 
+### Dependencies
+
+- Compile binaries using [go 1.23.8](https://github.com/etcd-io/etcd/pull/19725)
+
 <hr>
 
 ## v3.5.21 (2025-03-27)

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -14,6 +14,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 - [Switch to validating v3 when v2 and v3 are synchronized](https://github.com/etcd-io/etcd/pull/19703).
 
+### Dependencies
+
+- Compile binaries using [go 1.23.8](https://github.com/etcd-io/etcd/pull/19724)
+
 <hr>
 
 ## v3.6.0-rc.3 (2025-03-27)

--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 
 ## v3.7.0 (TBD)
 
+### Dependencies
+
+- Compile binaries using [go 1.24.2](https://github.com/etcd-io/etcd/pull/19723)
+
 ### Deprecations
 
 - Deprecated [UsageFunc in pkg/cobrautl](https://github.com/etcd-io/etcd/pull/18356).


### PR DESCRIPTION
Reference:
- https://github.com/etcd-io/etcd/issues/19713


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
