### PR TITLE
[release-3.4] Fix Go compiled module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 .PHONY: build
 build:
-	GO_BUILD_FLAGS="-v" ./build
+	GO_BUILD_FLAGS="-v -buildvcs=false" ./build
 	./bin/etcd --version
 	./bin/etcdctl version
 


### PR DESCRIPTION
Without the buildvcs=false argument, the compiled binary (starting in Go 1.24) shows the wrong module, as in this minor version, the main module is "go.etcd.io/etcd". Compiling with buildvcs set to false restores the previous behavior, keeping the module as a development version.

Fixes #20846.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
