### PR TITLE
Inject antithesis at verify.Verify

### DIFF
--- a/tests/antithesis/server/Dockerfile
+++ b/tests/antithesis/server/Dockerfile
@@ -6,6 +6,16 @@ FROM golang:$GO_VERSION
 # cloning etcd
 ARG REF=main
 RUN git clone --depth=1 https://github.com/etcd-io/etcd.git --branch=${REF} /etcd
+
+# replace verify with antithesis
+WORKDIR /etcd/client/pkg/verify
+COPY inject/verify.patch verify.patch
+RUN if [ "${REF}" == "main" ]; then \
+      git apply verify.patch; \
+    fi
+RUN rm verify.patch
+WORKDIR /etcd/client/pkg
+RUN go mod tidy
 WORKDIR /etcd
 
 # setup go mod

--- a/tests/antithesis/server/inject/verify.patch
+++ b/tests/antithesis/server/inject/verify.patch
@@ -1,0 +1,22 @@
+diff --git a/client/pkg/verify/verify.go b/client/pkg/verify/verify.go
+index cb48d8ff0..095f890ec 100644
+--- a/client/pkg/verify/verify.go
++++ b/client/pkg/verify/verify.go
+@@ -18,6 +18,8 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"strings"
++
++	"github.com/antithesishq/antithesis-sdk-go/assert"
+ )
+ 
+ const envVerify = "ETCD_VERIFY"
+@@ -69,7 +71,7 @@ func DisableVerifications() func() {
+ func Verify(msg string, f VerifyFunc) {
+ 	if IsVerificationEnabled(envVerifyValueAssert) {
+ 		ok, details := f()
+-		verifier(ok, msg, details)
++		assert.Always(ok, msg, details)
+ 	}
+ }
+ 


### PR DESCRIPTION
As a follow up of #20312.  This replaces `verify.Verify` with Antithesis's `assert.Always`.

Note, I had to use `git apply` instead of `patch` because patch does not exist on the image.

cc @serathius @ahrtr 