### PR TITLE
cache: rename validateWatchRange as validateRequestRange

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -252,13 +252,13 @@ func (c *Cache) validateWatch(key string, op clientv3.Op) (pred KeyPredicate, er
 	startKey := []byte(key)
 	endKey := op.RangeBytes() // nil = single key, {0}=FromKey, else explicit range
 
-	if err := c.validateWatchRange(startKey, endKey); err != nil {
+	if err := c.validateRange(startKey, endKey); err != nil {
 		return nil, err
 	}
 	return KeyPredForRange(startKey, endKey), nil
 }
 
-func (c *Cache) validateWatchRange(startKey, endKey []byte) error {
+func (c *Cache) validateRange(startKey, endKey []byte) error {
 	prefixStart := []byte(c.prefix)
 	prefixEnd := []byte(clientv3.GetPrefixRangeEnd(c.prefix))
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -381,7 +381,7 @@ func TestValidateWatchRange(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			dummyCache := &Cache{prefix: c.cachePrefix}
 			op := clientv3.OpGet(c.watchKey, c.opts...)
-			err := dummyCache.validateWatchRange([]byte(c.watchKey), op.RangeBytes())
+			err := dummyCache.validateRange([]byte(c.watchKey), op.RangeBytes())
 			if gotErr := err != nil; gotErr != c.wantErr {
 				t.Fatalf("validateWatchRange(%q, %q, %v) err=%v, wantErr=%v",
 					c.cachePrefix, c.watchKey, c.opts, err, c.wantErr)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

validateWatchRange is renamed as validateRequestRange so that it can be reused by other function in future like validateGet
@serathius @MadhavJivrajani 
