### PR TITLE
[release-3.4] Add verify-mod-tidy Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -555,7 +555,7 @@ gofail-disable: install-gofail
 	PASSES="toggle_failpoints" ./test
 
 .PHONY: verify
-verify: verify-go-versions verify-gofmt verify-bom verify-dep verify-shellcheck verify-goword verify-govet verify-revive verify-license-header verify-receiver-name verify-markdown-you verify-markdown-marker
+verify: verify-go-versions verify-gofmt verify-bom verify-dep verify-shellcheck verify-goword verify-govet verify-revive verify-license-header verify-mod-tidy verify-receiver-name verify-markdown-you verify-markdown-marker
 
 .PHONY: verify-shellcheck
 verify-shellcheck:
@@ -588,6 +588,10 @@ verify-revive:
 .PHONY: verify-license-header
 verify-license-header:
 	PASSES="license_header" ./test
+
+.PHONY: verify-mod-tidy
+verify-mod-tidy:
+	PASSES="mod_tidy" ./test
 
 .PHONY: verify-receiver-name
 verify-receiver-name:

--- a/build
+++ b/build
@@ -105,8 +105,6 @@ tools_build() {
 	done
 }
 
-toggle_failpoints_default
-
 if [[ "${ETCD_SETUP_GOPATH:-}" == "1" ]]; then
 	etcd_setup_gopath
 fi

--- a/test
+++ b/test
@@ -426,6 +426,26 @@ EOF
 	VERSION="${VERSION}" "./scripts/test_images.sh"
 }
 
+function mod_tidy_pass {
+	if ! output=$(go mod tidy -diff); then
+		echo -e "go mod tidy checking failed for go.mod (!=0 return code):\\n${output}"
+		exit 255
+	fi
+	if [ -n "${output}" ]; then
+		echo -e "go mod tidy checking failed for go.mod (printed output):\\n${output}"
+		exit 255
+	fi
+
+	if ! output=$(cd ./tools/mod && go mod tidy -diff); then
+		echo -e "go mod tidy checking failed for tools/mod/go.mod (!=0 return code):\\n${output}"
+		exit 255
+	fi
+	if [ -n "${output}" ]; then
+		echo -e "go mod tidy checking failed for tools/mod/go.mod (printed output):\\n${output}"
+		exit 255
+	fi
+}
+
 function shellcheck_pass {
 	SHELLCHECK=shellcheck
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Adds `verify-mod-tidy` to `make verify`. 

Ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @abdurrehman107 
