### PR TITLE
grafana_dashboard: update `cluster` variable to follow kubernetes-mixin

### DIFF
--- a/contrib/mixin/config.libsonnet
+++ b/contrib/mixin/config.libsonnet
@@ -21,6 +21,6 @@
     // 2 : On Time Range Change (Will refresh Dashboards variables when time range will be changed)
     dashboard_var_refresh: 2,
     // clusterLabel is used to identify a cluster.
-    clusterLabel: 'job',
+    clusterLabel: 'cluster',
   },
 }

--- a/contrib/mixin/dashboards/etcd-grafana7x.libsonnet
+++ b/contrib/mixin/dashboards/etcd-grafana7x.libsonnet
@@ -207,7 +207,7 @@
               steppedLine: false,
               targets: [
                 {
-                  expr: 'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})' % $._config,
+                  expr: 'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})' % $._config,
                   intervalFactor: 2,
                   legendFormat: 'Watch Streams',
                   metric: 'grpc_server_handled_total',
@@ -215,7 +215,7 @@
                   step: 4,
                 },
                 {
-                  expr: 'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})' % $._config,
+                  expr: 'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})' % $._config,
                   intervalFactor: 2,
                   legendFormat: 'Lease Streams',
                   metric: 'grpc_server_handled_total',

--- a/contrib/mixin/dashboards/etcd.libsonnet
+++ b/contrib/mixin/dashboards/etcd.libsonnet
@@ -18,6 +18,7 @@
       + g.dashboard.withVariables([
         v.datasource,
         v.cluster,
+        v.job,
       ])
       + g.dashboard.withPanels(
         [

--- a/contrib/mixin/dashboards/targets.libsonnet
+++ b/contrib/mixin/dashboards/targets.libsonnet
@@ -5,7 +5,7 @@ function(variables, config) {
   up:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(etcd_server_has_leader{%s, %s="$cluster"})' % [config.etcd_selector, config.clusterLabel]
+      'sum(etcd_server_has_leader{job="$job", %s="$cluster"})' % [config.clusterLabel]
     )
     + prometheusQuery.withLegendFormat(|||
       {{cluster}} - {{namespace}}
@@ -14,91 +14,91 @@ function(variables, config) {
   rpcRate:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(rate(grpc_server_started_total{%s, %s="$cluster",grpc_type="unary"}[$__rate_interval]))' % [config.etcd_selector, config.clusterLabel]
+      'sum(rate(grpc_server_started_total{job="$job", %s="$cluster",grpc_type="unary"}[$__rate_interval]))' % [config.clusterLabel]
     )
     + prometheusQuery.withLegendFormat('RPC rate'),
   rpcFailedRate:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(rate(grpc_server_handled_total{%s, %s="$cluster",grpc_type="unary",grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[$__rate_interval]))' % [config.etcd_selector, config.clusterLabel]
+      'sum(rate(grpc_server_handled_total{job="$job", %s="$cluster",grpc_type="unary",grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[$__rate_interval]))' % [config.clusterLabel]
     )
     + prometheusQuery.withLegendFormat('RPC failed rate'),
   watchStreams:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})' % config
+      'sum(grpc_server_started_total{job="$job",%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{job="$job",%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})' % config
     )
     + prometheusQuery.withLegendFormat('Watch streams'),
   leaseStreams:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(grpc_server_started_total{%(etcd_selector)s,%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})' % config
+      'sum(grpc_server_started_total{job="$job",%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{job="$job",%(clusterLabel)s="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})' % config
     )
     + prometheusQuery.withLegendFormat('Lease streams'),
   dbSize:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'etcd_mvcc_db_total_size_in_bytes{%s, %s="$cluster"}' % [config.etcd_selector, config.clusterLabel],
+      'etcd_mvcc_db_total_size_in_bytes{job="$job", %s="$cluster"}' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} DB size'),
   walFsync:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{%s, %s="$cluster"}[$__rate_interval])) by (instance, le))' % [config.etcd_selector, config.clusterLabel],
+      'histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="$job", %s="$cluster"}[$__rate_interval])) by (instance, le))' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} WAL fsync'),
   dbFsync:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{%s, %s="$cluster"}[$__rate_interval])) by (instance, le))' % [config.etcd_selector, config.clusterLabel],
