### PR TITLE
Fix error related to missing directory for mktemp command for `make bench-put`

### DIFF
--- a/scripts/benchmark_test.sh
+++ b/scripts/benchmark_test.sh
@@ -30,6 +30,9 @@ BENCHMARK_NAME="$1"
 ARGS="${*:2}"
 
 echo "Starting the etcd server..."
+
+# Create a directory for etcd data under /tmp/etcd
+mkdir -p /tmp/etcd
 DATA_DIR=$(mktemp -d /tmp/etcd/data-XXXXXX)
 ./bin/etcd --data-dir="$DATA_DIR" > /tmp/etcd.log 2>&1 &
 etcd_pid=$!


### PR DESCRIPTION

This PR aims at resolving an error while running the `make bench-put` command due to a missing sub-directory under `/tmp`. while benchmarking.
```
Starting the etcd server...
mktemp: failed to create directory via template '/tmp/etcd/data-XXXXXX': No such file or directory
```
The same has been remediated by creating the the following directory structure - `/tmp/etcd/` before creating the temporary directory for containing the etcd datadir.