### PR TITLE
Introduce Result struct to represent ternary result: success, failure unknown

### DIFF
--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -241,13 +241,9 @@ func TestValidateSerializableOperations(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			replay := model.NewReplay(tc.persistedRequests)
-			err := validateSerializableOperations(zaptest.NewLogger(t), tc.operations, replay)
-			var errStr string
-			if err != nil {
-				errStr = err.Error()
-			}
-			if errStr != tc.expectError {
-				t.Errorf("validateSerializableOperations(...), got: %q, want: %q", err, tc.expectError)
+			result := validateSerializableOperations(zaptest.NewLogger(t), tc.operations, replay)
+			if result.Message != tc.expectError {
+				t.Errorf("validateSerializableOperations(...), got: %q, want: %q", result.Message, tc.expectError)
 			}
 		})
 	}
@@ -395,9 +391,9 @@ func shuffleHistory(history []porcupine.Operation, shuffleCount int) [][]porcupi
 
 func validateShuffles(b *testing.B, lg *zap.Logger, shuffles [][]porcupine.Operation, duration time.Duration) {
 	for i := 0; i < len(shuffles); i++ {
-		result := validateLinearizableOperationsAndVisualize(shuffles[i], duration)
-		if result.Linearizable != porcupine.Ok {
-			b.Fatalf("Not linearizable: %v", result.Linearizable)
+		result := validateLinearizableOperationsAndVisualize(lg, shuffles[i], duration)
+		if err := result.Error(); err != nil {
+			b.Fatalf("Not linearizable: %v", err)
 		}
 	}
 }

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -1,0 +1,97 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/anishathalye/porcupine"
+	"go.uber.org/zap"
+)
+
+type RobustnessResult struct {
+	Assumptions   Result
+	Linearization LinearizationResult
+	Watch         Result
+	Serializable  Result
+}
+
+type Result struct {
+	Status  ResultStatus
+	Message string
+}
+
+type ResultStatus string
+
+var (
+	Unknown ResultStatus
+	Success ResultStatus = "Success"
+	Failure ResultStatus = "Failure"
+)
+
+func (r RobustnessResult) Error() error {
+	if err := r.Assumptions.Error(); err != nil {
+		return fmt.Errorf("assumptions: %w", err)
+	}
+	if err := r.Linearization.Error(); err != nil {
+		return fmt.Errorf("linearization: %w", err)
+	}
+	if err := r.Watch.Error(); err != nil {
+		return fmt.Errorf("watch: %w", err)
+	}
+	if err := r.Serializable.Error(); err != nil {
+		return fmt.Errorf("serializable: %w", err)
+	}
+	return nil
+}
+
+func ResultFromError(err error) Result {
+	if err != nil {
+		return Result{
+			Status:  Failure,
+			Message: err.Error(),
+		}
+	}
+	return Result{
+		Status: Success,
+	}
+}
+
+func (r Result) Error() error {
+	if r.Status == Failure {
+		if r.Message != "" {
+			return errors.New(r.Message)
+		}
+		return errors.New("failure")
+	}
+	return nil
+}
+
+type LinearizationResult struct {
+	Info  porcupine.LinearizationInfo
+	Model porcupine.Model
+	Result
+	Timeout bool
+}
+
+func (r LinearizationResult) Visualize(lg *zap.Logger, path string) error {
+	lg.Info("Saving visualization", zap.String("path", path))
+	err := porcupine.VisualizePath(r.Model, r.Info, path)
+	if err != nil {
+		return fmt.Errorf("failed to visualize, err: %w", err)
+	}
+	return nil
+}

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -169,7 +169,7 @@ func TestValidateAndReturnVisualize(t *testing.T) {
 				},
 			},
 			persistedRequests: []model.EtcdRequest{putRequest("key", "value")},
-			expectError:       "watch validation failed",
+			expectError:       "watch: broke Reliable",
 		},
 	}
 	for _, tc := range tcs {
@@ -1978,13 +1978,9 @@ func TestValidateWatch(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			replay := model.NewReplay(tc.persistedRequests)
-			err := validateWatch(zaptest.NewLogger(t), tc.config, tc.reports, replay)
-			var errStr string
-			if err != nil {
-				errStr = err.Error()
-			}
-			if errStr != tc.expectError {
-				t.Errorf("validateWatch(...), got: %q, want: %q", err, tc.expectError)
+			result := validateWatch(zaptest.NewLogger(t), tc.config, tc.reports, replay)
+			if result.Message != tc.expectError {
+				t.Errorf("validateWatch(...), got: %q, want: %q", result.Message, tc.expectError)
 			}
 		})
 	}

--- a/tests/robustness/validate/watch.go
+++ b/tests/robustness/validate/watch.go
@@ -16,6 +16,7 @@ package validate
 
 import (
 	"errors"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -37,7 +38,18 @@ var (
 	errBrokeFilter       = errors.New("event not matching watch filter")
 )
 
-func validateWatch(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) error {
+func validateWatch(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) Result {
+	lg.Info("Validating watch")
+	start := time.Now()
+	err := validateWatchError(lg, cfg, reports, replay)
+	if err != nil {
+		lg.Error("Watch validation failed", zap.Duration("duration", time.Since(start)), zap.Error(err))
+	}
+	lg.Info("Watch validation success", zap.Duration("duration", time.Since(start)))
+	return ResultFromError(err)
+}
+
+func validateWatchError(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) error {
 	// Validate etcd watch properties defined in https://etcd.io/docs/v3.6/learning/api_guarantees/#watch-apis
 	for _, r := range reports {
 		err := validateFilter(lg, r)


### PR DESCRIPTION
Fixes https://github.com/etcd-io/etcd/issues/19971

This allows to properly pass error message to antithesis assertion, and allows to avoid marking assertion success if the validation didn't run.

This helps with debugging cases like there where error is serialized to json as `{}` 
![image](https://github.com/user-attachments/assets/7a4916c3-3bc0-494e-bf15-cce259c26f1e)
From https://linuxfoundation.antithesis.com/report/619OBPxquzXWE8b5L9-nNH6t/tpWvKQeJd1lxZ5sgXF_V2MXxeFzD-ByofuZurvqSrZc.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoidHBXdktRZUpkMWx4WjVzZ1hGX1YyTVh4ZUZ6RC1CeW9mdVp1cnZxU3JaYy5odG1sIiwicmVwb3J0X2lkIjoiNjE5T0JQeHF1elhXRThiNUw5LW5OSDZ0In19LCJuYmYiOiIyMDI1LTA2LTAyVDIxOjI4OjQ5LjkxMDIxNDM0NFoiffD4EfpAyeld22ULRE3c7bLSwLfZnrndwoLK3xEZNS9NSodLnVBBi4dnOfNIrSFJFLb2JJu1jVudzbAh95w_HQw

/cc @nwnt @henrybear327 @joshjms @marcushodgsonantithesis @fuweid @siyuanfoundation 
