### PR TITLE
[release-3.6] Disable progress notify validation until we can guarantee response

### DIFF
--- a/tests/robustness/client/watch.go
+++ b/tests/robustness/client/watch.go
@@ -122,21 +122,3 @@ resetWatch:
 		}
 	}
 }
-
-func ValidateGotAtLeastOneProgressNotify(t *testing.T, reports []report.ClientReport, expectProgressNotify bool) {
-	gotProgressNotify := false
-external:
-	for _, r := range reports {
-		for _, op := range r.Watch {
-			for _, resp := range op.Responses {
-				if resp.IsProgressNotify {
-					gotProgressNotify = true
-					break external
-				}
-			}
-		}
-	}
-	if gotProgressNotify != expectProgressNotify {
-		t.Errorf("Progress notify does not match, expect: %v, got: %v", expectProgressNotify, gotProgressNotify)
-	}
-}

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -96,11 +96,6 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenari
 	persistedRequests, err := report.PersistedRequestsCluster(lg, c)
 	require.NoError(t, err)
 
-	failpointImpactingWatch := s.Failpoint == failpoint.SleepBeforeSendWatchResponse
-	if !failpointImpactingWatch {
-		watchProgressNotifyEnabled := c.Cfg.ServerConfig.ExperimentalWatchProgressNotifyInterval != 0
-		client.ValidateGotAtLeastOneProgressNotify(t, r.Client, s.Watch.RequestProgress || watchProgressNotifyEnabled)
-	}
 	validateConfig := validate.Config{ExpectRevisionUnique: s.Traffic.ExpectUniqueRevision()}
 	r.Visualize = validate.ValidateAndReturnVisualize(t, lg, validateConfig, r.Client, persistedRequests, 5*time.Minute)
 


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/20240 to prevent flakes in presubmits.

/cc @ahrtr @siyuanfoundation @fuweid @nwnt @henrybear327