### PR TITLE
Use security@etcd.io to receive any CVE report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,7 @@ body:
       label: Bug report criteria
       description: Please confirm this bug report meets the following criteria.
       options:
-        - label: This bug report is not security related, security issues should be disclosed privately via [etcd maintainers](mailto:etcd-maintainers@googlegroups.com).
+        - label: This bug report is not security related, security issues should be disclosed privately via security@etcd.io.
         - label: This is not a support request or question, support requests or questions should be raised in the etcd [discussion forums](https://github.com/etcd-io/etcd/discussions).
         - label: You have read the etcd [bug reporting guidelines](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md).
         - label: Existing open issues along with etcd [frequently asked questions](https://etcd.io/docs/latest/faq) have been checked and this is not a duplicate.

--- a/security/README.md
+++ b/security/README.md
@@ -6,7 +6,7 @@ Join the [etcd-dev](https://groups.google.com/g/etcd-dev) group for emails about
 
 We’re extremely grateful for security researchers and users that report vulnerabilities to the etcd Open Source Community. All reports are thoroughly investigated by a dedicated committee of community volunteers called [Product Security Committee](security-release-process.md#product-security-committee).
 
-To make a report, please email the private [etcd maintainers](mailto:etcd-maintainers@googlegroups.com) list with the security details and the details expected for [all etcd bug reports](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md).
+To make a report, please email the private [security@etcd.io](mailto:security@etcd.io) list with the security details and the details expected for [all etcd bug reports](https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/reporting_bugs.md).
 
 ### When Should I Report a Vulnerability?
 
@@ -43,6 +43,6 @@ This list provides actionable information regarding etcd security to multiple di
 
 ### Request to Join
 
-New membership requests are sent to [etcd maintainers](mailto:etcd-maintainers@googlegroups.com).
+New membership requests are sent to [security@etcd.io](mailto:security@etcd.io).
 
 File an issue [here](https://github.com/etcd-io/etcd/issues/new?template=distributors-application.md), filling in the criteria template.

--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -7,6 +7,7 @@ This is a collection of email templates to handle various situations the securit
 ```
 Subject: Upcoming security release of etcd $VERSION
 To: etcd-dev@googlegroups.com
+Cc: security@etcd-io
 Cc: etcd-maintainers@googlegroups.com
 
 Hello etcd Community,
@@ -34,6 +35,7 @@ $PERSON on behalf of the etcd Product Security Committee and maintainers
 ```
 Subject: Security release of etcd $VERSION is now available
 To: etcd-dev@googlegroups.com
+Cc: security@etcd-io
 Cc: etcd-maintainers@googlegroups.com
 
 Hello etcd Community,

--- a/security/security-release-process.md
+++ b/security/security-release-process.md
@@ -22,7 +22,7 @@ The PSC members will share various tasks as listed below:
 
 ### Contacting the Product Security Committee
 
-Contact the team by sending email to [etcd maintainers](mailto:etcd-maintainers@googlegroups.com).
+Contact the team by sending email to [security@etcd.io](mailto:security@etcd.io).
 
 ### Product Security Committee Membership
 
@@ -55,7 +55,7 @@ The etcd Community asks that all suspected vulnerabilities be privately and resp
 
 ### Public Disclosure Processes
 
-If anyone knows of a publicly disclosed security vulnerability please IMMEDIATELY email [etcd maintainers](mailto:etcd-maintainers@googlegroups.com) to inform the PSC about the vulnerability so they may start the patch, release, and communication process.
+If anyone knows of a publicly disclosed security vulnerability please IMMEDIATELY email [security@etcd.io](mailto:security@etcd.io) to inform the PSC about the vulnerability so they may start the patch, release, and communication process.
 
 If possible the PSC will ask the person making the public report if the issue can be handled via a private disclosure process. If the reporter denies the PSC will move swiftly with the fix and release process. In extreme cases GitHub can be asked to delete the issue but this generally isn't necessary and is unlikely to make a public disclosure less damaging.
 
@@ -90,7 +90,7 @@ If the CVSS score is under ~4.0
 
 Note: CVSS is convenient but imperfect. Ultimately, the PSC has discretion on classifying the severity of a vulnerability.
 
-The severity of the bug and related handling decisions must be discussed on the [etcd maintainers](mailto:etcd-maintainers@googlegroups.com) mailing list.
+The severity of the bug and related handling decisions must be discussed on the [security@etcd.io](mailto:security@etcd.io) mailing list.
 
 ### Fix Disclosure Process
 


### PR DESCRIPTION
Revert https://github.com/etcd-io/etcd/pull/17590

Previously we temporally moved to use etcd maintainers mailing list from security@etcd.io in https://github.com/etcd-io/etcd/pull/17590, while we were discussing how to resolve the security@etcd.io migration in https://github.com/kubernetes/k8s.io/pull/6542.

Now the security@etcd.io is working well, so let's continue to use security@etcd.io

cc @fuweid  @ivanvc @jberkus @jmhbnz  @serathius @siyuanfoundation @spzala 
