### PR TITLE
Move govet to golangci lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ fuzz:
 verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-goword \
 	verify-license-header verify-mod-tidy \
 	verify-shellws verify-proto-annotations verify-genproto verify-yamllint \
-	verify-govet-shadow verify-markdown-marker verify-go-versions verify-gomodguard \
+	verify-markdown-marker verify-go-versions verify-gomodguard \
 	verify-go-workspace
 
 .PHONY: fix
@@ -171,10 +171,6 @@ else
 	@echo "yamllint already installed..."
 	yamllint --config-file tools/.yamllint .
 endif
-
-.PHONY: verify-govet-shadow
-verify-govet-shadow:
-	PASSES="govet_shadow" ./scripts/test.sh
 
 .PHONY: verify-markdown-marker
 verify-markdown-marker:

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -18,6 +18,9 @@ linters:
     - usetesting
     - whitespace
   settings:
+    govet:
+      enable:
+        - shadow
     nakedret:
       # Align with https://github.com/alexkohler/nakedret/blob/v1.0.2/cmd/nakedret/main.go#L10
       max-func-lines: 5


### PR DESCRIPTION
This pull request simplifies our current static checks by running govet/govet shadow with golangci-lint.

Using shadow from golangci-lint doesn't lint generated files (protobufs), so it's safe to include all the files.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
