### PR TITLE
test: fix robustness tests failing with undefined -bin-dir flag

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -184,7 +184,7 @@ function e2e_pass {
 function robustness_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
   KEEP_GOING_TESTS=true \
-    run_go_tests ./tests/robustness/... \
+    run_go_tests ./tests/robustness \
                    -timeout="${TIMEOUT:-30m}" \
                    "${RUN_ARG[@]}" \
                    "$@"


### PR DESCRIPTION
The robustness CI jobs are failing with "flag provided but not defined: -bin-dir" because the test path includes subpackages (./tests/robustness/...) that don't register this flag.

Please see https://storage.googleapis.com/k8s-triage/index.html?job=ci-etcd-robustness

PR #20962 changed the test invocation to use ./tests/robustness/... which runs tests in all subpackages. The validate/ and model/ subpackages contain unit tests that don't import framework/e2e (which registers -bin-dir), so they fail when this flag is passed.

PR #21039 attempted to fix the issue but only changed the test runner function, not the package path.

This change removes the /... suffix to only run tests in the main robustness package, restoring the original behavior.
