### PR TITLE
[release-3.5] Add Makefile target for grpcproxy tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,14 @@ test-integration:
 test-e2e:
 	PASSES="build e2e" ./test.sh $(GO_TEST_FLAGS)
 
+.PHONY: test-grpcproxy-integration
+test-grpcproxy-integration:
+	PASSES='build grpcproxy_integration' RACE='true' ./test.sh $(GO_TEST_FLAGS)
+
+.PHONY: test-grpcproxy-e2e
+test-grpcproxy-e2e:
+	PASSES='build grpcproxy_e2e' RACE='true' ./test.sh $(GO_TEST_FLAGS)
+
 .PHONY: test-e2e-release
 test-e2e-release:
 	PASSES="build release e2e" ./test.sh $(GO_TEST_FLAGS)

--- a/test.sh
+++ b/test.sh
@@ -194,7 +194,17 @@ function functional_pass {
 }
 
 function grpcproxy_pass {
-  run_for_module "tests" go_test "./integration/... ./e2e" "fail_fast" : \
+  grpcproxy_integration_pass "$@"
+  grpcproxy_e2e_pass "$@"
+}
+
+function grpcproxy_integration_pass {
+  run_for_module "tests" go_test "./integration/..." "fail_fast" : \
+      -timeout=45m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
+}
+
+function grpcproxy_e2e_pass {
+  run_for_module "tests" go_test "./e2e/..." "fail_fast" : \
       -timeout=45m -tags cluster_proxy "${COMMON_TEST_FLAGS[@]}" "$@"
 }
 


### PR DESCRIPTION
<details>
<summary>integration</summary>
<pre>
➜  etcd-3.5 git:(release-3.5-grpcproxy-test) ✗ make test-grpcproxy-integration
PASSES='build grpcproxy_integration' RACE='true' ./test.sh 
% 'gofail' 'disable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
Running with --race=true
Starting at: Fri Jun 20 06:06:27 PM +08 2025

