### PR TITLE
Fix working dir for building antithesis client image

### DIFF
--- a/.github/workflows/antithesis-test.yml
+++ b/.github/workflows/antithesis-test.yml
@@ -73,7 +73,7 @@ jobs:
           docker push $IMAGE
 
       - name: Build and push client image
-        working-directory: ./tests/antithesis/test-template
+        working-directory: ./tests/antithesis
         run: |
           make antithesis-build-client-docker-image
           export IMAGE="${{ env.REGISTRY }}/${{ env.REPOSITORY }}/etcd-client:${{ inputs.etcd_ref }}_${{ github.sha }}"


### PR DESCRIPTION
Missed different working dir when reviewing https://github.com/etcd-io/etcd/pull/20219

/cc @joshjms @ahrtr @fuweid @siyuanfoundation @nwnt 
