### PR TITLE
Update 3.5 changelog to cover the v2store check false alarm

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -12,6 +12,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - Fix [mvcc: avoid double decrement of watcher gauge on close/cancel race](https://github.com/etcd-io/etcd/pull/20066)
 - Fix [Watch on future revision returns old events or notifications](https://github.com/etcd-io/etcd/pull/20290)
 - Fix [`--force-new-cluster` can't remove all other members in a corner case](https://github.com/etcd-io/etcd/pull/20339)
+- Fix [v2store check (IsMetaStoreOnly) returns wrong result even there is no any auth data](https://github.com/etcd-io/etcd/pull/20357)
 
 ### Package `clientv3`
 


### PR DESCRIPTION
Link to
- https://github.com/etcd-io/etcd/pull/20357
- https://github.com/etcd-io/etcd/issues/20351

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

cc @fuweid @ivanvc @jmhbnz @serathius 
