### PR TITLE
Remove verify.Assert

### DIFF
--- a/client/pkg/fileutil/fileutil.go
+++ b/client/pkg/fileutil/fileutil.go
@@ -22,8 +22,6 @@ import (
 	"path/filepath"
 
 	"go.uber.org/zap"
-
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 const (
@@ -47,7 +45,9 @@ func IsDirWriteable(dir string) error {
 // TouchDirAll is similar to os.MkdirAll. It creates directories with 0700 permission if any directory
 // does not exists. TouchDirAll also ensures the given directory is writable.
 func TouchDirAll(lg *zap.Logger, dir string) error {
-	verify.Assert(lg != nil, "nil log isn't allowed")
+	if lg == nil {
+		panic("nil log isn't allowed")
+	}
 	// If path is already a directory, MkdirAll does nothing and returns nil, so,
 	// first check if dir exists with an expected permission mode.
 	if Exist(dir) {

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -36,7 +36,6 @@ import (
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 // NewListener creates a new listner.
@@ -218,7 +217,9 @@ func (info TLSInfo) Empty() bool {
 }
 
 func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertValidity uint, additionalUsages ...x509.ExtKeyUsage) (TLSInfo, error) {
-	verify.Assert(lg != nil, "nil log isn't allowed")
+	if lg == nil {
+		panic("nil log isn't allowed")
+	}
 
 	var err error
 	info := TLSInfo{Logger: lg}

--- a/client/pkg/verify/verify.go
+++ b/client/pkg/verify/verify.go
@@ -15,7 +15,6 @@
 package verify
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -69,12 +68,5 @@ func DisableVerifications() func() {
 func Verify(f func()) {
 	if IsVerificationEnabled(envVerifyValueAssert) {
 		f()
-	}
-}
-
-// Assert will panic with a given formatted message if the given condition is false.
-func Assert(condition bool, msg string, v ...any) {
-	if !condition {
-		panic(fmt.Sprintf("assertion failed: "+msg, v...))
 	}
 }

--- a/pkg/ioutil/pagewriter.go
+++ b/pkg/ioutil/pagewriter.go
@@ -16,8 +16,6 @@ package ioutil
 
 import (
 	"io"
-
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 var defaultBufferBytes = 128 * 1024
@@ -43,7 +41,9 @@ type PageWriter struct {
 // NewPageWriter creates a new PageWriter. pageBytes is the number of bytes
 // to write per page. pageOffset is the starting offset of io.Writer.
 func NewPageWriter(w io.Writer, pageBytes, pageOffset int) *PageWriter {
-	verify.Assert(pageBytes > 0, "invalid pageBytes (%d) value, it must be greater than 0", pageBytes)
+	if pageBytes <= 0 {
+		panic("invalid pageBytes value, it must be greater than 0")
+	}
 	return &PageWriter{
 		w:                 w,
 		pageOffset:        pageOffset,

--- a/pkg/osutil/interrupt_unix.go
+++ b/pkg/osutil/interrupt_unix.go
@@ -23,8 +23,6 @@ import (
 	"syscall"
 
 	"go.uber.org/zap"
-
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 // InterruptHandler is a function that is called on receiving a
@@ -48,7 +46,9 @@ func RegisterInterruptHandler(h InterruptHandler) {
 
 // HandleInterrupts calls the handler functions on receiving a SIGINT or SIGTERM.
 func HandleInterrupts(lg *zap.Logger) {
-	verify.Assert(lg != nil, "the logger should not be nil")
+	if lg == nil {
+		panic("the logger should not be nil")
+	}
 	notifier := make(chan os.Signal, 1)
 	signal.Notify(notifier, syscall.SIGINT, syscall.SIGTERM)
 

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
-
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 type Job interface {
@@ -89,7 +87,9 @@ type fifo struct {
 // NewFIFOScheduler returns a Scheduler that schedules jobs in FIFO
 // order sequentially
 func NewFIFOScheduler(lg *zap.Logger) Scheduler {
-	verify.Assert(lg != nil, "the logger should not be nil")
+	if lg == nil {
+		panic("the logger should not be nil")
+	}
 
 	f := &fifo{
 		resume: make(chan struct{}, 1),

--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -27,7 +27,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 	pioutil "go.etcd.io/etcd/pkg/v3/ioutil"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap/snappb"
@@ -154,7 +153,9 @@ func (s *Snapshotter) loadSnap(name string) (*raftpb.Snapshot, error) {
 
 // Read reads the snapshot named by snapname and returns the snapshot.
 func Read(lg *zap.Logger, snapname string) (*raftpb.Snapshot, error) {
-	verify.Assert(lg != nil, "the logger should not be nil")
+	if lg == nil {
+		panic("the logger should not be nil")
+	}
 	b, err := os.ReadFile(snapname)
 	if err != nil {
 		lg.Warn("failed to read a snap file", zap.String("path", snapname), zap.Error(err))

--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -17,6 +17,7 @@ package v3rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"sync"
@@ -27,7 +28,6 @@ import (
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/auth"
 	"go.etcd.io/etcd/server/v3/etcdserver"
@@ -493,7 +493,9 @@ func (sws *serverWatchStream) sendLoop() {
 			// track id creation
 			wid := mvcc.WatchID(c.WatchId)
 
-			verify.Assert(!(c.Canceled && c.Created) || wid == clientv3.InvalidWatchID, "unexpected watchId: %d, wanted: %d, since both 'Canceled' and 'Created' are true", wid, clientv3.InvalidWatchID)
+			if c.Canceled && c.Created && wid != clientv3.InvalidWatchID {
+				panic(fmt.Sprintf("unexpected watchId: %d, wanted: %d, since both 'Canceled' and 'Created' are true", wid, clientv3.InvalidWatchID))
+			}
 
 			if c.Canceled && wid != clientv3.InvalidWatchID {
 				delete(ids, wid)

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/zap"
 
 	bolt "go.etcd.io/bbolt"
-	"go.etcd.io/etcd/client/pkg/v3/verify"
 )
 
 var (
@@ -464,7 +463,9 @@ func (b *backend) Defrag() error {
 }
 
 func (b *backend) defrag() error {
-	verify.Assert(b.lg != nil, "the logger should not be nil")
+	if b.lg == nil {
+		panic("the logger should not be nil")
+	}
 	now := time.Now()
 	isDefragActive.Set(1)
 	defer isDefragActive.Set(0)

--- a/server/storage/backend/tx_buffer.go
+++ b/server/storage/backend/tx_buffer.go
@@ -247,8 +247,9 @@ func (bb *bucketBuffer) Less(i, j int) bool {
 func (bb *bucketBuffer) Swap(i, j int) { bb.buf[i], bb.buf[j] = bb.buf[j], bb.buf[i] }
 
 func (bb *bucketBuffer) CopyUsed() *bucketBuffer {
-	verify.Assert(bb.used <= len(bb.buf),
-		"used (%d) should never be bigger than the length of buf (%d)", bb.used, len(bb.buf))
+	if bb.used > len(bb.buf) {
+		panic(fmt.Sprintf("used (%d) should never be bigger than the length of buf (%d)", bb.used, len(bb.buf)))
+	}
 	bbCopy := bucketBuffer{
 		buf:  make([]kv, bb.used),
 		used: bb.used,


### PR DESCRIPTION
The verify package is meant to build test only verification during runtime. Having a trivial function that always panics causes confusion.

There is no reason to have a library function just to replace a simple if with panic statement.

/cc @fuweid @ahrtr 