### PR TITLE
Handle duplicate key delete in one TXN

### DIFF
--- a/tests/robustness/model/replay.go
+++ b/tests/robustness/model/replay.go
@@ -74,7 +74,7 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 		} else {
 			ops = request.Txn.OperationsOnSuccess
 		}
-		for _, op := range ops {
+		for i, op := range ops {
 			switch op.Type {
 			case RangeOperation:
 			case DeleteOperation:
@@ -85,7 +85,7 @@ func toWatchEvents(prevState *EtcdState, request EtcdRequest, response MaybeEtcd
 					},
 					Revision: response.Revision,
 				}
-				if _, ok := prevState.KeyValues[op.Delete.Key]; ok {
+				if response.Txn.Results[i].Deleted != 0 {
 					events = append(events, e)
 				}
 			case PutOperation:


### PR DESCRIPTION
The PR https://github.com/etcd-io/etcd/pull/20002 added TXN with multiple delete operations on single key. Didn't know that was even possible as I don't think it's allowed for Puts.

Still, the logic for generating events for such TXN operation is wrong.

/cc @joshjms @henrybear327 @nwnt @siyuanfoundation @fuweid 