### PR TITLE
Update etcd OWNERS

### DIFF
--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -17,7 +17,6 @@ for ensuring the stability of the release branch.
 - Marek Siarkowicz [@serathius](https://github.com/serathius)
 - Sahdev Zala [@spzala](https://github.com/spzala)
 - Siyuan Zhang [@siyuanfoundation](https://github.com/siyuanfoundation)
-- Wenjia Zhang [@wenjiaswe](https://github.com/wenjiaswe)
 
 All release version numbers follow the format of [semantic versioning 2.0.0](http://semver.org/).
 

--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,19 @@ approvers:
   - jmhbnz           # James Blair <jablair@redhat.com> <mail@jamesblair.net>
   - serathius        # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
   - spzala           # Sahdev Zala <spzala@us.ibm.com>
-  - wenjiaswe        # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
 reviewers:
   - ivanvc           # Ivan Valdes <ivan@vald.es>
   - siyuanfoundation # Siyuan Zhang <sizhang@google.com> <physicsbug@gmail.com>
+emeritus_approvers:
+  - bdarnell         # Ben Darnell <ben@bendarnell.com>
+  - fanminshi        # Fanmin Shi <fanmin.shi@gmail.com>
+  - gyuho            # Gyuho Lee <gyuhox@gmail.com>
+  - hexfusion        # Sam Batschelet <sbatsche@redhat.com>
+  - heyitsanthony    # Anthony Romano <romanoanthony061@gmail.com>
+  - jingyih          # Jingyi Hu <jingyih@google.com>
+  - jpbetz           # Joe Betz <jpbetz@google.com>
+  - mitake           # Hitoshi Mitake <h.mitake@gmail.com>
+  - philips          # Brandon Philips <brandon@ifup.org>
+  - ptabor           # Piotr Tabor <piotr.tabor@gmail.com>
+  - wenjiaswe        # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
+  - xiang90          # Xiang Li <xiangli.cs@gmail.com>

--- a/README.md
+++ b/README.md
@@ -198,19 +198,7 @@ See [PR management](https://github.com/etcd-io/etcd/blob/main/Documentation/cont
 
 ## etcd Emeritus Maintainers
 
-These emeritus maintainers dedicated a part of their career to etcd and reviewed code, triaged bugs and pushed the project forward over a substantial period of time. Their contribution is greatly appreciated.
-
-* Fanmin Shi
-* Anthony Romano
-* Brandon Philips
-* Joe Betz
-* Gyuho Lee
-* Jingyi Hu
-* Xiang Li
-* Ben Darnell
-* Sam Batschelet
-* Piotr Tabor
-* Hitoshi Mitake
+etcd [emeritus maintainers](OWNERS) dedicated a part of their career to etcd and reviewed code, triaged bugs and pushed the project forward over a substantial period of time. Their contribution is greatly appreciated.
 
 ### License
 


### PR DESCRIPTION
As discussed in our June 5th leads meeting this pull request:
- Shifts our emeritus listing from `README.md` to adopt the `emeritus_approvers` spec for `OWNERS`.
- Shifts @wenjiaswe to emeritus following the recent sig co-chair leadership updates.

Refer: https://www.kubernetes.dev/docs/guide/owners/#emeritus

During the discussion we also discussed adopting https://www.kubernetes.dev/docs/guide/owners/#owners_aliases for grouping. I will address this in a follow-up pull request to keep things focused. 

cc @etcd-io/maintainers-etcd 