### PR TITLE
docs: Update the changelogs for versions 3.4,3.5 and 3.6

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -9,6 +9,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 ### Dependencies
 
 - [Compile binaries with `buildvcs=false` to avoid having a pseudo-version reported by `go version`](https://github.com/etcd-io/etcd/pull/20847).
+- Compile binaries using [go 1.24.10](https://github.com/etcd-io/etcd/pull/20903).
 
 ---
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -14,6 +14,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 - Add [flag `--wal-dir` to `etcdutl check v2store` command to support dedicated WAL directory](https://github.com/etcd-io/etcd/pull/20886)
 
+### Dependencies
+
+- Compile binaries using [go 1.24.10](https://github.com/etcd-io/etcd/pull/20902).
+
 ---
 
 ## v3.5.24 (2025-10-22)

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -15,7 +15,7 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ### Dependencies
 
-- Compile binaries using [go 1.24.9](https://github.com/etcd-io/etcd/pull/20801).
+- Compile binaries using [go 1.24.10](https://github.com/etcd-io/etcd/pull/20901).
 
 ---
 


### PR DESCRIPTION
This reflects the use of Go 1.24.10 for compiling binaries.

Contributes to #20891