### PR TITLE
do not remove range requests from TXN to ensure all members execute the same validation for TXN

### DIFF
--- a/tests/e2e/reproduce_18667_test.go
+++ b/tests/e2e/reproduce_18667_test.go
@@ -76,10 +76,6 @@ func TestReproduce18667(t *testing.T) {
 		// hasn't been resolved yet, so some members hold the wrong data
 		// "k2:foo". Once the issue is fixed, we should remove the if-else
 		// branch below, and all member should have consistent data k2:v2.
-		if i == 0 {
-			assert.Equal(t, "v2", string(resp.Kvs[0].Value))
-		} else {
-			assert.Equal(t, "foo", string(resp.Kvs[0].Value))
-		}
+		assert.Equal(t, "v2", string(resp.Kvs[0].Value))
 	}
 }


### PR DESCRIPTION
fix: #18667 

The code comes from https://github.com/etcd-io/etcd/issues/18667#issuecomment-2392093222

## Performance Testing:

### txn-mixed

#### Original

```
Details:
Summary:
  Total:        7.8784 secs.
  Slowest:      0.0074 secs.
  Fastest:      0.0001 secs.
  Average:      0.0002 secs.
  Stddev:       0.0001 secs.
  Requests/sec: 630.5875

Response time histogram:
  0.0001 [1]    |
  0.0008 [4958] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0015 [1]    |
  0.0023 [3]    |
  0.0030 [2]    |
  0.0037 [2]    |
  0.0045 [0]    |
  0.0052 [0]    |
  0.0059 [0]    |
  0.0066 [0]    |
  0.0074 [1]    |

Latency distribution:
  10% in 0.0001 secs.
  25% in 0.0001 secs.
  50% in 0.0002 secs.
  75% in 0.0002 secs.
  90% in 0.0002 secs.
  95% in 0.0002 secs.
  99% in 0.0003 secs.
  99.9% in 0.0030 secs.

Total Write Ops: 5032
Details:
Summary:
  Total:        7.8783 secs.
  Slowest:      0.0077 secs.
  Fastest:      0.0010 secs.
  Average:      0.0014 secs.
  Stddev:       0.0005 secs.
  Requests/sec: 638.7148

Response time histogram:
  0.0010 [1]    |
  0.0016 [3920] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0023 [1029] |∎∎∎∎∎∎∎∎∎∎
  0.0030 [9]    |
  0.0037 [27]   |
  0.0043 [25]   |
  0.0050 [13]   |
  0.0057 [1]    |
  0.0064 [0]    |
  0.0070 [2]    |
  0.0077 [5]    |

Latency distribution:
  10% in 0.0010 secs.
  25% in 0.0011 secs.
  50% in 0.0013 secs.
  75% in 0.0016 secs.
  90% in 0.0018 secs.
  95% in 0.0019 secs.
  99% in 0.0035 secs.
  99.9% in 0.0071 secs.
```


#### Modified

```
Details:
Summary:
  Total:        8.2452 secs.
  Slowest:      0.0022 secs.
  Fastest:      0.0001 secs.
  Average:      0.0002 secs.
  Stddev:       0.0001 secs.
  Requests/sec: 611.3825

Response time histogram:
  0.0001 [1]    |
  0.0003 [4971] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0005 [52]   |
  0.0007 [9]    |
  0.0009 [0]    |
  0.0011 [0]    |
  0.0014 [0]    |
  0.0016 [0]    |
  0.0018 [0]    |
  0.0020 [2]    |
  0.0022 [6]    |

Latency distribution:
  10% in 0.0001 secs.
  25% in 0.0002 secs.
  50% in 0.0002 secs.
  75% in 0.0002 secs.
  90% in 0.0002 secs.
  95% in 0.0002 secs.
  99% in 0.0004 secs.
  99.9% in 0.0020 secs.

Total Write Ops: 4959
Details:
Summary:
  Total:        8.2452 secs.
  Slowest:      0.0231 secs.
  Fastest:      0.0010 secs.
  Average:      0.0015 secs.
  Stddev:       0.0006 secs.
  Requests/sec: 601.4372

Response time histogram:
  0.0010 [1]    |
  0.0032 [4909] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0054 [40]   |
  0.0076 [6]    |
  0.0098 [1]    |
  0.0120 [1]    |
  0.0143 [0]    |
  0.0165 [0]    |
  0.0187 [0]    |
  0.0209 [0]    |
  0.0231 [1]    |

Latency distribution:
  10% in 0.0011 secs.
  25% in 0.0011 secs.
  50% in 0.0013 secs.
  75% in 0.0018 secs.
  90% in 0.0019 secs.
  95% in 0.0019 secs.
  99% in 0.0032 secs.
  99.9% in 0.0072 secs.
```


### txn-put

#### Original

``` 
Summary:
  Total:        15.8790 secs.
  Slowest:      0.0150 secs.
  Fastest:      0.0010 secs.
  Average:      0.0016 secs.
  Stddev:       0.0005 secs.
  Requests/sec: 629.7614

Response time histogram:
  0.0010 [1]    |
  0.0024 [9813] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0038 [48]   |
  0.0052 [114]  |
  0.0066 [3]    |
  0.0080 [15]   |
  0.0094 [4]    |
  0.0108 [1]    |
  0.0122 [0]    |
  0.0136 [0]    |
  0.0150 [1]    |

Latency distribution:
  10% in 0.0011 secs.
  25% in 0.0015 secs.
  50% in 0.0016 secs.
  75% in 0.0016 secs.
  90% in 0.0018 secs.
  95% in 0.0018 secs.
  99% in 0.0040 secs.
  99.9% in 0.0072 secs.
```

#### Modified

```
Summary:
  Total:        15.7357 secs.
  Slowest:      0.0189 secs.
  Fastest:      0.0010 secs.
  Average:      0.0016 secs.
  Stddev:       0.0005 secs.
  Requests/sec: 635.4970

Response time histogram:
  0.0010 [1]    |
  0.0028 [9816] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.0046 [159]  |
  0.0064 [6]    |
  0.0082 [15]   |
  0.0100 [1]    |
  0.0118 [1]    |
  0.0136 [0]    |
  0.0154 [0]    |
  0.0171 [0]    |
  0.0189 [1]    |

Latency distribution:
  10% in 0.0011 secs.
  25% in 0.0015 secs.
  50% in 0.0016 secs.
  75% in 0.0017 secs.
  90% in 0.0018 secs.
  95% in 0.0019 secs.
  99% in 0.0033 secs.
  99.9% in 0.0071 secs.
```

After the modification, there are some performance differences. I think this is just noise, as the results varied across multiple test runs.

cc @ahrtr @siyuanfoundation 