### PR TITLE
cleanup: remove redundant panicAlternativeStringer

### DIFF
--- a/server/etcdserver/util.go
+++ b/server/etcdserver/util.go
@@ -15,7 +15,6 @@
 package etcdserver
 
 import (
-	"fmt"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -95,22 +94,4 @@ func newNotifier() *notifier {
 func (nc *notifier) notify(err error) {
 	nc.err = err
 	close(nc.c)
-}
-
-// panicAlternativeStringer wraps a fmt.Stringer, and if calling String() panics, calls the alternative instead.
-// This is needed to ensure logging slow v2 requests does not panic, which occurs when running integration tests
-// with the embedded server with github.com/golang/protobuf v1.4.0+. See https://github.com/etcd-io/etcd/issues/12197.
-type panicAlternativeStringer struct {
-	stringer    fmt.Stringer
-	alternative func() string
-}
-
-func (n panicAlternativeStringer) String() (s string) {
-	defer func() {
-		if err := recover(); err != nil {
-			s = n.alternative()
-		}
-	}()
-	s = n.stringer.String()
-	return s
 }

--- a/server/etcdserver/util_test.go
+++ b/server/etcdserver/util_test.go
@@ -90,23 +90,3 @@ func (s *nopTransporterWithActiveTime) Stop()                               {}
 func (s *nopTransporterWithActiveTime) Pause()                              {}
 func (s *nopTransporterWithActiveTime) Resume()                             {}
 func (s *nopTransporterWithActiveTime) reset(am map[types.ID]time.Time)     { s.activeMap = am }
-
-func TestPanicAlternativeStringer(t *testing.T) {
-	p := panicAlternativeStringer{alternative: func() string { return "alternative" }}
-
-	p.stringer = testStringerFunc(func() string { panic("here") })
-	if s := p.String(); s != "alternative" {
-		t.Fatalf("expected 'alternative', got %q", s)
-	}
-
-	p.stringer = testStringerFunc(func() string { return "test" })
-	if s := p.String(); s != "test" {
-		t.Fatalf("expected 'test', got %q", s)
-	}
-}
-
-type testStringerFunc func() string
-
-func (s testStringerFunc) String() string {
-	return s()
-}


### PR DESCRIPTION
## Description
This PR removes the `panicAlternativeStringer` struct and its associated methods in `server/etcdserver/util.go`, as well as its unit tests.

## Motivation

### Historical Context
This struct was originally introduced in [d57feaa4c] to address a panic issue (#12197) in the v2 API logging caused by older `protobuf` versions (v1.4.0+).

### Dependency Update
`etcd` has since upgraded to `google.golang.org/protobuf v1.36.10`. The root cause of the original panic is no longer present in current dependencies.

### Dead Code
The primary consumer of this struct, `warnOfExpensiveRequest`, was removed in commit [4e04770ba]. Currently, the struct is not used anywhere in the codebase except for its own unit test.
