### PR TITLE
Add ubuntu image to antithesis configuration

### DIFF
--- a/.github/workflows/antithesis-test.yml
+++ b/.github/workflows/antithesis-test.yml
@@ -22,7 +22,7 @@ on:
       images:
         description: 'System images (separate with ;)'
         required: true
-        default: us-central1-docker.pkg.dev/molten-verve-216720/linuxfoundation-repository/etcd-client:latest;gcr.io/etcd-development/etcd:v3.5.21
+        default: us-central1-docker.pkg.dev/molten-verve-216720/linuxfoundation-repository/etcd-client:latest;gcr.io/etcd-development/etcd:v3.5.21;docker.io/library/ubuntu:latest
         type: string
       duration:
         description: 'Duration (exploration hours)'

--- a/tests/antithesis/docker-compose.yml
+++ b/tests/antithesis/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # By default, if the folders don't exist when mounting, compose creates them with root as owner.
   # With root owner, accessing the WAL files from local tests will fail due to an unauthorized access error.
   init:
-    image: 'ubuntu:latest'
+    image: 'docker.io/library/ubuntu:latest'
     user: root
     group_add:
       - '${GROUP_ID:-root}'


### PR DESCRIPTION
Fixing bug from https://github.com/etcd-io/etcd/pull/19889