### PR TITLE
Improve latest version log message

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -592,7 +592,7 @@ function release_pass {
   UPGRADE_VER=$(git ls-remote --tags https://github.com/etcd-io/etcd.git \
     | grep --only-matching --perl-regexp "(?<=v)${binary_major}.${previous_minor}.[\d]+?(?=[\^])" \
     | sort --numeric-sort --key 1.5 | tail -1 | sed 's/^/v/')
-  log_callout "Found latest release: ${UPGRADE_VER}."
+  log_callout "Found previous minor version (v${binary_major}.${previous_minor}) latest release: ${UPGRADE_VER}."
 
   if [ -n "${MANUAL_VER:-}" ]; then
     # in case, we need to test against different version


### PR DESCRIPTION
Improve the log message to avoid confusion on which version of etcd is downloaded for e2e tests.

```bash
$ PASSES=release ./scripts/test.sh                                                                                             
Running with --race                                            
Starting at: Thu Jun  5 12:00:11 PM PDT 2025                   
                                                                                                                               
'release' started at Thu Jun  5 12:00:11 PM PDT 2025                                                                           
Found previous minor version (v3.5) latest release: v3.5.21.
Downloading etcd-v3.5.21-linux-amd64.tar.gz      
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                
                                 Dload  Upload   Total   Spent    Left  Speed                                                  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0                                                 
100 19.9M  100 19.9M    0     0  32.6M      0 --:--:-- --:--:-- --:--:--  100M                                                 
etcd-v3.5.21-linux-amd64/Documentation/                                                                                        
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/                                                                              
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/apispec/
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/apispec/swagger/                                                              
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/apispec/swagger/v3lock.swagger.json                                           
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/apispec/swagger/v3election.swagger.json                                       
etcd-v3.5.21-linux-amd64/Documentation/dev-guide/apispec/swagger/rpc.swagger.json                                              
etcd-v3.5.21-linux-amd64/Documentation/README.md                                                                                                                                                                                                               
etcd-v3.5.21-linux-amd64/README-etcdutl.md                                                                                     
etcd-v3.5.21-linux-amd64/READMEv2-etcdctl.md                                                                                   
etcd-v3.5.21-linux-amd64/README-etcdctl.md                                                                                     
etcd-v3.5.21-linux-amd64/README.md                    
etcd-v3.5.21-linux-amd64/etcdutl                                                                                               
etcd-v3.5.21-linux-amd64/etcdctl
etcd-v3.5.21-linux-amd64/etcd       
'release' PASSED and completed at Thu Jun  5 12:00:12 PM PDT 2025                                                              
SUCCESS                                   
```

Emphasis on:

```
Found previous minor version (v3.5) latest release: v3.5.21.
```

Part of #20093.
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.