### PR TITLE
[release-3.5] Add tools into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ hack/tls-setup/certs
 *.tmp
 *.bak
 .gobincache/
+
+/tools/etcd-dump-db/etcd-dump-db
+/tools/etcd-dump-logs/etcd-dump-logs
+/tools/etcd-dump-metrics/etcd-dump-metrics
+/tools/benchmark/benchmark


### PR DESCRIPTION
Each time I switch from main to release-3.5, it always shows some modified files under /tools.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
