### PR TITLE
Fix run_go_tests_expanding_packages argument parsing

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -354,7 +354,7 @@ function run_go_tests_expanding_packages {
   local packages=()
   local args=()
   for arg in "$@"; do
-    if [[ "${arg}" =~ ./ ]]; then
+    if [[ "${arg}" =~ ^\./ || "${arg}" =~ ^go\.etcd\.io/etcd ]]; then
       packages+=("${arg}")
     else
       args+=("${arg}")


### PR DESCRIPTION
Escape the regular expression and ensure you capture go.etcd.io packages as well. As defined in `run_go_tests`.

Fixes #21033

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
