### PR TITLE
etcdctl: fix lease comparison in txn

### DIFF
--- a/etcdctl/ctlv3/command/txn_command.go
+++ b/etcdctl/ctlv3/command/txn_command.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
 )
@@ -222,7 +221,9 @@ func ParseCompare(line string) (*clientv3.Cmp, error) {
 	case "val", "value":
 		cmp = clientv3.Compare(clientv3.Value(key), op, val)
 	case "lease":
-		cmp = clientv3.Compare(clientv3.Cmp{Target: pb.Compare_LEASE}, op, val)
+		if v, err = strconv.ParseInt(val, 16, 64); err == nil {
+			cmp = clientv3.Compare(clientv3.LeaseValue(key), op, v)
+		}
 	default:
 		return nil, fmt.Errorf("malformed comparison: %s (unknown target %s)", line, target)
 	}


### PR DESCRIPTION
Added parse into hex for lease id in lease comparison in txn.

Fix https://github.com/etcd-io/etcd/issues/20773