### PR TITLE
Replace GOLANG_TEST_SHORT with testing.Short()

### DIFF
--- a/client/pkg/testutil/testutil.go
+++ b/client/pkg/testutil/testutil.go
@@ -16,6 +16,8 @@
 package testutil
 
 import (
+	"flag"
+	"log"
 	"net/url"
 	"os"
 	"runtime"
@@ -100,10 +102,13 @@ func SkipTestIfShortMode(t TB, reason string) {
 // ExitInShortMode closes the current process (with 0) if the short test mode detected.
 //
 // To be used in Test-main, where test context (testing.TB) is not available.
-//
-// Requires custom env-variable (GOLANG_TEST_SHORT) apart of `go test --short flag`.
 func ExitInShortMode(reason string) {
-	if os.Getenv("GOLANG_TEST_SHORT") == "true" {
+	// Calling testing.Short() requires flags to be parsed before.
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	if testing.Short() {
+		log.Println(reason)
 		os.Exit(0)
 	}
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -130,7 +130,7 @@ function run_unit_tests {
   local pkgs="${1:-./...}"
   shift 1
   # shellcheck disable=SC2068 #For context see - https://github.com/etcd-io/etcd/pull/16433#issuecomment-1684312755
-  GOLANG_TEST_SHORT=true go_test "${pkgs}" "parallel" : -short -timeout="${TIMEOUT:-3m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@"
+  go_test "${pkgs}" "parallel" : -short -timeout="${TIMEOUT:-3m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@"
 }
 
 function unit_pass {
@@ -309,7 +309,7 @@ function cov_pass {
 
   log_callout "[$(date)] Collecting coverage from unit tests ..."
   for m in $(module_dirs); do
-    GOLANG_TEST_SHORT=true run_for_module "${m}" go_test "./..." "parallel" "pkg_to_coverprofileflag unit_${m}" -short -timeout=30m \
+    run_for_module "${m}" go_test "./..." "parallel" "pkg_to_coverprofileflag unit_${m}" -short -timeout=30m \
        "${gocov_build_flags[@]}" "$@" || failed="$failed unit"
   done
 


### PR DESCRIPTION
Remove the custom environment variable `GOLANG_TEST_SHORT`.

It is currently used by Main tests (`TestMain`), as we can't skip tests because `testing.M` doesn't implement `testing.TB`. It is possible to do a clean `os.Exit(0)` (current behavior), but calling `testing.Short()` fails because this function expects flags to be parsed before.

So, it is possible to remove the custom behavior (`GOLANG_TEST_SHORT`) by parsing flags (if required) before calling `testing.Short()`, then immediately exit if the result is true (`-short` flag is set).

I believe the only place where this environment variable is used is by `tests/integration/clientv3/concurrency` (and `tests/integration/clientv3/examples`). Running with the new approach using only `-short`, works as expected:

```bash
$ pwd
[...]/etcd/tests/integration/clientv3/concurrency
$ go test . -count 1 -short -v
2025/10/30 10:20:49 Skipping: the tests require real cluster
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/concurrency       0.012s
$ go test . -count 1
ok      go.etcd.io/etcd/tests/v3/integration/clientv3/concurrency       3.172s
```

Omitting the verbose output, but focus on time spent and the new log line when short is set.

Part of #18409, as I found out about this while working on updating/simplifying test targets.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
