### PR TITLE
Add contract attribution to trace analysis

### DIFF
--- a/tests/robustness/coverage/README.md
+++ b/tests/robustness/coverage/README.md
@@ -14,9 +14,25 @@ This information can be used to track the coverage of k8s-etcd contract.
 At first we will manually set up the cluster, run e2e tests, download traces and
 then execute the test.
 
+1. Customize and set the environment variables used by the code snippets below:
+
+```shell
+# Used for patches, building kind nodes, and running e2e tests.
+export KUBERNETES_REPO="$(go env GOPATH)/src/k8s.io/kubernetes"
+# Used when creating kind cluster and running e2e tests.
+export KUBECONFIG="${KUBERNETES_REPO}/kind-with-tracing-config"
+```
+
 1. Set up [KIND
 cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) with
 tracing exporting to [Jaeger](https://www.jaegertracing.io/)
+
+   1. Patch and build kubernetes images
+
+      ```shell
+      git -C "$KUBERNETES_REPO" apply --recount ${PWD}/patches/kubernetes/*
+      kind build node-image
+      ```
 
    1. Create docker network:
 
@@ -39,10 +55,12 @@ tracing exporting to [Jaeger](https://www.jaegertracing.io/)
         jaegertracing/jaeger:2.6.0 --set=extensions.jaeger_storage.backends.some_storage.memory.max_traces=20000000
       ```
 
-   1. Run `etcd`:
+   1. Run `etcd` (in root of `etcd` repository):
 
       ```shell
-      etcd --watch-progress-notify-interval=5s \
+      make build
+      cp bin/etcd "${KUBERNETES_REPO}/third_party/etcd/etcd"
+      bin/etcd --watch-progress-notify-interval=5s \
         --listen-client-urls http://192.168.32.1:2379 \
         --advertise-client-urls http://192.168.32.1:2379 \
         --enable-distributed-tracing \
@@ -55,22 +73,20 @@ tracing exporting to [Jaeger](https://www.jaegertracing.io/)
 cluster](https://kind.sigs.k8s.io/docs/user/quick-start/#installation):
 
       ```shell
-      export KUBECONFIG="$(pwd)/kind-with-tracing-config"
-      export KIND_EXPERIMENTAL_DOCKER_NETWORK=kind-with-extrernal-etcd
-      kind create cluster --config kind-with-tracing.yaml --name kind-with-external-etcd
+      export KIND_EXPERIMENTAL_DOCKER_NETWORK=kind-with-external-etcd
+      kind create cluster --config kind-with-tracing.yaml --name kind-with-external-etcd --image kindest/node:latest
       ```
 
 1. Exercise Kubernetes API. For example, build and run Conformance tests from
 Kubernetes repository (this usually takes 30-40m or will time out after 1 hour):
 
 ```shell
-export KUBECONFIG="$(pwd)/kind-with-tracing-config"
-kind export kubeconfig --name kind-with-external-etcd
 make WHAT="test/e2e/e2e.test"
 ./_output/bin/e2e.test \
   -context kind-kind-with-external-etcd \
   -ginkgo.focus="\[sig-apps\].*Conformance" \
   -num-nodes 2
+build/run.sh make test-cmd
 ```
 
 1. Download traces and put them into `tests/robustness/coverage/testdata`

--- a/tests/robustness/coverage/contract_test.go
+++ b/tests/robustness/coverage/contract_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage_test
+
+import (
+	"iter"
+	"strings"
+	"testing"
+
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func contract(spansByID map[string]*tracev1.Span, span *tracev1.Span) (string, bool) {
+	for span := range walk(spansByID, span) {
+		for _, event := range span.GetEvents() {
+			name := event.GetName()
+			if strings.HasPrefix(name, "contract.") {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// walk iterates over the chain of spans starting from span and then going up
+// the tree to parent span if such exists.
+func walk(spansByID map[string]*tracev1.Span, span *tracev1.Span) iter.Seq[*tracev1.Span] {
+	return func(yield func(*tracev1.Span) bool) {
+		for node := span; node != nil; node = spansByID[string(node.GetParentSpanId())] {
+			if !yield(node) {
+				return
+			}
+		}
+	}
+}
+
+func TestContract(t *testing.T) {
+	spansByID := map[string]*tracev1.Span{
+		"child": {
+			ParentSpanId: []byte("middle"),
+		},
+		"middle": {
+			ParentSpanId: []byte("parent"),
+			Events: []*tracev1.Span_Event{
+				{Name: "wrong.contract"},
+			},
+		},
+		"parent": {
+			ParentSpanId: []byte("grandparent"),
+			Events: []*tracev1.Span_Event{
+				{Name: "contract.OptimisticPut"},
+			},
+		},
+		"grandparent": {
+			Events: []*tracev1.Span_Event{
+				{Name: "contract.Get"},
+			},
+		},
+		"outside_delete": {
+			Events: []*tracev1.Span_Event{
+				{Name: "otherEvent"},
+				{Name: "contract.OptimisticDelete"},
+			},
+		},
+		"outside_invalid": {
+			Events: []*tracev1.Span_Event{
+				{Name: "contractWrong"},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+		found  bool
+	}{
+		{
+			name:   "ok_chain",
+			source: "child",
+			want:   "contract.OptimisticPut",
+			found:  true,
+		},
+		{
+			name:   "ok_single",
+			source: "outside_delete",
+			want:   "contract.OptimisticDelete",
+			found:  true,
+		},
+		{
+			name:   "not_in_contract_chain",
+			source: "outside_invalid",
+			want:   "",
+			found:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := contract(spansByID, spansByID[tc.source])
+			if found != tc.found {
+				t.Errorf("got=%v, want=%v", found, tc.found)
+			}
+			if got != tc.want {
+				t.Errorf("got=%v, want=%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tests/robustness/coverage/patches/kubernetes/0001-Add-Open-Telemetry-trace-event-when-passing-through-.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0001-Add-Open-Telemetry-trace-event-when-passing-through-.patch
@@ -1,0 +1,81 @@
+From 135c75d2689318dd47b7778b8f87902e75178d52 Mon Sep 17 00:00:00 2001
+From: Aleksander Mistewicz <amistewicz@google.com>
+Date: Wed, 13 Aug 2025 13:45:20 +0200
+Subject: [PATCH 1/4] Add Open Telemetry trace event when passing through
+ contract interface
+
+Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
+---
+ .../etcd/client/v3/kubernetes/client.go       | 21 +++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go b/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go
+index 11f2a456447..0efab3711d7 100644
+--- a/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go
++++ b/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go
+@@ -21,6 +21,8 @@ import (
+ 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+ 	"go.etcd.io/etcd/api/v3/mvccpb"
+ 	clientv3 "go.etcd.io/etcd/client/v3"
++	"go.opentelemetry.io/otel/attribute"
++	"go.opentelemetry.io/otel/trace"
+ )
+ 
+ // New creates Client from config.
+@@ -45,6 +47,10 @@ type Client struct {
+ var _ Interface = (*Client)(nil)
+ 
+ func (k Client) Get(ctx context.Context, key string, opts GetOptions) (resp GetResponse, err error) {
++	trace.SpanFromContext(ctx).AddEvent("contract.Get", trace.WithAttributes(
++		attribute.String("key", key),
++		attribute.Int64("rev", opts.Revision),
++	))
+ 	rangeResp, err := k.KV.Get(ctx, key, clientv3.WithRev(opts.Revision), clientv3.WithLimit(1))
+ 	if err != nil {
+ 		return resp, err
+@@ -57,6 +63,10 @@ func (k Client) Get(ctx context.Context, key string, opts GetOptions) (resp GetR
+ }
+ 
+ func (k Client) List(ctx context.Context, prefix string, opts ListOptions) (resp ListResponse, err error) {
++	trace.SpanFromContext(ctx).AddEvent("contract.List", trace.WithAttributes(
++		attribute.String("prefix", prefix),
++		attribute.Int64("rev", opts.Revision),
++	))
+ 	rangeStart := prefix
+ 	if opts.Continue != "" {
+ 		rangeStart = opts.Continue
+@@ -73,6 +83,9 @@ func (k Client) List(ctx context.Context, prefix string, opts ListOptions) (resp
+ }
+ 
+ func (k Client) Count(ctx context.Context, prefix string, _ CountOptions) (int64, error) {
++	trace.SpanFromContext(ctx).AddEvent("contract.Count", trace.WithAttributes(
++		attribute.String("prefix", prefix),
++	))
+ 	resp, err := k.KV.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithCountOnly())
+ 	if err != nil {
+ 		return 0, err
+@@ -81,6 +94,10 @@ func (k Client) Count(ctx context.Context, prefix string, _ CountOptions) (int64
+ }
+ 
+ func (k Client) OptimisticPut(ctx context.Context, key string, value []byte, expectedRevision int64, opts PutOptions) (resp PutResponse, err error) {
++	trace.SpanFromContext(ctx).AddEvent("contract.OptimisticPut", trace.WithAttributes(
++		attribute.String("key", key),
++		attribute.Int64("expected_rev", expectedRevision),
++	))
+ 	txn := k.KV.Txn(ctx).If(
+ 		clientv3.Compare(clientv3.ModRevision(key), "=", expectedRevision),
+ 	).Then(
+@@ -107,6 +124,10 @@ func (k Client) OptimisticPut(ctx context.Context, key string, value []byte, exp
+ }
+ 
+ func (k Client) OptimisticDelete(ctx context.Context, key string, expectedRevision int64, opts DeleteOptions) (resp DeleteResponse, err error) {
++	trace.SpanFromContext(ctx).AddEvent("contract.OptimisticDelete", trace.WithAttributes(
++		attribute.String("key", key),
++		attribute.Int64("expected_rev", expectedRevision),
++	))
+ 	txn := k.KV.Txn(ctx).If(
+ 		clientv3.Compare(clientv3.ModRevision(key), "=", expectedRevision),
+ 	).Then(
+-- 
+2.51.0.rc2.233.g662b1ed5c5-goog
+

--- a/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
@@ -1,0 +1,121 @@
+From 84706912128912a37bfaf47ecf550463fadb805e Mon Sep 17 00:00:00 2001
+From: Aleksander Mistewicz <amistewicz@google.com>
+Date: Mon, 18 Aug 2025 12:32:16 +0200
+Subject: [PATCH 2/4] Add kubernetesEtcdContractTracker
+
+This decorator will make it easier to ensure that all calls to the
+underlying storage that go through the contract interface produce
+spans. TracerProvider needs to be passed to the contract tracker to
+ensure that all spans will be correctly exported.
+
+Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
+---
+ .../etcd3/kubernetes_contract_tracker.go      | 73 +++++++++++++++++++
+ .../storage/storagebackend/factory/etcd3.go   | 10 ++-
+ 2 files changed, 82 insertions(+), 1 deletion(-)
+ create mode 100644 staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go
+
+diff --git a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go
+new file mode 100644
+index 00000000000..c16eecb20fa
+--- /dev/null
++++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go
+@@ -0,0 +1,73 @@
++/*
++Copyright 2025 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package etcd3
++
++import (
++	"context"
++
++	"go.etcd.io/etcd/client/v3/kubernetes"
++	"go.opentelemetry.io/otel/attribute"
++	"go.opentelemetry.io/otel/trace"
++)
++
++const instrumentationScope = "k8s.io/apiserver/pkg/storage/etcd3"
++
++func NewKubernetesEtcdContractTracker(delegate kubernetes.Interface, tp trace.TracerProvider) kubernetes.Interface {
++	return &kubernetesEtcdContractTracker{Interface: delegate, tracer: tp.Tracer(instrumentationScope)}
++}
++
++type kubernetesEtcdContractTracker struct {
++	kubernetes.Interface
++
++	tracer trace.Tracer
++}
++
++func (k *kubernetesEtcdContractTracker) Get(ctx context.Context, key string, opts kubernetes.GetOptions) (kubernetes.GetResponse, error) {
++	ctx, span := k.tracer.Start(ctx, "Get kubernetesEtcdContract",
++		trace.WithAttributes(attribute.String("key", key), attribute.Int("rev", int(opts.Revision))))
++	defer span.End()
++	return k.Interface.Get(ctx, key, opts)
++}
++
++func (k *kubernetesEtcdContractTracker) List(ctx context.Context, prefix string, opts kubernetes.ListOptions) (kubernetes.ListResponse, error) {
++	ctx, span := k.tracer.Start(ctx, "List kubernetesEtcdContract",
++		trace.WithAttributes(attribute.String("key", prefix), attribute.Int("rev", int(opts.Revision)), attribute.Int("limit", int(opts.Limit))))
++	defer span.End()
++	return k.Interface.List(ctx, prefix, opts)
++}
++
++func (k *kubernetesEtcdContractTracker) Count(ctx context.Context, prefix string, opts kubernetes.CountOptions) (int64, error) {
++	ctx, span := k.tracer.Start(ctx, "Count kubernetesEtcdContract",
++		trace.WithNewRoot(), // Count is called periodically from the same context, so it would show up as a single trace otherwise
++		trace.WithAttributes(attribute.String("key", prefix)))
++	defer span.End()
++	return k.Interface.Count(ctx, prefix, opts)
++}
++
++func (k *kubernetesEtcdContractTracker) OptimisticPut(ctx context.Context, key string, value []byte, expectedRevision int64, opts kubernetes.PutOptions) (kubernetes.PutResponse, error) {
++	ctx, span := k.tracer.Start(ctx, "OptimisticPut kubernetesEtcdContract",
++		trace.WithAttributes(attribute.String("key", key), attribute.Int("rev", int(expectedRevision)), attribute.Int("lease", int(opts.LeaseID)), attribute.Bool("get_on_failure", opts.GetOnFailure)))
++	defer span.End()
++	return k.Interface.OptimisticPut(ctx, key, value, expectedRevision, opts)
++}
++
++func (k *kubernetesEtcdContractTracker) OptimisticDelete(ctx context.Context, key string, expectedRevision int64, opts kubernetes.DeleteOptions) (kubernetes.DeleteResponse, error) {
++	ctx, span := k.tracer.Start(ctx, "OptimisticDelete kubernetesEtcdContract",
++		trace.WithAttributes(attribute.String("key", key), attribute.Int("rev", int(expectedRevision)), attribute.Bool("get_on_failure", opts.GetOnFailure)))
++	defer span.End()
++	return k.Interface.OptimisticDelete(ctx, key, expectedRevision, opts)
++}
+diff --git a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+index c8ee0a12887..8f7f19d78d5 100644
+--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
++++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+@@ -351,8 +351,16 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
+ 		TLS:                  tlsConfig,
+ 		Logger:               etcd3ClientLogger,
+ 	}
++	client, err := kubernetes.New(cfg)
++	if err != nil {
++		return nil, err
++	}
++	if c.TracerProvider != nil {
++		// Decorate the Kubernetes instance so all events added later will belong to short-lived Spans.
++		client.Kubernetes = etcd3.NewKubernetesEtcdContractTracker(client, c.TracerProvider)
++	}
+ 
+-	return kubernetes.New(cfg)
++	return client, nil
+ }
+ 
+ type runningCompactor struct {
+-- 
+2.51.0.rc2.233.g662b1ed5c5-goog
+

--- a/tests/robustness/coverage/patches/kubernetes/0003-Add-1m-timeout-to-Watch-to-ensure-Spans-are-exported.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0003-Add-1m-timeout-to-Watch-to-ensure-Spans-are-exported.patch
@@ -1,0 +1,26 @@
+From 2a848f904aee8cff04d44fd14d2c17a2802f972b Mon Sep 17 00:00:00 2001
+From: Aleksander Mistewicz <amistewicz@google.com>
+Date: Fri, 22 Aug 2025 14:18:07 +0200
+Subject: [PATCH 3/4] Add 1m timeout to Watch to ensure Spans are exported
+
+Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
+---
+ vendor/go.etcd.io/etcd/client/v3/watch.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vendor/go.etcd.io/etcd/client/v3/watch.go b/vendor/go.etcd.io/etcd/client/v3/watch.go
+index a46f98b8e28..ac820cabbb1 100644
+--- a/vendor/go.etcd.io/etcd/client/v3/watch.go
++++ b/vendor/go.etcd.io/etcd/client/v3/watch.go
+@@ -273,7 +273,7 @@ func (vc *valCtx) Done() <-chan struct{}       { return valCtxCh }
+ func (vc *valCtx) Err() error                  { return nil }
+ 
+ func (w *watcher) newWatcherGRPCStream(inctx context.Context) *watchGRPCStream {
+-	ctx, cancel := context.WithCancel(&valCtx{inctx})
++	ctx, cancel := context.WithTimeout(&valCtx{inctx}, time.Minute)
+ 	wgs := &watchGRPCStream{
+ 		owner:      w,
+ 		remote:     w.remote,
+-- 
+2.51.0.rc2.233.g662b1ed5c5-goog
+

--- a/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
@@ -1,0 +1,64 @@
+From 1a689e5bc18757ec1d9127b551585596cee5e679 Mon Sep 17 00:00:00 2001
+From: Aleksander Mistewicz <amistewicz@google.com>
+Date: Mon, 4 Aug 2025 15:56:48 +0200
+Subject: [PATCH 4/4] Configure cmd tests
+
+---
+ hack/lib/etcd.sh            | 6 ++++--
+ hack/make-rules/test-cmd.sh | 9 +++++++++
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/hack/lib/etcd.sh b/hack/lib/etcd.sh
+index c6fc45a5fab..1f4fad6774d 100755
+--- a/hack/lib/etcd.sh
++++ b/hack/lib/etcd.sh
+@@ -17,6 +17,8 @@
+ # A set of helpers for starting/running etcd for tests
+ 
+ ETCD_VERSION=${ETCD_VERSION:-3.6.4}
++export PATH="${PATH}:/go/src/k8s.io/kubernetes/third_party/etcd"
++
+ ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ ETCD_PORT=${ETCD_PORT:-2379}
+ # This is intentionally not called ETCD_LOG_LEVEL:
+@@ -84,8 +86,8 @@ kube::etcd::start() {
+   else
+     ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
+   fi
+-  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=${ETCD_LOGLEVEL} 2> \"${ETCD_LOGFILE}\" >/dev/null"
+-  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level="${ETCD_LOGLEVEL}" 2> "${ETCD_LOGFILE}" >/dev/null &
++  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=${ETCD_LOGLEVEL} --enable-distributed-tracing --distributed-tracing-address=\"0.0.0.0:4317\" --distributed-tracing-service-name=\"etcd\" --distributed-tracing-sampling-rate=1000000 2> \"${ETCD_LOGFILE}\" >/dev/null"
++  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level="${ETCD_LOGLEVEL}" --enable-distributed-tracing --distributed-tracing-address="192.168.32.1:4317" --distributed-tracing-service-name="etcd" --distributed-tracing-sampling-rate=1000000 2> "${ETCD_LOGFILE}" >/dev/null &
+   ETCD_PID=$!
+ 
+   echo "Waiting for etcd to come up."
+diff --git a/hack/make-rules/test-cmd.sh b/hack/make-rules/test-cmd.sh
+index 7d9fb1db65c..179176533de 100755
+--- a/hack/make-rules/test-cmd.sh
++++ b/hack/make-rules/test-cmd.sh
+@@ -69,6 +69,14 @@ function run_kube_apiserver() {
+     VERSION_OVERRIDE="--version=$("${THIS_PLATFORM_BIN}/kube-apiserver" --version | awk '{print $2}')${CUSTOM_VERSION_SUFFIX:-}"
+   fi
+ 
++  cat <<EOF > "/tmp/kube-tracing-file"
++apiVersion: apiserver.config.k8s.io/v1beta1
++kind: TracingConfiguration
++# default value
++endpoint: 192.168.32.1:4317
++samplingRatePerMillion: 1000000
++EOF
++
+   "${THIS_PLATFORM_BIN}/kube-apiserver" \
+     ${VERSION_OVERRIDE:+"${VERSION_OVERRIDE}"} \
+     --bind-address="127.0.0.1" \
+@@ -84,6 +92,7 @@ function run_kube_apiserver() {
+     --service-account-issuer="https://kubernetes.default.svc" \
+     --service-account-signing-key-file="${SERVICE_ACCOUNT_KEY}" \
+     --storage-media-type="${KUBE_TEST_API_STORAGE_TYPE-}" \
++    --tracing-config-file="/tmp/kube-tracing-file" \
+     --cert-dir="${TMPDIR:-/tmp/}" \
+     --service-cluster-ip-range="10.0.0.0/24" \
+     --client-ca-file=hack/testdata/ca/ca.crt \
+-- 
+2.51.0.rc2.233.g662b1ed5c5-goog
+


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182

This approach requires patched kubernetes in order to:
1. Create spans from `Watch` calls. By default `Watch` runs indefinitely, with the patch it is capped at 1 minute
1. Add events to all traces of calls passing through the `Kubernetes` contract interface
1. Create OpenTelemetry spans for all methods of `Kubernetes` contract interface regardless of the information stored in the context (or not)
1. Use the latest `etcd` in both e2e and command tests

/cc @serathius 