### PR TITLE
Update fix-yamllint Makefile target to use common helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,9 @@ endif
 verify-markdown-marker:
 	PASSES="markdown_marker" ./scripts/test.sh
 
-YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
-
 .PHONY: fix-yamllint
 fix-yamllint:
-ifeq (, $(shell command -v yamlfmt))
-	$(shell go install github.com/google/yamlfmt/cmd/yamlfmt@$(YAMLFMT_VERSION))
-endif
-	yamlfmt -conf tools/.yamlfmt .
+	PASSES="yamllint_fix" ./scripts/test.sh
 
 .PHONY: run-govulncheck
 run-govulncheck:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -460,6 +460,10 @@ function gomodguard_pass {
   run_for_modules gomodguard_for_module
 }
 
+function yamllint_fix_pass {
+  run_go_tool github.com/google/yamlfmt/cmd/yamlfmt -conf "${ETCD_ROOT_DIR}/tools/.yamlfmt" .
+}
+
 ######## VARIOUS CHECKERS ######################################################
 
 function dump_deps_of_module() {


### PR DESCRIPTION
Not really a workspace-related PR. But a clean-up/standardization with other Makefile targets.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
