### PR TITLE
watch: Reproduce the deadlock between in-process client-server due to cancellation storm

### DIFF
--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -1446,7 +1446,7 @@ func TestV3WatchCancellationStorm(t *testing.T) {
 		ch     clientv3.WatchChan
 		cancel context.CancelFunc
 	}
-	const totalWatchers = 200
+	const totalWatchers = 300
 	watchers := make([]watcherInfo, 0, totalWatchers)
 	// Create many watchers distributed over the 10 unique keys.
 	for i := 0; i < totalWatchers; i++ {
@@ -1501,7 +1501,7 @@ func TestV3WatchCancellationStorm(t *testing.T) {
 	require.True(t, received, "probe watcher should be able receive events before cancel storm")
 
 	// Cancel most of the watchers in a burst to overwhelm the watch system
-	const canceledWatchers = 180
+	const canceledWatchers = 280
 	for i := 0; i < canceledWatchers; i++ {
 		watchers[i].cancel()
 	}

--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -39,7 +39,6 @@ import (
 	gofail "go.etcd.io/gofail/runtime"
 )
 
-// getMetricVal is a helper to parse the server metric into integer
 func getMetricVal(t *testing.T, member *integration.Member, metricName string) int64 {
 	t.Helper()
 	metricVal, err := member.Metric(metricName)

--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -1427,7 +1427,6 @@ func TestV3WatchCancellationStorm(t *testing.T) {
 			key := uniqueKeys[i%len(uniqueKeys)]
 			_, err := cli.Put(ctx, key, "")
 			if err != nil {
-				// Most likely the server is shutting down; just exit.
 				return
 			}
 			i++
@@ -1494,9 +1493,8 @@ func TestV3WatchCancellationStorm(t *testing.T) {
 }
 
 func canRecvWatchEvent(t *testing.T, watcherCh clientv3.WatchChan, watchKey string) bool {
-
-	helperCtx, helperCancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer helperCancel()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
 
 	for {
 		select {
@@ -1512,7 +1510,7 @@ func canRecvWatchEvent(t *testing.T, watcherCh clientv3.WatchChan, watchKey stri
 				require.Equal(t, watchKey, string(event.Kv.Key))
 			}
 			return true
-		case <-helperCtx.Done():
+		case <-ctx.Done():
 			return false
 		}
 	}

--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -1521,8 +1521,8 @@ func TestV3WatchCancellationStorm(t *testing.T) {
 	slowWatchers := getMetricVal(t, member, "etcd_debugging_mvcc_slow_watcher_total")
 	pendingEvents := getMetricVal(t, member, "etcd_debugging_mvcc_pending_events_total")
 
-	require.Positive(t, slowWatchers, "expected some slow watchers")
-	require.Positive(t, pendingEvents, "expected some pending events")
+	require.Positivef(t, slowWatchers, "expected some slow watchers")
+	require.Positivef(t, pendingEvents, "expected some pending events")
 
 	cancel()
 	writeWG.Wait()


### PR DESCRIPTION
Reproduces issues https://github.com/etcd-io/etcd/issues/18879 and https://github.com/etcd-io/etcd/issues/20716

The next PR https://github.com/etcd-io/etcd/pull/21065 properly solves these issues.

----
These two issues have the same root cause, and it only shows up with the in-process client–server path, not with a regular gRPC connection. Over the network, HTTP/2 flow control and socket teardown naturally apply backpressure and reset state, but the in-process transport is using the `chanStream`  in `server/proxy/grpcproxy/adapter/chan_stream.go` , which simply relies on go channels.

When we have a lot of watch cancel requests, we would easily run into deadlock. Refer to https://github.com/etcd-io/etcd/issues/20716 for a nice diagram analyzing the deadlock.



Conceptually, each watch stream should be owned by a single client: if we rerun the program, we should expect to start from a clean slate. Unfortunately, with the in-process design there are effectively two layers of clients:

1. user's client program
2. the long-lived in-process transport client that talks directly to the server - essentially a proxy sits between the user clients and the etcd server.

Rerunning the user program doesn’t reset the in-process client, so the connection between this in-process client and the server is still stuck in deadlock, and all subsequent user reruns would also be stuck (as long as these user programs rely on this in-process client, but notice that if you do `etcdctl` or other programs that can directly talk to the etcd server, you can still use the watch feature without problem).


This PR adds an integration test to reproduce this issue. It creates a lot of watchers, ensures they work fine at first, and then cancels most of these watchers. The remaining watchers stop receiving any watch events, and we will see non-zero `etcd_debugging_mvcc_slow_watcher_total` and `etcd_debugging_mvcc_pending_events_total` metrics.