### PR TITLE
[release-3.6] Add protection on `PromoteMember` and `UpdateRaftAttributes`

### DIFF
--- a/tests/e2e/force_new_cluster_test.go
+++ b/tests/e2e/force_new_cluster_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// TestForceNewCluster verified that etcd works as expected when --force-new-cluster.
+// Refer to discussion in https://github.com/etcd-io/etcd/issues/20009.
+func TestForceNewCluster(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	testCases := []struct {
+		name      string
+		snapcount int
+	}{
+		{
+			name:      "create a snapshot after promotion",
+			snapcount: 10,
+		},
+		{
+			name:      "no snapshot after promotion",
+			snapcount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			epc, promotedMembers := mustCreateNewClusterByPromotingMembers(t, e2e.CurrentVersion, 5,
+				e2e.WithKeepDataDir(true), e2e.WithSnapshotCount(uint64(tc.snapcount)))
+			require.Len(t, promotedMembers, 4)
+
+			for i := 0; i < tc.snapcount; i++ {
+				err := epc.Etcdctl().Put(ctx, "foo", "bar", config.PutOptions{})
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, epc.Close())
+
+			m := epc.Procs[0]
+			t.Logf("Forcibly create a one-member cluster with member: %s", m.Config().Name)
+			m.Config().Args = append(m.Config().Args, "--force-new-cluster")
+			require.NoError(t, m.Start(ctx))
+
+			t.Log("Restarting the member")
+			require.NoError(t, m.Restart(ctx))
+
+			t.Log("Closing the member")
+			require.NoError(t, m.Close())
+		})
+	}
+}


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/20026 to release-3.6.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.


FYI. also reproduced the panicking issue with only the first commit on release-3.6,

```
        	            	{"level":"panic","ts":"2025-05-29T08:44:44.090830+0100","caller":"schedule/schedule.go:202","msg":"execute job failed","job":"server_applyAll","panic":"runtime error: invalid memory address or nil pointer dereference","stacktrace":"go.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob.func1\n\tgo.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:202\nruntime.gopanic\n\truntime/panic.go:791\nruntime.panicmem\n\truntime/panic.go:262\nruntime.sigpanic\n\truntime/signal_unix.go:917\ngo.etcd.io/etcd/server/v3/etcdserver/api/membership.(*RaftCluster).PromoteMember\n\tgo.etcd.io/etcd/server/v3/etcdserver/api/membership/cluster.go:525\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyConfChange\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:2103\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:1902\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:1194\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:979\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func6\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:855\ngo.etcd.io/etcd/pkg/v3/schedule.job.Do\n\tgo.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:41\ngo.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob\n\tgo.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:206\ngo.etcd.io/etcd/pkg/v3/schedule.(*fifo).run\n\tgo.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:187"}
        	            	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        	            		panic: execute job failed
        	            	[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100bbe30c]
        	            	
        	            	goroutine 178 [running]:
        	            	go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x80?, 0x2?, {0xf?, 0x0?, 0x0?})
        	            		go.uber.org/zap@v1.27.0/zapcore/entry.go:196 +0x78
        	            	go.uber.org/zap/zapcore.(*CheckedEntry).Write(0x1400029e270, {0x14000436180, 0x2, 0x2})
        	            		go.uber.org/zap@v1.27.0/zapcore/entry.go:262 +0x1c4
        	            	go.uber.org/zap.(*Logger).Panic(0x100e41e69?, {0x100e50c08?, 0x101128640?}, {0x14000436180, 0x2, 0x2})
        	            		go.uber.org/zap@v1.27.0/logger.go:285 +0x54
        	            	go.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob.func1()
        	            		go.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:202 +0x24c
        	            	panic({0x101128640?, 0x101ae6bd0?})
        	            		runtime/panic.go:791 +0x124
        	            	go.etcd.io/etcd/server/v3/etcdserver/api/membership.(*RaftCluster).PromoteMember(0x1400032c620, 0xa5e3e2192b8e9cf2, 0x0)
        	            		go.etcd.io/etcd/server/v3/etcdserver/api/membership/cluster.go:525 +0xec
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyConfChange(0x140000cc308, {0x0, 0xa5e3e2192b8e9cf2, {0x140003a43c0, 0x3c, 0x40}, 0xd758971affb3f207}, 0x140000ea2d0, 0x0)
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:2103 +0x620
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply(0x140000cc308, {0x14000180a38, 0x17, 0x79?}, 0x140000ea2d0, 0x140000ae2a0)
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:1902 +0x440
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries(0x140000cc308, 0x140000ea2d0, 0x140001bc000?)
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:1194 +0x1fc
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll(0x140000cc308, 0x140000ea2d0, 0x140001bc000)
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:979 +0x40
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func6({0x1400006f6d8?, 0x100b56ea8?})
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:855 +0x28
        	            	go.etcd.io/etcd/pkg/v3/schedule.job.Do(...)
        	            		go.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:41
        	            	go.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob(0x0?, {0x1012ca638?, 0x1400038e108?}, 0x0?)
        	            		go.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:206 +0x78
        	            	go.etcd.io/etcd/pkg/v3/schedule.(*fifo).run(0x14000172bd0)
        	            		go.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:187 +0x15c
        	            	created by go.etcd.io/etcd/pkg/v3/schedule.NewFIFOScheduler in goroutine 144
        	            		go.etcd.io/etcd/pkg/v3@v3.6.0/schedule/schedule.go:101 +0x178
        	Test:       	TestForceNewCluster/no_snapshot_after_promotion
--- FAIL: TestForceNewCluster (61.18s)
    --- PASS: TestForceNewCluster/create_a_snapshot_after_promotion (31.79s)
    --- FAIL: TestForceNewCluster/no_snapshot_after_promotion (29.39s)
```

cc @fuweid @ivanvc @jmhbnz @serathius 