### PR TITLE
Update 3.6.2 changelog to cover bumping bbolt to 1.4.1

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.2 (TBD)
 
+### Dependencies
+
+- [Bump bbolt to v1.4.1](https://github.com/etcd-io/etcd/pull/20154)
+
 ---
 
 ## v3.6.1 (2025-06-06)


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/pull/20154

@Elbehery @fuweid @ivanvc @jmhbnz @serathius @tjungblu 
