### PR TITLE
Update 3.6 changelog to cover the etcdserver bootstrap failure when replaying learner promotion operation

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.4 (TBA)
 
+### etcd server
+
+- Fix [etcdserver bootstrap failure when replaying learner promotion operation due to not exist in v3store](https://github.com/etcd-io/etcd/pull/20387)
+
 ---
 
 ## v3.6.3 (2025-07-22)


### PR DESCRIPTION
link to
- https://github.com/etcd-io/etcd/pull/20387
- https://github.com/etcd-io/etcd/issues/20340


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
