### PR TITLE
[Robustness test] Implement RunWatchLoop and integrate into robustness test (part 2)

### DIFF
--- a/tests/robustness/client/watch.go
+++ b/tests/robustness/client/watch.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -32,7 +31,7 @@ type CollectClusterWatchEventsParam struct {
 	MaxRevisionChan <-chan int64
 	Cfg             WatchConfig
 	ClientSet       *ClientSet
-	options.BackgroundWatchConfig
+	options.WatchConfig
 }
 
 func CollectClusterWatchEvents(ctx context.Context, param CollectClusterWatchEventsParam) error {
@@ -50,28 +49,13 @@ func CollectClusterWatchEvents(ctx context.Context, param CollectClusterWatchEve
 			return watchUntilRevision(ctx, param.Lg, c, memberMaxRevisionChan, param.Cfg)
 		})
 	}
-	finish := make(chan struct{})
 	g.Go(func() error {
 		maxRevision := <-param.MaxRevisionChan
 		for _, memberChan := range memberMaxRevisionChans {
 			memberChan <- maxRevision
 		}
-		close(finish)
 		return nil
 	})
-
-	if param.BackgroundWatchConfig.Interval > 0 {
-		for _, endpoint := range param.Endpoints {
-			g.Go(func() error {
-				c, err := param.ClientSet.NewClient([]string{endpoint})
-				if err != nil {
-					return err
-				}
-				defer c.Close()
-				return openWatchPeriodically(ctx, &g, c, param.BackgroundWatchConfig, finish)
-			})
-		}
-	}
 
 	return g.Wait()
 }
@@ -142,40 +126,5 @@ resetWatch:
 				}
 			}
 		}
-	}
-}
-
-func openWatchPeriodically(ctx context.Context, g *errgroup.Group, c *RecordingClient, backgroundWatchConfig options.BackgroundWatchConfig, finish <-chan struct{}) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-finish:
-			return nil
-		case <-time.After(backgroundWatchConfig.Interval):
-		}
-		g.Go(func() error {
-			resp, err := c.Get(ctx, "/key")
-			if err != nil {
-				return err
-			}
-			rev := resp.Header.Revision + backgroundWatchConfig.RevisionOffset
-
-			watchCtx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			w := c.Watch(watchCtx, "", rev, true, true, true)
-			for {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-finish:
-					return nil
-				case _, ok := <-w:
-					if !ok {
-						return nil
-					}
-				}
-			}
-		})
 	}
 }

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -168,12 +168,12 @@ func runScenario(ctx context.Context, t *testing.T, s scenarios.TestScenario, lg
 	g.Go(func() error {
 		endpoints := processEndpoints(clus)
 		err := client.CollectClusterWatchEvents(ctx, client.CollectClusterWatchEventsParam{
-			Lg:                    lg,
-			Endpoints:             endpoints,
-			MaxRevisionChan:       maxRevisionChan,
-			Cfg:                   s.Watch,
-			ClientSet:             watchSet,
-			BackgroundWatchConfig: s.Profile.BackgroundWatchConfig,
+			Lg:              lg,
+			Endpoints:       endpoints,
+			MaxRevisionChan: maxRevisionChan,
+			Cfg:             s.Watch,
+			ClientSet:       watchSet,
+			WatchConfig:     s.Profile.WatchConfig,
 		})
 		return err
 	})

--- a/tests/robustness/options/options.go
+++ b/tests/robustness/options/options.go
@@ -16,7 +16,7 @@ package options
 
 import "time"
 
-type BackgroundWatchConfig struct {
+type WatchConfig struct {
 	Interval       time.Duration
 	RevisionOffset int64
 }

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -157,7 +157,10 @@ func (t etcdTraffic) RunKeyValueLoop(ctx context.Context, p RunTrafficLoopParam)
 }
 
 func (t etcdTraffic) RunWatchLoop(ctx context.Context, p RunWatchLoopParam) {
-	// TODO: implement in a subsequent commit
+	runWatchLoop(ctx, p, watchLoopConfig{
+		getKey:   "",
+		watchKey: p.KeyStore.GetPrefix(),
+	})
 }
 
 func (t etcdTraffic) RunCompactLoop(ctx context.Context, param RunCompactLoopParam) {


### PR DESCRIPTION
Implement `RunWatchLoop` in etcd traffic. 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
