### PR TITLE
Remove gofmt verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ fuzz:
 
 # Static analysis
 .PHONY: verify
-verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck \
+verify: verify-bom verify-lint verify-dep verify-shellcheck \
 	verify-license-header verify-mod-tidy \
 	verify-shellws verify-proto-annotations verify-genproto verify-yamllint \
 	verify-markdown-marker verify-go-versions verify-gomodguard \
@@ -105,10 +105,6 @@ verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck \
 .PHONY: fix
 fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive update-go-workspace
 	./scripts/fix.sh
-
-.PHONY: verify-gofmt
-verify-gofmt:
-	PASSES="gofmt" ./scripts/test.sh
 
 .PHONY: verify-bom
 verify-bom:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -70,7 +70,7 @@ if [ -n "${OUTPUT_FILE}" ]; then
   exec > >(tee -a "${OUTPUT_FILE}") 2>&1
 fi
 
-PASSES=${PASSES:-"gofmt bom dep build unit"}
+PASSES=${PASSES:-"bom dep build unit"}
 KEEP_GOING_SUITE=${KEEP_GOING_SUITE:-false}
 PKG=${PKG:-}
 SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"v0.10.0"}
@@ -421,15 +421,6 @@ function license_header_pass {
   run_for_modules generic_checker license_header_per_module
 }
 
-function go_fmt_for_package {
-  # We utilize 'go fmt' to find all files suitable for formatting,
-  # but reuse full power gofmt to perform just RO check.
-  go fmt -n "$1" | sed 's| -w | -d |g' | sh
-}
-
-function gofmt_pass {
-  run_for_modules generic_checker go_fmt_for_package
-}
 
 function bom_pass {
   log_callout "Checking bill of materials..."


### PR DESCRIPTION
The gofmt static check is already part of golangci-lint's gofmt formatter. Therefore, it's a duplicate check. We can simplify and let golangci-lint do the heavy lifting. Refer to: https://github.com/etcd-io/etcd/blob/75f7329092884cdb6f47de51b27b40a901341294/tools/.golangci.yaml#L129-L133

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
