### PR TITLE
Silence BOM first run expected error

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -519,7 +519,7 @@ function bom_pass {
   # Intentionally run the command once first, so it fetches dependencies. The exit code on the first
   # run in a just cloned repository is always dirty.
   GOOS=linux run_go_tool github.com/appscodelabs/license-bill-of-materials \
-    --override-file ./bill-of-materials.override.json "${modules[@]}"
+    --override-file ./bill-of-materials.override.json "${modules[@]}" &> /dev/null
 
   # BOM file should be generated for linux. Otherwise running this command on other operating systems such as OSX
   # results in certain dependencies being excluded from the BOM file, such as procfs.

--- a/scripts/updatebom.sh
+++ b/scripts/updatebom.sh
@@ -27,6 +27,9 @@ function bom_fixlet {
   # shellcheck disable=SC2207
   modules=($(modules_for_bom))
 
+  GOOS=linux run_go_tool "github.com/appscodelabs/license-bill-of-materials" \
+    --override-file ./bill-of-materials.override.json "${modules[@]}" &> /dev/null
+
   # BOM file should be generated for linux. Otherwise running this command on other operating systems such as OSX
   # results in certain dependencies being excluded from the BOM file, such as procfs. 
   # For more info, https://github.com/etcd-io/etcd/issues/19665


### PR DESCRIPTION
The tool `github.com/appscodelabs/license-bill-of-materials` fails during the first run in a recently cloned/fresh repository. Because it captures the output, and the first run shows the download of dependencies. In 8b0241630167ba48133c7b9a9bfb149e8af15c2e, we intentionally added a new execution before evaluating whether the BOM is up to date. However, this is polluting the logs as it has the expected failure. Redirecting the output to /dev/null alleviates the issue.

Follow up on: https://github.com/etcd-io/etcd/pull/20788#issuecomment-3411649618.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