'build' started at Fri Jun 20 06:06:27 PM +08 2025
Building etcd
% (cd api && 'go' 'build' './...')
% (cd pkg && 'go' 'build' './...')
% (cd raft && 'go' 'build' './...')
% (cd client/pkg && 'go' 'build' './...')
% (cd client/v2 && 'go' 'build' './...')
% (cd client/v3 && 'go' 'build' './...')
% (cd server && 'go' 'build' './...')
% (cd etcdutl && 'go' 'build' './...')
% (cd etcdctl && 'go' 'build' './...')
% (cd tests && 'go' 'build' './...')
% 'go' 'build' './...'
% 'gofail' 'disable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
% 'rm' '-f' 'bin/etcd'
% (cd server && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcd' '.')
stderr: internal/unsafeheader
stderr: unicode
stderr: internal/profilerecord
stderr: internal/coverage/rtcov
stderr: internal/race
stderr: internal/asan
stderr: internal/byteorder
stderr: internal/goexperiment
stderr: internal/itoa
stderr: internal/goos
stderr: internal/goarch
stderr: internal/cpu
stderr: internal/msan
stderr: internal/runtime/syscall
stderr: internal/runtime/atomic
stderr: internal/godebugs
stderr: sync/atomic
stderr: unicode/utf8
stderr: container/list
stderr: math/bits
stderr: crypto/internal/alias
stderr: crypto/subtle
stderr: crypto/internal/boring/sig
stderr: unicode/utf16
stderr: cmp
stderr: internal/abi
stderr: internal/chacha8rand
stderr: runtime/internal/math
stderr: runtime/internal/sys
stderr: vendor/golang.org/x/crypto/cryptobyte/asn1
stderr: vendor/golang.org/x/crypto/internal/alias
stderr: internal/nettrace
stderr: encoding
stderr: log/internal
stderr: google.golang.org/protobuf/internal/flags
stderr: google.golang.org/grpc/serviceconfig
stderr: log/slog/internal
stderr: go.opentelemetry.io/otel/trace/embedded
stderr: go.opentelemetry.io/otel/metric/embedded
stderr: go.opentelemetry.io/otel/sdk
stderr: go.etcd.io/etcd/client/v3/naming/endpoints/internal
stderr: github.com/golang/groupcache/lru
stderr: google.golang.org/protobuf/internal/set
stderr: internal/bytealg
stderr: internal/runtime/exithook
stderr: math
stderr: internal/stringslite
stderr: runtime
stderr: go.opentelemetry.io/otel/internal
stderr: internal/reflectlite
stderr: iter
stderr: sync
stderr: internal/weak
stderr: maps
stderr: slices
stderr: internal/singleflight
stderr: internal/testlog
stderr: google.golang.org/protobuf/internal/pragma
stderr: log/slog/internal/buffer
stderr: internal/bisect
stderr: errors
stderr: sort
stderr: internal/godebug
stderr: internal/oserror
stderr: vendor/golang.org/x/net/dns/dnsmessage
stderr: google.golang.org/grpc/internal/buffer
stderr: io
stderr: crypto/internal/edwards25519/field
stderr: path
stderr: crypto/internal/nistec/fiat
stderr: strconv
stderr: math/rand/v2
stderr: syscall
stderr: go.etcd.io/etcd/client/pkg/v3/pathutil
stderr: math/rand
stderr: crypto/internal/edwards25519
stderr: internal/concurrent
stderr: crypto/internal/randutil
stderr: hash
stderr: strings
stderr: bytes
stderr: unique
stderr: hash/fnv
stderr: hash/crc32
stderr: github.com/beorn7/perks/quantile
stderr: container/heap
stderr: go.etcd.io/etcd/pkg/v3/crc
stderr: crypto/cipher
stderr: crypto
stderr: crypto/rc4
stderr: reflect
stderr: net/netip
stderr: vendor/golang.org/x/text/transform
stderr: golang.org/x/text/transform
stderr: golang.org/x/crypto/blowfish
stderr: bufio
stderr: net/http/internal/ascii
stderr: github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
stderr: html
stderr: regexp/syntax
stderr: crypto/md5
stderr: crypto/des
stderr: crypto/internal/boring
stderr: crypto/aes
stderr: crypto/sha1
stderr: crypto/sha256
stderr: crypto/sha512
stderr: crypto/hmac
stderr: vendor/golang.org/x/crypto/hkdf
stderr: internal/syscall/execenv
stderr: time
stderr: internal/syscall/unix
stderr: regexp
stderr: context
stderr: google.golang.org/grpc/backoff
stderr: google.golang.org/grpc/balancer/pickfirst/internal
stderr: google.golang.org/grpc/keepalive
stderr: go.uber.org/zap/buffer
stderr: go.etcd.io/etcd/pkg/v3/contention
stderr: github.com/jonboulle/clockwork
stderr: go.etcd.io/etcd/pkg/v3/idutil
stderr: io/fs
stderr: internal/poll
stderr: go.uber.org/zap/internal/bufferpool
stderr: golang.org/x/net/context
stderr: google.golang.org/grpc/internal/backoff
stderr: go.etcd.io/etcd/pkg/v3/schedule
stderr: go.opentelemetry.io/otel/internal/baggage
stderr: github.com/cenkalti/backoff/v4
stderr: google.golang.org/grpc/internal/grpcsync
stderr: embed
stderr: internal/filepathlite
stderr: google.golang.org/protobuf/internal/editiondefaults
stderr: crypto/internal/nistec
stderr: os
stderr: internal/fmtsort
stderr: go.opentelemetry.io/otel/internal/attribute
stderr: encoding/binary
stderr: vendor/golang.org/x/crypto/chacha20
stderr: encoding/base64
stderr: go.etcd.io/etcd/pkg/v3/cpuutil
stderr: github.com/cespare/xxhash/v2
stderr: vendor/golang.org/x/crypto/internal/poly1305
stderr: golang.org/x/sys/unix
stderr: crypto/ecdh
stderr: encoding/pem
stderr: go.uber.org/zap/internal/exit
stderr: io/ioutil
stderr: google.golang.org/grpc/internal/envconfig
stderr: os/signal
stderr: fmt
stderr: google.golang.org/protobuf/internal/detrand
stderr: go.opentelemetry.io/otel/sdk/internal/x
stderr: go.etcd.io/etcd/pkg/v3/runtime
stderr: vendor/golang.org/x/sys/cpu
stderr: path/filepath
stderr: net
stderr: github.com/grpc-ecosystem/grpc-gateway/utilities
stderr: github.com/prometheus/procfs/internal/util
stderr: vendor/golang.org/x/crypto/chacha20poly1305
stderr: vendor/golang.org/x/crypto/sha3
stderr: go.etcd.io/etcd/server/v3/datadir
stderr: net/url
stderr: encoding/hex
stderr: log
stderr: google.golang.org/protobuf/internal/errors
stderr: mime/quotedprintable
stderr: flag
stderr: compress/flate
stderr: mime
stderr: encoding/json
stderr: go/token
stderr: vendor/golang.org/x/text/unicode/norm
stderr: math/big
stderr: vendor/golang.org/x/net/http2/hpack
stderr: net/http/internal
stderr: google.golang.org/protobuf/encoding/protowire
stderr: google.golang.org/protobuf/internal/version
stderr: github.com/prometheus/procfs/internal/fs
stderr: runtime/debug
stderr: text/template/parse
stderr: google.golang.org/protobuf/reflect/protoreflect
stderr: text/tabwriter
stderr: vendor/golang.org/x/text/unicode/bidi
stderr: golang.org/x/net/internal/timeseries
stderr: google.golang.org/grpc/attributes
stderr: google.golang.org/grpc/internal/idle
stderr: golang.org/x/text/unicode/bidi
stderr: golang.org/x/text/unicode/norm
stderr: compress/gzip
stderr: golang.org/x/net/http2/hpack
stderr: encoding/csv
stderr: github.com/coreos/go-semver/semver
stderr: go.uber.org/zap/internal/color
stderr: runtime/trace
stderr: internal/profile
stderr: runtime/pprof
stderr: vendor/golang.org/x/text/secure/bidirule
stderr: go.opentelemetry.io/otel/baggage
stderr: go.etcd.io/etcd/api/v3/version
stderr: go.etcd.io/etcd/pkg/v3/pbutil
stderr: go.etcd.io/etcd/pkg/v3/wait
stderr: go.etcd.io/etcd/raft/v3/quorum
stderr: go.etcd.io/etcd/pkg/v3/adt
stderr: golang.org/x/time/rate
stderr: github.com/modern-go/concurrent
stderr: golang.org/x/text/secure/bidirule
stderr: github.com/google/btree
stderr: google.golang.org/protobuf/internal/encoding/messageset
stderr: google.golang.org/protobuf/internal/strs
stderr: google.golang.org/protobuf/internal/genid
stderr: google.golang.org/protobuf/internal/order
stderr: google.golang.org/protobuf/runtime/protoiface
stderr: google.golang.org/protobuf/internal/descfmt
stderr: google.golang.org/protobuf/internal/descopts
stderr: text/template
stderr: github.com/modern-go/reflect2
stderr: google.golang.org/protobuf/internal/encoding/text
stderr: google.golang.org/protobuf/internal/encoding/json
stderr: google.golang.org/protobuf/internal/protolazy
stderr: database/sql/driver
stderr: google.golang.org/protobuf/reflect/protoregistry
stderr: os/user
stderr: go.etcd.io/bbolt
stderr: vendor/golang.org/x/net/idna
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry
stderr: github.com/grpc-ecosystem/grpc-gateway/v2/utilities
stderr: gopkg.in/natefinch/lumberjack.v2
stderr: gopkg.in/yaml.v2
stderr: github.com/grpc-ecosystem/grpc-gateway/v2/internal/httprule
stderr: google.golang.org/protobuf/internal/encoding/defval
stderr: google.golang.org/protobuf/proto
stderr: github.com/prometheus/common/model
stderr: go.uber.org/atomic
stderr: google.golang.org/grpc/grpclog/internal
stderr: github.com/gogo/protobuf/proto
stderr: go.opentelemetry.io/otel/attribute
stderr: golang.org/x/net/idna
stderr: log/slog
stderr: google.golang.org/grpc/grpclog
stderr: go.uber.org/multierr
stderr: go.opentelemetry.io/auto/sdk/internal/telemetry
stderr: crypto/elliptic
stderr: crypto/internal/bigmod
stderr: crypto/internal/boring/bbig
stderr: encoding/asn1
stderr: crypto/rand
stderr: crypto/dsa
stderr: google.golang.org/grpc/connectivity
stderr: google.golang.org/grpc/internal/grpclog
stderr: go.uber.org/zap/zapcore
stderr: google.golang.org/protobuf/encoding/prototext
stderr: google.golang.org/protobuf/internal/filedesc
stderr: crypto/ed25519
stderr: crypto/internal/hpke
stderr: crypto/internal/mlkem768
stderr: html/template
stderr: go.opentelemetry.io/otel/semconv/v1.17.0
stderr: go.opentelemetry.io/otel/codes
stderr: go.opentelemetry.io/otel/semconv/v1.26.0
stderr: crypto/rsa
stderr: vendor/golang.org/x/crypto/cryptobyte
stderr: crypto/x509/pkix
stderr: github.com/coreos/go-systemd/v22/daemon
stderr: net/textproto
stderr: vendor/golang.org/x/net/http/httpproxy
stderr: github.com/prometheus/procfs
stderr: google.golang.org/grpc/internal
stderr: google.golang.org/grpc/internal/syscall
stderr: google.golang.org/grpc/internal/resolver/dns/internal
stderr: github.com/spf13/pflag
stderr: google.golang.org/grpc/metadata
stderr: google.golang.org/grpc/codes
stderr: google.golang.org/grpc/mem
stderr: vendor/golang.org/x/net/http/httpguts
stderr: mime/multipart
stderr: google.golang.org/grpc/stats
stderr: google.golang.org/grpc/internal/grpcutil
stderr: google.golang.org/grpc/internal/balancerload
stderr: golang.org/x/net/http/httpguts
stderr: crypto/ecdsa
stderr: google.golang.org/grpc/tap
stderr: google.golang.org/grpc/experimental/stats
stderr: github.com/coreos/go-systemd/v22/journal
stderr: go.etcd.io/etcd/client/pkg/v3/systemd
stderr: go.etcd.io/etcd/client/pkg/v3/types
stderr: go.etcd.io/etcd/client/v3/internal/endpoint
stderr: google.golang.org/grpc/encoding
stderr: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/internal
stderr: google.golang.org/grpc/internal/stats
stderr: go.opentelemetry.io/otel/trace
stderr: github.com/go-logr/logr
stderr: go.opentelemetry.io/otel/metric
stderr: github.com/sirupsen/logrus
stderr: golang.org/x/crypto/bcrypt
stderr: github.com/dustin/go-humanize
stderr: go.opentelemetry.io/otel/sdk/instrumentation
stderr: github.com/json-iterator/go
stderr: github.com/google/uuid
stderr: go.etcd.io/etcd/client/pkg/v3/srv
stderr: google.golang.org/grpc/encoding/gzip
stderr: sigs.k8s.io/yaml
stderr: crypto/x509
stderr: github.com/go-logr/logr/funcr
stderr: go.opentelemetry.io/otel/trace/noop
stderr: go.opentelemetry.io/auto/sdk
stderr: google.golang.org/protobuf/encoding/protojson
stderr: google.golang.org/protobuf/internal/encoding/tag
stderr: google.golang.org/protobuf/internal/impl
stderr: github.com/go-logr/stdr
stderr: github.com/spf13/cobra
stderr: crypto/tls
stderr: github.com/golang-jwt/jwt/v4
stderr: github.com/gogo/protobuf/protoc-gen-gogo/descriptor
stderr: github.com/gogo/protobuf/gogoproto
stderr: go.etcd.io/etcd/client/pkg/v3/tlsutil
stderr: google.golang.org/grpc/internal/credentials
stderr: net/http/httptrace
stderr: google.golang.org/grpc/credentials
stderr: google.golang.org/protobuf/internal/filetype
stderr: golang.org/x/net/internal/httpcommon
stderr: net/http
stderr: google.golang.org/grpc/credentials/insecure
stderr: google.golang.org/grpc/resolver
stderr: google.golang.org/grpc/internal/channelz
stderr: google.golang.org/grpc/peer
stderr: google.golang.org/protobuf/runtime/protoimpl
stderr: google.golang.org/grpc/internal/metadata
stderr: google.golang.org/grpc/internal/resolver/passthrough
stderr: google.golang.org/grpc/internal/transport/networktype
stderr: google.golang.org/grpc/balancer/grpclb/state
stderr: google.golang.org/grpc/resolver/manual
stderr: google.golang.org/grpc/internal/proxyattributes
stderr: google.golang.org/protobuf/types/known/anypb
stderr: google.golang.org/protobuf/types/descriptorpb
stderr: google.golang.org/protobuf/types/known/durationpb
stderr: google.golang.org/protobuf/types/known/timestamppb
stderr: google.golang.org/protobuf/protoadapt
stderr: google.golang.org/grpc/internal/resolver/unix
stderr: google.golang.org/grpc/internal/resolver/dns
stderr: google.golang.org/genproto/googleapis/api
stderr: google.golang.org/protobuf/types/known/wrapperspb
stderr: google.golang.org/protobuf/types/known/fieldmaskpb
stderr: go.opentelemetry.io/proto/otlp/common/v1
stderr: go.etcd.io/etcd/client/v3/internal/resolver
stderr: google.golang.org/protobuf/types/known/structpb
stderr: google.golang.org/grpc/internal/pretty
stderr: google.golang.org/grpc/encoding/proto
stderr: github.com/golang/protobuf/ptypes/timestamp
stderr: github.com/golang/protobuf/ptypes/duration
stderr: google.golang.org/grpc/binarylog/grpc_binarylog_v1
stderr: google.golang.org/genproto/googleapis/rpc/errdetails
stderr: google.golang.org/genproto/protobuf/field_mask
stderr: google.golang.org/grpc/resolver/dns
stderr: github.com/golang/protobuf/ptypes/wrappers
stderr: go.opentelemetry.io/proto/otlp/resource/v1
stderr: github.com/golang/protobuf/ptypes/any
stderr: google.golang.org/genproto/googleapis/rpc/status
stderr: google.golang.org/genproto/googleapis/api/httpbody
stderr: google.golang.org/grpc/channelz
stderr: go.opentelemetry.io/proto/otlp/trace/v1
stderr: google.golang.org/grpc/balancer
stderr: google.golang.org/grpc/internal/status
stderr: google.golang.org/grpc/balancer/base
stderr: google.golang.org/grpc/balancer/pickfirst/pickfirstleaf
stderr: google.golang.org/grpc/internal/serviceconfig
stderr: google.golang.org/grpc/status
stderr: google.golang.org/grpc/internal/resolver
stderr: google.golang.org/grpc/balancer/endpointsharding
stderr: google.golang.org/grpc/internal/balancer/gracefulswitch
stderr: google.golang.org/grpc/internal/binarylog
stderr: go.etcd.io/etcd/api/v3/v3rpc/rpctypes
stderr: google.golang.org/grpc/balancer/roundrobin
stderr: google.golang.org/grpc/balancer/pickfirst
stderr: go.etcd.io/etcd/client/v3/credentials
stderr: google.golang.org/protobuf/internal/editionssupport
stderr: google.golang.org/protobuf/types/gofeaturespb
stderr: github.com/golang/protobuf/protoc-gen-go/descriptor
stderr: google.golang.org/genproto/googleapis/api/annotations
stderr: google.golang.org/protobuf/reflect/protodesc
stderr: github.com/golang/protobuf/proto
stderr: go.etcd.io/etcd/api/v3/authpb
stderr: github.com/prometheus/client_model/go
stderr: github.com/golang/protobuf/ptypes
stderr: github.com/matttproud/golang_protobuf_extensions/pbutil
stderr: go.etcd.io/etcd/api/v3/membershippb
stderr: github.com/golang/protobuf/descriptor
stderr: go.etcd.io/etcd/api/v3/mvccpb
stderr: github.com/grpc-ecosystem/grpc-gateway/internal
stderr: github.com/golang/protobuf/jsonpb
stderr: go.etcd.io/etcd/raft/v3/raftpb
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/snap/snappb
stderr: github.com/prometheus/client_golang/prometheus/internal
stderr: go.etcd.io/etcd/raft/v3/tracker
stderr: go.etcd.io/etcd/server/v3/wal/walpb
stderr: go.etcd.io/etcd/raft/v3/confchange
stderr: go.etcd.io/etcd/raft/v3
stderr: expvar
stderr: google.golang.org/grpc/internal/resolver/delegatingresolver
stderr: golang.org/x/net/trace
stderr: net/http/pprof
stderr: github.com/prometheus/common/expfmt
stderr: net/http/httputil
stderr: go.etcd.io/etcd/pkg/v3/httputil
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2error
stderr: github.com/xiang90/probing
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2http/httptypes
stderr: go.etcd.io/etcd/client/v2
stderr: github.com/grpc-ecosystem/grpc-gateway/runtime
stderr: github.com/gorilla/websocket
stderr: go.uber.org/zap
stderr: golang.org/x/net/http2
stderr: go.opentelemetry.io/otel/propagation
stderr: go.opentelemetry.io/otel/semconv/internal
stderr: go.opentelemetry.io/otel/internal/global
stderr: go.etcd.io/etcd/pkg/v3/debugutil
stderr: go.opentelemetry.io/otel/semconv/v1.4.0
stderr: github.com/prometheus/client_golang/prometheus
stderr: github.com/tmc/grpc-websocket-proxy/wsproxy
stderr: go.opentelemetry.io/otel/sdk/internal/env
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig
stderr: go.opentelemetry.io/otel
stderr: go.uber.org/zap/zapgrpc
stderr: go.etcd.io/etcd/client/pkg/v3/logutil
stderr: go.etcd.io/etcd/pkg/v3/flags
stderr: go.etcd.io/etcd/pkg/v3/traceutil
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2stats
stderr: go.etcd.io/etcd/pkg/v3/netutil
stderr: go.etcd.io/etcd/client/pkg/v3/fileutil
stderr: go.etcd.io/etcd/server/v3/proxy/tcpproxy
stderr: go.etcd.io/etcd/pkg/v3/osutil
stderr: go.opentelemetry.io/otel/sdk/resource
stderr: go.etcd.io/etcd/pkg/v3/ioutil
stderr: go.etcd.io/etcd/client/pkg/v3/transport
stderr: go.opentelemetry.io/otel/sdk/trace
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/snap
stderr: go.etcd.io/etcd/server/v3/mvcc/backend
stderr: go.etcd.io/etcd/server/v3/wal
stderr: github.com/prometheus/client_golang/prometheus/promhttp
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2store
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2discovery
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform
stderr: go.etcd.io/etcd/server/v3/mvcc/buckets
stderr: go.etcd.io/etcd/server/v3/etcdserver/cindex
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/membership
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace
stderr: go.etcd.io/etcd/server/v3/verify
stderr: go.etcd.io/etcd/server/v3/proxy/httpproxy
stderr: github.com/soheilhy/cmux
stderr: google.golang.org/grpc/internal/transport
stderr: go.etcd.io/etcd/server/v3/etcdserver/api
stderr: google.golang.org/grpc
stderr: github.com/grpc-ecosystem/go-grpc-prometheus
stderr: github.com/grpc-ecosystem/go-grpc-middleware
stderr: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig
stderr: google.golang.org/grpc/health/grpc_health_v1
stderr: go.etcd.io/etcd/api/v3/etcdserverpb
stderr: google.golang.org/grpc/health
stderr: github.com/grpc-ecosystem/grpc-gateway/v2/runtime
stderr: go.etcd.io/etcd/server/v3/config
stderr: go.opentelemetry.io/proto/otlp/collector/trace/v1
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm
stderr: go.etcd.io/etcd/server/v3/lease/leasepb
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb
stderr: go.etcd.io/etcd/client/v3
stderr: go.etcd.io/etcd/api/v3/etcdserverpb/gw
stderr: go.etcd.io/etcd/server/v3/proxy/grpcproxy/cache
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb
stderr: go.etcd.io/etcd/server/v3/auth
stderr: go.etcd.io/etcd/server/v3/lease
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb/gw
stderr: go.etcd.io/etcd/server/v3/lease/leasehttp
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb/gw
stderr: go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter
stderr: go.etcd.io/etcd/client/v3/namespace
stderr: go.etcd.io/etcd/client/v3/concurrency
stderr: go.etcd.io/etcd/client/v3/ordering
stderr: go.etcd.io/etcd/client/v3/naming/endpoints
stderr: go.etcd.io/etcd/server/v3/mvcc
stderr: go.etcd.io/etcd/client/v3/leasing
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3compactor
stderr: go.etcd.io/etcd/server/v3/etcdserver
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2auth
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2v3
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2http
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3client
stderr: go.etcd.io/etcd/server/v3/proxy/grpcproxy
stderr: go.etcd.io/etcd/server/v3/embed
stderr: go.etcd.io/etcd/server/v3/etcdmain
stderr: go.etcd.io/etcd/server/v3
% 'rm' '-f' 'bin/etcdutl'
% (cd etcdutl && 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcdutl' '.')
stderr: github.com/mattn/go-runewidth
stderr: go.etcd.io/etcd/server/v3/datadir
stderr: go.etcd.io/etcd/pkg/v3/cobrautl
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/snap/snappb
stderr: go.etcd.io/etcd/server/v3/wal/walpb
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2error
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2http/httptypes
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2stats
stderr: go.etcd.io/etcd/server/v3/mvcc/backend
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2discovery
stderr: go.etcd.io/etcd/server/v3/config
stderr: go.etcd.io/etcd/server/v3/lease/leasepb
stderr: go.etcd.io/etcd/client/v3/snapshot
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2store
stderr: github.com/olekukonko/tablewriter
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/snap
stderr: go.etcd.io/etcd/server/v3/wal
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp
stderr: go.etcd.io/etcd/server/v3/mvcc/buckets
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm
stderr: go.etcd.io/etcd/server/v3/etcdserver/cindex
stderr: go.etcd.io/etcd/server/v3/auth
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/membership
stderr: go.etcd.io/etcd/server/v3/lease
stderr: go.etcd.io/etcd/server/v3/verify
stderr: go.etcd.io/etcd/server/v3/lease/leasehttp
stderr: go.etcd.io/etcd/server/v3/mvcc
stderr: go.etcd.io/etcd/server/v3/etcdserver/api
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3compactor
stderr: go.etcd.io/etcd/server/v3/etcdserver
stderr: go.etcd.io/etcd/etcdutl/v3/snapshot
stderr: go.etcd.io/etcd/etcdutl/v3/etcdutl
stderr: go.etcd.io/etcd/etcdutl/v3
% 'rm' '-f' 'bin/etcdctl'
% (cd etcdctl && 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcdctl' '.')
stderr: github.com/shurcooL/sanitized_anchor_name
stderr: github.com/bgentry/speakeasy
stderr: github.com/russross/blackfriday/v2
stderr: go.etcd.io/etcd/pkg/v3/report
stderr: os/exec
stderr: gopkg.in/cheggaaa/pb.v1
stderr: go.etcd.io/etcd/client/v3/mirror
stderr: go.etcd.io/etcd/etcdutl/v3/snapshot
stderr: go.etcd.io/etcd/etcdutl/v3/etcdutl
stderr: github.com/cpuguy83/go-md2man/v2/md2man
stderr: github.com/urfave/cli
stderr: go.etcd.io/etcd/etcdctl/v3/ctlv3/command
stderr: go.etcd.io/etcd/etcdctl/v3/ctlv2/command
stderr: go.etcd.io/etcd/etcdctl/v3/ctlv2
stderr: go.etcd.io/etcd/etcdctl/v3/ctlv3
stderr: go.etcd.io/etcd/etcdctl/v3
Building 'tools/benchmark'...
% 'rm' '-f' 'bin/tools/benchmark'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/benchmark' './tools/benchmark'
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb
stderr: go.etcd.io/etcd/v3/tools/benchmark/cmd
stderr: go.etcd.io/etcd/v3/tools/benchmark
Building 'tools/etcd-dump-db'...
% 'rm' '-f' 'bin/tools/etcd-dump-db'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/etcd-dump-db' './tools/etcd-dump-db'
stderr: go.etcd.io/etcd/v3/tools/etcd-dump-db
Building 'tools/etcd-dump-logs'...
% 'rm' '-f' 'bin/tools/etcd-dump-logs'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/etcd-dump-logs' './tools/etcd-dump-logs'
stderr: go.etcd.io/etcd/v3/tools/etcd-dump-logs
Building 'tools/local-tester/bridge'...
% 'rm' '-f' 'bin/tools/local-tester/bridge'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/local-tester/bridge' './tools/local-tester/bridge'
stderr: go.etcd.io/etcd/v3/tools/local-tester/bridge
Building 'functional/cmd/etcd-agent'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-agent')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-agent' './functional/cmd/etcd-agent')
stderr: net
stderr: os/user
stderr: github.com/coreos/go-systemd/v22/journal
stderr: go.etcd.io/etcd/client/pkg/v3/systemd
stderr: vendor/golang.org/x/net/http/httpproxy
stderr: google.golang.org/grpc/internal/resolver/dns/internal
stderr: google.golang.org/grpc/internal/syscall
stderr: net/textproto
stderr: google.golang.org/grpc/internal
stderr: go.etcd.io/etcd/client/v3/internal/endpoint
stderr: go.etcd.io/etcd/client/pkg/v3/types
stderr: crypto/x509
stderr: github.com/google/uuid
stderr: github.com/spf13/pflag
stderr: github.com/prometheus/procfs
stderr: google.golang.org/grpc/metadata
stderr: google.golang.org/grpc/mem
stderr: google.golang.org/grpc/codes
stderr: go.etcd.io/etcd/client/pkg/v3/srv
stderr: google.golang.org/grpc/internal/status
stderr: vendor/golang.org/x/net/http/httpguts
stderr: mime/multipart
stderr: golang.org/x/net/http/httpguts
stderr: google.golang.org/grpc/internal/balancerload
stderr: google.golang.org/grpc/stats
stderr: google.golang.org/grpc/internal/grpcutil
stderr: google.golang.org/grpc/tap
stderr: google.golang.org/grpc/status
stderr: google.golang.org/grpc/experimental/stats
stderr: google.golang.org/grpc/encoding
stderr: google.golang.org/grpc/internal/stats
stderr: google.golang.org/grpc/encoding/proto
stderr: google.golang.org/grpc/encoding/gzip
stderr: google.golang.org/grpc/internal/binarylog
stderr: go.etcd.io/etcd/api/v3/v3rpc/rpctypes
stderr: github.com/golang-jwt/jwt/v4
stderr: crypto/tls
stderr: net/http/httptrace
stderr: go.etcd.io/etcd/client/pkg/v3/tlsutil
stderr: google.golang.org/grpc/internal/credentials
stderr: google.golang.org/grpc/credentials
stderr: golang.org/x/net/internal/httpcommon
stderr: net/http
stderr: google.golang.org/grpc/peer
stderr: google.golang.org/grpc/resolver
stderr: go.etcd.io/etcd/client/v3/credentials
stderr: google.golang.org/grpc/credentials/insecure
stderr: google.golang.org/grpc/internal/channelz
stderr: google.golang.org/grpc/internal/transport/networktype
stderr: google.golang.org/grpc/internal/resolver/passthrough
stderr: google.golang.org/grpc/resolver/manual
stderr: google.golang.org/grpc/internal/proxyattributes
stderr: google.golang.org/grpc/internal/metadata
stderr: google.golang.org/grpc/balancer/grpclb/state
stderr: google.golang.org/grpc/internal/resolver/unix
stderr: google.golang.org/grpc/internal/resolver/dns
stderr: go.etcd.io/etcd/client/v3/internal/resolver
stderr: google.golang.org/grpc/resolver/dns
stderr: google.golang.org/grpc/channelz
stderr: google.golang.org/grpc/balancer
stderr: google.golang.org/grpc/balancer/base
stderr: google.golang.org/grpc/internal/serviceconfig
stderr: google.golang.org/grpc/balancer/pickfirst/pickfirstleaf
stderr: google.golang.org/grpc/internal/resolver
stderr: google.golang.org/grpc/balancer/endpointsharding
stderr: google.golang.org/grpc/internal/balancer/gracefulswitch
stderr: google.golang.org/grpc/balancer/roundrobin
stderr: google.golang.org/grpc/balancer/pickfirst
stderr: expvar
stderr: google.golang.org/grpc/internal/resolver/delegatingresolver
stderr: net/http/httputil
stderr: go.etcd.io/etcd/pkg/v3/httputil
stderr: golang.org/x/net/trace
stderr: net/http/pprof
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2error
stderr: go.opentelemetry.io/otel/propagation
stderr: github.com/prometheus/common/expfmt
stderr: github.com/grpc-ecosystem/grpc-gateway/runtime
stderr: go.uber.org/zap
stderr: github.com/gorilla/websocket
stderr: go.etcd.io/etcd/client/v2
stderr: golang.org/x/net/http2
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2http/httptypes
stderr: github.com/xiang90/probing
stderr: go.opentelemetry.io/otel/semconv/internal
stderr: go.opentelemetry.io/otel/internal/global
stderr: go.opentelemetry.io/otel/semconv/v1.4.0
stderr: go.etcd.io/etcd/pkg/v3/debugutil
stderr: github.com/prometheus/client_golang/prometheus
stderr: go.opentelemetry.io/otel/sdk/internal/env
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig
stderr: go.opentelemetry.io/otel
stderr: go.etcd.io/etcd/pkg/v3/netutil
stderr: go.etcd.io/etcd/pkg/v3/flags
stderr: go.uber.org/zap/zapgrpc
stderr: go.etcd.io/etcd/client/pkg/v3/fileutil
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2stats
stderr: go.etcd.io/etcd/pkg/v3/traceutil
stderr: go.etcd.io/etcd/client/pkg/v3/logutil
stderr: github.com/tmc/grpc-websocket-proxy/wsproxy
stderr: go.opentelemetry.io/otel/sdk/resource
stderr: go.etcd.io/etcd/pkg/v3/ioutil
stderr: go.etcd.io/etcd/client/pkg/v3/transport
stderr: go.opentelemetry.io/otel/sdk/trace
stderr: go.etcd.io/etcd/server/v3/mvcc/backend
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2store
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/snap
stderr: go.etcd.io/etcd/server/v3/wal
stderr: github.com/prometheus/client_golang/prometheus/promhttp
stderr: go.etcd.io/etcd/pkg/v3/proxy
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2discovery
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform
stderr: go.etcd.io/etcd/server/v3/mvcc/buckets
stderr: go.etcd.io/etcd/server/v3/etcdserver/cindex
stderr: github.com/soheilhy/cmux
stderr: google.golang.org/grpc/internal/transport
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/membership
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace
stderr: go.etcd.io/etcd/server/v3/verify
stderr: go.etcd.io/etcd/server/v3/etcdserver/api
stderr: google.golang.org/grpc
stderr: github.com/grpc-ecosystem/go-grpc-prometheus
stderr: google.golang.org/grpc/health/grpc_health_v1
stderr: github.com/grpc-ecosystem/go-grpc-middleware
stderr: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig
stderr: go.etcd.io/etcd/api/v3/etcdserverpb
stderr: google.golang.org/grpc/health
stderr: github.com/grpc-ecosystem/grpc-gateway/v2/runtime
stderr: go.etcd.io/etcd/server/v3/config
stderr: go.opentelemetry.io/proto/otlp/collector/trace/v1
stderr: go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
stderr: go.etcd.io/etcd/api/v3/etcdserverpb/gw
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm
stderr: go.etcd.io/etcd/server/v3/lease/leasepb
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb
stderr: go.etcd.io/etcd/server/v3/auth
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb
stderr: go.etcd.io/etcd/client/v3
stderr: go.etcd.io/etcd/server/v3/lease
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb/gw
stderr: go.etcd.io/etcd/server/v3/lease/leasehttp
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election/v3electionpb/gw
stderr: go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter
stderr: go.etcd.io/etcd/client/v3/snapshot
stderr: go.etcd.io/etcd/client/v3/concurrency
stderr: go.etcd.io/etcd/server/v3/mvcc
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3election
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3lock
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3compactor
stderr: go.etcd.io/etcd/server/v3/etcdserver
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/etcdhttp
stderr: go.etcd.io/etcd/etcdutl/v3/snapshot
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2v3
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2auth
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v2http
stderr: go.etcd.io/etcd/tests/v3/functional/rpcpb
stderr: go.etcd.io/etcd/server/v3/etcdserver/api/v3client
stderr: go.etcd.io/etcd/server/v3/embed
stderr: go.etcd.io/etcd/tests/v3/functional/agent
stderr: go.etcd.io/etcd/tests/v3/functional/cmd/etcd-agent
Building 'functional/cmd/etcd-proxy'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-proxy')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-proxy' './functional/cmd/etcd-proxy')
stderr: go.etcd.io/etcd/tests/v3/functional/cmd/etcd-proxy
Building 'functional/cmd/etcd-runner'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-runner')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-runner' './functional/cmd/etcd-runner')
stderr: github.com/spf13/cobra
stderr: go.etcd.io/etcd/tests/v3/functional/runner
stderr: go.etcd.io/etcd/tests/v3/functional/cmd/etcd-runner
Building 'functional/cmd/etcd-tester'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-tester')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-tester' './functional/cmd/etcd-tester')
stderr: go.etcd.io/gofail/runtime
stderr: go.etcd.io/etcd/tests/v3/functional/tester
stderr: go.etcd.io/etcd/tests/v3/functional/cmd/etcd-tester
'build' completed at Fri Jun 20 06:06:53 PM +08 2025

