### PR TITLE
Update 3.5 changelog to cover the learner not persisted across multiple upgrades issue

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -10,6 +10,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 - [Reject watch request with -1 revision to prevent invalid resync behavior on uncompacted etcd](https://github.com/etcd-io/etcd/pull/20709)
 - [Change the TLS handshake 'EOF' errors to DEBUG not to spam logs](https://github.com/etcd-io/etcd/pull/20751)
+- Fix [Learner promotion not being persisted into v3store may be propagated across multiple upgrades](https://github.com/etcd-io/etcd/pull/20797)
 
 ---
 


### PR DESCRIPTION
Link to
- https://github.com/etcd-io/etcd/pull/20797
- https://github.com/etcd-io/etcd/issues/20793

cc @fuweid @ivanvc @jmhbnz @serathius @siyuanfoundation @spzala 




Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
