### PR TITLE
Reduce the antithesis docker image footprint

### DIFF
--- a/tests/antithesis/server/Dockerfile
+++ b/tests/antithesis/server/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.24.6
 ARG ARCH=amd64
 
-FROM golang:$GO_VERSION
+FROM golang:$GO_VERSION AS build
 
 # cloning etcd
 ARG REF=main
@@ -39,7 +39,6 @@ RUN cp -r /etcd_instrumented/symbols/* /symbols
 
 EXPOSE 2379 2380
 
-# start etcd server
 WORKDIR /etcd_instrumented/customer
 
 # Some previous versions hardcode CGO_ENABLED=0
@@ -54,4 +53,8 @@ RUN for d in server etcdutl etcdctl; do (cd ${d} && go mod tidy || true); done
 # The instrumentation also adds a new main file which clashes with dummy.go found in non release-3.4 branches
 RUN if [ -f "dummy.go" ]; then sed -i 's/package main_test/package main/' dummy.go; fi
 RUN CGO_ENABLED=1 make build
-CMD ["./bin/etcd"]
+
+FROM ubuntu:24.04
+COPY --from=build /etcd_instrumented/ /etcd
+
+CMD ["/etcd/customer/bin/etcd"]

--- a/tests/antithesis/test-template/Dockerfile
+++ b/tests/antithesis/test-template/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_VERSION=1.24.6
 ARG ARCH=amd64
 
-FROM golang:$GO_VERSION
+FROM golang:$GO_VERSION AS build
 ARG CFG_NODE_COUNT=3
 WORKDIR /build
 COPY . .
@@ -10,3 +10,6 @@ WORKDIR /build/tests
 RUN go build -ldflags "-X main.NodeCount=$CFG_NODE_COUNT" -o /opt/antithesis/entrypoint/entrypoint -race ./antithesis/test-template/entrypoint/main.go
 RUN go build -ldflags "-X main.NodeCount=$CFG_NODE_COUNT" -o /opt/antithesis/test/v1/robustness/singleton_driver_traffic -race ./antithesis/test-template/robustness/traffic/main.go
 RUN go build -ldflags "-X main.NodeCount=$CFG_NODE_COUNT" -o /opt/antithesis/test/v1/robustness/finally_validation -race ./antithesis/test-template/robustness/finally/main.go
+
+FROM ubuntu:24.04
+COPY --from=build /opt/ /opt/


### PR DESCRIPTION
Reduce the image size of the client and server used in antithesis tests.  Currently each of them is ~2GB.  With this change, each of them takes up less than 100MB.

```
REPOSITORY                                             TAG                                        IMAGE ID       CREATED         SIZE
etcd-client                                            latest                                     6d4d890aa661   5 minutes ago   93MB
etcd-server                                            latest                                     6921ccd8241a   7 minutes ago   39.7MB
```

@serathius 