### PR TITLE
robustness: improved visualization for EtcdState and WatchOperation

### DIFF
--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"html"
 	"maps"
 	"reflect"
 	"sort"
@@ -54,20 +55,20 @@ var DeterministicModel = porcupine.Model{
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), MaybeEtcdResponse{EtcdResponse: out.(EtcdResponse)}))
 	},
 	DescribeState: func(st any) string {
-		data, err := json.Marshal(st)
+		data, err := json.MarshalIndent(st, "", "  ")
 		if err != nil {
 			panic(err)
 		}
-		return string(data)
+		return "<pre>" + html.EscapeString(string(data)) + "</pre>"
 	},
 }
 
 type EtcdState struct {
-	Revision        int64
-	CompactRevision int64
-	KeyValues       map[string]ValueRevision
-	KeyLeases       map[string]int64
-	Leases          map[int64]EtcdLease
+	Revision        int64                    `json:",omitempty"`
+	CompactRevision int64                    `json:",omitempty"`
+	KeyValues       map[string]ValueRevision `json:",omitempty"`
+	KeyLeases       map[string]int64         `json:",omitempty"`
+	Leases          map[int64]EtcdLease      `json:",omitempty"`
 }
 
 func (s EtcdState) Equal(other EtcdState) bool {
@@ -458,14 +459,14 @@ func (el EtcdLease) DeepCopy() EtcdLease {
 }
 
 type ValueRevision struct {
-	Value       ValueOrHash
-	ModRevision int64
-	Version     int64
+	Value       ValueOrHash `json:",omitempty"`
+	ModRevision int64       `json:",omitempty"`
+	Version     int64       `json:",omitempty"`
 }
 
 type ValueOrHash struct {
-	Value string
-	Hash  uint32
+	Value string `json:",omitempty"`
+	Hash  uint32 `json:",omitempty"`
 }
 
 func ToValueOrHash(value string) ValueOrHash {

--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -17,6 +17,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"reflect"
 
 	"github.com/anishathalye/porcupine"
@@ -40,11 +41,11 @@ var NonDeterministicModel = porcupine.Model{
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), out.(MaybeEtcdResponse)))
 	},
 	DescribeState: func(st any) string {
-		data, err := json.Marshal(st)
+		data, err := json.MarshalIndent(st, "", "  ")
 		if err != nil {
 			panic(err)
 		}
-		return string(data)
+		return "<pre>" + html.EscapeString(string(data)) + "</pre>"
 	},
 }
 

--- a/tests/robustness/model/replay.go
+++ b/tests/robustness/model/replay.go
@@ -134,20 +134,20 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 }
 
 type WatchEvent struct {
-	PersistedEvent
-	PrevValue *ValueRevision
+	PersistedEvent `json:",omitempty"`
+	PrevValue      *ValueRevision `json:",omitempty"`
 }
 
 type PersistedEvent struct {
-	Event
-	Revision int64
-	IsCreate bool
+	Event    `json:",omitempty"`
+	Revision int64 `json:",omitempty"`
+	IsCreate bool  `json:",omitempty"`
 }
 
 type Event struct {
-	Type  OperationType
-	Key   string
-	Value ValueOrHash
+	Type  OperationType `json:",omitempty"`
+	Key   string        `json:",omitempty"`
+	Value ValueOrHash   `json:",omitempty"`
 }
 
 func (e Event) Match(request WatchRequest) bool {

--- a/tests/robustness/model/watch.go
+++ b/tests/robustness/model/watch.go
@@ -17,14 +17,14 @@ package model
 import "time"
 
 type WatchOperation struct {
-	Request   WatchRequest
-	Responses []WatchResponse
+	Request   WatchRequest    `json:",omitempty"`
+	Responses []WatchResponse `json:",omitempty"`
 }
 
 type WatchResponse struct {
-	Events           []WatchEvent
-	IsProgressNotify bool
-	Revision         int64
-	Time             time.Duration
-	Error            string
+	Events           []WatchEvent  `json:",omitempty"`
+	IsProgressNotify bool          `json:",omitempty"`
+	Revision         int64         `json:",omitempty"`
+	Time             time.Duration `json:",omitempty"`
+	Error            string        `json:",omitempty"`
 }

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -177,12 +177,13 @@ func persistWatchOperations(t *testing.T, lg *zap.Logger, path string, responses
 		return
 	}
 	defer file.Close()
-	encoder := json.NewEncoder(file)
 	for _, resp := range responses {
-		err := encoder.Encode(resp)
+		data, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {
 			t.Errorf("Failed to encode operation: %v", err)
 		}
+		file.Write(data)
+		file.WriteString("\n")
 	}
 }
 
@@ -194,11 +195,12 @@ func persistKeyValueOperations(t *testing.T, lg *zap.Logger, path string, operat
 		return
 	}
 	defer file.Close()
-	encoder := json.NewEncoder(file)
 	for _, op := range operations {
-		err := encoder.Encode(op)
+		data, err := json.MarshalIndent(op, "", "  ")
 		if err != nil {
 			t.Errorf("Failed to encode KV operation: %v", err)
 		}
+		file.Write(data)
+		file.WriteString("\n")
 	}
 }


### PR DESCRIPTION
Improved visualization for robustness test reports.
* Added `omitempty` to omit empty JSON fields
* Added indentation for report files (e.g. watch.json and operations.json)

Ref: https://github.com/etcd-io/etcd/issues/19901

/cc @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
