### PR TITLE
docs: Update changelogs for versions 3.4, 3.5, and 3.6 to reflect the…

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -16,7 +16,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ### Dependencies
 
-- Compile binaries using [go 1.24.7](https://github.com/etcd-io/etcd/pull/20618).
+- Compile binaries using [go 1.24.9](https://github.com/etcd-io/etcd/pull/20807).
 - [Bump bbolt to v1.3.12](https://github.com/etcd-io/etcd/pull/20515).
 
 ---

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -11,6 +11,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 - [Reject watch request with -1 revision to prevent invalid resync behavior on uncompacted etcd](https://github.com/etcd-io/etcd/pull/20709)
 - [Change the TLS handshake 'EOF' errors to DEBUG not to spam logs](https://github.com/etcd-io/etcd/pull/20751)
 
+### Dependencies
+
+- Compile binaries using [go 1.24.9](https://github.com/etcd-io/etcd/pull/20806).
+
 ---
 
 ## v3.5.23 (2025-09-19)

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -12,6 +12,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 - [Change the TLS handshake 'EOF' errors to DEBUG not to spam logs](https://github.com/etcd-io/etcd/pull/20749)
 - Fix [endpoint status not retuning the correct storage quota](https://github.com/etcd-io/etcd/pull/20790)
 
+### Dependencies
+
+- Compile binaries using [go 1.24.9](https://github.com/etcd-io/etcd/pull/20801).
+
 ---
 
 ## v3.6.5 (2025-09-19)


### PR DESCRIPTION
… use of Go 1.24.9 for compiling binaries.

Ref: https://github.com/etcd-io/etcd/issues/20799
