### PR TITLE
[release-3.5] Add makefile target for run-govuluncheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,6 +582,13 @@ gofail-enable: install-gofail
 gofail-disable: install-gofail
 	PASSES="toggle_failpoints" ./test.sh
 
+.PHONY: run-govulncheck
+run-govulncheck:
+ifeq (, $(shell which govulncheck))
+	$(shell go install golang.org/x/vuln/cmd/govulncheck@latest)
+endif
+	PASSES="govuln" ./test.sh
+
 # Static analysis
 
 .PHONY: verify

--- a/test.sh
+++ b/test.sh
@@ -434,6 +434,10 @@ function markdown_marker_pass {
   fi
 }
 
+function govuln_pass {
+  run_for_modules run govulncheck -show verbose
+}
+
 function govet_pass {
   run_for_modules generic_checker run go vet
 }


### PR DESCRIPTION
This PR adds `run-govuluncheck` makefile target for release-3.5.

ref: https://github.com/kubernetes/test-infra/issues/32754#issuecomment-2942746295

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
