### PR TITLE
Fix yamllint errors

### DIFF
--- a/tests/robustness/coverage/kind-with-tracing.yaml
+++ b/tests/robustness/coverage/kind-with-tracing.yaml
@@ -1,16 +1,17 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: ClusterConfiguration
-    etcd:
-      local:
-        extraArgs:
-          experimental-enable-distributed-tracing: "true"
-          experimental-distributed-tracing-address: "0.0.0.0:4317"
-          experimental-distributed-tracing-service-name: "etcd"
-          experimental-distributed-tracing-sampling-rate: "1000000"
-- role: worker
-- role: worker
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        etcd:
+          local:
+            extraArgs:
+              experimental-enable-distributed-tracing: "true"
+              experimental-distributed-tracing-address: "0.0.0.0:4317"
+              experimental-distributed-tracing-service-name: "etcd"
+              experimental-distributed-tracing-sampling-rate: "1000000"
+  - role: worker
+  - role: worker


### PR DESCRIPTION
Introduced in https://github.com/etcd-io/etcd/pull/20181. It caused `make verify-yamllint` fail with the following error:
```
./tests/robustness/coverage/kind-with-tracing.yaml
  1:1       warning  missing document start "---"  (document-start)
  4:1       error    wrong indentation: expected at least 1  (indentation)
  6:3       error    wrong indentation: expected at least 3  (indentation)
```
/cc @serathius 