### PR TITLE
[Robustness test] rename RunTrafficLoop and add RunWatchLoop method (Part 1)

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -154,7 +154,7 @@ func simulateTraffic(ctx context.Context, tf traffic.Traffic, hosts []string, cl
 		go func(c *client.RecordingClient) {
 			defer wg.Done()
 			defer c.Close()
-			tf.RunTrafficLoop(ctx, traffic.RunTrafficLoopParam{
+			tf.RunKeyValueLoop(ctx, traffic.RunTrafficLoopParam{
 				Client:                             c,
 				QPSLimiter:                         limiter,
 				IDs:                                clientSet.IdentityProvider(),
@@ -171,7 +171,7 @@ func simulateTraffic(ctx context.Context, tf traffic.Traffic, hosts []string, cl
 		go func(c *client.RecordingClient) {
 			defer wg.Done()
 			defer c.Close()
-			tf.RunTrafficLoop(ctx, traffic.RunTrafficLoopParam{
+			tf.RunKeyValueLoop(ctx, traffic.RunTrafficLoopParam{
 				Client:                             c,
 				QPSLimiter:                         limiter,
 				IDs:                                clientSet.IdentityProvider(),

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -109,7 +109,7 @@ func (t etcdTraffic) Name() string {
 	return "Etcd"
 }
 
-func (t etcdTraffic) RunTrafficLoop(ctx context.Context, p RunTrafficLoopParam) {
+func (t etcdTraffic) RunKeyValueLoop(ctx context.Context, p RunTrafficLoopParam) {
 	lastOperationSucceeded := true
 	var lastRev int64
 	var requestType etcdRequestType
@@ -154,6 +154,10 @@ func (t etcdTraffic) RunTrafficLoop(ctx context.Context, p RunTrafficLoopParam) 
 		}
 		p.QPSLimiter.Wait(ctx)
 	}
+}
+
+func (t etcdTraffic) RunWatchLoop(ctx context.Context, p RunWatchLoopParam) {
+	// TODO: implement in a subsequent commit
 }
 
 func (t etcdTraffic) RunCompactLoop(ctx context.Context, param RunCompactLoopParam) {

--- a/tests/robustness/traffic/kubernetes.go
+++ b/tests/robustness/traffic/kubernetes.go
@@ -88,7 +88,7 @@ func (t kubernetesTraffic) ExpectUniqueRevision() bool {
 	return true
 }
 
-func (t kubernetesTraffic) RunTrafficLoop(ctx context.Context, p RunTrafficLoopParam) {
+func (t kubernetesTraffic) RunKeyValueLoop(ctx context.Context, p RunTrafficLoopParam) {
 	kc := kubernetes.Client{Client: &clientv3.Client{KV: p.Client}}
 	s := newStorage()
 	keyPrefix := "/registry/" + t.resource + "/"
@@ -134,6 +134,10 @@ func (t kubernetesTraffic) RunTrafficLoop(ctx context.Context, p RunTrafficLoopP
 		}
 	})
 	g.Wait()
+}
+
+func (t kubernetesTraffic) RunWatchLoop(ctx context.Context, p RunWatchLoopParam) {
+	// TODO: implement in a subsequent commit
 }
 
 func (t kubernetesTraffic) Read(ctx context.Context, c *client.RecordingClient, s *storage, limiter *rate.Limiter, keyPrefix string) error {

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -85,7 +85,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 			defer wg.Done()
 			defer c.Close()
 
-			traffic.RunTrafficLoop(ctx, RunTrafficLoopParam{
+			traffic.RunKeyValueLoop(ctx, RunTrafficLoopParam{
 				Client:                             c,
 				QPSLimiter:                         limiter,
 				IDs:                                clientSet.IdentityProvider(),
@@ -105,7 +105,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 			defer wg.Done()
 			defer c.Close()
 
-			traffic.RunTrafficLoop(ctx, RunTrafficLoopParam{
+			traffic.RunKeyValueLoop(ctx, RunTrafficLoopParam{
 				Client:                             c,
 				QPSLimiter:                         limiter,
 				IDs:                                clientSet.IdentityProvider(),
@@ -335,8 +335,22 @@ type RunCompactLoopParam struct {
 	Finish <-chan struct{}
 }
 
+type RunWatchLoopParam struct {
+	Client         *client.RecordingClient
+	KeyStore       *keyStore
+	Finish         <-chan struct{}
+	RevisionOffset int64   // Random offset range: -RevisionOffset <= offset <= RevisionOffset
+	WatchQPS       float64 // QPS limit for watch requests
+}
+
+const (
+	DefaultWatchQPS       = 10.0
+	DefaultRevisionOffset = 100
+)
+
 type Traffic interface {
-	RunTrafficLoop(ctx context.Context, param RunTrafficLoopParam)
+	RunKeyValueLoop(ctx context.Context, param RunTrafficLoopParam)
+	RunWatchLoop(ctx context.Context, param RunWatchLoopParam)
 	RunCompactLoop(ctx context.Context, param RunCompactLoopParam)
 	ExpectUniqueRevision() bool
 }


### PR DESCRIPTION
Rename RunTrafficLoop to RunKeyValueLoop to better reflect that it handles key-value operations (get, put, delete, etc.).

Add a new RunWatchLoop method to the Traffic interface that will create watches in a controlled loop with configurable QPS and revision offset parameters. This provides better lifecycle control than the previous periodic background watch mechanism.

The RunWatchLoop implementations are stubs that will be filled in a subsequent commit.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
