### PR TITLE
feat(client/v3/naming): add Attributes into Endpoint and deprecate Metadata

### DIFF
--- a/client/v3/internal/resolver/resolver.go
+++ b/client/v3/internal/resolver/resolver.go
@@ -61,13 +61,15 @@ func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
 
 func (r EtcdManualResolver) updateState() {
 	if r.CC != nil {
-		addresses := make([]resolver.Address, len(r.endpoints))
+		eps := make([]resolver.Endpoint, len(r.endpoints))
 		for i, ep := range r.endpoints {
 			addr, serverName := endpoint.Interpret(ep)
-			addresses[i] = resolver.Address{Addr: addr, ServerName: serverName}
+			eps[i] = resolver.Endpoint{Addresses: []resolver.Address{
+				{Addr: addr, ServerName: serverName},
+			}}
 		}
 		state := resolver.State{
-			Addresses:     addresses,
+			Endpoints:     eps,
 			ServiceConfig: r.serviceConfig,
 		}
 		r.UpdateState(state)

--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -32,6 +32,8 @@ type Endpoint struct {
 	// Metadata is the information associated with Addr, which may be used
 	// to make load balancing decision.
 	// Since etcd 3.1
+	//
+	// Deprecated: The field is deprecated and should not be used.
 	Metadata any
 }
 

--- a/client/v3/naming/resolver/resolver.go
+++ b/client/v3/naming/resolver/resolver.go
@@ -100,22 +100,26 @@ func (r *resolver) watch() {
 				}
 			}
 
-			addrs := convertToGRPCAddress(allUps)
-			r.cc.UpdateState(gresolver.State{Addresses: addrs})
+			eps := convertToGRPCEndpoint(allUps)
+			r.cc.UpdateState(gresolver.State{Endpoints: eps})
 		}
 	}
 }
 
-func convertToGRPCAddress(ups map[string]*endpoints.Update) []gresolver.Address {
-	var addrs []gresolver.Address
+func convertToGRPCEndpoint(ups map[string]*endpoints.Update) []gresolver.Endpoint {
+	var eps []gresolver.Endpoint
 	for _, up := range ups {
-		addr := gresolver.Address{
-			Addr:     up.Endpoint.Addr,
-			Metadata: up.Endpoint.Metadata,
+		ep := gresolver.Endpoint{
+			Addresses: []gresolver.Address{
+				{
+					Addr:     up.Endpoint.Addr,
+					Metadata: up.Endpoint.Metadata,
+				},
+			},
 		}
-		addrs = append(addrs, addr)
+		eps = append(eps, ep)
 	}
-	return addrs
+	return eps
 }
 
 // ResolveNow is a no-op here.


### PR DESCRIPTION
This implementation adds the new Attributes *attributes.Attributes into Endpoint and deprecate Metadata accordingly. The metadata field is still supported for backward compatibility

Fixes #19706 

cc: @ahrtr @siyuanfoundation

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
