### PR TITLE
pkg/cobrautl: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/pkg/cobrautl/help.go
+++ b/pkg/cobrautl/help.go
@@ -45,7 +45,7 @@ var (
 		},
 		"indent": func(s string) string {
 			pad := strings.Repeat(" ", 2)
-			return pad + strings.Replace(s, "\n", "\n"+pad, -1)
+			return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
 		},
 	}
 )
@@ -106,7 +106,11 @@ GLOBAL OPTIONS:
 {{end}}
 `[1:]
 
-	commandUsageTemplate = template.Must(template.New("command_usage").Funcs(templFuncs).Parse(strings.ReplaceAll(commandUsage, "\\\n", "")))
+	commandUsageTemplate = template.Must(
+		template.New("command_usage").
+			Funcs(templFuncs).
+			Parse(strings.ReplaceAll(commandUsage, "\\\n", "")),
+	)
 }
 
 func etcdFlagUsages(flagSet *pflag.FlagSet) string {


### PR DESCRIPTION
  Replace deprecated strings.Replace(s, old, new, -1) with the more
  modern and readable strings.ReplaceAll(s, old, new).

  Also improve readability of commandUsageTemplate initialization
  by breaking it into multiple lines.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
