### PR TITLE
Add key window to achieve unique keys for delete operations

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -119,6 +119,7 @@ func simulateTraffic(ctx context.Context, hosts []string, ids identity.Provider,
 	concurrencyLimiter := traffic.NewConcurrencyLimiter(profile.MaxNonUniqueRequestConcurrency)
 	finish := closeAfter(ctx, duration)
 	reports := []report.ClientReport{}
+	keyStore := traffic.NewKeyStore(profile.ClientCount, "key")
 	for i := 0; i < profile.ClientCount; i++ {
 		c := connect([]string{hosts[i%len(hosts)]}, ids, baseTime)
 		defer c.Close()
@@ -131,6 +132,7 @@ func simulateTraffic(ctx context.Context, hosts []string, ids identity.Provider,
 				ids,
 				storage,
 				concurrencyLimiter,
+				keyStore,
 				finish,
 			)
 			mux.Lock()

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -121,13 +121,13 @@ func (t etcdTraffic) Name() string {
 	return "Etcd"
 }
 
-func (t etcdTraffic) RunTrafficLoop(ctx context.Context, c *client.RecordingClient, limiter *rate.Limiter, ids identity.Provider, lm identity.LeaseIDStorage, nonUniqueWriteLimiter ConcurrencyLimiter, finish <-chan struct{}) {
+func (t etcdTraffic) RunTrafficLoop(ctx context.Context, c *client.RecordingClient, limiter *rate.Limiter, ids identity.Provider, lm identity.LeaseIDStorage, nonUniqueWriteLimiter ConcurrencyLimiter, keyStore *keyStore, finish <-chan struct{}) {
 	lastOperationSucceeded := true
 	var lastRev int64
 	var requestType etcdRequestType
 	client := etcdTrafficClient{
 		etcdTraffic:  t,
-		keyPrefix:    "key",
+		keyStore:     keyStore,
 		client:       c,
 		limiter:      limiter,
 		idProvider:   ids,
@@ -208,7 +208,7 @@ func filterOutNonUniqueEtcdWrites(choices []random.ChoiceWeight[etcdRequestType]
 
 type etcdTrafficClient struct {
 	etcdTraffic
-	keyPrefix    string
+	keyStore     *keyStore
 	client       *client.RecordingClient
 	limiter      *rate.Limiter
 	idProvider   identity.Provider
@@ -223,57 +223,57 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 	switch request {
 	case StaleGet:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Get(opCtx, c.randomKey(), clientv3.WithRev(lastRev))
+		resp, err = c.client.Get(opCtx, c.keyStore.GetKey(), clientv3.WithRev(lastRev))
 		if err == nil {
 			rev = resp.Header.Revision
 		}
 	case Get:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Get(opCtx, c.randomKey(), clientv3.WithRev(0))
+		resp, err = c.client.Get(opCtx, c.keyStore.GetKey(), clientv3.WithRev(0))
 		if err == nil {
 			rev = resp.Header.Revision
 		}
 	case List:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Range(ctx, c.keyPrefix, clientv3.GetPrefixRangeEnd(c.keyPrefix), 0, limit)
+		resp, err = c.client.Range(ctx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit)
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case StaleList:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Range(ctx, c.keyPrefix, clientv3.GetPrefixRangeEnd(c.keyPrefix), lastRev, limit)
+		resp, err = c.client.Range(ctx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit)
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case Put:
 		var resp *clientv3.PutResponse
-		resp, err = c.client.Put(opCtx, c.randomKey(), fmt.Sprintf("%d", c.idProvider.NewRequestID()))
+		resp, err = c.client.Put(opCtx, c.keyStore.GetKey(), fmt.Sprintf("%d", c.idProvider.NewRequestID()))
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case LargePut:
 		var resp *clientv3.PutResponse
-		resp, err = c.client.Put(opCtx, c.randomKey(), random.RandString(c.largePutSize))
+		resp, err = c.client.Put(opCtx, c.keyStore.GetKey(), random.RandString(c.largePutSize))
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case Delete:
 		var resp *clientv3.DeleteResponse
-		resp, err = c.client.Delete(opCtx, c.randomKey())
+		resp, err = c.client.Delete(opCtx, c.keyStore.GetKeyForDelete())
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case MultiOpTxn:
 		var resp *clientv3.TxnResponse
 		resp, err = c.client.Txn(opCtx).Then(
-			c.pickMultiTxnOps()...,
+			c.pickMultiTxnOps(c.keyStore)...,
 		).Commit()
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case CompareAndSet:
 		var kv *mvccpb.KeyValue
-		key := c.randomKey()
+		key := c.keyStore.GetKey()
 		var resp *clientv3.GetResponse
 		resp, err = c.client.Get(opCtx, key, clientv3.WithRev(0))
 		if err == nil {
@@ -315,7 +315,7 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 		if leaseID != 0 {
 			putCtx, putCancel := context.WithTimeout(ctx, RequestTimeout)
 			var resp *clientv3.PutResponse
-			resp, err = c.client.PutWithLease(putCtx, c.randomKey(), fmt.Sprintf("%d", c.idProvider.NewRequestID()), leaseID)
+			resp, err = c.client.PutWithLease(putCtx, c.keyStore.GetKey(), fmt.Sprintf("%d", c.idProvider.NewRequestID()), leaseID)
 			putCancel()
 			if resp != nil {
 				rev = resp.Header.Revision
@@ -346,8 +346,7 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 	return rev, err
 }
 
-func (c etcdTrafficClient) pickMultiTxnOps() (ops []clientv3.Op) {
-	keys := rand.Perm(c.keyCount)
+func (c etcdTrafficClient) pickMultiTxnOps(keyStore *keyStore) (ops []clientv3.Op) {
 	opTypes := make([]model.OperationType, 4)
 
 	atLeastOnePut := false
@@ -362,8 +361,10 @@ func (c etcdTrafficClient) pickMultiTxnOps() (ops []clientv3.Op) {
 		opTypes[0] = model.PutOperation
 	}
 
+	keys := keyStore.GetKeysForMultiTxnOps(opTypes)
+
 	for i, opType := range opTypes {
-		key := c.key(keys[i])
+		key := keys[i]
 		switch opType {
 		case model.RangeOperation:
 			ops = append(ops, clientv3.OpGet(key))
@@ -377,14 +378,6 @@ func (c etcdTrafficClient) pickMultiTxnOps() (ops []clientv3.Op) {
 		}
 	}
 	return ops
-}
-
-func (c etcdTrafficClient) randomKey() string {
-	return c.key(rand.Int())
-}
-
-func (c etcdTrafficClient) key(i int) string {
-	return fmt.Sprintf("%s%d", c.keyPrefix, i%c.keyCount)
 }
 
 func (t etcdTraffic) pickOperationType() model.OperationType {

--- a/tests/robustness/traffic/key_store.go
+++ b/tests/robustness/traffic/key_store.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traffic
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"go.etcd.io/etcd/tests/v3/robustness/model"
+)
+
+// Stores the key pool to use for operations. This allows keys used in Put and Delete operations to be more unique by probabilistically swapping out used keys.
+type keyStore struct {
+	mu sync.Mutex
+
+	counter   int
+	keys      []string
+	keyPrefix string
+}
+
+func NewKeyStore(size int, keyPrefix string) *keyStore {
+	k := &keyStore{
+		keys:      make([]string, size),
+		counter:   0,
+		keyPrefix: keyPrefix,
+	}
+
+	// Fill with default values i.e. key0-key9
+	for ; k.counter < len(k.keys); k.counter++ {
+		k.keys[k.counter] = fmt.Sprintf("%s%d", k.keyPrefix, k.counter)
+	}
+
+	return k
+}
+
+func (k *keyStore) GetKey() string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	useKey := k.keys[rand.Intn(len(k.keys))]
+
+	return useKey
+}
+
+func (k *keyStore) GetKeyForDelete() string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	useKeyIndex := rand.Intn(len(k.keys))
+	useKey := k.keys[useKeyIndex]
+
+	k.replaceKey(useKeyIndex)
+
+	return useKey
+}
+
+func (k *keyStore) GetKeysForMultiTxnOps(ops []model.OperationType) []string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	numOps := len(ops)
+
+	if numOps > len(k.keys) {
+		panic("GetKeysForMultiTxnOps: number of operations is more than the key pool size")
+	}
+
+	keys := make([]string, numOps)
+
+	permutedKeyIndexes := rand.Perm(len(k.keys))
+	for i, op := range ops {
+		keys[i] = k.keys[permutedKeyIndexes[i]]
+
+		if op == model.DeleteOperation {
+			k.replaceKey(permutedKeyIndexes[i])
+		}
+	}
+
+	return keys
+}
+
+func (k *keyStore) GetPrefix() string {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	return k.keyPrefix
+}
+
+func (k *keyStore) replaceKey(index int) {
+	if rand.Intn(100) < 90 {
+		k.keys[index] = fmt.Sprintf("%s%d", k.keyPrefix, k.counter)
+		k.counter++
+	}
+}

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -71,7 +71,7 @@ func (t kubernetesTraffic) ExpectUniqueRevision() bool {
 	return true
 }
 
-func (t kubernetesTraffic) RunTrafficLoop(ctx context.Context, c *client.RecordingClient, limiter *rate.Limiter, ids identity.Provider, lm identity.LeaseIDStorage, nonUniqueWriteLimiter ConcurrencyLimiter, finish <-chan struct{}) {
+func (t kubernetesTraffic) RunTrafficLoop(ctx context.Context, c *client.RecordingClient, limiter *rate.Limiter, ids identity.Provider, lm identity.LeaseIDStorage, nonUniqueWriteLimiter ConcurrencyLimiter, keyStore *keyStore, finish <-chan struct{}) {
 	kc := kubernetes.Client{Client: &clientv3.Client{KV: c}}
 	s := newStorage()
 	keyPrefix := "/registry/" + t.resource + "/"


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Adds the `keyStore` into `etcdTraffic` which maintains a consistent pool of keys (size 10) such that used keys will be swapped out and replaced with a new key. 

```bash
PERSIST_RESULTS=true EXPECT_DEBUG=true GO_TEST_FLAGS='-v' make test-robustness
```

The porcupine results shows that the uniqueness of keys in early stages for EtcdTrafficDeleteLeases:

![image](https://github.com/user-attachments/assets/a44084d4-1a28-4f5c-9229-4df403cbcc7e)

and in the later stages:

![image](https://github.com/user-attachments/assets/092808d4-8ab0-4a69-9c2f-4335cf442ecf)


ref: https://github.com/etcd-io/etcd/issues/19984
/cc @serathius 

