### PR TITLE
Robustness reads all entries from WAL with no consideration for snapshots

### DIFF
--- a/tests/robustness/report/wal_test.go
+++ b/tests/robustness/report/wal_test.go
@@ -17,8 +17,12 @@ package report
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -358,6 +362,297 @@ func TestMergeMemberEntries(t *testing.T) {
 				require.ErrorContains(t, err, tc.expectErr)
 			}
 			require.Equal(t, tc.expectEntries, entries)
+		})
+	}
+}
+
+func TestWriteReadWAL(t *testing.T) {
+	type batch struct {
+		state    *raftpb.HardState
+		entries  []raftpb.Entry
+		snapshot *walpb.Snapshot
+	}
+	type want struct {
+		wantState   raftpb.HardState
+		wantEntries []raftpb.Entry
+		wantError   string
+	}
+
+	tcs := []struct {
+		name           string
+		operations     []batch
+		readAt         walpb.Snapshot
+		walReadAll     want
+		readAllEntries want
+	}{
+		{
+			name: "single batch",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 5},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+				},
+			},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+		},
+		{
+			name: "multiple committed batches",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 2},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 4},
+					entries: []raftpb.Entry{{Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 5},
+					entries: []raftpb.Entry{{Index: 5, Data: []byte("e")}},
+				},
+			},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+		},
+		{
+			name: "uncommitted ovewritten entries",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 1},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("a")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 3},
+					entries: []raftpb.Entry{{Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("b")}, {Index: 4, Data: []byte("b")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 4},
+					entries: []raftpb.Entry{{Index: 4, Data: []byte("c")}, {Index: 5, Data: []byte("c")}},
+				},
+			},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 4},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("b")}, {Index: 4, Data: []byte("c")}, {Index: 5, Data: []byte("c")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 4},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("b")}, {Index: 4, Data: []byte("c")}, {Index: 5, Data: []byte("c")}},
+			},
+		},
+		{
+			name: "entries in bad order",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 2},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 6},
+					entries: []raftpb.Entry{{Index: 5, Data: []byte("e")}, {Index: 6, Data: []byte("f")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 4},
+					entries: []raftpb.Entry{{Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}},
+				},
+			},
+			walReadAll: want{
+				wantError:   "slice bounds out of range",
+				wantState:   raftpb.HardState{Commit: 2},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 4},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}},
+			},
+		},
+		{
+			name: "read before snapshot",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 1},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					snapshot: &walpb.Snapshot{Index: 3, ConfState: &raftpb.ConfState{}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 5},
+					entries: []raftpb.Entry{{Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+				},
+			},
+			walReadAll: want{
+				wantError:   "slice bounds out of range",
+				wantState:   raftpb.HardState{Commit: 1},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+		},
+		{
+			name: "read at snapshot",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 1},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					snapshot: &walpb.Snapshot{Index: 3, ConfState: &raftpb.ConfState{}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 5},
+					entries: []raftpb.Entry{{Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+				},
+			},
+			readAt: walpb.Snapshot{Index: 3},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+		},
+		{
+			name: "uncommitted entries before snapshot",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 1},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 3},
+					entries: []raftpb.Entry{{Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}},
+				},
+				{
+					snapshot: &walpb.Snapshot{Index: 3, ConfState: &raftpb.ConfState{}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 4},
+					entries: []raftpb.Entry{{Index: 4, Data: []byte("e")}, {Index: 5, Data: []byte("f")}},
+				},
+			},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 4},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("e")}, {Index: 5, Data: []byte("f")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 4},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("e")}, {Index: 5, Data: []byte("f")}},
+			},
+		},
+		{
+			name: "entries preceding snapshot",
+			operations: []batch{
+				{
+					snapshot: &walpb.Snapshot{Index: 4, ConfState: &raftpb.ConfState{}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 2},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 4},
+					entries: []raftpb.Entry{{Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 6},
+					entries: []raftpb.Entry{{Index: 5, Data: []byte("e")}, {Index: 6, Data: []byte("f")}},
+				},
+			},
+			readAt: walpb.Snapshot{Index: 4},
+			walReadAll: want{
+				wantState:   raftpb.HardState{Commit: 6},
+				wantEntries: []raftpb.Entry{{Index: 5, Data: []byte("e")}, {Index: 6, Data: []byte("f")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 6},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 3, Data: []byte("c")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}, {Index: 6, Data: []byte("f")}},
+			},
+		},
+		{
+			name: "read after snapshot",
+			operations: []batch{
+				{
+					state:   &raftpb.HardState{Commit: 1},
+					entries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}},
+				},
+				{
+					snapshot: &walpb.Snapshot{Index: 3, ConfState: &raftpb.ConfState{}},
+				},
+				{
+					state:   &raftpb.HardState{Commit: 5},
+					entries: []raftpb.Entry{{Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+				},
+			},
+			readAt: walpb.Snapshot{Index: 4},
+			walReadAll: want{
+				wantError:   "snapshot not found",
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 5, Data: []byte("e")}},
+			},
+			readAllEntries: want{
+				wantState:   raftpb.HardState{Commit: 5},
+				wantEntries: []raftpb.Entry{{Index: 1, Data: []byte("a")}, {Index: 2, Data: []byte("b")}, {Index: 4, Data: []byte("d")}, {Index: 5, Data: []byte("e")}},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			lg := zaptest.NewLogger(t)
+			w, err := wal.Create(lg, dir, nil)
+			require.NoError(t, err)
+			for _, op := range tc.operations {
+				if op.state != nil {
+					err = w.Save(*op.state, op.entries)
+					require.NoError(t, err)
+				}
+				if op.snapshot != nil {
+					err = w.SaveSnapshot(*op.snapshot)
+					require.NoError(t, err)
+				}
+			}
+			w.Close()
+
+			w2, err := wal.OpenForRead(lg, dir, tc.readAt)
+			require.NoError(t, err)
+			defer w2.Close()
+			t.Run("wal.ReadAll", func(t *testing.T) {
+				_, state, entries, err := w2.ReadAll()
+				if tc.walReadAll.wantError != "" {
+					require.ErrorContains(t, err, tc.walReadAll.wantError)
+				} else {
+					require.NoError(t, err)
+				}
+				assert.Equal(t, tc.walReadAll.wantState, state)
+				assert.Equal(t, tc.walReadAll.wantEntries, entries)
+			})
+			t.Run("ReadAllEntries", func(t *testing.T) {
+				state, entries, err := ReadAllWALEntries(lg, dir)
+				if tc.readAllEntries.wantError != "" {
+					require.ErrorContains(t, err, tc.walReadAll.wantError)
+				} else {
+					require.NoError(t, err)
+				}
+				assert.Equal(t, tc.readAllEntries.wantState, state)
+				assert.Equal(t, tc.readAllEntries.wantEntries, entries)
+			})
 		})
 	}
 }


