### PR TITLE
etcdserver: add size of the watchevent metrics

### DIFF
--- a/server/etcdserver/api/v3rpc/codec.go
+++ b/server/etcdserver/api/v3rpc/codec.go
@@ -14,12 +14,21 @@
 
 package v3rpc
 
-import "github.com/golang/protobuf/proto"
+import (
+	"github.com/golang/protobuf/proto"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
 
 type codec struct{}
 
 func (c *codec) Marshal(v any) ([]byte, error) {
 	b, err := proto.Marshal(v.(proto.Message))
+	switch v.(type) {
+	case *pb.WatchResponse:
+		sentWatchResponseSize.Observe(float64(len(b)))
+	default:
+	}
 	sentBytes.Add(float64(len(b)))
 	return b, err
 }

--- a/server/etcdserver/api/v3rpc/metrics.go
+++ b/server/etcdserver/api/v3rpc/metrics.go
@@ -26,6 +26,15 @@ var (
 		Help:      "The total number of bytes sent to grpc clients.",
 	})
 
+	sentWatchResponseSize = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd",
+		Subsystem: "network",
+		Name:      "watch_events_size_bytes",
+		// 64 bytes to 16MB (default kv size is 1.5M)
+		Buckets: []float64{64, 256, 512, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216},
+		Help:    "The watch response size sent to watch clients in bytes.",
+	})
+
 	receivedBytes = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "etcd",
 		Subsystem: "network",
@@ -56,6 +65,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(sentBytes)
+	prometheus.MustRegister(sentWatchResponseSize)
 	prometheus.MustRegister(receivedBytes)
 	prometheus.MustRegister(streamFailures)
 	prometheus.MustRegister(clientRequests)


### PR DESCRIPTION
To improve observability of etcd v3. we counted the size of WatchResponse sent by watchServer. Metrics are counted using histograms, which can record the number of WatchResponses sent and the size of WatchResponses. When there are a large number of Watchers (especially when watching a lot of kvs), sending WatchResponses will incur memory overhead. add this metric, we can give users more information to find the root cause.