### PR TITLE
[release-3.4] Add grpcproxy Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,14 @@ test-integration:
 test-e2e:
 	PASSES="build e2e" ./test $(GO_TEST_FLAGS)
 
+.PHONY: test-grpcproxy-integration
+test-grpcproxy-integration:
+	PASSES='build grpcproxy_integration' RACE='true' ./test $(GO_TEST_FLAGS)
+
+.PHONY: test-grpcproxy-e2e
+test-grpcproxy-e2e:
+	PASSES='build grpcproxy_e2e' RACE='true' ./test $(GO_TEST_FLAGS)
+
 .PHONY: test-e2e-release
 test-e2e-release:
 	PASSES="build release e2e" ./test $(GO_TEST_FLAGS)

--- a/test
+++ b/test
@@ -361,8 +361,16 @@ function integration_e2e_pass {
 }
 
 function grpcproxy_pass {
+	grpcproxy_integration_pass "$@"
+	grpcproxy_e2e_pass "$@"
+}
+
+function grpcproxy_integration_pass {
 	go test -timeout 30m -v "${RACE}" -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/integration"
 	go test -timeout 30m -v "${RACE}" -tags cluster_proxy -cpu "${TEST_CPUS}" "$@" "${REPO_PATH}/clientv3/integration"
+}
+
+function grpcproxy_e2e_pass {
 	go test -timeout 30m -v -tags cluster_proxy "$@" "${REPO_PATH}/tests/e2e"
 }
 


### PR DESCRIPTION
Separates the grpcproxy tests and adds the Makefile target for integration and e2e grpcproxy tests.

Ref: https://github.com/kubernetes/test-infra/issues/32754

/cc @ivanvc @abdurrehman107 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
