### PR TITLE
refactor: use WaitGroup.Go to simplify code

### DIFF
--- a/contrib/raftexample/raftexample_test.go
+++ b/contrib/raftexample/raftexample_test.go
@@ -155,14 +155,12 @@ func TestCloseProposerInflight(t *testing.T) {
 	defer clus.closeNoErrors(t)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
 	// some inflight ops
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		clus.proposeC[0] <- "foo"
 		clus.proposeC[0] <- "bar"
-	}()
+	})
 
 	// wait for one message
 	if c, ok := <-clus.commitC[0]; !ok || c.data[0] != "foo" {

--- a/tools/benchmark/cmd/lease.go
+++ b/tools/benchmark/cmd/lease.go
@@ -65,14 +65,12 @@ func leaseKeepaliveFunc(cmd *cobra.Command, _ []string) {
 		}(clients[i])
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; i < leaseKeepaliveTotal; i++ {
 			requests <- struct{}{}
 		}
 		close(requests)
-	}()
+	})
 
 	rc := r.Run()
 	wg.Wait()

--- a/tools/benchmark/cmd/watch_latency.go
+++ b/tools/benchmark/cmd/watch_latency.go
@@ -76,9 +76,7 @@ func watchLatencyFunc(cmd *cobra.Command, _ []string) {
 
 	for i, wch := range wchs {
 		eventTimes[i] = make([]time.Time, watchLPutTotal)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			eventCount := 0
 			for eventCount < watchLPutTotal {
 				resp := <-wch
@@ -88,7 +86,7 @@ func watchLatencyFunc(cmd *cobra.Command, _ []string) {
 					bar.Increment()
 				}
 			}
-		}()
+		})
 	}
 
 	putReport := newReport(cmd.Name() + "-put")


### PR DESCRIPTION
use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796
