### PR TITLE
Disable progress notify validation until we can guarantee response

### DIFF
--- a/tests/robustness/client/watch.go
+++ b/tests/robustness/client/watch.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -121,23 +120,5 @@ resetWatch:
 				}
 			}
 		}
-	}
-}
-
-func ValidateGotAtLeastOneProgressNotify(t *testing.T, reports []report.ClientReport, expectProgressNotify bool) {
-	gotProgressNotify := false
-external:
-	for _, r := range reports {
-		for _, op := range r.Watch {
-			for _, resp := range op.Responses {
-				if resp.IsProgressNotify {
-					gotProgressNotify = true
-					break external
-				}
-			}
-		}
-	}
-	if gotProgressNotify != expectProgressNotify {
-		t.Errorf("Progress notify does not match, expect: %v, got: %v", expectProgressNotify, gotProgressNotify)
 	}
 }

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -114,11 +114,6 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenari
 		t.Error(err)
 	}
 
-	failpointImpactingWatch := s.Failpoint == failpoint.SleepBeforeSendWatchResponse
-	if !failpointImpactingWatch {
-		watchProgressNotifyEnabled := c.Cfg.ServerConfig.WatchProgressNotifyInterval != 0
-		client.ValidateGotAtLeastOneProgressNotify(t, r.Client, s.Watch.RequestProgress || watchProgressNotifyEnabled)
-	}
 	validateConfig := validate.Config{ExpectRevisionUnique: s.Traffic.ExpectUniqueRevision()}
 	result := validate.ValidateAndReturnVisualize(lg, validateConfig, r.Client, persistedRequests, 5*time.Minute)
 	r.Visualize = result.Linearization.Visualize


### PR DESCRIPTION
After https://github.com/etcd-io/etcd/pull/20229 restriction in progress notification has started causing flakes in robustness tests 

![image](https://github.com/user-attachments/assets/27babc8d-c93b-4927-b9eb-fd3d840fdab8)

/cc @ahrtr @siyuanfoundation @fuweid @nwnt @henrybear327 