### PR TITLE
Use btree to avoid expensive copy and sorting response

### DIFF
--- a/tests/robustness/model/replay.go
+++ b/tests/robustness/model/replay.go
@@ -85,7 +85,7 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 					},
 					Revision: response.Revision,
 				}
-				if _, ok := prevState.KeyValues[op.Delete.Key]; ok {
+				if _, ok := prevState.KeyValues.Get(KeyValue{Key: op.Delete.Key}); ok {
 					events = append(events, e)
 				}
 			case PutOperation:
@@ -102,7 +102,7 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 					},
 					Revision: response.Revision,
 				}
-				if _, ok := prevState.KeyValues[op.Put.Key]; !ok {
+				if _, ok := prevState.KeyValues.Get(KeyValue{Key: op.Put.Key}); !ok {
 					e.IsCreate = true
 				}
 				events = append(events, e)
@@ -113,7 +113,7 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 	case LeaseRevoke:
 		deletedKeys := []string{}
 		for key := range prevState.Leases[request.LeaseRevoke.LeaseID].Keys {
-			if _, ok := prevState.KeyValues[key]; ok {
+			if _, ok := prevState.KeyValues.Get(KeyValue{Key: key}); ok {
 				deletedKeys = append(deletedKeys, key)
 			}
 		}


### PR DESCRIPTION
```
                                                      │  new3.bench  │            new4-4.bench             │
                                                      │    sec/op    │   sec/op     vs base                │
ValidateLinearizableOperations/Successes-14              3.639m ± 3%   3.508m ± 3%   -3.60% (p=0.003 n=10)
ValidateLinearizableOperations/AllFailures-14            1.538m ± 1%   1.459m ± 1%   -5.18% (p=0.000 n=10)
ValidateLinearizableOperations/PutFailuresWithRead-14   1052.6µ ± 1%   845.4µ ± 2%  -19.68% (p=0.000 n=10)
geomean                                                  1.806m        1.629m        -9.79%
```
