### PR TITLE
[release-3.5] makefile: Split fmt into separate verify commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -583,7 +583,7 @@ gofail-disable: install-gofail
 	PASSES="toggle_failpoints" ./test.sh
 
 .PHONY: verify
-verify: verify-go-versions verify-dep
+verify: verify-go-versions verify-dep verify-shellcheck
 
 .PHONY: verify-go-versions
 verify-go-versions:
@@ -592,6 +592,10 @@ verify-go-versions:
 .PHONY: verify-dep
 verify-dep:
 	PASSES="dep" ./test.sh 2<&1
+
+.PHONY: verify-shellcheck
+verify-shellcheck:
+	PASSES="shellcheck" ./test.sh
 
 .PHONY: fix
 fix: sync-toolchain-directive


### PR DESCRIPTION
Partial backport of b8347edf3b5bd5cd8f64a2259458777ee772b5db / PR #14481.

* Add verify-shellcheck make target and call it from the verify parent target


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
