### PR TITLE
Increase the number of clients in antithesis tests to match robustness

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -41,7 +41,7 @@ var profile = traffic.Profile{
 	MinimalQPS:                     100,
 	MaximalQPS:                     1000,
 	BurstableQPS:                   1000,
-	ClientCount:                    3,
+	ClientCount:                    traffic.DefaultClientCount,
 	MaxNonUniqueRequestConcurrency: 3,
 }
 

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -243,7 +243,7 @@ func Regression(t *testing.T) []TestScenario {
 			MinimalQPS:                     50,
 			MaximalQPS:                     100,
 			BurstableQPS:                   100,
-			ClientCount:                    8,
+			ClientCount:                    traffic.DefaultClientCount,
 			MaxNonUniqueRequestConcurrency: 3,
 		}.WithoutCompaction(),
 		Failpoint: failpoint.BatchCompactBeforeSetFinishedCompactPanic,

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -38,19 +38,20 @@ var (
 	WatchTimeout                  = time.Second
 	MultiOpTxnOpCount             = 4
 	DefaultCompactionPeriod       = 200 * time.Millisecond
+	DefaultClientCount            = 8
 
 	LowTraffic = Profile{
 		MinimalQPS:                     100,
 		MaximalQPS:                     200,
 		BurstableQPS:                   1000,
-		ClientCount:                    8,
+		ClientCount:                    DefaultClientCount,
 		MaxNonUniqueRequestConcurrency: 3,
 	}
 	HighTrafficProfile = Profile{
 		MinimalQPS:                     100,
 		MaximalQPS:                     1000,
 		BurstableQPS:                   1000,
-		ClientCount:                    8,
+		ClientCount:                    DefaultClientCount,
 		MaxNonUniqueRequestConcurrency: 3,
 	}
 )


### PR DESCRIPTION
Think we need to increase number of clients to improve quality of space exploration.

/hold