### PR TITLE
mvcc: switch to fail point in test

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -31,6 +31,7 @@ require (
 	go.etcd.io/etcd/client/v2 v2.306.0-alpha.0
 	go.etcd.io/etcd/client/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/pkg/v3 v3.6.0-alpha.0
+	go.etcd.io/gofail v0.2.0
 	go.etcd.io/raft/v3 v3.6.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
 	go.opentelemetry.io/otel v1.35.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -125,6 +125,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
+go.etcd.io/gofail v0.2.0 h1:p19drv16FKK345a09a1iubchlw/vmRuksmRzgBIGjcA=
+go.etcd.io/gofail v0.2.0/go.mod h1:nL3ILMGfkXTekKI3clMBNazKnjUZjYLKmBHzsVAnC1o=
 go.etcd.io/raft/v3 v3.6.0 h1:5NtvbDVYpnfZWcIHgGRk9DyzkBIXOi8j+DDp1IcnUWQ=
 go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/server/storage/mvcc/watcher.go
+++ b/server/storage/mvcc/watcher.go
@@ -153,6 +153,9 @@ func (ws *watchStream) Cancel(id WatchID) error {
 	if !ok {
 		return ErrWatcherNotExist
 	}
+
+	// gofail: var beforeWatchStreamCancelWhileUnlocked struct{}
+
 	cancel()
 
 	ws.mu.Lock()


### PR DESCRIPTION
This test is hard to provoke without inserting a sleep at the right place... fortunately this is what failpoints can do for us.

Note that to my understanding, the user still needs to run `gofail enable` etc in order to run this unit test with this delay inserted (i.e., I don't see that we are using failpoints already as part of the unit testing flow for anything in this package).


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
