### PR TITLE
CHANGELOG(3.6): Add bbolt 1.4.2 entry

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -8,7 +8,7 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ### Dependencies
 
-- [Bump bbolt to v1.4.1](https://github.com/etcd-io/etcd/pull/20154)
+- [Bump bbolt to v1.4.2](https://github.com/etcd-io/etcd/pull/20267)
 
 ---
 


### PR DESCRIPTION
Add 3.6.2 changelog entry from the bbolt bump to 1.4.2.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
