### PR TITLE
Add test-release-tests Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ test-grpcproxy-e2e: build
 test-e2e-release: build
 	PASSES="release e2e" ./scripts/test.sh $(GO_TEST_FLAGS)
 
+.PHONY: test-release
+test-release:
+	PASSES="release_tests" CI=$$CI ./scripts/test.sh $(GO_TEST_FLAGS)
+
 .PHONY: test-robustness
 test-robustness:
 	PASSES="robustness" ./scripts/test.sh $(GO_TEST_FLAGS)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -623,6 +623,31 @@ function release_pass {
   mv /tmp/etcd ./bin/etcd-last-release
 }
 
+function release_tests_pass {
+  VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+
+  if [ -n "${CI:-}" ]; then
+    git config user.email "prow@etcd.io"
+    git config user.name "Prow"
+
+    gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: 1
+Key-Length: 2048
+Subkey-Type: 1
+Subkey-Length: 2048
+Name-Real: Prow
+Name-Email: prow@etcd.io
+Expire-Date: 0
+EOF
+
+    git remote add origin https://github.com/etcd-io/etcd.git
+  fi
+
+  DRY_RUN=true run "${ETCD_ROOT_DIR}/scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION}"
+  VERSION="${VERSION}" run "${ETCD_ROOT_DIR}/scripts/test_images.sh"
+}
+
 function mod_tidy_for_module {
   run go mod tidy -diff
 }


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Moving scripts from Prow job (https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-presubmits.yaml) to `test.sh`. 

This is for ease of migrating `release-3.4` and `release-3.5` Github Actions workflows to Prow.

ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc 