### PR TITLE
Replace returned Trace with Context argument in internal Applier interface

### DIFF
--- a/server/etcdserver/api/v3rpc/validationfuzz_test.go
+++ b/server/etcdserver/api/v3rpc/validationfuzz_test.go
@@ -175,7 +175,7 @@ func execTransaction(t *testing.T, req *pb.RequestOp) {
 		Success: []*pb.RequestOp{req},
 	}
 
-	_, _, err := txn.Txn(ctx, zaptest.NewLogger(t), request, false, s, &lease.FakeLessor{})
+	_, err := txn.Txn(ctx, zaptest.NewLogger(t), request, false, s, &lease.FakeLessor{})
 	if err != nil {
 		t.Skipf("Application erroring. %s", err.Error())
 	}

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -440,7 +440,7 @@ func TestAuthApplierV3_Put(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.Put(tc.request)
+			_, err := authApplier.Put(t.Context(), tc.request)
 			require.Equalf(t, tc.expectError, err, "Put returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -459,7 +459,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// The user should be able to put the key
 	setAuthInfo(authApplier, userWriteOnly)
-	_, _, err = authApplier.Put(&pb.PutRequest{
+	_, err = authApplier.Put(t.Context(), &pb.PutRequest{
 		Key:   []byte(key),
 		Value: []byte("1"),
 		Lease: leaseID,
@@ -468,7 +468,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// Put a key under the lease outside user's key range
 	setAuthInfo(authApplier, userRoot)
-	_, _, err = authApplier.Put(&pb.PutRequest{
+	_, err = authApplier.Put(t.Context(), &pb.PutRequest{
 		Key:   []byte(keyOutsideRange),
 		Value: []byte("1"),
 		Lease: leaseID,
@@ -477,7 +477,7 @@ func TestAuthApplierV3_LeasePut(t *testing.T) {
 
 	// The user should not be able to put the key anymore
 	setAuthInfo(authApplier, userWriteOnly)
-	_, _, err = authApplier.Put(&pb.PutRequest{
+	_, err = authApplier.Put(t.Context(), &pb.PutRequest{
 		Key:   []byte(key),
 		Value: []byte("1"),
 		Lease: leaseID,
@@ -523,7 +523,7 @@ func TestAuthApplierV3_Range(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.Range(tc.request)
+			_, err := authApplier.Range(t.Context(), tc.request)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -587,7 +587,7 @@ func TestAuthApplierV3_DeleteRange(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.DeleteRange(tc.request)
+			_, err := authApplier.DeleteRange(t.Context(), tc.request)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -657,7 +657,7 @@ func TestAuthApplierV3_Txn(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.Txn(tc.request)
+			_, err := authApplier.Txn(t.Context(), tc.request)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}
@@ -690,7 +690,7 @@ func TestAuthApplierV3_LeaseRevoke(t *testing.T) {
 
 	// Put a key under the lease outside user's key range
 	setAuthInfo(authApplier, userRoot)
-	_, _, err = authApplier.Put(&pb.PutRequest{
+	_, err = authApplier.Put(t.Context(), &pb.PutRequest{
 		Key:   []byte(keyOutsideRange),
 		Value: []byte("1"),
 		Lease: leaseID,

--- a/server/etcdserver/apply/corrupt.go
+++ b/server/etcdserver/apply/corrupt.go
@@ -15,8 +15,9 @@
 package apply
 
 import (
+	"context"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
 )
 
@@ -26,24 +27,24 @@ type applierV3Corrupt struct {
 
 func newApplierV3Corrupt(a applierV3) *applierV3Corrupt { return &applierV3Corrupt{a} }
 
-func (a *applierV3Corrupt) Put(_ *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
-	return nil, nil, errors.ErrCorrupt
+func (a *applierV3Corrupt) Put(_ context.Context, _ *pb.PutRequest) (*pb.PutResponse, error) {
+	return nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) Range(_ *pb.RangeRequest) (*pb.RangeResponse, *traceutil.Trace, error) {
-	return nil, nil, errors.ErrCorrupt
+func (a *applierV3Corrupt) Range(_ context.Context, _ *pb.RangeRequest) (*pb.RangeResponse, error) {
+	return nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) DeleteRange(_ *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, *traceutil.Trace, error) {
-	return nil, nil, errors.ErrCorrupt
+func (a *applierV3Corrupt) DeleteRange(_ context.Context, _ *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	return nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) Txn(_ *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
-	return nil, nil, errors.ErrCorrupt
+func (a *applierV3Corrupt) Txn(_ context.Context, _ *pb.TxnRequest) (*pb.TxnResponse, error) {
+	return nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) Compaction(_ *pb.CompactionRequest) (*pb.CompactionResponse, <-chan struct{}, *traceutil.Trace, error) {
-	return nil, nil, nil, errors.ErrCorrupt
+func (a *applierV3Corrupt) Compaction(_ context.Context, _ *pb.CompactionRequest) (*pb.CompactionResponse, <-chan struct{}, error) {
+	return nil, nil, errors.ErrCorrupt
 }
 
 func (a *applierV3Corrupt) LeaseGrant(_ *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {

--- a/server/etcdserver/apply/uber_applier.go
+++ b/server/etcdserver/apply/uber_applier.go
@@ -15,12 +15,14 @@
 package apply
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3alarm"
 	"go.etcd.io/etcd/server/v3/etcdserver/txn"
@@ -130,19 +132,29 @@ func (a *uberApplier) dispatch(r *pb.InternalRaftRequest, shouldApplyV3 membersh
 	switch {
 	case r.Range != nil:
 		op = "Range"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.Range(r.Range)
+		ctx, trace := traceutil.EnsureTrace(context.Background(), a.lg, op)
+		ar.Resp, ar.Err = a.applyV3.Range(ctx, r.Range)
+		ar.Trace = trace
 	case r.Put != nil:
 		op = "Put"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.Put(r.Put)
+		ctx, trace := traceutil.EnsureTrace(context.Background(), a.lg, op)
+		ar.Resp, ar.Err = a.applyV3.Put(ctx, r.Put)
+		ar.Trace = trace
 	case r.DeleteRange != nil:
 		op = "DeleteRange"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.DeleteRange(r.DeleteRange)
+		ctx, trace := traceutil.EnsureTrace(context.Background(), a.lg, op)
+		ar.Resp, ar.Err = a.applyV3.DeleteRange(ctx, r.DeleteRange)
+		ar.Trace = trace
 	case r.Txn != nil:
 		op = "Txn"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.Txn(r.Txn)
+		ctx, trace := traceutil.EnsureTrace(context.Background(), a.lg, op)
+		ar.Resp, ar.Err = a.applyV3.Txn(ctx, r.Txn)
+		ar.Trace = trace
 	case r.Compaction != nil:
 		op = "Compaction"
-		ar.Resp, ar.Physc, ar.Trace, ar.Err = a.applyV3.Compaction(r.Compaction)
+		ctx, trace := traceutil.EnsureTrace(context.Background(), a.lg, op)
+		ar.Resp, ar.Physc, ar.Err = a.applyV3.Compaction(ctx, r.Compaction)
+		ar.Trace = trace
 	case r.LeaseGrant != nil:
 		op = "LeaseGrant"
 		ar.Resp, ar.Err = a.applyV3.LeaseGrant(r.LeaseGrant)

--- a/server/etcdserver/txn/delete.go
+++ b/server/etcdserver/txn/delete.go
@@ -25,15 +25,15 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-func DeleteRange(ctx context.Context, lg *zap.Logger, kv mvcc.KV, dr *pb.DeleteRangeRequest) (resp *pb.DeleteRangeResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = traceutil.EnsureTrace(ctx, lg, "delete_range",
+func DeleteRange(ctx context.Context, lg *zap.Logger, kv mvcc.KV, dr *pb.DeleteRangeRequest) (resp *pb.DeleteRangeResponse, err error) {
+	ctx, trace := traceutil.EnsureTrace(ctx, lg, "delete_range",
 		traceutil.Field{Key: "key", Value: string(dr.Key)},
 		traceutil.Field{Key: "range_end", Value: string(dr.RangeEnd)},
 	)
 	txnWrite := kv.Write(trace)
 	defer txnWrite.End()
 	resp, err = deleteRange(ctx, txnWrite, dr)
-	return resp, trace, err
+	return resp, err
 }
 
 func deleteRange(ctx context.Context, txnWrite mvcc.TxnWrite, dr *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {

--- a/server/etcdserver/txn/put.go
+++ b/server/etcdserver/txn/put.go
@@ -26,22 +26,22 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-func Put(ctx context.Context, lg *zap.Logger, lessor lease.Lessor, kv mvcc.KV, p *pb.PutRequest) (resp *pb.PutResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = traceutil.EnsureTrace(ctx, lg, "put",
+func Put(ctx context.Context, lg *zap.Logger, lessor lease.Lessor, kv mvcc.KV, p *pb.PutRequest) (resp *pb.PutResponse, err error) {
+	ctx, trace := traceutil.EnsureTrace(ctx, lg, "put",
 		traceutil.Field{Key: "key", Value: string(p.Key)},
 		traceutil.Field{Key: "req_size", Value: p.Size()},
 	)
 	err = checkLease(lessor, p)
 	if err != nil {
-		return nil, trace, err
+		return nil, err
 	}
 	txnWrite := kv.Write(trace)
 	defer txnWrite.End()
 	prevKV, err := checkAndGetPrevKV(trace, txnWrite, p)
 	if err != nil {
-		return nil, trace, err
+		return nil, err
 	}
-	return put(ctx, txnWrite, p, prevKV), trace, nil
+	return put(ctx, txnWrite, p, prevKV), nil
 }
 
 func put(ctx context.Context, txnWrite mvcc.TxnWrite, p *pb.PutRequest, prevKV *mvcc.RangeResult) *pb.PutResponse {

--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -28,8 +28,8 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) (resp *pb.RangeResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = traceutil.EnsureTrace(ctx, lg, "range")
+func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) (resp *pb.RangeResponse, err error) {
+	ctx, trace := traceutil.EnsureTrace(ctx, lg, "range")
 	defer func(start time.Time) {
 		success := err == nil
 		RangeSecObserve(success, time.Since(start))
@@ -37,7 +37,7 @@ func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) 
 	txnRead := kv.Read(mvcc.ConcurrentReadTxMode, trace)
 	defer txnRead.End()
 	resp, err = executeRange(ctx, lg, txnRead, r)
-	return resp, trace, err
+	return resp, err
 }
 
 func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *pb.RangeRequest) (*pb.RangeResponse, error) {

--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -228,7 +228,7 @@ func TestCheckTxn(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			_, _, err := Txn(ctx, zaptest.NewLogger(t), tc.txn, false, s, lessor)
+			_, err := Txn(ctx, zaptest.NewLogger(t), tc.txn, false, s, lessor)
 
 			gotErr := ""
 			if err != nil {
@@ -248,7 +248,7 @@ func TestCheckPut(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			_, _, err := Put(ctx, zaptest.NewLogger(t), lessor, s, tc.op.GetRequestPut())
+			_, err := Put(ctx, zaptest.NewLogger(t), lessor, s, tc.op.GetRequestPut())
 
 			gotErr := ""
 			if err != nil {
@@ -268,7 +268,7 @@ func TestCheckRange(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			_, _, err := Range(ctx, zaptest.NewLogger(t), s, tc.op.GetRequestRange())
+			_, err := Range(ctx, zaptest.NewLogger(t), s, tc.op.GetRequestRange())
 
 			gotErr := ""
 			if err != nil {
@@ -333,7 +333,7 @@ func TestReadonlyTxnError(t *testing.T) {
 		},
 	}
 
-	_, _, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{})
+	_, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{})
 	if err == nil || !strings.Contains(err.Error(), "applyTxn: failed Range: rangeKeys: context cancelled: context canceled") {
 		t.Fatalf("Expected context canceled error, got %v", err)
 	}

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -131,7 +131,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		return s.authStore.IsRangePermitted(ai, r.Key, r.RangeEnd)
 	}
 
-	get := func() { resp, _, err = txn.Range(ctx, s.Logger(), s.KV(), r) }
+	get := func() { resp, err = txn.Range(ctx, s.Logger(), s.KV(), r) }
 	if serr := s.doSerialize(ctx, chk, get); serr != nil {
 		err = serr
 		return nil, err
@@ -181,7 +181,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		}(time.Now())
 
 		get := func() {
-			resp, _, err = txn.Txn(ctx, s.Logger(), r, s.Cfg.ServerFeatureGate.Enabled(features.TxnModeWriteWithSharedBuffer), s.KV(), s.lessor)
+			resp, err = txn.Txn(ctx, s.Logger(), r, s.Cfg.ServerFeatureGate.Enabled(features.TxnModeWriteWithSharedBuffer), s.KV(), s.lessor)
 		}
 		if serr := s.doSerialize(ctx, chk, get); serr != nil {
 			return nil, serr


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/12460.

`context.Context` argument is added to replace returning `traceutil.Trace`. This solves the problem of "merging" two traces and makes it easy to transition to nested spans possible in OpenTelemetry tracing.

Some occurrences of `context.TODO()` were also replaced with actual context.