### PR TITLE
Add test-robustness-release-3.6 Makefile target

### DIFF
--- a/tests/robustness/Makefile
+++ b/tests/robustness/Makefile
@@ -13,8 +13,12 @@ test-robustness-reports:
 TOPLEVEL_MAKE := $(MAKE) --directory=$(REPOSITORY_ROOT)
 
 .PHONY: test-robustness-main
-test-robustness-main: /tmp/etcd-main-failpoints/bin /tmp/etcd-release-3.5-failpoints/bin
-	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-main-failpoints/bin --bin-last-release=/tmp/etcd-release-3.5-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
+test-robustness-main: /tmp/etcd-main-failpoints/bin /tmp/etcd-release-3.6-failpoints/bin
+	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-main-failpoints/bin --bin-last-release=/tmp/etcd-release-3.6-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
+
+.PHONY: test-robustness-release-3.6
+test-robustness-release-3.6: /tmp/etcd-release-3.6-failpoints/bin /tmp/etcd-release-3.5-failpoints/bin
+	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-release-3.6-failpoints/bin --bin-last-release=/tmp/etcd-release-3.5-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
 
 .PHONY: test-robustness-release-3.5
 test-robustness-release-3.5: /tmp/etcd-release-3.5-failpoints/bin /tmp/etcd-release-3.4-failpoints/bin
@@ -109,6 +113,14 @@ $(GOPATH)/bin/gofail: $(REPOSITORY_ROOT)/tools/mod/go.mod $(REPOSITORY_ROOT)/too
 	mkdir -p /tmp/etcd-v3.6.0-failpoints/
 	cd /tmp/etcd-v3.6.0-failpoints/; \
 	  git clone --depth 1 --branch main https://github.com/etcd-io/etcd.git .; \
+	  $(MAKE) gofail-enable; \
+	  $(MAKE) build;
+
+/tmp/etcd-release-3.6-failpoints/bin: $(GOPATH)/bin/gofail
+	rm -rf /tmp/etcd-release-3.6-failpoints/
+	mkdir -p /tmp/etcd-release-3.6-failpoints/
+	cd /tmp/etcd-release-3.6-failpoints/; \
+	  git clone --depth 1 --branch release-3.6 https://github.com/etcd-io/etcd.git .; \
 	  $(MAKE) gofail-enable; \
 	  $(MAKE) build;
 


### PR DESCRIPTION
Add `test-robustness-release-3.6` Makefile target

```
make gofail-enable
make build
make gofail-disable

make test-robustness-release-3.6
```

Ref: https://github.com/etcd-io/etcd/issues/19942
/cc @ivanvc @serathius 