### PR TITLE
Add bearer support for authorization headers

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -72,6 +72,8 @@ const (
 
 	tokenTypeSimple = "simple"
 	tokenTypeJWT    = "jwt"
+
+	bearerPrefix = "Bearer "
 )
 
 type AuthInfo struct {
@@ -1072,6 +1074,12 @@ func (as *authStore) AuthInfoFromCtx(ctx context.Context) (*AuthInfo, error) {
 	}
 
 	token := ts[0]
+
+	// support authorization headers with bearer prefix.
+	if strings.HasPrefix(token, bearerPrefix) {
+		token = strings.Split(token, bearerPrefix)[1]
+	}
+
 	authInfo, uok := as.authInfoFromToken(ctx, token)
 	if !uok {
 		as.lg.Warn("invalid auth token", zap.String("token", token))

--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -1077,7 +1077,7 @@ func (as *authStore) AuthInfoFromCtx(ctx context.Context) (*AuthInfo, error) {
 
 	// support authorization headers with bearer prefix.
 	if strings.HasPrefix(token, bearerPrefix) {
-		token = strings.Split(token, bearerPrefix)[1]
+		token = token[len(bearerPrefix):]
 	}
 
 	authInfo, uok := as.authInfoFromToken(ctx, token)

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -836,13 +836,40 @@ func TestAuthInfoFromCtx(t *testing.T) {
 		t.Errorf("expected %v, got %v", ErrInvalidAuthToken, err)
 	}
 
+	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: "Bearer"}))
+	_, err = as.AuthInfoFromCtx(ctx)
+	if !errors.Is(err, ErrInvalidAuthToken) {
+		t.Errorf("expected %v, got %v", ErrInvalidAuthToken, err)
+	}
+
 	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: "Invalid.Token"}))
 	_, err = as.AuthInfoFromCtx(ctx)
 	if !errors.Is(err, ErrInvalidAuthToken) {
 		t.Errorf("expected %v, got %v", ErrInvalidAuthToken, err)
 	}
 
+	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: bearerPrefix + "Invalid.Token"}))
+	_, err = as.AuthInfoFromCtx(ctx)
+	if !errors.Is(err, ErrInvalidAuthToken) {
+		t.Errorf("expected %v, got %v", ErrInvalidAuthToken, err)
+	}
+
+	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: bearerPrefix}))
+	_, err = as.AuthInfoFromCtx(ctx)
+	if !errors.Is(err, ErrInvalidAuthToken) {
+		t.Errorf("expected %v, got %v", ErrInvalidAuthToken, err)
+	}
+
 	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: resp.Token}))
+	ai, err = as.AuthInfoFromCtx(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	if ai.Username != "foo" {
+		t.Errorf("expected %v, got %v", "foo", ai.Username)
+	}
+
+	ctx = metadata.NewIncomingContext(t.Context(), metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: bearerPrefix + resp.Token}))
 	ai, err = as.AuthInfoFromCtx(ctx)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This PR tries to fix #19752. It adds support to authorization headers containing the keyword `Bearer`. It would let proxies expecting bearer headers work with etcd APIs.