### PR TITLE
Expose opWatch & boolean accessors for Watch opts so the cache can validate unsupported watch flags

### DIFF
--- a/client/v3/op.go
+++ b/client/v3/op.go
@@ -131,6 +131,24 @@ func (op Op) IsOptsWithFromKey() bool { return op.isOptsWithFromKey }
 
 func (op Op) IsOptsWithPrefix() bool { return op.isOptsWithPrefix }
 
+// IsPrevKV returns whether WithPrevKV() is set.
+func (op Op) IsPrevKV() bool { return op.prevKV }
+
+// IsFragment returns whether WithFragment() is set.
+func (op Op) IsFragment() bool { return op.fragment }
+
+// IsProgressNotify returns whether WithProgressNotify() is set.
+func (op Op) IsProgressNotify() bool { return op.progressNotify }
+
+// IsCreatedNotify returns whether WithCreatedNotify() is set.
+func (op Op) IsCreatedNotify() bool { return op.createdNotify }
+
+// IsFilterPut returns whether WithFilterPut() is set.
+func (op Op) IsFilterPut() bool { return op.filterPut }
+
+// IsFilterDelete returns whether WithFilterDelete() is set.
+func (op Op) IsFilterDelete() bool { return op.filterDelete }
+
 // MinModRev returns the operation's minimum modify revision.
 func (op Op) MinModRev() int64 { return op.minModRev }
 
@@ -308,7 +326,7 @@ func OpTxn(cmps []Cmp, thenOps []Op, elseOps []Op) Op {
 	return Op{t: tTxn, cmps: cmps, thenOps: thenOps, elseOps: elseOps}
 }
 
-func opWatch(key string, opts ...OpOption) Op {
+func OpWatch(key string, opts ...OpOption) Op {
 	ret := Op{t: tRange, key: []byte(key)}
 	ret.applyOpts(opts)
 	switch {

--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -296,7 +296,7 @@ func (w *watcher) newWatcherGRPCStream(inctx context.Context) *watchGRPCStream {
 
 // Watch posts a watch request to run() and waits for a new watcher channel
 func (w *watcher) Watch(ctx context.Context, key string, opts ...OpOption) WatchChan {
-	ow := opWatch(key, opts...)
+	ow := OpWatch(key, opts...)
 
 	var filters []pb.WatchCreateRequest_FilterType
 	if ow.filterPut {


### PR DESCRIPTION
Provide boolean accessors (IsPrevKV, IsFragment, IsProgressNotify, IsCreatedNotify, IsFilterPut, IsFilterDelete) on clientv3.Op so the cache can validate unsupported watch flags.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

@serathius @MadhavJivrajani 