### PR TITLE
cache: make the cache progress-aware

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -271,13 +271,7 @@ func (c *Cache) applyStorage(storeW *watcher) error {
 			if !ok {
 				return nil
 			}
-			if resp.Canceled {
-				return nil
-			}
-			if len(resp.Events) == 0 {
-				continue
-			}
-			if err := c.store.Apply(resp.Events); err != nil {
+			if err := c.store.Apply(resp); err != nil {
 				return err
 			}
 		}

--- a/cache/demux_test.go
+++ b/cache/demux_test.go
@@ -263,6 +263,7 @@ func TestBroadcastBatching(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := newDemux(16, 10*time.Millisecond)
 			w := newWatcher(len(tt.input)+1, nil)
+			d.Init(1)
 			d.Register(w, 0)
 
 			d.Broadcast(respWithEventRevs(tt.input...))
@@ -311,6 +312,7 @@ func TestSlowWatcherResync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := newDemux(16, 10*time.Millisecond)
 			w := newWatcher(1, nil)
+			d.Init(1)
 			d.Register(w, 0)
 
 			d.Broadcast(respWithEventRevs(tt.input...))

--- a/cache/store_test.go
+++ b/cache/store_test.go
@@ -281,7 +281,8 @@ func TestStoreApply(t *testing.T) {
 
 			var gotErr error
 			for batchIndex, batch := range test.eventBatches {
-				if err := s.Apply(batch); err != nil {
+				resp := clientv3.WatchResponse{Events: batch}
+				if err := s.Apply(resp); err != nil {
 					gotErr = err
 					if !test.expectErr {
 						t.Fatalf("Apply(batch %d) unexpected error: %v", batchIndex, err)
@@ -397,7 +398,8 @@ func TestRestoreAppendCloneImmutability(t *testing.T) {
 				s.Restore(test.initialKVs, test.initialRev)
 			}
 			if len(test.events) > 0 {
-				if err := s.Apply(test.events); err != nil {
+				resp := clientv3.WatchResponse{Events: test.events}
+				if err := s.Apply(resp); err != nil {
 					t.Fatalf("Apply failed: %v", err)
 				}
 			}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

As pre-requisite of consistent reads from cache, this PR attempts to make the cache progress-aware. That includes:

- added `demux.progressRev` to capture progress notifications so the cache can prove freshness even without new events. Thinking that `demux` is the natural owner as it processes watch responses and serves watchers (though consistent reads will be serving applied state, so will need to figure how to unify semantics in future).  

- `demux.progressRev` is set to 0 on upstream compaction/errors (But we are still serving cached snapshot during rebuild period as in #20476

- modified `WaitForRevision` to temporarily read both `demux.progressRev` and the store’s applied revision; again, probably need to consolidate this in future.

@serathius @MadhavJivrajani 
