### PR TITLE
Migrate unit tests to use Go workspace

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -125,16 +125,13 @@ function build_pass {
 
 ################# REGULAR TESTS ################################################
 
-# run_unit_tests [pkgs] runs unit tests for a current module and givesn set of [pkgs]
-function run_unit_tests {
-  local pkgs="${1:-./...}"
-  shift 1
-  # shellcheck disable=SC2068 #For context see - https://github.com/etcd-io/etcd/pull/16433#issuecomment-1684312755
-  go_test "${pkgs}" "parallel" : -short -timeout="${TIMEOUT:-3m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@"
-}
-
 function unit_pass {
-  run_for_modules run_unit_tests "$@"
+  run_for_all_workspace_modules \
+    run_go_tests -short \
+                 -timeout="${TIMEOUT:-3m}" \
+                 "${COMMON_TEST_FLAGS[@]}" \
+                 "${RUN_ARG[@]}" \
+                 "$@"
 }
 
 function integration_extra {


### PR DESCRIPTION
Introduce the new functions: `run_go_tests` and `run_go_test_expanding_packages`, which implement (without Shellcheck exceptions) the old behavior from `go_test`, simplifying the arguments received.

Replaced the three possible values mode with:

1. keep_going: By using the `KEEP_GOING_TESTS` environment variable. This mode expanded the relative modules; it can be run by using `run_go_tests_expanding_packages`.
2. parallel: It worked without expanding the relative modules with the absolute modules. Therefore, this mode can be run directly using `run_go_tests`.
3. fail_fast: By adding an argument "-failfast", and not setting the `KEEP_GOING_TESTS` environment variable.

The argument `flags_for_package_func` can be replaced by regular arguments passed to the function.

These two changes simplify the complexity of the go test wrapper function and allow further customization in the callers.

The JUnit XML generation works the same way, by reading the `JUNIT_REPORT_DIR` or `ARTIFACTS` environment variable. It generates the same reports.

Temporarily introduce the get_junit_filename_prefix function, as a replacement for `junitFilenamePrefix`. The latter will be removed once all test targets are using the new functions.

Finally, update the unit tests function to make use of the new functions, and allow running the tests by using the workspace (i.e., there's no need to change directories anymore).

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
