### PR TITLE
cache: remove early compaction check from Cache.Watch

### DIFF
--- a/cache/watcher.go
+++ b/cache/watcher.go
@@ -15,24 +15,24 @@
 package cache
 
 import (
-	"sync/atomic"
+	"sync"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // watcher holds one client’s buffered stream of events.
 type watcher struct {
 	eventQueue chan []*clientv3.Event
+	cancelResp *clientv3.WatchResponse
 	keyPred    KeyPredicate
-	stopped    int32
-	done       chan struct{} // closed together with Stop()
+	stopOnce   sync.Once
 }
 
 func newWatcher(bufSize int, pred KeyPredicate) *watcher {
 	return &watcher{
 		eventQueue: make(chan []*clientv3.Event, bufSize),
 		keyPred:    pred,
-		done:       make(chan struct{}),
 	}
 }
 
@@ -59,12 +59,21 @@ func (w *watcher) enqueueEvent(eventBatch []*clientv3.Event) bool {
 	}
 }
 
-// Stop closes the event channel atomically.
-func (w *watcher) Stop() {
-	if atomic.CompareAndSwapInt32(&w.stopped, 0, 1) {
-		close(w.eventQueue)
-		close(w.done)
+func (w *watcher) Compact(compactRev int64) {
+	resp := &clientv3.WatchResponse{
+		Canceled:        true,
+		CompactRevision: compactRev,
+		CancelReason:    rpctypes.ErrCompacted.Error(),
 	}
+	w.stopOnce.Do(func() {
+		w.cancelResp = resp
+		close(w.eventQueue)
+	})
 }
 
-func (w *watcher) Done() <-chan struct{} { return w.done }
+// Stop closes the event channel atomically.
+func (w *watcher) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.eventQueue)
+	})
+}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

To address the issue #20488
#20491 follow-up: we want to:

- remove early compaction check from `Cache.Watch` (therefore `demux.PeekOldest` is not needed)
- rely on `demux.resyncLaggingWatchers` to handle compacted watchers
- make `watcher` carry cancel response so that `Cache.Watch` goroutine can forward it

@serathius @MadhavJivrajani 
