### PR TITLE
tests/integration: address usetesting issues

### DIFF
--- a/tests/integration/cluster_test.go
+++ b/tests/integration/cluster_test.go
@@ -130,12 +130,12 @@ func TestForceNewCluster(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
 	defer c.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	resp, err := c.Members[0].Client.Put(ctx, "/foo", "bar")
 	require.NoErrorf(t, err, "unexpected create error")
 	cancel()
 	// ensure create has been applied in this machine
-	ctx, cancel = context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), integration.RequestTimeout)
 	watch := c.Members[0].Client.Watcher.Watch(ctx, "/foo", clientv3.WithRev(resp.Header.Revision-1))
 	for resp := range watch {
 		if len(resp.Events) != 0 {
@@ -156,7 +156,7 @@ func TestForceNewCluster(t *testing.T) {
 
 	// use new http client to init new connection
 	// ensure force restart keep the old data, and new Cluster can make progress
-	ctx, cancel = context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), integration.RequestTimeout)
 	watch = c.Members[0].Client.Watcher.Watch(ctx, "/foo", clientv3.WithRev(resp.Header.Revision-1))
 	for resp := range watch {
 		if len(resp.Events) != 0 {
@@ -240,7 +240,7 @@ func TestIssue2904(t *testing.T) {
 	c.Members[2].Stop(t)
 
 	// send remove member-1 request to the Cluster.
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	// the proposal is not committed because member 1 is stopped, but the
 	// proposal is appended to leader'Server raft log.
 	c.Members[0].Client.MemberRemove(ctx, uint64(c.Members[2].Server.MemberID()))
@@ -312,7 +312,7 @@ func TestIssue3699(t *testing.T) {
 
 	t.Logf("Expecting successful put...")
 	// try to participate in Cluster
-	ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 	_, err := c.Members[0].Client.Put(ctx, "/foo", "bar")
 	require.NoErrorf(t, err, "unexpected error on Put")
 	cancel()
@@ -441,7 +441,7 @@ func clusterMustProgress(t *testing.T, members []*integration.Member) {
 	)
 	// retry in case of leader loss induced by slow CI
 	for i := 0; i < 3; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		resp, err = members[0].Client.Put(ctx, key, "bar")
 		cancel()
 		if err == nil {
@@ -452,7 +452,7 @@ func clusterMustProgress(t *testing.T, members []*integration.Member) {
 	require.NoErrorf(t, err, "create on #0 error")
 
 	for i, m := range members {
-		mctx, mcancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		mctx, mcancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		watch := m.Client.Watcher.Watch(mctx, key, clientv3.WithRev(resp.Header.Revision-1))
 		for resp := range watch {
 			if len(resp.Events) != 0 {
@@ -494,16 +494,16 @@ func TestConcurrentRemoveMember(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer c.Terminate(t)
 
-	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
+	addResp, err := c.Members[0].Client.MemberAddAsLearner(t.Context(), []string{"http://localhost:123"})
 	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second / 2)
-		c.Members[0].Client.MemberRemove(context.Background(), removeID)
+		c.Members[0].Client.MemberRemove(t.Context(), removeID)
 		close(done)
 	}()
-	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	_, err = c.Members[0].Client.MemberRemove(t.Context(), removeID)
 	require.NoError(t, err)
 	<-done
 }
@@ -513,16 +513,16 @@ func TestConcurrentMoveLeader(t *testing.T) {
 	c := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer c.Terminate(t)
 
-	addResp, err := c.Members[0].Client.MemberAddAsLearner(context.Background(), []string{"http://localhost:123"})
+	addResp, err := c.Members[0].Client.MemberAddAsLearner(t.Context(), []string{"http://localhost:123"})
 	require.NoError(t, err)
 	removeID := addResp.Member.ID
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(time.Second / 2)
-		c.Members[0].Client.MoveLeader(context.Background(), removeID)
+		c.Members[0].Client.MoveLeader(t.Context(), removeID)
 		close(done)
 	}()
-	_, err = c.Members[0].Client.MemberRemove(context.Background(), removeID)
+	_, err = c.Members[0].Client.MemberRemove(t.Context(), removeID)
 	require.NoError(t, err)
 	<-done
 }

--- a/tests/integration/corrupt_test.go
+++ b/tests/integration/corrupt_test.go
@@ -38,7 +38,7 @@ func TestPeriodicCheck(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var totalRevisions int64 = 1210
 	var rev int64
@@ -74,7 +74,7 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
@@ -112,7 +112,7 @@ func TestCompactHashCheck(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var totalRevisions int64 = 1210
 	var rev int64
@@ -149,7 +149,7 @@ func TestCompactHashCheckDetectCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))
@@ -186,7 +186,7 @@ func TestCompactHashCheckDetectMultipleCorruption(t *testing.T) {
 	cc, err := clus.ClusterClient(t)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for i := 0; i < 10; i++ {
 		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i))

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -20,7 +20,6 @@
 package embed_test
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	defer cli.Close()
 
 	// open watch connection
-	cli.Watch(context.Background(), "foo")
+	cli.Watch(t.Context(), "foo")
 
 	donec := make(chan struct{})
 	go func() {

--- a/tests/integration/grpc_test.go
+++ b/tests/integration/grpc_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	tls "crypto/tls"
 	"fmt"
 	"strings"
@@ -105,7 +104,7 @@ func TestAuthority(t *testing.T) {
 
 				putRequestMethod := "/etcdserverpb.KV/Put"
 				for i := 0; i < 100; i++ {
-					_, err := kv.Put(context.TODO(), "foo", "bar")
+					_, err := kv.Put(t.Context(), "foo", "bar")
 					require.NoError(t, err)
 				}
 

--- a/tests/integration/hashkv_test.go
+++ b/tests/integration/hashkv_test.go
@@ -46,7 +46,7 @@ func TestCompactionHash(t *testing.T) {
 		},
 	}
 
-	testutil.TestCompactionHash(context.Background(), t, hashTestCase{cc, clus.Members[0].GRPCURL, client, clus.Members[0].Server}, 1000)
+	testutil.TestCompactionHash(t.Context(), t, hashTestCase{cc, clus.Members[0].GRPCURL, client, clus.Members[0].Server}, 1000)
 }
 
 type hashTestCase struct {

--- a/tests/integration/member_test.go
+++ b/tests/integration/member_test.go
@@ -91,7 +91,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 
 	var err error
 	for i := 0; i < 120; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		_, err = m.Client.Put(ctx, "/"+key, "bar")
 		require.NoErrorf(t, err, "#%d: create on %s error", i, m.URL())
@@ -102,7 +102,7 @@ func TestSnapshotAndRestartMember(t *testing.T) {
 
 	m.WaitOK(t)
 	for i := 0; i < 120; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		key := fmt.Sprintf("foo%d", i)
 		resp, err := m.Client.Get(ctx, "/"+key)
 		require.NoErrorf(t, err, "#%d: get on %s error", i, m.URL())
@@ -145,7 +145,7 @@ func TestRemoveMemberAndWALReplay(t *testing.T) {
 
 	// Add some k/v to trigger snapshot
 	for i := 0; i < 15; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), integration.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), integration.RequestTimeout)
 		_, err := c.Members[0].Client.Put(ctx, fmt.Sprintf("k%d", i), fmt.Sprintf("v%d", i))
 		cancel()
 		require.NoErrorf(t, err, "failed to put key-value")
@@ -174,7 +174,7 @@ func checkMemberCount(t *testing.T, m *integration.Member, expectedMemberCount i
 	if len(membersFromBackend) != expectedMemberCount {
 		t.Errorf("Expect member count read from backend=%d, got %d", expectedMemberCount, len(membersFromBackend))
 	}
-	membersResp, err := m.Client.MemberList(context.Background())
+	membersResp, err := m.Client.MemberList(t.Context())
 	require.NoError(t, err)
 	if len(membersResp.Members) != expectedMemberCount {
 		t.Errorf("Expect len(MemberList)=%d, got %d", expectedMemberCount, len(membersResp.Members))

--- a/tests/integration/proxy/grpcproxy/cluster_test.go
+++ b/tests/integration/proxy/grpcproxy/cluster_test.go
@@ -15,7 +15,6 @@
 package grpcproxy
 
 import (
-	"context"
 	"net"
 	"os"
 	"testing"
@@ -59,7 +58,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	var mresp *clientv3.MemberListResponse
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 
 	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
@@ -73,7 +72,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// check add member succ
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 	require.Lenf(t, mresp.Members, 2, "len(mresp.Members) expected 2, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{newMemberAddr}})
@@ -84,7 +83,7 @@ func TestClusterProxyMemberList(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// check delete member succ
-	mresp, err = client.Cluster.MemberList(context.Background())
+	mresp, err = client.Cluster.MemberList(t.Context())
 	require.NoErrorf(t, err, "err %v, want nil", err)
 	require.Lenf(t, mresp.Members, 1, "len(mresp.Members) expected 1, got %d (%+v)", len(mresp.Members), mresp.Members)
 	assert.Contains(t, mresp.Members, &pb.Member{Name: hostname, ClientURLs: []string{cts.caddr}})

--- a/tests/integration/proxy/grpcproxy/kv_test.go
+++ b/tests/integration/proxy/grpcproxy/kv_test.go
@@ -15,7 +15,6 @@
 package grpcproxy
 
 import (
-	"context"
 	"net"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ func TestKVProxyRange(t *testing.T) {
 	}
 	client, err := integration2.NewClient(t, cfg)
 	require.NoErrorf(t, err, "err = %v, want nil", err)
-	_, err = client.Get(context.Background(), "foo")
+	_, err = client.Get(t.Context(), "foo")
 	require.NoErrorf(t, err, "err = %v, want nil", err)
 	client.Close()
 }

--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -81,7 +81,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	ctx, cancel := context.WithTimeout(t.Context(), testDuration)
 	defer cancel()
 
 	wg := sync.WaitGroup{}
@@ -104,7 +104,7 @@ func testRevisionMonotonicWithFailures(t *testing.T, testDuration time.Duration,
 	injectFailures(clus)
 	wg.Wait()
 	kv := clus.Client(0)
-	resp, err := kv.Get(context.Background(), "foo")
+	resp, err := kv.Get(t.Context(), "foo")
 	require.NoError(t, err)
 	t.Logf("Revision %d", resp.Header.Revision)
 }

--- a/tests/integration/snapshot/member_test.go
+++ b/tests/integration/snapshot/member_test.go
@@ -56,7 +56,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 
 	urls := newEmbedURLs(t, 2)
 	newCURLs, newPURLs := urls[:1], urls[1:]
-	_, err = cli.MemberAdd(context.Background(), []string{newPURLs[0].String()})
+	_, err = cli.MemberAdd(t.Context(), []string{newPURLs[0].String()})
 	require.NoError(t, err)
 
 	// wait for membership reconfiguration apply
@@ -89,7 +89,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 	require.NoError(t, err)
 	defer cli2.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	mresp, err := cli2.MemberList(ctx)
 	cancel()
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestSnapshotV3RestoreMultiMemberAdd(t *testing.T) {
 
 	// make sure restored cluster has kept all data on recovery
 	var gresp *clientv3.GetResponse
-	ctx, cancel = context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel = context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	gresp, err = cli2.Get(ctx, "foo", clientv3.WithPrefix())
 	cancel()
 	require.NoError(t, err)

--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -86,7 +86,7 @@ func TestSnapshotV3RestoreSingle(t *testing.T) {
 	defer cli.Close()
 	for i := range kvs {
 		var gresp *clientv3.GetResponse
-		gresp, err = cli.Get(context.Background(), kvs[i].k)
+		gresp, err = cli.Get(t.Context(), kvs[i].k)
 		require.NoError(t, err)
 		require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 	}
@@ -117,7 +117,7 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 		defer cli.Close()
 		for i := range kvs {
 			var gresp *clientv3.GetResponse
-			gresp, err = cli.Get(context.Background(), kvs[i].k)
+			gresp, err = cli.Get(t.Context(), kvs[i].k)
 			require.NoError(t, err)
 			require.Equalf(t, string(gresp.Kvs[0].Value), kvs[i].v, "#%d: value expected %s, got %s", i, kvs[i].v, gresp.Kvs[0].Value)
 		}
@@ -182,7 +182,7 @@ func createSnapshotFile(t *testing.T, kvs []kv) string {
 	require.NoError(t, err)
 	defer cli.Close()
 	for i := range kvs {
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 		_, err = cli.Put(ctx, kvs[i].k, kvs[i].v)
 		cancel()
 		require.NoError(t, err)
@@ -190,7 +190,7 @@ func createSnapshotFile(t *testing.T, kvs []kv) string {
 
 	sp := snapshot.NewV3(zaptest.NewLogger(t))
 	dpPath := filepath.Join(t.TempDir(), fmt.Sprintf("snapshot%d.db", time.Now().Nanosecond()))
-	_, err = sp.Save(context.Background(), ccfg, dpPath)
+	_, err = sp.Save(t.Context(), ccfg, dpPath)
 	require.NoError(t, err)
 	return dpPath
 }

--- a/tests/integration/tracing_test.go
+++ b/tests/integration/tracing_test.go
@@ -43,7 +43,7 @@ func TestTracing(t *testing.T) {
 	t.Run("UnaryRPC", func(t *testing.T) {
 		testRPCTracing(t, "UnaryRPC", containsUnaryRPCSpan, func(cli *clientv3.Client) error {
 			// make a request with the instrumented client
-			resp, err := cli.Get(context.TODO(), "key")
+			resp, err := cli.Get(t.Context(), "key")
 			require.NoError(t, err)
 			require.Empty(t, resp.Kvs)
 			return nil
@@ -54,14 +54,14 @@ func TestTracing(t *testing.T) {
 	t.Run("StreamRPC", func(t *testing.T) {
 		testRPCTracing(t, "StreamRPC", containsStreamRPCSpan, func(cli *clientv3.Client) error {
 			// Create a context with a reasonable timeout
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			// Create a watch channel
 			watchChan := cli.Watch(ctx, "watch-key")
 
 			// Put a value to trigger the watch
-			_, err := cli.Put(context.TODO(), "watch-key", "watch-value")
+			_, err := cli.Put(t.Context(), "watch-key", "watch-value")
 			require.NoError(t, err)
 
 			// Wait for watch event
@@ -118,7 +118,7 @@ func testRPCTracing(t *testing.T, testName string, filterFunc func(*traceservice
 
 	// create a client that has tracing enabled
 	tracer := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
-	defer tracer.Shutdown(context.TODO())
+	defer tracer.Shutdown(t.Context())
 	tp := trace.TracerProvider(tracer)
 
 	tracingOpts := []otelgrpc.Option{

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -63,7 +63,7 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 
 	// Once the cluster version has been updated, any entity's storage
 	// version should be align with cluster version.
-	ctx, cancel := context.WithTimeout(context.Background(), testutil.RequestTimeout)
+	ctx, cancel := context.WithTimeout(t.Context(), testutil.RequestTimeout)
 	_, err = cli.AuthStatus(ctx)
 	cancel()
 	if err != nil {

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -108,7 +108,7 @@ func putWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 		// put data test
 		err := func() error {
 			t.Log("Sanity test, putting data")
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 
 			if _, putErr := cli.Put(ctx, key, val); putErr != nil {
@@ -133,7 +133,7 @@ func getWithRetries(t *testing.T, cli *clientv3.Client, key, val string, retryCo
 		// get data test
 		err := func() error {
 			t.Log("Sanity test, getting data")
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 			resp, getErr := cli.Get(ctx, key)
 			if getErr != nil {

--- a/tests/integration/v3_grpc_inflight_test.go
+++ b/tests/integration/v3_grpc_inflight_test.go
@@ -39,10 +39,10 @@ func TestV3MaintenanceDefragmentInflightRange(t *testing.T) {
 
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
-	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 
 	donec := make(chan struct{})
 	go func() {
@@ -51,7 +51,7 @@ func TestV3MaintenanceDefragmentInflightRange(t *testing.T) {
 	}()
 
 	mvc := integration.ToGRPC(cli).Maintenance
-	mvc.Defragment(context.Background(), &pb.DefragmentRequest{})
+	mvc.Defragment(t.Context(), &pb.DefragmentRequest{})
 	cancel()
 
 	<-donec
@@ -69,10 +69,10 @@ func TestV3KVInflightRangeRequests(t *testing.T) {
 	cli := clus.RandClient()
 	kvc := integration.ToGRPC(cli).KV
 
-	_, err := kvc.Put(context.Background(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+	_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 
 	reqN := 10 // use 500+ for fast machine
 	var wg sync.WaitGroup

--- a/tests/integration/v3_kv_test.go
+++ b/tests/integration/v3_kv_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,15 +33,15 @@ func TestKVWithEmptyValue(t *testing.T) {
 
 	client := clus.RandClient()
 
-	_, err := client.Put(context.Background(), "my-namespace/foobar", "data")
+	_, err := client.Put(t.Context(), "my-namespace/foobar", "data")
 	require.NoError(t, err)
-	_, err = client.Put(context.Background(), "my-namespace/foobar1", "data")
+	_, err = client.Put(t.Context(), "my-namespace/foobar1", "data")
 	require.NoError(t, err)
-	_, err = client.Put(context.Background(), "namespace/foobar1", "data")
+	_, err = client.Put(t.Context(), "namespace/foobar1", "data")
 	require.NoError(t, err)
 
 	// Range over all keys.
-	resp, err := client.Get(context.Background(), "", clientv3.WithFromKey())
+	resp, err := client.Get(t.Context(), "", clientv3.WithFromKey())
 	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
@@ -50,18 +49,18 @@ func TestKVWithEmptyValue(t *testing.T) {
 
 	// Range over all keys in a namespace.
 	client.KV = namespace.NewKV(client.KV, "my-namespace/")
-	resp, err = client.Get(context.Background(), "", clientv3.WithFromKey())
+	resp, err = client.Get(t.Context(), "", clientv3.WithFromKey())
 	require.NoError(t, err)
 	for _, kv := range resp.Kvs {
 		t.Log(string(kv.Key), "=", string(kv.Value))
 	}
 
 	// Remove all keys without WithFromKey/WithPrefix func
-	_, err = client.Delete(context.Background(), "")
+	_, err = client.Delete(t.Context(), "")
 	// fatal error duo to without WithFromKey/WithPrefix func called.
 	require.Error(t, err)
 
-	respDel, err := client.Delete(context.Background(), "", clientv3.WithFromKey())
+	respDel, err := client.Delete(t.Context(), "", clientv3.WithFromKey())
 	// fatal error duo to with WithFromKey/WithPrefix func called.
 	require.NoError(t, err)
 	t.Logf("delete keys:%d", respDel.Deleted)

--- a/tests/integration/v3_leadership_test.go
+++ b/tests/integration/v3_leadership_test.go
@@ -63,7 +63,7 @@ func testMoveLeader(t *testing.T, auto bool) {
 		require.NoError(t, err)
 	} else {
 		mvc := integration.ToGRPC(clus.Client(oldLeadIdx)).Maintenance
-		_, err := mvc.MoveLeader(context.TODO(), &pb.MoveLeaderRequest{TargetID: target})
+		_, err := mvc.MoveLeader(t.Context(), &pb.MoveLeaderRequest{TargetID: target})
 		require.NoError(t, err)
 	}
 
@@ -108,7 +108,7 @@ func TestMoveLeaderError(t *testing.T) {
 	target := uint64(clus.Members[(oldLeadIdx+2)%3].Server.MemberID())
 
 	mvc := integration.ToGRPC(clus.Client(followerIdx)).Maintenance
-	_, err := mvc.MoveLeader(context.TODO(), &pb.MoveLeaderRequest{TargetID: target})
+	_, err := mvc.MoveLeader(t.Context(), &pb.MoveLeaderRequest{TargetID: target})
 	if !eqErrGRPC(err, rpctypes.ErrGRPCNotLeader) {
 		t.Errorf("err = %v, want %v", err, rpctypes.ErrGRPCNotLeader)
 	}
@@ -136,7 +136,7 @@ func TestMoveLeaderToLearnerError(t *testing.T) {
 	learnerID := learners[0].ID
 	leaderIdx := clus.WaitLeader(t)
 	cli := clus.Client(leaderIdx)
-	_, err = cli.MoveLeader(context.Background(), learnerID)
+	_, err = cli.MoveLeader(t.Context(), learnerID)
 	if err == nil {
 		t.Fatalf("expecting leader transfer to learner to fail, got no error")
 	}
@@ -183,7 +183,7 @@ func TestTransferLeadershipWithLearner(t *testing.T) {
 
 func TestFirstCommitNotification(t *testing.T) {
 	integration.BeforeTest(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	clusterSize := 3
 	cluster := integration.NewCluster(t, &integration.ClusterConfig{Size: clusterSize})
 	defer cluster.Terminate(t)
@@ -199,7 +199,7 @@ func TestFirstCommitNotification(t *testing.T) {
 		notifiers[i] = clusterMember.Server.FirstCommitInTermNotify()
 	}
 
-	_, err := oldLeaderClient.MoveLeader(context.Background(), newLeaderID)
+	_, err := oldLeaderClient.MoveLeader(t.Context(), newLeaderID)
 	if err != nil {
 		t.Errorf("got error during leadership transfer: %v", err)
 	}

--- a/tests/integration/v3_watch_restore_test.go
+++ b/tests/integration/v3_watch_restore_test.go
@@ -64,7 +64,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 	defer clus.Terminate(t)
 
 	// spawn a watcher before shutdown, and put it in synced watcher
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.Client(0)).Watch.Watch(ctx)
 	require.NoError(t, errW)
@@ -92,7 +92,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 
 	// to trigger snapshot from the leader to the stopped follower
 	for i := 0; i < 15; i++ {
-		_, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
+		_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")})
 		if err != nil {
 			t.Errorf("#%d: couldn't put key (%v)", i, err)
 		}
@@ -177,7 +177,7 @@ func TestV3WatchRestoreSnapshotUnsync(t *testing.T) {
 }
 
 func expectMemberLog(t *testing.T, m *integration.Member, timeout time.Duration, s string, count int) {
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	lines, err := m.LogObserver.Expect(ctx, s, count)

--- a/tests/integration/v3_watch_test.go
+++ b/tests/integration/v3_watch_test.go
@@ -233,7 +233,7 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 			defer clus.Terminate(t)
 
 			wAPI := integration.ToGRPC(clus.RandClient()).Watch
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 			wStream, err := wAPI.Watch(ctx)
 			if err != nil {
@@ -268,7 +268,7 @@ func TestV3WatchFromCurrentRevision(t *testing.T) {
 				for _, k := range tt.putKeys {
 					kvc := integration.ToGRPC(clus.RandClient()).KV
 					req := &pb.PutRequest{Key: []byte(k), Value: []byte("bar")}
-					if _, err := kvc.Put(context.TODO(), req); err != nil {
+					if _, err := kvc.Put(t.Context(), req); err != nil {
 						t.Errorf("#%d: couldn't put key (%v)", i, err)
 					}
 				}
@@ -320,7 +320,7 @@ func TestV3WatchFutureRevision(t *testing.T) {
 	defer clus.Terminate(t)
 
 	wAPI := integration.ToGRPC(clus.RandClient()).Watch
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, err := wAPI.Watch(ctx)
 	if err != nil {
@@ -349,7 +349,7 @@ func TestV3WatchFutureRevision(t *testing.T) {
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	for {
 		req := &pb.PutRequest{Key: wkey, Value: []byte("bar")}
-		resp, rerr := kvc.Put(context.TODO(), req)
+		resp, rerr := kvc.Put(t.Context(), req)
 		if rerr != nil {
 			t.Fatalf("couldn't put key (%v)", rerr)
 		}
@@ -382,7 +382,7 @@ func TestV3WatchWrongRange(t *testing.T) {
 	defer clus.Terminate(t)
 
 	wAPI := integration.ToGRPC(clus.RandClient()).Watch
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, err := wAPI.Watch(ctx)
 	if err != nil {
@@ -436,7 +436,7 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if errW != nil {
@@ -478,7 +478,7 @@ func testV3WatchCancel(t *testing.T, startRev int64) {
 	}
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Errorf("couldn't put key (%v)", err)
 	}
 
@@ -496,7 +496,7 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -513,7 +513,7 @@ func TestV3WatchCurrentPutOverlap(t *testing.T) {
 			defer wg.Done()
 			kvc := integration.ToGRPC(clus.RandClient()).KV
 			req := &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}
-			if _, err := kvc.Put(context.TODO(), req); err != nil {
+			if _, err := kvc.Put(t.Context(), req); err != nil {
 				t.Errorf("couldn't put key (%v)", err)
 			}
 		}()
@@ -582,7 +582,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
@@ -599,7 +599,7 @@ func TestV3WatchEmptyKey(t *testing.T) {
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	_, err = kvc.Put(context.TODO(), preq)
+	_, err = kvc.Put(t.Context(), preq)
 	require.NoError(t, err)
 
 	// check received PUT
@@ -636,7 +636,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, errW := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if errW != nil {
@@ -676,7 +676,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 		ids[wresp.WatchId] = struct{}{}
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -704,7 +704,7 @@ func testV3WatchMultipleWatchers(t *testing.T, startRev int64) {
 	}
 
 	// now put one key that has only one matching watcher
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("fo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("fo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 	wresp, err := wStream.Recv()
@@ -740,7 +740,7 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -771,7 +771,7 @@ func testV3WatchMultipleEventsTxn(t *testing.T, startRev int64) {
 		txn.Success = append(txn.Success, ru)
 	}
 
-	tresp, err := kvc.Txn(context.Background(), &txn)
+	tresp, err := kvc.Txn(t.Context(), &txn)
 	if err != nil {
 		t.Fatalf("kvc.Txn error: %v", err)
 	}
@@ -829,14 +829,14 @@ func TestV3WatchMultipleEventsPutUnsynced(t *testing.T) {
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -852,10 +852,10 @@ func TestV3WatchMultipleEventsPutUnsynced(t *testing.T) {
 		t.Fatalf("wStream.Send error: %v", err)
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo0"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo1"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -916,7 +916,7 @@ func TestV3WatchProgressOnMemberRestart(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	errC := make(chan error, 1)
@@ -1029,7 +1029,7 @@ func testV3WatchMultipleStreams(t *testing.T, startRev int64) {
 
 	streams := make([]pb.Watch_WatchClient, 5)
 	for i := range streams {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 		defer cancel()
 		wStream, errW := wAPI.Watch(ctx)
 		if errW != nil {
@@ -1056,7 +1056,7 @@ func testV3WatchMultipleStreams(t *testing.T, startRev int64) {
 		}
 	}
 
-	if _, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
+	if _, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")}); err != nil {
 		t.Fatalf("couldn't put key (%v)", err)
 	}
 
@@ -1129,7 +1129,7 @@ func TestWatchWithProgressNotify(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	wStream, wErr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
 	if wErr != nil {
@@ -1188,7 +1188,7 @@ func TestV3WatchClose(t *testing.T) {
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		go func() {
-			ctx, cancel := context.WithCancel(context.TODO())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer func() {
 				wg.Done()
 				cancel()
@@ -1219,7 +1219,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(ctx)
@@ -1247,7 +1247,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	// put a key with empty value
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 	preq := &pb.PutRequest{Key: []byte("foo")}
-	_, err = kvc.Put(context.TODO(), preq)
+	_, err = kvc.Put(t.Context(), preq)
 	require.NoError(t, err)
 
 	select {
@@ -1257,7 +1257,7 @@ func TestV3WatchWithFilter(t *testing.T) {
 	}
 
 	dreq := &pb.DeleteRangeRequest{Key: []byte("foo")}
-	_, err = kvc.DeleteRange(context.TODO(), dreq)
+	_, err = kvc.DeleteRange(t.Context(), dreq)
 	require.NoError(t, err)
 
 	select {
@@ -1281,7 +1281,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	wctx, wcancel := context.WithCancel(context.Background())
+	wctx, wcancel := context.WithCancel(t.Context())
 	defer wcancel()
 
 	tests := []struct {
@@ -1299,7 +1299,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 	}}
 	for i, tt := range tests {
 		kvc := integration.ToGRPC(clus.RandClient()).KV
-		_, err := kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])})
+		_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[0])})
 		require.NoError(t, err)
 
 		ws, werr := integration.ToGRPC(clus.RandClient()).Watch.Watch(wctx)
@@ -1317,7 +1317,7 @@ func TestV3WatchWithPrevKV(t *testing.T) {
 		_, err = ws.Recv()
 		require.NoError(t, err)
 
-		_, err = kvc.Put(context.TODO(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])})
+		_, err = kvc.Put(t.Context(), &pb.PutRequest{Key: []byte(tt.key), Value: []byte(tt.vals[1])})
 		require.NoError(t, err)
 
 		recv := make(chan *pb.WatchResponse, 1)
@@ -1351,7 +1351,7 @@ func TestV3WatchCancellation(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	cli := clus.RandClient()
@@ -1391,7 +1391,7 @@ func TestV3WatchCloseCancelRace(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	cli := clus.RandClient()
@@ -1436,7 +1436,7 @@ func TestV3WatchProgressWaitsForSync(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	// Write a couple values into key to make sure there's a
@@ -1499,7 +1499,7 @@ func TestV3WatchProgressWaitsForSyncNoEvents(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	resp, err := client.Put(ctx, "bar", "1")
@@ -1547,7 +1547,7 @@ func TestV3NoEventsLostOnCompact(t *testing.T) {
 	defer clus.Terminate(t)
 
 	client := clus.RandClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// sendLoop throughput is rate-limited to 1 event per second

--- a/tests/integration/v3lock_grpc_test.go
+++ b/tests/integration/v3lock_grpc_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -33,18 +32,18 @@ func TestV3LockLockWaiter(t *testing.T) {
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
-	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
+	lease1, err1 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err1)
-	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(context.TODO(), &pb.LeaseGrantRequest{TTL: 30})
+	lease2, err2 := integration.ToGRPC(clus.RandClient()).Lease.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
 	require.NoError(t, err2)
 
 	lc := integration.ToGRPC(clus.Client(0)).Lock
-	l1, lerr1 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})
+	l1, lerr1 := lc.Lock(t.Context(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease1.ID})
 	require.NoError(t, lerr1)
 
 	lockc := make(chan struct{})
 	go func() {
-		l2, lerr2 := lc.Lock(context.TODO(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease2.ID})
+		l2, lerr2 := lc.Lock(t.Context(), &lockpb.LockRequest{Name: []byte("foo"), Lease: lease2.ID})
 		if lerr2 != nil {
 			t.Error(lerr2)
 		}
@@ -60,7 +59,7 @@ func TestV3LockLockWaiter(t *testing.T) {
 		t.Fatalf("locked before unlock")
 	}
 
-	_, uerr := lc.Unlock(context.TODO(), &lockpb.UnlockRequest{Key: l1.Key})
+	_, uerr := lc.Unlock(t.Context(), &lockpb.UnlockRequest{Key: l1.Key})
 	require.NoError(t, uerr)
 
 	select {


### PR DESCRIPTION
Address usetesting linter issues in `tests/integration`. This is the last part before re-enabling the `usetesting` linter.

Part of #19581.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
