### PR TITLE
Add OpenTelemetry replacements for bespoke trace logging

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/sys v0.40.0
@@ -21,10 +23,13 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -9,6 +9,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/pkg/traceutil/exporter.go
+++ b/pkg/traceutil/exporter.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
+)
+
+// LogExporter writes Span to specified Logger.
+type LogExporter struct {
+	// Log is usually zap.Logger.Info.
+	Log func(msg string, fields ...zap.Field)
+}
+
+var _ trace.SpanExporter = (*LogExporter)(nil)
+
+// NewLogExporter creates a new LogExporter which will write Spans as Log messages.
+func NewLogExporter(logger *zap.Logger) *LogExporter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &LogExporter{Log: logger.Info}
+}
+
+func (e *LogExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan) error {
+	for _, span := range spans {
+		if span == nil {
+			continue
+		}
+		msg, fields := logSpan(span)
+		e.Log(msg, fields...)
+	}
+	return nil
+}
+
+func (e *LogExporter) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func logSpan(s trace.ReadOnlySpan) (string, []zap.Field) {
+	start := s.StartTime()
+	end := s.EndTime()
+	duration := end.Sub(start)
+	events := s.Events()
+	steps := make([]string, 0, len(events))
+	slices.SortFunc(events, func(a, b trace.Event) int {
+		return a.Time.Compare(b.Time)
+	})
+	for _, event := range events {
+		step := fmt.Sprintf("%s %s [+%.3fms]",
+			event.Name, writeAttrs(event.Attributes), float64(event.Time.Sub(start).Microseconds())/1_000)
+		steps = append(steps, step)
+	}
+	msg := fmt.Sprintf("trace[%s] %s", s.SpanContext().SpanID().String(), s.Name())
+
+	return msg, []zap.Field{
+		zap.String("detail", writeAttrs(s.Attributes())),
+		zap.Duration("duration", duration),
+		zap.Time("start", s.StartTime()),
+		zap.Time("end", s.EndTime()),
+		zap.Strings("steps", steps),
+		zap.Int("step_count", len(steps)),
+	}
+}
+
+func writeAttrs(attrs []attribute.KeyValue) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	var buf strings.Builder
+	buf.WriteString("{")
+	for _, attr := range attrs {
+		buf.WriteString(string(attr.Key))
+		buf.WriteString(":")
+		// As value may be controlled by the client, consider sanitization.
+		buf.WriteString(attr.Value.Emit())
+		buf.WriteString("; ")
+	}
+	buf.WriteString("}")
+	return buf.String()
+}

--- a/pkg/traceutil/exporter_test.go
+++ b/pkg/traceutil/exporter_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/pkg/v3/traceutil"
+)
+
+func TestLogSpan(t *testing.T) {
+	duration := 123 * time.Second
+
+	startTime, _ := time.Parse("2006-01-02 15:04:05", "2025-01-01 00:00:00")
+	endTime := startTime.Add(duration)
+
+	tests := []struct {
+		name       string
+		span       trace.ReadOnlySpan
+		wantMsg    string
+		wantFields []zap.Field
+	}{
+		{
+			name: "span_with_two_events",
+			span: tracetest.SpanStub{
+				Name:      "span_with_two_events",
+				StartTime: startTime,
+				EndTime:   endTime,
+				Attributes: []attribute.KeyValue{
+					attribute.String("key1", "value1"),
+					attribute.String("key2", "value2"),
+				},
+				Events: []trace.Event{
+					{
+						Time:       startTime.Add(1 * time.Second),
+						Name:       "event1",
+						Attributes: []attribute.KeyValue{attribute.String("key3", "value3")},
+					},
+					{
+						Time:       startTime.Add(2 * time.Second),
+						Name:       "event2",
+						Attributes: []attribute.KeyValue{attribute.String("key4", "value4")},
+					},
+				},
+			}.Snapshot(),
+			wantMsg: "trace[0000000000000000] span_with_two_events",
+			wantFields: []zap.Field{
+				zap.String("detail", "{key1:value1; key2:value2; }"),
+				zap.Duration("duration", duration),
+				zap.Time("start", startTime),
+				zap.Time("end", endTime),
+				zap.Strings("steps", []string{"event1 {key3:value3; } [+1000.000ms]", "event2 {key4:value4; } [+2000.000ms]"}),
+				zap.Int("step_count", 2),
+			},
+		},
+		{
+			name: "nil_span",
+			span: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := traceutil.LogExporter{
+				Log: func(msg string, fields ...zap.Field) {
+					assert.Equal(t, tt.wantMsg, msg)
+					assert.Equal(t, tt.wantFields, fields)
+				},
+			}
+			exporter.ExportSpans(t.Context(), []trace.ReadOnlySpan{tt.span})
+		})
+	}
+}

