### PR TITLE
Fix robustness tests execution

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -184,10 +184,10 @@ function e2e_pass {
 function robustness_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
   KEEP_GOING_TESTS=true \
-    run_go_tests_expanding_packages ./tests/robustness/... \
-                                      -timeout="${TIMEOUT:-30m}" \
-                                      "${RUN_ARG[@]}" \
-                                      "$@"
+    run_go_tests ./tests/robustness/... \
+                   -timeout="${TIMEOUT:-30m}" \
+                   "${RUN_ARG[@]}" \
+                   "$@"
 }
 
 function integration_e2e_pass {


### PR DESCRIPTION
Remove running the tests for all the packages under ./tests/robustness. Restore the old behavior of running only the tests from the top-level robustness package.

Fixes #21033.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
