### PR TITLE
[Robustness test] Refactor RunTrafficLoop, RunCompactLoop, and CollectClusterWatchEvents in Robustness test.

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -167,7 +167,13 @@ func runScenario(ctx context.Context, t *testing.T, s scenarios.TestScenario, lg
 	defer watchSet.Close()
 	g.Go(func() error {
 		endpoints := processEndpoints(clus)
-		err := client.CollectClusterWatchEvents(ctx, lg, endpoints, maxRevisionChan, s.Watch, watchSet)
+		err := client.CollectClusterWatchEvents(ctx, client.CollectClusterWatchEventsParam{
+			Lg:              lg,
+			Endpoints:       endpoints,
+			MaxRevisionChan: maxRevisionChan,
+			Cfg:             s.Watch,
+			ClientSet:       watchSet,
+		})
 		return err
 	})
 	err := g.Wait()


### PR DESCRIPTION
In light of the ever-increasing number of configuration options that we have passed in and will be passing in, a refactoring is performed for improving readability and maintainability.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
