### PR TITLE
pkg/featuregate: Return MutableFeatureGate interface in New function

### DIFF
--- a/pkg/featuregate/feature_gate.go
+++ b/pkg/featuregate/feature_gate.go
@@ -166,7 +166,7 @@ func setUnsetBetaGates(known map[Feature]FeatureSpec, enabled map[Feature]bool, 
 // Set, String, and Type implement pflag.Value
 var _ pflag.Value = &featureGate{}
 
-func New(name string, lg *zap.Logger) *featureGate {
+func New(name string, lg *zap.Logger) MutableFeatureGate {
 	if lg == nil {
 		lg = zap.NewNop()
 	}

--- a/pkg/featuregate/feature_gate_test.go
+++ b/pkg/featuregate/feature_gate_test.go
@@ -219,7 +219,7 @@ func TestFeatureGateFlag(t *testing.T) {
 				t.Errorf("%d: Parse() Expected nil, Got %v", i, err)
 			}
 			for k, v := range test.expect {
-				actual := f.enabled.Load().(map[Feature]bool)[k]
+				actual := f.Enabled(k)
 				assert.Equalf(t, actual, v, "%d: expected %s=%v, Got %v", i, k, v, actual)
 			}
 		})


### PR DESCRIPTION
Avoid returning an unexported struct in the exported New function. Instead, return the MutableFeatureGate interface.

I found this issue in the recently introduced `featuregate` package while reviewing the staleness of #18370. Since this package was introduced in v3.6, it makes sense to merge and backport to `release-3.6`.

/cc @ahrtr @siyuanfoundation 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
