### PR TITLE
stability enhancement during overload conditions

### DIFF
--- a/server/etcdserver/util.go
+++ b/server/etcdserver/util.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
@@ -40,6 +41,26 @@ func isConnectedSince(transport rafthttp.Transporter, since time.Time, remote ty
 // members in the cluster since the given time.
 func isConnectedFullySince(transport rafthttp.Transporter, since time.Time, self types.ID, members []*membership.Member) bool {
 	return numConnectedSince(transport, since, self, members) == len(members)
+}
+
+// isTooManyRequest checks whether the gap between applied index and committed
+// index is too large. r *pb.InternalRaftRequest should read-only.
+func isTooManyRequest(ai, ci uint64, r *pb.InternalRaftRequest) bool {
+	// Critical request kinds include LeaseRevoke
+	isCritical := r != nil && r.LeaseRevoke != nil
+
+	// If the gap is larger than maxGapBetweenApplyAndCommitIndex, reject all normal request
+	if !isCritical && ci > ai+maxGapBetweenApplyAndCommitIndex {
+		return true
+	}
+
+	// Make an extra 10% gap buffer for critical requests, so thay can be applied
+	// during overload conditions.
+	if isCritical && ci-ai > maxGapBetweenApplyAndCommitIndex+500 {
+		return true
+	}
+
+	return false
 }
 
 // numConnectedSince counts how many members are connected to the local member

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -792,7 +792,8 @@ func (s *EtcdServer) doSerialize(ctx context.Context, chk func(*auth.AuthInfo) e
 func (s *EtcdServer) processInternalRaftRequestOnce(ctx context.Context, r pb.InternalRaftRequest) (*apply2.Result, error) {
 	ai := s.getAppliedIndex()
 	ci := s.getCommittedIndex()
-	if ci > ai+maxGapBetweenApplyAndCommitIndex {
+
+	if isTooManyRequest(ai, ci, &r) {
 		return nil, errors.ErrTooManyRequests
 	}
 


### PR DESCRIPTION
The PR is for the proposal #20396 
Based on the previous discussion, we agreed that `LeaseRevoke` should have higher priority, and we remain cautious about `Compact`. Therefore, I've prepared a table comparing the potential impacts of applying and not-applying `Compact`.

| Request | Effect of Apply | Effect of No Apply | Is Critical | Typical Scenario |
|--------|--------|--------|--------|--------|
| LeaseRevoke | Cleaning a few keys, which is supposed to happen | Keys cannot stop growing, maybe finally trigger a crash of server. It takes very long time to reboot because of large db size. Upstream watcher may be oom-killed due to writing too many resources to cache. | YES | K8S apiserver recording events |
| Compact | Clean obsolete KVs in index and db, but make the applying slower | treeIndex and db size growing, may reach disk quota. Requires SREs to recover the service. | TBD | default periodical compaction  | 

I would like to have some advices that should I add a unit test or an e2e test? I am not quite sure how this feature should be tested.