### PR TITLE
mardownlint: allow hr inline tags

### DIFF
--- a/tools/.markdownlint.jsonc
+++ b/tools/.markdownlint.jsonc
@@ -148,7 +148,7 @@
     // MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md033.md
     "MD033": {
       // Allowed elements
-      "allowed_elements": []
+      "allowed_elements": ["hr"]
     },
   
     // MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md034.md


### PR DESCRIPTION
The CHANGELOG uses `<hr />` instead of `---` historically. Adding an exception to `MD033` to allow this HTML tag.

Link to https://github.com/etcd-io/etcd/pull/19789#discussion_r2056719094, #18059.

/cc @ahrtr 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
