### PR TITLE
feat(client/v3/naming): deprecate usage of gresolver.Address.Metadata

### DIFF
--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"google.golang.org/grpc/attributes"
 )
 
 // Endpoint represents a single address the connection can be established with.
@@ -33,6 +35,10 @@ type Endpoint struct {
 	// to make load balancing decision.
 	// Since etcd 3.1
 	Metadata any
+
+	// Attributes contains arbitrary data about this address
+	// Since etcd 3.5
+	Attributes *attributes.Attributes
 }
 
 type Operation uint8


### PR DESCRIPTION
This implementation adds the new Addributes field to resolver to better align with gRPC's API as highlighted in issue #19706


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
