### PR TITLE
lease: Reproduce incorrect gRPC Unavailable on client cancel during LeaseKeepAlive forwarding

### DIFF
--- a/server/lease/leasehttp/http.go
+++ b/server/lease/leasehttp/http.go
@@ -73,6 +73,7 @@ func (h *leaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, ErrLeaseHTTPTimeout.Error(), http.StatusRequestTimeout)
 			return
 		}
+		// gofail: var beforeServeHTTPLeaseRenew struct{}
 		ttl, rerr := h.l.Renew(lease.LeaseID(lreq.ID))
 		if rerr != nil {
 			if errors.Is(rerr, lease.ErrLeaseNotFound) {

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -311,6 +312,137 @@ func TestV3LeaseKeepAlive(t *testing.T) {
 		}
 		_, err = lc.LeaseRevoke(t.Context(), &pb.LeaseRevokeRequest{ID: leaseID})
 		return err
+	})
+}
+
+// TestV3LeaseKeepAliveForwardingCatchError ensures the server properly generates error
+// codes while the follower server is forwarding LeaseKeepAlive request to the leader.
+func TestV3LeaseKeepAliveForwardingCatchError(t *testing.T) {
+	if len(gofail.List()) == 0 {
+		t.Skip("please run 'make gofail-enable' before running the test")
+	}
+	integration.BeforeTest(t)
+	// Longer than leaseHandler.ServeHTTP()'s default timeout duration
+	sleepDuration := 8 * time.Second
+
+	t.Run("forwarding succeeds", func(t *testing.T) {
+		leaderClient, follower := setupLeaseForwardingCluster(t)
+
+		grantResp, err := leaderClient.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
+		require.NoError(t, err)
+		leaseID := grantResp.ID
+
+		keepAliveClient, err := integration.ToGRPC(follower.Client).Lease.LeaseKeepAlive(t.Context())
+		require.NoError(t, err)
+		defer keepAliveClient.CloseSend()
+
+		require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+		resp, err := keepAliveClient.Recv()
+		require.NoError(t, err)
+		require.Equal(t, leaseID, resp.ID)
+		require.Positive(t, resp.TTL)
+	})
+
+	// Shows current behavior: client cancel during forwarding incorrectly returns Unavailable.
+	t.Run("client cancels while forwarding", func(t *testing.T) {
+		leaderClient, follower := setupLeaseForwardingCluster(t)
+
+		grantResp, err := leaderClient.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
+		require.NoError(t, err)
+		leaseID := grantResp.ID
+
+		ctx, cancel := context.WithCancel(t.Context())
+		keepAliveClient, err := integration.ToGRPC(follower.Client).Lease.LeaseKeepAlive(ctx)
+		require.NoError(t, err)
+		defer keepAliveClient.CloseSend()
+
+		require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+		_, err = keepAliveClient.Recv()
+		require.NoError(t, err)
+
+		sleepBeforeServingLeaseRenew(t, sleepDuration)
+
+		// Use server metrics to verify behavior since client.Recv() always returns Canceled
+		// after cancel() regardless of the actual server response.
+		prevCanceledCount := getLeaseKeepAliveMetric(t, follower, "Canceled")
+		prevUnavailableCount := getLeaseKeepAliveMetric(t, follower, "Unavailable")
+
+		require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		// Client sees Canceled (gRPC returns this immediately after cancel()),
+		// but server actually generated Unavailable (verified by metrics below).
+		_, err = keepAliveClient.Recv()
+		require.Equal(t, codes.Canceled, status.Code(err))
+
+		require.Eventually(t, func() bool {
+			return getLeaseKeepAliveMetric(t, follower, "Unavailable") == prevUnavailableCount+1
+		}, 3*time.Second, 100*time.Millisecond)
+		require.Equal(t, prevCanceledCount, getLeaseKeepAliveMetric(t, follower, "Canceled"))
+	})
+
+	t.Run("forwarding times out", func(t *testing.T) {
+		leaderClient, follower := setupLeaseForwardingCluster(t)
+
+		grantResp, err := leaderClient.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
+		require.NoError(t, err)
+		leaseID := grantResp.ID
+
+		keepAliveClient, err := integration.ToGRPC(follower.Client).Lease.LeaseKeepAlive(t.Context())
+		require.NoError(t, err)
+		defer keepAliveClient.CloseSend()
+
+		require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+		_, err = keepAliveClient.Recv()
+		require.NoError(t, err)
+
+		sleepBeforeServingLeaseRenew(t, sleepDuration)
+
+		prevUnavailableCount := getLeaseKeepAliveMetric(t, follower, "Unavailable")
+		require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+
+		_, err = keepAliveClient.Recv()
+		require.Equal(t, rpctypes.ErrGRPCTimeout, err)
+
+		require.Eventually(t, func() bool {
+			return getLeaseKeepAliveMetric(t, follower, "Unavailable") == prevUnavailableCount+1
+		}, 3*time.Second, 100*time.Millisecond)
+	})
+}
+
+func setupLeaseForwardingCluster(t *testing.T) (pb.LeaseClient, *integration.Member) {
+	t.Helper()
+	cluster := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
+	t.Cleanup(func() { cluster.Terminate(t) })
+
+	leaderIdx := cluster.WaitLeader(t)
+	followerIdx := (leaderIdx + 1) % 3
+	return integration.ToGRPC(cluster.Client(leaderIdx)).Lease, cluster.Members[followerIdx]
+}
+
+func getLeaseKeepAliveMetric(t *testing.T, member *integration.Member, grpcCode string) int64 {
+	t.Helper()
+	metricVal, err := member.Metric(
+		"grpc_server_handled_total",
+		`grpc_method="LeaseKeepAlive"`,
+		fmt.Sprintf(`grpc_code="%v"`, grpcCode),
+	)
+	require.NoError(t, err)
+	count, err := strconv.ParseInt(metricVal, 10, 32)
+	require.NoError(t, err)
+	return count
+}
+
+func sleepBeforeServingLeaseRenew(t *testing.T, duration time.Duration) {
+	t.Helper()
+	failpointName := "beforeServeHTTPLeaseRenew"
+	require.NoError(t, gofail.Enable(failpointName, fmt.Sprintf(`sleep("%s")`, duration)))
+	t.Cleanup(func() {
+		terr := gofail.Disable(failpointName)
+		if terr != nil && !errors.Is(terr, gofail.ErrDisabled) {
+			t.Fatalf("Failed to disable failpoint %v, got error: %v", failpointName, terr)
+		}
 	})
 }
 
