### PR TITLE
Fix endpoint status not retuning the correct storage quota

### DIFF
--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -196,6 +196,7 @@ func (p *fieldsPrinter) EndpointStatus(eps []epStatus) {
 		fmt.Printf("\"StorageVersion\" : %q\n", ep.Resp.StorageVersion)
 		fmt.Println(`"DBSize" :`, ep.Resp.DbSize)
 		fmt.Println(`"DBSizeInUse" :`, ep.Resp.DbSizeInUse)
+		fmt.Println(`"DBSizeQuota" :`, ep.Resp.DbSizeQuota)
 		fmt.Println(`"Leader" :`, ep.Resp.Leader)
 		fmt.Println(`"IsLearner" :`, ep.Resp.IsLearner)
 		fmt.Println(`"RaftIndex" :`, ep.Resp.RaftIndex)

--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -32,6 +32,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/apply"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
 	serverversion "go.etcd.io/etcd/server/v3/etcdserver/version"
+	"go.etcd.io/etcd/server/v3/storage"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 	"go.etcd.io/etcd/server/v3/storage/schema"
@@ -269,6 +270,9 @@ func (ms *maintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (
 		IsLearner:        ms.cs.IsLearner(),
 		DbSizeQuota:      ms.cg.Config().QuotaBackendBytes,
 		DowngradeInfo:    &pb.DowngradeInfo{Enabled: false},
+	}
+	if resp.DbSizeQuota == 0 {
+		resp.DbSizeQuota = storage.DefaultQuotaBytes
 	}
 	if storageVersion := ms.vs.GetStorageVersion(); storageVersion != nil {
 		resp.StorageVersion = storageVersion.String()


### PR DESCRIPTION
In PR https://github.com/etcd-io/etcd/pull/17877, the endpoint status just returns the user configured quota. So it alway returns 0 when users do not configure it at all.

```
$ ./bin/etcdctl endpoint status -w table --cluster
+------------------------+------------------+---------+-----------------+---------+--------+-----------------------+-------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
|        ENDPOINT        |        ID        | VERSION | STORAGE VERSION | DB SIZE | IN USE | PERCENTAGE NOT IN USE | QUOTA | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | DOWNGRADE TARGET VERSION | DOWNGRADE ENABLED |
+------------------------+------------------+---------+-----------------+---------+--------+-----------------------+-------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
|  http://127.0.0.1:2379 | 8211f1d0f64f3269 |   3.6.4 |           3.6.0 |   98 kB |  98 kB |                    0% |   0 B |     false |      false |         2 |          8 |                  8 |        |                          |             false |
| http://127.0.0.1:22379 | 91bc3c398fb3c146 |   3.6.4 |           3.6.0 |   98 kB |  98 kB |                    0% |   0 B |      true |      false |         2 |          8 |                  8 |        |                          |             false |
| http://127.0.0.1:32379 | fd422379fda50e48 |   3.6.4 |           3.6.0 |   98 kB |  98 kB |                    0% |   0 B |     false |      false |         2 |          8 |                  8 |        |                          |             false |
+------------------------+------------------+---------+-----------------+---------+--------+-----------------------+-------+-----------+------------+-----------+------------+--------------------+--------+--------------------------+-------------------+
```

This PR fixes the issue, to ensure it always returns the correct real quota,

```
$ ./bin/etcdctl endpoint status -w table --cluster
┌────────────────────────┬──────────────────┬───────────────┬─────────────────┬─────────┬────────┬───────────────────────┬────────┬───────────┬────────────┬───────────┬────────────┬────────────────────┬────────┬──────────────────────────┬───────────────────┐
│        ENDPOINT        │        ID        │    VERSION    │ STORAGE VERSION │ DB SIZE │ IN USE │ PERCENTAGE NOT IN USE │ QUOTA  │ IS LEADER │ IS LEARNER │ RAFT TERM │ RAFT INDEX │ RAFT APPLIED INDEX │ ERRORS │ DOWNGRADE TARGET VERSION │ DOWNGRADE ENABLED │
├────────────────────────┼──────────────────┼───────────────┼─────────────────┼─────────┼────────┼───────────────────────┼────────┼───────────┼────────────┼───────────┼────────────┼────────────────────┼────────┼──────────────────────────┼───────────────────┤
│  http://127.0.0.1:2379 │ 8211f1d0f64f3269 │ 3.7.0-alpha.0 │           3.7.0 │   98 kB │  98 kB │                    0% │ 2.1 GB │      true │      false │        10 │         28 │                 28 │        │                          │             false │
│ http://127.0.0.1:22379 │ 91bc3c398fb3c146 │ 3.7.0-alpha.0 │           3.7.0 │   98 kB │  98 kB │                    0% │ 2.1 GB │     false │      false │        10 │         28 │                 28 │        │                          │             false │
│ http://127.0.0.1:32379 │ fd422379fda50e48 │ 3.7.0-alpha.0 │           3.7.0 │   98 kB │  98 kB │                    0% │ 2.1 GB │     false │      false │        10 │         28 │                 28 │        │                          │             false │
└────────────────────────┴──────────────────┴───────────────┴─────────────────┴─────────┴────────┴───────────────────────┴────────┴───────────┴────────────┴───────────┴────────────┴────────────────────┴────────┴──────────────────────────┴───────────────────┘
```

Previous PR also missed the `-w fields` format output, resolved it as well in this PR,

```
$ ./bin/etcdctl endpoint status -w fields --cluster 
"ClusterID" : 17237436991929493444
"MemberID" : 9372538179322589801
"Revision" : 1
"RaftTerm" : 12
"Version" : "3.7.0-alpha.0"
"StorageVersion" : "3.7.0"
"DBSize" : 98304
"DBSizeInUse" : 98304
"DbSizeQuota" : 2147483648
"Leader" : 10501334649042878790
"IsLearner" : false
"RaftIndex" : 33
"RaftTerm" : 12
"RaftAppliedIndex" : 33
"Errors" : []
"Endpoint" : "http://127.0.0.1:2379"
"DowngradeTargetVersion" : ""
"DowngradeEnabled" : false

"ClusterID" : 17237436991929493444
"MemberID" : 10501334649042878790
"Revision" : 1
"RaftTerm" : 12
"Version" : "3.7.0-alpha.0"
"StorageVersion" : "3.7.0"
"DBSize" : 98304
"DBSizeInUse" : 98304
"DbSizeQuota" : 2147483648
"Leader" : 10501334649042878790
"IsLearner" : false
"RaftIndex" : 33
"RaftTerm" : 12
"RaftAppliedIndex" : 33
"Errors" : []
"Endpoint" : "http://127.0.0.1:22379"
"DowngradeTargetVersion" : ""
"DowngradeEnabled" : false

"ClusterID" : 17237436991929493444
"MemberID" : 18249187646912138824
"Revision" : 1
"RaftTerm" : 12
"Version" : "3.7.0-alpha.0"
"StorageVersion" : "3.7.0"
"DBSize" : 98304
"DBSizeInUse" : 98304
"DbSizeQuota" : 2147483648
"Leader" : 10501334649042878790
"IsLearner" : false
"RaftIndex" : 33
"RaftTerm" : 12
"RaftAppliedIndex" : 33
"Errors" : []
"Endpoint" : "http://127.0.0.1:32379"
"DowngradeTargetVersion" : ""
"DowngradeEnabled" : false
```

cc @tjungblu @ivanvc @fuweid @serathius @jmhbnz 