### PR TITLE
etcdserver: improve linearizable renew lease

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -17,6 +17,7 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 - [Add Support for Unix Socket endpoints](https://github.com/etcd-io/etcd/pull/19760)
 - [Improves performance of lease and user/role operations (up to 2x) by updating `(*readView) Rev()` to use `SharedBufReadTxMode`](https://github.com/etcd-io/etcd/pull/20411)
 - [Allow client to retrieve AuthStatus without authentication](https://github.com/etcd-io/etcd/pull/20802)
+- [Add FastLeaseKeepAlive feature to enable faster lease renewal by skipping the wait for the applied index](https://github.com/etcd-io/etcd/pull/20589)
 
 ### Package `clientv3`
 

--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -111,6 +111,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 				features.TxnModeWriteWithSharedBuffer: true,
 				features.LeaseCheckpoint:              false,
 				features.LeaseCheckpointPersist:       false,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -119,6 +120,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.StopGRPCServiceOnDefrag:      true,
 				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -127,6 +129,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.InitialCorruptCheck:          true,
 				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -135,6 +138,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.StopGRPCServiceOnDefrag:      false,
 				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -142,6 +146,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			serverFeatureGatesJSON: "TxnModeWriteWithSharedBuffer=true",
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -149,6 +154,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			serverFeatureGatesJSON: "TxnModeWriteWithSharedBuffer=false",
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.TxnModeWriteWithSharedBuffer: false,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -157,6 +163,7 @@ func TestConfigFileFeatureGates(t *testing.T) {
 			expectedFeatures: map[featuregate.Feature]bool{
 				features.CompactHashCheck:             true,
 				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           true,
 			},
 		},
 		{
@@ -166,6 +173,15 @@ func TestConfigFileFeatureGates(t *testing.T) {
 				features.TxnModeWriteWithSharedBuffer: true,
 				features.LeaseCheckpoint:              true,
 				features.LeaseCheckpointPersist:       true,
+				features.FastLeaseKeepAlive:           true,
+			},
+		},
+		{
+			name:                   "can set feature gate FastLeaseKeepAlive to true from feature gate flag",
+			serverFeatureGatesJSON: "FastLeaseKeepAlive=false",
+			expectedFeatures: map[featuregate.Feature]bool{
+				features.TxnModeWriteWithSharedBuffer: true,
+				features.FastLeaseKeepAlive:           false,
 			},
 		},
 	}
@@ -894,6 +910,37 @@ func TestDiscoveryCfg(t *testing.T) {
 			err := cfg.Validate()
 
 			require.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}
+
+func TestFastLeaseKeepAliveValidate(t *testing.T) {
+	tcs := []struct {
+		name               string
+		serverFeatureGates string
+		expectEnabled      bool
+	}{
+		{
+			name:          "Default config should pass",
+			expectEnabled: true,
+		},
+		{
+			name:               "Enabling FastLeaseKeepAlive should pass",
+			serverFeatureGates: "FastLeaseKeepAlive=true",
+			expectEnabled:      true,
+		},
+		{
+			name:               "Disabling FastLeaseKeepAlive should pass",
+			serverFeatureGates: "FastLeaseKeepAlive=false",
+			expectEnabled:      false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := *NewConfig()
+			cfg.ServerFeatureGate.(featuregate.MutableFeatureGate).Set(tc.serverFeatureGates)
+			require.NoError(t, cfg.Validate())
+			require.Equal(t, tc.expectEnabled, cfg.ServerFeatureGate.Enabled(features.FastLeaseKeepAlive))
 		})
 	}
 }

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -74,6 +74,11 @@ const (
 	// alpha: v3.6
 	// main PR: https://github.com/etcd-io/etcd/pull/17661
 	SetMemberLocalAddr featuregate.Feature = "SetMemberLocalAddr"
+	// FastLeaseKeepAlive enables lease renewal to skip waiting for the applied index.
+	// owner: @aaronjzhang
+	// beta: v3.7
+	// main PR: https://github.com/etcd-io/etcd/pull/20589
+	FastLeaseKeepAlive featuregate.Feature = "FastLeaseKeepAlive"
 )
 
 var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -84,6 +89,7 @@ var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LeaseCheckpoint:              {Default: false, PreRelease: featuregate.Alpha},
 	LeaseCheckpointPersist:       {Default: false, PreRelease: featuregate.Alpha},
 	SetMemberLocalAddr:           {Default: false, PreRelease: featuregate.Alpha},
+	FastLeaseKeepAlive:           {Default: true, PreRelease: featuregate.Beta},
 }
 
 func NewDefaultServerFeatureGate(name string, lg *zap.Logger) featuregate.FeatureGate {

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -24,21 +24,72 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestCtlV3LeaseKeepAlive(t *testing.T) { testCtl(t, leaseTestKeepAlive) }
+func TestCtlV3LeaseKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigAutoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigAutoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
 func TestCtlV3LeaseKeepAliveNoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigNoTLS()))
+	cfg := e2e.NewConfigNoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveNoTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigNoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAliveClientTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientTLS()))
+	cfg := e2e.NewConfigClientTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveClientTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigClientTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAliveClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientAutoTLS()))
+	cfg := e2e.NewConfigClientAutoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveClientAutoTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigClientAutoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAlivePeerTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigPeerTLS()))
+	cfg := e2e.NewConfigPeerTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAlivePeerTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigPeerTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func enableFastLeaseKeepAlive(cfg *e2e.EtcdProcessClusterConfig) {
+	e2e.WithServerFeatureGate("FastLeaseKeepAlive", true)(cfg)
+}
+
+func disableFastLeaseKeepAlive(cfg *e2e.EtcdProcessClusterConfig) {
+	e2e.WithServerFeatureGate("FastLeaseKeepAlive", false)(cfg)
 }
 
 func leaseTestKeepAlive(cx ctlCtx) {


### PR DESCRIPTION
This change fixes the issue where excessive "apply request took too long" warnings can potentially block all lease keep-alive operations which is discussed in #18100 . The changes mitigates this impact while preserving system correctness:

1. Lease Not Found Handling: When a lease is not found, it might be undergoing application processing. We wait for the applied index to advance to confirm whether the lease truly doesn't exist, preventing false negatives.

2. Revoking Lease Handling: When a lease is found but in revoking state, the revoke request has been committed but not yet applied. Allowing the current renewal to proceed doesn't compromise correctness since the lease will still be properly revoked once the revoke request is applied.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
