### PR TITLE
Implement a feature to periodically open watches in robustness test and make it configurable

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -33,6 +33,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/antithesis/test-template/robustness/common"
 	"go.etcd.io/etcd/tests/v3/robustness/client"
 	"go.etcd.io/etcd/tests/v3/robustness/identity"
+	"go.etcd.io/etcd/tests/v3/robustness/options"
 	robustnessrand "go.etcd.io/etcd/tests/v3/robustness/random"
 	"go.etcd.io/etcd/tests/v3/robustness/report"
 	"go.etcd.io/etcd/tests/v3/robustness/traffic"
@@ -46,6 +47,10 @@ var (
 		MemberClientCount:              3,
 		ClusterClientCount:             1,
 		MaxNonUniqueRequestConcurrency: 3,
+		BackgroundWatchConfig: options.BackgroundWatchConfig{
+			Interval:       0,
+			RevisionOffset: 0,
+		},
 	}
 	trafficNames = []string{
 		"etcd",
@@ -121,11 +126,12 @@ func runTraffic(ctx context.Context, lg *zap.Logger, tf traffic.Traffic, hosts [
 	defer watchSet.Close()
 	g.Go(func() error {
 		err := client.CollectClusterWatchEvents(ctx, client.CollectClusterWatchEventsParam{
-			Lg:              lg,
-			Endpoints:       hosts,
-			MaxRevisionChan: maxRevisionChan,
-			Cfg:             watchConfig,
-			ClientSet:       watchSet,
+			Lg:                    lg,
+			Endpoints:             hosts,
+			MaxRevisionChan:       maxRevisionChan,
+			Cfg:                   watchConfig,
+			ClientSet:             watchSet,
+			BackgroundWatchConfig: profile.BackgroundWatchConfig,
 		})
 		return err
 	})

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -168,11 +168,12 @@ func runScenario(ctx context.Context, t *testing.T, s scenarios.TestScenario, lg
 	g.Go(func() error {
 		endpoints := processEndpoints(clus)
 		err := client.CollectClusterWatchEvents(ctx, client.CollectClusterWatchEventsParam{
-			Lg:              lg,
-			Endpoints:       endpoints,
-			MaxRevisionChan: maxRevisionChan,
-			Cfg:             s.Watch,
-			ClientSet:       watchSet,
+			Lg:                    lg,
+			Endpoints:             endpoints,
+			MaxRevisionChan:       maxRevisionChan,
+			Cfg:                   s.Watch,
+			ClientSet:             watchSet,
+			BackgroundWatchConfig: s.Profile.BackgroundWatchConfig,
 		})
 		return err
 	})

--- a/tests/robustness/options/options.go
+++ b/tests/robustness/options/options.go
@@ -1,0 +1,22 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import "time"
+
+type BackgroundWatchConfig struct {
+	Interval       time.Duration
+	RevisionOffset int64
+}

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -28,6 +28,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/robustness/client"
 	"go.etcd.io/etcd/tests/v3/robustness/identity"
 	"go.etcd.io/etcd/tests/v3/robustness/model"
+	"go.etcd.io/etcd/tests/v3/robustness/options"
 	"go.etcd.io/etcd/tests/v3/robustness/report"
 	"go.etcd.io/etcd/tests/v3/robustness/validate"
 )
@@ -295,6 +296,7 @@ type Profile struct {
 	ClusterClientCount             int
 	ForbidCompaction               bool
 	CompactPeriod                  time.Duration
+	options.BackgroundWatchConfig
 }
 
 func (p Profile) WithoutCompaction() Profile {
@@ -304,6 +306,16 @@ func (p Profile) WithoutCompaction() Profile {
 
 func (p Profile) WithCompactionPeriod(cp time.Duration) Profile {
 	p.CompactPeriod = cp
+	return p
+}
+
+func (p Profile) WithBackgroundWatchConfigInterval(interval time.Duration) Profile {
+	p.BackgroundWatchConfig.Interval = interval
+	return p
+}
+
+func (p Profile) WithBackgroundWatchConfigRevisionOffset(offset int64) Profile {
+	p.BackgroundWatchConfig.RevisionOffset = offset
 	return p
 }
 


### PR DESCRIPTION
Evolved the [code](https://github.com/serathius/etcd/blob/52673cee64e7da995f4bc700977a88a21a304066/tests/robustness/client/watch.go) from Marek based on the work we did together on Sep. 12, 2025, and based on https://github.com/etcd-io/etcd/pull/20234 and https://github.com/etcd-io/etcd/issues/20221#issuecomment-3013240962 from Marek, we settled on those 2 configuration options for future robustness test use cases.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Parent issue: https://github.com/etcd-io/etcd/issues/20349

