### PR TITLE
Run update-go-workspace late in the fix Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,9 @@ verify: verify-bom verify-lint verify-dep verify-shellcheck verify-mod-tidy \
 	verify-go-workspace
 
 .PHONY: fix
-fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive update-go-workspace
+fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive
 	./scripts/fix.sh
+	$(MAKE) update-go-workspace
 
 .PHONY: verify-bom
 verify-bom:


### PR DESCRIPTION
The file ./scripts/fix.sh updates the go modules to make them tidy. However, we're running the workspace update before go mod tidy (part of the prerequisite targets), since the fix script isn't a prerequisite but the actual target command.

Therefore, it is required to run make fix twice right now. Hence, because we can't change the order of prerequisites, call make update-go-workspace after the fix.sh script.

I'm planning on reworking our fix targets as part of #18409. But right now I'm still working on the verify targets. So, this is just a temporary fix to make the manual dependency update smoother (i.e., #20830).

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
