### PR TITLE
Move go mod tidy to a test.sh pass, update it to use the Go workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,9 @@ verify: verify-bom verify-lint verify-dep verify-shellcheck verify-mod-tidy \
 	verify-go-workspace
 
 .PHONY: fix
-fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive
+fix: fix-mod-tidy fix-bom fix-lint fix-yamllint sync-toolchain-directive \
+	update-go-workspace
 	./scripts/fix.sh
-	$(MAKE) update-go-workspace
 
 .PHONY: verify-bom
 verify-bom:
@@ -133,6 +133,10 @@ verify-shellcheck:
 .PHONY: verify-mod-tidy
 verify-mod-tidy:
 	PASSES="mod_tidy" ./scripts/test.sh
+
+.PHONY: fix-mod-tidy
+fix-mod-tidy:
+	PASSES="mod_tidy_fix" ./scripts/test.sh
 
 .PHONY: verify-shellws
 verify-shellws:

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -15,9 +15,6 @@
 
 set -euo pipefail
 
-# Top level problems with modules can lead to test_lib being not functional
-go mod tidy
-
 source ./scripts/test_lib.sh
 source ./scripts/updatebom.sh
 
@@ -26,11 +23,6 @@ source ./scripts/updatebom.sh
 # gotip download
 # GO_CMD="gotip"
 GO_CMD="go"
-
-function mod_tidy_fix {
-  run rm ./go.sum
-  run ${GO_CMD} mod tidy || return 2
-}
 
 function bash_ws_fix {
   TAB=$'\t'
@@ -44,7 +36,6 @@ function bash_ws_fix {
 
 log_callout -e "\\nFixing etcd code for you...\n"
 
-run_for_modules mod_tidy_fix || exit 2
 run_for_modules run ${GO_CMD} fmt || exit 2
 bash_ws_fix || exit 2
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -594,6 +594,15 @@ function mod_tidy_pass {
   run_for_workspace_modules run go mod tidy -diff
 }
 
+function module_mod_tidy_fix {
+  run rm ./go.sum
+  run go mod tidy || return 2
+}
+
+function mod_tidy_fix_pass {
+  run_for_workspace_modules module_mod_tidy_fix
+}
+
 function proto_annotations_pass {
   "${ETCD_ROOT_DIR}/scripts/verify_proto_annotations.sh"
 }


### PR DESCRIPTION
Use the new workspace helper functions.

By moving it to a test.sh pass, we can chain it in the fix Makefile target prerequisites, and it can be called before update-go-workspace.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
