### PR TITLE
Ignore leases from failed requests greatly reducing linearization search space

### DIFF
--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -200,6 +200,10 @@ func (s EtcdState) Step(request EtcdRequest) (EtcdState, MaybeEtcdResponse) {
 		}
 		return newState, MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Failure: failure, Results: opResp}, Revision: newState.Revision}}
 	case LeaseGrant:
+		// Empty LeaseID means the request failed and client didn't get response. Ignore it as client cannot use lease without knowing its id.
+		if request.LeaseGrant.LeaseID == 0 {
+			return newState, MaybeEtcdResponse{EtcdResponse: EtcdResponse{Revision: newState.Revision, LeaseGrant: &LeaseGrantReponse{}}}
+		}
 		lease := EtcdLease{
 			LeaseID: request.LeaseGrant.LeaseID,
 			Keys:    map[string]struct{}{},


### PR DESCRIPTION
/cc @nwnt @henrybear327 @joshjms @marcushodgsonantithesis @fuweid @siyuanfoundation