### PR TITLE
[release-3.4] Add test-release Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ test-e2e:
 test-e2e-release:
 	PASSES="build release e2e" ./test $(GO_TEST_FLAGS)
 
+.PHONY: test-release
+test-release:
+	PASSES="release_tests" VERSION=3.4.99 ./test $(GO_TEST_FLAGS)
+
 docker-test:
 	$(info GO_VERSION: $(GO_VERSION))
 	$(info ETCD_VERSION: $(ETCD_VERSION))

--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -8,14 +8,14 @@ source ./scripts/test_lib.sh
 
 function startContainer {
     # run docker in the background
-    docker run -d --rm --name "${RUN_NAME}" "${IMAGE}"
+    docker run -d --rm --name "${RUN_NAME}" "${TEST_IMAGE}"
 
     # wait for etcd daemon to bootstrap
     sleep 5
 }
 
 function runVersionCheck {
-    Out=$(docker run --rm "${IMAGE}" "${@}")
+    Out=$(docker run --rm "${TEST_IMAGE}" "${@}")
     foundVersion=$(echo "$Out" | head -1 | rev  | cut -d" "  -f 1 | rev )
     if [[ "${foundVersion}" != "${VERSION}" ]]; then
         echo "error: Invalid Version. Got $foundVersion, expected $VERSION. Error: $Out"
@@ -50,15 +50,15 @@ else
     echo "Terminating test, VERSION not supplied"
     exit 1
 fi
-IMAGE=${IMAGE:-"${REPOSITARY}:${TAG}"}
+TEST_IMAGE=${TEST_IMAGE:-"${REPOSITARY}:${TAG}"}
 
 # ETCD related values
 RUN_NAME="test_etcd"
 KEY="foo"
 VALUE="bar"
 
-if [[ "$(docker images -q "${IMAGE}" 2> /dev/null)" == "" ]]; then
-    echo "${IMAGE} not present locally"
+if [[ "$(docker images -q "${TEST_IMAGE}" 2> /dev/null)" == "" ]]; then
+    echo "${TEST_IMAGE} not present locally"
     exit 1
 fi
 

--- a/test
+++ b/test
@@ -398,6 +398,34 @@ function release_pass {
 	mv /tmp/etcd ./bin/etcd-last-release
 }
 
+function release_tests_pass {
+	if [ -z "${VERSION:-}" ]; then
+    	VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | \
+     	 awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+  	fi
+	
+	if [ -n "${CI:-}" ]; then
+		git config user.email "prow@etcd.io"
+		git config user.name "Prow"
+
+		gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: 1
+Key-Length: 2048
+Subkey-Type: 1
+Subkey-Length: 2048
+Name-Real: Prow
+Name-Email: prow@etcd.io
+Expire-Date: 0
+EOF
+
+    	git remote add origin https://github.com/etcd-io/etcd.git
+  	fi
+
+	DRY_RUN=true "scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION:-}"
+	VERSION="${VERSION:-}" "scripts/test_images.sh"
+}
+
 function shellcheck_pass {
 	SHELLCHECK=shellcheck
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Add `test-release` Makefile target for release-3.4 Prow job.

ref: https://github.com/kubernetes/test-infra/issues/32754 

/cc @ivanvc @jmhbnz 