### PR TITLE
Add missing keys_only attribute to tracing test

### DIFF
--- a/tests/integration/tracing_test.go
+++ b/tests/integration/tracing_test.go
@@ -88,6 +88,10 @@ func TestTracing(t *testing.T) {
 						Key:   "count_only",
 						Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_BoolValue{BoolValue: true}},
 					},
+					{
+						Key:   "keys_only",
+						Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_BoolValue{BoolValue: false}},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
It was broken by https://github.com/etcd-io/etcd/pull/20389

```
    logger.go:146: 2025-07-24T10:46:57.742Z	WARN	default	request stats	{"start time": "2025-07-24T10:46:57.741Z", "time spent": "433.165µs", "remote": "127.0.0.1:41996", "response type": "/etcdserverpb.KV/Range", "request count": 0, "request size": 7, "response count": 0, "response size": 28, "request content": "key:\"key\" count_only:true "}
    tracing_test.go:204: Span mismatch (-want +got):
          (*v1.Span)(Inverse(protocmp.Transform, protocmp.Message{
          	"@type": s"opentelemetry.proto.trace.v1.Span",
          	"attributes": []protocmp.Message{
          		... // 3 identical elements
          		{"@type": s"opentelemetry.proto.common.v1.KeyValue", "key": string("limit"), "value": protocmp.Message{"@type": s"opentelemetry.proto.common.v1.AnyValue", "int_value": int64(0)}},
          		{"@type": s"opentelemetry.proto.common.v1.KeyValue", "key": string("count_only"), "value": protocmp.Message{"@type": s"opentelemetry.proto.common.v1.AnyValue", "bool_value": bool(true)}},
        + 		s`{key:"keys_only", value:{bool_value:false}}`,
          	},
          	... // 8 ignored and 1 identical entries
          }))
 ```

/cc @serathius @fuweid 