### PR TITLE
[release-3.5] Add test-release makefile target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ test-e2e:
 test-e2e-release:
 	PASSES="build release e2e" ./test.sh $(GO_TEST_FLAGS)
 
+.PHONY: test-release
+test-release:
+	PASSES="release_tests" ./test.sh $(GO_TEST_FLAGS)
+
 ensure-docker-test-image-exists:
 	make pull-docker-test || ( echo "WARNING: Container Image not found in registry, building locally"; make build-docker-test )
 

--- a/test.sh
+++ b/test.sh
@@ -687,6 +687,34 @@ function release_pass {
   mv /tmp/etcd ./bin/etcd-last-release
 }
 
+function release_tests_pass {
+  if [ -z "${VERSION:-}" ]; then
+    VERSION=$(go list -m go.etcd.io/etcd/api/v3 2>/dev/null | \
+     awk '{split(substr($2,2), a, "."); print a[1]"."a[2]".99"}')
+  fi
+
+  if [ -n "${CI:-}" ]; then
+    git config user.email "prow@etcd.io"
+    git config user.name "Prow"
+
+    gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: 1
+Key-Length: 2048
+Subkey-Type: 1
+Subkey-Length: 2048
+Name-Real: Prow
+Name-Email: prow@etcd.io
+Expire-Date: 0
+EOF
+
+    git remote add origin https://github.com/etcd-io/etcd.git
+  fi
+
+  DRY_RUN=true run "${ETCD_ROOT_DIR}/scripts/release.sh" --no-upload --no-docker-push --no-gh-release --in-place "${VERSION}"
+  VERSION="${VERSION}" run "${ETCD_ROOT_DIR}/scripts/test_images.sh"
+}
+
 function mod_tidy_for_module {
   # Watch for upstream solution: https://github.com/golang/go/issues/27005
   local tmpModDir


### PR DESCRIPTION
This PR adds `test-release` makefile target for release-3.5. 

ref: [kubernetes/test-infra#32754](https://github.com/kubernetes/test-infra/issues/32754#issuecomment-2942746295)

