### PR TITLE
[robustness] Add short timeout before member recovers

### DIFF
--- a/tests/robustness/failpoint/network.go
+++ b/tests/robustness/failpoint/network.go
@@ -139,6 +139,7 @@ func waitTillSnapshot(ctx context.Context, t *testing.T, clus *e2e.EtcdProcessCl
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	time.Sleep(1 * time.Second)
 	return nil
 }
 


### PR DESCRIPTION
Should solve https://github.com/etcd-io/etcd/issues/20190 by waiting an additional second for the snapshot to actually be applied. 

Ref: https://github.com/etcd-io/etcd/issues/20190

/cc @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
