### PR TITLE
Add OpenTelemetry Spans to Range and Txn

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0
+	go.opentelemetry.io/otel/trace v1.37.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.73.0
 )

--- a/pkg/traceutil/trace.go
+++ b/pkg/traceutil/trace.go
@@ -22,8 +22,18 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 )
+
+const instrumentationScope = "go.etcd.io/etcd"
+
+var Tracer trace.Tracer = noop.NewTracerProvider().Tracer(instrumentationScope)
+
+func Init(tp trace.TracerProvider) {
+	Tracer = tp.Tracer(instrumentationScope)
+}
 
 // TraceKey is used as a key of context for Trace.
 type TraceKey struct{}

--- a/server/embed/config_tracing.go
+++ b/server/embed/config_tracing.go
@@ -25,6 +25,8 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/pkg/v3/traceutil"
 )
 
 const maxSamplingRatePerMillion = 1000000
@@ -80,6 +82,8 @@ func newTracingExporter(ctx context.Context, cfg *Config) (*tracingExporter, err
 			tracesdk.ParentBased(determineSampler(cfg.DistributedTracingSamplingRatePerMillion)),
 		),
 	)
+
+	traceutil.Init(traceProvider)
 
 	options := []otelgrpc.Option{
 		otelgrpc.WithPropagators(

--- a/server/go.mod
+++ b/server/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
+	go.opentelemetry.io/otel/trace v1.37.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.39.0
 	golang.org/x/net v0.41.0
@@ -67,7 +68,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
-	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182 and https://github.com/etcd-io/etcd/issues/12460

This adds new spans in `Range` and `Txn` methods. This makes it easier to distinguish actual execution time from the overhead of grpc and other pre/post processing.

Attributes added:
1. `Range`:
   * `range_begin` (`key` field in proto), `range_end` - used to better understand key transformations from other systems (like Kubernetes)
   * `rev` - revision used to distinguish between requests for old or latest data
   * `limit` - lists vs gets
   * `count_only` (boolean)
2. `Txn`:
   * `first_compare_key` - first non-empty key from `compare`s
   * `compare_len` - the number of compare operation in the request
   * `failure_len`, `success_len` - counts for `failure` and `success` operations in the request
   * `read_only` (boolean) - if any of the operations can modify data

Example trace from Jeager with Apiserver tracing also configured:
<img width="1657" height="866" alt="image" src="https://github.com/user-attachments/assets/b3f377af-24b3-4567-a365-7e093cd04b65" />
