### PR TITLE
Prevent flakes with TestWatchRestore

### DIFF
--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -676,7 +676,7 @@ func readEventsForSecond(t *testing.T, ws <-chan WatchResponse) []mvccpb.Event {
 			events = append(events, resp.Events...)
 		case <-deadline:
 			return events
-		case <-time.After(watchResyncPeriod):
+		case <-time.After(watchResyncPeriod * 3 / 2):
 			return events
 		}
 	}


### PR DESCRIPTION
Found flake in new test https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-release35-arm64/1941048743893667840

/cc @ahrtr @fuweid 