### PR TITLE
Fix number of operations is more than the key pool size

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -128,7 +128,7 @@ func simulateTraffic(ctx context.Context, hosts []string, ids identity.Provider,
 	concurrencyLimiter := traffic.NewConcurrencyLimiter(profile.MaxNonUniqueRequestConcurrency)
 	finish := closeAfter(ctx, duration)
 	reports := []report.ClientReport{}
-	keyStore := traffic.NewKeyStore(profile.ClientCount, "key")
+	keyStore := traffic.NewKeyStore(10, "key")
 	for i := 0; i < profile.ClientCount; i++ {
 		c := connect([]string{hosts[i%len(hosts)]}, ids, baseTime)
 		defer c.Close()


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Fixes 
```

robustness/singleton_driver_traffic client
panic: GetKeysForMultiTxnOps: number of operations is more than the key pool size
30.379
robustness/singleton_driver_traffic client
goroutine 184 [running]:
30.379
robustness/singleton_driver_traffic client
go.etcd.io/etcd/tests/v3/robustness/traffic.(*keyStore).GetKeysForMultiTxnOps(0xc000470f40, {0xc00059f488, 0x4, 0x0?})
30.380
robustness/singleton_driver_traffic client
	/build/tests/robustness/traffic/key_store.go:77 +0x485
30.381
robustness/singleton_driver_traffic client
go.etcd.io/etcd/tests/v3/robustness/traffic.etcdTrafficClient.pickMultiTxnOps({{0xa, {0x1b6f760, 0x7, 0x7}, 0x1c20, 0x8001}, 0xc000470f40, 0xc000254288, 0xc0005061e0, {0x14e94d8, ...}, ...}, ...)
30.381
robustness/singleton_driver_traffic client
	/build/tests/robustness/traffic/etcd.go:367 +0x62a
30.382
robustness/singleton_driver_traffic client
go.etcd.io/etcd/tests/v3/robustness/traffic.etcdTrafficClient.Request({{0xa, {0x1b6f760, 0x7, 0x7}, 0x1c20, 0x8001}, 0xc000470f40, 0xc000254288, 0xc0005061e0, {0x14e94d8, ...}, ...}, ...)
30.382
robustness/singleton_driver_traffic client
	/build/tests/robustness/traffic/etcd.go:272 +0x9db
30.383
robustness/singleton_driver_traffic client
go.etcd.io/etcd/tests/v3/robustness/traffic.etcdTraffic.RunTrafficLoop({0xa, {0x1b6f760, 0x7, 0x7}, 0x1c20, 0x8001}, {0x14eccd0, 0x2b41e20}, 0xc000254288, 0xc0005061e0, ...)
30.383
robustness/singleton_driver_traffic client
	/build/tests/robustness/traffic/etcd.go:159 +0x316
30.383
robustness/singleton_driver_traffic client
main.simulateTraffic.func1(0xc000254288)
30.383
robustness/singleton_driver_traffic client
	/build/tests/antithesis/test-template/robustness/traffic/main.go:140 +0x238
30.383
robustness/singleton_driver_traffic client
created by main.simulateTraffic in goroutine 163
30.383
robustness/singleton_driver_traffic client
	/build/tests/antithesis/test-template/robustness/traffic/main.go:136 +0x38b
```

In Antithesis we just run 3 clients, which is lower than number of operations in the `MultiOpTxn` which requires 4 keys being used.
/assign @ahrtr 