### PR TITLE
Add image scan script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,14 @@ run-govulncheck:
 install-golangci-lint:
 	./scripts/verify_golangci-lint_version.sh
 
+TRIVY_VERSION = $(shell cut -d: -f2 tools/container-images/trivy/Dockerfile | sed 's/^/v/')
+.PHONY: install-trivy
+install-trivy: bin/trivy
+bin/trivy: bin/trivy-$(TRIVY_VERSION)
+	cd bin && ln -sf ./trivy-$(TRIVY_VERSION)/trivy
+bin/trivy-$(TRIVY_VERSION):
+	curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-$(TRIVY_VERSION) $(TRIVY_VERSION)
+
 .PHONY: install-lazyfs
 install-lazyfs: bin/lazyfs
 bin/lazyfs:

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,10 @@ bin/trivy: bin/trivy-$(TRIVY_VERSION)
 bin/trivy-$(TRIVY_VERSION):
 	curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin/trivy-$(TRIVY_VERSION) $(TRIVY_VERSION)
 
+.PHONY: run-trivy-image-scan
+run-trivy-image-scan: install-trivy
+	./scripts/run_trivy_image_scan.sh $(VERSION)
+
 .PHONY: install-lazyfs
 install-lazyfs: bin/lazyfs
 bin/lazyfs:

--- a/scripts/run_trivy_image_scan.sh
+++ b/scripts/run_trivy_image_scan.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Default image registry to use.
+REGISTRY=${REGISTRY:-gcr.io/etcd-development/etcd}
+
+# Default severity levels to report.
+SEVERITY=${SEVERITY:-HIGH,CRITICAL}
+
+source ./scripts/test_lib.sh
+
+if [ "$#" -lt 1 ]; then
+  log_error "Error: missing version to check."
+  log_error "Usage: ${0} <VERSION TO CHECK>"
+  log_error "Example: ${0} 3.7"
+  exit 1
+fi
+
+if ! command -v "${ETCD_ROOT_DIR}/bin/trivy" >/dev/null; then
+  log_error "Error: Cannot find trivy. Please run make install-trivy."
+  exit 1
+fi
+
+function main {
+  local version=${1#v}
+
+  if [ $(tr -dc '.' <<<"$version" | wc -c) -eq 1 ]; then
+    # Resolve the latest version for the minor
+    version=$(git ls-remote --tags https://github.com/etcd-io/etcd.git |
+      grep --only-matching --perl-regexp "(?<=v)${version}.[\d]+(?:-[\w.]+)?(?=[\^])" |
+      sort --numeric-sort --key 1.5 | tail -1)
+  fi
+
+  trivy image --severity "${SEVERITY}" "${REGISTRY}:v${version}"
+}
+
+main "$1"

--- a/tools/container-images/README.md
+++ b/tools/container-images/README.md
@@ -3,8 +3,17 @@
 The container images defined in this directory are used to maintain
 depenendencies up to date. **These images are not used to build the project.**
 
-These images cause [Dependabot] to do a version bump. After that, a [GitHub
-action] will update other artifacts in the repository.
+## `devcontainer`
+
+The `devcontainer` image triggers [Dependabot] to do a version bump. After that,
+a [GitHub action] will update other artifacts in the repository.
+
+## `trivy`
+
+We keep the `trivy` image to track the tool version. Even though it is a Go
+project, it's not possible to track it as our other tools
+(`tools/mod/tools.go`), because they point the Go directive to the latest
+version patch. This breaks our Go workspace.
 
 [Dependabot]: ../../.github/dependabot.yml
 [GitHub action]: ../../.github/workflows/bump-devcontainer-version.yml

--- a/tools/container-images/trivy/Dockerfile
+++ b/tools/container-images/trivy/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/aquasec/trivy:0.72.0


### PR DESCRIPTION
Introduce a new script that can run on stable branches that checks the vulnerabilities for the latest tag (from the given branch).

Adds Trivy as a tool dependency, to keep track of the latest released version.

A periodic Prow job will later execute this. We'll get alerts when a CVE is found in our images, either by a direct vulnerability or for a dependency with a reported vulnerability of high or critical severity.

Part of #19363.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
