### PR TITLE
make: upload partial coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,11 @@ test-coverage:
 	COVERDIR=covdir PASSES="build cov" ./scripts/test.sh $(GO_TEST_FLAGS)
 
 .PHONY: upload-coverage-report
-upload-coverage-report: test-coverage
-	COVERDIR=covdir ./scripts/codecov_upload.sh
+upload-coverage-report:
+	return_code=0; \
+	$(MAKE) test-coverage || return_code=$$?; \
+	COVERDIR=covdir ./scripts/codecov_upload.sh; \
+	exit $$return_code
 
 .PHONY: fuzz
 fuzz: 


### PR DESCRIPTION
In the case of workflow failures (e.g., flaky tests), we should still upload a partial coverage report to avoid lagging reports on the stable branches.

This is a second take on https://github.com/kubernetes/test-infra/pull/34381.

Fixes #19835.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
