### PR TITLE
[Antithesis] Migrate from fixed paths to env-based vars

### DIFF
--- a/tests/antithesis/config/docker-compose-1-node.yml
+++ b/tests/antithesis/config/docker-compose-1-node.yml
@@ -50,6 +50,10 @@ services:
     container_name: client
     entrypoint: ["/opt/antithesis/entrypoint/entrypoint"]
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
+    environment:
+      ETCD_ROBUSTNESS_ENDPOINTS: "etcd0:2379"
+      ETCD_ROBUSTNESS_DATA_PATHS: "/var/etcddata0"
+      ETCD_ROBUSTNESS_REPORT_PATH: "/var/report"
     depends_on:
       etcd0:
         condition: service_started

--- a/tests/antithesis/config/docker-compose-3-node.yml
+++ b/tests/antithesis/config/docker-compose-3-node.yml
@@ -106,6 +106,10 @@ services:
     container_name: client
     entrypoint: ["/opt/antithesis/entrypoint/entrypoint"]
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
+    environment:
+      ETCD_ROBUSTNESS_ENDPOINTS: "etcd0:2379,etcd1:2379,etcd2:2379"
+      ETCD_ROBUSTNESS_DATA_PATHS: "/var/etcddata0,/var/etcddata1,/var/etcddata2"
+      ETCD_ROBUSTNESS_REPORT_PATH: "/var/report"
     depends_on:
       etcd0:
         condition: service_started

--- a/tests/antithesis/test-template/entrypoint/main.go
+++ b/tests/antithesis/test-template/entrypoint/main.go
@@ -35,17 +35,16 @@ var NodeCount = "3"
 // CheckHealth checks health of all etcd nodes
 func CheckHealth() bool {
 	cfg := common.MakeConfig(NodeCount)
+	hosts, _, _ := common.GetPaths(cfg)
 
-	nodeOptions := []string{"etcd0", "etcd1", "etcd2"}[:cfg.NodeCount]
-
-	// iterate over each node and check health
-	for _, node := range nodeOptions {
+	// iterate over each host and check health
+	for _, host := range hosts {
 		cli, err := clientv3.New(clientv3.Config{
-			Endpoints:   []string{fmt.Sprintf("http://%s:2379", node)},
+			Endpoints:   []string{fmt.Sprintf("http://%s", host)},
 			DialTimeout: 5 * time.Second,
 		})
 		if err != nil {
-			fmt.Printf("Client [entrypoint]: connection failed with %s\n", node)
+			fmt.Printf("Client [entrypoint]: connection failed with %s\n", host)
 			fmt.Printf("Client [entrypoint]: error: %v\n", err)
 			return false
 		}
@@ -60,12 +59,12 @@ func CheckHealth() bool {
 		// fetch the key setting-up to confirm that the node is available
 		_, err = cli.Get(context.Background(), "setting-up")
 		if err != nil {
-			fmt.Printf("Client [entrypoint]: connection failed with %s\n", node)
+			fmt.Printf("Client [entrypoint]: connection failed with %s\n", host)
 			fmt.Printf("Client [entrypoint]: error: %v\n", err)
 			return false
 		}
 
-		fmt.Printf("Client [entrypoint]: connection successful with %s\n", node)
+		fmt.Printf("Client [entrypoint]: connection successful with %s\n", host)
 	}
 
 	return true

--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	cfg := common.MakeConfig(NodeCount)
 
-	_, reportPath, dirs := common.DefaultPaths(cfg)
+	_, reportPath, dirs := common.GetPaths(cfg)
 	if *local {
 		_, reportPath, dirs = common.LocalPaths(cfg)
 	}

--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	cfg := common.MakeConfig(NodeCount)
 
-	hosts, reportPath, etcdetcdDataPaths := common.DefaultPaths(cfg)
+	hosts, reportPath, etcdetcdDataPaths := common.GetPaths(cfg)
 	if *local {
 		hosts, reportPath, etcdetcdDataPaths = common.LocalPaths(cfg)
 	}


### PR DESCRIPTION
As a continuation of breaking #20736 down, I'm making the clients' data and report paths configurable from the new environment variables (DATA_PATHS and REPORT_PATH).

@serathius 