### PR TITLE
tests: skip TestCorruptedBackupFileCheck test on big endian platforms

### DIFF
--- a/tests/integration/snapshot/v3_snapshot_test.go
+++ b/tests/integration/snapshot/v3_snapshot_test.go
@@ -16,6 +16,7 @@ package snapshot_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net/url"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.etcd.io/etcd/pkg/v3/cpuutil"
 	"go.etcd.io/etcd/server/v3/embed"
 	integration2 "go.etcd.io/etcd/tests/v3/framework/integration"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
@@ -126,6 +128,9 @@ func TestSnapshotV3RestoreMulti(t *testing.T) {
 
 // TestCorruptedBackupFileCheck tests if we can correctly identify a corrupted backup file.
 func TestCorruptedBackupFileCheck(t *testing.T) {
+	if cpuutil.ByteOrder() == binary.BigEndian {
+		t.Skipf("skipping on big endian platforms since testdata/corrupted_backup.db is in little endian format")
+	}
 	dbPath := testutils.MustAbsPath("testdata/corrupted_backup.db")
 	integration2.BeforeTest(t)
 	_, err := os.Stat(dbPath)


### PR DESCRIPTION
On big endian platforms, skip the TestCorruptedBackupFileCheck test that uses a little endian format file as test input and causes the test to fail for the wrong reason. See earlier discussion here: https://github.com/etcd-io/etcd/issues/11306

I would like to get a fix for this in because this test fails in the newly added https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-etcd-integration-1-cpu-s390x job which runs on the big endian s390x platform.

Closes issue: https://github.com/etcd-io/etcd/issues/20517