### PR TITLE
Update `etcdctl member update` command to support printing clusterID and memberID in hex

### DIFF
--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -75,6 +75,7 @@ func (p *jsonPrinter) EndpointHashKV(r []epHashKV) { printJSON(r) }
 
 func (p *jsonPrinter) MemberAdd(r clientv3.MemberAddResponse)                 { p.printJSON(r) }
 func (p *jsonPrinter) MemberRemove(_ uint64, r clientv3.MemberRemoveResponse) { p.printJSON(r) }
+func (p *jsonPrinter) MemberUpdate(_ uint64, r clientv3.MemberUpdateResponse) { p.printJSON(r) }
 func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse)               { p.printJSON(r) }
 
 func printJSONTo(w io.Writer, v any) {
@@ -118,6 +119,18 @@ func (p *jsonPrinter) printJSON(v any) {
 		data = &struct {
 			Header  *HexResponseHeader `json:"header"`
 			Member  *HexMember         `json:"member"`
+			Members []*HexMember       `json:"members"`
+			*Alias
+		}{
+			Header:  (*HexResponseHeader)(r.Header),
+			Members: toHexMembers(r.Members),
+			Alias:   (*Alias)(&r),
+		}
+	case clientv3.MemberUpdateResponse:
+		type Alias clientv3.MemberUpdateResponse
+
+		data = &struct {
+			Header  *HexResponseHeader `json:"header"`
 			Members []*HexMember       `json:"members"`
 			*Alias
 		}{


### PR DESCRIPTION
Fix #19262.

Example output of `etcdctl member update 5d3ef35c349993e4 --peer-urls=http://127.0.0.1:32380 -w json --hex` command:

### Before:
```json
{
  "header": {
    "cluster_id": 14841639068965178418,
    "member_id": 10276657743932975437,
    "raft_term": 7
  },
  "members": [
    {
      "ID": 6719075271428379620,
      "peerURLs": [
        "http://127.0.0.1:32380"
      ]
    },
    {
      "ID": 10276657743932975437,
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```
### After:
```json
{
  "header": {
    "cluster_id": "cdf818194e3a8c32",
    "member_id": "8e9e05c52164694d",
    "raft_term": 7
  },
  "members": [
    {
      "ID": "5d3ef35c349993e4",
      "peerURLs": [
        "http://127.0.0.1:22380"
      ]
    },
    {
      "ID": "8e9e05c52164694d",
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```




