### PR TITLE
Add Kubernetes API coverage test consuming traces

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
+	github.com/olekukonko/tablewriter v1.0.7
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.65.0
@@ -80,7 +81,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.8 // indirect
-	github.com/olekukonko/tablewriter v1.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -39,7 +39,6 @@ require (
 	go.etcd.io/etcd/server/v3 v3.6.0-alpha.0
 	go.etcd.io/gofail v0.2.0
 	go.etcd.io/raft/v3 v3.6.0
-	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
@@ -75,12 +74,9 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.8 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -39,6 +39,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.6.0-alpha.0
 	go.etcd.io/gofail v0.2.0
 	go.etcd.io/raft/v3 v3.6.0
+	go.opentelemetry.io/collector/pdata v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
@@ -74,9 +75,12 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
 	github.com/olekukonko/ll v0.0.8 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -68,6 +68,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
@@ -84,6 +85,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -102,6 +105,11 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 h1:r3FaAI0NZK3hSmtTDrBVREhKULp8oUeqLT5Eyl2mSPo=
@@ -142,6 +150,7 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -160,6 +169,8 @@ go.etcd.io/raft/v3 v3.6.0 h1:5NtvbDVYpnfZWcIHgGRk9DyzkBIXOi8j+DDp1IcnUWQ=
 go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/collector/pdata v1.35.0 h1:ck6WO6hCNjepADY/p9sT9/rLECTLO5ukYTumKzsqB/E=
+go.opentelemetry.io/collector/pdata v1.35.0/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 h1:rbRJ8BBoVMsQShESYZ0FkvcITu8X8QNwJogcLUmDNNw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0/go.mod h1:ru6KHrNtNHxM4nD/vd6QrLVWgKhxPYgblq4VAtNawTQ=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -68,7 +68,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
@@ -85,8 +84,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -105,11 +102,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 h1:r3FaAI0NZK3hSmtTDrBVREhKULp8oUeqLT5Eyl2mSPo=
@@ -150,7 +142,6 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -169,8 +160,6 @@ go.etcd.io/raft/v3 v3.6.0 h1:5NtvbDVYpnfZWcIHgGRk9DyzkBIXOi8j+DDp1IcnUWQ=
 go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
-go.opentelemetry.io/collector/pdata v1.35.0 h1:ck6WO6hCNjepADY/p9sT9/rLECTLO5ukYTumKzsqB/E=
-go.opentelemetry.io/collector/pdata v1.35.0/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 h1:rbRJ8BBoVMsQShESYZ0FkvcITu8X8QNwJogcLUmDNNw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0/go.mod h1:ru6KHrNtNHxM4nD/vd6QrLVWgKhxPYgblq4VAtNawTQ=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=

--- a/tests/robustness/coverage/README.md
+++ b/tests/robustness/coverage/README.md
@@ -1,0 +1,60 @@
+## Overview
+
+Go tests in this directory analyze the usage of Etcd API based on collected
+traces from a Kubernetes cluster. They output information on:
+
+1. Number of calls per gRPC method used by Kubernetes
+
+This information can be used to track the coverage of k8s-etcd contract.
+
+### Manual test execution
+
+At first we will manually set up the cluster, run e2e tests, download traces and
+then execute the test.
+
+1\. Set up [KIND
+cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) with
+tracing exporting to [Jaeger](https://www.jaegertracing.io/)
+
+```
+export KUBECONFIG="$(pwd)/kind-with-tracing-config"
+kind create cluster --config kind-with-tracing.yaml
+kubectl run jaeger --overrides='{ "apiVersion": "v1", "spec": { "hostNetwork": true, "nodeName": "kind-control-plane", "tolerations": [{"effect": "NoExecute", "operator": "Exists"}]} }' \
+  --labels='tier=control-plane' \
+  --image jaegertracing/jaeger:2.6.0 \
+  -- --set=extensions.jaeger_storage.backends.some_storage.memory.max_traces=2000000
+```
+
+2\. Exercise Kubernetes API. For example, build and run Conformance tests from
+Kubernetes repository (this usually takes 30-40m or will time out after 1 hour):
+
+```
+export KUBECONFIG="$(pwd)/kind-with-tracing-config"
+kind export kubeconfig
+make WHAT="test/e2e/e2e.test"
+./_output/bin/e2e.test -context kind-kind -ginkgo.focus=".*Conformance" -num-nodes 2
+```
+
+3\. Download traces and put them into `tests/robustness/coverage/testdata`
+directory in Etcd git repository:
+
+```
+kubectl port-forward jaeger --address localhost --address :: 16686:16686 &
+curl -v --get --retry 10 --retry-connrefused -o testdata/demo_traces.json \
+  -H "Content-Type: application/json" \
+  --data-urlencode "query.start_time_min=$(date --date="5 days ago" -Ins)" \
+  --data-urlencode "query.start_time_max=$(date -Ins)" \
+  --data-urlencode "query.service_name=etcd" \
+  "http://127.0.0.1:16686/api/v3/traces"
+kill $!
+```
+
+4\. Run Go test
+
+```
+go test -v -timeout 60s go.etcd.io/etcd/tests/v3/robustness/coverage
+```
+
+### Automated test execution
+
+Work on improving these tests is tracked in https://github.com/etcd-io/etcd/issues/20182

--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -73,11 +73,20 @@ func testInterfaceUse(t *testing.T, filename string) {
 		"etcdserverpb.Lease/LeaseGrant":   true, // Used to manage masterleases and events
 		"etcdserverpb.Maintenance/Status": true, // Used to expose database size on apiserver's metrics endpoint
 	}
-	for opName := range callsByOperationName {
-		if !knownMethodsUsedByKubernetes[opName] {
-			t.Errorf("method called outside the list: %s", opName)
-		}
+	for method := range knownMethodsUsedByKubernetes {
+		t.Run(method, func(t *testing.T) {
+			if _, ok := callsByOperationName[method]; !ok {
+				t.Errorf("expected %q method to be called at least once", method)
+			}
+		})
 	}
+	t.Run("only_expected_methods_were_called", func(t *testing.T) {
+		for opName := range callsByOperationName {
+			if !knownMethodsUsedByKubernetes[opName] {
+				t.Errorf("method called outside the list: %s", opName)
+			}
+		}
+	})
 }
 
 type Traces struct {

--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestInterfaceUse(t *testing.T) {
+	files, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range files {
+		filename := file.Name()
+		if filename == ".gitignore" {
+			continue
+		}
+		t.Run(filename, func(t *testing.T) { testInterfaceUse(t, filename) })
+	}
+}
+
+func testInterfaceUse(t *testing.T, filename string) {
+	b, err := os.ReadFile(filepath.Join("testdata", filename))
+	if err != nil {
+		t.Fatalf("read test data: %v", err)
+	}
+	var dump Dump
+	err = json.Unmarshal(b, &dump)
+	if err != nil {
+		t.Fatalf("unmarshal testdata %s: %v", filename, err)
+	}
+	traces := dump.Result
+	t.Log("Traces found:", traces.ResourceSpans().Len())
+
+	callsByOperationName := make(map[string]int)
+	for _, trace := range traces.ResourceSpans().All() {
+		serviceName := getServiceName(trace)
+		if serviceName != "etcd" {
+			continue
+		}
+		opName := getOperationName(trace)
+		callsByOperationName[opName]++
+	}
+	t.Logf("API calls by gRPC method: %+v", callsByOperationName)
+
+	knownMethodsUsedByKubernetes := map[string]bool{
+		"etcdserverpb.KV/Range":           true, // All calls should go through etcd-k8s interface
+		"etcdserverpb.KV/Txn":             true, // All calls should go through etcd-k8s interface
+		"etcdserverpb.KV/Compact":         true, // Compaction should move to using internal Etcd mechanism
+		"etcdserverpb.Watch/Watch":        true, // Not part of the contract interface (yet)
+		"etcdserverpb.Lease/LeaseGrant":   true, // Used to manage masterleases and events
+		"etcdserverpb.Maintenance/Status": true, // Used to expose database size on apiserver's metrics endpoint
+	}
+	for opName := range callsByOperationName {
+		if !knownMethodsUsedByKubernetes[opName] {
+			t.Errorf("method called outside the list: %s", opName)
+		}
+	}
+}
+
+type Traces struct {
+	ptrace.Traces
+}
+
+func (t *Traces) UnmarshalJSON(b []byte) error {
+	traces, err := new(ptrace.JSONUnmarshaler).UnmarshalTraces(b)
+	if err != nil {
+		return err
+	}
+	t.Traces = traces
+	return nil
+}
+
+type Dump struct {
+	Result *Traces `json:"result"`
+}
+
+func getServiceName(trace ptrace.ResourceSpans) string {
+	serviceName, _ := trace.Resource().Attributes().Get("service.name")
+	return serviceName.AsString()
+}
+
+func getOperationName(trace ptrace.ResourceSpans) string {
+	for _, scopeSpan := range trace.ScopeSpans().All() {
+		for _, span := range scopeSpan.Spans().All() {
+			name := span.Name()
+			if strings.HasPrefix(name, "etcdserverpb") {
+				return name
+			}
+		}
+	}
+	return ""
+}

--- a/tests/robustness/coverage/kind-with-tracing.yaml
+++ b/tests/robustness/coverage/kind-with-tracing.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    etcd:
+      local:
+        extraArgs:
+          experimental-enable-distributed-tracing: "true"
+          experimental-distributed-tracing-address: "0.0.0.0:4317"
+          experimental-distributed-tracing-service-name: "etcd"
+          experimental-distributed-tracing-sampling-rate: "1000000"
+- role: worker
+- role: worker

--- a/tests/robustness/coverage/testdata/.gitignore
+++ b/tests/robustness/coverage/testdata/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
It pulls a file from testdata with traces collected by Jaeger and then iterates over them in order to group them into those which use the contract interface, are known (and usually valid) uses outside of it. Later it can further analyze the parameters used over the run of Kubernetes conformance tests.

```
=== RUN   TestInterfaceUse/otlp_etcd-2025-07-03.json
    coverage_test.go:55: Traces found: 64228
    coverage_test.go:66: API calls by gRPC method: map[etcdserverpb.KV/Compact:50 etcdserverpb.KV/R
ange:36761 etcdserverpb.KV/Txn:25450 etcdserverpb.Lease/LeaseGrant:1554 etcdserverpb.Maintenance/St
atus:412 etcdserverpb.Watch/Watch:1]
=== RUN   TestInterfaceUse/otlp_etcd-2025-07-04.json
    coverage_test.go:55: Traces found: 100000
    coverage_test.go:66: API calls by gRPC method: map[etcdserverpb.KV/Compact:84 etcdserverpb.KV/Range:56498 etcdserverpb.KV/Txn:40247 etcdserverpb.Lease/LeaseGrant:2503 etcdserverpb.Maintenance/Status:668]
--- FAIL: TestInterfaceUse (5.24s)
    --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json (2.06s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.KV/Range (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.KV/Txn (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.KV/Compact (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.Watch/Watch (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.Lease/LeaseGrant (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/etcdserverpb.Maintenance/Status (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-03.json/only_expected_methods_were_called (0.00s)
    --- FAIL: TestInterfaceUse/otlp_etcd-2025-07-04.json (3.19s)
        --- FAIL: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.Watch/Watch (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.Lease/LeaseGrant (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.Maintenance/Status (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.KV/Range (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.KV/Txn (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/etcdserverpb.KV/Compact (0.00s)
        --- PASS: TestInterfaceUse/otlp_etcd-2025-07-04.json/only_expected_methods_were_called (0.00s)
 ```