### PR TITLE
Antithesis: Use RecordingClient from robustness tests

### DIFF
--- a/tests/antithesis/test-template/go-delete-keys/serial_driver_delete_keys.go
+++ b/tests/antithesis/test-template/go-delete-keys/serial_driver_delete_keys.go
@@ -26,20 +26,19 @@ import (
 	"github.com/antithesishq/antithesis-sdk-go/random"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/robustness/client"
+	"go.etcd.io/etcd/tests/v3/robustness/identity"
 )
 
-func Connect() *clientv3.Client {
+func Connect() *client.RecordingClient {
 	// This function returns a client connection to an etcd node
 
-	hosts := [][]string{{"etcd0:2379"}, {"etcd1:2379"}, {"etcd2:2379"}}
-	host := random.RandomChoice(hosts)
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   host,
-		DialTimeout: 5 * time.Second,
-	})
+	hosts := []string{"etcd0:2379", "etcd1:2379", "etcd2:2379"}
+	cli, err := client.NewRecordingClient(hosts, identity.NewIDProvider(), time.Now())
 	if err != nil {
 		log.Fatalf("Failed to connect to etcd: %v", err)
 		// Antithesis Assertion: client should always be able to connect to an etcd host
+		host := random.RandomChoice(hosts)
 		assert.Unreachable("Client failed to connect to an etcd host", map[string]any{"host": host, "error": err})
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR addresses [this](https://github.com/etcd-io/etcd/issues/19788) issue. We wish to use the `RecordingClient` existing in the robustness test client library. 
cc @serathius 