### PR TITLE
CHANGELOG: update 3.7 changelog, hide global flags in etcdctl commands

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -34,3 +34,4 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 ### etcdctl
 
 - [Organize etcdctl commands](https://github.com/etcd-io/etcd/pull/20162) to make them more concise and easier to understand.
+- [Hide the global flags](https://github.com/etcd-io/etcd/pull/20493) to make the output of `etcdctl --help` looks cleaner and is consistent with kubectl.

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -112,7 +112,7 @@ func init() {
 	)
 	command.SetHelpCmdGroup(rootCmd)
 
-	hideAllPersistentFlags()
+	hideAllGlobalFlags()
 	hideHelpFlag()
 	addOptionsPrompt()
 }
@@ -130,7 +130,7 @@ func MustStart() {
 	}
 }
 
-func hideAllPersistentFlags() {
+func hideAllGlobalFlags() {
 	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		rootCmd.PersistentFlags().MarkHidden(f.Name)
 	})


### PR DESCRIPTION
Part of: #20466 

cc @ahrtr @ivanvc @siyuanfoundation 