### PR TITLE
[release-3.4] Backport removing obsolete http 1.0 version for cmux tests

### DIFF
--- a/tests/e2e/cmux_test.go
+++ b/tests/e2e/cmux_test.go
@@ -137,7 +137,7 @@ func testConnectionMultiplexing(ctx context.Context, t *testing.T, member etcdPr
 		assert.NoError(t, err)
 	})
 	t.Run("curl", func(t *testing.T) {
-		for _, httpVersion := range []string{"2", "1.1", "1.0", ""} {
+		for _, httpVersion := range []string{"2", "1.1", ""} {
 			tname := "http" + httpVersion
 			if httpVersion == "" {
 				tname = "default"


### PR DESCRIPTION
Ensures tests to run successfully in Debian 12.

Partial backport of https://github.com/etcd-io/etcd/pull/16516.

/cc @ivanvc @jmhbnz 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
