### PR TITLE
Don't manually run go fmt

### DIFF
--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -18,12 +18,6 @@ set -euo pipefail
 source ./scripts/test_lib.sh
 source ./scripts/updatebom.sh
 
-# To fix according to newer version of go:
-# go get golang.org/dl/gotip
-# gotip download
-# GO_CMD="gotip"
-GO_CMD="go"
-
 function bash_ws_fix {
   TAB=$'\t'
 
@@ -36,7 +30,6 @@ function bash_ws_fix {
 
 log_callout -e "\\nFixing etcd code for you...\n"
 
-run_for_modules run ${GO_CMD} fmt || exit 2
 bash_ws_fix || exit 2
 
 log_success -e "\\nSUCCESS: etcd code is fixed :)"


### PR DESCRIPTION
We're already calling `golangci-lint --fix`. We require the gofmt formatter, and it supports autofix. Therefore, running go fmt manually after `golangci-lint --fix` runs doesn't have any effect.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
