### PR TITLE
cache: preserve resumable guarantee with empty history watchers

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -27,7 +27,6 @@ import (
 )
 
 var (
-	// TODO: add gap-free replay for arbitrary startRevs and drop this guard.
 	// Returned when an option combination isn’t yet handled by the cache (e.g. WithPrevKV, WithProgressNotify for Watch(), WithCountOnly for Get()).
 	ErrUnsupportedRequest = errors.New("cache: unsupported request parameters")
 	// Returned when the requested key or key‑range is invalid (empty or reversed) or lies outside c.prefix.


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

I open this PR to address the issue #20488

The root issue is that a cache can be ready but still have no history. So we need to ensure proper watcher and gap handling when history is empty. That includes:

- When history is empty, a watcher with a non-zero `startRev` should be registered as lagging. 
- `resyncLaggingWatchers` will not promote watcher to active while history is empty.
- `Broadcast` could defensively detect a gap (`firstRev` > `nextRev`) and move such watchers back to lagging instead of streaming past the gap.

/cc @serathius @MadhavJivrajani 

