### PR TITLE
Start collecting traces from apiserver in robustness/coverage/README.md

### DIFF
--- a/tests/robustness/coverage/README.md
+++ b/tests/robustness/coverage/README.md
@@ -4,6 +4,8 @@ Go tests in this directory analyze the usage of Etcd API based on collected
 traces from a Kubernetes cluster. They output information on:
 
 1. Number of calls per gRPC method used by Kubernetes
+1. Key pattern
+1. Arguments provided to KV, Watch and Lease methods
 
 This information can be used to track the coverage of k8s-etcd contract.
 
@@ -12,49 +14,90 @@ This information can be used to track the coverage of k8s-etcd contract.
 At first we will manually set up the cluster, run e2e tests, download traces and
 then execute the test.
 
-1\. Set up [KIND
+1. Set up [KIND
 cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) with
 tracing exporting to [Jaeger](https://www.jaegertracing.io/)
 
-```
-export KUBECONFIG="$(pwd)/kind-with-tracing-config"
-kind create cluster --config kind-with-tracing.yaml
-kubectl run jaeger --overrides='{ "apiVersion": "v1", "spec": { "hostNetwork": true, "nodeName": "kind-control-plane", "tolerations": [{"effect": "NoExecute", "operator": "Exists"}]} }' \
-  --labels='tier=control-plane' \
-  --image jaegertracing/jaeger:2.6.0 \
-  -- --set=extensions.jaeger_storage.backends.some_storage.memory.max_traces=2000000
-```
+   1. Create docker network:
 
-2\. Exercise Kubernetes API. For example, build and run Conformance tests from
+      ```shell
+      docker network create kind-with-external-etcd \
+        --driver bridge \
+        --gateway "192.168.32.1" \
+        --subnet "192.168.32.0/24"
+      ```
+
+      Note: You will need to adjust the configuration files and commands if you
+      choose a different subnet.
+
+   1. Run [Jaeger](https://www.jaegertracing.io/) container:
+
+      ```shell
+      docker run --rm --name jaeger \
+        -p 16686:16686 \
+        -p 4317:4317 \
+        jaegertracing/jaeger:2.6.0 --set=extensions.jaeger_storage.backends.some_storage.memory.max_traces=20000000
+      ```
+
+   1. Run `etcd`:
+
+      ```shell
+      etcd --watch-progress-notify-interval=5s \
+        --listen-client-urls http://192.168.32.1:2379 \
+        --advertise-client-urls http://192.168.32.1:2379 \
+        --enable-distributed-tracing \
+        --distributed-tracing-address="192.168.32.1:4317" \
+        --distributed-tracing-service-name="etcd" \
+        --distributed-tracing-sampling-rate=1000000
+      ```
+
+   1. Create [KIND
+cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation):
+
+      ```shell
+      export KUBECONFIG="$(pwd)/kind-with-tracing-config"
+      export KIND_EXPERIMENTAL_DOCKER_NETWORK=kind-with-extrernal-etcd
+      kind create cluster --config kind-with-tracing.yaml --name kind-with-external-etcd
+      ```
+
+1. Exercise Kubernetes API. For example, build and run Conformance tests from
 Kubernetes repository (this usually takes 30-40m or will time out after 1 hour):
 
-```
+```shell
 export KUBECONFIG="$(pwd)/kind-with-tracing-config"
-kind export kubeconfig
+kind export kubeconfig --name kind-with-external-etcd
 make WHAT="test/e2e/e2e.test"
-./_output/bin/e2e.test -context kind-kind -ginkgo.focus=".*Conformance" -num-nodes 2
+./_output/bin/e2e.test \
+  -context kind-kind-with-external-etcd \
+  -ginkgo.focus="\[sig-apps\].*Conformance" \
+  -num-nodes 2
 ```
 
-3\. Download traces and put them into `tests/robustness/coverage/testdata`
+1. Download traces and put them into `tests/robustness/coverage/testdata`
 directory in Etcd git repository:
 
-```
-kubectl port-forward jaeger --address localhost --address :: 16686:16686 &
+```shell
 curl -v --get --retry 10 --retry-connrefused -o testdata/demo_traces.json \
   -H "Content-Type: application/json" \
   --data-urlencode "query.start_time_min=$(date --date="5 days ago" -Ins)" \
-  --data-urlencode "query.start_time_max=$(date -Ins)" \
+  --data-urlencode "query.start_time_max=$(date --date="2 minutes ago" -Ins)" \
   --data-urlencode "query.service_name=etcd" \
-  "http://127.0.0.1:16686/api/v3/traces"
-kill $!
+  "http://192.168.32.1:16686/api/v3/traces"
 ```
 
-4\. Run Go test
+1. Run Go test
 
-```
+```shell
 go test -v -timeout 60s go.etcd.io/etcd/tests/v3/robustness/coverage
+```
+
+1. Clean up the environment
+
+```shell
+kind delete cluster --name kind-with-external-etcd
+docker network rm kind-with-external-etcd
 ```
 
 ### Automated test execution
 
-Work on improving these tests is tracked in https://github.com/etcd-io/etcd/issues/20182
+Work on improving these tests is tracked in [#20182](https://github.com/etcd-io/etcd/issues/20182).

--- a/tests/robustness/coverage/apiserver-shared-conf/tracing.yaml
+++ b/tests/robustness/coverage/apiserver-shared-conf/tracing.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: TracingConfiguration
+endpoint: 192.168.32.1:4317
+samplingRatePerMillion: 1000000

--- a/tests/robustness/coverage/kind-with-tracing.yaml
+++ b/tests/robustness/coverage/kind-with-tracing.yaml
@@ -1,17 +1,27 @@
 ---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  "APIServerTracing": true
 nodes:
   - role: control-plane
+    extraMounts:
+      - hostPath: apiserver-shared-conf
+        containerPath: /apiserver-shared-conf
+        readOnly: true
     kubeadmConfigPatches:
       - |
         kind: ClusterConfiguration
         etcd:
-          local:
+          external:
+            endpoints:
+              - http://192.168.32.1:2379
+        apiServer:
             extraArgs:
-              experimental-enable-distributed-tracing: "true"
-              experimental-distributed-tracing-address: "0.0.0.0:4317"
-              experimental-distributed-tracing-service-name: "etcd"
-              experimental-distributed-tracing-sampling-rate: "1000000"
+              tracing-config-file: "/apiserver-shared-conf/tracing.yaml"
+            extraVolumes:
+              - name: tracing
+                hostPath: "/apiserver-shared-conf"
+                mountPath: "/apiserver-shared-conf"
   - role: worker
   - role: worker


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182

What changed:
 * runs Jeager in docker instead of KiND cluster
 * uses a separate docker network to make IP address management easier
 * provides new configuration of apiserver and kind cluster
 * focuses test execution on sig-apps conformance tests to make them faster
 
 Why it changed:
 * until Etcd publishes nightly image (or tracing changes are backported/released) it is easier to run `etcd` instance from command line (replacing etcd image in KiND without using external repository is difficult)
 * we want to start collecting traces from apiserver to make it easier to attribute calls to contract interface
 
 /cc @serathius 