### PR TITLE
cache: consolidate ErrKeyRangeInvalid assertion in TestCacheWithPrefixGet

### DIFF
--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -777,8 +777,8 @@ func TestCacheWithPrefixGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := c.Get(ctx, tc.key, tc.opts...)
 			if tc.expectError {
-				if err == nil {
-					t.Fatalf("expected error for Get %q under prefix /foo, got none", tc.key)
+				if !errors.Is(err, cache.ErrKeyRangeInvalid) {
+					t.Fatalf("expected ErrKeyRangeInvalid for Get %q, got: %v", tc.key, err)
 				}
 				return
 			}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

To address this comment: https://github.com/etcd-io/etcd/pull/20372#discussion_r2226341294 

This PR updates `TestCacheWithPrefixGet` to assert the specific `ErrKeyRangeInvalid` error instead of merely checking that `err != nil`.

@serathius @MadhavJivrajani 
