### PR TITLE
Avoid encoding to Json to reduce overhead

### DIFF
--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -28,31 +28,49 @@ import (
 // Failed requests fork the possible states, while successful requests merge and filter them.
 var NonDeterministicModel = porcupine.Model{
 	Init: func() any {
-		data, err := json.Marshal(nonDeterministicState{freshEtcdState()})
+		return nonDeterministicState{freshEtcdState()}
+	},
+	Step: func(st any, in any, out any) (bool, any) {
+		return st.(nonDeterministicState).apply(in.(EtcdRequest), out.(MaybeEtcdResponse))
+	},
+	Equal: func(st1, st2 any) bool {
+		return st1.(nonDeterministicState).Equal(st2.(nonDeterministicState))
+	},
+	DescribeOperation: func(in, out any) string {
+		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), out.(MaybeEtcdResponse)))
+	},
+	DescribeState: func(st any) string {
+		data, err := json.Marshal(st)
 		if err != nil {
 			panic(err)
 		}
 		return string(data)
 	},
-	Step: func(st any, in any, out any) (bool, any) {
-		var states nonDeterministicState
-		err := json.Unmarshal([]byte(st.(string)), &states)
-		if err != nil {
-			panic(err)
-		}
-		ok, states := states.apply(in.(EtcdRequest), out.(MaybeEtcdResponse))
-		data, err := json.Marshal(states)
-		if err != nil {
-			panic(err)
-		}
-		return ok, string(data)
-	},
-	DescribeOperation: func(in, out any) string {
-		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), out.(MaybeEtcdResponse)))
-	},
 }
 
 type nonDeterministicState []EtcdState
+
+func (states nonDeterministicState) Equal(other nonDeterministicState) bool {
+	if len(states) != len(other) {
+		return false
+	}
+
+	otherMatched := make([]bool, len(other))
+	for _, sItem := range states {
+		foundMatchInOther := false
+		for j, otherItem := range other {
+			if !otherMatched[j] && sItem.Equal(otherItem) {
+				otherMatched[j] = true
+				foundMatchInOther = true
+				break
+			}
+		}
+		if !foundMatchInOther {
+			return false
+		}
+	}
+	return true
+}
 
 func (states nonDeterministicState) apply(request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
 	var newStates nonDeterministicState


### PR DESCRIPTION
```
                                                      │  old.bench   │              new.bench              │
                                                      │    sec/op    │   sec/op     vs base                │
ValidateLinearizableOperations/Successes-14             13.493m ± 4%   3.658m ± 3%  -72.89% (p=0.000 n=10)
ValidateLinearizableOperations/AllFailures-14           10.663m ± 1%   1.539m ± 6%  -85.57% (p=0.000 n=10)
ValidateLinearizableOperations/PutFailuresWithRead-14    9.742m ± 2%   1.365m ± 1%  -85.99% (p=0.000 n=10)
geomean                                                  11.19m        1.973m       -82.37%
```

/cc @siyuanfoundation @fuweid @nwnt @henrybear327 