### PR TITLE
Update `etcdctl member promote` command to support printing clusterID and memberID in hex

### DIFF
--- a/etcdctl/ctlv3/command/printer_json.go
+++ b/etcdctl/ctlv3/command/printer_json.go
@@ -73,10 +73,11 @@ func (p *jsonPrinter) EndpointHealth(r []epHealth) { printJSON(r) }
 func (p *jsonPrinter) EndpointStatus(r []epStatus) { printJSON(r) }
 func (p *jsonPrinter) EndpointHashKV(r []epHashKV) { printJSON(r) }
 
-func (p *jsonPrinter) MemberAdd(r clientv3.MemberAddResponse)                 { p.printJSON(r) }
-func (p *jsonPrinter) MemberRemove(_ uint64, r clientv3.MemberRemoveResponse) { p.printJSON(r) }
-func (p *jsonPrinter) MemberUpdate(_ uint64, r clientv3.MemberUpdateResponse) { p.printJSON(r) }
-func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse)               { p.printJSON(r) }
+func (p *jsonPrinter) MemberAdd(r clientv3.MemberAddResponse)                   { p.printJSON(r) }
+func (p *jsonPrinter) MemberRemove(_ uint64, r clientv3.MemberRemoveResponse)   { p.printJSON(r) }
+func (p *jsonPrinter) MemberUpdate(_ uint64, r clientv3.MemberUpdateResponse)   { p.printJSON(r) }
+func (p *jsonPrinter) MemberPromote(_ uint64, r clientv3.MemberPromoteResponse) { p.printJSON(r) }
+func (p *jsonPrinter) MemberList(r clientv3.MemberListResponse)                 { p.printJSON(r) }
 
 func printJSONTo(w io.Writer, v any) {
 	b, err := json.Marshal(v)
@@ -127,6 +128,18 @@ func (p *jsonPrinter) printJSON(v any) {
 		}
 	case clientv3.MemberUpdateResponse:
 		type Alias clientv3.MemberUpdateResponse
+
+		data = &struct {
+			Header  *HexResponseHeader `json:"header"`
+			Members []*HexMember       `json:"members"`
+			*Alias
+		}{
+			Header:  (*HexResponseHeader)(r.Header),
+			Members: toHexMembers(r.Members),
+			Alias:   (*Alias)(&r),
+		}
+	case clientv3.MemberPromoteResponse:
+		type Alias clientv3.MemberPromoteResponse
 
 		data = &struct {
 			Header  *HexResponseHeader `json:"header"`

--- a/etcdctl/ctlv3/command/printer_json_test.go
+++ b/etcdctl/ctlv3/command/printer_json_test.go
@@ -247,6 +247,46 @@ func TestMemberUpdate(t *testing.T) {
 	}
 }
 
+func TestMemberPromote(t *testing.T) {
+	tests := []testScenario{
+		{name: "decimal", isHex: false, cases: testCases},
+		{name: "hex", isHex: true, cases: testCases},
+	}
+
+	for _, testGroup := range tests {
+		t.Run(testGroup.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			p := &jsonPrinter{writer: &buffer, isHex: testGroup.isHex}
+
+			for _, tt := range testGroup.cases {
+				t.Run(fmt.Sprintf("number=%d", tt.number), func(t *testing.T) {
+					buffer.Reset()
+					decoder := json.NewDecoder(&buffer)
+					decoder.UseNumber()
+
+					response := clientv3.MemberPromoteResponse{
+						Header: &pb.ResponseHeader{
+							ClusterId: tt.number,
+							MemberId:  tt.number,
+							Revision:  int64(tt.number),
+							RaftTerm:  tt.number,
+						},
+						Members: []*pb.Member{{ID: tt.number}},
+					}
+					p.MemberPromote(0, response)
+
+					var got map[string]any
+					err := decoder.Decode(&got)
+					require.NoErrorf(t, err, "failed to decode JSON")
+
+					assertHeader(t, &testGroup, &tt, got)
+					assertMembers(t, &testGroup, &tt, got)
+				})
+			}
+		})
+	}
+}
+
 func TestMemberList(t *testing.T) {
 	tests := []testScenario{
 		{name: "decimal", isHex: false, cases: testCases},


### PR DESCRIPTION
Fix #19262.

Example output of `etcdctl member promote 21a5a012a514cca2 -w json --hex` command:

### Before:
```json
{
  "header": {
    "cluster_id": 14841639068965178418,
    "member_id": 10276657743932975437,
    "raft_term": 3
  },
  "members": [
    {
      "ID": 2424519976348339362,
      "name": "test-node",
      "peerURLs": [
        "http://127.0.0.1:12380"
      ],
      "clientURLs": [
        "http://127.0.0.1:12379"
      ]
    },
    {
      "ID": 10276657743932975437,
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    }
  ]
}
```
### After:
```json
{
  "header": {
    "cluster_id": "cdf818194e3a8c32",
    "member_id": "8e9e05c52164694d",
    "raft_term": 4
  },
  "members": [
    {
      "ID": "8e9e05c52164694d",
      "name": "default",
      "peerURLs": [
        "http://localhost:2380"
      ],
      "clientURLs": [
        "http://localhost:2379"
      ]
    },
    {
      "ID": "21a5a012a514cca2",
      "name": "test-node",
      "peerURLs": [
        "http://127.0.0.1:12380"
      ],
      "clientURLs": [
        "http://127.0.0.1:12379"
      ]
    }
  ]
}
```




