### PR TITLE
[release-3.6] Add defer-recover block to prevent panic when cc is nil

### DIFF
--- a/client/v3/internal/resolver/resolver.go
+++ b/client/v3/internal/resolver/resolver.go
@@ -60,7 +60,7 @@ func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
 }
 
 func (r EtcdManualResolver) updateState() {
-	if r.CC != nil {
+	if getCC(r) != nil {
 		eps := make([]resolver.Endpoint, len(r.endpoints))
 		for i, ep := range r.endpoints {
 			addr, serverName := endpoint.Interpret(ep)
@@ -74,4 +74,14 @@ func (r EtcdManualResolver) updateState() {
 		}
 		r.UpdateState(state)
 	}
+}
+
+func getCC(r EtcdManualResolver) (cc resolver.ClientConn) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			cc = nil
+		}
+	}()
+
+	return r.CC()
 }


### PR DESCRIPTION
Backport fa38b54dd5db2f1f321ab6118cf55bec6124336b to release-3.6.

This silences GRPC warnings being issued during etcd client creation like this:

```text
2025/10/15 12:55:29 WARNING: [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379", ServerName: "127.0.0.1:2379", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:2379: operation was canceled"
```

or this:

```
2025/10/15 12:56:24 WARNING: [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:2379", ServerName: "127.0.0.1:2379", }. Err: connection error: desc = "transport: authentication handshake failed: context canceled"
```

These warnings appear since #13203, so I'm not sure if the backported commit is duct-taping something introduced in that PR, or if it is useful in other circumstances, as well. I've observed that the warnings can also be silenced by changing something in the original PR: https://github.com/etcd-io/etcd/pull/13203#discussion_r2432128223

/cc @joshjms