### PR TITLE
[release-3.5] server: cleanup zombie membership information

### DIFF
--- a/tests/e2e/reproduce_20967_test.go
+++ b/tests/e2e/reproduce_20967_test.go
@@ -1,0 +1,150 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/bbolt"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/datadir"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestIssue20967_Upgrade(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	snapshotCount := 20
+
+	t.Log("Creating cluster with zombie members...")
+	epc := createClustewithZombieMembers(t, snapshotCount)
+
+	t.Log("Upgradeing cluster to the new version...")
+	for _, proc := range epc.Procs {
+		serverCfg := proc.Config()
+
+		t.Logf("Stopping node: %v", serverCfg.Name)
+		require.NoError(t, proc.Stop(), "error closing etcd process (%v)", serverCfg.Name)
+
+		serverCfg.ExecPath = e2e.BinPath
+		serverCfg.KeepDataDir = true
+
+		t.Logf("Restarting node in the new version: %v", serverCfg.Name)
+		require.NoError(t, proc.Restart(), "error restarting etcd process (%v)", serverCfg.Name)
+	}
+
+	t.Log("Cluster upgraded to current version successfully")
+	epc.WaitLeader(t)
+
+	t.Log("Verifying zombie members are removed from v3store...")
+	require.NoError(t, epc.Stop())
+	for _, proc := range epc.Procs {
+		members := readMembersFromV3Store(t, proc.Config().DataDirPath)
+		require.Lenf(t, members, 3, "expected 3 members in v3store after upgrade, got %v", members)
+	}
+
+	t.Log("Restarting cluster")
+	require.NoError(t, epc.Start())
+	epc.WaitLeader(t)
+
+	t.Log("Writing key/values")
+	for i := 0; i < snapshotCount; i++ {
+		k, v := fmt.Sprintf("key-%d", i), fmt.Sprintf("value-%d", i)
+
+		require.NoError(t, epc.Procs[i%len(epc.Procs)].Etcdctl(e2e.ClientNonTLS, false, false).Put(k, v))
+	}
+}
+
+func TestIssue20967_Snapshot(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	snapshotCount := 20
+	keyCount := snapshotCount
+
+	t.Log("Creating cluster with zombie members...")
+	epc := createClustewithZombieMembers(t, snapshotCount)
+
+	lastProc := epc.Procs[2]
+	t.Logf("Stopping last member %s", lastProc.Config().Name)
+	require.NoError(t, lastProc.Stop())
+
+	epc.WaitLeader(t)
+
+	cli, err := clientv3.New(clientv3.Config{Endpoints: epc.Procs[0].EndpointsGRPC()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	t.Log("Writing key/values to trigger snapshot...")
+	for i := 0; i < keyCount; i++ {
+		k, v := fmt.Sprintf("key-%d", i), fmt.Sprintf("value-%d", i)
+
+		_, err = cli.Put(t.Context(), k, v)
+		require.NoErrorf(t, err, "failed to put key %s", k)
+	}
+	cli.Close()
+
+	t.Log("Restart the first two members to drop pre-snapshot in-memory log entries," +
+		"ensuring the last member is forced to recover from the snapshot." +
+		"(Note: SnapshotCatchUpEntries in v3.4.x is a fixed value of 5000.)")
+	require.NoError(t, epc.Procs[0].Restart())
+	require.NoError(t, epc.Procs[1].Restart())
+	epc.WaitLeader(t)
+
+	t.Logf("Restarting last member %s with new version", lastProc.Config().Name)
+	lastProc.Config().ExecPath = e2e.BinPath
+	require.NoError(t, lastProc.Start(), "failed to start member process")
+
+	t.Logf("Verifying last member %s was recovered from snapshot sent by leader", lastProc.Config().Name)
+	found := false
+	for _, line := range lastProc.Logs().Lines() {
+		if strings.Contains(line, "applied snapshot") {
+			t.Logf("Found %s", line)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "last member did not receive snapshot from leader")
+
+	for i := 0; i < keyCount; i++ {
+		k, v := fmt.Sprintf("key-%d", i), fmt.Sprintf("value-%d", i)
+
+		value, err := lastProc.Etcdctl(e2e.ClientNonTLS, false, false).Get(k)
+		require.NoErrorf(t, err, "failed to get key %s from rejoined member", k)
+
+		require.Len(t, value.Kvs, 1)
+		require.Equal(t, v, string(value.Kvs[0].Value))
+	}
+
+	t.Log("Verifying zombie members for last member")
+	require.NoError(t, lastProc.Stop())
+	members := readMembersFromV3Store(t, lastProc.Config().DataDirPath)
+	require.Lenf(t, members, 3, "expected 3 members in v3store after upgrade, got %v", members)
+}
+
+// readMembersFromV3Store read all members from the v3store in the given dataDir.
+func readMembersFromV3Store(t *testing.T, dataDir string) []membership.Member {
+	dbPath := datadir.ToBackendFileName(dataDir)
+	db, err := bbolt.Open(dbPath, 0400, &bbolt.Options{ReadOnly: true})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	var members []membership.Member
+	_ = db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(buckets.Members.Name()).ForEach(func(_, v []byte) error {
+			m := membership.Member{}
+			err := json.Unmarshal(v, &m)
+			require.NoError(t, err)
+
+			members = append(members, m)
+			return nil
+		})
+	})
+	return members
+}

--- a/tests/e2e/reproduce_20967_util_test.go
+++ b/tests/e2e/reproduce_20967_util_test.go
@@ -1,0 +1,201 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/bbolt"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/server/v3/datadir"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
+	"go.etcd.io/etcd/server/v3/mvcc/buckets"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// createClustewithZombieMembers creates a cluster with zombie members in v3store.
+//
+// There are two ways to create zombie members:
+//
+// 1. Restoring a cluster using a snapshot taken from version <= v3.4.39.
+//
+//	The `etcdctl snapshot restore` tool in versions <= v3.4.39 contains a bug
+//	that fails to clean up old member information during restore. This leaves
+//	behind stale (zombie) member entries in the v3store.
+//
+// 2. Using ForceNewCluster on a cluster running a version < v3.5.22.
+//
+//	If ETCD commits a ConfChangeAddNode entry to the v3store but crashes before
+//	the corresponding hard state is persisted to the WAL, then after restarting
+//	with ForceNewCluster, the member entries in the v3store are not cleaned up,
+//	resulting in zombie members. This issue was fixed in [v3.5.22][1].
+//
+//	It may be possible to create zombie member in versions < [v3.4.0][2] through a
+//	single-node ForceNewCluster restart. For example, suppose we start with a
+//	one-node cluster. We add a second node, but the second node fails to join
+//	and the cluster loses quorum. We then restart the first node with ForceNewCluster,
+//	which results in a zombie member entry for the second node. However, it
+//	is still unlikely for three zombie members (like [issue-20967][3]) to
+//	appear at the same time.
+//
+//	So in theory, this could happen when using ForceNewCluster. However, it is
+//	extremely unlikely in practice because multiple members are running, and it
+//	would require all of them to panic at the same time. It would also require
+//	selecting one of the crashed members to restart with ForceNewCluster, where
+//	that member had failed to persist the hard state to the WAL—an improbable
+//	combination of events (what a coincidence).
+//
+// So, in this function, we use the first method to create zombie members for
+// testing.
+//
+// REF:
+//
+// [1]: https://github.com/etcd-io/etcd/commit/ccf66456e7237ef5251d9fdc96f1624d1aa4daf1
+// [2]: https://github.com/etcd-io/etcd/issues/14370
+// [3]: https://github.com/etcd-io/etcd/issues/20967
+func createClustewithZombieMembers(t *testing.T, snapshotCount int) *e2e.EtcdProcessCluster {
+	if !fileutil.Exist(e2e.BinPathLastRelease) {
+		t.Skipf("%q does not exist", e2e.BinPathLastRelease)
+	}
+
+	t.Log("Creating initial cluster with LastVersion...")
+	epc, err := e2e.NewEtcdProcessCluster(t,
+		&e2e.EtcdProcessClusterConfig{
+			Version:      e2e.LastVersion,
+			ClusterSize:  3,
+			KeepDataDir:  true,
+			RollingStart: true,
+			// LogLevel:      "debug",
+			SnapshotCount: snapshotCount,
+		})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, epc.Close())
+	})
+
+	t.Log("Fetching snapshot from cluster")
+	snapFile := fetchSnapshotFromMember(t, e2e.CtlBinPathV3439Release, epc.Procs[0])
+
+	t.Log("Stopping all members")
+	require.NoError(t, epc.Stop())
+
+	t.Log("Restoring snapshot using etcdctl v3.4.39 to create zombie members...")
+	for _, proc := range epc.Procs {
+		serverCfg := proc.Config()
+
+		require.NoError(t, restoreSnapshotIntoMemberDir(t, e2e.CtlBinPathV3439Release, snapFile, serverCfg.InitialCluster, proc),
+			"failed to restore snapshot for member %s", serverCfg.Name)
+	}
+
+	t.Log("Restarting all members from restored data dirs...")
+	require.NoError(t, epc.RollingStart())
+
+	t.Log("Ensuring zombie members exist in v3store...")
+	require.NoError(t, epc.Stop())
+	for _, proc := range epc.Procs {
+		ensureZombieMembers(t, proc.Config().DataDirPath)
+	}
+	require.NoError(t, epc.RollingStart())
+	epc.WaitLeader(t)
+	return epc
+}
+
+// ensureZombieMembers checks that there are 6 members in the v3store.
+func ensureZombieMembers(t *testing.T, dataDir string) {
+	dbPath := datadir.ToBackendFileName(dataDir)
+	db, err := bbolt.Open(dbPath, 0400, &bbolt.Options{ReadOnly: true})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	count := 0
+	members := map[string]int{}
+	_ = db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(buckets.Members.Name()).ForEach(func(_, v []byte) error {
+			m := membership.Member{}
+			err := json.Unmarshal(v, &m)
+			require.NoError(t, err)
+
+			key := fmt.Sprintf("name=%s,peerURLs=%v,isLearner=%v", m.Name, m.PeerURLs, m.IsLearner)
+			members[key]++
+
+			count++
+			return nil
+		})
+	})
+	require.Equal(t, 6, count, "expected 6 members in v3store")
+	require.Equal(t, 3, len(members), "expected 3 member names in v3store")
+}
+
+// restoreSnapshotIntoMemberDir restores snapshot into the given member's data dir.
+func restoreSnapshotIntoMemberDir(t *testing.T, etcdctlBin string, snapshotPath string, initialCluster string, proc e2e.EtcdProcess) error {
+	serverCfg := proc.Config()
+	require.NoError(t, os.RemoveAll(serverCfg.DataDirPath), "failed to remove data dir %s", serverCfg.DataDirPath)
+
+	serverCfg.DataDirPath = filepath.Join(t.TempDir(), "restored-"+serverCfg.Name)
+	updateServerCfgArgs(serverCfg, "--data-dir", serverCfg.DataDirPath)
+
+	serverCfg.InitialCluster = initialCluster
+	updateServerCfgArgs(serverCfg, "--initial-cluster", initialCluster)
+
+	// We can use AddMember to create unique member ID with same cluter name.
+	// However, it takes long time to wait for the cluster to be healthy.
+	// So, we simply update the initial cluster configuration with different
+	// cluster name here. This achieves the same effect for testing zombie
+	// members.
+	//
+	// NOTE: If we use same cluster name without using AddMember before,
+	// etcd will generate same member ID and it won't create zombie members.
+	serverCfg.InitialToken = "restored"
+	updateServerCfgArgs(serverCfg, "--initial-cluster-token", serverCfg.InitialToken)
+
+	ctl := proc.Etcdctl(e2e.ClientNonTLS, false, false)
+	args := ctl.GenerateCmdArgs(
+		"snapshot", "restore", snapshotPath,
+		"--data-dir", serverCfg.DataDirPath,
+		"--name", serverCfg.Name,
+		"--initial-cluster", serverCfg.InitialCluster,
+		"--initial-cluster-token", serverCfg.InitialToken,
+		"--initial-advertise-peer-urls", serverCfg.Purl.String(),
+	)
+	args[0] = etcdctlBin
+
+	t.Logf("Restoring command args: %v", args)
+	return e2e.SpawnWithExpectWithEnv(args, ctl.Envs(), "restored snapshot")
+}
+
+// fetchSnapshotFromMember fetches snapshot from the given member and returnes
+// the snapshot file path.
+func fetchSnapshotFromMember(t *testing.T, etcdctlBin string, proc e2e.EtcdProcess) string {
+	fPath := filepath.Join(t.TempDir(), "snapshot.db")
+
+	ctl := proc.Etcdctl(e2e.ClientNonTLS, false, false)
+
+	args := ctl.GenerateCmdArgs("snapshot", "save", fPath)
+	args[0] = etcdctlBin
+
+	require.NoError(t,
+		e2e.SpawnWithExpectWithEnv(
+			args,
+			ctl.Envs(),
+			fmt.Sprintf("Snapshot saved at %s", fPath),
+		),
+	)
+	return fPath
+}
+
+// updateServerCfgArgs updates the given argKey to argValue in serverCfg.
+func updateServerCfgArgs(serverCfg *e2e.EtcdServerProcessConfig, argKey, argValue string) {
+	for i := range serverCfg.Args {
+		if serverCfg.Args[i] == argKey {
+			serverCfg.Args[i+1] = argValue
+			return
+		}
+	}
+}

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -41,6 +41,9 @@ var (
 	BinPathLastRelease   string
 	CtlBinPath           string
 	UtlBinPath           string
+
+	CtlBinPathLastRelease  string
+	CtlBinPathV3439Release string
 )
 
 // EtcdProcess is a process that serves etcd requests.

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -216,6 +216,14 @@ func (ctl *Etcdctl) Status() ([]*clientv3.StatusResponse, error) {
 	return resp, err
 }
 
