### PR TITLE
remove antithesis-sdk-go from bill-of-materials.json

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -18,15 +18,6 @@
 		]
 	},
 	{
-		"project": "github.com/antithesishq/antithesis-sdk-go",
-		"licenses": [
-			{
-				"type": "MIT License",
-				"confidence": 1
-			}
-		]
-	},
-	{
 		"project": "github.com/beorn7/perks/quantile",
 		"licenses": [
 			{


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Modified by `make fix`
