### PR TITLE
dependency: lock antithesis-trigger-action to v0.9

### DIFF
--- a/.github/workflows/antithesis-test.yml
+++ b/.github/workflows/antithesis-test.yml
@@ -82,7 +82,7 @@ jobs:
           docker push $IMAGE
 
       - name: Run Antithesis Tests
-        uses: antithesishq/antithesis-trigger-action@6c0a27302c0a3cd97d87d40bd6704e673abed4bb # main commit on Mar 13, 2025
+        uses: antithesishq/antithesis-trigger-action@6c0a27302c0a3cd97d87d40bd6704e673abed4bb # v0.9
         with:
           notebook_name: etcd
           tenant: linuxfoundation


### PR DESCRIPTION
This is just metadata for Dependabot. The release v0.9 has the same commit as what we were using. Reference: https://github.com/antithesishq/antithesis-trigger-action/releases/tag/v0.9.



Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
