### PR TITLE
[release-3.4] Cleanup functional tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,6 @@ jobs:
         - linux-amd64-integration-1-cpu
         - linux-amd64-integration-2-cpu
         - linux-amd64-integration-4-cpu
-        - linux-amd64-functional
         - linux-amd64-unit-4-cpu-race
         - all-build
         - linux-amd64-grpcproxy
@@ -44,9 +43,6 @@ jobs:
           linux-amd64-integration-4-cpu)
             make install-gofail
             GOARCH=amd64 CPU=4 RACE='false' FAILPOINTS='true' make test-integration
-            ;;
-          linux-amd64-functional)
-            ./build && GOARCH=amd64 PASSES='functional' ./test
             ;;
           linux-amd64-unit-4-cpu-race)
             GOARCH=amd64 RACE='true' CPU='4' GO_TEST_FLAGS='-p=2' make test-unit


### PR DESCRIPTION
Adds the `test-functional` Makefile target.

Previously in `.github/workflows/tests.yaml`:
```
...
          linux-amd64-functional)
            ./build && GOARCH=amd64 PASSES='functional' ./test
            ;;
...
```

This is to standardize the commands used in the Prow job, we aim to simplify jobs to a single `make [something]` as much as possible. 

/cc @ivanvc 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
