### PR TITLE
[release 3.5] Backport Deprecated Metadata field in Endpoint struct

### DIFF
--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -18,7 +18,9 @@ type Endpoint struct {
 	// Metadata is the information associated with Addr, which may be used
 	// to make load balancing decision.
 	// Since etcd 3.1
-	Metadata interface{}
+	//
+	// Deprecated: The field is deprecated and will be removed in 3.7.
+	Metadata any
 }
 
 type Operation uint8


### PR DESCRIPTION
This PR cherry-picks commit `28d10d35c07d4fe9faf84e4bf63aa79385c1a821` from `main` into the `release-3.5` branch.

cc: @ahrtr 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
