### PR TITLE
[Robustness test] Fix an accidental editing of a log line in the robustness test report

### DIFF
--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -43,7 +43,7 @@ func (r *TestReport) Report(path string) error {
 	}
 	for server, dataPath := range r.ServersDataPath {
 		serverReportPath := filepath.Join(path, fmt.Sprintf("server-%s", server))
-		r.Logger.Info("Saving member data directory", zap.String("member", server), zap.String("path", serverReportPath))
+		r.Logger.Info("Saving member data dir", zap.String("member", server), zap.String("data-dir", dataPath), zap.String("path", serverReportPath))
 		if err := os.CopyFS(serverReportPath, os.DirFS(dataPath)); err != nil {
 			return err
 		}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Thanks to @ivanvc for flagging this (https://github.com/etcd-io/etcd/pull/20575#discussion_r2343274820). 

The error stemmed from my rebasing error. Sorry about this.