### PR TITLE
stale action: exempt help wanted label for stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
           days-until-close: 21
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-labels: 'stage/tracked'
+          exempt-labels: 'stage/tracked,help wanted'
           exempt-projects: false
           exempt-milestones: false
           exempt-assignees: false


### PR DESCRIPTION
As @ivanvc and @jmhbnz  suggested, exempt `help wanted` label for stale action.

Ref: https://github.com/etcd-io/etcd/pull/19932#issuecomment-2892286858