### PR TITLE
[release-3.4] Use buildvcs=false in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -124,7 +124,7 @@ main() {
     fi
 
     log_callout "Building etcd and checking --version output"
-    ./build
+    GO_BUILD_FLAGS="-v -buildvcs=false" ./build
     local etcd_version
     etcd_version=$(bin/etcd --version | grep "etcd Version" | awk '{ print $3 }')
     if [[ "${etcd_version}" != "${VERSION}" ]]; then


### PR DESCRIPTION
Follow up on #20847 and #20950, which tried to fix the issue. However, the release script calls `./build` straight, not the make target nor `scripts/build-binary.sh`. Therefore, this change straight in `scripts/release.sh` addresses the version reported in the released binary.

Link to #20846.

Confirmed by running a `DRY_RUN=true` release from branch 3.4, using the fictional 3.4.100 version:

```
$ pwd
/tmp/etcd-release-3.4.100/etcd
$ go version -m ./bin/etcd | head
./bin/etcd: go1.24.11
        path    go.etcd.io/etcd
        mod     go.etcd.io/etcd (devel) 
...
```

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
