### PR TITLE
etcdserver: add validation of remoteServer

### DIFF
--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -473,7 +473,11 @@ func checkClusterCompatibilityFromHeader(lg *zap.Logger, localID types.ID, heade
 		remoteMinClusterVs = remoteMinClusterVer.String()
 	}
 
-	localServer, localMinCluster, err := checkVersionCompatibility(remoteName, remoteServer, remoteMinClusterVer)
+	localServer := nil
+	localMinCluster := nil
+	if remoteServer != nil {
+		localServer, localMinCluster, err := checkVersionCompatibility(remoteName, remoteServer, remoteMinClusterVer)
+	}
 
 	localVs := ""
 	if localServer != nil {


### PR DESCRIPTION
The remoteServer was used unsafely after nil check
Found by PostgresPro with the Svace Static Analyzer

