### PR TITLE
Add golang.org/x/tools/cmd/goimports tool dependency

### DIFF
--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -17,6 +17,7 @@ require (
 	go.etcd.io/gofail v0.2.0
 	go.etcd.io/protodoc v0.0.0-20180829002748-484ab544e116
 	go.etcd.io/raft/v3 v3.6.0
+	golang.org/x/tools v0.36.0
 	gotest.tools/gotestsum v1.13.0
 	gotest.tools/v3 v3.5.2
 	honnef.co/go/tools v0.6.1
@@ -241,7 +242,6 @@ require (
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
-	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/grpc v1.75.1 // indirect

--- a/tools/mod/tools.go
+++ b/tools/mod/tools.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/google/yamlfmt/cmd/yamlfmt"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
+	_ "golang.org/x/tools/cmd/goimports"
 	_ "gotest.tools/gotestsum"
 	_ "gotest.tools/v3"
 	_ "honnef.co/go/tools/cmd/staticcheck"


### PR DESCRIPTION
This missing dependency was caught by the weekly dependency bump from 2025-09-22 (#20703). Even though golang.org/x/tools/cmd/goimports is installed through `tools/mod`, it was never defined in that module.

The `verify-gen-proto` check fails with:

```bash
 Running gofast (gogo) proto generation...
% 'pushd' './server/storage/wal/walpb'
/tmp/twd.Y5hm7E/etcd/server/storage/wal/walpb /tmp/twd.Y5hm7E/etcd
% (cd server/storage/wal/walpb && 'protoc' '--gofast_out=plugins=grpc:.' '-I=.:/home/prow/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/..:/home/prow/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/proto/../protobuf:/tmp/twd.Y5hm7E/etcd/..:/home/prow/go/pkg/mod/go.etcd.io/raft/v3@v3.6.0/raftpb/..:/tmp/twd.Y5hm7E/etcd:/tmp/googleapi.QTbHM' '--gofast_opt=paths=source_relative,Mraftpb/raft.proto=go.etcd.io/raft/v3/raftpb,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor' '-I/home/prow/go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.2/protoc-gen-grpc-gateway/..' '--plugin=/home/prow/go/bin/protoc-gen-gofast' './record.proto')
              
% (cd server/storage/wal/walpb && 'gofmt' '-s' '-w' './record.pb.go')
% (cd tools/mod && 'go' 'install' 'golang.org/x/tools/cmd/goimports')
stderr: /home/prow/go/pkg/mod/golang.org/x/tools@v0.37.0/cmd/goimports/goimports.go:23:2: missing go.sum entry for module providing package golang.org/x/telemetry/counter (imported by golang.org/x/tools/cmd/goimports); to add:
stderr: go get golang.org/x/tools/cmd/goimports@v0.37.0
[0;31mFAIL: (code:1):
  % (cd tools/mod && 'go' 'install' 'golang.org/x/tools/cmd/goimports')
Failed to install tool 'golang.org/x/tools/cmd/goimports'
              
```

Prow failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/20703/pull-etcd-verify/1970948599852306432#

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
