### PR TITLE
Update fix-yamllint Makefile target to use stand-alone script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,9 @@ endif
 verify-markdown-marker:
 	PASSES="markdown_marker" ./scripts/test.sh
 
-YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
-
 .PHONY: fix-yamllint
 fix-yamllint:
-ifeq (, $(shell command -v yamlfmt))
-	$(shell go install github.com/google/yamlfmt/cmd/yamlfmt@$(YAMLFMT_VERSION))
-endif
-	yamlfmt -conf tools/.yamlfmt .
+	./scripts/fix/yamllint.sh
 
 .PHONY: run-govulncheck
 run-govulncheck:

--- a/scripts/fix/yamllint.sh
+++ b/scripts/fix/yamllint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2025 The etcd Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fixes linter issues in YAML files.
+
+set -euo pipefail
+
+ETCD_ROOT_DIR=${ETCD_ROOT_DIR:-$(git rev-parse --show-toplevel)}
+source "${ETCD_ROOT_DIR}/scripts/test_lib.sh"
+
+function main {
+  run_go_tool github.com/google/yamlfmt/cmd/yamlfmt \
+    -conf "${ETCD_ROOT_DIR}/tools/.yamlfmt" .
+}
+
+# only run when called directly, not sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi


### PR DESCRIPTION
Moves `Makefile`'s `fix-yamllint` target body into a new stand-alone script.

* This is a proposal to implement #20856.
* Alternative to #20850.
* Related to #20850.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
