### PR TITLE
Replace local command line flag with environment variables

### DIFF
--- a/tests/antithesis/Makefile
+++ b/tests/antithesis/Makefile
@@ -68,11 +68,13 @@ antithesis-run-container-validation: validate-node-count
 
 .PHONY: antithesis-run-local-traffic
 antithesis-run-local-traffic:
-	go run -ldflags "-X main.NodeCount=$(CFG_NODE_COUNT)" --race ./test-template/robustness/traffic/main.go --local
+	export ETCD_ROBUSTNESS_DATA_PATHS=/tmp/etcddata0,/tmp/etcddata1,/tmp/etcddata2 && export ETCD_ROBUSTNESS_REPORT_PATH=report && export ETCD_ROBUSTNESS_ENDPOINTS=127.0.0.1:12379,127.0.0.1:22379,127.0.0.1:32379 && \
+		go run -ldflags "-X main.NodeCount=$(CFG_NODE_COUNT)" --race ./test-template/robustness/traffic/main.go
 
 .PHONY: antithesis-run-local-validation
 antithesis-run-local-validation:
-	go run -ldflags "-X main.NodeCount=$(CFG_NODE_COUNT)" --race ./test-template/robustness/finally/main.go --local
+	export ETCD_ROBUSTNESS_DATA_PATHS=/tmp/etcddata0,/tmp/etcddata1,/tmp/etcddata2 && export ETCD_ROBUSTNESS_REPORT_PATH=report && export ETCD_ROBUSTNESS_ENDPOINTS=127.0.0.1:12379,127.0.0.1:22379,127.0.0.1:32379 && \
+		go run -ldflags "-X main.NodeCount=$(CFG_NODE_COUNT)" --race ./test-template/robustness/finally/main.go
 
 .PHONY: antithesis-clean
 antithesis-clean: validate-node-count

--- a/tests/antithesis/test-template/robustness/common/path.go
+++ b/tests/antithesis/test-template/robustness/common/path.go
@@ -30,14 +30,6 @@ const (
 	defaultetcdDataPath = "/var/etcddata%d"
 	defaultReportPath   = "/var/report/"
 
-	localetcd0 = "127.0.0.1:12379"
-	localetcd1 = "127.0.0.1:22379"
-	localetcd2 = "127.0.0.1:32379"
-	// used by default when running the client locally
-	defaultetcdLocalDataPath = "/tmp/etcddata%d"
-	localetcdDataPathEnv     = "ETCD_ROBUSTNESS_DATA_PATH_PREFIX"
-	localReportPath          = "report"
-
 	endpointsEnv  = "ETCD_ROBUSTNESS_ENDPOINTS"
 	dataPathsEnv  = "ETCD_ROBUSTNESS_DATA_PATHS"
 	reportPathEnv = "ETCD_ROBUSTNESS_REPORT_PATH"
@@ -83,18 +75,6 @@ func defaultPaths(cfg *Config) (hosts []string, reportPath string, dataPaths map
 	hosts = []string{defaultetcd0, defaultetcd1, defaultetcd2}[:cfg.NodeCount]
 	reportPath = defaultReportPath
 	dataPaths = etcdDataPaths(defaultetcdDataPath, cfg.NodeCount)
-	return hosts, reportPath, dataPaths
-}
-
-func LocalPaths(cfg *Config) (hosts []string, reportPath string, dataPaths map[string]string) {
-	hosts = []string{localetcd0, localetcd1, localetcd2}[:cfg.NodeCount]
-	reportPath = localReportPath
-	etcdDataPath := defaultetcdLocalDataPath
-	envPath := os.Getenv(localetcdDataPathEnv)
-	if envPath != "" {
-		etcdDataPath = envPath + "%d"
-	}
-	dataPaths = etcdDataPaths(etcdDataPath, cfg.NodeCount)
 	return hosts, reportPath, dataPaths
 }
 

--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"flag"
 	"maps"
 	"os"
 	"path/filepath"
@@ -39,15 +38,8 @@ const (
 var NodeCount = "3"
 
 func main() {
-	local := flag.Bool("local", false, "run finally locally and connect to etcd instances via localhost")
-	flag.Parse()
-
 	cfg := common.MakeConfig(NodeCount)
-
 	_, reportPath, dirs := common.GetPaths(cfg)
-	if *local {
-		_, reportPath, dirs = common.LocalPaths(cfg)
-	}
 
 	lg, err := zap.NewProduction()
 	if err != nil {

--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"math/rand/v2"
 	"os"
 	"slices"
@@ -64,15 +63,8 @@ var (
 )
 
 func main() {
-	local := flag.Bool("local", false, "run tests locally and connect to etcd instances via localhost")
-	flag.Parse()
-
 	cfg := common.MakeConfig(NodeCount)
-
 	hosts, reportPath, etcdetcdDataPaths := common.GetPaths(cfg)
-	if *local {
-		hosts, reportPath, etcdetcdDataPaths = common.LocalPaths(cfg)
-	}
 
 	ctx := context.Background()
 	baseTime := time.Now()


### PR DESCRIPTION
Tested by running:
```
make antithesis-build-etcd-image
make antithesis-docker-compose-up
make antithesis-run-container-traffic
make antithesis-run-container-validation
```
Confirmed that validation passed 

Ref https://github.com/etcd-io/etcd/pull/20844

