### PR TITLE
Move EnsureTrace to traceutil

### DIFF
--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -72,7 +72,7 @@ type step struct {
 	isSubTraceEnd   bool
 }
 
-func New(op string, lg *zap.Logger, fields ...Field) *Trace {
+func newTrace(op string, lg *zap.Logger, fields ...Field) *Trace {
 	return &Trace{operation: op, lg: lg, startTime: time.Now(), fields: fields}
 }
 
@@ -92,7 +92,7 @@ func Get(ctx context.Context) *Trace {
 func EnsureTrace(ctx context.Context, lg *zap.Logger, operation string, fields ...Field) (context.Context, *Trace) {
 	trace := Get(ctx)
 	if trace.IsEmpty() {
-		trace = New(operation,
+		trace = newTrace(operation,
 			lg,
 			fields...,
 		)

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -88,6 +88,19 @@ func Get(ctx context.Context) *Trace {
 	return TODO()
 }
 
+// EnsureTrace creates a new trace if needed and adds it to the context.
+func EnsureTrace(ctx context.Context, lg *zap.Logger, operation string, fields ...Field) (context.Context, *Trace) {
+	trace := Get(ctx)
+	if trace.IsEmpty() {
+		trace = New(operation,
+			lg,
+			fields...,
+		)
+		ctx = context.WithValue(ctx, TraceKey{}, trace)
+	}
+	return ctx, trace
+}
+
 func (t *Trace) GetStartTime() time.Time {
 	return t.startTime
 }

--- a/pkg/traceutil/trace_test.go
+++ b/pkg/traceutil/trace_test.go
@@ -73,7 +73,7 @@ func TestCreate(t *testing.T) {
 		}
 	)
 
-	trace := New(op, nil, fields[0], fields[1])
+	_, trace := EnsureTrace(t.Context(), nil, op, fields[0], fields[1])
 	assert.Equalf(t, trace.operation, op, "Expected %v; Got %v", op, trace.operation)
 	for i, f := range trace.fields {
 		assert.Equalf(t, f.Key, fields[i].Key, "Expected %v; Got %v", fields[i].Key, f.Key)

--- a/server/etcdserver/apply/apply.go
+++ b/server/etcdserver/apply/apply.go
@@ -161,8 +161,7 @@ func (a *applierV3backend) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.T
 func (a *applierV3backend) Compaction(compaction *pb.CompactionRequest) (*pb.CompactionResponse, <-chan struct{}, *traceutil.Trace, error) {
 	resp := &pb.CompactionResponse{}
 	resp.Header = &pb.ResponseHeader{}
-	trace := traceutil.New("compact",
-		a.options.Logger,
+	ctx, trace := traceutil.EnsureTrace(context.TODO(), a.options.Logger, "compact",
 		traceutil.Field{Key: "revision", Value: compaction.Revision},
 	)
 
@@ -171,7 +170,7 @@ func (a *applierV3backend) Compaction(compaction *pb.CompactionRequest) (*pb.Com
 		return nil, ch, nil, err
 	}
 	// get the current revision. which key to get is not important.
-	rr, _ := a.options.KV.Range(context.TODO(), []byte("compaction"), nil, mvcc.RangeOptions{})
+	rr, _ := a.options.KV.Range(ctx, []byte("compaction"), nil, mvcc.RangeOptions{})
 	resp.Header.Revision = rr.Rev
 	return resp, ch, trace, err
 }

--- a/server/etcdserver/txn/delete.go
+++ b/server/etcdserver/txn/delete.go
@@ -26,7 +26,7 @@ import (
 )
 
 func DeleteRange(ctx context.Context, lg *zap.Logger, kv mvcc.KV, dr *pb.DeleteRangeRequest) (resp *pb.DeleteRangeResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = ensureTrace(ctx, lg, "delete_range",
+	ctx, trace = traceutil.EnsureTrace(ctx, lg, "delete_range",
 		traceutil.Field{Key: "key", Value: string(dr.Key)},
 		traceutil.Field{Key: "range_end", Value: string(dr.RangeEnd)},
 	)

--- a/server/etcdserver/txn/put.go
+++ b/server/etcdserver/txn/put.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Put(ctx context.Context, lg *zap.Logger, lessor lease.Lessor, kv mvcc.KV, p *pb.PutRequest) (resp *pb.PutResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = ensureTrace(ctx, lg, "put",
+	ctx, trace = traceutil.EnsureTrace(ctx, lg, "put",
 		traceutil.Field{Key: "key", Value: string(p.Key)},
 		traceutil.Field{Key: "req_size", Value: p.Size()},
 	)

--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -29,7 +29,7 @@ import (
 )
 
 func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) (resp *pb.RangeResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = ensureTrace(ctx, lg, "range")
+	ctx, trace = traceutil.EnsureTrace(ctx, lg, "range")
 	defer func(start time.Time) {
 		success := err == nil
 		RangeSecObserve(success, time.Since(start))

--- a/server/etcdserver/txn/txn.go
+++ b/server/etcdserver/txn/txn.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWithSharedBuffer bool, kv mvcc.KV, lessor lease.Lessor) (txnResp *pb.TxnResponse, trace *traceutil.Trace, err error) {
-	ctx, trace = ensureTrace(ctx, lg, "transaction")
+	ctx, trace = traceutil.EnsureTrace(ctx, lg, "transaction")
 	isWrite := !IsTxnReadonly(rt)
 	// When the transaction contains write operations, we use ReadTx instead of
 	// ConcurrentReadTx to avoid extra overhead of copying buffer.
@@ -405,16 +405,4 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 	}
 
 	return nil
-}
-
-func ensureTrace(ctx context.Context, lg *zap.Logger, operation string, fields ...traceutil.Field) (context.Context, *traceutil.Trace) {
-	trace := traceutil.Get(ctx)
-	if trace.IsEmpty() {
-		trace = traceutil.New(operation,
-			lg,
-			fields...,
-		)
-		ctx = context.WithValue(ctx, traceutil.TraceKey{}, trace)
-	}
-	return ctx, trace
 }

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -203,7 +203,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 func (s *EtcdServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
 	startTime := time.Now()
 	result, err := s.processInternalRaftRequestOnce(ctx, pb.InternalRaftRequest{Compaction: r})
-	trace := traceutil.TODO()
+	ctx, trace := traceutil.EnsureTrace(ctx, s.Logger(), "compact")
 	if result != nil && result.Trace != nil {
 		trace = result.Trace
 		defer func() {


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/12460 split from https://github.com/etcd-io/etcd/pull/20307.

`traceutil.New` is removed in favor of `traceutil.EnsureTrace` (previously used only in `go.etcd.io/etcd/server/v3/etcdserver`) in order to unify the method of creating Spans. This in turn makes it easier to migrate to OpenTelemetry tracing.