### PR TITLE
make verify_golangci-lint_version.sh output more friendly

### DIFF
--- a/scripts/verify_golangci-lint_version.sh
+++ b/scripts/verify_golangci-lint_version.sh
@@ -27,7 +27,13 @@ if [ -z "$GOLANGCI_LINT_PRESENT" ]; then
     install_golangci_lint
     exit 0
 fi
-GOLANGCI_LINT_INSTALLED=v$(golangci-lint version | grep -oP 'version \K[0-9.]+')
+GOLANGCI_LINT_INSTALLED=v$(golangci-lint version | grep -oP 'version \K[0-9.]+' 2>&1)
+
+# Check if the result contains "invalid option" which may happen on macOS with outdated grep
+if [[ "$GOLANGCI_LINT_INSTALLED" == *"invalid option"* ]]; then
+    echo "If you are on Mac, run: brew install grep."
+    exit 1
+fi
 
 if [ "$GOLANGCI_LINT_VERSION" != "$GOLANGCI_LINT_INSTALLED" ]; then
     echo "different golangci-lint version installed: $GOLANGCI_LINT_INSTALLED"


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

default grep on darwin arm64 does not recognize `-P` flag, so `make verify-lint` will try to re-install golangci-lint everytime `verify_golangci-lint_version.sh` is executed.
```
make verify-lint
./scripts/verify_golangci-lint_version.sh
golangci-lint version: v1.64.8
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
different golangci-lint version installed: v
Installing golangci-lint v1.64.8
```

This PR checks whether the error is caused by `grep`, and suggests users to install the correct version of `grep`.