### PR TITLE
scripts: fix bash array handling with `set -o nounset`

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -130,7 +130,7 @@ function unit_pass {
     run_go_tests -short \
                  -timeout="${TIMEOUT:-3m}" \
                  "${COMMON_TEST_FLAGS[@]}" \
-                 "${RUN_ARG[@]}" \
+                 "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                  "$@"
 }
 
@@ -140,7 +140,7 @@ function integration_extra {
       run_go_tests_expanding_packages ./tests/integration/v2store/... \
                                       -timeout="${TIMEOUT:-5m}" \
                                       "${COMMON_TEST_FLAGS[@]}" \
-                                      "${RUN_ARG[@]}" \
+                                      "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                                       "$@"
   else
     log_warning "integration_extra ignored when PKG is specified"
@@ -152,7 +152,7 @@ function integration_pass {
                -p=2 \
                -timeout="${TIMEOUT:-15m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                "$@"
 
   run_go_tests ./tests/common/... \
@@ -160,7 +160,7 @@ function integration_pass {
                -tags=integration \
                -timeout="${TIMEOUT:-15m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                "$@"
 
   integration_extra "$@"
@@ -171,13 +171,13 @@ function e2e_pass {
   KEEP_GOING_TESTS=true \
     run_go_tests_expanding_packages ./tests/e2e/... \
                                       -timeout="${TIMEOUT:-30m}" \
-                                      "${RUN_ARG[@]}" \
+                                      "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                                       "$@"
   KEEP_GOING_TESTS=true \
     run_go_tests_expanding_packages ./tests/common/... \
                                       -tags=e2e \
                                       -timeout="${TIMEOUT:-30m}" \
-                                      "${RUN_ARG[@]}" \
+                                      "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                                       "$@"
 }
 
@@ -186,7 +186,7 @@ function robustness_pass {
   KEEP_GOING_TESTS=true \
     run_go_tests ./tests/robustness \
                    -timeout="${TIMEOUT:-30m}" \
-                   "${RUN_ARG[@]}" \
+                   "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                    "$@"
 }
 
@@ -222,7 +222,7 @@ function grpcproxy_integration_pass {
                -tags=cluster_proxy \
                -timeout="${TIMEOUT:-30m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                "$@"
 }
 
@@ -231,7 +231,7 @@ function grpcproxy_e2e_pass {
                -tags=cluster_proxy \
                -timeout="${TIMEOUT:-30m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               "${RUN_ARG[@]+"${RUN_ARG[@]}"}" \
                "$@"
 }
 


### PR DESCRIPTION
Fixed the issue arose from executing
`time EXPECT_DEBUG=true GO_TEST_FLAGS='-v --failfast --count 1 --timeout 10h' make test-robustness`.

The test scripts enable `set -o nounset` (set -u) which causes bash to error when accessing unbound variables, including empty arrays. This was causing test execution to fail with "unbound variable" errors.

The fix mainly consisted of using the pattern
"${ARRAY[@]+"${ARRAY[@]}"}" for safely expanding arrays when `set -o nounset` is enabled. It expands to nothing when the array is empty, and to the array elements when the array contains values.

Also some misc. fixes:
- Changed `failures` from string to array initialization in go_test()
- Fixed failures array append from incorrect expansion to `+=` operator
- Changed array emptiness checks from `[ -n "${failures[*]}" ]` to `[ ${#failures[@]} -gt 0 ]` which works correctly with `set -o nounset`
- Fixed unsafe array expansions for go_test_flags, args, packages, unpacked_packages, and _modules arrays using the safe expansion pattern "${ARRAY[@]+"${ARRAY[@]}"}"


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
