### PR TITLE
Inject antithesis assertion in place of etcd verify.Verify

### DIFF
--- a/client/pkg/verify/verify.go
+++ b/client/pkg/verify/verify.go
@@ -66,9 +66,18 @@ func DisableVerifications() func() {
 
 // Verify performs verification if the assertions are enabled.
 // In the default setup running in tests and skipped in the production code.
-func Verify(f func()) {
+func Verify(msg string, f VerifyFunc) {
 	if IsVerificationEnabled(envVerifyValueAssert) {
-		f()
+		ok, details := f()
+		verifier(ok, msg, details)
+	}
+}
+
+type VerifyFunc func() (condition bool, details map[string]any)
+
+func verifier(condition bool, msg string, details map[string]any) {
+	if !condition {
+		panic(fmt.Sprintf("%s. details: %v.", msg, details))
 	}
 }
 

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -201,10 +201,8 @@ func (c *Client) Sync(ctx context.Context) error {
 	}
 	// The linearizable `MemberList` returned successfully, so the
 	// endpoints shouldn't be empty.
-	verify.Verify(func() {
-		if len(eps) == 0 {
-			panic("empty endpoints returned from etcd cluster")
-		}
+	verify.Verify("empty endpoints returned from etcd cluster", func() (bool, map[string]any) {
+		return len(eps) > 0, nil
 	})
 	c.SetEndpoints(eps...)
 	c.lg.Debug("set etcd endpoints by autoSync", zap.Strings("endpoints", eps))

--- a/server/storage/mvcc/kvstore.go
+++ b/server/storage/mvcc/kvstore.go
@@ -459,9 +459,10 @@ func restoreIntoIndex(lg *zap.Logger, idx index) (chan<- revKeyValue, <-chan int
 			}
 
 			rev := BytesToRev(rkv.key)
-			verify.Verify(func() {
-				if rev.Main < currentRev {
-					panic(fmt.Errorf("revision %d shouldn't be less than the previous revision %d", rev.Main, currentRev))
+			verify.Verify("revision shouldn't be less than the previous revision", func() (bool, map[string]any) {
+				return rev.Main >= currentRev, map[string]any{
+					"revision":          rev.Main,
+					"previous revision": currentRev,
 				}
 			})
 			currentRev = rev.Main

--- a/server/storage/schema/cindex.go
+++ b/server/storage/schema/cindex.go
@@ -16,7 +16,6 @@ package schema
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"go.etcd.io/etcd/client/pkg/v3/verify"
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -76,10 +75,11 @@ func unsafeUpdateConsistentIndex(tx backend.UnsafeReadWriter, index uint64, term
 	binary.BigEndian.PutUint64(bs1, index)
 
 	if !allowDecreasing {
-		verify.Verify(func() {
+		verify.Verify("update of consistent index not advancing", func() (bool, map[string]any) {
 			previousIndex, _ := UnsafeReadConsistentIndex(tx)
-			if index < previousIndex {
-				panic(fmt.Errorf("update of consistent index not advancing: previous: %v new: %v", previousIndex, index))
+			return index >= previousIndex, map[string]any{
+				"previousIndex": previousIndex,
+				"currentIndex":  index,
 			}
 		})
 	}


### PR DESCRIPTION
Fix #20283 

Background: we want to be able to dynamically inject Antithesis tests without explicitly make etcd depend on Antithesis's library.

Proposed solution: the current `client`'s `verify.Verify` is adjusted so that:
- it eventually calls the function that will be replaced by Antithesis's `assert.Always` during Antithesis test build time.
- in other cases, the function falls back to `panic` which is the existing behavior of all references of `verify.Verify` and `verify.Assert`
- it retains the behavior of `verify.Verify` where no work is done when `verify.Verify` is not enabled - no work required for the evaluation will be done.
- All references to the existing `verify.Assert` are converted to `verify.Verify`.  `verify.Assert` is then removed.
