### PR TITLE
[release-3.4] add test release makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ test-e2e:
 test-e2e-release:
 	PASSES="build release e2e" ./test $(GO_TEST_FLAGS)
 
+.PHONY: test-release
+test-release:
+	PASSES="release_tests" VERSION="3.4.99" CI=$$CI ./scripts/test.sh $(GO_TEST_FLAGS)
+
 docker-test:
 	$(info GO_VERSION: $(GO_VERSION))
 	$(info ETCD_VERSION: $(ETCD_VERSION))

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-e2e-release:
 
 .PHONY: test-release
 test-release:
-	PASSES="release_tests" VERSION="3.4.99" CI=$$CI ./scripts/test.sh $(GO_TEST_FLAGS)
+	PASSES="release_tests" VERSION="3.4.99" ./test $(GO_TEST_FLAGS)
 
 docker-test:
 	$(info GO_VERSION: $(GO_VERSION))

--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -8,14 +8,14 @@ source ./scripts/test_lib.sh
 
 function startContainer {
     # run docker in the background
-    docker run -d --rm --name "${RUN_NAME}" "${IMAGE}"
+    docker run -d --rm --name "${RUN_NAME}" "${TEST_IMAGE}"
 
     # wait for etcd daemon to bootstrap
     sleep 5
 }
 
 function runVersionCheck {
-    Out=$(docker run --rm "${IMAGE}" "${@}")
+    Out=$(docker run --rm "${TEST_IMAGE}" "${@}")
     foundVersion=$(echo "$Out" | head -1 | rev  | cut -d" "  -f 1 | rev )
     if [[ "${foundVersion}" != "${VERSION}" ]]; then
         echo "error: Invalid Version. Got $foundVersion, expected $VERSION. Error: $Out"
@@ -50,15 +50,15 @@ else
     echo "Terminating test, VERSION not supplied"
     exit 1
 fi
-IMAGE=${IMAGE:-"${REPOSITARY}:${TAG}"}
+TEST_IMAGE=${TEST_IMAGE:-"${REPOSITARY}:${TAG}"}
 
 # ETCD related values
 RUN_NAME="test_etcd"
 KEY="foo"
 VALUE="bar"
 
-if [[ "$(docker images -q "${IMAGE}" 2> /dev/null)" == "" ]]; then
-    echo "${IMAGE} not present locally"
+if [[ "$(docker images -q "${TEST_IMAGE}" 2> /dev/null)" == "" ]]; then
+    echo "${TEST_IMAGE} not present locally"
     exit 1
 fi
 

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -52,3 +52,27 @@ function log_info {
   >&2 echo "$@"
   >&2 echo -n -e "${COLOR_NONE}"
 }
+
+# The version present in the .go-verion is the default version that test and build scripts will use.
+# However, it is possible to control the version that should be used with the help of env vars:
+# - FORCE_HOST_GO: if set to a non-empty value, use the version of go installed in system's $PATH.
+# - GO_VERSION: desired version of go to be used, might differ from what is present in .go-version.
+#               If empty, the value defaults to the version in .go-version.
+function determine_go_version {
+  # Borrowing from how Kubernetes does this:
+  #  https://github.com/kubernetes/kubernetes/blob/17854f0e0a153b06f9d0db096e2cd8ab2fa89c11/hack/lib/golang.sh#L510-L520
+  #
+  # default GO_VERSION to content of .go-version
+  GO_VERSION="${GO_VERSION:-"$(cat "./.go-version")"}"
+  if [ "${GOTOOLCHAIN:-auto}" != 'auto' ]; then
+    # no-op, just respect GOTOOLCHAIN
+    :
+  elif [ -n "${FORCE_HOST_GO:-}" ]; then
+    export GOTOOLCHAIN='local'
+  else
+    GOTOOLCHAIN="go${GO_VERSION}"
+    export GOTOOLCHAIN
+  fi
+}
+
+determine_go_version

--- a/test
+++ b/test
@@ -399,7 +399,10 @@ function release_pass {
 }
 
 function release_tests_pass {
-  	VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+  	if [ -z "${VERSION:-}" ]; then
+    	VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | \
+     	 awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+  	fi
 
   	if [ -n "${CI:-}" ]; then
 		git config user.email "prow@etcd.io"
@@ -419,8 +422,8 @@ EOF
     	git remote add origin https://github.com/etcd-io/etcd.git
   	fi
 
-	DRY_RUN=true run "./scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION}"
-	VERSION="${VERSION}" run "./scripts/test_images.sh"
+	DRY_RUN=true "./scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION}"
+	VERSION="${VERSION}" "./scripts/test_images.sh"
 }
 
 function shellcheck_pass {

--- a/test
+++ b/test
@@ -398,6 +398,31 @@ function release_pass {
 	mv /tmp/etcd ./bin/etcd-last-release
 }
 
+function release_tests_pass {
+  	VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+
+  	if [ -n "${CI:-}" ]; then
+		git config user.email "prow@etcd.io"
+		git config user.name "Prow"
+
+		gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: 1
+Key-Length: 2048
+Subkey-Type: 1
+Subkey-Length: 2048
+Name-Real: Prow
+Name-Email: prow@etcd.io
+Expire-Date: 0
+EOF
+
+    	git remote add origin https://github.com/etcd-io/etcd.git
+  	fi
+
+	DRY_RUN=true run "./scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION}"
+	VERSION="${VERSION}" run "./scripts/test_images.sh"
+}
+
 function shellcheck_pass {
 	SHELLCHECK=shellcheck
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Add test-release Makefile target for release-3.4 Prow job.

ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @jmhbnz