### PR TITLE
Add the missing range options for test clients

### DIFF
--- a/tests/framework/config/client.go
+++ b/tests/framework/config/client.go
@@ -28,16 +28,21 @@ import (
 type ClientOption func(any)
 
 type GetOptions struct {
-	Revision     int
-	End          string
-	CountOnly    bool
-	Serializable bool
-	Prefix       bool
-	FromKey      bool
-	Limit        int
-	Order        clientv3.SortOrder
-	SortBy       clientv3.SortTarget
-	Timeout      time.Duration
+	Revision          int
+	End               string
+	CountOnly         bool
+	Serializable      bool
+	Prefix            bool
+	FromKey           bool
+	Limit             int
+	Order             clientv3.SortOrder
+	SortBy            clientv3.SortTarget
+	Timeout           time.Duration
+	KeysOnly          bool
+	MinModRevision    int
+	MaxModRevision    int
+	MinCreateRevision int
+	MaxCreateRevision int
 }
 
 type PutOptions struct {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -124,10 +124,28 @@ func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) 
 	if o.FromKey {
 		args = append(args, "--from-key")
 	}
+	writeOut := "json"
+	if o.CountOnly || o.KeysOnly {
+		writeOut = "fields"
+	}
+	args = append(args, "-w", writeOut)
 	if o.CountOnly {
-		args = append(args, "-w", "fields", "--count-only")
-	} else {
-		args = append(args, "-w", "json")
+		args = append(args, "--count-only")
+	}
+	if o.KeysOnly {
+		args = append(args, "--keys-only")
+	}
+	if o.MaxCreateRevision != 0 {
+		args = append(args, fmt.Sprintf("--max-create-rev=%d", o.MaxCreateRevision))
+	}
+	if o.MinCreateRevision != 0 {
+		args = append(args, fmt.Sprintf("--min-create-rev=%d", o.MinCreateRevision))
+	}
+	if o.MaxModRevision != 0 {
+		args = append(args, fmt.Sprintf("--max-mod-rev=%d", o.MaxModRevision))
+	}
+	if o.MinModRevision != 0 {
+		args = append(args, fmt.Sprintf("--min-mod-rev=%d", o.MinModRevision))
 	}
 	switch o.SortBy {
 	case clientv3.SortByCreateRevision:

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -212,8 +212,23 @@ func (c integrationClient) Get(ctx context.Context, key string, o config.GetOpti
 	if o.CountOnly {
 		clientOpts = append(clientOpts, clientv3.WithCountOnly())
 	}
+	if o.KeysOnly {
+		clientOpts = append(clientOpts, clientv3.WithKeysOnly())
+	}
 	if o.SortBy != clientv3.SortByKey || o.Order != clientv3.SortNone {
 		clientOpts = append(clientOpts, clientv3.WithSort(o.SortBy, o.Order))
+	}
+	if o.MaxCreateRevision != 0 {
+		clientOpts = append(clientOpts, clientv3.WithMaxCreateRev(int64(o.MaxCreateRevision)))
+	}
+	if o.MinCreateRevision != 0 {
+		clientOpts = append(clientOpts, clientv3.WithMinCreateRev(int64(o.MinCreateRevision)))
+	}
+	if o.MaxModRevision != 0 {
+		clientOpts = append(clientOpts, clientv3.WithMaxModRev(int64(o.MaxModRevision)))
+	}
+	if o.MinModRevision != 0 {
+		clientOpts = append(clientOpts, clientv3.WithMinModRev(int64(o.MinModRevision)))
 	}
 	return c.Client.Get(ctx, key, clientOpts...)
 }


### PR DESCRIPTION
Add the missing range options for clients in tests.  Needed for #20386, so I can add tests with the options.