### PR TITLE
Add make target for running benchmark tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,23 @@ include $(REPOSITORY_ROOT)/tests/robustness/Makefile
 build:
 	GO_BUILD_FLAGS="${GO_BUILD_FLAGS} -v -mod=readonly" ./scripts/build.sh
 
+.PHONY: bench
+bench: build
+ifeq (, $(shell which benchmark))
+	@echo "Installing etcd benchmark tool..."
+	go install -v ./tools/benchmark
+else
+	@echo "benchmark tool already installed..."
+endif
+
+ifeq ($(strip $(TESTS)),)
+	@echo "Running the default benchmark suite..."
+	./scripts/benchmark_test.sh
+else
+	@echo "Running benchmarks tests with TESTS='$(TESTS)'"
+	./scripts/benchmark_test.sh $(TESTS)
+endif
+
 PLATFORMS=linux-amd64 linux-386 linux-arm linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64 windows-amd64 windows-arm64
 
 .PHONY: build-all

--- a/scripts/benchmark_test.sh
+++ b/scripts/benchmark_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# This scripts runs benchmark tests on the locally spun-up etcd instance
+
+set -euo pipefail
+
+source ./scripts/test_lib.sh
+
+declare -A BENCHMARK_FLAGS
+BENCHMARKS_TO_RUN=()
+COMMON_BENCHMARK_FLAGS="--report-perfdash"
+
+# Supported benchmarks
+ALL_BENCHMARKS=(put lease-keepalive range stm txn-mixed txn-put watch watch-get watch-latency)
+
+for arg in "$@"; do
+  if [[ "$arg" == *:* ]]; then
+    key="${arg%%:*}"
+    value="${arg#*:}"
+    BENCHMARKS_TO_RUN+=("$key")
+    BENCHMARK_FLAGS["$key"]="$value"
+  else
+    BENCHMARKS_TO_RUN+=("$arg")
+    BENCHMARK_FLAGS["$arg"]=""
+  fi
+done
+
+# If there are no specific benchmarks mentioned, run benchmarks of all types apart from mvcc.
+if [ ${#BENCHMARKS_TO_RUN[@]} -eq 0 ]; then
+  BENCHMARKS_TO_RUN=("${ALL_BENCHMARKS[@]}")
+fi
+
+# Set default "key" flag only if benchmark range needs to be run and no flags were passed
+if [[ " ${BENCHMARKS_TO_RUN[*]} " == *" range "* ]] && [[ -z "${BENCHMARK_FLAGS[range]+set}" ]]; then
+  BENCHMARK_FLAGS[range]="key"
+fi
+
+echo "Starting the etcd server..."
+./bin/etcd > /tmp/etcd.log 2>&1 &
+etcd_pid=$!
+
+# Poll on the health endpoint while the etcd server is still setting up before running benchmarks
+for retry in {1..10}; do
+  if curl -fs http://127.0.0.1:2379/health | grep -q '"health":"true"'; then
+    log_success -e "\\netcd is healthy"
+    break
+  fi
+  log_warning -e "\\nWaiting for etcd to be healthy..."
+  sleep 1
+  # Exit if the 10th attempt is unsuccessful.
+  if [[ $retry -eq 10 ]]; then
+    log_error -e "\\nFailed to confirm etcd health after $retry attempts. Check /tmp/etcd.log for more information"
+    exit 1
+  fi
+done
+
+log_success -e "etcd process is running with pid $etcd_pid"
+trap 'log_warning -e "Stopping etcd server - PID:$etcd_pid"; kill $etcd_pid 2>/dev/null' EXIT
+
+for bench in "${BENCHMARKS_TO_RUN[@]}"; do
+  args="${BENCHMARK_FLAGS[$bench]:-}"
+  if [[ -z "$args" ]]; then
+    log_callout -e "\\nPerforming benchmark $bench with default arguments"
+  else
+    log_callout -e "\\nPerforming benchmark $bench with arguments: $args"
+  fi
+  read -r -a TESTER_OPTIONS <<< "$args"
+  printf "Running: benchmark %s %s %s\n" "$bench" "${TESTER_OPTIONS[*]}" "$COMMON_BENCHMARK_FLAGS"
+  benchmark "$bench" "${TESTER_OPTIONS[@]}" $COMMON_BENCHMARK_FLAGS
+done


### PR DESCRIPTION
This PR introduces a new `make target (make bench)` to automate the running of benchmark tests against etcd, using the benchmark utility.
The current design is the build the `etcd` binary and then proceed to run a set of user-configurable tests through the `make bench` target while leveraging the `TESTS` variable to run the exact test required with the required parameters, in the form 
 of  TESTS='benchmark_type:"args"', for example `TESTS='put:"--clients=100 --val-size=4096"'  make bench` . 
 
By default, this command picks defaults for all tests and proceeds to generate the related test-reports and the perfdash-formatted data and the MTR a Logs woa
 
 
 Sample run:
 ```
[root@image-builder etcd]# TESTS='put:"--clients=100 --val-size=4096"' make bench
GO_BUILD_FLAGS=" -v -mod=readonly" ./scripts/build.sh
Running etcd_build
% 'rm' '-f' 'bin/etcd'
% (cd server && 'env' 'CGO_ENABLED=0' 'GO_BUILD_FLAGS= -v -mod=readonly' 'GOOS=linux' 'GOARCH=amd64' 'go' 'build' '-v' '-mod=readonly' '-trimpath' '-installsuffix=cgo' '-ldflags=-X=go.etcd.io/etcd/api/v3/version.GitSHA=b94c9f73f' '-o=../bin/etcd' '.')
...
...
stderr: go.etcd.io/etcd/etcdctl/v3
SUCCESS: etcd_build (GOARCH=amd64)
benchmark tool already installed...
Running benchmarks tests with TESTS='put:--clients=100 --val-size=4096'
./scripts/benchmark_test.sh put:"--clients=100 --val-size=4096"

Starting the etcd server...

Waiting for etcd to be healthy...

etcd is healthy
etcd process is running with pid 3543377

Performing benchmark put with arguments: --clients=100 --val-size=4096
Running: benchmark put --clients=100 --val-size=4096 --report-perfdash
2025/07/07 12:56:23 INFO: [core] [Channel #1 SubChannel #2]Subchannel Connectivity change to CONNECTING
2025/07/07 12:56:23 INFO: [core] [Channel #1 SubChannel #2]Subchannel picks a new address "127.0.0.1:2379" to connect
2025/07/07 12:56:23 INFO: [core] [Channel #1 SubChannel #2]Subchannel Connectivity change to READY
2025/07/07 12:56:23 INFO: [core] [Channel #1]Channel Connectivity change to READY
10000 / 10000 [----------------------------------------------------------------------------------------------------------------------------] 100.00% 43881 p/s
Successfully created a JSON perf report at _artifacts/etcd_perf_put_2025-07-07T16:56:24Z.json

Summary:
  Total:	0.4278 secs.
  Slowest:	0.0161 secs.
  Fastest:	0.0012 secs.
  Average:	0.0043 secs.
  Stddev:	0.0023 secs.
  Requests/sec:	23374.9783

Response time histogram:
  0.0012 [1]	|
  0.0027 [1196]	|∎∎∎∎∎∎∎∎
  0.0042 [5790]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0057 [1875]	|∎∎∎∎∎∎∎∎∎∎∎∎
  0.0072 [462]	|∎∎∎
  0.0087 [40]	|
  0.0102 [232]	|∎
  0.0117 [114]	|
  0.0132 [54]	|
  0.0146 [62]	|
  0.0161 [174]	|∎
....

Stopping etcd server - PID:3543377