### PR TITLE
Update contrib/mixin alerting thresholds

### DIFF
--- a/contrib/mixin/test.yaml
+++ b/contrib/mixin/test.yaml
@@ -22,7 +22,7 @@ tests:
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: warning
+              severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
               summary: etcd cluster members are down.
@@ -35,8 +35,8 @@ tests:
               job: etcd
               severity: critical
             exp_annotations:
-              description: 'etcd cluster "etcd": insufficient members (1).'
-              summary: etcd cluster has insufficient number of members.
+              description: "etcd cluster \"etcd\": is reporting fewer instances are available than are needed (1). When etcd does not have a majority of instances available the Kubernetes APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional."
+              summary: "etcd is reporting that a majority of instances are unavailable."
       - eval_time: 15m
         alertname: etcdInsufficientMembers
         exp_alerts:
@@ -44,8 +44,8 @@ tests:
               job: etcd
               severity: critical
             exp_annotations:
-              description: 'etcd cluster "etcd": insufficient members (0).'
-              summary: etcd cluster has insufficient number of members.
+              description: "etcd cluster \"etcd\": is reporting fewer instances are available than are needed (0). When etcd does not have a majority of instances available the Kubernetes APIs will reject read and write requests and operations that preserve the health of workloads cannot be performed. This can occur when multiple control plane nodes are powered off or are unable to connect to each other via the network. Check that all control plane nodes are powered on and that network connections between each machine are functional."
+              summary: "etcd is reporting that a majority of instances are unavailable."
   - interval: 1m
     input_series:
       - series: up{job="etcd",instance="10.10.10.0"}
@@ -60,7 +60,7 @@ tests:
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: warning
+              severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (3).'
               summary: etcd cluster members are down.
@@ -78,40 +78,26 @@ tests:
         exp_alerts:
           - exp_labels:
               job: etcd
-              severity: warning
+              severity: critical
             exp_annotations:
               description: 'etcd cluster "etcd": members are down (1).'
               summary: etcd cluster members are down.
   - interval: 1m
     input_series:
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}
-        values: 0 0 2 0 0 1 0 0 0 0 0 0 0 0 0 0
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}
-        values: 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}
-        values: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      - series: etcd_server_is_leader{job="etcd"}
+        values: 0 0 1 0 0 1 0 1 0 1 0 1 1 0 1 0 1 0 1 0 1 0
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 5m
+        alertname: etcdHighNumberOfLeaderChanges
+      - eval_time: 15m
         alertname: etcdHighNumberOfLeaderChanges
         exp_alerts:
           - exp_labels:
               job: etcd
               severity: warning
             exp_annotations:
-              description: 'etcd cluster "etcd": 4 leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
+              description: 'etcd cluster "etcd": 9 leader changes within the last 10 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
               summary: etcd cluster has high number of leader changes.
-  - interval: 1m
-    input_series:
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.0"}
-        values: 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.1"}
-        values: 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0
-      - series: etcd_server_leader_changes_seen_total{job="etcd",instance="10.10.10.2"}
-        values: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
-    alert_rule_test:
-      - eval_time: 10m
-        alertname: etcdHighNumberOfLeaderChanges
-        exp_alerts:
   - interval: 1m
     input_series:
       - series: etcd_mvcc_db_total_size_in_bytes{job="etcd",instance="10.10.10.0"}


### PR DESCRIPTION
With the help of @dgoodwin we were able to identify better threshold based on our fleet telemetry. Along with it, I wanted to contribute some minor improvements we did to our alerts over the years.

Here's a summary by Claude:

Alert Severity Changes
- etcdMembersDown: Increased severity from warning to critical (alerts/alerts.libsonnet:10)

Improved Alert Descriptions
- etcdInsufficientMembers: Enhanced description with detailed troubleshooting guidance about control plane nodes, network connectivity, and the impact on Kubernetes APIs (alerts/alerts.libsonnet:20-21)

Alert Query Improvements

- etcdHighNumberOfLeaderChanges: Rewrote query to use changes(etcd_server_is_leader) instead of increase(etcd_server_leader_changes_seen_total), changed time window from 15m to 10m (alerts/alerts.libsonnet:30)

More Aggressive Disk Performance Thresholds

- etcdHighFsyncDurations (warning): Lowered threshold from 0.5s to 0.05s (alerts/alerts.libsonnet:47)
- etcdHighFsyncDurations (critical): Lowered threshold from 1s to 0.07s (alerts/alerts.libsonnet:56)
- etcdHighCommitDurations (warning): Lowered threshold from 0.25s to 0.08s (alerts/alerts.libsonnet:65)
- etcdHighCommitDurations (critical): Added new critical alert at 0.1s threshold (alerts/alerts.libsonnet:74-87)

Database Quota Alerts
- etcdDatabaseQuotaLowSpace: Added tiered alerts at 65% (info), 75% (warning), and lowered critical from 95% to 85% (alerts/alerts.libsonnet:89-121)


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
