### PR TITLE
After failed request fallback to LIST

### DIFF
--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -149,7 +149,7 @@ func (t etcdTraffic) RunTrafficLoop(ctx context.Context, c *client.RecordingClie
 			}
 			requestType = random.PickRandom(choices)
 		} else {
-			requestType = Get
+			requestType = List
 		}
 		rev, err := client.Request(ctx, requestType, lastRev)
 		if shouldReturn {


### PR DESCRIPTION
This should help recovery from failed Put requests. LIST will read all keys allowing us identify if requests previous write succeeded, thus making linearization cheaper.

/cc @henrybear327 @nwnt