### PR TITLE
client/pkg: fix revive unexported-return issue

### DIFF
--- a/client/pkg/types/set.go
+++ b/client/pkg/types/set.go
@@ -31,7 +31,12 @@ type Set interface {
 	Sub(Set) Set
 }
 
-func NewUnsafeSet(values ...string) *unsafeSet {
+type UnsafeSet interface {
+	Set
+	ContainsAll(values []string) bool
+}
+
+func NewUnsafeSet(values ...string) UnsafeSet {
 	set := &unsafeSet{make(map[string]struct{})}
 	for _, v := range values {
 		set.Add(v)
@@ -39,10 +44,12 @@ func NewUnsafeSet(values ...string) *unsafeSet {
 	return set
 }
 
-func NewThreadsafeSet(values ...string) *tsafeSet {
+func NewThreadsafeSet(values ...string) Set {
 	us := NewUnsafeSet(values...)
 	return &tsafeSet{us, sync.RWMutex{}}
 }
+
+var _ UnsafeSet = (*unsafeSet)(nil)
 
 type unsafeSet struct {
 	d map[string]struct{}
@@ -122,8 +129,10 @@ func (us *unsafeSet) Sub(other Set) Set {
 	return result
 }
 
+var _ Set = (*tsafeSet)(nil)
+
 type tsafeSet struct {
-	us *unsafeSet
+	us Set
 	m  sync.RWMutex
 }
 


### PR DESCRIPTION
Fixes part of #18370

This PR updates the `client/pkg` to fix unexported-return linter issue.

In this pull request, I introduced a `UnsafeSet` interface that contains the original `Set` interface, along with a method ContainsAll(). This was to avoid making changes to this unsafeSet unit-test [here](https://github.com/etcd-io/etcd/blob/main/client/pkg/types/set_test.go#L161). 

The changes are:
- NewUnsafeSet() now returns an `UnsafeSet` interface, instead of `*unsafeSet` struct
- NewThreadsafeSet now returns a `Set` interface, instead of `*tsafeSet` struct
