### PR TITLE
client: Better error handling in Watcher.Close()

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -391,13 +391,10 @@ func (w *watcher) Close() (err error) {
 	w.streams = nil
 	w.mu.Unlock()
 	for _, wgs := range streams {
-		if werr := wgs.close(); werr != nil {
-			err = werr
+		// Consider context.Canceled as a successful close
+		if werr := wgs.close(); werr != nil && !errors.Is(err, context.Canceled) {
+			err = errors.Join(err, werr)
 		}
-	}
-	// Consider context.Canceled as a successful close
-	if errors.Is(err, context.Canceled) {
-		err = nil
 	}
 	return err
 }


### PR DESCRIPTION
The previous implementation might've ignored a real error if the last error happened to be context.Cancelled.

While we're at it, might as well use the new errors.Join() to actually return all errors.