### PR TITLE
Add Support for Unix Socket Connections in etcd Client

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -1215,9 +1215,8 @@ func (cfg *Config) Validate() error {
 		addrs := cfg.getAdvertisePeerURLs()
 		return fmt.Errorf(`--initial-advertise-peer-urls %q must be "host:port" (%w)`, strings.Join(addrs, ","), err)
 	}
-	if err := checkHostURLs(cfg.AdvertiseClientUrls); err != nil {
-		addrs := cfg.getAdvertiseClientURLs()
-		return fmt.Errorf(`--advertise-client-urls %q must be "host:port" (%w)`, strings.Join(addrs, ","), err)
+	if err := checkBindURLs(cfg.AdvertiseClientUrls); err != nil {
+		return err
 	}
 	// Check if conflicting flags are passed.
 	nSet := 0


### PR DESCRIPTION
This pull request addresses [issue #19704](https://github.com/etcd-io/etcd/issues/19704), which highlights the lack of support for connecting to etcd servers using the Unix socket format (unix://). The changes introduce support for Unix sockets, making it possible to leverage them in single-node etcd setups for local communication. The validation logic has been updated to allow Unix socket schemes while ensuring compatibility with the existing host:port format required for multi-node clusters.
