### PR TITLE
Add more attributes to OpenTelemetry Txn spans

### DIFF
--- a/server/etcdserver/tracing.go
+++ b/server/etcdserver/tracing.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdserver
+
+import pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+
+// firstCompareKey returns first non-empty key in the list of comparison operations.
+func firstCompareKey(c []*pb.Compare) string {
+	for _, op := range c {
+		key := string(op.GetKey())
+		if key != "" {
+			return key
+		}
+	}
+	return ""
+}
+
+// firstOpKey returns first non-empty key in the list of request operations.
+func firstOpKey(ops []*pb.RequestOp) string {
+	for _, operation := range ops {
+		var key string
+		switch op := operation.GetRequest().(type) {
+		case *pb.RequestOp_RequestPut:
+			key = string(op.RequestPut.GetKey())
+		case *pb.RequestOp_RequestRange:
+			key = string(op.RequestRange.GetKey())
+		case *pb.RequestOp_RequestDeleteRange:
+			key = string(op.RequestDeleteRange.GetKey())
+		}
+		if key != "" {
+			return key
+		}
+	}
+	return ""
+}
+
+// firstOpType returns type of the first operation in the list.
+func firstOpType(ops []*pb.RequestOp) string {
+	for _, operation := range ops {
+		switch operation.GetRequest().(type) {
+		case *pb.RequestOp_RequestPut:
+			return "put"
+		case *pb.RequestOp_RequestRange:
+			return "range"
+		case *pb.RequestOp_RequestDeleteRange:
+			return "delete_range"
+		case *pb.RequestOp_RequestTxn:
+			return "txn"
+		}
+	}
+	return ""
+}
+
+// firstOpLease returns lease ID of the first PUT operation in the list.
+func firstOpLease(ops []*pb.RequestOp) int64 {
+	for _, operation := range ops {
+		if op, ok := operation.GetRequest().(*pb.RequestOp_RequestPut); ok {
+			return op.RequestPut.GetLease()
+		}
+	}
+	return -1
+}

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -182,23 +182,15 @@ func (s *EtcdServer) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) 
 	return resp.(*pb.DeleteRangeResponse), nil
 }
 
-// firstCompareKey returns first non-empty key in the list of comparison operations.
-func firstCompareKey(c []*pb.Compare) string {
-	for _, op := range c {
-		key := string(op.GetKey())
-		if key != "" {
-			return key
-		}
-	}
-	return ""
-}
-
 func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse, error) {
 	readOnly := txn.IsTxnReadonly(r)
 
 	var span trace.Span
 	ctx, span = traceutil.Tracer.Start(ctx, "txn", trace.WithAttributes(
 		attribute.String("compare_first_key", firstCompareKey(r.GetCompare())),
+		attribute.String("success_first_key", firstOpKey(r.GetSuccess())),
+		attribute.String("success_first_type", firstOpType(r.GetSuccess())),
+		attribute.Int64("success_first_lease", firstOpLease(r.GetSuccess())),
 		attribute.Int("compare_len", len(r.GetCompare())),
 		attribute.Int("success_len", len(r.GetSuccess())),
 		attribute.Int("failure_len", len(r.GetFailure())),


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182 and https://github.com/etcd-io/etcd/issues/12460

It adds the following attributes to `txn` spans:
1. `success_first_key` - `key` of the first success operation
2. `success_first_type` - either "put", "range", "delete_range", "txn"
3. `success_first_lease` - lease ID or `-1` if no `put` operation in the transaction or `0` if not set

Example: 
<img width="1658" height="1213" alt="image" src="https://github.com/user-attachments/assets/cc25d797-3cb1-4aba-bf9e-28fdfae6f35b" />


/cc @serathius 