### PR TITLE
Verify that the discovery endpoint isn't empty

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -1003,6 +1003,12 @@ func (cfg *Config) Validate() error {
 		return errors.New("both --discovery-token and --discovery-endpoints must be set")
 	}
 
+	for _, ep := range cfg.DiscoveryCfg.Endpoints {
+		if strings.TrimSpace(ep) == "" {
+			return errors.New("--discovery-endpoints must not contain empty endpoints")
+		}
+	}
+
 	if cfg.TickMs == 0 {
 		return fmt.Errorf("--heartbeat-interval must be >0 (set to %dms)", cfg.TickMs)
 	}


### PR DESCRIPTION
Extracted from https://github.com/etcd-io/etcd/pull/20109.

Verify that the discovery endpoint isn't empty, and we should backport this minor fix to 3.6.

cc @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
