### PR TITLE
[release-3.4] Add run-govulncheck Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,3 +563,10 @@ fix: sync-toolchain-directive
 .PHONY: sync-toolchain-directive
 sync-toolchain-directive:
 	./scripts/sync_go_toolchain_directive.sh
+
+.PHONY: run-govulncheck
+run-govulncheck:
+ifeq (, $(shell which govulncheck))
+	$(shell go install golang.org/x/vuln/cmd/govulncheck@latest)
+endif
+	PASSES="govuln" ./test

--- a/test
+++ b/test
@@ -451,6 +451,10 @@ function markdown_marker_pass {
 	fi
 }
 
+function govuln_pass {
+  	govulncheck -show verbose ./...
+}
+
 function goword_pass {
 	if command -v goword >/dev/null; then
 		# get all go files to process


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Add `run-govulncheck` Makefile target for release-3.4 Prow job.

<details>
<summary> Results </summary>
<pre>
➜  etcd git:(makefile-govulncheck) ✗ make run-govulncheck
PASSES="govuln" ./test
Running with TEST_CPUS: 1,2,4
Starting 'govuln' pass at Sun Apr 27 12:13:44 AM +08 2025
Fetching vulnerabilities from the database...

Checking the code against the vulnerabilities...

The package pattern matched the following 131 root packages:
  go.etcd.io/etcd/auth/authpb
  go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes
  go.etcd.io/etcd/clientv3/credentials
  go.etcd.io/etcd/clientv3/internal/endpoint
  go.etcd.io/etcd/clientv3/internal/resolver
  go.etcd.io/etcd/mvcc/mvccpb
  go.etcd.io/etcd/etcdserver/etcdserverpb
  go.etcd.io/etcd/pkg/systemd
  go.etcd.io/etcd/raft/quorum
  go.etcd.io/etcd/raft/raftpb
  go.etcd.io/etcd/raft/tracker
  go.etcd.io/etcd/raft/confchange
  go.etcd.io/etcd/raft
  go.etcd.io/etcd/pkg/logutil
  go.etcd.io/etcd/pkg/types
  go.etcd.io/etcd/version
  go.etcd.io/etcd/clientv3
  go.etcd.io/etcd/clientv3/concurrency
  go.etcd.io/etcd/clientv3/leasing
  go.etcd.io/etcd/clientv3/namespace
  go.etcd.io/etcd/clientv3/ordering
  go.etcd.io/etcd/mvcc/backend
  go.etcd.io/etcd/pkg/adt
  go.etcd.io/etcd/auth
  go.etcd.io/etcd/etcdserver/api/v2error
  go.etcd.io/etcd/etcdserver/api/v2store
  go.etcd.io/etcd/pkg/cpuutil
  go.etcd.io/etcd/pkg/netutil
  go.etcd.io/etcd/etcdserver/api/membership
  go.etcd.io/etcd/etcdserver/api
  go.etcd.io/etcd/etcdserver/api/snap/snappb
  go.etcd.io/etcd/pkg/fileutil
  go.etcd.io/etcd/pkg/ioutil
  go.etcd.io/etcd/pkg/pbutil
  go.etcd.io/etcd/wal/walpb
  go.etcd.io/etcd/etcdserver/api/snap
  go.etcd.io/etcd/etcdserver/api/v2stats
  go.etcd.io/etcd/pkg/httputil
  go.etcd.io/etcd/pkg/tlsutil
  go.etcd.io/etcd/pkg/transport
  go.etcd.io/etcd/etcdserver/api/rafthttp
  go.etcd.io/etcd/pkg/pathutil
  go.etcd.io/etcd/pkg/srv
  go.etcd.io/etcd/client
  go.etcd.io/etcd/etcdserver/api/v2discovery
  go.etcd.io/etcd/etcdserver/api/v2http/httptypes
  go.etcd.io/etcd/etcdserver/api/v3alarm
  go.etcd.io/etcd/lease/leasepb
  go.etcd.io/etcd/lease
  go.etcd.io/etcd/pkg/schedule
  go.etcd.io/etcd/pkg/traceutil
  go.etcd.io/etcd/mvcc
  go.etcd.io/etcd/etcdserver/api/v3compactor
  go.etcd.io/etcd/lease/leasehttp
  go.etcd.io/etcd/pkg/contention
  go.etcd.io/etcd/pkg/idutil
  go.etcd.io/etcd/pkg/runtime
  go.etcd.io/etcd/pkg/wait
  go.etcd.io/etcd/pkg/crc
  go.etcd.io/etcd/wal
  go.etcd.io/etcd/etcdserver
  go.etcd.io/etcd/etcdserver/api/etcdhttp
  go.etcd.io/etcd/etcdserver/api/v2auth
  go.etcd.io/etcd/etcdserver/api/v2http
  go.etcd.io/etcd/etcdserver/api/v2v3
  go.etcd.io/etcd/etcdserver/api/v3rpc
  go.etcd.io/etcd/etcdserver/api/v3election/v3electionpb
  go.etcd.io/etcd/etcdserver/api/v3lock/v3lockpb
  go.etcd.io/etcd/proxy/grpcproxy/adapter
  go.etcd.io/etcd/etcdserver/api/v3client
  go.etcd.io/etcd/etcdserver/api/v3election
  go.etcd.io/etcd/etcdserver/api/v3election/v3electionpb/gw
  go.etcd.io/etcd/etcdserver/api/v3lock
  go.etcd.io/etcd/etcdserver/api/v3lock/v3lockpb/gw
  go.etcd.io/etcd/etcdserver/etcdserverpb/gw
  go.etcd.io/etcd/etcdserver/verify
  go.etcd.io/etcd/pkg/debugutil
  go.etcd.io/etcd/pkg/flags
  go.etcd.io/etcd/embed
  go.etcd.io/etcd/pkg/osutil
  go.etcd.io/etcd/clientv3/naming/endpoints/internal
  go.etcd.io/etcd/clientv3/naming/endpoints
  go.etcd.io/etcd/proxy/grpcproxy/cache
  go.etcd.io/etcd/proxy/grpcproxy
  go.etcd.io/etcd/proxy/httpproxy
  go.etcd.io/etcd/proxy/tcpproxy
  go.etcd.io/etcd/etcdmain
  go.etcd.io/etcd
  go.etcd.io/etcd/client/integration
  go.etcd.io/etcd/clientv3/clientv3util
  go.etcd.io/etcd/clientv3/integration
  go.etcd.io/etcd/clientv3/integration/naming
  go.etcd.io/etcd/clientv3/mirror
  go.etcd.io/etcd/clientv3/naming
  go.etcd.io/etcd/clientv3/naming/resolver
  go.etcd.io/etcd/clientv3/snapshot
  go.etcd.io/etcd/clientv3/yaml
  go.etcd.io/etcd/contrib/raftexample
  go.etcd.io/etcd/contrib/recipes
  go.etcd.io/etcd/etcdctl/ctlv2/command
  go.etcd.io/etcd/etcdctl/ctlv2
  go.etcd.io/etcd/pkg/report
  go.etcd.io/etcd/etcdctl/ctlv3/command
  go.etcd.io/etcd/etcdctl/ctlv3
  go.etcd.io/etcd/etcdctl
  go.etcd.io/etcd/functional/rpcpb
  go.etcd.io/etcd/pkg/proxy
  go.etcd.io/etcd/functional/agent
  go.etcd.io/etcd/functional/cmd/etcd-agent
  go.etcd.io/etcd/functional/cmd/etcd-proxy
  go.etcd.io/etcd/pkg/stringutil
  go.etcd.io/etcd/functional/runner
  go.etcd.io/etcd/functional/cmd/etcd-runner
  go.etcd.io/etcd/functional/tester
  go.etcd.io/etcd/functional/cmd/etcd-tester
  go.etcd.io/etcd/pkg/testutil
  go.etcd.io/etcd/integration
  go.etcd.io/etcd/pkg/expect
  go.etcd.io/etcd/pkg/grpc_testing
  go.etcd.io/etcd/pkg/mock/mockserver
  go.etcd.io/etcd/pkg/mock/mockstorage
  go.etcd.io/etcd/pkg/mock/mockstore
  go.etcd.io/etcd/pkg/mock/mockwait
  go.etcd.io/etcd/raft/rafttest
  go.etcd.io/etcd/tests/e2e
  go.etcd.io/etcd/tools/benchmark/cmd
  go.etcd.io/etcd/tools/benchmark
  go.etcd.io/etcd/tools/etcd-dump-db
  go.etcd.io/etcd/tools/etcd-dump-logs
  go.etcd.io/etcd/tools/etcd-dump-metrics
  go.etcd.io/etcd/tools/local-tester/bridge
Govulncheck scanned the following 55 modules and the go1.23.8 standard library:
  go.etcd.io/etcd
  github.com/beorn7/perks@v1.0.1
  github.com/bgentry/speakeasy@v0.1.0
  github.com/cespare/xxhash/v2@v2.2.0
  github.com/cockroachdb/datadriven@v0.0.0-20190809214429-80d97fb3cbaa
  github.com/coreos/go-semver@v0.2.0
  github.com/coreos/go-systemd@v0.0.0-20180511133405-39ca1b05acc7
  github.com/coreos/pkg@v0.0.0-20160727233714-3ac0863d7acf
  github.com/creack/pty@v1.1.11
  github.com/dustin/go-humanize@v0.0.0-20171111073723-bb3d318650d4
  github.com/gogo/protobuf@v1.3.2
  github.com/golang-jwt/jwt/v4@v4.5.2
  github.com/golang/groupcache@v0.0.0-20160516000752-02826c3e7903
  github.com/golang/protobuf@v1.5.4
  github.com/google/btree@v1.0.0
  github.com/gorilla/websocket@v1.4.2
  github.com/grpc-ecosystem/go-grpc-middleware@v1.0.1-0.20190118093823-f849b5445de4
  github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0
  github.com/grpc-ecosystem/grpc-gateway@v1.11.0
  github.com/jonboulle/clockwork@v0.1.0
  github.com/json-iterator/go@v1.1.11
  github.com/mattn/go-runewidth@v0.0.2
  github.com/matttproud/golang_protobuf_extensions@v1.0.1
  github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd
  github.com/modern-go/reflect2@v1.0.1
  github.com/olekukonko/tablewriter@v0.0.0-20170122224234-a0225b3f23b5
  github.com/prometheus/client_golang@v1.11.1
  github.com/prometheus/client_model@v0.2.0
  github.com/prometheus/common@v0.26.0
  github.com/prometheus/procfs@v0.6.0
  github.com/sirupsen/logrus@v1.9.3
  github.com/soheilhy/cmux@v0.1.5
  github.com/spf13/cobra@v0.0.3
  github.com/spf13/pflag@v1.0.1
  github.com/tmc/grpc-websocket-proxy@v0.0.0-20200427203606-3cfed13b9966
  github.com/urfave/cli@v1.20.0
  github.com/xiang90/probing@v0.0.0-20190116061207-43a291ad63a2
  go.etcd.io/bbolt@v1.3.11
  go.uber.org/atomic@v1.3.2
  go.uber.org/multierr@v1.1.0
  go.uber.org/zap@v1.10.0
  golang.org/x/crypto@v0.35.0
  golang.org/x/net@v0.36.0
  golang.org/x/sync@v0.11.0
  golang.org/x/sys@v0.30.0
  golang.org/x/text@v0.22.0
  golang.org/x/time@v0.0.0-20180412165947-fbb02b2291d2
  google.golang.org/genproto@v0.0.0-20230711160842-782d3b101e98
  google.golang.org/genproto/googleapis/api@v0.0.0-20230711160842-782d3b101e98
  google.golang.org/genproto/googleapis/rpc@v0.0.0-20230711160842-782d3b101e98
  google.golang.org/grpc@v1.58.3
  google.golang.org/protobuf@v1.33.0
  gopkg.in/cheggaaa/pb.v1@v1.0.25
  gopkg.in/yaml.v2@v2.4.0
  sigs.k8s.io/yaml@v1.1.0

=== Symbol Results ===

No vulnerabilities found.

=== Package Results ===

No other vulnerabilities found.

=== Module Results ===

Vulnerability #1: GO-2025-3595
    Incorrect Neutralization of Input During Web Page Generation in x/net in
    golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2025-3595
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.36.0
    Fixed in: golang.org/x/net@v0.38.0

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Finished 'govuln' pass at Sun Apr 27 12:13:48 AM +08 2025
Success
</pre>
</details>

Example failure:
Using the example in https://go.dev/doc/tutorial/govulncheck, we can downgrade golang.org/x/text to v0.3.5

```bash
go get golang.org/x/text@v0.3.5
```

<details>
<summary> Results </summary>

<pre>
➜  etcd git:(makefile-govulncheck) ✗ make run-govulncheck
PASSES="govuln" ./test
Running with TEST_CPUS: 1,2,4
Starting 'govuln' pass at Sun Apr 27 12:20:55 AM +08 2025
Fetching vulnerabilities from the database...

Checking the code against the vulnerabilities...

The package pattern matched the following 131 root packages:
  go.etcd.io/etcd/auth/authpb
  go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes
  go.etcd.io/etcd/clientv3/credentials
  go.etcd.io/etcd/clientv3/internal/endpoint
  go.etcd.io/etcd/clientv3/internal/resolver
  go.etcd.io/etcd/mvcc/mvccpb
  go.etcd.io/etcd/etcdserver/etcdserverpb
  go.etcd.io/etcd/pkg/systemd
  go.etcd.io/etcd/raft/quorum
  go.etcd.io/etcd/raft/raftpb
  go.etcd.io/etcd/raft/tracker
  go.etcd.io/etcd/raft/confchange
  go.etcd.io/etcd/raft
  go.etcd.io/etcd/pkg/logutil
  go.etcd.io/etcd/pkg/types
  go.etcd.io/etcd/version
  go.etcd.io/etcd/clientv3
  go.etcd.io/etcd/clientv3/concurrency
  go.etcd.io/etcd/clientv3/leasing
  go.etcd.io/etcd/clientv3/namespace
  go.etcd.io/etcd/clientv3/ordering
  go.etcd.io/etcd/mvcc/backend
  go.etcd.io/etcd/pkg/adt
  go.etcd.io/etcd/auth
  go.etcd.io/etcd/etcdserver/api/v2error
  go.etcd.io/etcd/etcdserver/api/v2store
  go.etcd.io/etcd/pkg/cpuutil
  go.etcd.io/etcd/pkg/netutil
  go.etcd.io/etcd/etcdserver/api/membership
  go.etcd.io/etcd/etcdserver/api
  go.etcd.io/etcd/etcdserver/api/snap/snappb
  go.etcd.io/etcd/pkg/fileutil
  go.etcd.io/etcd/pkg/ioutil
  go.etcd.io/etcd/pkg/pbutil
  go.etcd.io/etcd/wal/walpb
  go.etcd.io/etcd/etcdserver/api/snap
  go.etcd.io/etcd/etcdserver/api/v2stats
  go.etcd.io/etcd/pkg/httputil
  go.etcd.io/etcd/pkg/tlsutil
  go.etcd.io/etcd/pkg/transport
  go.etcd.io/etcd/etcdserver/api/rafthttp
  go.etcd.io/etcd/pkg/pathutil
  go.etcd.io/etcd/pkg/srv
  go.etcd.io/etcd/client
  go.etcd.io/etcd/etcdserver/api/v2discovery
  go.etcd.io/etcd/etcdserver/api/v2http/httptypes
  go.etcd.io/etcd/etcdserver/api/v3alarm
  go.etcd.io/etcd/lease/leasepb
  go.etcd.io/etcd/lease
  go.etcd.io/etcd/pkg/schedule
  go.etcd.io/etcd/pkg/traceutil
  go.etcd.io/etcd/mvcc
  go.etcd.io/etcd/etcdserver/api/v3compactor
  go.etcd.io/etcd/lease/leasehttp
  go.etcd.io/etcd/pkg/contention
  go.etcd.io/etcd/pkg/idutil
  go.etcd.io/etcd/pkg/runtime
  go.etcd.io/etcd/pkg/wait
  go.etcd.io/etcd/pkg/crc
  go.etcd.io/etcd/wal
  go.etcd.io/etcd/etcdserver
  go.etcd.io/etcd/etcdserver/api/etcdhttp
  go.etcd.io/etcd/etcdserver/api/v2auth
  go.etcd.io/etcd/etcdserver/api/v2http
  go.etcd.io/etcd/etcdserver/api/v2v3
  go.etcd.io/etcd/etcdserver/api/v3rpc
  go.etcd.io/etcd/etcdserver/api/v3election/v3electionpb
  go.etcd.io/etcd/etcdserver/api/v3lock/v3lockpb
  go.etcd.io/etcd/proxy/grpcproxy/adapter
  go.etcd.io/etcd/etcdserver/api/v3client
  go.etcd.io/etcd/etcdserver/api/v3election
  go.etcd.io/etcd/etcdserver/api/v3election/v3electionpb/gw
  go.etcd.io/etcd/etcdserver/api/v3lock
  go.etcd.io/etcd/etcdserver/api/v3lock/v3lockpb/gw
  go.etcd.io/etcd/etcdserver/etcdserverpb/gw
  go.etcd.io/etcd/etcdserver/verify
  go.etcd.io/etcd/pkg/debugutil
  go.etcd.io/etcd/pkg/flags
  go.etcd.io/etcd/embed
  go.etcd.io/etcd/pkg/osutil
  go.etcd.io/etcd/clientv3/naming/endpoints/internal
  go.etcd.io/etcd/clientv3/naming/endpoints
  go.etcd.io/etcd/proxy/grpcproxy/cache
  go.etcd.io/etcd/proxy/grpcproxy
  go.etcd.io/etcd/proxy/httpproxy
  go.etcd.io/etcd/proxy/tcpproxy
  go.etcd.io/etcd/etcdmain
  go.etcd.io/etcd
  go.etcd.io/etcd/client/integration
  go.etcd.io/etcd/clientv3/clientv3util
  go.etcd.io/etcd/clientv3/integration
  go.etcd.io/etcd/clientv3/integration/naming
  go.etcd.io/etcd/clientv3/mirror
  go.etcd.io/etcd/clientv3/naming
  go.etcd.io/etcd/clientv3/naming/resolver
  go.etcd.io/etcd/clientv3/snapshot
  go.etcd.io/etcd/clientv3/yaml
  go.etcd.io/etcd/contrib/raftexample
  go.etcd.io/etcd/contrib/recipes
  go.etcd.io/etcd/etcdctl/ctlv2/command
  go.etcd.io/etcd/etcdctl/ctlv2
  go.etcd.io/etcd/pkg/report
  go.etcd.io/etcd/etcdctl/ctlv3/command
  go.etcd.io/etcd/etcdctl/ctlv3
  go.etcd.io/etcd/etcdctl
  go.etcd.io/etcd/functional/rpcpb
  go.etcd.io/etcd/pkg/proxy
  go.etcd.io/etcd/functional/agent
  go.etcd.io/etcd/functional/cmd/etcd-agent
  go.etcd.io/etcd/functional/cmd/etcd-proxy
  go.etcd.io/etcd/pkg/stringutil
  go.etcd.io/etcd/functional/runner
  go.etcd.io/etcd/functional/cmd/etcd-runner
  go.etcd.io/etcd/functional/tester
  go.etcd.io/etcd/functional/cmd/etcd-tester
  go.etcd.io/etcd/pkg/testutil
  go.etcd.io/etcd/integration
  go.etcd.io/etcd/pkg/expect
  go.etcd.io/etcd/pkg/grpc_testing
  go.etcd.io/etcd/pkg/mock/mockserver
  go.etcd.io/etcd/pkg/mock/mockstorage
  go.etcd.io/etcd/pkg/mock/mockstore
  go.etcd.io/etcd/pkg/mock/mockwait
  go.etcd.io/etcd/raft/rafttest
  go.etcd.io/etcd/tests/e2e
  go.etcd.io/etcd/tools/benchmark/cmd
  go.etcd.io/etcd/tools/benchmark
  go.etcd.io/etcd/tools/etcd-dump-db
  go.etcd.io/etcd/tools/etcd-dump-logs
  go.etcd.io/etcd/tools/etcd-dump-metrics
  go.etcd.io/etcd/tools/local-tester/bridge
Govulncheck scanned the following 53 modules and the go1.23.8 standard library:
  go.etcd.io/etcd
  github.com/beorn7/perks@v1.0.1
  github.com/bgentry/speakeasy@v0.1.0
  github.com/cespare/xxhash/v2@v2.2.0
  github.com/cockroachdb/datadriven@v0.0.0-20190809214429-80d97fb3cbaa
  github.com/coreos/go-semver@v0.2.0
  github.com/coreos/go-systemd@v0.0.0-20180511133405-39ca1b05acc7
  github.com/coreos/pkg@v0.0.0-20160727233714-3ac0863d7acf
  github.com/creack/pty@v1.1.11
  github.com/dustin/go-humanize@v0.0.0-20171111073723-bb3d318650d4
  github.com/gogo/protobuf@v1.3.2
  github.com/golang-jwt/jwt/v4@v4.5.2
  github.com/golang/groupcache@v0.0.0-20160516000752-02826c3e7903
  github.com/golang/protobuf@v1.5.4
  github.com/google/btree@v1.0.0
  github.com/gorilla/websocket@v1.4.2
  github.com/grpc-ecosystem/go-grpc-middleware@v1.0.1-0.20190118093823-f849b5445de4
  github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0
  github.com/grpc-ecosystem/grpc-gateway@v1.11.0
  github.com/jonboulle/clockwork@v0.1.0
  github.com/json-iterator/go@v1.1.11
  github.com/mattn/go-runewidth@v0.0.2
  github.com/matttproud/golang_protobuf_extensions@v1.0.1
  github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd
  github.com/modern-go/reflect2@v1.0.1
  github.com/olekukonko/tablewriter@v0.0.0-20170122224234-a0225b3f23b5
  github.com/prometheus/client_golang@v1.11.1
  github.com/prometheus/client_model@v0.2.0
  github.com/prometheus/common@v0.26.0
  github.com/prometheus/procfs@v0.6.0
  github.com/sirupsen/logrus@v1.9.3
  github.com/soheilhy/cmux@v0.1.5
  github.com/spf13/cobra@v0.0.3
  github.com/spf13/pflag@v1.0.1
  github.com/tmc/grpc-websocket-proxy@v0.0.0-20200427203606-3cfed13b9966
  github.com/urfave/cli@v1.20.0
  github.com/xiang90/probing@v0.0.0-20190116061207-43a291ad63a2
  go.etcd.io/bbolt@v1.3.11
  go.uber.org/atomic@v1.3.2
  go.uber.org/multierr@v1.1.0
  go.uber.org/zap@v1.10.0
  golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
  golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
  golang.org/x/sync@v0.13.0
  golang.org/x/sys@v0.30.0
  golang.org/x/text@v0.3.5
  golang.org/x/time@v0.0.0-20180412165947-fbb02b2291d2
  google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013
  google.golang.org/grpc@v1.51.0-dev
  google.golang.org/protobuf@v1.33.0
  gopkg.in/cheggaaa/pb.v1@v1.0.25
  gopkg.in/yaml.v2@v2.4.0
  sigs.k8s.io/yaml@v1.1.0

=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.23.0
    Example traces found:
      #1: embed/serve.go:316:30: embed.configureHttpServer calls http2.ConfigureServer
      #2: proxy/httpproxy/proxy.go:49:34: httpproxy.NewHandler calls http2.ConfigureTransport
      #3: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.ConnectionError.Error
      #4: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.ErrCode.String
      #5: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameHeader.String
      #6: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameType.String
      #7: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameWriteRequest.String
      #8: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.ReadFrame
      #9: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteContinuation
      #10: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteData
      #11: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteGoAway
      #12: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteHeaders
      #13: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WritePing
      #14: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteRSTStream
      #15: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteSettings
      #16: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteSettingsAck
      #17: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteWindowUpdate
      #18: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.GoAwayError.Error
      #19: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn
      #20: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.Setting.String
      #21: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.SettingID.String
      #22: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.SettingsFrame.ForeachSetting
      #23: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.StreamError.Error
      #24: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.Transport.NewClientConn
      #25: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.Transport.RoundTrip
      #26: pkg/report/timeseries.go:142:20: report.TimeSeries.String calls csv.Writer.Error, which eventually calls http2.chunkWriter.Write
      #27: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.connError.Error
      #28: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.duplicatePseudoHeaderError.Error
      #29: client/client.go:603:18: client.simpleHTTPClient.Do calls http2.gzipReader.Close
      #30: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls io.multiReader.Read, which calls http2.gzipReader.Read
      #31: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.headerFieldNameError.Error
      #32: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.headerFieldValueError.Error
      #33: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.noDialH2RoundTripper.RoundTrip
      #34: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.pseudoHeaderError.Error
      #35: etcdserver/corrupt.go:462:2: etcdserver.hashKVHandler.ServeHTTP calls http2.requestBody.Close
      #36: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls http2.requestBody.Read
      #37: etcdserver/api/rafthttp/http.go:481:24: rafthttp.streamHandler.ServeHTTP calls http2.responseWriter.Flush
      #38: etcdserver/corrupt.go:495:9: etcdserver.hashKVHandler.ServeHTTP calls http2.responseWriter.Write
      #39: embed/serve.go:530:17: embed.corsHandler.ServeHTTP calls http2.responseWriter.WriteHeader
      #40: pkg/expect/expect.go:167:26: expect.ExpectProcess.Send calls io.WriteString, which calls http2.responseWriter.WriteString
      #41: pkg/report/timeseries.go:142:20: report.TimeSeries.String calls csv.Writer.Error, which eventually calls http2.stickyErrWriter.Write
      #42: client/client.go:603:18: client.simpleHTTPClient.Do calls http2.transportResponseBody.Close
      #43: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls io.multiReader.Read, which calls http2.transportResponseBody.Read
      #44: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.writeData.String

Vulnerability #2: GO-2023-2153
    Denial of service from HTTP/2 Rapid Reset in google.golang.org/grpc
  More info: https://pkg.go.dev/vuln/GO-2023-2153
  Module: google.golang.org/grpc
    Found in: google.golang.org/grpc@v1.51.0-dev
    Fixed in: google.golang.org/grpc@v1.56.3
    Example traces found:
      #1: pkg/mock/mockserver/mockserver.go:134:23: mockserver.MockServers.StartAt calls grpc.NewServer
      #2: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve
      #3: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls transport.NewServerTransport

Vulnerability #3: GO-2023-2102
    HTTP/2 rapid reset can cause excessive work in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2102
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.17.0
    Example traces found:
      #1: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn

Vulnerability #4: GO-2023-1571
    Denial of service via crafted HTTP/2 stream in net/http and golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2023-1571
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.7.0
    Example traces found:
      #1: client/client.go:603:18: client.simpleHTTPClient.Do calls http2.transportResponseBody.Close, which eventually calls hpack.Decoder.Write
      #2: embed/serve.go:316:30: embed.configureHttpServer calls http2.ConfigureServer
      #3: proxy/httpproxy/proxy.go:49:34: httpproxy.NewHandler calls http2.ConfigureTransport
      #4: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.ConnectionError.Error
      #5: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.ErrCode.String
      #6: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameHeader.String
      #7: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameType.String
      #8: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.FrameWriteRequest.String
      #9: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.ReadFrame
      #10: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteContinuation
      #11: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteData
      #12: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteGoAway
      #13: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteHeaders
      #14: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WritePing
      #15: pkg/proxy/server.go:636:16: proxy.server.Close calls sync.Once.Do, which eventually calls http2.Framer.WriteRSTStream
      #16: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteSettings
      #17: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteSettingsAck
      #18: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.Framer.WriteWindowUpdate
      #19: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.GoAwayError.Error
      #20: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn
      #21: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.Setting.String
      #22: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.SettingID.String
      #23: integration/cluster.go:846:3: integration.member.Launch calls grpc.Server.Serve, which eventually calls http2.SettingsFrame.ForeachSetting
      #24: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.StreamError.Error
      #25: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.Transport.NewClientConn
      #26: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.Transport.RoundTrip
      #27: pkg/report/timeseries.go:142:20: report.TimeSeries.String calls csv.Writer.Error, which eventually calls http2.chunkWriter.Write
      #28: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.connError.Error
      #29: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.duplicatePseudoHeaderError.Error
      #30: client/client.go:603:18: client.simpleHTTPClient.Do calls http2.gzipReader.Close
      #31: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls io.multiReader.Read, which calls http2.gzipReader.Read
      #32: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.headerFieldNameError.Error
      #33: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.headerFieldValueError.Error
      #34: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls http2.noDialH2RoundTripper.RoundTrip
      #35: etcdserver/server.go:1804:49: etcdserver.EtcdServer.PromoteMember calls http2.pseudoHeaderError.Error
      #36: etcdserver/corrupt.go:462:2: etcdserver.hashKVHandler.ServeHTTP calls http2.requestBody.Close
      #37: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls http2.requestBody.Read
      #38: etcdserver/api/rafthttp/http.go:481:24: rafthttp.streamHandler.ServeHTTP calls http2.responseWriter.Flush
      #39: etcdserver/corrupt.go:495:9: etcdserver.hashKVHandler.ServeHTTP calls http2.responseWriter.Write
      #40: embed/serve.go:530:17: embed.corsHandler.ServeHTTP calls http2.responseWriter.WriteHeader
      #41: pkg/expect/expect.go:167:26: expect.ExpectProcess.Send calls io.WriteString, which calls http2.responseWriter.WriteString
      #42: pkg/report/timeseries.go:142:20: report.TimeSeries.String calls csv.Writer.Error, which eventually calls http2.stickyErrWriter.Write
      #43: client/client.go:603:18: client.simpleHTTPClient.Do calls http2.transportResponseBody.Close
      #44: pkg/ioutil/reader.go:39:17: ioutil.limitedBufferReader.Read calls io.multiReader.Read, which calls http2.transportResponseBody.Read
      #45: raft/rafttest/interaction_env_handler_deliver_msgs.go:81:16: rafttest.InteractionEnv.DeliverMsgs calls fmt.Fprintln, which eventually calls http2.writeData.String

Vulnerability #5: GO-2022-1144
    Excessive memory growth in net/http and golang.org/x/net/http2
  More info: https://pkg.go.dev/vuln/GO-2022-1144
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.4.0
    Example traces found:
      #1: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn

Vulnerability #6: GO-2022-0969
    Denial of service in net/http and golang.org/x/net/http2
  More info: https://pkg.go.dev/vuln/GO-2022-0969
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.0.0-20220906165146-f3363e06e74c
    Example traces found:
      #1: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn

Vulnerability #7: GO-2022-0288
    Unbounded memory growth in net/http and golang.org/x/net/http2
  More info: https://pkg.go.dev/vuln/GO-2022-0288
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.0.0-20211209124913-491a49abca63
    Example traces found:
      #1: functional/cmd/etcd-proxy/main.go:217:27: etcd.main calls http.Server.ListenAndServe, which eventually calls http2.Server.ServeConn

Vulnerability #8: GO-2022-0236
    Panic due to large headers in net/http and golang.org/x/net/http/httpguts
  More info: https://pkg.go.dev/vuln/GO-2022-0236
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.0.0-20210428140749-89ef3d95e781
    Example traces found:
      #1: pkg/transport/transport.go:70:32: transport.unixTransport.RoundTrip calls http.Transport.RoundTrip, which eventually calls httpguts.HeaderValuesContainsToken

Vulnerability #9: GO-2021-0113
    Out-of-bounds read in golang.org/x/text/language
  More info: https://pkg.go.dev/vuln/GO-2021-0113
  Module: golang.org/x/text
    Found in: golang.org/x/text@v0.3.5
    Fixed in: golang.org/x/text@v0.3.7
    Example traces found:
      #1: badcode.go:12:29: etcd.badcode calls language.Parse

=== Package Results ===

Vulnerability #1: GO-2022-1059
    Denial of service via crafted Accept-Language header in
    golang.org/x/text/language
  More info: https://pkg.go.dev/vuln/GO-2022-1059
  Module: golang.org/x/text
    Found in: golang.org/x/text@v0.3.5
    Fixed in: golang.org/x/text@v0.3.8

=== Module Results ===

Vulnerability #1: GO-2025-3595
    Incorrect Neutralization of Input During Web Page Generation in x/net in
    golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2025-3595
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.38.0

Vulnerability #2: GO-2025-3503
    HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2025-3503
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.36.0

Vulnerability #3: GO-2025-3487
    Potential denial of service in golang.org/x/crypto
  More info: https://pkg.go.dev/vuln/GO-2025-3487
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.35.0

Vulnerability #4: GO-2024-3333
    Non-linear parsing of case-insensitive content in golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2024-3333
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.33.0

Vulnerability #5: GO-2024-3321
    Misuse of connection.serverAuthenticate may cause authorization bypass in
    golang.org/x/crypto
  More info: https://pkg.go.dev/vuln/GO-2024-3321
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.31.0

Vulnerability #6: GO-2024-2961
    Limited directory traversal vulnerability on Windows in golang.org/x/crypto
  More info: https://pkg.go.dev/vuln/GO-2024-2961
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20220525230936-793ad666bf5e
    Platforms: windows

Vulnerability #7: GO-2023-2402
    Man-in-the-middle attacker can compromise integrity of secure channel in
    golang.org/x/crypto
  More info: https://pkg.go.dev/vuln/GO-2023-2402
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.17.0

Vulnerability #8: GO-2023-1988
    Improper rendering of text nodes in golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2023-1988
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.13.0

Vulnerability #9: GO-2022-0968
    Panic on malformed packets in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2022-0968
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20211202192323-5770296d904e

Vulnerability #10: GO-2021-0356
    Denial of service via crafted Signer in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2021-0356
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20220314234659-1baeb1ce4c0b

Vulnerability #11: GO-2021-0238
    Infinite loop when parsing inputs in golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2021-0238
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.0.0-20201202161906-c7110b5ffcbb
    Fixed in: golang.org/x/net@v0.0.0-20210520170846-37e1c6afe023

Vulnerability #12: GO-2021-0227
    Panic on crafted authentication request message in golang.org/x/crypto/ssh
  More info: https://pkg.go.dev/vuln/GO-2021-0227
  Module: golang.org/x/crypto
    Found in: golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9
    Fixed in: golang.org/x/crypto@v0.0.0-20201216223049-8b5274cf687f

Your code is affected by 9 vulnerabilities from 3 modules.
This scan also found 1 vulnerability in packages you import and 12
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
make: *** [Makefile:572: run-govulncheck] Error 3
</pre>
</details>

ref: https://github.com/kubernetes/test-infra/issues/32754 https://github.com/kubernetes/test-infra/pull/32801