### PR TITLE
etcdserver: keep range request limit when sorting by key ascending

### DIFF
--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -67,7 +67,10 @@ func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *
 
 func rangeLimit(r *pb.RangeRequest) int64 {
 	limit := r.Limit
-	if r.SortOrder != pb.RangeRequest_NONE ||
+	// If the requested sort is anything other than sort by key in ascending order (the default order used by the backend),
+	// we need to fetch everything and sort it in memory.
+	if r.SortOrder != pb.RangeRequest_NONE &&
+		!(r.SortOrder == pb.RangeRequest_ASCEND && r.SortTarget == pb.RangeRequest_KEY) ||
 		r.MinModRevision != 0 || r.MaxModRevision != 0 ||
 		r.MinCreateRevision != 0 || r.MaxCreateRevision != 0 {
 		// fetch everything; sort and truncate afterwards


### PR DESCRIPTION
The rangeLimit function was incorrectly setting limit=0 (fetch everything)  for all sort operations, including the common case of sorting by key in  ascending order. Since the backend already returns keys in lexicographically  ascending order, we can preserve the limit for this case to improve  performance and reduce memory usage.

This change modifies the condition to only fetch everything when:
- Sort order is not NONE AND
- Sort is not by key in ascending order (the default backend order) OR
- Revision filters are applied

Fixes #20745
