### PR TITLE
Prevent flakes with TestWatchRestore

### DIFF
--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -676,7 +676,7 @@ func readEventsForSecond(t *testing.T, ws <-chan WatchResponse) []mvccpb.Event {
 			events = append(events, resp.Events...)
 		case <-deadline:
 			return events
-		case <-time.After(watchResyncPeriod):
+		case <-time.After(watchResyncPeriod * 3 / 2):
 			return events
 		}
 	}


### PR DESCRIPTION
(cherry picked from commit 9671fb369cb185c5cf905e5ab151d7a7d23565f2)

This PR is a manual cherry-pick of https://github.com/etcd-io/etcd/pull/20292, which contains the fix for a flaky tests under - TestWatchRestore. The CI for unit tests on the release branches require these changes to de-flake tests added through - https://github.com/etcd-io/etcd/pull/20281. These flakes are observed on amd64,arm64 and ppc64le architectures. 

xref: 
ci-etcd-unit-test-release36-arm64 - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-unit-test-release36-arm64/1944384969128284160
ci-etcd-unit-test-release36-amd64 - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-unit-test-release36-amd64/1944323815949471744

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
