### PR TITLE
Migrate integration tests to use Go workspace

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -136,18 +136,33 @@ function unit_pass {
 
 function integration_extra {
   if [ -z "${PKG}" ] ; then
-    # shellcheck disable=SC2068
-    run_for_module "tests"  go_test "./integration/v2store/..." "keep_going" : -timeout="${TIMEOUT:-5m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} "$@" || return $?
+    KEEP_GOING_TESTS=true \
+      run_go_tests_expanding_packages ./tests/integration/v2store/... \
+                                      -timeout="${TIMEOUT:-5m}" \
+                                      "${COMMON_TEST_FLAGS[@]}" \
+                                      "${RUN_ARG[@]}" \
+                                      "$@"
   else
     log_warning "integration_extra ignored when PKG is specified"
   fi
 }
 
 function integration_pass {
-  # shellcheck disable=SC2068
-  run_for_module "tests" go_test "./integration/..." "parallel" : -timeout="${TIMEOUT:-15m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} -p=2 "$@" || return $?
-  # shellcheck disable=SC2068
-  run_for_module "tests" go_test "./common/..." "parallel" : --tags=integration -timeout="${TIMEOUT:-15m}" ${COMMON_TEST_FLAGS[@]:-} ${RUN_ARG[@]:-} -p=2 "$@" || return $?
+  run_go_tests ./tests/integration/... \
+               -p=2 \
+               -timeout="${TIMEOUT:-15m}" \
+               "${COMMON_TEST_FLAGS[@]}" \
+               "${RUN_ARG[@]}" \
+               "$@"
+
+  run_go_tests ./tests/common/... \
+               -p=2 \
+               -tags=integration \
+               -timeout="${TIMEOUT:-15m}" \
+               "${COMMON_TEST_FLAGS[@]}" \
+               "${RUN_ARG[@]}" \
+               "$@"
+
   integration_extra "$@"
 }
 

--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -349,7 +349,7 @@ function go_test {
 # run_go_tests_expanding_packages [arguments to pass to go test]
 # Expands the packages in the list of arguments, i.e. ./... into a list of
 # packages for that given module. Then, it calls run_go_tests with the expanded
-# packages.
+# packages. Implements the legacy modes for non-parallel testing.
 function run_go_tests_expanding_packages {
   local packages=()
   local args=()


### PR DESCRIPTION
Switch the integration tests to use the new `run_go_tests` function.

Part of #18409.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
