### PR TITLE
Add benchmark type to perfdash filename

### DIFF
--- a/pkg/report/perfdash.go
+++ b/pkg/report/perfdash.go
@@ -74,7 +74,7 @@ func (r *report) writePerfDashReport(benchmarkOp string) {
 		artifactsDir = "./_artifacts"
 	}
 
-	fileName := fmt.Sprintf("EtcdAPI_benchmark_%s.json", time.Now().UTC().Format(time.RFC3339))
+	fileName := fmt.Sprintf("EtcdAPI_benchmark_%s_%s.json", benchmarkOp, time.Now().UTC().Format(time.RFC3339))
 	err := os.MkdirAll(artifactsDir, 0o755)
 	if err != nil {
 		fmt.Println("Error creating artifacts directory:", err)


### PR DESCRIPTION
Changes in the PR:
This PR updates the naming format of the generated Perfdash reports to make them easier to distinguish from other benchmark types that may be supported in the future..

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
