### PR TITLE
Add watch compact to tests

### DIFF
--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -134,6 +134,10 @@ var referenceUsageOfEtcdAPI = map[string]refOp{
 	"etcdserverpb.KV/Compact": {
 		// Compaction should move to using internal Etcd mechanism
 		// Discussed in https://github.com/kubernetes/kubernetes/issues/80513
+		args: []column{
+			{name: "rev", matcher: isRevisionSet},
+			{name: "physical", matcher: boolAttrSet("is_physical")},
+		},
 	},
 	"etcdserverpb.Watch/Watch": {
 		// Not part of the contract interface (yet)
@@ -253,6 +257,9 @@ func testInterfaceUse(t *testing.T, filename string) {
 }
 
 func extractPattern(trace *tracev1.ResourceSpans, key string) (string, bool) {
+	if key == "" {
+		return "", true
+	}
 	k, found := strAttr(trace, key)
 	if !found {
 		return "", false
@@ -303,6 +310,9 @@ func argsToDescription(matched string, cols []column) string {
 }
 
 func extractMethod(methodToMatched []method, trace *tracev1.ResourceSpans) (string, bool) {
+	if len(methodToMatched) == 0 {
+		return getOperationName(trace), true
+	}
 	for _, mm := range methodToMatched {
 		if mm.matcher(trace) {
 			return mm.name, true

--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -137,6 +137,17 @@ var referenceUsageOfEtcdAPI = map[string]refOp{
 	},
 	"etcdserverpb.Watch/Watch": {
 		// Not part of the contract interface (yet)
+		args: []column{
+			{name: "range_end", matcher: isRangeEndSet},
+			{name: "start_rev", matcher: intAttrSet("start_rev")},
+			{name: "prev_kv", matcher: boolAttrSet("prev_kv")},
+			{name: "fragment", matcher: boolAttrSet("fragment")},
+			{name: "progress_notify", matcher: boolAttrSet("progress_notify")},
+		},
+		keyAttrName: "key",
+		methods: []method{
+			{name: "Watch", matcher: notMatcher(keyIsEqualStr("key", "compact_rev_key"))},
+		},
 	},
 	"etcdserverpb.Lease/LeaseGrant": {
 		// Used to manage masterleases and events

--- a/tests/robustness/coverage/matchers_test.go
+++ b/tests/robustness/coverage/matchers_test.go
@@ -47,14 +47,16 @@ func keyIsEqualInt(key string, want int) Matcher {
 	}
 }
 
-func isLimitSet(trace *tracev1.ResourceSpans) bool {
-	limit, found := intAttr(trace, "limit")
-	return found && limit > 0
-}
+var (
+	isLimitSet    = intAttrSet("limit")
+	isRevisionSet = intAttrSet("rev")
+)
 
-func isRevisionSet(trace *tracev1.ResourceSpans) bool {
-	rev, found := intAttr(trace, "rev")
-	return found && rev > 0
+func intAttrSet(key string) Matcher {
+	return func(trace *tracev1.ResourceSpans) bool {
+		val, found := intAttr(trace, key)
+		return found && val > 0
+	}
 }
 
 func intAttr(trace *tracev1.ResourceSpans, key string) (int, bool) {
@@ -95,19 +97,17 @@ func strAttr(trace *tracev1.ResourceSpans, key string) (string, bool) {
 	return "", false
 }
 
-func isReadOnly(trace *tracev1.ResourceSpans) bool {
-	isRO, found := boolAttr(trace, "read_only")
-	return found && isRO
-}
+var (
+	isReadOnly  = boolAttrSet("read_only")
+	isKeysOnly  = boolAttrSet("keys_only")
+	isCountOnly = boolAttrSet("count_only")
+)
 
-func isKeysOnly(trace *tracev1.ResourceSpans) bool {
-	isKeys, found := boolAttr(trace, "keys_only")
-	return found && isKeys
-}
-
-func isCountOnly(trace *tracev1.ResourceSpans) bool {
-	isCount, found := boolAttr(trace, "count_only")
-	return found && isCount
+func boolAttrSet(key string) Matcher {
+	return func(trace *tracev1.ResourceSpans) bool {
+		val, found := boolAttr(trace, key)
+		return found && val
+	}
 }
 
 func boolAttr(trace *tracev1.ResourceSpans, key string) (bool, bool) {


### PR DESCRIPTION
Related to https://github.com/etcd-io/etcd/issues/20182 and continuation of https://github.com/etcd-io/etcd/pull/20425

It detects difference in call pattern between 1.33 and 1.34 caused by: https://github.com/kubernetes/kubernetes/pull/132876