### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/tools/proto-annotations/cmd/etcd_version.go
+++ b/tools/proto-annotations/cmd/etcd_version.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
@@ -72,10 +73,8 @@ func allEtcdVersionAnnotations() (annotations []etcdVersionAnnotation, err error
 	var fileAnnotations []etcdVersionAnnotation
 	protoregistry.GlobalFiles.RangeFiles(func(file protoreflect.FileDescriptor) bool {
 		pkg := string(file.Package())
-		for _, externalPkg := range externalPackages {
-			if pkg == externalPkg {
-				return true
-			}
+		if slices.Contains(externalPackages, pkg) {
+			return true
 		}
 		fileAnnotations, err = fileEtcdVersionAnnotations(file)
 		if err != nil {


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.