### PR TITLE
Make Report Persist Traffic Detail

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -76,7 +76,7 @@ func main() {
 	choice := rand.IntN(len(traffics))
 	tf := traffics[choice]
 	lg.Info("Traffic", zap.String("Type", trafficNames[choice]))
-	r := report.TestReport{Logger: lg, ServersDataPath: etcdetcdDataPaths}
+	r := report.TestReport{Logger: lg, ServersDataPath: etcdetcdDataPaths, Traffic: &report.TrafficDetail{ExpectUniqueRevision: tf.ExpectUniqueRevision()}}
 	defer func() {
 		if err = r.Report(reportPath); err != nil {
 			lg.Error("Failed to save traffic generation report", zap.Error(err))

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -88,7 +88,11 @@ func TestRobustnessRegression(t *testing.T) {
 
 func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenarios.TestScenario, c *e2e.EtcdProcessCluster) {
 	serverDataPaths := report.ServerDataPaths(c)
-	r := report.TestReport{Logger: lg, ServersDataPath: serverDataPaths}
+	r := report.TestReport{
+		Logger:          lg,
+		ServersDataPath: serverDataPaths,
+		Traffic:         &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()},
+	}
 	// t.Failed() returns false during panicking. We need to forcibly
 	// save data on panicking.
 	// Refer to: https://github.com/golang/go/issues/49929


### PR DESCRIPTION
As a follow up to #20149, we now save the traffic detail to be used in the report folder so it can be retrieved and used by the validation.

cc @serathius 