### PR TITLE
Update `etcdctl member remove` command to support printing clusterID and memberID in hex

### DIFF
--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -73,8 +73,9 @@ func (p *jsonPrinter) EndpointHealth(r []epHealth) { printJSON(r) }
 func (p *jsonPrinter) EndpointStatus(r []epStatus) { printJSON(r) }
 func (p *jsonPrinter) EndpointHashKV(r []epHashKV) { printJSON(r) }
 
-func (p *jsonPrinter) MemberAdd(r clientv3.MemberAddResponse)   { p.printJSON(r) }
-func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse) { p.printJSON(r) }
+func (p *jsonPrinter) MemberAdd(r clientv3.MemberAddResponse)                 { p.printJSON(r) }
+func (p *jsonPrinter) MemberRemove(_ uint64, r clientv3.MemberRemoveResponse) { p.printJSON(r) }
+func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse)               { p.printJSON(r) }
 
 func printJSONTo(w io.Writer, v any) {
 	b, err := json.Marshal(v)
@@ -108,6 +109,19 @@ func (p *jsonPrinter) printJSON(v any) {
 		}{
 			Header:  (*HexResponseHeader)(r.Header),
 			Member:  (*HexMember)(r.Member),
+			Members: toHexMembers(r.Members),
+			Alias:   (*Alias)(&r),
+		}
+	case clientv3.MemberRemoveResponse:
+		type Alias clientv3.MemberRemoveResponse
+
+		data = &struct {
+			Header  *HexResponseHeader `json:"header"`
+			Member  *HexMember         `json:"member"`
+			Members []*HexMember       `json:"members"`
+			*Alias
+		}{
+			Header:  (*HexResponseHeader)(r.Header),
 			Members: toHexMembers(r.Members),
 			Alias:   (*Alias)(&r),
 		}

--- a/etcdctl/ctlv3/command/printer_json_test.go
+++ b/etcdctl/ctlv3/command/printer_json_test.go
@@ -167,6 +167,46 @@ func TestMemberAdd(t *testing.T) {
 	}
 }
 
+func TestMemberRemove(t *testing.T) {
+	tests := []testScenario{
+		{name: "decimal", isHex: false, cases: testCases},
+		{name: "hex", isHex: true, cases: testCases},
+	}
+
+	for _, testGroup := range tests {
+		t.Run(testGroup.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			p := &jsonPrinter{writer: &buffer, isHex: testGroup.isHex}
+
+			for _, tt := range testGroup.cases {
+				t.Run(fmt.Sprintf("number=%d", tt.number), func(t *testing.T) {
+					buffer.Reset()
+					decoder := json.NewDecoder(&buffer)
+					decoder.UseNumber()
+
+					response := clientv3.MemberRemoveResponse{
+						Header: &pb.ResponseHeader{
+							ClusterId: tt.number,
+							MemberId:  tt.number,
+							Revision:  int64(tt.number),
+							RaftTerm:  tt.number,
+						},
+						Members: []*pb.Member{{ID: tt.number}},
+					}
+					p.MemberRemove(0, response)
+
+					var got map[string]any
+					err := decoder.Decode(&got)
+					require.NoErrorf(t, err, "failed to decode JSON")
+
+					assertHeader(t, &testGroup, &tt, got)
+					assertMembers(t, &testGroup, &tt, got)
+				})
+			}
+		})
+	}
+}
+
 func TestMemberList(t *testing.T) {
 	tests := []testScenario{
 		{name: "decimal", isHex: false, cases: testCases},


### PR DESCRIPTION
Fix #19262.

Example output of `etcdctl member remove 1234567890 --write-out json --hex` command:

### Before:
```json
{
  "header": {
    "cluster_id": 14841639068965178418,
    "member_id": 10276657743932975437,
    "raft_term": 5
  },
  "members": [
    {
      "ID": 10276657743932975437,
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```
### After:
```json
{
  "header": {
    "cluster_id": "cdf818194e3a8c32",
    "member_id": "8e9e05c52164694d",
    "raft_term": 5
  },
  "members": [
    {
      "ID": "8e9e05c52164694d",
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```
