### PR TITLE
Sync keys in keystore on list request response

### DIFF
--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -240,6 +240,7 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 		var resp *clientv3.GetResponse
 		resp, err = c.client.Range(ctx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit)
 		if resp != nil {
+			c.keyStore.SyncKeys(resp)
 			rev = resp.Header.Revision
 		}
 	case StaleList:


### PR DESCRIPTION
Syncs keys to prevent leaked keys when receiving ListResponse.

Ref: https://github.com/etcd-io/etcd/issues/20034

/cc @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
