### PR TITLE
CHANGELOG(3.6): add Go 1.23.9 entry

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -19,6 +19,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 - [Replace `resolver.State.Addresses` with `resolver.State.Endpoint.Addresses`](https://github.com/etcd-io/etcd/pull/19782).
 - [Deprecated the Metadata field in the Endpoint struct from the client/v3/naming/endpoints package](https://github.com/etcd-io/etcd/pull/19842).
 
+### Dependencies
+
+- Compile binaries using [go 1.23.9](https://github.com/etcd-io/etcd/pull/19867).
+
 ---
 
 ## v3.6.0-rc.4 (2025-04-15)


### PR DESCRIPTION
3.6 entry for the Go 1.23.9 update.

Part of #19866.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
