### PR TITLE
fix(mixin): Fix alerts aggregation by improving config defaults

### DIFF
--- a/contrib/mixin/config.libsonnet
+++ b/contrib/mixin/config.libsonnet
@@ -11,7 +11,7 @@
     // that are about an etcd cluster as a whole. For example, if etcd
     // instances are deployed on K8s, you will likely want to change
     // this to 'instance, pod'.
-    etcd_instance_labels: 'instance',
+    etcd_instance_labels: 'instance,pod',
     // scrape_interval_seconds is the global scrape interval which can be
     // used to dynamically adjust rate windows as a function of the interval.
     scrape_interval_seconds: 30,


### PR DESCRIPTION
If not all labels are mentioned you might get 3 similar alerts (as etcdInsufficientMembers) instead of just one per cluster. 

`pod` and `instance` are always present in typical k8s prometheus setups so best to provide those as defaults , so alerts work properly in most cases.