### PR TITLE
Update mod tidy check to not use old module system

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -591,12 +591,8 @@ EOF
   VERSION="${VERSION}" run "${ETCD_ROOT_DIR}/scripts/test_images.sh"
 }
 
-function mod_tidy_for_module {
-  run go mod tidy -diff
-}
-
 function mod_tidy_pass {
-  run_for_modules generic_checker mod_tidy_for_module
+  run_for_workspace_modules run go mod tidy -diff
 }
 
 function proto_annotations_pass {


### PR DESCRIPTION
We should always ensure that any go.mod in the repository is tidy. With the current approach, only modules that are hardcoded in the test_lib.sh file will be checked for tidinness. We can rely on the find command to run the command, rather than using a custom-made function.

Let me know if this is too extreme, and I could revert back to introducing a new function that will work with the workspace approach.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