### PR DESCRIPTION
Fix for `Watch validation passes` failure in https://linuxfoundation.antithesis.com/report/Ew3BqFjqBiz9fy2llIRu_Q9D/7GNVZUFiqAB78sl0S26kEVUY9BWH1pcdLUq2P7J8RHI.html?auth=v2.public.eyJuYmYiOiIyMDI1LTEyLTI1VDEyOjMxOjM1Ljc3ODg3NTIxMloiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiN0dOVlpVRmlxQUI3OHNsMFMyNmtFVlVZOUJXSDFwY2RMVXEyUDdKOFJISS5odG1sIiwicmVwb3J0X2lkIjoiRXczQnFGanFCaXo5ZnkybGxJUnVfUTlEIn19fWTUZlPlyB5exQBQN6IDElbxMsKHcixgEYkubb20M3XFIepp-mXQoz1jEeqe16ZZU-Y4rQgf5FPVMpBRMsXoJQs

Failure was reported for an additional unexpected watch event that was not available in persisted requests.
```
{"level":"error","ts":1766621741.571743,"caller":"validate/watch.go:221","msg":"Broke watch guarantee","guarantee":"reliable","client":4,"stacktrace":"go.etcd.io/etcd/tests/v3/robustness/validate.validateReliable\n\t/build/tests/robustness/validate/watch.go:221\ngo.etcd.io/etcd/tests/v3/robustness/validate.validateWatchError\n\t/build/tests/robustness/validate/watch.go:84\ngo.etcd.io/etcd/tests/v3/robustness/validate.validateWatch\n\t/build/tests/robustness/validate/watch.go:45\ngo.etcd.io/etcd/tests/v3/robustness/validate.ValidateAndReturnVisualize\n\t/build/tests/robustness/validate/validate.go:57\nmain.validateReports\n\t/build/tests/antithesis/test-template/robustness/finally/main.go:63\nmain.main\n\t/build/tests/antithesis/test-template/robustness/finally/main.go:52\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285"}
  []model.PersistedEvent{
  	... // 533 identical elements
  	{Event: {Type: "put-operation", Key: "/registry/pods/default/1DwyQ", Value: {Value: "603"}}, Revision: 535},
  	{Event: {Type: "put-operation", Key: "/registry/pods/default/ez7yv", Value: {Value: "604"}}, Revision: 536},
+ 	{
+ 		Event: model.Event{
+ 			Type:  "put-operation",
+ 			Key:   "/registry/pods/default/PZDA7",
+ 			Value: model.ValueOrHash{Value: "346"},
+ 		},
+ 		Revision: 537,
+ 		IsCreate: true,
+ 	},
  }
```

The root cause was that persisted requests read from WAL were not complete. The entry only appeared in WAL files of members that at some point loaded snapshot from other members. Loading snapshot results in incomplete WAL history, which is unhanded in the current implementation as by etcd expects to read from latest snapshot. 

Proposed fix: rewrite WAL reading to ignore any snapshots and just read all entries.

Still thinking how to implement a test.

/cc @nwnt @fuweid @henrybear327 @joshjms 