### PR TITLE
fix(grpcproxy): support grpc context propagation in grpc proxy

### DIFF
--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"google.golang.org/grpc/metadata"
 	"io"
 	"log"
 	"math"
@@ -29,6 +28,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"google.golang.org/grpc/metadata"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
@@ -440,10 +441,10 @@ func newClientCfg(lg *zap.Logger, eps []string) (*clientv3.Config, error) {
 func contextPropagationUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		if md, ok := metadata.FromIncomingContext(ctx); ok {
 			ctx = metadata.NewOutgoingContext(ctx, md)
 		}

--- a/server/proxy/grpcproxy/watch.go
+++ b/server/proxy/grpcproxy/watch.go
@@ -123,7 +123,8 @@ func (wp *watchProxy) Watch(stream pb.Watch_WatchServer) (err error) {
 
 	// post to stopc => terminate server stream; can't use a waitgroup
 	// since all goroutines will only terminate after Watch() exits.
-	stopc := make(chan struct{}, 3)
+	stopc := make(chan struct{}, 2)
+	leaderc := make(chan struct{}, 1)
 	go func() {
 		defer func() { stopc <- struct{}{} }()
 		wps.recvLoop()
@@ -142,7 +143,7 @@ func (wp *watchProxy) Watch(stream pb.Watch_WatchServer) (err error) {
 		}
 	}()
 
-	<-stopc
+	<-leaderc
 	cancel()
 
 	// recv/send may only shutdown after function exits;


### PR DESCRIPTION
Copy of https://github.com/etcd-io/etcd/pull/18012 in the event we need this PR instead of the original. 
