### PR TITLE
Update kubernetes patches used in etcd-k8s coverage tests

### DIFF
--- a/tests/robustness/coverage/patches/kubernetes/0001-Add-Open-Telemetry-trace-event-when-passing-through-.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0001-Add-Open-Telemetry-trace-event-when-passing-through-.patch
@@ -1,13 +1,10 @@
-From 135c75d2689318dd47b7778b8f87902e75178d52 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aleksander Mistewicz <amistewicz@google.com>
 Date: Wed, 13 Aug 2025 13:45:20 +0200
 Subject: [PATCH 1/4] Add Open Telemetry trace event when passing through
  contract interface
 
 Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
----
- .../etcd/client/v3/kubernetes/client.go       | 21 +++++++++++++++++++
- 1 file changed, 21 insertions(+)
 
 diff --git a/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go b/vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go
 index 11f2a456447..0efab3711d7 100644
@@ -76,6 +73,3 @@ index 11f2a456447..0efab3711d7 100644
  	txn := k.KV.Txn(ctx).If(
  		clientv3.Compare(clientv3.ModRevision(key), "=", expectedRevision),
  	).Then(
--- 
-2.51.0.rc2.233.g662b1ed5c5-goog
-

--- a/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
@@ -1,4 +1,4 @@
-From 84706912128912a37bfaf47ecf550463fadb805e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aleksander Mistewicz <amistewicz@google.com>
 Date: Mon, 18 Aug 2025 12:32:16 +0200
 Subject: [PATCH 2/4] Add kubernetesEtcdContractTracker
@@ -9,11 +9,6 @@ spans. TracerProvider needs to be passed to the contract tracker to
 ensure that all spans will be correctly exported.
 
 Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
----
- .../etcd3/kubernetes_contract_tracker.go      | 73 +++++++++++++++++++
- .../storage/storagebackend/factory/etcd3.go   | 10 ++-
- 2 files changed, 82 insertions(+), 1 deletion(-)
- create mode 100644 staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go
 
 diff --git a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/kubernetes_contract_tracker.go
 new file mode 100644
@@ -95,7 +90,7 @@ index 00000000000..c16eecb20fa
 +	return k.Interface.OptimisticDelete(ctx, key, expectedRevision, opts)
 +}
 diff --git a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
-index c8ee0a12887..8f7f19d78d5 100644
+index 53fc9f97a70..8870369d471 100644
 --- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
 +++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
 @@ -351,8 +351,16 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