--- a/pkg/traceutil/processor.go
+++ b/pkg/traceutil/processor.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// LongSpanProcessor is a SpanProcessor that passes to SpanExporter only Spans
+// with a duration longer than Threshold and operation in Allowlist.
+type LongSpanProcessor struct {
+	trace.SpanExporter
+	// Threshold is the duration under which spans are not logged.
+	Threshold time.Duration
+	// Allowlist specifies operations for which a log may be emitted.
+	Allowlist map[string]bool
+}
+
+var _ trace.SpanProcessor = (*LongSpanProcessor)(nil)
+
+// NewLongSpanProcessor creates a new LongSpanProcessor which will pass to
+// SpanExporter all Spans with duration longer than Threshold and operation in
+// Allowlist.
+func NewLongSpanProcessor(exporter trace.SpanExporter, threshold time.Duration) *LongSpanProcessor {
+	return &LongSpanProcessor{
+		SpanExporter: exporter,
+		Threshold:    threshold,
+		Allowlist: map[string]bool{
+			"txn":          true,
+			"range":        true,
+			"put":          true,
+			"delete_range": true,
+			"compact":      true,
+			"lease_grant":  true,
+			"lease_revoke": true,
+		},
+	}
+}
+
+func (f LongSpanProcessor) OnStart(parent context.Context, s trace.ReadWriteSpan) {}
+func (f LongSpanProcessor) ForceFlush(_ context.Context) error                    { return nil }
+func (f LongSpanProcessor) OnEnd(s trace.ReadOnlySpan) {
+	if f.Threshold > 0 && s.EndTime().Sub(s.StartTime()) < f.Threshold {
+		return
+	}
+	if f.Allowlist != nil && !f.Allowlist[s.Name()] {
+		return
+	}
+	f.ExportSpans(context.Background(), []trace.ReadOnlySpan{s})
+}

--- a/pkg/traceutil/processor_test.go
+++ b/pkg/traceutil/processor_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traceutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"go.etcd.io/etcd/pkg/v3/traceutil"
+)
+
+func TestLogSpanThreshold(t *testing.T) {
+	startTime, _ := time.Parse("2006-01-02 15:04:05", "2025-01-01 00:00:00")
+	threshold := 60 * time.Second
+
+	tests := []struct {
+		span   trace.ReadOnlySpan
+		called bool
+	}{
+		{
+			span: tracetest.SpanStub{
+				Name:      "above_threshold",
+				StartTime: startTime,
+				EndTime:   startTime.Add(61 * time.Second),
+			}.Snapshot(),
+			called: true,
+		},
+		{
+			span: tracetest.SpanStub{
+				Name:      "on_threshold",
+				StartTime: startTime,
+				EndTime:   startTime.Add(60 * time.Second),
+			}.Snapshot(),
+			called: true,
+		},
+		{
+			span: tracetest.SpanStub{
+				Name:      "above_threshold",
+				StartTime: startTime,
+				EndTime:   startTime.Add(59 * time.Second),
+			}.Snapshot(),
+			called: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.span.Name(), func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			l := traceutil.LongSpanProcessor{
+				SpanExporter: exporter,
+				Threshold:    threshold,
+			}
+			l.OnEnd(tt.span)
+			got := exporter.GetSpans()
+			assert.Equal(t, tt.called, len(got) == 1)
+		})
+	}
+}
+
+func TestLogSpanAllowlist(t *testing.T) {
+	tests := []struct {
+		span   trace.ReadOnlySpan
+		called bool
+	}{
+		{
+			span: tracetest.SpanStub{
+				Name: "allowed",
+			}.Snapshot(),
+			called: true,
+		},
+		{
+			span: tracetest.SpanStub{
+				Name: "not_allowed",
+			}.Snapshot(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.span.Name(), func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			l := traceutil.LongSpanProcessor{
+				SpanExporter: exporter,
+				Allowlist: map[string]bool{
+					"allowed": true,
+				},
+			}
+			l.OnEnd(tt.span)
+			got := exporter.GetSpans()
+			assert.Equal(t, tt.called, len(got) == 1)
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/12460

`SpanProcessor` filters `Spans` to mimic behavior of `LogIfLong` and passes them to `SpanExporter`.

`SpanExporter` writes `Spans` to `zap.Logger` as `Info` messages while trying to keep the same format and contents as the original bespoke solution.

Currently, the only difference are "child traces" which are not yet instrumented in Etcd's OpenTelemetry tracing. This can be later mitigated by adding "links" or copying events between spans. I also have other ideas...