### PR TITLE
etcdclient: remove Metadata field from Endpoint struct

### DIFF
--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -28,13 +28,6 @@ type Endpoint struct {
 	// Addr is the server address on which a connection will be established.
 	// Since etcd 3.1
 	Addr string
-
-	// Metadata is the information associated with Addr, which may be used
-	// to make load balancing decision.
-	// Since etcd 3.1
-	//
-	// Deprecated: The field is deprecated and will be removed in 3.7.
-	Metadata any
 }
 
 type Operation uint8

--- a/client/v3/naming/endpoints/endpoints_impl.go
+++ b/client/v3/naming/endpoints/endpoints_impl.go
@@ -63,9 +63,8 @@ func (m *endpointManager) Update(ctx context.Context, updates []*UpdateWithOpts)
 		switch update.Op {
 		case Add:
 			internalUpdate := &internal.Update{
-				Op:       internal.Add,
-				Addr:     update.Endpoint.Addr,
-				Metadata: update.Endpoint.Metadata,
+				Op:   internal.Add,
+				Addr: update.Endpoint.Addr,
 			}
 
 			var v []byte
@@ -109,7 +108,7 @@ func (m *endpointManager) NewWatchChannel(ctx context.Context) (WatchChannel, er
 		up := &Update{
 			Op:       Add,
 			Key:      string(kv.Key),
-			Endpoint: Endpoint{Addr: iup.Addr, Metadata: iup.Metadata},
+			Endpoint: Endpoint{Addr: iup.Addr},
 		}
 		initUpdates = append(initUpdates, up)
 	}
@@ -162,7 +161,7 @@ func (m *endpointManager) watch(ctx context.Context, rev int64, upch chan []*Upd
 				default:
 					continue
 				}
-				up := &Update{Op: op, Key: string(e.Kv.Key), Endpoint: Endpoint{Addr: iup.Addr, Metadata: iup.Metadata}}
+				up := &Update{Op: op, Key: string(e.Kv.Key), Endpoint: Endpoint{Addr: iup.Addr}}
 				deltaUps = append(deltaUps, up)
 			}
 			if len(deltaUps) > 0 {
@@ -186,7 +185,7 @@ func (m *endpointManager) List(ctx context.Context) (Key2EndpointMap, error) {
 			continue
 		}
 
-		eps[string(kv.Key)] = Endpoint{Addr: iup.Addr, Metadata: iup.Metadata}
+		eps[string(kv.Key)] = Endpoint{Addr: iup.Addr}
 	}
 	return eps, nil
 }

--- a/client/v3/naming/resolver/resolver.go
+++ b/client/v3/naming/resolver/resolver.go
@@ -112,8 +112,7 @@ func convertToGRPCEndpoint(ups map[string]*endpoints.Update) []gresolver.Endpoin
 		ep := gresolver.Endpoint{
 			Addresses: []gresolver.Address{
 				{
-					Addr:     up.Endpoint.Addr,
-					Metadata: up.Endpoint.Metadata,
+					Addr: up.Endpoint.Addr,
 				},
 			},
 		}

--- a/server/proxy/grpcproxy/cluster.go
+++ b/server/proxy/grpcproxy/cluster.go
@@ -143,7 +143,7 @@ func (cp *clusterProxy) membersFromUpdates() ([]*pb.Member, error) {
 	defer cp.umu.RUnlock()
 	mbs := make([]*pb.Member, 0, len(cp.umap))
 	for _, upt := range cp.umap {
-		m, err := decodeMeta(fmt.Sprint(upt.Metadata))
+		m, err := decodeMeta(fmt.Sprint())
 		if err != nil {
 			return nil, err
 		}

--- a/server/proxy/grpcproxy/register.go
+++ b/server/proxy/grpcproxy/register.go
@@ -16,7 +16,6 @@ package grpcproxy
 
 import (
 	"encoding/json"
-	"os"
 
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
@@ -72,7 +71,7 @@ func registerSession(lg *zap.Logger, c *clientv3.Client, prefix string, addr str
 		ss.Close()
 		return nil, err
 	}
-	endpoint := endpoints.Endpoint{Addr: addr, Metadata: getMeta()}
+	endpoint := endpoints.Endpoint{Addr: addr}
 	if err = em.AddEndpoint(c.Ctx(), prefix+"/"+addr, endpoint, clientv3.WithLease(ss.Lease())); err != nil {
 		ss.Close()
 		return nil, err
@@ -89,12 +88,6 @@ func registerSession(lg *zap.Logger, c *clientv3.Client, prefix string, addr str
 // meta represents metadata of proxy register.
 type meta struct {
 	Name string `json:"name"`
-}
-
-func getMeta() string {
-	hostname, _ := os.Hostname()
-	bts, _ := json.Marshal(meta{Name: hostname})
-	return string(bts)
 }
 
 func decodeMeta(s string) (meta, error) {

--- a/tests/integration/clientv3/naming/endpoints_test.go
+++ b/tests/integration/clientv3/naming/endpoints_test.go
@@ -43,7 +43,7 @@ func TestEndpointManager(t *testing.T) {
 		t.Fatal("failed to establish watch", err)
 	}
 
-	e1 := endpoints.Endpoint{Addr: "127.0.0.1", Metadata: "metadata"}
+	e1 := endpoints.Endpoint{Addr: "127.0.0.1"}
 	err = em.AddEndpoint(t.Context(), "foo/a1", e1)
 	if err != nil {
 		t.Fatal("failed to add foo", err)
@@ -130,14 +130,14 @@ func TestEndpointManagerCRUD(t *testing.T) {
 
 	// Add
 	k1 := "foo/a1"
-	e1 := endpoints.Endpoint{Addr: "127.0.0.1", Metadata: "metadata1"}
+	e1 := endpoints.Endpoint{Addr: "127.0.0.1"}
 	err = em.AddEndpoint(t.Context(), k1, e1)
 	if err != nil {
 		t.Fatal("failed to add", k1, err)
 	}
 
 	k2 := "foo/a2"
-	e2 := endpoints.Endpoint{Addr: "127.0.0.2", Metadata: "metadata2"}
+	e2 := endpoints.Endpoint{Addr: "127.0.0.2"}
 	err = em.AddEndpoint(t.Context(), k2, e2)
 	if err != nil {
 		t.Fatal("failed to add", k2, err)
@@ -166,7 +166,7 @@ func TestEndpointManagerCRUD(t *testing.T) {
 
 	// Update
 	k3 := "foo/a3"
-	e3 := endpoints.Endpoint{Addr: "127.0.0.3", Metadata: "metadata3"}
+	e3 := endpoints.Endpoint{Addr: "127.0.0.3"}
 	updates := []*endpoints.UpdateWithOpts{
 		{Update: endpoints.Update{Op: endpoints.Add, Key: k3, Endpoint: e3}},
 		{Update: endpoints.Update{Op: endpoints.Delete, Key: k2}},


### PR DESCRIPTION
Remove Metadata field for 3.7 release.

Closes https://github.com/etcd-io/etcd/issues/19706

Maybe a new issue should be created since this entirely removes the `Metadata` field rather than only deprecating it.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

`make test-unit` all pass
`make test-integration` some failing
`make test-e2e` all pass