@@ -116,6 +111,3 @@ index c8ee0a12887..8f7f19d78d5 100644
  }
  
  type runningCompactor struct {
--- 
-2.51.0.rc2.233.g662b1ed5c5-goog
-

--- a/tests/robustness/coverage/patches/kubernetes/0003-Add-1m-timeout-to-Watch-to-ensure-Spans-are-exported.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0003-Add-1m-timeout-to-Watch-to-ensure-Spans-are-exported.patch
@@ -1,12 +1,9 @@
-From 2a848f904aee8cff04d44fd14d2c17a2802f972b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aleksander Mistewicz <amistewicz@google.com>
 Date: Fri, 22 Aug 2025 14:18:07 +0200
 Subject: [PATCH 3/4] Add 1m timeout to Watch to ensure Spans are exported
 
 Signed-off-by: Aleksander Mistewicz <amistewicz@google.com>
----
- vendor/go.etcd.io/etcd/client/v3/watch.go | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/vendor/go.etcd.io/etcd/client/v3/watch.go b/vendor/go.etcd.io/etcd/client/v3/watch.go
 index a46f98b8e28..ac820cabbb1 100644
@@ -21,6 +18,3 @@ index a46f98b8e28..ac820cabbb1 100644
  	wgs := &watchGRPCStream{
  		owner:      w,
  		remote:     w.remote,
--- 
-2.51.0.rc2.233.g662b1ed5c5-goog
-

--- a/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
@@ -1,26 +1,22 @@
-From 1a689e5bc18757ec1d9127b551585596cee5e679 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aleksander Mistewicz <amistewicz@google.com>
 Date: Mon, 4 Aug 2025 15:56:48 +0200
 Subject: [PATCH 4/4] Configure cmd tests
 
----
- hack/lib/etcd.sh            | 6 ++++--
- hack/make-rules/test-cmd.sh | 9 +++++++++
- 2 files changed, 13 insertions(+), 2 deletions(-)
 
 diff --git a/hack/lib/etcd.sh b/hack/lib/etcd.sh
-index c6fc45a5fab..1f4fad6774d 100755
+index 6e99d244c80..62af49e3e5c 100755
 --- a/hack/lib/etcd.sh
 +++ b/hack/lib/etcd.sh
-@@ -17,6 +17,8 @@
- # A set of helpers for starting/running etcd for tests
+@@ -25,6 +25,8 @@ ETCD_PORT=${ETCD_PORT:-2379}
+ ETCD_LOGLEVEL=${ETCD_LOGLEVEL:-warn}
+ export KUBE_INTEGRATION_ETCD_URL="http://${ETCD_HOST}:${ETCD_PORT}"
  
- ETCD_VERSION=${ETCD_VERSION:-3.6.4}
 +export PATH="${PATH}:/go/src/k8s.io/kubernetes/third_party/etcd"
 +
- ETCD_HOST=${ETCD_HOST:-127.0.0.1}
- ETCD_PORT=${ETCD_PORT:-2379}
- # This is intentionally not called ETCD_LOG_LEVEL:
+ kube::etcd::validate() {
+   # validate if in path
+   command -v etcd >/dev/null || {
 @@ -84,8 +86,8 @@ kube::etcd::start() {
    else
      ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
@@ -33,17 +29,16 @@ index c6fc45a5fab..1f4fad6774d 100755
  
    echo "Waiting for etcd to come up."
 diff --git a/hack/make-rules/test-cmd.sh b/hack/make-rules/test-cmd.sh
-index 7d9fb1db65c..179176533de 100755
+index 7d9fb1db65c..be3b95341bb 100755
 --- a/hack/make-rules/test-cmd.sh
 +++ b/hack/make-rules/test-cmd.sh
-@@ -69,6 +69,14 @@ function run_kube_apiserver() {
+@@ -69,6 +69,13 @@ function run_kube_apiserver() {
      VERSION_OVERRIDE="--version=$("${THIS_PLATFORM_BIN}/kube-apiserver" --version | awk '{print $2}')${CUSTOM_VERSION_SUFFIX:-}"
    fi
  
 +  cat <<EOF > "/tmp/kube-tracing-file"
 +apiVersion: apiserver.config.k8s.io/v1beta1
 +kind: TracingConfiguration
-+# default value
 +endpoint: 192.168.32.1:4317
 +samplingRatePerMillion: 1000000
 +EOF
@@ -51,7 +46,7 @@ index 7d9fb1db65c..179176533de 100755
    "${THIS_PLATFORM_BIN}/kube-apiserver" \
      ${VERSION_OVERRIDE:+"${VERSION_OVERRIDE}"} \
      --bind-address="127.0.0.1" \
-@@ -84,6 +92,7 @@ function run_kube_apiserver() {
+@@ -84,6 +91,7 @@ function run_kube_apiserver() {
      --service-account-issuer="https://kubernetes.default.svc" \
      --service-account-signing-key-file="${SERVICE_ACCOUNT_KEY}" \
      --storage-media-type="${KUBE_TEST_API_STORAGE_TYPE-}" \
@@ -59,6 +54,3 @@ index 7d9fb1db65c..179176533de 100755
      --cert-dir="${TMPDIR:-/tmp/}" \
      --service-cluster-ip-range="10.0.0.0/24" \
      --client-ca-file=hack/testdata/ca/ca.crt \
--- 
-2.51.0.rc2.233.g662b1ed5c5-goog
-


### PR DESCRIPTION
Used `git format-patch --no-signature --minimal -p --zero-commit` to make future patch diffs smaller and easier to maintain. Moved `PATH` override from `hack/lib/etcd.sh` to a file section that doesn't have frequent updates (context lines don't change).

Fixes:
```
Applying patches to Kubernetes repo...
/home/prow/go/src/k8s.io/kubernetes /home/prow/go/src/github.com/etcd-io/etcd/tests/robustness
error: patch failed: vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go:21
error: vendor/go.etcd.io/etcd/client/v3/kubernetes/client.go: patch does not apply
warning: recount: unexpected line: 2.51.0.rc2.233.g662b1ed5c5-goog
warning: recount: unexpected line: 2.51.0.rc2.233.g662b1ed5c5-goog
warning: recount: unexpected line: 2.51.0.rc2.233.g662b1ed5c5-goog
warning: recount: unexpected line: 2.51.0.rc2.233.g662b1ed5c5-goog
error: patch failed: hack/lib/etcd.sh:17
error: hack/lib/etcd.sh: patch does not apply
make: *** [Makefile:84: k8s-coverage] Error 1
```

Seen in: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-k8s-coverage-amd64/1974426341293953024

Tested locally with:
```
git clone https://github.com/kubernetes/kubernetes --depth 128 /tmp/kubernetes
KUBERNETES_REPO=/tmp/kubernetes make k8s-coverage
```

/cc @serathius 
