### PR TITLE
Remove required headings rule in markdown checker

### DIFF
--- a/tools/.markdownlint.jsonc
+++ b/tools/.markdownlint.jsonc
@@ -195,12 +195,7 @@
     "MD042": true,
   
     // MD043/required-headings : Required heading structure : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md043.md
-    "MD043": {
-      // List of headings
-      "headings": [],
-      // Match case of headings
-      "match_case": false
-    },
+    "MD043": false,
   
     // MD044/proper-names : Proper names should have the correct capitalization : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md044.md
     "MD044": {


### PR DESCRIPTION
Since our markdown files can be quite varying, we can remove the enforced headings rule. 

Should allow PRs such as https://github.com/etcd-io/etcd/pull/19717 to pass `pull-etcd-markdown-lint` test. Refer to [this](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/19717/pull-etcd-markdown-lint/1910163428895363072) message in prow. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
