### PR TITLE
Add OpenTelemetry Spans to Put, DeleteRange, Compact

### DIFF
--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -152,6 +152,12 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 }
 
 func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, error) {
+	var span trace.Span
+	ctx, span = traceutil.Tracer.Start(ctx, "put", trace.WithAttributes(
+		attribute.String("key", string(r.GetKey())),
+	))
+	defer span.End()
+
 	ctx = context.WithValue(ctx, traceutil.StartTimeKey{}, time.Now())
 	resp, err := s.raftRequest(ctx, pb.InternalRaftRequest{Put: r})
 	if err != nil {
@@ -161,6 +167,13 @@ func (s *EtcdServer) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse
 }
 
 func (s *EtcdServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	var span trace.Span
+	ctx, span = traceutil.Tracer.Start(ctx, "delete_range", trace.WithAttributes(
+		attribute.String("range_begin", string(r.GetKey())),
+		attribute.String("range_end", string(r.GetRangeEnd())),
+	))
+	defer span.End()
+
 	resp, err := s.raftRequest(ctx, pb.InternalRaftRequest{DeleteRange: r})
 	if err != nil {
 		return nil, err

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -111,6 +111,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		attribute.Int64("rev", r.GetRevision()),
 		attribute.Int64("limit", r.GetLimit()),
 		attribute.Bool("count_only", r.GetCountOnly()),
+		attribute.Bool("keys_only", r.GetKeysOnly()),
 	))
 	defer span.End()
 

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -245,6 +245,13 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 }
 
 func (s *EtcdServer) Compact(ctx context.Context, r *pb.CompactionRequest) (*pb.CompactionResponse, error) {
+	var span trace.Span
+	ctx, span = traceutil.Tracer.Start(ctx, "compact", trace.WithAttributes(
+		attribute.Bool("is_physical", r.GetPhysical()),
+		attribute.Int64("rev", r.GetRevision()),
+	))
+	defer span.End()
+
 	startTime := time.Now()
 	ctx, trace := traceutil.EnsureTrace(ctx, s.Logger(), "compact")
 	result, err := s.processInternalRaftRequestOnce(ctx, pb.InternalRaftRequest{Compaction: r})


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182 and https://github.com/etcd-io/etcd/issues/12460

Attributes added:
1. `Put`: method not used by Kubernetes outside integration tests
   * `key`
2. `DeleteRange`: method not used by Kubernetes outside integration tests
   * `range_begin`
   * `range_end`
3. `Compact`: method not part of k8s-etcd interface, but added for completeness
   * `rev`
4. `Range`:
    * `keys_only` - used by Kubernetes 1.34 since https://github.com/kubernetes/kubernetes/pull/132355 (depending on feature gate)

Events added:
1. `Send raft proposal`
2. `Receive raft result`