### PR TITLE
cache: make ring buffer generic for events and snapshots

### DIFF
--- a/cache/demux.go
+++ b/cache/demux.go
@@ -27,7 +27,7 @@ type demux struct {
 	// activeWatchers & laggingWatchers hold the first revision the watcher still needs (nextRev).
 	activeWatchers  map[*watcher]int64
 	laggingWatchers map[*watcher]int64
-	history         *ringBuffer
+	history         ringBuffer[*clientv3.Event]
 	resyncInterval  time.Duration
 }
 
@@ -45,7 +45,7 @@ func newDemux(historyWindowSize int, resyncInterval time.Duration) *demux {
 	return &demux{
 		activeWatchers:  make(map[*watcher]int64),
 		laggingWatchers: make(map[*watcher]int64),
-		history:         newRingBuffer(historyWindowSize),
+		history:         *newRingBuffer(historyWindowSize, func(ev *clientv3.Event) int64 { return ev.Kv.ModRevision }),
 		resyncInterval:  resyncInterval,
 	}
 }


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
@serathius @MadhavJivrajani 

Opened this PR to makes ring buffer generic (not just for events but for snapshots in future). This includes:
- renamed `Filter` as `GetFromRevision` and apply binary search instead of full scan
- added a few new functions like `FindAtOrBefore` which might be useful for snapshots

For now I use a `RevisionOf[T]` function to extract revisions from any item type, maybe should later switch to a wrapper that contains the revision directly

