### PR TITLE
Allow retryable check of database empty and enable failure injection in Antithesis

### DIFF
--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -74,7 +74,7 @@ And it will stay running indefinitely.
 ### 4. Running the tests
 
 ```bash
-docker-compose exec client /opt/antithesis/test/v1/main/robustness`
+docker-compose exec client /opt/antithesis/test/v1/robustness/singleton_driver_main`
 ```
 
 Alternatively, with the etcd cluster from step 3, to run the tests locally without rebuilding the client image:

--- a/tests/antithesis/test-template/Dockerfile
+++ b/tests/antithesis/test-template/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 
 WORKDIR /build/tests
 RUN go build -o /opt/antithesis/entrypoint/entrypoint -race ./antithesis/test-template/entrypoint/main.go
-RUN go build -o /opt/antithesis/test/v1/robustness/first_main -race ./antithesis/test-template/robustness/main.go
+RUN go build -o /opt/antithesis/test/v1/robustness/singleton_driver_main -race ./antithesis/test-template/robustness/main.go

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -105,7 +105,7 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenari
 	result := validate.ValidateAndReturnVisualize(lg, validateConfig, r.Client, persistedRequests, 5*time.Minute)
 	r.Visualize = result.Linearization.Visualize
 	if result.Error != nil {
-		t.Error(err)
+		t.Error(result.Error)
 	}
 
 	panicked = false


### PR DESCRIPTION
In Antithesis we don't have control of failure injection. So we don't have guarantee that the first request will pass.

Changing first request to read fixes the issue of first request not being retryable. Changing the test name prefix to "singleton_driver_" enables antithesis fault injection.

/cc @siyuanfoundation @fuweid @nwnt @henrybear327 