### PR TITLE
Implement OWNERS_ALIASES for sig-etcd roles

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - ahrtr            # Benjamin Wang <benjamin.ahrtr@gmail.com> <benjamin.wang@broadcom.com>
-  - fuweid           # Wei Fu <fuweid89@gmail.com>
-  - jmhbnz           # James Blair <jablair@redhat.com> <mail@jamesblair.net>
-  - serathius        # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>
-  - spzala           # Sahdev Zala <spzala@us.ibm.com>
-reviewers:
-  - ivanvc           # Ivan Valdes <ivan@vald.es>
-  - siyuanfoundation # Siyuan Zhang <sizhang@google.com> <physicsbug@gmail.com>
+  - sig-etcd-chairs     # Defined in OWNERS_ALIASES
+  - sig-etcd-tech-leads # Defined in OWNERS_ALIASES
+  - fuweid              # Wei Fu <fuweid89@gmail.com>
 emeritus_approvers:
-  - bdarnell         # Ben Darnell <ben@bendarnell.com>
-  - fanminshi        # Fanmin Shi <fanmin.shi@gmail.com>
-  - gyuho            # Gyuho Lee <gyuhox@gmail.com>
-  - hexfusion        # Sam Batschelet <sbatsche@redhat.com>
-  - heyitsanthony    # Anthony Romano <romanoanthony061@gmail.com>
-  - jingyih          # Jingyi Hu <jingyih@google.com>
-  - jpbetz           # Joe Betz <jpbetz@google.com>
-  - mitake           # Hitoshi Mitake <h.mitake@gmail.com>
-  - philips          # Brandon Philips <brandon@ifup.org>
-  - ptabor           # Piotr Tabor <piotr.tabor@gmail.com>
-  - wenjiaswe        # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
-  - xiang90          # Xiang Li <xiangli.cs@gmail.com>
+  - bdarnell            # Ben Darnell <ben@bendarnell.com>
+  - fanminshi           # Fanmin Shi <fanmin.shi@gmail.com>
+  - gyuho               # Gyuho Lee <gyuhox@gmail.com>
+  - hexfusion           # Sam Batschelet <sbatsche@redhat.com>
+  - heyitsanthony       # Anthony Romano <romanoanthony061@gmail.com>
+  - jingyih             # Jingyi Hu <jingyih@google.com>
+  - jpbetz              # Joe Betz <jpbetz@google.com>
+  - mitake              # Hitoshi Mitake <h.mitake@gmail.com>
+  - philips             # Brandon Philips <brandon@ifup.org>
+  - ptabor              # Piotr Tabor <piotr.tabor@gmail.com>
+  - wenjiaswe           # Wenjia Zhang <wenjiazhang@google.com> <wenjia.swe@gmail.com>
+  - xiang90             # Xiang Li <xiangli.cs@gmail.com>

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,8 @@
+aliases:
+  sig-etcd-chairs:
+    - ivanvc           # Ivan Valdes <ivan@vald.es>
+    - jmhbnz           # James Blair <jablair@redhat.com> <mail@jamesblair.net>
+    - siyuanfoundation # Siyuan Zhang <sizhang@google.com> <physicsbug@gmail.com>
+  sig-etcd-tech-leads:
+    - ahrtr            # Benjamin Wang <benjamin.ahrtr@gmail.com> <benjamin.wang@broadcom.com>
+    - serathius        # Marek Siarkowicz <siarkowicz@google.com> <marek.siarkowicz@gmail.com>


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/etcd-io/etcd/pull/20203 adding a basic implementation of `OWNERS_ALIASES` for our **Chair** and **Tech Lead** roles.

Currently our `OWNERS` file does not make it clear who holds a specific role with the sig, i.e. chair or tech lead.  By adding an aliases file we can create arbitrary groupings that are publically auditable.  This is the k8s approch to grouping GitHub users, refer to: https://www.kubernetes.dev/docs/guide/owners/#owners_aliases

Please note - this pull request shifts @ivanvc and @siyuanfoundation from `reviewer` section to `approver` due to their roles as co-chairs. We should have got to this update earlier when their promotions were announced.

cc @etcd-io/maintainers-etcd 




