### PR TITLE
tests: Add PutResponse to Put method in common test pkg client interface

### DIFF
--- a/tests/common/alarm_test.go
+++ b/tests/common/alarm_test.go
@@ -41,12 +41,13 @@ func TestAlarm(t *testing.T) {
 	testutils.ExecuteUntil(ctx, t, func() {
 		// test small put still works
 		smallbuf := strings.Repeat("a", 64)
-		require.NoErrorf(t, cc.Put(ctx, "1st_test", smallbuf, config.PutOptions{}), "alarmTest: put kv error")
+		_, err := cc.Put(ctx, "1st_test", smallbuf, config.PutOptions{})
+		require.NoErrorf(t, err, "alarmTest: put kv error")
 
 		// write some chunks to fill up the database
 		buf := strings.Repeat("b", os.Getpagesize())
 		for {
-			if err := cc.Put(ctx, "2nd_test", buf, config.PutOptions{}); err != nil {
+			if _, err = cc.Put(ctx, "2nd_test", buf, config.PutOptions{}); err != nil {
 				require.ErrorContains(t, err, "etcdserver: mvcc: database space exceeded")
 				break
 			}
@@ -57,7 +58,7 @@ func TestAlarm(t *testing.T) {
 		require.NoErrorf(t, err, "alarmTest: Alarm error")
 
 		// check that Put is rejected when alarm is on
-		if err = cc.Put(ctx, "3rd_test", smallbuf, config.PutOptions{}); err != nil {
+		if _, err = cc.Put(ctx, "3rd_test", smallbuf, config.PutOptions{}); err != nil {
 			require.ErrorContains(t, err, "etcdserver: mvcc: database space exceeded")
 		}
 
@@ -90,7 +91,7 @@ func TestAlarm(t *testing.T) {
 		}
 
 		// put one more key below quota
-		err = cc.Put(ctx, "4th_test", smallbuf, config.PutOptions{})
+		_, err = cc.Put(ctx, "4th_test", smallbuf, config.PutOptions{})
 		require.NoError(t, err)
 	})
 }

--- a/tests/common/compact_test.go
+++ b/tests/common/compact_test.go
@@ -51,7 +51,8 @@ func TestCompact(t *testing.T) {
 			testutils.ExecuteUntil(ctx, t, func() {
 				kvs := []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 				for i := range kvs {
-					require.NoErrorf(t, cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}), "compactTest #%d: put kv error", i)
+					_, err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{})
+					require.NoErrorf(t, err, "compactTest #%d: put kv error", i)
 				}
 				get, err := cc.Get(ctx, "key", config.GetOptions{Revision: 3})
 				require.NoErrorf(t, err, "compactTest: Get kv by revision error")

--- a/tests/common/defrag_test.go
+++ b/tests/common/defrag_test.go
@@ -36,7 +36,8 @@ func TestDefragOnline(t *testing.T) {
 		defer clus.Close()
 		kvs := []testutils.KV{{Key: "key", Val: "val1"}, {Key: "key", Val: "val2"}, {Key: "key", Val: "val3"}}
 		for i := range kvs {
-			require.NoErrorf(t, cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{}), "compactTest #%d: put kv error", i)
+			_, err := cc.Put(ctx, kvs[i].Key, kvs[i].Val, config.PutOptions{})
+			require.NoErrorf(t, err, "compactTest #%d: put kv error", i)
 		}
 		_, err := cc.Compact(ctx, 4, config.CompactOption{Physical: true, Timeout: 10 * time.Second})
 		require.NoErrorf(t, err, "defrag_test: compact with revision error (%v)", err)

--- a/tests/common/endpoint_test.go
+++ b/tests/common/endpoint_test.go
@@ -51,7 +51,8 @@ func TestEndpointHashKV(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
-		require.NoErrorf(t, cc.Put(ctx, key, value, config.PutOptions{}), "count not put key %q", key)
+		_, err := cc.Put(ctx, key, value, config.PutOptions{})
+		require.NoErrorf(t, err, "count not put key %q", key)
 	}
 
 	t.Log("Check all members' Hash and HashRevision")

--- a/tests/common/grpc_test.go
+++ b/tests/common/grpc_test.go
@@ -155,7 +155,8 @@ func TestAuthority(t *testing.T) {
 				cc := testutils.MustClient(clus.Client(WithEndpoints(endpoints)))
 
 				for i := 0; i < 100; i++ {
-					require.NoError(t, cc.Put(ctx, "foo", "bar", config.PutOptions{}))
+					_, err := cc.Put(ctx, "foo", "bar", config.PutOptions{})
+					require.NoError(t, err)
 				}
 
 				testutils.ExecuteWithTimeout(t, 5*time.Second, func() {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -40,7 +40,8 @@ func TestKVPut(t *testing.T) {
 			testutils.ExecuteUntil(ctx, t, func() {
 				key, value := "foo", "bar"
 
-				require.NoErrorf(t, cc.Put(ctx, key, value, config.PutOptions{}), "count not put key %q", key)
+				_, err := cc.Put(ctx, key, value, config.PutOptions{})
+				require.NoErrorf(t, err, "count not put key %q", key)
 				resp, err := cc.Get(ctx, key, config.GetOptions{})
 				require.NoErrorf(t, err, "count not get key %q, err: %s", key, err)
 				assert.Lenf(t, resp.Kvs, 1, "Unexpected length of response, got %d", len(resp.Kvs))
@@ -70,7 +71,8 @@ func TestKVGet(t *testing.T) {
 				)
 
 				for i := range kvs {
-					require.NoErrorf(t, cc.Put(ctx, kvs[i], "bar", config.PutOptions{}), "count not put key %q", kvs[i])
+					_, err := cc.Put(ctx, kvs[i], "bar", config.PutOptions{})
+					require.NoErrorf(t, err, "count not put key %q", kvs[i])
 				}
 				tests := []struct {
 					begin   string
@@ -166,7 +168,8 @@ func TestKVDelete(t *testing.T) {
 				}
 				for _, tt := range tests {
 					for i := range kvs {
-						require.NoErrorf(t, cc.Put(ctx, kvs[i], "bar", config.PutOptions{}), "count not put key %q", kvs[i])
+						_, err := cc.Put(ctx, kvs[i], "bar", config.PutOptions{})
+						require.NoErrorf(t, err, "count not put key %q", kvs[i])
 					}
 					del, err := cc.Delete(ctx, tt.deleteKey, tt.options)
 					require.NoErrorf(t, err, "count not get key %q, err", tt.deleteKey)

--- a/tests/common/lease_test.go
+++ b/tests/common/lease_test.go
@@ -132,7 +132,7 @@ func TestLeaseGrantTimeToLiveExpired(t *testing.T) {
 				leaseResp, err := cc.Grant(ctx, 2)
 				require.NoError(t, err)
 
-				err = cc.Put(ctx, "foo", "bar", config.PutOptions{LeaseID: leaseResp.ID})
+				_, err = cc.Put(ctx, "foo", "bar", config.PutOptions{LeaseID: leaseResp.ID})
 				require.NoError(t, err)
 
 				getResp, err := cc.Get(ctx, "foo", config.GetOptions{})
@@ -230,7 +230,7 @@ func TestLeaseGrantRevoke(t *testing.T) {
 				leaseResp, err := cc.Grant(ctx, 20)
 				require.NoError(t, err)
 
-				err = cc.Put(ctx, "foo", "bar", config.PutOptions{LeaseID: leaseResp.ID})
+				_, err = cc.Put(ctx, "foo", "bar", config.PutOptions{LeaseID: leaseResp.ID})
 				require.NoError(t, err)
 
 				getResp, err := cc.Get(ctx, "foo", config.GetOptions{})

--- a/tests/common/txn_test.go
+++ b/tests/common/txn_test.go
@@ -65,9 +65,9 @@ func TestTxnSucc(t *testing.T) {
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
-				err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
+				_, err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
 				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key1", "value1")
-				err = cc.Put(ctx, "key2", "value2", config.PutOptions{})
+				_, err = cc.Put(ctx, "key2", "value2", config.PutOptions{})
 				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key2", "value2")
 				for _, req := range reqs {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{
@@ -105,7 +105,7 @@ func TestTxnFail(t *testing.T) {
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
 			testutils.ExecuteUntil(ctx, t, func() {
-				err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
+				_, err := cc.Put(ctx, "key1", "value1", config.PutOptions{})
 				require.NoErrorf(t, err, "could not create key:%s, value:%s", "key1", "value1")
 				for _, req := range reqs {
 					resp, err := cc.Txn(ctx, req.compare, req.ifSuccess, req.ifFail, config.TxnOptions{

--- a/tests/common/watch_test.go
+++ b/tests/common/watch_test.go
@@ -76,7 +76,7 @@ func TestWatch(t *testing.T) {
 					require.NotNilf(t, wch, "failed to watch %s", tt.watchKey)
 
 					for j := range tt.puts {
-						err := cc.Put(ctx, tt.puts[j].Key, tt.puts[j].Val, config.PutOptions{})
+						_, err := cc.Put(ctx, tt.puts[j].Key, tt.puts[j].Val, config.PutOptions{})
 						require.NoErrorf(t, err, "can't not put key %q, err: %s", tt.puts[j].Key, err)
 					}
 

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -252,7 +252,7 @@ func generateSnapshot(t *testing.T, snapshotCount uint64, cc *e2e.EtcdctlV3) {
 	var i uint64
 	t.Logf("Adding keys")
 	for i = 0; i < snapshotCount*3; i++ {
-		err := cc.Put(ctx, fmt.Sprintf("%d", i), "1", config.PutOptions{})
+		_, err := cc.Put(ctx, fmt.Sprintf("%d", i), "1", config.PutOptions{})
 		assert.NoError(t, err)
 	}
 }

--- a/tests/e2e/corrupt_test.go
+++ b/tests/e2e/corrupt_test.go
@@ -124,7 +124,7 @@ func TestInPlaceRecovery(t *testing.T) {
 	oldCc, err := e2e.NewEtcdctl(epcOld.Cfg.Client, epcOld.EndpointsGRPC())
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
-		err = oldCc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
+		_, err = oldCc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
 		require.NoErrorf(t, err, "error on put")
 	}
 
@@ -210,7 +210,7 @@ func TestPeriodicCheckDetectsCorruption(t *testing.T) {
 
 	cc := epc.Etcdctl()
 	for i := 0; i < 10; i++ {
-		err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
+		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
 		require.NoErrorf(t, err, "error on put")
 	}
 
@@ -261,7 +261,7 @@ func testCompactHashCheckDetectCorruption(t *testing.T, useFeatureGate bool) {
 
 	cc := epc.Etcdctl()
 	for i := 0; i < 10; i++ {
-		err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
+		_, err = cc.Put(ctx, testutil.PickKey(int64(i)), fmt.Sprint(i), config.PutOptions{})
 		require.NoErrorf(t, err, "error on put")
 	}
 	memberID, found, err := getMemberIDByName(ctx, cc, epc.Procs[0].Config().Name)
@@ -341,7 +341,7 @@ func testCompactHashCheckDetectCorruptionInterrupt(t *testing.T, useFeatureGate 
 	t.Log("putting 10 values to the identical key...")
 	cc := epc.Etcdctl()
 	for i := 0; i < 10; i++ {
-		err = cc.Put(ctx, "key", fmt.Sprint(i), config.PutOptions{})
+		_, err = cc.Put(ctx, "key", fmt.Sprint(i), config.PutOptions{})
 		require.NoErrorf(t, err, "error on put")
 	}
 

--- a/tests/e2e/ctl_v3_auth_cluster_test.go
+++ b/tests/e2e/ctl_v3_auth_cluster_test.go
@@ -58,7 +58,7 @@ func TestAuthCluster(t *testing.T) {
 
 	// write more than SnapshotCount keys to single leader to make sure snapshot is created
 	for i := 0; i <= 10; i++ {
-		if err := epc.Etcdctl(testUserClientOpts).Put(ctx, fmt.Sprintf("/test/%d", i), "test", config.PutOptions{}); err != nil {
+		if _, err := epc.Etcdctl(testUserClientOpts).Put(ctx, fmt.Sprintf("/test/%d", i), "test", config.PutOptions{}); err != nil {
 			t.Fatalf("failed to Put (%v)", err)
 		}
 	}
@@ -72,7 +72,7 @@ func TestAuthCluster(t *testing.T) {
 	endpoints := epc.EndpointsGRPC()
 	assert.Len(t, endpoints, 2)
 	for _, endpoint := range epc.EndpointsGRPC() {
-		if err := epc.Etcdctl(testUserClientOpts, e2e.WithEndpoints([]string{endpoint})).Put(ctx, "/test/key", endpoint, config.PutOptions{}); err != nil {
+		if _, err := epc.Etcdctl(testUserClientOpts, e2e.WithEndpoints([]string{endpoint})).Put(ctx, "/test/key", endpoint, config.PutOptions{}); err != nil {
 			t.Fatalf("failed to write to Put to %q (%v)", endpoint, err)
 		}
 	}

--- a/tests/e2e/ctl_v3_auth_no_proxy_test.go
+++ b/tests/e2e/ctl_v3_auth_no_proxy_test.go
@@ -113,7 +113,7 @@ func TestCtlV3AuthCertCNWithWithConcurrentOperation(t *testing.T) {
 			key := fmt.Sprintf("key-%d", i)
 			value := fmt.Sprintf("value-%d", i)
 
-			if err := epcClient.Put(ctx, key, value, config.PutOptions{}); err != nil {
+			if _, err := epcClient.Put(ctx, key, value, config.PutOptions{}); err != nil {
 				errs <- fmt.Errorf("failed to put key %q: %w", key, err)
 				break
 			}

--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -315,7 +315,8 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 
 	kvs := []testutils.KV{{Key: "foo1", Val: "val1"}, {Key: "foo2", Val: "val2"}, {Key: "foo3", Val: "val3"}}
 	for i := range kvs {
-		require.NoError(t, ctl.Put(t.Context(), kvs[i].Key, kvs[i].Val, config.PutOptions{}))
+		_, err = ctl.Put(t.Context(), kvs[i].Key, kvs[i].Val, config.PutOptions{})
+		require.NoError(t, err)
 	}
 
 	watchTimeout := 1 * time.Second
@@ -337,7 +338,8 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 	// add some more kvs that are not in the snapshot that will be lost after restore
 	unsnappedKVs := []testutils.KV{{Key: "unsnapped1", Val: "one"}, {Key: "unsnapped2", Val: "two"}, {Key: "unsnapped3", Val: "three"}}
 	for i := range unsnappedKVs {
-		require.NoError(t, ctl.Put(t.Context(), unsnappedKVs[i].Key, unsnappedKVs[i].Val, config.PutOptions{}))
+		_, err = ctl.Put(t.Context(), unsnappedKVs[i].Key, unsnappedKVs[i].Val, config.PutOptions{})
+		require.NoError(t, err)
 	}
 
 	membersBefore, err := ctl.MemberList(t.Context(), false)
@@ -403,7 +405,8 @@ func TestRestoreCompactionRevBump(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), watchTimeout*5)
 	defer cancel()
 	watchCh = ctl.Watch(ctx, "foo", config.WatchOptions{Prefix: true, Revision: int64(bumpAmount + currentRev + 1)})
-	require.NoError(t, ctl.Put(t.Context(), "foo4", "val4", config.PutOptions{}))
+	_, err = ctl.Put(ctx, "foo4", "val4", config.PutOptions{})
+	require.NoError(t, err)
 	watchRes, err = testutils.KeyValuesFromWatchChan(watchCh, 1, watchTimeout)
 	require.NoErrorf(t, err, "failed to get key-values from watch channel %s", err)
 	require.Equal(t, []testutils.KV{{Key: "foo4", Val: "val4"}}, watchRes)

--- a/tests/e2e/defrag_no_space_test.go
+++ b/tests/e2e/defrag_no_space_test.go
@@ -60,7 +60,9 @@ func TestDefragNoSpace(t *testing.T) {
 			require.ErrorContains(t, member.Etcdctl().Defragment(t.Context(), config.DefragOption{Timeout: time.Minute}), tc.err)
 
 			// Make sure etcd continues to run even after the failed defrag attempt
-			require.NoError(t, member.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{}))
+
+			_, err = member.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
+			require.NoError(t, err)
 			value, err := member.Etcdctl().Get(t.Context(), "foo", config.GetOptions{})
 			require.NoError(t, err)
 			require.Len(t, value.Kvs, 1)

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -621,7 +621,7 @@ func TestEtcdHealthyWithTinySnapshotCatchupEntries(t *testing.T) {
 		g.Go(func() error {
 			cc := epc.Etcdctl()
 			for j := 0; j < 100; j++ {
-				if err := cc.Put(ctx, "foo", fmt.Sprintf("bar%d", clientID), config.PutOptions{}); err != nil {
+				if _, err := cc.Put(ctx, "foo", fmt.Sprintf("bar%d", clientID), config.PutOptions{}); err != nil {
 					return err
 				}
 			}

--- a/tests/e2e/etcd_grpcproxy_test.go
+++ b/tests/e2e/etcd_grpcproxy_test.go
@@ -61,7 +61,7 @@ func TestGrpcProxyAutoSync(t *testing.T) {
 
 	proxyCtl, err := e2e.NewEtcdctl(e2e.ClientConfig{}, []string{proxyClientURL})
 	require.NoError(t, err)
-	err = proxyCtl.Put(ctx, "k1", "v1", config.PutOptions{})
+	_, err = proxyCtl.Put(ctx, "k1", "v1", config.PutOptions{})
 	require.NoError(t, err)
 
 	// Add and start second member

--- a/tests/e2e/etcd_mix_versions_test.go
+++ b/tests/e2e/etcd_mix_versions_test.go
@@ -169,7 +169,7 @@ func writeKVs(t *testing.T, etcdctl *e2e.EtcdctlV3, startIdx, endIdx int) {
 	for i := startIdx; i < endIdx; i++ {
 		key := fmt.Sprintf("key-%d", i)
 		value := fmt.Sprintf("value-%d", i)
-		err := etcdctl.Put(t.Context(), key, value, config.PutOptions{})
+		_, err := etcdctl.Put(t.Context(), key, value, config.PutOptions{})
 		require.NoErrorf(t, err, "failed to put %q", key)
 	}
 }

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -208,7 +208,7 @@ func TestClusterUpgradeAfterPromotingMembers(t *testing.T) {
 			}()
 
 			for i := 0; i < tc.snapshot; i++ {
-				err = epc.Etcdctl().Put(ctx, "foo", "bar", config.PutOptions{})
+				_, err = epc.Etcdctl().Put(ctx, "foo", "bar", config.PutOptions{})
 				require.NoError(t, err)
 			}
 
@@ -220,7 +220,7 @@ func TestClusterUpgradeAfterPromotingMembers(t *testing.T) {
 
 			t.Logf("Checking all members are ready to serve client requests")
 			for i := 0; i < clusterSize; i++ {
-				err = epc.Procs[i].Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
+				_, err = epc.Procs[i].Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
 				require.NoError(t, err)
 			}
 		})

--- a/tests/e2e/force_new_cluster_test.go
+++ b/tests/e2e/force_new_cluster_test.go
@@ -59,7 +59,7 @@ func TestForceNewCluster(t *testing.T) {
 			require.Len(t, promotedMembers, 4)
 
 			for i := 0; i < tc.snapcount; i++ {
-				err := epc.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
+				_, err := epc.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
 				require.NoError(t, err)
 			}
 
@@ -153,7 +153,7 @@ func TestForceNewCluster_AddLearner_MemberCount(t *testing.T) {
 			})
 
 			for i := 0; i < tc.snapcount; i++ {
-				werr := epc.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
+				_, werr := epc.Etcdctl().Put(t.Context(), "foo", "bar", config.PutOptions{})
 				require.NoError(t, werr)
 			}
 			require.NoError(t, epc.Close())

--- a/tests/e2e/leader_snapshot_no_proxy_test.go
+++ b/tests/e2e/leader_snapshot_no_proxy_test.go
@@ -93,6 +93,6 @@ func TestRecoverSnapshotBackend(t *testing.T) {
 	require.NoError(t, err)
 	_, err = blackholedMember.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "Recovering from snapshot backend"})
 	require.NoError(t, err)
-	err = blackholedMember.Etcdctl().Put(ctx, "a", "1", config.PutOptions{})
+	_, err = blackholedMember.Etcdctl().Put(ctx, "a", "1", config.PutOptions{})
 	assert.NoError(t, err)
 }

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -111,7 +111,8 @@ func learnerMetricApplyFromSnapshotTest(cx ctlCtx) {
 func triggerSnapshot(ctx context.Context, cx ctlCtx) {
 	etcdctl := cx.epc.Procs[0].Etcdctl()
 	for i := 0; i < int(cx.epc.Cfg.ServerConfig.SnapshotCount); i++ {
-		require.NoError(cx.t, etcdctl.Put(ctx, "k", "v", config.PutOptions{}))
+		_, err := etcdctl.Put(ctx, "k", "v", config.PutOptions{})
+		require.NoError(cx.t, err)
 	}
 }
 
@@ -310,7 +311,7 @@ func TestNoMetricsMissing(t *testing.T) {
 
 			c := epc.Procs[0].Etcdctl()
 			for i := 0; i < 3; i++ {
-				err = c.Put(ctx, fmt.Sprintf("key_%d", i), fmt.Sprintf("value_%d", i), config.PutOptions{})
+				_, err = c.Put(ctx, fmt.Sprintf("key_%d", i), fmt.Sprintf("value_%d", i), config.PutOptions{})
 				require.NoError(t, err)
 			}
 			_, err = c.Get(ctx, "k", config.GetOptions{})

--- a/tests/e2e/promote_experimental_flag_test.go
+++ b/tests/e2e/promote_experimental_flag_test.go
@@ -41,7 +41,7 @@ func TestWarningApplyDuration(t *testing.T) {
 	})
 
 	cc := epc.Etcdctl()
-	err = cc.Put(t.Context(), "foo", "bar", config.PutOptions{})
+	_, err = cc.Put(t.Context(), "foo", "bar", config.PutOptions{})
 	require.NoErrorf(t, err, "error on put")
 
 	// verify warning

--- a/tests/e2e/reproduce_20271_test.go
+++ b/tests/e2e/reproduce_20271_test.go
@@ -54,10 +54,11 @@ func TestIssue20271(t *testing.T) {
 
 	t.Log("Step 1: Write some data to the cluster")
 	for i := 0; i < snapCount*5; i++ {
-		require.NoError(t, epc.Procs[0].Etcdctl().Put(ctx,
+		_, err = epc.Procs[0].Etcdctl().Put(ctx,
 			fmt.Sprintf("foo%d", i),
 			strings.Repeat("Oops", 1024),
-			config.PutOptions{}))
+			config.PutOptions{})
+		require.NoError(t, err)
 	}
 
 	t.Log(`Step 2: Config the third member to sleep 15s after OpenSnapshotBackend and use SIGSTOP to pause it.`)
@@ -86,7 +87,7 @@ to override boltdb file. So, for the following changes, the third member will co
 
 	t.Log("Step 6: Write some data to the cluster")
 	for i := 0; i < snapCount/2; i++ {
-		err = epc.Procs[0].Etcdctl().Put(ctx, fmt.Sprintf("foo%d", i), strings.Repeat("Oops", 1), config.PutOptions{})
+		_, err = epc.Procs[0].Etcdctl().Put(ctx, fmt.Sprintf("foo%d", i), strings.Repeat("Oops", 1), config.PutOptions{})
 		require.NoError(t, err)
 	}
 

--- a/tests/e2e/v2store_deprecation_test.go
+++ b/tests/e2e/v2store_deprecation_test.go
@@ -138,7 +138,7 @@ func addAndRemoveKeysAndMembers(ctx context.Context, tb testing.TB, cc *e2e.Etcd
 	// Execute some non-trivial key&member operation
 	var i uint64
 	for i = 0; i < snapshotCount*3; i++ {
-		err := cc.Put(ctx, fmt.Sprintf("%d", i), "1", config.PutOptions{})
+		_, err := cc.Put(ctx, fmt.Sprintf("%d", i), "1", config.PutOptions{})
 		require.NoError(tb, err)
 	}
 	member1, err := cc.MemberAddAsLearner(ctx, "member1", []string{"http://127.0.0.1:2000"})
@@ -153,7 +153,7 @@ func addAndRemoveKeysAndMembers(ctx context.Context, tb testing.TB, cc *e2e.Etcd
 	require.NoError(tb, err)
 
 	for i = 0; i < snapshotCount; i++ {
-		err = cc.Put(ctx, fmt.Sprintf("%d", i), "2", config.PutOptions{})
+		_, err = cc.Put(ctx, fmt.Sprintf("%d", i), "2", config.PutOptions{})
 		require.NoError(tb, err)
 	}
 	member2, err := cc.MemberAddAsLearner(ctx, "member2", []string{"http://127.0.0.1:2001"})
@@ -161,7 +161,7 @@ func addAndRemoveKeysAndMembers(ctx context.Context, tb testing.TB, cc *e2e.Etcd
 	members = append(members, member2.Member.ID)
 
 	for i = 0; i < snapshotCount/2; i++ {
-		err = cc.Put(ctx, fmt.Sprintf("%d", i), "3", config.PutOptions{})
+		_, err = cc.Put(ctx, fmt.Sprintf("%d", i), "3", config.PutOptions{})
 		assert.NoError(tb, err)
 	}
 	return members

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -166,8 +166,9 @@ func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) 
 	return &resp, err
 }
 
-func (ctl *EtcdctlV3) Put(ctx context.Context, key, value string, opts config.PutOptions) error {
-	args := ctl.cmdArgs()
+func (ctl *EtcdctlV3) Put(ctx context.Context, key, value string, opts config.PutOptions) (*clientv3.PutResponse, error) {
+	resp := clientv3.PutResponse{}
+	args := []string{}
 	args = append(args, "put", key, value)
 	if opts.LeaseID != 0 {
 		args = append(args, "--lease", strconv.FormatInt(int64(opts.LeaseID), 16))
@@ -175,8 +176,8 @@ func (ctl *EtcdctlV3) Put(ctx context.Context, key, value string, opts config.Pu
 	if opts.Timeout != 0 {
 		args = append(args, fmt.Sprintf("--command-timeout=%s", opts.Timeout))
 	}
-	_, err := SpawnWithExpectLines(ctx, args, nil, expect.ExpectedResponse{Value: "OK"})
-	return err
+	err := ctl.spawnJSONCmd(ctx, &resp, args...)
+	return &resp, err
 }
 
 func (ctl *EtcdctlV3) Delete(ctx context.Context, key string, o config.DeleteOptions) (*clientv3.DeleteResponse, error) {

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -218,7 +218,7 @@ func (c integrationClient) Get(ctx context.Context, key string, o config.GetOpti
 	return c.Client.Get(ctx, key, clientOpts...)
 }
 
-func (c integrationClient) Put(ctx context.Context, key, value string, opts config.PutOptions) error {
+func (c integrationClient) Put(ctx context.Context, key, value string, opts config.PutOptions) (*clientv3.PutResponse, error) {
 	if opts.Timeout != 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
@@ -228,8 +228,7 @@ func (c integrationClient) Put(ctx context.Context, key, value string, opts conf
 	if opts.LeaseID != 0 {
 		clientOpts = append(clientOpts, clientv3.WithLease(opts.LeaseID))
 	}
-	_, err := c.Client.Put(ctx, key, value, clientOpts...)
-	return err
+	return c.Client.Put(ctx, key, value, clientOpts...)
 }
 
 func (c integrationClient) Delete(ctx context.Context, key string, o config.DeleteOptions) (*clientv3.DeleteResponse, error) {

--- a/tests/framework/interfaces/interface.go
+++ b/tests/framework/interfaces/interface.go
@@ -43,7 +43,7 @@ type Member interface {
 }
 
 type Client interface {
-	Put(context context.Context, key, value string, opts config.PutOptions) error
+	Put(context context.Context, key, value string, opts config.PutOptions) (*clientv3.PutResponse, error)
 	Get(context context.Context, key string, opts config.GetOptions) (*clientv3.GetResponse, error)
 	Delete(context context.Context, key string, opts config.DeleteOptions) (*clientv3.DeleteResponse, error)
 	Compact(context context.Context, rev int64, opts config.CompactOption) (*clientv3.CompactResponse, error)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Ref: https://github.com/etcd-io/etcd/issues/20607

Some tests that we want to migrate to common package require PutResponse:

`TestStartWatcherFromCompactedRevision`

```go
} else {
	value := fmt.Sprintf("%d", vi)

	t.Logf("PUT key=%s, val=%s", key, value)
	resp, perr := c.KV.Put(ctx, key, value) // Like this
	assert.NoError(t, perr)
	respHeader = resp.Header

	requestedValues = append(requestedValues, valueEvent{value: value, typ: mvccpb.PUT})
}
```

/cc @yagikota @serathius 