@@ -891,7 +1023,7 @@ func TestV3LeaseRecoverKeyWithDetachedLease(t *testing.T) {
 	}
 }
 
-func TestV3LeaseRecoverKeyWithMutipleLease(t *testing.T) {
+func TestV3LeaseRecoverKeyWithMultipleLease(t *testing.T) {
 	integration.BeforeTest(t)
 
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1, UseBridge: true})


### PR DESCRIPTION
Helps investigate the long-lasting issue [https://github.com/etcd-io/etcd/issues/13632](https://github.com/etcd-io/etcd/issues/13632) (Github action mistakenly closed it due to inactivity).  

**This PR only reproduces the issue. I will post the fix PR after this one is merged.**

## Problem

Some users reported that `grpc_server_handled_total{grpc_code="Unavailable"}` was unexpectedly inflating for LeaseKeepAlive requests even when the cluster is healthy.

## Incoming Fix (Spoiler Alert: This is for the next PR)

The function `LeaseServer.LeaseKeepAlive` always turns `context.Canceled` (which is grpc `codes.Canceled`) into `rpctypes.ErrGRPCNoLeader` (which is grpc `codes.Unavailable`), even when it’s the client that initializes the cancellation. As a result, the grpc metrics count incorrectly.

**The old comment is wrong: `// the only server-side cancellation is noleader for now.`** 

In fact, there’s no server-side cancellation inside the worker function `EtcdServer.LeaseRenew` path. The only possible scenario when this function returns `errors.ErrCanceled` is when the client cancels the request, and then the Done signal propagates into this function. 

The fix is pretty straightforward. To validate the fix, I added two test cases where I send LeaseKeepAlive request to one follower in the cluster, and while it’s forwarding the request to the leader, I block the leader’s `ServeHTTP` path via go failpoint.

As the process is blocked, one test case cancels the request, while the other waits until the forwarding request times out. Both cases should receive expected errors.