+      'histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job="$job", %s="$cluster"}[$__rate_interval])) by (instance, le))' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} DB fsync'),
   memory:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'process_resident_memory_bytes{%s, %s="$cluster"}' % [config.etcd_selector, config.clusterLabel],
+      'process_resident_memory_bytes{job="$job", %s="$cluster"}' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} resident memory'),
   clientTrafficIn:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'rate(etcd_network_client_grpc_received_bytes_total{%s, %s="$cluster"}[$__rate_interval])' % [config.etcd_selector, config.clusterLabel],
+      'rate(etcd_network_client_grpc_received_bytes_total{job="$job", %s="$cluster"}[$__rate_interval])' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} client traffic in'),
   clientTrafficOut:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'rate(etcd_network_client_grpc_sent_bytes_total{%s, %s="$cluster"}[$__rate_interval])' % [config.etcd_selector, config.clusterLabel],
+      'rate(etcd_network_client_grpc_sent_bytes_total{job="$job", %s="$cluster"}[$__rate_interval])' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} client traffic out'),
   peerTrafficIn:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(rate(etcd_network_peer_received_bytes_total{%s, %s="$cluster"}[$__rate_interval])) by (instance)' % [config.etcd_selector, config.clusterLabel],
+      'sum(rate(etcd_network_peer_received_bytes_total{job="$job", %s="$cluster"}[$__rate_interval])) by (instance)' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} peer traffic in'),
   peerTrafficOut:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'sum(rate(etcd_network_peer_sent_bytes_total{%s, %s="$cluster"}[$__rate_interval])) by (instance)' % [config.etcd_selector, config.clusterLabel],
+      'sum(rate(etcd_network_peer_sent_bytes_total{job="$job", %s="$cluster"}[$__rate_interval])) by (instance)' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} peer traffic out'),
   raftProposals:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'changes(etcd_server_leader_changes_seen_total{%s, %s="$cluster"}[1d])' % [config.etcd_selector, config.clusterLabel],
+      'changes(etcd_server_leader_changes_seen_total{job="$job", %s="$cluster"}[1d])' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} total leader elections per day'),
   leaderElections:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'changes(etcd_server_leader_changes_seen_total{%s, %s="$cluster"}[1d])' % [config.etcd_selector, config.clusterLabel],
+      'changes(etcd_server_leader_changes_seen_total{job="$job", %s="$cluster"}[1d])' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} total leader elections per day'),
   peerRtt:
     prometheusQuery.new(
       '$' + variables.datasource.name,
-      'histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{%s, %s="$cluster"}[$__rate_interval])))' % [config.etcd_selector, config.clusterLabel],
+      'histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job="$job", %s="$cluster"}[$__rate_interval])))' % [config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} peer round trip time'),
 }

--- a/contrib/mixin/dashboards/variables.libsonnet
+++ b/contrib/mixin/dashboards/variables.libsonnet
@@ -15,7 +15,17 @@ function(config) {
     + { refresh: config.dashboard_var_refresh }
     + var.query.queryTypes.withLabelValues(
       config.clusterLabel,
-      'etcd_server_has_leader{%s}' % [config.etcd_selector]
+      'etcd_server_has_leader'
+    ),
+
+  job:
+    var.query.new('job')
+    + var.query.generalOptions.withLabel('job')
+    + var.query.withDatasourceFromVariable(self.datasource)
+    + { refresh: config.dashboard_var_refresh }
+    + var.query.queryTypes.withLabelValues(
+      'job',
+      'etcd_server_has_leader{cluster="$cluster", %s}' % [config.etcd_selector]
     ),
 
 }


### PR DESCRIPTION
https://github.com/kubernetes-monitoring/kubernetes-mixin has set the standard of templating the `cluster` variable exactly as this repo has done, only the two seem to define the variable differently.  kubernetes-mixin defines it as a selector of multiple kubernetes clusters, whereas the existing config here seems to treat it as a selector for multiple instances of etcd.  This approach doesn't work if you've installed etcd to each cluster using the same set of labels such as `job`.

My proposed change is to change the definition of `cluster` to follow the standard set by kubernetes-mixin, and add an additional variable `job` which acts as the instance selector.  There are some challenges with this which I'll get into in the comments.

