### PR TITLE
[Antithesis] Add randomization of etcd server configurations

### DIFF
--- a/tests/antithesis/config/docker-compose-1-node.yml
+++ b/tests/antithesis/config/docker-compose-1-node.yml
@@ -32,6 +32,9 @@ services:
       ETCD_INITIAL_CLUSTER: "etcd0=http://etcd0:2380"
       ETCD_INITIAL_CLUSTER_STATE: "new"
       ETCD_DATA_DIR: "/var/etcd/data"
+      ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
+      ETCD_SNAPSHOT_COUNT: 50
+      ETCD_COMPACTION_BATCH_LIMIT: 10
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
       init:

--- a/tests/antithesis/config/docker-compose-3-node.yml
+++ b/tests/antithesis/config/docker-compose-3-node.yml
@@ -34,6 +34,9 @@ services:
       ETCD_INITIAL_CLUSTER: "etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380"
       ETCD_INITIAL_CLUSTER_STATE: "new"
       ETCD_DATA_DIR: "/var/etcd/data"
+      ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
+      ETCD_SNAPSHOT_COUNT: 50
+      ETCD_COMPACTION_BATCH_LIMIT: 10
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
       init:
@@ -57,6 +60,9 @@ services:
       ETCD_INITIAL_CLUSTER: "etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380"
       ETCD_INITIAL_CLUSTER_STATE: "new"
       ETCD_DATA_DIR: "/var/etcd/data"
+      ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
+      ETCD_SNAPSHOT_COUNT: 50
+      ETCD_COMPACTION_BATCH_LIMIT: 10
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
       init:
@@ -80,6 +86,9 @@ services:
       ETCD_INITIAL_CLUSTER: "etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380"
       ETCD_INITIAL_CLUSTER_STATE: "new"
       ETCD_DATA_DIR: "/var/etcd/data"
+      ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
+      ETCD_SNAPSHOT_COUNT: 50
+      ETCD_COMPACTION_BATCH_LIMIT: 10
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
       init:


### PR DESCRIPTION
Added the following randomization for Antithesis tests:
* `ETCD_SNAPSHOT_COUNT`: 50, 100, or 1000
* `ETCD_SNAPSHOT_CATCHUP_ENTRIES`: 50, 100, or 5000
* `ETCD_COMPACTION_BATCH_LIMIT`: 10, 100, or 1000

```
make antithesis-docker-compose-up
```

or to specify value:

```
CFG_ETCD_SNAPSHOT_COUNT=167 make antithesis-docker-compose-up
```

/cc @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
