### PR TITLE
Fix antithesis docker file removing distroless layer.

### DIFF
--- a/tests/antithesis/Makefile
+++ b/tests/antithesis/Makefile
@@ -2,4 +2,4 @@ REPOSITORY_ROOT := $(shell git rev-parse --show-toplevel)
 
 .PHONY: antithesis-build-client-docker-image
 antithesis-build-client-docker-image:
-	docker build --build-arg GO_VERSION=$(shell cat $(REPOSITORY_ROOT)/.go-version) -f $(REPOSITORY_ROOT)/tests/antithesis/test-template/Dockerfile $(REPOSITORY_ROOT)
+	docker build --build-arg GO_VERSION=$(shell cat $(REPOSITORY_ROOT)/.go-version) -f $(REPOSITORY_ROOT)/tests/antithesis/test-template/Dockerfile $(REPOSITORY_ROOT) -t etcd-client:latest

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -7,7 +7,7 @@ This directory enables integration of Antithesis with etcd. There are 4 containe
 Run this command from the `antithesis/test-template` directory:
 
 ```bash
-docker build . -f Dockerfile -t etcd-client:latest
+make antithesis-build-client-docker-image
 ```
 
 ### 2. (Optional) Check the Image Locally

--- a/tests/antithesis/test-template/Dockerfile
+++ b/tests/antithesis/test-template/Dockerfile
@@ -1,14 +1,10 @@
 ARG GO_VERSION=1.24.2
 ARG ARCH=amd64
 
-FROM golang:$GO_VERSION AS builder
+FROM golang:$GO_VERSION
 WORKDIR /build
 COPY . .
 
 WORKDIR /build/tests
-RUN go build -o /opt/entrypoint -race ./antithesis/test-template/entrypoint/entrypoint.go
-RUN go build -o /opt/serial_driver_delete_keys -race ./antithesis/test-template/go-delete-keys/serial_driver_delete_keys.go
-
-FROM --platform=linux/${ARCH} gcr.io/distroless/static-debian12@sha256:3d0f463de06b7ddff27684ec3bfd0b54a425149d0f8685308b1fdf297b0265e9
-COPY --from=builder /opt/entrypoint /opt/antithesis/entrypoint/entrypoint
-COPY --from=builder /opt/serial_driver_delete_keys /opt/antithesis/test/v1/main/serial_driver_delete_keys
+RUN go build -o /opt/antithesis/entrypoint/entrypoint -race ./antithesis/test-template/entrypoint/entrypoint.go
+RUN go build -o /opt/antithesis/test/v1/main/serial_driver_delete_keys -race ./antithesis/test-template/go-delete-keys/serial_driver_delete_keys.go


### PR DESCRIPTION
As antithesis requires CGO we cannot compile binary staticly.

/cc @jmhbnz @ivanvc @nwnt 