+func (ctl *Etcdctl) GenerateCmdArgs(baseArgs ...string) []string {
+	return ctl.cmdArgs(baseArgs...)
+}
+
+func (ctl *Etcdctl) Envs() map[string]string {
+	return ctl.env()
+}
+
 func (ctl *Etcdctl) spawnJsonCmd(output interface{}, args ...string) error {
 	args = append(args, "-w", "json")
 	cmd, err := SpawnCmd(append(ctl.cmdArgs(), args...), ctl.env())

--- a/tests/framework/e2e/flags.go
+++ b/tests/framework/e2e/flags.go
@@ -56,6 +56,10 @@ func InitFlags() {
 
 	BinPath = BinDir + "/etcd"
 	BinPathLastRelease = BinDir + "/etcd-last-release"
+
+	CtlBinPathLastRelease = BinDir + "/etcdctl-last-release"
+	CtlBinPathV3439Release = BinDir + "/etcdctl-v3439-release"
+
 	CtlBinPath = BinDir + "/etcdctl"
 	UtlBinPath = BinDir + "/etcdutl"
 	CertPath = CertDir + "/server.crt"


### PR DESCRIPTION
There are three places where zombie membership information can be cleaned up:

```
1. ApplierV2 -> UpdateAttributes

   Ideally, each member updates its own attributes only once before serving
   requests. Since this happens only at startup and at low frequency, it is
   safe to clean up zombie members during this operation.

   Additionally, pending logs are always applied before attributes are updated,
   so there is no data race.

2. Applying a snapshot via Raft message

   When a member receives a snapshot through a Raft message, the v2store is
   synchronized with the v3store. This makes it safe to detect and clean up
   zombie membership entries at that time.

3. Applying ConfChange

   Check and cleanup zombie members after ConfChange. Ideally, there aren't
   too many ConfChange, the impact on performance should be minimal.
```

Fixes: #20967

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
