### PR TITLE
Consider adding an iterator-based version of List to Kubernetes client interface

### DIFF
--- a/client/v3/kubernetes/interface.go
+++ b/client/v3/kubernetes/interface.go
@@ -16,6 +16,7 @@ package kubernetes
 
 import (
 	"context"
+	"iter"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -40,6 +41,14 @@ type Interface interface {
 	// specified by it. When paginating, the Continue value should be set
 	// to the last observed key with "\x00" appended to it.
 	List(ctx context.Context, prefix string, opts ListOptions) (ListResponse, error)
+
+	// ListIter returns an iterator over key-value pairs with the specified prefix,
+	// ordered lexicographically by key.
+	//
+	// It seamlessly requests further pages and passes individual key-value pairs
+	// via the returned iterator. Instead of a direct error, it returns a function
+	// to get an error, which should be checked after completing the iteration.
+	ListIter(ctx context.Context, prefix string, opts ListOptions) (iter.Seq[*mvccpb.KeyValue], func() error)
 
 	// Count returns the number of keys with the specified prefix.
 	//

--- a/client/v3/kubernetes/interface.go
+++ b/client/v3/kubernetes/interface.go
@@ -42,13 +42,14 @@ type Interface interface {
 	// to the last observed key with "\x00" appended to it.
 	List(ctx context.Context, prefix string, opts ListOptions) (ListResponse, error)
 
-	// ListIter returns an iterator over key-value pairs with the specified prefix,
-	// ordered lexicographically by key.
+	// ListIter returns an iterator over key-value pairs with the specified
+	// prefix, ordered lexicographically by key.
 	//
-	// It seamlessly requests further pages and passes individual key-value pairs
-	// via the returned iterator. Instead of a direct error, it returns a function
-	// to get an error, which should be checked after completing the iteration.
-	ListIter(ctx context.Context, prefix string, opts ListOptions) (iter.Seq[*mvccpb.KeyValue], func() error)
+	// It seamlessly requests further pages and passes individual key-value
+	// pairs via the returned iterator. The provided Limit in ListOptions is the
+	// size of the page. The caller should check for error stored in
+	// ListResponseErr.Err before processing the key-pair.
+	ListIter(ctx context.Context, prefix string, opts ListOptions) iter.Seq2[*mvccpb.KeyValue, ListResponseErr]
 
 	// Count returns the number of keys with the specified prefix.
 	//
@@ -88,6 +89,11 @@ type ListOptions struct {
 	// It should be set to the last key from a previous ListResponse
 	// with "\x00" appended to it when paginating.
 	Continue string
+}
+
+type ListResponseErr struct {
+	ListResponse
+	Err error
 }
 
 // CountOptions is a placeholder for potential future options for the Count operation.


### PR DESCRIPTION
There is at least one place where page handling logic of `List` is duplicated. For example when sending the initial list of items in k8s watch: https://github.com/kubernetes/kubernetes/blob/v1.34.0/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go#L267-L325. It can't use the existing [GetList](https://github.com/kubernetes/kubernetes/blob/v1.34.0/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L717-L899), because `sync` is optimized in two ways:
1. It requests pages so it doesn't need to store unbounded number of items (by default: `10_000`)
2. It removes references to key-value pairs after they were processed

In the first version of `ListIter` the client may process the list and then check for error:
```go
items, getErr := client.ListIter(ctx, "/registry/pods/", kubernetes.ListOptions{Limit: 1_000})
for item := range items {
  // process the item
}
err := getErr()
if err != nil {
  return fmt.Errorf("list pods: %w", err)
}
return nil
```

In the second (current) version the error handling is moved to within the loop with added benefit of access to `ListResponse`:
```go
for item, respErr := range client.ListIter(ctx, "/registry/pods/", kubernetes.ListOptions{Limit: 1_000}) {
  if respErr.Err != nil {
    // maybe use respErr.ListResponse to retry
    return fmt.Errorf("list pods: %w", err)
  }
  // process the item
}
return nil
```

The goal of this PR is discussion. Quality code (and tests) will be done in a separate PR once an agreement is reached.