### PR TITLE
adt: split interval tree by right endpoint on matched left endpoints

### DIFF
--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -472,8 +472,16 @@ func (ivt *intervalTree) Insert(ivl Interval, val any) {
 	x := ivt.root
 	for x != ivt.sentinel {
 		y = x
-		if z.iv.Ivl.Begin.Compare(x.iv.Ivl.Begin) < 0 {
+		// Split on left endpoint. If left endpoints match, instead split on right endpoint.
+		beginCompare := z.iv.Ivl.Begin.Compare(x.iv.Ivl.Begin)
+		if beginCompare < 0 {
 			x = x.left
+		} else if beginCompare == 0 {
+			if z.iv.Ivl.End.Compare(x.iv.Ivl.End) < 0 {
+				x = x.left
+			} else {
+				x = x.right
+			}
 		} else {
 			x = x.right
 		}
@@ -483,8 +491,15 @@ func (ivt *intervalTree) Insert(ivl Interval, val any) {
 	if y == ivt.sentinel {
 		ivt.root = z
 	} else {
-		if z.iv.Ivl.Begin.Compare(y.iv.Ivl.Begin) < 0 {
+		beginCompare := z.iv.Ivl.Begin.Compare(y.iv.Ivl.Begin)
+		if beginCompare < 0 {
 			y.left = z
+		} else if beginCompare == 0 {
+			if z.iv.Ivl.End.Compare(y.iv.Ivl.End) < 0 {
+				y.left = z
+			} else {
+				y.right = z
+			}
 		} else {
 			y.right = z
 		}
@@ -701,16 +716,29 @@ func (ivt *intervalTree) Visit(ivl Interval, ivv IntervalVisitor) {
 
 // find the exact node for a given interval
 func (ivt *intervalTree) find(ivl Interval) *intervalNode {
-	ret := ivt.sentinel
-	f := func(n *intervalNode) bool {
-		if n.iv.Ivl != ivl {
-			return true
+	x := ivt.root
+	// Search until hit sentinel or exact match.
+	for x != ivt.sentinel {
+		beginCompare := ivl.Begin.Compare(x.iv.Ivl.Begin)
+		endCompare := ivl.End.Compare(x.iv.Ivl.End)
+		if beginCompare == 0 && endCompare == 0 {
+			return x
 		}
-		ret = n
-		return false
+		// Split on left endpoint. If left endpoints match,
+		// instead split on right endpoints.
+		if beginCompare < 0 {
+			x = x.left
+		} else if beginCompare == 0 {
+			if endCompare < 0 {
+				x = x.left
+			} else {
+				x = x.right
+			}
+		} else {
+			x = x.right
+		}
 	}
-	ivt.root.visit(&ivl, ivt.sentinel, f)
-	return ret
+	return x
 }
 
 // Find gets the IntervalValue for the node matching the given interval


### PR DESCRIPTION
Splits interval trees by right endpoint on matched left endpoints, to improve exact interval matching performance. 
This addresses the issue: https://github.com/etcd-io/etcd/issues/19769


Additionally I've attached below code snippets and outputs for non-rigorous (Go benchmarks on before/after performance of `Find()` and `Insert()` on randomly built interval trees with multiple occurrences of given left/right endpoint values, which is the regime where I think a performance difference may appear. Run on my laptop, there appears to be no change to the `Insert()` op performance, but a roughly 88% at p-value of 0 (according to benchstat output below) performance increase in `Find()`, on such interval trees.

```
// Benchmark of the Insert op on random interval trees of up to 128 nodes with endpoint values in 0..9
func BenchmarkIntervalTreeRandomInsert(b *testing.B) {
	ivs := make(map[xy]struct{})
	ivt := NewIntervalTree()
	maxv := 128

	xmax := 10
	ymax := 10

	for b.Loop() {
		// Setup random tree.
		for i := rand.Intn(maxv) + 1; i != 0; i-- {
			x, y := int64(rand.Intn(xmax)), int64(rand.Intn(ymax))
			if x > y {
				t := x
				x = y
				y = t
			} else if x == y {
				y++
			}
			iv := xy{x, y}
			if _, ok := ivs[iv]; ok {
				// don't double insert
				continue
			}
			ivt.Insert(NewInt64Interval(x, y), 123)
			ivs[iv] = struct{}{}
		}
	}

}

// Benchmark of the Find op on random interval trees of up to 128 nodes with endpoint values in 0..9
func BenchmarkIntervalTreeRandomFind(b *testing.B) {
	ivs := make(map[xy]struct{})
	ivt := NewIntervalTree()
	maxv := 128

	xmax := 10
	ymax := 10

	// Setup random tree.
	for i := rand.Intn(maxv) + 1; i != 0; i-- {
		x, y := int64(rand.Intn(xmax)), int64(rand.Intn(ymax))
		if x > y {
			t := x
			x = y
			y = t
		} else if x == y {
			y++
		}
		iv := xy{x, y}
		if _, ok := ivs[iv]; ok {
			// don't double insert
			continue
		}
		ivt.Insert(NewInt64Interval(x, y), 123)
		ivs[iv] = struct{}{}
	}

	// Benchmark Find() operation time.
	for b.Loop() {
		for ab := range ivs {
			_ = ivt.Find(NewInt64Interval(ab.x, ab.y))
		}
	}
}


```

Benchmark results for before (count of 10 in each case)

```

goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
BenchmarkIntervalTreeRandomFind-10    	   79048	     15180 ns/op
BenchmarkIntervalTreeRandomFind-10    	   67766	     17690 ns/op
BenchmarkIntervalTreeRandomFind-10    	   94506	     12688 ns/op
BenchmarkIntervalTreeRandomFind-10    	   77904	     15427 ns/op
BenchmarkIntervalTreeRandomFind-10    	  157444	      7627 ns/op
BenchmarkIntervalTreeRandomFind-10    	  247746	      4840 ns/op
BenchmarkIntervalTreeRandomFind-10    	   72440	     16566 ns/op
BenchmarkIntervalTreeRandomFind-10    	   98607	     12179 ns/op
BenchmarkIntervalTreeRandomFind-10    	   76416	     15652 ns/op
BenchmarkIntervalTreeRandomFind-10    	   67321	     17829 ns/op
PASS
ok  	go.etcd.io/etcd/pkg/v3/adt	12.270s


goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
BenchmarkIntervalTreeRandomInsert-10    	  531319	      2243 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  555193	      2137 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  555756	      2158 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  554901	      2136 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  542766	      2194 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  546540	      2212 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  555234	      2195 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  549458	      2154 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  543097	      2240 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  535682	      2254 ns/op
PASS
ok  	go.etcd.io/etcd/pkg/v3/adt	12.278s

```

Benchmark results for after:

```
goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
BenchmarkIntervalTreeRandomFind-10    	  698035	      1720 ns/op
BenchmarkIntervalTreeRandomFind-10    	 2167977	       553.4 ns/op
BenchmarkIntervalTreeRandomFind-10    	  692677	      1734 ns/op
BenchmarkIntervalTreeRandomFind-10    	 1000000	      1142 ns/op
BenchmarkIntervalTreeRandomFind-10    	  667176	      1797 ns/op
BenchmarkIntervalTreeRandomFind-10    	  714930	      1679 ns/op
BenchmarkIntervalTreeRandomFind-10    	  778672	      1543 ns/op
BenchmarkIntervalTreeRandomFind-10    	  687740	      1745 ns/op
BenchmarkIntervalTreeRandomFind-10    	  659038	      1823 ns/op
BenchmarkIntervalTreeRandomFind-10    	  643330	      1859 ns/op
PASS
ok  	go.etcd.io/etcd/pkg/v3/adt	12.244s

goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
BenchmarkIntervalTreeRandomInsert-10    	  553756	      2149 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  540813	      2224 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  546811	      2181 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  525974	      2237 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  542532	      2218 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  514786	      2328 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  538801	      2233 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  532995	      2262 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  526350	      2265 ns/op
BenchmarkIntervalTreeRandomInsert-10    	  559215	      2183 ns/op
PASS
ok  	go.etcd.io/etcd/pkg/v3/adt	12.296s

```


Benchstat (https://pkg.go.dev/golang.org/x/perf/cmd/benchstat#hdr-Example) summary:

```
goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
                          │ old_find.txt  │             new_find.txt             │
                          │    sec/op     │    sec/op     vs base                │
IntervalTreeRandomFind-10   15.304µ ± 50%   1.727µ ± 34%  -88.71% (p=0.000 n=10)



goos: darwin
goarch: arm64
pkg: go.etcd.io/etcd/pkg/v3/adt
cpu: Apple M1 Pro
                            │ old_insert.txt │        new_insert.txt         │
                            │     sec/op     │   sec/op     vs base          │
IntervalTreeRandomInsert-10      2.195µ ± 3%   2.228µ ± 2%  ~ (p=0.190 n=10)

```

which I believe says, for the above benchmark cases, 88% speedup with p-value of 0 for `Find`, and no noticeable difference for `Insert`.