### PR TITLE
[release-3.6] Update release script to exactly match the target tag

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -184,7 +184,7 @@ main() {
     fi
 
     # Tag release.
-    if [ "$(git tag --list | grep -c "${RELEASE_VERSION}")" -gt 0 ]; then
+    if git tag --list | grep --quiet "^${RELEASE_VERSION}$"; then
       log_callout "Skipping tag step. git tag ${RELEASE_VERSION} already exists."
     else
       log_callout "Tagging release..."


### PR DESCRIPTION
When we release etcd v3.6.0, we ran into an issue. The command `git tag --list | grep -c "${RELEASE_VERSION}")" -gt 0` returned 64, so it thought the tag v3.6.0 already existed, but actually not. 


So updating the script to exactly match the target tag.

Normally we fix in main, and backport to stable releases, given the tight schedule, so we fix it release-3.6 for now, and backport and forward port to other branches.