### PR TITLE
Update matchers in trace analysis

### DIFF
--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -122,6 +122,7 @@ var referenceUsageOfWatchAndKV = map[string]refOp{
 		args: []column{
 			{name: "getOnFailure", matcher: keyIsEqualInt("failure_len", 1)},
 			{name: "readOnly", matcher: isReadOnly},
+			{name: "lease", matcher: intAttrSet("success_first_lease")},
 		},
 		keyAttrName: "compare_first_key",
 		methods: []method{
@@ -130,8 +131,22 @@ var referenceUsageOfWatchAndKV = map[string]refOp{
 				matcher: keyIsEqualStr("compare_first_key", "compact_rev_key"),
 			},
 			{
-				name:    "OptimisticPutOrDelete",
-				matcher: andMatcher(keyIsEqualInt("compare_len", 1), keyIsEqualInt("success_len", 1), notMatcher(isReadOnly)),
+				name: "OptimisticPut",
+				matcher: andMatcher(
+					keyIsEqualInt("compare_len", 1),
+					keyIsEqualInt("success_len", 1),
+					keyIsEqualStr("success_first_type", "put"),
+					notMatcher(isReadOnly),
+				),
+			},
+			{
+				name: "OptimisticDelete",
+				matcher: andMatcher(
+					keyIsEqualInt("compare_len", 1),
+					keyIsEqualInt("success_len", 1),
+					keyIsEqualStr("success_first_type", "delete_range"),
+					notMatcher(isReadOnly),
+				),
 			},
 		},
 	},

--- a/tests/robustness/coverage/coverage_test.go
+++ b/tests/robustness/coverage/coverage_test.go
@@ -102,6 +102,14 @@ var referenceUsageOfWatchAndKV = map[string]refOp{
 				),
 			},
 			{
+				name: "Keys",
+				matcher: andMatcher(
+					isKeysOnly,
+					isRangeEndSet,
+					notMatcher(orMatcher(isCountOnly, isLimitSet, isRevisionSet)),
+				),
+			},
+			{
 				name: "List",
 				matcher: andMatcher(
 					isRangeEndSet,
@@ -169,7 +177,13 @@ var referenceUsageOfWatchAndKV = map[string]refOp{
 		},
 		keyAttrName: "key",
 		methods: []method{
-			{name: "Watch", matcher: notMatcher(keyIsEqualStr("key", "compact_rev_key"))},
+			{name: "Compaction", matcher: keyIsEqualStr("key", "compact_rev_key")},
+			{name: "Watch", matcher: andMatcher(
+				isRangeEndSet,
+				intAttrSet("start_rev"),
+				boolAttrSet("prev_kv"),
+				notMatcher(boolAttrSet("fragment")),
+			)},
 		},
 	},
 }


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/20182

New cases (Watch on compaction key and Range with keys_only) cover new usage of Etcd API by Kubernetes v1.34. Matchers are tighter to better detect future changes (Watch without `prev_kv`).

Optimistic Put and Delete are split. `lease` information is added to the table.