### PR TITLE
[release-3.4] release: Fix the tar unzip command, avoid permissions issues

### DIFF
--- a/scripts/release_notes.tpl.txt
+++ b/scripts/release_notes.tpl.txt
@@ -16,7 +16,7 @@ rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
 rm -rf /tmp/etcd-download-test && mkdir -p /tmp/etcd-download-test
 
 curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
-tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd-download-test --strip-components=1
+tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd-download-test --strip-components=1 --no-same-owner
 rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
 
 /tmp/etcd-download-test/etcd --version

--- a/test
+++ b/test
@@ -393,7 +393,7 @@ function release_pass {
 			;;
 	esac
 
-	tar xzvf "/tmp/$file" -C /tmp/ --strip-components=1
+	tar xzvf "/tmp/$file" -C /tmp/ --strip-components=1 --no-same-owner
 	mkdir -p ./bin
 	mv /tmp/etcd ./bin/etcd-last-release
 }


### PR DESCRIPTION
fix: https://github.com/etcd-io/etcd/issues/17278

A part of https://github.com/etcd-io/etcd/pull/19862

Because auto cherry-pick to release-3.4 branch failed, manually backport commit.

/cc @ivanvc @ahrtr 