### PR TITLE
server/embed: Log EOF on DEBUG in TLS handshake

### DIFF
--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -167,6 +167,12 @@ func (cfg *Config) setupLogging() error {
 
 		logTLSHandshakeFailureFunc := func(msg string) func(conn *tls.Conn, err error) {
 			return func(conn *tls.Conn, err error) {
+				// Log EOF errors on DEBUG not to spam logs too much.
+				logFunc := cfg.logger.Warn
+				if errors.Is(err, io.EOF) {
+					logFunc = cfg.logger.Debug
+				}
+
 				state := conn.ConnectionState()
 				remoteAddr := conn.RemoteAddr().String()
 				serverName := state.ServerName
@@ -176,7 +182,7 @@ func (cfg *Config) setupLogging() error {
 					for i := range cert.IPAddresses {
 						ips[i] = cert.IPAddresses[i].String()
 					}
-					cfg.logger.Warn(
+					logFunc(
 						msg,
 						zap.String("remote-addr", remoteAddr),
 						zap.String("server-name", serverName),
@@ -185,7 +191,7 @@ func (cfg *Config) setupLogging() error {
 						zap.Error(err),
 					)
 				} else {
-					cfg.logger.Warn(
+					logFunc(
 						msg,
 						zap.String("remote-addr", remoteAddr),
 						zap.String("server-name", serverName),


### PR DESCRIPTION
When EOF is encountered during TLS handshake, it is still logged as a warning. This seems excessive and not really useful.

This patch ensures EOF is logged on debug only.

Fixes #20565 
