### PR TITLE
server/embed: default WarningUnaryRequestDuration

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -510,10 +510,11 @@ func NewConfig() *Config {
 		SnapshotCount:          etcdserver.DefaultSnapshotCount,
 		SnapshotCatchUpEntries: etcdserver.DefaultSnapshotCatchUpEntries,
 
-		MaxTxnOps:            DefaultMaxTxnOps,
-		MaxRequestBytes:      DefaultMaxRequestBytes,
-		MaxConcurrentStreams: DefaultMaxConcurrentStreams,
-		WarningApplyDuration: DefaultWarningApplyDuration,
+		MaxTxnOps:                   DefaultMaxTxnOps,
+		MaxRequestBytes:             DefaultMaxRequestBytes,
+		MaxConcurrentStreams:        DefaultMaxConcurrentStreams,
+		WarningApplyDuration:        DefaultWarningApplyDuration,
+		WarningUnaryRequestDuration: DefaultWarningUnaryRequestDuration,
 
 		GRPCKeepAliveMinTime:  DefaultGRPCKeepAliveMinTime,
 		GRPCKeepAliveInterval: DefaultGRPCKeepAliveInterval,


### PR DESCRIPTION
No default is applied right now, either by NewConfig nor any subsequent code. This results in every single request being logged at warning level as the threshold duration is zero.

Fixes: 2a26f7ae4c8 ("etcdserver: configure "expensive" requests duration")
Signed-off-by: Lorenz Brun <lorenz@monogon.tech>