### PR TITLE
[release-3.4] scripts/build-binary.sh: use buildvcs=false for binary

### DIFF
--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -78,7 +78,7 @@ function main {
 			export GOARCH=${TARGET_ARCH}
 
 			pushd etcd >/dev/null
-			GO_LDFLAGS="-s" ./build
+			GO_LDFLAGS="-s" GO_BUILD_FLAGS="-v -buildvcs=false" ./build
 			popd >/dev/null
 
 			TARGET="etcd-${VER}-${GOOS}-${GOARCH}"


### PR DESCRIPTION
```bash
$ ./scripts/build-release.sh v3.4.39

$ go version -m  ./release/etcd-v3.4.39-linux-amd64/etcd | head
./release/etcd-v3.4.39-linux-amd64/etcd: go1.24.10
        path    go.etcd.io/etcd
        mod     go.etcd.io/etcd (devel)
        dep     github.com/beorn7/perks v1.0.1  h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
        dep     github.com/cespare/xxhash/v2    v2.2.0  h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
        dep     github.com/coreos/go-semver     v0.2.0  h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
        dep     github.com/coreos/go-systemd    v0.0.0-20180511133405-39ca1b05acc7      h1:u9SHYsPQNyt5tgDm3YN7+9dYrpK96E5wFilTFWIDZOM=
        dep     github.com/coreos/pkg   v0.0.0-20160727233714-3ac0863d7acf      h1:CAKfRE2YtTUIjjh1bkBtyYFaUT/WmOqsJjgtihT0vMI=
        dep     github.com/dustin/go-humanize   v0.0.0-20171111073723-bb3d318650d4      h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
        dep     github.com/gogo/protobuf        v1.3.2  h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

```

Closes: #20846

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
