### PR TITLE
netutil: Refactor IPv6 address comparison logic

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -19,6 +19,7 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 ### Package `pkg`
 
 - [Optimize find performance by splitting intervals with the same left endpoint by their right endpoints](https://github.com/etcd-io/etcd/pull/19768)
+- [netutil: Refactor IPv6 address comparison logic](https://github.com/etcd-io/etcd/pull/20365)
 
 ### Dependencies
 

--- a/pkg/netutil/host_normalize.go
+++ b/pkg/netutil/host_normalize.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutil
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// urlsHostNormalizedEqual compares two URLs for scheme, normalized host (including IPv6), and path equality.
+func urlsHostNormalizedEqual(a, b url.URL) bool {
+	return a.Scheme == b.Scheme &&
+		normalizeHost(a.Host) == normalizeHost(b.Host) &&
+		a.Path == b.Path
+}
+
+// normalizeHost returns the canonical string for the host and normalizes IPv6 and IPv4 addresses.
+func normalizeHost(host string) string {
+	hostOnly, port, err := net.SplitHostPort(host)
+	if err != nil {
+		hostOnly = host
+		port = ""
+	}
+
+	// Check if hostOnly is an IPv6 address. It could be with or without brackets.
+	ipStr := strings.Trim(hostOnly, "[]")
+	if ip := net.ParseIP(ipStr); ip != nil {
+		if ip.To4() == nil {
+			// For IPv6 address, always use brackets when there is a port.
+			return "[" + ip.String() + "]" + normalizePort(port)
+		}
+		// IPv4 address
+		return ip.String() + normalizePort(port)
+	}
+	return host
+}
+
+func normalizePort(port string) string {
+	if port == "" {
+		return ""
+	}
+	return ":" + port
+}

--- a/pkg/netutil/host_normalize_test.go
+++ b/pkg/netutil/host_normalize_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestIPv6AddressNormalization(t *testing.T) {
+	testCases := []struct {
+		name     string
+		urlsA    []string
+		urlsB    []string
+		expected bool
+	}{
+		{
+			name:     "IPv6 with leading zeros vs without should match",
+			urlsA:    []string{"https://[c262:266f:fa53:0ee6:966e:e3f0:d68f:b046]:2380"},
+			urlsB:    []string{"https://[c262:266f:fa53:ee6:966e:e3f0:d68f:b046]:2380"},
+			expected: true,
+		},
+		{
+			name:     "IPv6 different (lower/upper) case should match",
+			urlsA:    []string{"https://[2001:DB8::1]:2380"},
+			urlsB:    []string{"https://[2001:db8::1]:2380"},
+			expected: true,
+		},
+		{
+			name:     "IPv4 address normalization should still work",
+			urlsA:    []string{"http://192.168.1.1:2380"},
+			urlsB:    []string{"http://192.168.1.1:2380"},
+			expected: true,
+		},
+		{
+			name:     "Different IPv6 addresses should not match",
+			urlsA:    []string{"https://[2001:db8::1]:2380"},
+			urlsB:    []string{"https://[2001:db8::2]:2380"},
+			expected: false,
+		},
+		{
+			name:     "IPv6 without port should match",
+			urlsA:    []string{"https://[2001:db8::1]"},
+			urlsB:    []string{"https://[2001:0db8:0:00:000:0000:0:01]"},
+			expected: true,
+		},
+		{
+			name:     "IPv4 without port should match",
+			urlsA:    []string{"http://192.168.1.1"},
+			urlsB:    []string{"http://192.168.1.1"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := URLStringsEqual(t.Context(), zaptest.NewLogger(t), tc.urlsA, tc.urlsB)
+			if tc.expected {
+				assert.True(t, result)
+			} else {
+				if err != nil {
+					t.Logf("Got expected error for non-matching URLs: %v", err)
+				} else {
+					assert.False(t, result)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeHostFunction(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "IPv6 with leading zeros should be normalized",
+			input:    "[c262:266f:fa53:0ee6:966e:e3f0:d68f:b046]:2380",
+			expected: "[c262:266f:fa53:ee6:966e:e3f0:d68f:b046]:2380",
+		},
+		{
+			name:     "Compressed IPv6 should remain compressed",
+			input:    "[2001:db8::1]:2380",
+			expected: "[2001:db8::1]:2380",
+		},
+		{
+			name:     "IPv6 case should be normalized to lowercase",
+			input:    "[2001:DB8::1]:2380",
+			expected: "[2001:db8::1]:2380",
+		},
+		{
+			name:     "IPv4 should remain unchanged",
+			input:    "192.168.1.1:2380",
+			expected: "192.168.1.1:2380",
+		},
+		{
+			name:     "Hostname should remain unchanged",
+			input:    "example.com:2380",
+			expected: "example.com:2380",
+		},
+		{
+			name:     "IPv6 without port",
+			input:    "[2025:db8::1]",
+			expected: "[2025:db8::1]",
+		},
+		{
+			name:     "IPv4 without port",
+			input:    "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "Hostname without port",
+			input:    "example.com",
+			expected: "example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := normalizeHost(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"reflect"
 	"sort"
 	"time"
 
@@ -154,7 +153,7 @@ func urlsEqual(ctx context.Context, lg *zap.Logger, a []url.URL, b []url.URL) (b
 	sort.Sort(types.URLs(b))
 	var needResolve bool
 	for i := range a {
-		if !reflect.DeepEqual(a[i], b[i]) {
+		if !urlsHostNormalizedEqual(a[i], b[i]) {
 			needResolve = true
 			break
 		}
@@ -172,7 +171,7 @@ func urlsEqual(ctx context.Context, lg *zap.Logger, a []url.URL, b []url.URL) (b
 	sort.Sort(types.URLs(a))
 	sort.Sort(types.URLs(b))
 	for i := range a {
-		if !reflect.DeepEqual(a[i], b[i]) {
+		if !urlsHostNormalizedEqual(a[i], b[i]) {
 			return false, fmt.Errorf("resolved urls: %q != %q", a[i].String(), b[i].String())
 		}
 	}


### PR DESCRIPTION
## Summary
 This is an IPv6 address comparison logic fix for Issue #15127
The issue is that `etcd` fails to bootstrap clusters because IPv6 addresses do not match literally even when they are equivalent (Example: `c262:266f:fa53:0ee6:966e:e3f0:d68f:b046` vs `c262:266f:fa53:ee6:966e:e3f0:d68f:b046` - note the leading zero difference in the fourth group)

## Changes
1. Created new IPv6 normalization logic that normalizes IPv6 and IPv4 addresses to their canonical string representation
2. Modified [urlsEqual()](https://github.com/etcd-io/etcd/blob/ea69bcafdbbcb57e2c12d5a394b630564db8c7e0/pkg/netutil/netutil.go#L148) function to use the new normalization-based comparison instead of [reflect.DeepEqual](https://github.com/etcd-io/etcd/blob/ea69bcafdbbcb57e2c12d5a394b630564db8c7e0/pkg/netutil/netutil.go#L157)
3. These changes are backward compatible with existing functionality

## Tests
1. Unit tests pass with `make test-unit`
2. Integration tests pass with `make test-integration`
3. E2E tests pass with `make test-e2e`
4. New IPv6-specific tests pass
5. The exact test case from Issue #15127 (https://[c262:266f:fa53:0ee6:966e:e3f0:d68f:b046]:2380 vs https://[c262:266f:fa53:ee6:966e:e3f0:d68f:b046]:2380) now returns true correctly

cc @WilliamDEdwards @ahrtr 