### PR TITLE
Update changelog and instructions following v3.6.2 release

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -4,7 +4,11 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ---
 
-## v3.6.2 (TBD)
+## v3.6.3 (TBD)
+
+---
+
+## v3.6.2 (2025-07-09)
 
 ### etcd server
 

--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -108,8 +108,8 @@ On the day of the release:
    - Open the **draft** release URL shown by the release script
    - Click the pen button at the top right to edit the release
    - Review that it looks correct, reviewing that the bottom checkboxes are checked depending on the
-     release version (v3.4 no checkboxes, v3.5 has the set as latest release checkbox checked,
-     v3.6 has the set as pre-release checkbox checked)
+     release version (v3.4 & v3.5 no checkboxes, v3.6 has the set as latest release checkbox checked,
+     v3.7 has the set as pre-release checkbox checked)
    - Then, publish the release
 5. Announce to the etcd-dev googlegroup
 


### PR DESCRIPTION
This pull request:
- Adds release date for v3.6.2 to CHANGELOG-3.6.md.
- Corrects instructions for GitHub release checkboxes following 3.6.0 full release.

cc @ivanvc 