### PR TITLE
tests: migrate TestCtlV3PutTimeout to common framework

### DIFF
--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	clientv3 "go.etcd.io/etcd/client/v3"
+
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -222,6 +222,27 @@ func TestKVGetNoQuorum(t *testing.T) {
 					require.NoError(t, err)
 				}
 			})
+		})
+	}
+}
+
+func TestKV_PutTimeout(t *testing.T) {
+	testRunner.BeforeTest(t)
+	for _, tc := range clusterTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
+			defer clus.Close()
+
+			client := testutils.MustClient(clus.Client())
+
+			_, err := client.Put(ctx, "foo", "bar", config.PutOptions{
+				Timeout: time.Nanosecond,
+			})
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "deadline")
 		})
 	}
 }


### PR DESCRIPTION
### What this PR does

This PR migrates the legacy e2e test `TestCtlV3PutTimeout` to the common
test framework as `TestKV_PutTimeout`.

The new test validates that KV put operations respect the configured
command timeout and return an error when the deadline is exceeded.

As part of the migration, the original e2e test is removed.

### Why this change is needed

The etcd project is moving away from the custom e2e test suite toward
the common framework for better maintainability and consistency across
integration and e2e environments.

This PR performs a focused migration of a single test to keep the change
small and easy to review.

### Related issue

Part of #20550
