### PR TITLE
Add support to generate JSON report to the benchmark tool

### DIFF
--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -182,7 +182,7 @@ func newCheckPerfCommand(cmd *cobra.Command, args []string) {
 	bar := pb.New(cfg.duration)
 	bar.Start()
 
-	r := report.NewReport("%4.4f")
+	r := report.NewReport("%4.4f", "", false)
 	var wg sync.WaitGroup
 
 	wg.Add(len(clients))
@@ -353,7 +353,7 @@ func newCheckDatascaleCommand(cmd *cobra.Command, args []string) {
 	ksize, vsize := 512, 512
 	k, v := make([]byte, ksize), string(make([]byte, vsize))
 
-	r := report.NewReport("%4.4f")
+	r := report.NewReport("%4.4f", "", false)
 	var wg sync.WaitGroup
 	wg.Add(len(clients))
 

--- a/pkg/report/perfdash.go
+++ b/pkg/report/perfdash.go
@@ -1,0 +1,87 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Metrics struct {
+	Perc50 float64 `json:"Perc50"`
+	Perc90 float64 `json:"Perc90"`
+	Perc99 float64 `json:"Perc99"`
+}
+
+type Labels struct {
+	Metric string `json:"Metric"`
+}
+
+type DataItem struct {
+	Data   Metrics `json:"data"`
+	Labels Labels  `json:"labels"`
+	Unit   string  `json:"unit"`
+}
+
+type perfdashFormattedReport struct {
+	Version   string     `json:"version"`
+	DataItems []DataItem `json:"dataItems"`
+}
+
+func (r *report) writePerfDashReport(reportName string) {
+	pcls, data := Percentiles(r.stats.Lats)
+	pclsData := make(map[float64]float64)
+	for i := 0; i < len(pcls); i++ {
+		pclsData[pcls[i]] = data[i] * 1000 // Since the reported data is in seconds, convert to ms.
+	}
+	report := perfdashFormattedReport{
+		Version: "v1",
+		DataItems: []DataItem{
+			{
+				Data: Metrics{
+					Perc50: math.Round(pclsData[50]*10000) / 10000,
+					Perc90: math.Round(pclsData[90]*10000) / 10000,
+					Perc99: math.Round(pclsData[99]*10000) / 10000,
+				},
+				Unit: "ms",
+				Labels: Labels{
+					Metric: "APIResponsiveness",
+				},
+			},
+		},
+	}
+	reportB, _ := json.MarshalIndent(report, "", "  ")
+
+	artifactsDir := os.Getenv("ARTIFACTS")
+	if artifactsDir == "" {
+		artifactsDir = "./_artifacts"
+	}
+
+	fileName := fmt.Sprintf("etcd_perf_%s_%s.json", reportName, time.Now().UTC().Format(time.RFC3339))
+	err := os.MkdirAll(artifactsDir, 0o755)
+	if err != nil {
+		fmt.Println("Error creating artifacts directory:", err)
+	}
+	destPath := filepath.Join(artifactsDir, fileName)
+	err = os.WriteFile(destPath, reportB, 0o644)
+	if err != nil {
+		fmt.Println("Error writing to file:", err)
+	}
+	fmt.Println("Successfully created a JSON perf report at", destPath)
+}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -37,7 +37,7 @@ func TestPercentiles(t *testing.T) {
 }
 
 func TestReport(t *testing.T) {
-	r := NewReportSample("%f")
+	r := NewReportSample("%f", "", false)
 	go func() {
 		start := time.Now()
 		for i := 0; i < 5; i++ {
@@ -77,7 +77,7 @@ func TestReport(t *testing.T) {
 }
 
 func TestWeightedReport(t *testing.T) {
-	r := NewWeightedReport(NewReport("%f"), "%f")
+	r := NewWeightedReport(NewReport("%f", "", false), "%f", "", false)
 	go func() {
 		start := time.Now()
 		for i := 0; i < 5; i++ {

--- a/pkg/report/weighted.go
+++ b/pkg/report/weighted.go
@@ -30,10 +30,10 @@ type weightedReport struct {
 
 // NewWeightedReport returns a report that includes
 // both weighted and unweighted statistics.
-func NewWeightedReport(r Report, precision string) Report {
+func NewWeightedReport(r Report, precision string, generatePerfJson bool) Report {
 	return &weightedReport{
 		baseReport: r,
-		report:     newReport(precision),
+		report:     newReport(precision, generatePerfJson),
 		results:    make(chan Result, 16),
 	}
 }

--- a/pkg/report/weighted.go
+++ b/pkg/report/weighted.go
@@ -30,10 +30,10 @@ type weightedReport struct {
 
 // NewWeightedReport returns a report that includes
 // both weighted and unweighted statistics.
-func NewWeightedReport(r Report, precision string, generatePerfJson bool) Report {
+func NewWeightedReport(r Report, precision, reportName string, generatePerfReport bool) Report {
 	return &weightedReport{
 		baseReport: r,
-		report:     newReport(precision, generatePerfJson),
+		report:     newReport(precision, reportName, generatePerfReport),
 		results:    make(chan Result, 16),
 	}
 }

--- a/tools/benchmark/cmd/lease.go
+++ b/tools/benchmark/cmd/lease.go
@@ -40,14 +40,14 @@ func init() {
 	leaseKeepaliveCmd.Flags().IntVar(&leaseKeepaliveTotal, "total", 10000, "Total number of lease keepalive requests")
 }
 
-func leaseKeepaliveFunc(_ *cobra.Command, _ []string) {
+func leaseKeepaliveFunc(cmd *cobra.Command, _ []string) {
 	requests := make(chan struct{})
 	clients := mustCreateClients(totalClients, totalConns)
 
 	bar = pb.New(leaseKeepaliveTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go func(c v3.Lease) {

--- a/tools/benchmark/cmd/mvcc-put.go
+++ b/tools/benchmark/cmd/mvcc-put.go
@@ -69,7 +69,7 @@ func createBytesSlice(bytesN, sliceN int) [][]byte {
 	return rs
 }
 
-func mvccPutFunc(_ *cobra.Command, _ []string) {
+func mvccPutFunc(cmd *cobra.Command, _ []string) {
 	if cpuProfPath != "" {
 		f, err := os.Create(cpuProfPath)
 		if err != nil {
@@ -105,7 +105,7 @@ func mvccPutFunc(_ *cobra.Command, _ []string) {
 	vals := createBytesSlice(valueSize, mvccTotalRequests*nrTxnOps)
 
 	weight := float64(nrTxnOps)
-	r := newWeightedReport()
+	r := newWeightedReport(cmd.Name())
 	rrc := r.Results()
 
 	rc := r.Run()

--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -88,7 +88,7 @@ func putFunc(cmd *cobra.Command, _ []string) {
 	bar = pb.New(putTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {

--- a/tools/benchmark/cmd/range.go
+++ b/tools/benchmark/cmd/range.go
@@ -86,7 +86,7 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 	bar = pb.New(rangeTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {

--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -55,6 +55,8 @@ var (
 
 	targetLeader     bool
 	autoSyncInterval time.Duration
+
+	generateJsonReport bool
 )
 
 func init() {
@@ -74,4 +76,6 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&targetLeader, "target-leader", false, "connect only to the leader node")
 	RootCmd.PersistentFlags().DurationVar(&autoSyncInterval, "auto-sync-interval", time.Duration(0), "AutoSyncInterval is the interval to update endpoints with its latest members")
+
+	RootCmd.PersistentFlags().BoolVar(&generateJsonReport, "json", false, "Generate the output in JSON format for perfdash consumption")
 }

--- a/tools/benchmark/cmd/root.go
+++ b/tools/benchmark/cmd/root.go
@@ -56,7 +56,7 @@ var (
 	targetLeader     bool
 	autoSyncInterval time.Duration
 
-	generateJsonReport bool
+	generatePerfReport bool
 )
 
 func init() {
@@ -77,5 +77,5 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&targetLeader, "target-leader", false, "connect only to the leader node")
 	RootCmd.PersistentFlags().DurationVar(&autoSyncInterval, "auto-sync-interval", time.Duration(0), "AutoSyncInterval is the interval to update endpoints with its latest members")
 
-	RootCmd.PersistentFlags().BoolVar(&generateJsonReport, "json", false, "Generate the output in JSON format for perfdash consumption")
+	RootCmd.PersistentFlags().BoolVar(&generatePerfReport, "report-perfdash", false, "Generate benchmark report in perfdash format")
 }

--- a/tools/benchmark/cmd/stm.go
+++ b/tools/benchmark/cmd/stm.go
@@ -110,7 +110,7 @@ func stmFunc(cmd *cobra.Command, _ []string) {
 	bar = pb.New(stmTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go doSTM(clients[i], requests, r.Results())

--- a/tools/benchmark/cmd/txn_mixed.go
+++ b/tools/benchmark/cmd/txn_mixed.go
@@ -95,8 +95,8 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 	bar = pb.New(mixedTxnTotal)
 	bar.Start()
 
-	reportRead := newReport()
-	reportWrite := newReport()
+	reportRead := newReport(cmd.Name() + "-read")
+	reportWrite := newReport(cmd.Name() + "-write")
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {

--- a/tools/benchmark/cmd/txn_put.go
+++ b/tools/benchmark/cmd/txn_put.go
@@ -55,7 +55,7 @@ func init() {
 	txnPutCmd.Flags().IntVar(&keySpaceSize, "key-space-size", 1, "Maximum possible keys")
 }
 
-func txnPutFunc(_ *cobra.Command, _ []string) {
+func txnPutFunc(cmd *cobra.Command, _ []string) {
 	if keySpaceSize <= 0 {
 		fmt.Fprintf(os.Stderr, "expected positive --key-space-size, got (%v)", keySpaceSize)
 		os.Exit(1)
@@ -78,7 +78,7 @@ func txnPutFunc(_ *cobra.Command, _ []string) {
 	bar = pb.New(txnPutTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -157,24 +157,24 @@ func mustRandBytes(n int) []byte {
 	return rb
 }
 
-func newReport() report.Report {
+func newReport(reportName string) report.Report {
 	p := "%4.4f"
 	if precise {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p, generateJsonReport)
+		return report.NewReportSample(p, reportName, generatePerfReport)
 	}
-	return report.NewReport(p, generateJsonReport)
+	return report.NewReport(p, reportName, generatePerfReport)
 }
 
-func newWeightedReport() report.Report {
+func newWeightedReport(reportName string) report.Report {
 	p := "%4.4f"
 	if precise {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p, generateJsonReport)
+		return report.NewReportSample(p, reportName, generatePerfReport)
 	}
-	return report.NewWeightedReport(report.NewReport(p, generateJsonReport), p, generateJsonReport)
+	return report.NewWeightedReport(report.NewReport(p, reportName, generatePerfReport), p, reportName, generatePerfReport)
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -163,9 +163,9 @@ func newReport() report.Report {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p)
+		return report.NewReportSample(p, generateJsonReport)
 	}
-	return report.NewReport(p)
+	return report.NewReport(p, generateJsonReport)
 }
 
 func newWeightedReport() report.Report {
@@ -174,7 +174,7 @@ func newWeightedReport() report.Report {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p)
+		return report.NewReportSample(p, generateJsonReport)
 	}
-	return report.NewWeightedReport(report.NewReport(p), p)
+	return report.NewWeightedReport(report.NewReport(p, generateJsonReport), p, generateJsonReport)
 }

--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -117,7 +117,7 @@ func benchMakeWatches(clients []*clientv3.Client, wk *watchedKeys) {
 	bar = pb.New(watchStreams * watchWatchesPerStream)
 	bar.Start()
 
-	r := newReport()
+	r := newReport("watch-make")
 	rch := r.Results()
 
 	wg.Add(len(streams) + 1)
@@ -189,7 +189,7 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 	bar = pb.New(eventsTotal)
 	bar.Start()
 
-	r := newReport()
+	r := newReport("watch-put")
 
 	wg.Add(len(wk.watches))
 	nrRxed := int32(eventsTotal)

--- a/tools/benchmark/cmd/watch_get.go
+++ b/tools/benchmark/cmd/watch_get.go
@@ -49,7 +49,7 @@ func init() {
 	watchGetCmd.Flags().IntVar(&watchEvents, "events", 8, "Number of events per watcher")
 }
 
-func watchGetFunc(_ *cobra.Command, _ []string) {
+func watchGetFunc(cmd *cobra.Command, _ []string) {
 	clients := mustCreateClients(totalClients, totalConns)
 	getClient := mustCreateClients(1, 1)
 
@@ -75,7 +75,7 @@ func watchGetFunc(_ *cobra.Command, _ []string) {
 	bar.Start()
 
 	// report from trying to do serialized gets with concurrent watchers
-	r := newReport()
+	r := newReport(cmd.Name())
 	ctx, cancel := context.WithCancel(context.TODO())
 	f := func() {
 		defer close(r.Results())

--- a/tools/benchmark/cmd/watch_latency.go
+++ b/tools/benchmark/cmd/watch_latency.go
@@ -60,7 +60,7 @@ func init() {
 	watchLatencyCmd.Flags().IntVar(&watchLValueSize, "val-size", 32, "Value size of watch response")
 }
 
-func watchLatencyFunc(_ *cobra.Command, _ []string) {
+func watchLatencyFunc(cmd *cobra.Command, _ []string) {
 	key := string(mustRandBytes(watchLKeySize))
 	value := string(mustRandBytes(watchLValueSize))
 	wchs := setupWatchChannels(key)
@@ -93,9 +93,9 @@ func watchLatencyFunc(_ *cobra.Command, _ []string) {
 		}()
 	}
 
-	putReport := newReport()
+	putReport := newReport(cmd.Name() + "-put")
 	putReportResults := putReport.Run()
-	watchReport := newReport()
+	watchReport := newReport(cmd.Name() + "-watch")
 	watchReportResults := watchReport.Run()
 	for i := 0; i < watchLPutTotal; i++ {
 		// limit key put as per reqRate


### PR DESCRIPTION
This PR introduces the `--json` flag to the benchmark utility to produce JSON reports that are compatible with the `perfdash` format. 

This will enable systematic performance tracking and visualization of etcd performance metrics over time, with the scope to integrate with CI while helping to identify regressions and analysis of performance trends over time.

Sample usage:
```
> benchmark put --json

...
2025/06/10 08:14:01 INFO: [core] [Channel #1]Channel Connectivity change to READY
10000 / 10000 [---------------------------------------------------------------------------------------------------------------------------] 100.00% 2062 p/s
Successfully created a JSON perf report at _artifacts/etcd_perf_2025-06-10T12:14:06Z.json

Summary:
  Total:	5.0494 secs.
  Slowest:	0.0036 secs.
  Fastest:	0.0004 secs.
  Average:	0.0005 secs.
  Stddev:	0.0001 secs.
  Requests/sec:	1980.4177

...
  
> cat _artifacts/etcd_perf_2025-06-10T12:14:06Z.json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Perc50": 0.4749,
        "Perc90": 0.564,
        "Perc99": 1.1201
      },
      "unit": "ms",
      "labels": {
        "Metric": "APIResponsiveness"
      }
    }
  ]
}


```