### PR TITLE
[release-3.4] back port gofail comments

### DIFF
--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -874,6 +874,7 @@ func (c *RaftCluster) IsMemberExist(id types.ID) bool {
 	c.Lock()
 	defer c.Unlock()
 	_, ok := c.members[id]
+	// gofail: var afterIsMemberExist struct{}
 	return ok
 }
 

--- a/etcdserver/api/v3rpc/watch.go
+++ b/etcdserver/api/v3rpc/watch.go
@@ -457,6 +457,7 @@ func (sws *serverWatchStream) sendLoop() {
 			sws.mu.RUnlock()
 
 			var serr error
+			// gofail: var beforeSendWatchResponse struct{}
 			if !fragmented && !ok {
 				serr = sws.gRPCStream.Send(wr)
 			} else {

--- a/etcdserver/raft.go
+++ b/etcdserver/raft.go
@@ -358,6 +358,7 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 					notifyc <- struct{}{}
 				}
 
+				// gofail: var raftBeforeAdvance struct{}
 				r.Advance()
 			case <-r.stopped:
 				return

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1301,6 +1301,7 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	// wait for raftNode to persist snapshot onto the disk
 	<-apply.notifyc
 
+	// gofail: var applyBeforeOpenSnapshot struct{}
 	newbe, err := openSnapshotBackend(s.Cfg, s.snapshotter, apply.snapshot)
 	if err != nil {
 		if lg != nil {
@@ -2287,6 +2288,7 @@ func (s *EtcdServer) apply(
 			if e.Index > s.consistIndex.ConsistentIndex() {
 				s.consistIndex.setConsistentIndex(e.Index)
 			}
+			// gofail: var beforeApplyOneConfChange struct{}
 			var cc raftpb.ConfChange
 			pbutil.MustUnmarshal(&cc, e.Data)
 			removedSelf, err := s.applyConfChange(cc, confState)

--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -653,7 +653,9 @@ func (b *backend) begin(write bool) *bolt.Tx {
 }
 
 func (b *backend) unsafeBegin(write bool) *bolt.Tx {
+	// gofail: var beforeStartDBTxn struct{}
 	tx, err := b.db.Begin(write)
+	// gofail: var afterStartDBTxn struct{}
 	if err != nil {
 		if b.lg != nil {
 			b.lg.Fatal("failed to begin tx", zap.Error(err))

--- a/mvcc/backend/batch_tx.go
+++ b/mvcc/backend/batch_tx.go
@@ -279,6 +279,7 @@ func (t *batchTxBuffered) Unlock() {
 		t.backend.readTx.Lock() // blocks txReadBuffer for writing.
 		// gofail: var beforeWritebackBuf struct{}
 		t.buf.writeback(&t.backend.readTx.buf)
+		// gofail: var afterWritebackBuf struct{}
 		t.backend.readTx.Unlock()
 		// We commit the transaction when the number of pending operations
 		// reaches the configured limit(batchLimit) to prevent it from

--- a/mvcc/kvstore.go
+++ b/mvcc/kvstore.go
@@ -283,7 +283,9 @@ func (s *store) updateCompactRev(rev int64) (<-chan struct{}, error) {
 	tx.UnsafePut(metaBucketName, scheduledCompactKeyName, rbytes)
 	tx.Unlock()
 	// ensure that desired compaction is persisted
+	// gofail: var compactBeforeCommitScheduledCompact struct{}
 	s.b.ForceCommit()
+	// gofail: var compactAfterCommitScheduledCompact struct{}
 
 	s.revMu.Unlock()
 

--- a/mvcc/kvstore_compaction.go
+++ b/mvcc/kvstore_compaction.go
@@ -54,6 +54,7 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 			revToBytes(revision{main: compactMainRev}, rbytes)
 			tx.UnsafePut(metaBucketName, finishedCompactKeyName, rbytes)
 			tx.Unlock()
+			// gofail: var compactAfterSetFinishedCompact struct{}
 			size, sizeInUse := s.b.Size(), s.b.SizeInUse()
 			if s.lg != nil {
 				s.lg.Info(
@@ -75,7 +76,9 @@ func (s *store) scheduleCompaction(compactMainRev int64, keep map[revision]struc
 		revToBytes(revision{main: rev.main, sub: rev.sub + 1}, last)
 		tx.Unlock()
 		// Immediately commit the compaction deletes instead of letting them accumulate in the write buffer
+		// gofail: var compactBeforeCommitBatch struct{}
 		s.b.ForceCommit()
+		// gofail: var compactAfterCommitBatch struct{}
 		dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 
 		select {


### PR DESCRIPTION
fixes #17817

This PR backports gofail comments to the release-3.4 branch.

Skipping gofail comments for [`batch_tx.go`](https://github.com/etcd-io/etcd/blob/release-3.5/server/mvcc/backend/batch_tx.go) since this hook is not used/available in `v3.4`.

https://github.com/etcd-io/etcd/blob/e483d1f1b66e76bfaa14128dfa6a98827fbe67d2/server/mvcc/backend/batch_tx.go#L361-L366