### PR TITLE
Update go version for consistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/v3
 
-go 1.25.0
+go 1.25.1
 
 toolchain go1.25.1
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 // This is a generated file. Do not edit directly.
 
-go 1.25.0
+go 1.25.1
 
 toolchain go1.25.1
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd/tests/v3
 
-go 1.25.0
+go 1.25.1
 
 toolchain go1.25.1
 


### PR DESCRIPTION
The go versions in go.mod, go.work files are mismatched and causing the validation run in antithesis  #20781 to fail (see [here](https://github.com/etcd-io/etcd/actions/runs/18364418236/job/52314468005?pr=20781)).  Not sure if this is the right fix, but would love to hear your thoughts @joshjms @ivanvc.