### PR TITLE
[release-3.4] cherry-pick 20590: Re-check that the lease still exists during the renew process

### DIFF
--- a/build
+++ b/build
@@ -21,7 +21,7 @@ GOFAIL_VERSION=$(cd tools/mod && go list -m -f "{{.Version}}" go.etcd.io/gofail)
 toggle_failpoints() {
 	mode="$1"
 	if command -v gofail >/dev/null 2>&1; then
-		gofail "$mode" etcdserver/ lease/leasehttp/ mvcc/ mvcc/backend/ wal/
+		gofail "$mode" etcdserver/ lease/ lease/leasehttp/ mvcc/ mvcc/backend/ wal/
 		# shellcheck disable=SC2086
 		if [[ "$mode" == "enable" ]]; then
 			go get go.etcd.io/gofail@${GOFAIL_VERSION}

--- a/lease/lessor.go
+++ b/lease/lessor.go
@@ -430,6 +430,8 @@ func (le *lessor) Renew(id LeaseID) (int64, error) {
 		}
 	}
 
+	// gofail: var beforeCheckpointInLeaseRenew struct{}
+
 	// Clear remaining TTL when we renew if it is set
 	// By applying a RAFT entry only when the remainingTTL is already set, we limit the number
 	// of RAFT entries written per lease to a max of 2 per checkpoint interval.
@@ -440,6 +442,12 @@ func (le *lessor) Renew(id LeaseID) (int64, error) {
 	}
 
 	le.mu.Lock()
+	// Re-check in case the lease was revoked immediately after the previous check
+	l = le.leaseMap[id]
+	if l == nil {
+		le.mu.Unlock()
+		return -1, ErrLeaseNotFound
+	}
 	l.refresh(0)
 	item := &LeaseWithTime{id: l.ID, time: l.expiry.UnixNano()}
 	le.leaseExpiredNotifier.RegisterOrUpdate(item)

--- a/tests/e2e/v3_lease_no_proxy_test.go
+++ b/tests/e2e/v3_lease_no_proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/pkg/testutil"
 )
 
@@ -163,4 +164,60 @@ func testLeaseRevokeIssue(t *testing.T, clusterSize int, connectToOneFollower bo
 	t.Log("Waiting for the keepAlive goroutine to exit")
 	close(stopC)
 	<-doneC
+}
+
+func TestLeaseRevokeDuringRenew(t *testing.T) {
+
+	ctx := t.Context()
+
+	t.Log("Starting a new etcd cluster")
+	epc, err := newEtcdProcessCluster(t, &etcdProcessClusterConfig{
+		clusterSize:         1,
+		goFailEnabled:       true,
+		goFailClientTimeout: 40 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoErrorf(t, epc.Close(), "error closing etcd processes")
+	}()
+
+	eps := epc.procs[0].EndpointsGRPC()
+	t.Logf("Creating two clients for lease operations: %v", eps)
+	clientForRenew, err := clientv3.New(clientv3.Config{Endpoints: eps, DialTimeout: 3 * time.Second})
+	require.NoError(t, err)
+	defer clientForRenew.Close()
+
+	clientForRevoke, err := clientv3.New(clientv3.Config{Endpoints: eps, DialTimeout: 3 * time.Second})
+	require.NoError(t, err)
+	defer clientForRevoke.Close()
+
+	t.Log("Creating a new lease")
+	leaseRsp, err := clientForRenew.Grant(ctx, 60)
+	require.NoError(t, err)
+
+	t.Log("Activate the 'beforeCheckpointInLeaseRenew' failpoint")
+	require.NoError(t, epc.procs[0].Failpoints().SetupHTTP(ctx, "beforeCheckpointInLeaseRenew", `sleep("3s")`))
+
+	t.Logf("Starting a goroutine to keep alive the lease: %d", leaseRsp.ID)
+	doneC := make(chan struct{})
+	startC := make(chan struct{}, 1)
+	var renewError error
+	go func() {
+		defer close(doneC)
+		startC <- struct{}{}
+		_, renewError = clientForRenew.KeepAliveOnce(ctx, leaseRsp.ID)
+	}()
+
+	t.Log("Wait for the KeepAliveOnce goroutine to get started")
+	<-startC
+	time.Sleep(200 * time.Millisecond)
+
+	t.Logf("Revoke the lease: %d", leaseRsp.ID)
+	_, lerr := clientForRevoke.Revoke(ctx, leaseRsp.ID)
+	require.NoError(t, lerr)
+
+	t.Log("Waiting for the keepAlive goroutine to exit")
+	<-doneC
+
+	require.ErrorIs(t, rpctypes.ErrLeaseNotFound, renewError)
 }


### PR DESCRIPTION
Ref: https://github.com/etcd-io/etcd/pull/20590 https://github.com/etcd-io/etcd/issues/20547