### PR TITLE
Update verify license header to use Go workspace

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -410,15 +410,10 @@ function lint_fix_pass {
   run_for_all_workspace_modules golangci-lint run --config "${ETCD_ROOT_DIR}/tools/.golangci.yaml" --fix
 }
 
-function license_header_per_module {
-  # bash 3.x compatible replacement of: mapfile -t gofiles < <(go_srcs_in_module)
-  local gofiles=()
-  while IFS= read -r line; do gofiles+=("$line"); done < <(go_srcs_in_module)
-  run_go_tool "github.com/google/addlicense" --check "${gofiles[@]}"
-}
-
 function license_header_pass {
-  run_for_modules generic_checker license_header_per_module
+  local src_files=()
+  load_all_workspace_go_source_files src_files
+  run_go_tool "github.com/google/addlicense" --check "${src_files[@]}"
 }
 
 function go_fmt_for_package {


### PR DESCRIPTION
With the workspace, we can get all the Go source files from the repository's top level. This can simplify tools such as github.com/google/addlicense that take as input a list of source code files.

Part of #18409

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
