### PR TITLE
tests: Refactor ClusterContext option in e2e and integration tests

### DIFF
--- a/tests/common/e2e_test.go
+++ b/tests/common/e2e_test.go
@@ -112,37 +112,13 @@ func WithEndpoints(endpoints []string) config.ClientOption {
 }
 
 func WithHTTP2Debug() config.ClusterOption {
-	return func(c *config.ClusterConfig) {
-		ctx := ensureE2EClusterContext(c)
-		if ctx.EnvVars == nil {
-			ctx.EnvVars = map[string]string{}
-		}
-		// Enable debug mode to get logs with http2 headers (including authority)
-		ctx.EnvVars["GODEBUG"] = "http2debug=2"
-		c.ClusterContext = ctx
-	}
+	return e2e.WithHTTP2Debug()
 }
 
 func WithUnixClient() config.ClusterOption {
-	return func(c *config.ClusterConfig) {
-		ctx := ensureE2EClusterContext(c)
-		ctx.UseUnix = true
-		c.ClusterContext = ctx
-	}
+	return e2e.WithUnixClient()
 }
 
 func WithTCPClient() config.ClusterOption {
-	return func(c *config.ClusterConfig) {
-		ctx := ensureE2EClusterContext(c)
-		ctx.UseUnix = false
-		c.ClusterContext = ctx
-	}
-}
-
-func ensureE2EClusterContext(c *config.ClusterConfig) *e2e.ClusterContext {
-	ctx, _ := c.ClusterContext.(*e2e.ClusterContext)
-	if ctx == nil {
-		ctx = &e2e.ClusterContext{}
-	}
-	return ctx
+	return e2e.WithTCPClient()
 }

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -57,29 +57,13 @@ func WithEndpoints(endpoints []string) config.ClientOption {
 }
 
 func WithHTTP2Debug() config.ClusterOption {
-	return func(c *config.ClusterConfig) {}
+	return integration.WithHTTP2Debug()
 }
 
 func WithUnixClient() config.ClusterOption {
-	return func(c *config.ClusterConfig) {
-		ctx := ensureIntegrationClusterContext(c)
-		ctx.UseUnix = true
-		c.ClusterContext = ctx
-	}
+	return integration.WithUnixClient()
 }
 
 func WithTCPClient() config.ClusterOption {
-	return func(c *config.ClusterConfig) {
-		ctx := ensureIntegrationClusterContext(c)
-		ctx.UseUnix = false
-		c.ClusterContext = ctx
-	}
-}
-
-func ensureIntegrationClusterContext(c *config.ClusterConfig) *integration.ClusterContext {
-	ctx, _ := c.ClusterContext.(*integration.ClusterContext)
-	if ctx == nil {
-		ctx = &integration.ClusterContext{}
-	}
-	return ctx
+	return integration.WithTCPClient()
 }

--- a/tests/framework/e2e/config.go
+++ b/tests/framework/e2e/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 
 	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/tests/v3/framework/config"
 )
 
 type ClusterVersion string
@@ -43,6 +44,42 @@ type ClusterContext struct {
 	Version ClusterVersion
 	EnvVars map[string]string
 	UseUnix bool
+}
+
+func WithHTTP2Debug() config.ClusterOption {
+	return func(c *config.ClusterConfig) {
+		ctx := ensureE2EClusterContext(c)
+		if ctx.EnvVars == nil {
+			ctx.EnvVars = map[string]string{}
+		}
+		// Enable debug mode to get logs with http2 headers (including authority)
+		ctx.EnvVars["GODEBUG"] = "http2debug=2"
+		c.ClusterContext = ctx
+	}
+}
+
+func WithUnixClient() config.ClusterOption {
+	return func(c *config.ClusterConfig) {
+		ctx := ensureE2EClusterContext(c)
+		ctx.UseUnix = true
+		c.ClusterContext = ctx
+	}
+}
+
+func WithTCPClient() config.ClusterOption {
+	return func(c *config.ClusterConfig) {
+		ctx := ensureE2EClusterContext(c)
+		ctx.UseUnix = false
+		c.ClusterContext = ctx
+	}
+}
+
+func ensureE2EClusterContext(c *config.ClusterConfig) *ClusterContext {
+	ctx, _ := c.ClusterContext.(*ClusterContext)
+	if ctx == nil {
+		ctx = &ClusterContext{}
+	}
+	return ctx
 }
 
 var experimentalFlags = map[string]struct{}{

--- a/tests/framework/integration/config.go
+++ b/tests/framework/integration/config.go
@@ -14,6 +14,36 @@
 
 package integration
 
+import "go.etcd.io/etcd/tests/v3/framework/config"
+
 type ClusterContext struct {
 	UseUnix bool
+}
+
+func WithHTTP2Debug() config.ClusterOption {
+	return func(c *config.ClusterConfig) {}
+}
+
+func WithUnixClient() config.ClusterOption {
+	return func(c *config.ClusterConfig) {
+		ctx := ensureIntegrationClusterContext(c)
+		ctx.UseUnix = true
+		c.ClusterContext = ctx
+	}
+}
+
+func WithTCPClient() config.ClusterOption {
+	return func(c *config.ClusterConfig) {
+		ctx := ensureIntegrationClusterContext(c)
+		ctx.UseUnix = false
+		c.ClusterContext = ctx
+	}
+}
+
+func ensureIntegrationClusterContext(c *config.ClusterConfig) *ClusterContext {
+	ctx, _ := c.ClusterContext.(*ClusterContext)
+	if ctx == nil {
+		ctx = &ClusterContext{}
+	}
+	return ctx
 }


### PR DESCRIPTION
## What
- Moved `WithHTTP2Debug`, `WithUnixClient`, and `WithTCPClient` functions to the `framework/e2e` and `framework/integration` packages.

## Why

- To improve modularity by placing runner-specific options directly in the framework packages