### PR TITLE
Add non-linearizable requests to visualization

### DIFF
--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -412,7 +412,7 @@ func TestPatchHistory(t *testing.T) {
 					Watch:    tc.watchOperations,
 				},
 			}
-			operations, _ := prepareAndCategorizeOperations(reports)
+			operations, _, _ := prepareAndCategorizeOperations(reports)
 			patched := patchLinearizableOperations(operations, reports, tc.persistedRequest)
 			if diff := cmp.Diff(tc.expectedRemainingOperations, patched,
 				cmpopts.EquateEmpty(),

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -87,11 +87,24 @@ type LinearizationResult struct {
 	Timeout bool
 }
 
-func (r LinearizationResult) Visualize(lg *zap.Logger, path string) error {
+func (r *LinearizationResult) Visualize(lg *zap.Logger, path string) error {
 	lg.Info("Saving visualization", zap.String("path", path))
 	err := porcupine.VisualizePath(r.Model, r.Info, path)
 	if err != nil {
 		return fmt.Errorf("failed to visualize, err: %w", err)
 	}
 	return nil
+}
+
+func (r *LinearizationResult) AddToVisualization(serializable []porcupine.Operation) {
+	annotations := []porcupine.Annotation{}
+	for _, op := range serializable {
+		annotations = append(annotations, porcupine.Annotation{
+			ClientId:    op.ClientId,
+			Start:       op.Call,
+			End:         op.Return,
+			Description: r.Model.DescribeOperation(op.Input, op.Output),
+		})
+	}
+	r.Info.AddAnnotations(annotations)
 }


### PR DESCRIPTION
This PR adds requests that we don't linearize to visualization.

Ref https://github.com/etcd-io/etcd/issues/19029

![image](https://github.com/user-attachments/assets/43f9d642-9784-4f39-ab73-20214d8d87a0)

We don't linearize all requests, because it's inefficient or impossible. This prevents them being showed in linearization. A new feature in porcupine allows adding manual annotations. The added requests are shown as gray.

As result we have more complete view of everything that happens during a test.

/cc @ahrtr @joshjms @nwnt @siyuanfoundation @fuweid 