### PR TITLE
CHANGELOG(3.4,3.5): Add Go 1.23.10 note

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -12,7 +12,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### Dependencies
 
-- Compile binaries using [go 1.23.9](https://github.com/etcd-io/etcd/pull/19872).
+- Compile binaries using [go 1.23.10](https://github.com/etcd-io/etcd/pull/20166).
 
 ---
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -18,7 +18,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ### Dependencies
 
-- Compile binaries using [go 1.23.9](https://github.com/etcd-io/etcd/pull/19870)
+- Compile binaries using [go 1.23.10](https://github.com/etcd-io/etcd/pull/20164)
 
 ---
 


### PR DESCRIPTION
Part of: https://github.com/etcd-io/etcd/issues/20126

