### PR TITLE
CHANGELOG(3.5): add Go 1.23.9 entry

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -17,7 +17,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Dependencies
 
-- Compile binaries using [go 1.23.8](https://github.com/etcd-io/etcd/pull/19725)
+- Compile binaries using [go 1.23.9](https://github.com/etcd-io/etcd/pull/19870)
 
 ---
 


### PR DESCRIPTION
3.5 entry for the Go 1.23.9 update.

Part of https://github.com/etcd-io/etcd/issues/19866.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.