### PR TITLE
[release-3.6] backport etcdserver: improve linearizable renew lease

### DIFF
--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -290,8 +290,22 @@ func (s *EtcdServer) LeaseRenew(ctx context.Context, id lease.LeaseID) (int64, e
 		if !s.ensureLeadership() {
 			return -1, lease.ErrNotPrimary
 		}
-		if err := s.waitAppliedIndex(); err != nil {
-			return 0, err
+
+		// This change aims to make lease renewal faster under high server load
+		// while preserving correctness. If a lease is not found, it might still be in
+		// the process of being created. We must wait for the applied index to advance
+		// to verify whether the lease truly does not exist.
+		if s.FeatureEnabled(features.FastLeaseKeepAlive) {
+			le := s.lessor.Lookup(id)
+			if le == nil {
+				if err := s.waitAppliedIndex(); err != nil {
+					return 0, err
+				}
+			}
+		} else {
+			if err := s.waitAppliedIndex(); err != nil {
+				return 0, err
+			}
 		}
 
 		ttl, err := s.lessor.Renew(id)

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -74,6 +74,11 @@ const (
 	// alpha: v3.6
 	// main PR: https://github.com/etcd-io/etcd/pull/17661
 	SetMemberLocalAddr featuregate.Feature = "SetMemberLocalAddr"
+	// FastLeaseKeepAlive enables lease renewal to skip waiting for the applied index.
+	// owner: @aaronjzhang
+	// beta: v3.6
+	// main PR: https://github.com/etcd-io/etcd/pull/20589
+	FastLeaseKeepAlive featuregate.Feature = "FastLeaseKeepAlive"
 )
 
 var (
@@ -85,7 +90,8 @@ var (
 		LeaseCheckpoint:              {Default: false, PreRelease: featuregate.Alpha},
 		LeaseCheckpointPersist:       {Default: false, PreRelease: featuregate.Alpha},
 		SetMemberLocalAddr:           {Default: false, PreRelease: featuregate.Alpha},
-	}
+        FastLeaseKeepAlive:           {Default: true, PreRelease: featuregate.Beta},
+    }
 	// ExperimentalFlagToFeatureMap is the map from the cmd line flags of experimental features
 	// to their corresponding feature gates.
 	// Deprecated: Only add existing experimental features here. DO NOT use for new features.

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -24,21 +24,72 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestCtlV3LeaseKeepAlive(t *testing.T) { testCtl(t, leaseTestKeepAlive) }
+func TestCtlV3LeaseKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigAutoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigAutoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
 func TestCtlV3LeaseKeepAliveNoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigNoTLS()))
+	cfg := e2e.NewConfigNoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveNoTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigNoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAliveClientTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientTLS()))
+	cfg := e2e.NewConfigClientTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveClientTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigClientTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAliveClientAutoTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigClientAutoTLS()))
+	cfg := e2e.NewConfigClientAutoTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAliveClientAutoTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigClientAutoTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
 }
 
 func TestCtlV3LeaseKeepAlivePeerTLS(t *testing.T) {
-	testCtl(t, leaseTestKeepAlive, withCfg(*e2e.NewConfigPeerTLS()))
+	cfg := e2e.NewConfigPeerTLS()
+	enableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func TestCtlV3LeaseKeepAlivePeerTLSDisableFastKeepAlive(t *testing.T) {
+	cfg := e2e.NewConfigPeerTLS()
+	disableFastLeaseKeepAlive(cfg)
+	testCtl(t, leaseTestKeepAlive, withCfg(*cfg))
+}
+
+func enableFastLeaseKeepAlive(cfg *e2e.EtcdProcessClusterConfig) {
+	e2e.WithServerFeatureGate("FastLeaseKeepAlive", true)(cfg)
+}
+
+func disableFastLeaseKeepAlive(cfg *e2e.EtcdProcessClusterConfig) {
+	e2e.WithServerFeatureGate("FastLeaseKeepAlive", false)(cfg)
 }
 
 func leaseTestKeepAlive(cx ctlCtx) {


### PR DESCRIPTION
Cherry pick pr #20589 
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