'grpcproxy_integration' started at Fri Jun 20 06:06:53 PM +08 2025
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration')
ok      go.etcd.io/etcd/tests/v3/integration    334.760s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/client')
ok      go.etcd.io/etcd/tests/v3/integration/client     1.180s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/client/examples')
ok      go.etcd.io/etcd/tests/v3/integration/client/examples    1.152s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3   96.794s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/concurrency')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/concurrency       4.226s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/connectivity')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/connectivity      28.584s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/examples')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/examples  2.404s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/experimental/recipes')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/experimental/recipes      4.835s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/lease')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/lease     98.383s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/naming')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/naming    1.740s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/clientv3/snapshot')
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/snapshot  1.770s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/embed')
ok      go.etcd.io/etcd/tests/v3/integration/embed      1.012s [no tests to run]
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/proxy/grpcproxy')
ok      go.etcd.io/etcd/tests/v3/integration/proxy/grpcproxy    2.397s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/snapshot')
ok      go.etcd.io/etcd/tests/v3/integration/snapshot   20.176s
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/integration/v2store')
ok      go.etcd.io/etcd/tests/v3/integration/v2store    2.032s
'grpcproxy_integration' completed at Fri Jun 20 06:17:25 PM +08 2025
SUCCESS
</pre>
</details>


