### PR TITLE
Remove checking `confState` during schema migration

### DIFF
--- a/server/storage/schema/schema.go
+++ b/server/storage/schema/schema.go
@@ -95,15 +95,11 @@ func UnsafeDetectSchemaVersion(lg *zap.Logger, tx backend.UnsafeReader) (v semve
 		return *vp, nil
 	}
 
-	// TODO: remove the operations of reading the fields `confState`
-	// and `term` in 3.7. We only need to be back-compatible
-	// with 3.6 when we are running 3.7, and the `storageVersion`
-	// already exists in all versions >= 3.6, so we don't need to
-	// use any other fields to identify the etcd's storage version.
-	confstate := UnsafeConfStateFromBackend(lg, tx)
-	if confstate == nil {
-		return v, fmt.Errorf("missing confstate information")
-	}
+	// TODO: remove the operations of reading the field `term`
+	// in 3.7. We only need to be back-compatible with 3.6 when
+	// we are running 3.7, and the `storageVersion` already exists
+	// in all versions >= 3.6, so we don't need to use any other
+	// fields to identify the etcd's storage version.
 	_, term := UnsafeReadConsistentIndex(tx)
 	if term == 0 {
 		return v, fmt.Errorf("missing term information")

--- a/server/storage/schema/schema_test.go
+++ b/server/storage/schema/schema_test.go
@@ -115,16 +115,7 @@ func TestMigrate(t *testing.T) {
 		expectErrorMsg string
 	}{
 		// As storage version field was added in v3.6, for v3.5 we will not set it.
-		// For storage to be considered v3.5 it have both confstate and term key set.
-		{
-			name:           `Upgrading v3.5 to v3.6 should be rejected if confstate is not set`,
-			version:        version.V3_5,
-			overrideKeys:   func(tx backend.UnsafeReadWriter) {},
-			targetVersion:  version.V3_6,
-			expectVersion:  nil,
-			expectError:    true,
-			expectErrorMsg: `cannot detect storage schema version: missing confstate information`,
-		},
+		// For storage to be considered v3.5 it has term key set.
 		{
 			name:    `Upgrading v3.5 to v3.6 should be rejected if term is not set`,
 			version: version.V3_5,

--- a/tests/e2e/logging_test.go
+++ b/tests/e2e/logging_test.go
@@ -40,7 +40,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 				"setting up serving from embedded etcd failed.": true,
 				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
 				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
+				"cannot detect storage schema version: missing term information": true,
 			},
 		},
 		{
@@ -53,7 +53,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 				"setting up serving from embedded etcd failed.": true,
 				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
 				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
+				"cannot detect storage schema version: missing term information": true,
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 				"setting up serving from embedded etcd failed.": true,
 				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
 				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
+				"cannot detect storage schema version: missing term information": true,
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 				"setting up serving from embedded etcd failed.": true,
 				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
 				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
+				"cannot detect storage schema version: missing term information": true,
 			},
 		},
 		{
@@ -100,7 +100,7 @@ func TestNoErrorLogsDuringNormalOperations(t *testing.T) {
 				"setting up serving from embedded etcd failed.": true,
 				// See https://github.com/etcd-io/etcd/pull/19040#issuecomment-2539173800
 				// TODO: Remove with etcd 3.7
-				"cannot detect storage schema version: missing confstate information": true,
+				"cannot detect storage schema version: missing term information": true,
 			},
 		},
 	}


### PR DESCRIPTION
The field `confState` was added since etcd v3.5. If an etcd cluster was created since v3.4, then it wouldn't have this field. In 3.5+, the field will only be automatically populated during conf change (i.e. add/remove/update member). So when upgrading from 3.4 to 3.5, and from 3.5 to 3.6, the field will never be populated unless users add or remove or update members.

Note if you can't reproduce this issue, it should be because that there is no v2 snapshot, and etcdserver will replay all WAL records (including add member records) on bootstrap.

See also https://github.com/etcd-io/etcd/discussions/20446#discussioncomment-14114666

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
