### PR TITLE
CHANGELOG(3.4): add Go 1.23.9 entry

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.38 (TBC)
 
+### Dependencies
+
+- Compile binaries using [go 1.23.9](https://github.com/etcd-io/etcd/pull/19872).
+
 ---
 
 ## v3.4.37 (2025-04-15)


### PR DESCRIPTION
3.4 entry for the Go 1.23.9 update.

Part of https://github.com/etcd-io/etcd/issues/19866.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @ivanvc 