### PR TITLE
 benchmark: Minor tweaks to make the perfdash data more parseable

### DIFF
--- a/pkg/report/perfdash.go
+++ b/pkg/report/perfdash.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -30,7 +31,7 @@ type Metrics struct {
 }
 
 type Labels struct {
-	Metric string `json:"Metric"`
+	Operation string `json:"Operation"`
 }
 
 type DataItem struct {
@@ -44,7 +45,7 @@ type perfdashFormattedReport struct {
 	DataItems []DataItem `json:"dataItems"`
 }
 
-func (r *report) writePerfDashReport(reportName string) {
+func (r *report) writePerfDashReport(benchmarkOp string) {
 	pcls, data := Percentiles(r.stats.Lats)
 	pclsData := make(map[float64]float64)
 	for i := 0; i < len(pcls); i++ {
@@ -61,7 +62,7 @@ func (r *report) writePerfDashReport(reportName string) {
 				},
 				Unit: "ms",
 				Labels: Labels{
-					Metric: "APIResponsiveness",
+					Operation: strings.ToUpper(benchmarkOp),
 				},
 			},
 		},
@@ -73,7 +74,7 @@ func (r *report) writePerfDashReport(reportName string) {
 		artifactsDir = "./_artifacts"
 	}
 
-	fileName := fmt.Sprintf("etcd_perf_%s_%s.json", reportName, time.Now().UTC().Format(time.RFC3339))
+	fileName := fmt.Sprintf("EtcdAPI_benchmark_%s.json", time.Now().UTC().Format(time.RFC3339))
 	err := os.MkdirAll(artifactsDir, 0o755)
 	if err != nil {
 		fmt.Println("Error creating artifacts directory:", err)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -42,7 +42,7 @@ func (res *Result) Duration() time.Duration { return res.End.Sub(res.Start) }
 
 type report struct {
 	generatePerfReport bool
-	reportName         string
+	benchmarkOp        string
 	precision          string
 	results            chan Result
 
@@ -83,23 +83,23 @@ type Report interface {
 	Stats() <-chan Stats
 }
 
-func NewReport(precision, reportName string, generatePerfReport bool) Report {
-	return newReport(precision, reportName, generatePerfReport)
+func NewReport(precision, benchmarkOp string, generatePerfReport bool) Report {
+	return newReport(precision, benchmarkOp, generatePerfReport)
 }
 
-func newReport(precision, reportName string, generatePerfReport bool) *report {
+func newReport(precision, benchmarkOp string, generatePerfReport bool) *report {
 	r := &report{
 		results:            make(chan Result, 16),
 		precision:          precision,
 		generatePerfReport: generatePerfReport,
-		reportName:         reportName,
+		benchmarkOp:        benchmarkOp,
 	}
 	r.stats.ErrorDist = make(map[string]int)
 	return r
 }
 
-func NewReportSample(precision, reportName string, generatePerfReport bool) Report {
-	r := NewReport(precision, reportName, generatePerfReport).(*report)
+func NewReportSample(precision, benchmarkOp string, generatePerfReport bool) Report {
+	r := NewReport(precision, benchmarkOp, generatePerfReport).(*report)
 	r.sps = newSecondPoints()
 	return r
 }
@@ -112,7 +112,7 @@ func (r *report) Run() <-chan string {
 		defer close(donec)
 		r.processResults()
 		if r.generatePerfReport {
-			r.writePerfDashReport(r.reportName)
+			r.writePerfDashReport(r.benchmarkOp)
 		}
 		donec <- r.String()
 	}()
@@ -164,8 +164,8 @@ func (r *report) sec2str(sec float64) string { return fmt.Sprintf(r.precision+" 
 
 type reportRate struct{ *report }
 
-func NewReportRate(precision, reportName string, generatePerfReport bool) Report {
-	return &reportRate{NewReport(precision, reportName, generatePerfReport).(*report)}
+func NewReportRate(precision, benchmarkOp string, generatePerfReport bool) Report {
+	return &reportRate{NewReport(precision, benchmarkOp, generatePerfReport).(*report)}
 }
 
 func (r *reportRate) String() string {

--- a/pkg/report/weighted.go
+++ b/pkg/report/weighted.go
@@ -30,10 +30,10 @@ type weightedReport struct {
 
 // NewWeightedReport returns a report that includes
 // both weighted and unweighted statistics.
-func NewWeightedReport(r Report, precision, reportName string, generatePerfReport bool) Report {
+func NewWeightedReport(r Report, precision, benchmarkOp string, generatePerfReport bool) Report {
 	return &weightedReport{
 		baseReport: r,
-		report:     newReport(precision, reportName, generatePerfReport),
+		report:     newReport(precision, benchmarkOp, generatePerfReport),
 		results:    make(chan Result, 16),
 	}
 }

--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -157,24 +157,24 @@ func mustRandBytes(n int) []byte {
 	return rb
 }
 
-func newReport(reportName string) report.Report {
+func newReport(benchmarkOp string) report.Report {
 	p := "%4.4f"
 	if precise {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p, reportName, generatePerfReport)
+		return report.NewReportSample(p, benchmarkOp, generatePerfReport)
 	}
-	return report.NewReport(p, reportName, generatePerfReport)
+	return report.NewReport(p, benchmarkOp, generatePerfReport)
 }
 
-func newWeightedReport(reportName string) report.Report {
+func newWeightedReport(benchmarkOp string) report.Report {
 	p := "%4.4f"
 	if precise {
 		p = "%g"
 	}
 	if sample {
-		return report.NewReportSample(p, reportName, generatePerfReport)
+		return report.NewReportSample(p, benchmarkOp, generatePerfReport)
 	}
-	return report.NewWeightedReport(report.NewReport(p, reportName, generatePerfReport), p, reportName, generatePerfReport)
+	return report.NewWeightedReport(report.NewReport(p, benchmarkOp, generatePerfReport), p, benchmarkOp, generatePerfReport)
 }


### PR DESCRIPTION
This PR contains changes related to a discussion on perf-tests to allow multiple sections of the benchmark report to be processed by the parser..
Ref: https://github.com/kubernetes/perf-tests/pull/3592

Sample updated perfdash report:
```
#cat _artifacts/EtcdAPI_benchmark_2025-09-14T08:07:21Z.json

{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Perc50": 5.1265,
        "Perc90": 6.3797,
        "Perc99": 16.0841
      },
      "labels": {
        "Operation": "PUT"
      },
      "unit": "ms"
    }
  ]
}
```