### PR TITLE
chore: Replace which with command -v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 
 .PHONY: install-benchmark
 install-benchmark: build
-ifeq (, $(shell which benchmark))
+ifeq (, $(shell command -v benchmark))
 	@echo "Installing etcd benchmark tool..."
 	go install -v ./tools/benchmark
 else
@@ -163,7 +163,7 @@ verify-genproto:
 
 .PHONY: verify-yamllint
 verify-yamllint:
-ifeq (, $(shell which yamllint))
+ifeq (, $(shell command -v yamllint))
 	@echo "Installing yamllint..."
 	tmpdir=$$(mktemp -d); \
 	trap "rm -rf $$tmpdir" EXIT; \
@@ -187,14 +187,14 @@ YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.co
 
 .PHONY: fix-yamllint
 fix-yamllint:
-ifeq (, $(shell which yamlfmt))
+ifeq (, $(shell command -v yamlfmt))
 	$(shell go install github.com/google/yamlfmt/cmd/yamlfmt@$(YAMLFMT_VERSION))
 endif
 	yamlfmt -conf tools/.yamlfmt .
 
 .PHONY: run-govulncheck
 run-govulncheck:
-ifeq (, $(shell which govulncheck))
+ifeq (, $(shell command -v govulncheck))
 	$(shell go install golang.org/x/vuln/cmd/govulncheck@latest)
 endif
 	PASSES="govuln" ./scripts/test.sh

--- a/hack/patch/cherrypick.sh
+++ b/hack/patch/cherrypick.sh
@@ -26,7 +26,7 @@ if [[ -z ${GITHUB_USER:-} ]]; then
   exit 1
 fi
 
-if ! which hub > /dev/null; then
+if ! command -v hub > /dev/null; then
   echo "Can't find 'hub' tool in PATH, please install from https://github.com/github/hub"
   exit 1
 fi

--- a/tests/fixtures/gencerts.sh
+++ b/tests/fixtures/gencerts.sh
@@ -22,7 +22,7 @@ fi
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca
 mv ca.pem ca.crt
 
-if which openssl >/dev/null; then
+if command -v openssl >/dev/null; then
   openssl x509 -in ca.crt -noout -text
 fi
 

--- a/tests/integration/fixtures-expired/gencerts.sh
+++ b/tests/integration/fixtures-expired/gencerts.sh
@@ -21,7 +21,7 @@ fi
 
 cfssl gencert --initca=true ./ca-csr.json | cfssljson --bare ./ca
 mv ca.pem ca.crt
-if which openssl >/dev/null; then
+if command -v openssl >/dev/null; then
   openssl x509 -in ca.crt -noout -text
 fi
 
@@ -43,7 +43,7 @@ cfssl gencert \
 mv server-ip.pem server-ip.crt
 mv server-ip-key.pem server-ip.key.insecure
 
-if which openssl >/dev/null; then
+if command -v openssl >/dev/null; then
   openssl x509 -in ./server.crt -text -noout
   openssl x509 -in ./server-ip.crt -text -noout
 fi


### PR DESCRIPTION
command -v is a shell built-in, while which requires a separate binary to be around.