### PR TITLE
CHAGELOG-3.6: Remove `etcdutl snapshot save` removal note

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -87,7 +87,6 @@ See [code changes](https://github.com/etcd-io/etcd/compare/v3.5.0...v3.6.0).
 - Removed [etcdctl defrag --data-dir](https://github.com/etcd-io/etcd/pull/13793).
 - Removed [etcdctl snapshot status](https://github.com/etcd-io/etcd/pull/13809).
 - Removed [etcdctl snapshot restore](https://github.com/etcd-io/etcd/pull/13809).
-- Removed [etcdutl snapshot save](https://github.com/etcd-io/etcd/pull/13809).
 - Removed [NewZapCoreLoggerBuilder in server/embed](https://github.com/etcd-io/etcd/pull/19404)
 
 ### etcdctl v3


### PR DESCRIPTION
`etcdutl snapshot save` never made it to v3.5, so there's no need to list it as a deprecation/removal.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