<details>
<summary>e2e</summary>
<pre>
➜  etcd-3.5 git:(release-3.5-grpcproxy-test) ✗ make test-grpcproxy-e2e        
PASSES='build grpcproxy_e2e' RACE='true' ./test.sh 
% 'gofail' 'disable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
Running with --race=true
Starting at: Fri Jun 20 09:23:51 PM +08 2025

'build' started at Fri Jun 20 09:23:51 PM +08 2025
Building etcd
% (cd api && 'go' 'build' './...')
% (cd pkg && 'go' 'build' './...')
% (cd raft && 'go' 'build' './...')
% (cd client/pkg && 'go' 'build' './...')
% (cd client/v2 && 'go' 'build' './...')
% (cd client/v3 && 'go' 'build' './...')
% (cd server && 'go' 'build' './...')
% (cd etcdutl && 'go' 'build' './...')
% (cd etcdctl && 'go' 'build' './...')
% (cd tests && 'go' 'build' './...')
% 'go' 'build' './...'
% 'gofail' 'disable' 'server/etcdserver/' 'server/lease/leasehttp' 'server/mvcc/' 'server/wal/' 'server/mvcc/backend/'
% 'rm' '-f' 'bin/etcd'
% (cd server && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcd' '.')
% 'rm' '-f' 'bin/etcdutl'
% (cd etcdutl && 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcdutl' '.')
% 'rm' '-f' 'bin/etcdctl'
% (cd etcdctl && 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/etcdctl' '.')
Building 'tools/benchmark'...
% 'rm' '-f' 'bin/tools/benchmark'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/benchmark' './tools/benchmark'
Building 'tools/etcd-dump-db'...
% 'rm' '-f' 'bin/tools/etcd-dump-db'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/etcd-dump-db' './tools/etcd-dump-db'
Building 'tools/etcd-dump-logs'...
% 'rm' '-f' 'bin/tools/etcd-dump-logs'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/etcd-dump-logs' './tools/etcd-dump-logs'
Building 'tools/local-tester/bridge'...
% 'rm' '-f' 'bin/tools/local-tester/bridge'
% 'env' 'GO_BUILD_FLAGS=-v' 'CGO_ENABLED=0' 'go' 'build' '-v' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=bin/tools/local-tester/bridge' './tools/local-tester/bridge'
Building 'functional/cmd/etcd-agent'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-agent')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-agent' './functional/cmd/etcd-agent')
Building 'functional/cmd/etcd-proxy'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-proxy')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-proxy' './functional/cmd/etcd-proxy')
Building 'functional/cmd/etcd-runner'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-runner')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-runner' './functional/cmd/etcd-runner')
Building 'functional/cmd/etcd-tester'...
% (cd tests && 'rm' '-f' '../bin/functional/cmd/etcd-tester')
% (cd tests && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS=-v' 'go' 'build' '-v' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=75357ec9f' '-o=../bin/functional/cmd/etcd-tester' './functional/cmd/etcd-tester')
'build' completed at Fri Jun 20 09:24:02 PM +08 2025

'grpcproxy_e2e' started at Fri Jun 20 09:24:02 PM +08 2025
% (cd tests && 'env' 'go' 'test' '-timeout=45m' '-tags' 'cluster_proxy' '--race=true' 'go.etcd.io/etcd/tests/v3/e2e')
ok      go.etcd.io/etcd/tests/v3/e2e    696.391s
'grpcproxy_e2e' completed at Fri Jun 20 09:35:41 PM +08 2025
SUCCESS
</pre>
</details>

Ref: https://github.com/kubernetes/test-infra/issues/32754
/cc @ivanvc @abdurrehman107 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
