### PR TITLE
Remove prefix `--experimental-` instead of `--experimental` from flag

### DIFF
--- a/tests/framework/e2e/config.go
+++ b/tests/framework/e2e/config.go
@@ -92,7 +92,7 @@ func convertFlags(args []string, ver *semver.Version) []string {
 		}
 
 		name := strings.TrimPrefix(kv[0], "--")
-		name = strings.TrimPrefix(name, "experimental")
+		name = strings.TrimPrefix(name, "experimental-")
 
 		retArgs = append(retArgs, convertFlag(name, kv[1], ver))
 	}


### PR DESCRIPTION
Otherwise, we will get flags something like below when converting experimental flag to non-experimental flag,

- `---compaction-batch-limit=10`
- `---watch-progress-notify-interval=100ms`

See errors below,
```
    main_test.go:144: failed triggering failpoint, err: failed to find etcd ready lines ["ready to serve client requests"], err: match not found.  Set EXPECT_DEBUG for more info Errs: [unexpected exit code [2] after running [/tmp/etcd-release-3.6-failpoints/bin/etcd --name=TestRobustnessExploratoryKubernetesLowTrafficClusterOfSize1-test-0 --listen-client-urls=http://localhost:20000 --advertise-client-urls=http://localhost:20000 --listen-peer-urls=http://localhost:20001 --initial-advertise-peer-urls=http://localhost:20001 --initial-cluster-token=new --data-dir=/tmp/TestRobustnessExploratoryKubernetesLowTrafficClusterOfSize13155801533/001 --snapshot-count=1000 --snapshot-count=1000 ---compaction-batch-limit=1000 ---watch-progress-notify-interval=100ms --initial-cluster-token=new --initial-cluster=TestRobustnessExploratoryKubernetesLowTrafficClusterOfSize1-test-0=http://localhost:20001 --initial-cluster-state=new]], last lines:
        bad flag syntax: ---compaction-batch-limit=1000
        Usage:
        
          etcd [flags]
            Start an etcd server.
        
          etcd --version
            Show the version of etcd.
        
          etcd -h | --help
            Show the help information about etcd.
        
          etcd --config-file
            Path to the server configuration file. Note that if a configuration file is provided, other command line flags and environment variables will be ignored.
        
          etcd gateway
            Run the stateless pass-through etcd TCP connection forwarding proxy.
        
          etcd grpc-proxy
            Run the stateless etcd v3 gRPC L7 reverse proxy.

```


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
