### PR TITLE
Remove 'Private Distributor List' from security guide

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -37,12 +37,3 @@ A public disclosure date is negotiated by the etcd Product Security Committee an
 A third party security audit was performed by Trail of Bits, find the full report [here](SECURITY_AUDIT.pdf).
 A third party fuzzing audit was performed by Ada Logics, find the full report [here](FUZZING_AUDIT_2022.PDF).
 
-## Private Distributor List
-
-This list provides actionable information regarding etcd security to multiple distributors. Members of the list may not use the information for anything other than fixing the issue for respective distribution's users. If you continue to leak information and break the policy outlined here, you will be removed from the list.
-
-### Request to Join
-
-New membership requests are sent to [security@etcd.io](mailto:security@etcd.io).
-
-File an issue [here](https://github.com/etcd-io/etcd/issues/new?template=distributors-application.md), filling in the criteria template.


### PR DESCRIPTION
We don't have such a list for now, so remove it to avoid any confusion


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
