### PR TITLE
deflake TestCacheLaggingWatcher by waiting for resync

### DIFF
--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -1063,6 +1063,7 @@ func TestCacheLaggingWatcher(t *testing.T) {
 		wantExactEventCount int
 		wantAtMaxEventCount int
 		wantClosed          bool
+		postGenerateDelay   time.Duration
 	}{
 		{
 			name:                "all event fit",
@@ -1091,6 +1092,7 @@ func TestCacheLaggingWatcher(t *testing.T) {
 			eventCount:          12,
 			wantAtMaxEventCount: 1, // Either 0 or 1.
 			wantClosed:          true,
+			postGenerateDelay:   100 * time.Millisecond,
 		},
 	}
 
@@ -1113,6 +1115,11 @@ func TestCacheLaggingWatcher(t *testing.T) {
 			ch := c.Watch(t.Context(), prefix, clientv3.WithPrefix())
 
 			generateEvents(t, client, prefix, tt.eventCount)
+
+			if tt.postGenerateDelay > 0 {
+				time.Sleep(tt.postGenerateDelay)
+			}
+
 			gotEvents, ok := collectAndAssertAtomicEvents(t, ch)
 			closed := !ok
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

To address #20852 

This PR tries to deflake `TestCacheLaggingWatcher/pipeline_overflow` by adding a short wait before asserting on the collected events.

@serathius
