### PR TITLE
etcdctl: hide global flags

### DIFF
--- a/etcdctl/ctlv3/command/options_command.go
+++ b/etcdctl/ctlv3/command/options_command.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NewOptionsCommand(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "options",
+		Short: "Show the global command-line flags",
+		Run: func(cmd *cobra.Command, args []string) {
+			fs := unhideCopy(rootCmd.PersistentFlags())
+			fmt.Fprintf(cmd.OutOrStdout(), "The following options can be passed to any command:\n\n")
+			fmt.Fprint(cmd.OutOrStdout(), fs.FlagUsages())
+		},
+		GroupID: groupUtilityID,
+	}
+	return cmd
+}
+
+func unhideCopy(src *pflag.FlagSet) *pflag.FlagSet {
+	out := pflag.NewFlagSet("global", pflag.ContinueOnError)
+	src.VisitAll(func(f *pflag.Flag) {
+		nf := *f
+		nf.Hidden = false
+		out.AddFlag(&nf)
+	})
+	return out
+}


### PR DESCRIPTION
fix: #20466 

before

```
./bin/etcdctl --help       
A simple command line client for etcd3.

Usage:
  etcdctl [command]

Key-value commands
  compaction  Compacts the event history in etcd
  del         Removes the specified key or range of keys [key, range_end)
  get         Gets the key or a range of keys
  lease       Lease related commands. Use `etcdctl lease --help` to see subcommands
  put         Puts the given key into the store
  txn         Txn processes all the requests in one transaction
  watch       Watches events stream on keys or prefixes

Cluster maintenance commands
  alarm       Alarm related commands. Use `etcdctl alarm --help` to see subcommands
  defrag      Defragments the storage of the etcd members with given endpoints
  downgrade   Downgrade related commands. Use `etcdctl downgrade --help` to see subcommands
  endpoint    Endpoint related commands. Use `etcdctl endpoint --help` to see subcommands
  member      Membership related commands. Use `etcdctl member --help` to see subcommands
  move-leader Transfers leadership to another etcd cluster member.
  snapshot    Manages etcd node snapshots

Concurrency commands
  elect       Observes and participates in leader election
  lock        Acquires a named lock

Authentication commands
  auth        Enable or disable authentication. Use `etcdctl auth --help` to see subcommands
  role        Role related commands. Use `etcdctl role --help` to see subcommands
  user        User related commands. Use `etcdctl user --help` to see subcommands

Utility commands
  check       commands for checking properties of the etcd cluster. Use `etcdctl check --help` to see subcommands
  completion  Generate completion script
  help        Help about any command
  make-mirror Makes a mirror at the destination etcd cluster
  version     Prints the version of etcdctl

Flags:
      --auth-jwt-token string        JWT token used for authentication (if this option is used, --user and --password should not be set)
      --cacert string                verify certificates of TLS-enabled secure servers using this CA bundle
      --cert string                  identify secure client using this TLS certificate file
      --command-timeout duration     timeout for short running command (excluding dial timeout) (default 5s)
      --debug                        enable client-side debug logging
      --dial-timeout duration        dial timeout for client connections (default 2s)
  -d, --discovery-srv string         domain name to query for SRV records describing cluster endpoints
      --discovery-srv-name string    service name to query when using DNS discovery
      --endpoints strings            gRPC endpoints (default [127.0.0.1:2379])
  -h, --help                         help for etcdctl
      --hex                          print byte strings as hex encoded strings
      --insecure-discovery           accept insecure SRV records describing cluster endpoints (default true)
      --insecure-skip-tls-verify     skip server certificate verification (CAUTION: this option should be enabled only for testing purposes)
      --insecure-transport           disable transport security for client connections (default true)
      --keepalive-time duration      keepalive time for client connections (default 2s)
      --keepalive-timeout duration   keepalive timeout for client connections (default 6s)
      --key string                   identify secure client using this TLS key file
      --max-recv-bytes int           client-side response receive limit in bytes (if 0, it defaults to "math.MaxInt32")
      --max-request-bytes int        client-side request send limit in bytes (if 0, it defaults to 2.0 MiB (2 * 1024 * 1024).)
      --password string              password for authentication (if this option is used, --user option shouldn't include password)
      --user string                  username[:password] for authentication (prompt if password is not supplied)
  -w, --write-out string             set the output format (fields, json, protobuf, simple, table) (default "simple")

Use "etcdctl [command] --help" for more information about a command.

```

after

```
$ ./bin/etcdctl --help  
A simple command line client for etcd3.

Usage:
  etcdctl [command]

Key-value commands
  compaction  Compacts the event history in etcd
  del         Removes the specified key or range of keys [key, range_end)
  get         Gets the key or a range of keys
  lease       Lease related commands. Use `etcdctl lease --help` to see subcommands
  put         Puts the given key into the store
  txn         Txn processes all the requests in one transaction
  watch       Watches events stream on keys or prefixes

Cluster maintenance commands
  alarm       Alarm related commands. Use `etcdctl alarm --help` to see subcommands
  defrag      Defragments the storage of the etcd members with given endpoints
  downgrade   Downgrade related commands. Use `etcdctl downgrade --help` to see subcommands
  endpoint    Endpoint related commands. Use `etcdctl endpoint --help` to see subcommands
  member      Membership related commands. Use `etcdctl member --help` to see subcommands
  move-leader Transfers leadership to another etcd cluster member.
  snapshot    Manages etcd node snapshots

Concurrency commands
  elect       Observes and participates in leader election
  lock        Acquires a named lock

Authentication commands
  auth        Enable or disable authentication. Use `etcdctl auth --help` to see subcommands
  role        Role related commands. Use `etcdctl role --help` to see subcommands
  user        User related commands. Use `etcdctl user --help` to see subcommands

Utility commands
  check       commands for checking properties of the etcd cluster. Use `etcdctl check --help` to see subcommands
  completion  Generate completion script
  help        Help about any command
  make-mirror Makes a mirror at the destination etcd cluster
  options     Show the global command-line flags
  version     Prints the version of etcdctl

Use "etcdctl [command] --help" for more information about a command.
Use "etcdctl options" for a list of global command-line options (applies to all commands).
```