### PR TITLE
[release-3.5] Fix error in pull-etcd-release-tests when running in Prow

### DIFF
--- a/scripts/test_images.sh
+++ b/scripts/test_images.sh
@@ -8,14 +8,14 @@ source ./scripts/test_lib.sh
 
 function startContainer {
     # run docker in the background
-    docker run -d --rm --name "${RUN_NAME}" "${IMAGE}"
+    docker run -d --rm --name "${RUN_NAME}" "${TEST_IMAGE}"
 
     # wait for etcd daemon to bootstrap
     sleep 5
 }
 
 function runVersionCheck {
-    Out=$(docker run --rm "${IMAGE}" "${@}")
+    Out=$(docker run --rm "${TEST_IMAGE}" "${@}")
     foundVersion=$(echo "$Out" | head -1 | rev  | cut -d" "  -f 1 | rev )
     if [[ "${foundVersion}" != "${VERSION}" ]]; then
         echo "error: Invalid Version. Got $foundVersion, expected $VERSION. Error: $Out"
@@ -45,15 +45,15 @@ else
     echo "Terminating test, VERSION not supplied"
     exit 1
 fi
-IMAGE=${IMAGE:-"${REPOSITARY}:${TAG}"}
+TEST_IMAGE=${TEST_IMAGE:-"${REPOSITARY}:${TAG}"}
 
 # ETCD related values
 RUN_NAME="test_etcd"
 KEY="foo"
 VALUE="bar"
 
-if [[ "$(docker images -q "${IMAGE}" 2> /dev/null)" == "" ]]; then
-    echo "${IMAGE} not present locally"
+if [[ "$(docker images -q "${TEST_IMAGE}" 2> /dev/null)" == "" ]]; then
+    echo "${TEST_IMAGE} not present locally"
     exit 1
 fi
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/32754
Continuation of #20168
Partial backport of #19305

Rename the input "IMAGE" to "TEST_IMAGE" to avoid clashing with the environment variable from the Prow infrastructure.

<details>
<summary>Results in pj-on-kind</summary>
<pre>
% '/home/prow/go/src/github.com/etcd-io/etcd/scripts/test_images.sh'
a92a0d16d13e6ac3add6d08bb8edb7b7b8541bc07ac21804ffb3f134862c638d
Succesfully tested etcd local image v3.5.99-amd64
Correct Architecture v3.5.99-amd64
Correct Architecture v3.5.99-arm64
Correct Architecture v3.5.99-ppc64le
Correct Architecture v3.5.99-s390x
test_etcd
'release_tests' completed at Mon Jul  7 09:39:51 UTC 2025
SUCCESS
+ EXIT_VALUE=0
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Cleaning up after docker
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
</pre>
</details>

/cc @ivanvc @abdurrehman107 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
