### PR TITLE
Makefile: enforce version of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,13 +187,11 @@ endif
 
 # Tools
 
-GOLANGCI_LINT_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} github.com/golangci/golangci-lint)
+
 .PHONY: install-golangci-lint
 install-golangci-lint:
-ifeq (, $(shell which golangci-lint))
-	$(shell curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION))
-endif
-
+	./scripts/verify_golangci-lint_version.sh
+	
 .PHONY: install-lazyfs
 install-lazyfs: bin/lazyfs
 bin/lazyfs:

--- a/scripts/verify_golangci-lint_version.sh
+++ b/scripts/verify_golangci-lint_version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+function install_golangci_lint() {
+    echo "Installing golangci-lint ${GOLANGCI_LINT_VERSION}"
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
+}
+
+GOLANGCI_LINT_VERSION=$(cd tools/mod && go list -m -f {{.Version}} github.com/golangci/golangci-lint)
+GOLANGCI_LINT_PRESENT=$(which golangci-lint)
+
+if [ -z "$GOLANGCI_LINT_PRESENT" ]; then
+    echo "golangci-lint is not available"
+    install_golangci_lint
+    exit 0
+fi
+GOLANGCI_LINT_INSTALLED=v$(golangci-lint version | grep -oP 'version \K[0-9.]+')
+
+if [ "$GOLANGCI_LINT_VERSION" != "$GOLANGCI_LINT_INSTALLED" ]; then
+    echo "different golangci-lint version installed: $GOLANGCI_LINT_INSTALLED"
+    install_golangci_lint
+    echo "golangci-lint version: $GOLANGCI_LINT_VERSION"
+fi


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

tested against no golangci-lint and latest version installed (I think it matter, if the version is 2 instead of 1)

add into makefile:
latest-golangci-lint:
	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin

vscode ➜ /workspaces/etcd (main) $ make latest-golangci-lint 
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /go/bin
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 2.1.6 for v2.1.6/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
vscode ➜ /workspaces/etcd (main) $ make verify-lint
./scripts/verify_golangci-lint_version.sh
different golangci-lint version installed: v2.1.6
Installing golangci-lint v1.64.8
golangci/golangci-lint info checking GitHub for tag 'v1.64.8'
golangci/golangci-lint info found version: 1.64.8 for v1.64.8/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
golangci-lint version: v1.64.8
PASSES="lint" ./scripts/test.sh
Running with --race
Starting at: Sat Jun 21 12:22:51 PM UTC 2025

'lint' started at Sat Jun 21 12:22:51 PM UTC 2025
% (cd api && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd pkg && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd client/pkg && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd client/v3 && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd server && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd etcdutl && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd etcdctl && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tests && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/mod && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/rw-heatmaps && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/testgrid-analysis && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd cache && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...'
'lint' PASSED and completed at Sat Jun 21 12:22:55 PM UTC 2025
SUCCESS

remove-lint:
	rm -rf $(GOPATH)/bin/golangci-lint

vscode ➜ /workspaces/etcd (main) $ make remove-lint 
rm -rf /go/bin/golangci-lint
vscode ➜ /workspaces/etcd (main) $ make verify-lint
./scripts/verify_golangci-lint_version.sh
golangci-lint is not available
Installing golangci-lint v1.64.8
golangci/golangci-lint info checking GitHub for tag 'v1.64.8'
golangci/golangci-lint info found version: 1.64.8 for v1.64.8/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
PASSES="lint" ./scripts/test.sh
Running with --race
Starting at: Sat Jun 21 12:24:43 PM UTC 2025

'lint' started at Sat Jun 21 12:24:43 PM UTC 2025
% (cd api && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd pkg && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd client/pkg && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd client/v3 && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd server && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd etcdutl && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd etcdctl && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tests && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/mod && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/rw-heatmaps && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd tools/testgrid-analysis && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% (cd cache && 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...')
% 'golangci-lint' 'run' '--config' '/workspaces/etcd/tools/.golangci.yaml' './...'
'lint' PASSED and completed at Sat Jun 21 12:24:46 PM UTC 2025
SUCCESS
