### PR TITLE
refactor: use strings.Cut to simplify code

### DIFF
--- a/tools/benchmark/cmd/util.go
+++ b/tools/benchmark/cmd/util.go
@@ -37,8 +37,9 @@ func getUsernamePassword(usernameFlag string) (string, string, error) {
 	if globalUserName != "" && globalPassword != "" {
 		return globalUserName, globalPassword, nil
 	}
-	colon := strings.Index(usernameFlag, ":")
-	if colon == -1 {
+	var ok bool
+	globalUserName, globalPassword, ok = strings.Cut(usernameFlag, ":")
+	if !ok {
 		// Prompt for the password.
 		password, err := speakeasy.Ask("Password: ")
 		if err != nil {
@@ -46,9 +47,6 @@ func getUsernamePassword(usernameFlag string) (string, string, error) {
 		}
 		globalUserName = usernameFlag
 		globalPassword = password
-	} else {
-		globalUserName = usernameFlag[:colon]
-		globalPassword = usernameFlag[colon+1:]
 	}
 	return globalUserName, globalPassword, nil
 }


### PR DESCRIPTION
The `strings.Cut` function was introduced in Go 1.18 as part of a proposal to add more efficient string manipulation functions. 

This change enhances code readability and makes it easier to understand the intent of the operation, as strings.Cut directly provides the substring before the specified delimiter, along with a boolean indicating its presence.


More info can see Go Issue https://github.com/golang/go/issues/46336