### PR TITLE
Refactor: etcdserver-move rafthttp.Transport initialization to bootstrap

### DIFF
--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stats "go.etcd.io/etcd/server/v3/etcdserver/api/v2stats"
 	"io"
 	"net/http"
 	"os"
@@ -104,24 +105,54 @@ func bootstrap(cfg config.ServerConfig) (b *bootstrappedServer, err error) {
 		backend.Close()
 		return nil, err
 	}
+	sstats := stats.NewServerStats(cfg.Name, cluster.cl.String())
+	lstats := stats.NewLeaderStats(cfg.Logger, cluster.nodeID.String())
+
+	raftTransport := &rafthttp.Transport{
+		Logger:      cfg.Logger,
+		TLSInfo:     cfg.PeerTLSInfo,
+		DialTimeout: cfg.PeerDialTimeout(),
+		ID:          cluster.nodeID,
+		URLs:        cfg.PeerURLs,
+		ClusterID:   cluster.cl.ID(),
+		ServerStats: sstats,
+		LeaderStats: lstats,
+		ErrorC:      make(chan error, 1), // placeholder, can override later
+	}
+	if err = raftTransport.Start(); err != nil {
+		return nil, err
+	}
+	for _, m := range cluster.remotes {
+		if m.ID != cluster.nodeID {
+			raftTransport.AddRemote(m.ID, m.PeerURLs)
+		}
+	}
+	for _, m := range cluster.cl.Members() {
+		if m.ID != cluster.nodeID {
+			raftTransport.AddPeer(m.ID, m.PeerURLs)
+		}
+	}
 
 	cfg.Logger.Info("bootstrapping raft")
 	raft := bootstrapRaft(cfg, cluster, s.wal)
+
 	return &bootstrappedServer{
-		prt:     prt,
-		ss:      ss,
-		storage: s,
-		cluster: cluster,
-		raft:    raft,
+		prt:           prt,
+		ss:            ss,
+		storage:       s,
+		cluster:       cluster,
+		raft:          raft,
+		raftTransport: raftTransport,
 	}, nil
 }
 
 type bootstrappedServer struct {
-	storage *bootstrappedStorage
-	cluster *bootstrappedCluster
-	raft    *bootstrappedRaft
-	prt     http.RoundTripper
-	ss      *snap.Snapshotter
+	storage       *bootstrappedStorage
+	cluster       *bootstrappedCluster
+	raft          *bootstrappedRaft
+	prt           http.RoundTripper
+	ss            *snap.Snapshotter
+	raftTransport *rafthttp.Transport
 }
 
 func (s *bootstrappedServer) Close() {


### PR DESCRIPTION
### Descriptions:
* This PR addresses the existing TODO comment in the NewServer function:`// TODO: move transport initialization near the definition of remote.`
* This PR refactors the server initialization process by decoupling the Raft consensus component from the initial bootstrap phase. Previously, Raft was initialized within the bootstrap function, which tightly coupled cluster setup with consensus mechanics. 
### Changes Include:
* Moved the initialization and startup of rafthttp.Transport into the bootstrap() function.

* The transport instance is now part of the returned bootstrappedServer struct.

* Refactored NewServer() to simply assign the bootstrapped transport and wire it up.


