### PR TITLE
cache: prevent unbuffered store watcher causing TestCacheWatchOldRevisionCompacted flake

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -241,7 +241,11 @@ func (c *Cache) get(ctx context.Context) (*clientv3.GetResponse, error) {
 func (c *Cache) watch(rev int64) error {
 	readyOnce := sync.Once{}
 	for {
-		storeW := newWatcher(c.cfg.PerWatcherBufferSize, nil)
+		buf := c.cfg.PerWatcherBufferSize
+		if buf < 1 {
+			buf = 1
+		}
+		storeW := newWatcher(buf, nil)
 		c.demux.Register(storeW, rev)
 		applyErr := make(chan error, 1)
 		c.waitGroup.Add(1)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

After merging #20483, we're experiencing a test flake in `TestCacheWatchOldRevisionCompacted` ([here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-integration-1-cpu-arm64/1957629391110410240
)).

The test builds the cache with `WithPerWatcherBufferSize(0)` to force immediate failures when requesting compacted revisions. But with the recent changes in #20483, `store` is now a normal watcher and also affected by this setup and hence causing below chain of events (my understanding):

1. With `storeW.eventQueue` unbuffered, `demux.Broadcast` uses non-blocking sends that consistently fail
2. this causes `storeW` lagging behind, and it gets stopped when falling outside the history window
3. `applyStorage` then exits cleanly due to the stopped watcher
4. `watchEvents` interprets this clean exit as an error and purges the history
5. too old-revision watches hence never got canceled

This understanding might be wrong, but I found that making sure store watcher have at least 1 slot buffer solves the flake. 

Sorry it took me a while to realize the issue is related to `storeW`, not sending cancel response.

@serathius @MadhavJivrajani 
