### PR TITLE
Add protection on `PromoteMember` and `UpdateRaftAttributes`

### DIFF
--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
@@ -994,6 +995,118 @@ func TestIsReadyToPromoteMember(t *testing.T) {
 		if got := c.IsReadyToPromoteMember(tt.promoteID); got != tt.want {
 			t.Errorf("%d: isReadyToPromoteMember returned %t, want %t", i, got, tt.want)
 		}
+	}
+}
+
+func TestPromoteMember(t *testing.T) {
+	clientURLs := []string{"http://127.0.0.1:2379"}
+	testCases := []struct {
+		name        string
+		members     []*Member
+		promoteID   types.ID
+		wantMembers map[types.ID]*Member
+	}{
+		{
+			name: "promote a voting member",
+			members: []*Member{
+				newTestMember(1, nil, "1", clientURLs),
+				newTestMemberAsLearner(2, nil, "2", clientURLs),
+			},
+			promoteID: 1,
+			wantMembers: map[types.ID]*Member{
+				1: newTestMember(1, nil, "1", clientURLs),
+				2: newTestMemberAsLearner(2, nil, "2", clientURLs),
+			},
+		},
+		{
+			name: "promote a learner",
+			members: []*Member{
+				newTestMember(1, nil, "1", clientURLs),
+				newTestMemberAsLearner(2, nil, "2", clientURLs),
+			},
+			promoteID: 2,
+			wantMembers: map[types.ID]*Member{
+				1: newTestMember(1, nil, "1", clientURLs),
+				2: newTestMember(2, nil, "2", clientURLs),
+			},
+		},
+		{
+			name: "promote a non-exist member",
+			members: []*Member{
+				newTestMember(1, nil, "1", clientURLs),
+				newTestMemberAsLearner(2, nil, "2", clientURLs),
+			},
+			promoteID: 3,
+			wantMembers: map[types.ID]*Member{
+				1: newTestMember(1, nil, "1", clientURLs),
+				2: newTestMemberAsLearner(2, nil, "2", clientURLs),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestCluster(t, tc.members)
+			st := v2store.New("/0", "/1")
+			c.Store(st)
+			c.SetStore(st)
+
+			c.PromoteMember(tc.promoteID, false)
+
+			mst, _ := membersFromStore(c.lg, st)
+			require.Equal(t, tc.wantMembers, mst)
+		})
+	}
+}
+
+func TestUpdateRaftAttributes(t *testing.T) {
+	clientURLs := []string{"http://127.0.0.1:2379"}
+	oldPeerURLs := []string{"http://127.0.0.1:2380"}
+	newPeerURLs := []string{"http://127.0.0.1:2382"}
+	testCases := []struct {
+		name           string
+		members        []*Member
+		updateMemberID types.ID
+		wantMembers    map[types.ID]*Member
+	}{
+		{
+			name: "update an existing member",
+			members: []*Member{
+				newTestMember(1, oldPeerURLs, "1", clientURLs),
+				newTestMember(2, oldPeerURLs, "2", clientURLs),
+			},
+			updateMemberID: 2,
+			wantMembers: map[types.ID]*Member{
+				1: newTestMember(1, oldPeerURLs, "1", clientURLs),
+				2: newTestMember(2, newPeerURLs, "2", clientURLs),
+			},
+		},
+		{
+			name: "update a non-exist member",
+			members: []*Member{
+				newTestMember(1, oldPeerURLs, "1", clientURLs),
+				newTestMember(2, oldPeerURLs, "2", clientURLs),
+			},
+			updateMemberID: 3,
+			wantMembers: map[types.ID]*Member{
+				1: newTestMember(1, oldPeerURLs, "1", clientURLs),
+				2: newTestMember(2, oldPeerURLs, "2", clientURLs),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestCluster(t, tc.members)
+			st := v2store.New("/0", "/1")
+			c.Store(st)
+			c.SetStore(st)
+
+			c.UpdateRaftAttributes(tc.updateMemberID, RaftAttributes{PeerURLs: newPeerURLs}, false)
+
+			mst, _ := membersFromStore(c.lg, st)
+			require.Equal(t, tc.wantMembers, mst)
+		})
 	}
 }
 

--- a/tests/e2e/force_new_cluster_test.go
+++ b/tests/e2e/force_new_cluster_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// TestForceNewCluster verified that etcd works as expected when --force-new-cluster.
+// Refer to discussion in https://github.com/etcd-io/etcd/issues/20009.
+func TestForceNewCluster(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	testCases := []struct {
+		name      string
+		snapcount int
+	}{
+		{
+			name:      "create a snapshot after promotion",
+			snapcount: 10,
+		},
+		{
+			name:      "no snapshot after promotion",
+			snapcount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			epc, promotedMembers := mustCreateNewClusterByPromotingMembers(t, e2e.CurrentVersion, 5,
+				e2e.WithKeepDataDir(true), e2e.WithSnapshotCount(uint64(tc.snapcount)))
+			require.Len(t, promotedMembers, 4)
+
+			for i := 0; i < tc.snapcount; i++ {
+				err := epc.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, epc.Close())
+
+			m := epc.Procs[0]
+			t.Logf("Forcibly create a one-member cluster with member: %s", m.Config().Name)
+			m.Config().Args = append(m.Config().Args, "--force-new-cluster")
+			require.NoError(t, m.Start(t.Context()))
+
+			t.Log("Restarting the member")
+			require.NoError(t, m.Restart(t.Context()))
+
+			t.Log("Closing the member")
+			require.NoError(t, m.Close())
+		})
+	}
+}


### PR DESCRIPTION
Fix the second issue mentioned in https://github.com/etcd-io/etcd/issues/20009#issuecomment-2910091109

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
