### PR TITLE
etcdserver: remove permission check on AuthStatus api

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -16,6 +16,7 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 - [Update go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc to v0.61.0 and replaced the deprecated `UnaryServerInterceptor` and `StreamServerInterceptor` with `NewServerHandler`](https://github.com/etcd-io/etcd/pull/20017)
 - [Add Support for Unix Socket endpoints](https://github.com/etcd-io/etcd/pull/19760)
 - [Improves performance of lease and user/role operations (up to 2x) by updating `(*readView) Rev()` to use `SharedBufReadTxMode`](https://github.com/etcd-io/etcd/pull/20411)
+- [Allow client to retrieve AuthStatus without authentication](https://github.com/etcd-io/etcd/pull/20802)
 
 ### Package `clientv3`
 

--- a/server/etcdserver/apply/auth.go
+++ b/server/etcdserver/apply/auth.go
@@ -172,8 +172,6 @@ func needAdminPermission(r *pb.InternalRaftRequest) bool {
 		return true
 	case r.AuthDisable != nil:
 		return true
-	case r.AuthStatus != nil:
-		return true
 	case r.AuthUserAdd != nil:
 		return true
 	case r.AuthUserDelete != nil:

--- a/server/etcdserver/apply/auth_test.go
+++ b/server/etcdserver/apply/auth_test.go
@@ -317,11 +317,6 @@ func TestAuthApplierV3_AdminPermission(t *testing.T) {
 			adminPermissionNeeded: true,
 		},
 		{
-			name:                  "AuthStatus needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthStatus: &pb.AuthStatusRequest{}},
-			adminPermissionNeeded: true,
-		},
-		{
 			name:                  "AuthUserAdd needs admin permission",
 			request:               &pb.InternalRaftRequest{AuthUserAdd: &pb.AuthUserAddRequest{}},
 			adminPermissionNeeded: true,

--- a/tests/e2e/ctl_v3_auth_test.go
+++ b/tests/e2e/ctl_v3_auth_test.go
@@ -44,6 +44,19 @@ func TestCtlV3AuthSnapshotJWT(t *testing.T) {
 	testCtl(t, authTestSnapshot, withCfg(*e2e.NewConfigJWT()))
 }
 
+func TestCtlV3GetAuthStatus(t *testing.T) { testCtl(t, authTestGetAuthStatus) }
+
+func ctlV3AuthStatus(cx ctlCtx, expected string) error {
+	cmd := append(cx.PrefixArgs(), "auth", "status")
+	return e2e.SpawnWithExpectWithEnv(cmd, cx.envMap, expect.ExpectedResponse{Value: expected})
+}
+
+func authTestGetAuthStatus(cx ctlCtx) {
+	require.NoError(cx.t, ctlV3AuthStatus(cx, "Authentication Status: false"))
+	require.NoError(cx.t, authEnable(cx))
+	require.NoError(cx.t, ctlV3AuthStatus(cx, "Authentication Status: true"))
+}
+
 func authEnable(cx ctlCtx) error {
 	// create root user with root role
 	if err := ctlV3User(cx, []string{"add", "root", "--interactive=false"}, "User root created", []string{"root"}); err != nil {


### PR DESCRIPTION

Any client managing their own JWTs outside of etcd, need to track the auth revision to create another token.
One possible solution is to loosen the access control on AuthStatus so that you can always get the latest authRevision no matter whether or not you have a valid token.

This is related to #19828 