### PR TITLE
tests/common: address Go 1.24 usetesting issues

### DIFF
--- a/tests/common/auth_test.go
+++ b/tests/common/auth_test.go
@@ -767,7 +767,7 @@ func TestAuthJWTExpire(t *testing.T) {
 
 func TestAuthJWTOnly(t *testing.T) {
 	testRunner.BeforeTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(config.ClusterConfig{ClusterSize: 1, AuthToken: verifyJWTOnlyAuth}))
 	defer clus.Close()


### PR DESCRIPTION
Address usetesting linter issues in `tests/common`.

Part of #19581

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
