### PR TITLE
etcdmain: centralize exit handling

### DIFF
--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -122,18 +122,18 @@ func newConfig() *config {
 	return cfg
 }
 
-func (cfg *config) parse(arguments []string) error {
+func (cfg *config) parse(arguments []string) (bool, error) {
 	perr := cfg.cf.flagSet.Parse(arguments)
 	switch {
 	case perr == nil:
 	case errors.Is(perr, flag.ErrHelp):
 		fmt.Println(flagsline)
-		os.Exit(0)
+		return true, nil
 	default:
-		os.Exit(2)
+		return false, fmt.Errorf("%w: %v", ErrArgumentError, perr)
 	}
 	if len(cfg.cf.flagSet.Args()) != 0 {
-		return fmt.Errorf("%q is not a valid flag", cfg.cf.flagSet.Arg(0))
+		return false, fmt.Errorf("%w: %q is not a valid flag", ErrArgumentError, cfg.cf.flagSet.Arg(0))
 	}
 
 	if cfg.printVersion {
@@ -141,7 +141,7 @@ func (cfg *config) parse(arguments []string) error {
 		fmt.Printf("Git SHA: %s\n", version.GitSHA)
 		fmt.Printf("Go Version: %s\n", runtime.Version())
 		fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-		os.Exit(0)
+		return true, nil
 	}
 
 	var err error
@@ -187,7 +187,7 @@ func (cfg *config) parse(arguments []string) error {
 		}
 	}
 
-	return err
+	return false, err
 }
 
 func (cfg *config) configFromCmdLine() error {

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -130,7 +130,7 @@ func (cfg *config) parse(arguments []string) (bool, error) {
 		fmt.Println(flagsline)
 		return true, nil
 	default:
-		return false, fmt.Errorf("%w: %v", ErrArgumentError, perr)
+		return false, fmt.Errorf("%w: %w", ErrArgumentError, perr)
 	}
 	if len(cfg.cf.flagSet.Args()) != 0 {
 		return false, fmt.Errorf("%w: %q is not a valid flag", ErrArgumentError, cfg.cf.flagSet.Arg(0))

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -52,7 +52,7 @@ func TestConfigParsingMemberFlags(t *testing.T) {
 	}
 
 	cfg := newConfig()
-	err := cfg.parse(args)
+	_, err := cfg.parse(args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestConfigFileMemberFields(t *testing.T) {
 	args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 	cfg := newConfig()
-	if err = cfg.parse(args); err != nil {
+	if _, err = cfg.parse(args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -113,7 +113,7 @@ func TestConfigParsingClusteringFlags(t *testing.T) {
 	}
 
 	cfg := newConfig()
-	if err := cfg.parse(args); err != nil {
+	if _, err := cfg.parse(args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,7 +145,7 @@ func TestConfigFileClusteringFields(t *testing.T) {
 
 	args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 	cfg := newConfig()
-	err = cfg.parse(args)
+	_, err = cfg.parse(args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestConfigFileClusteringFlags(t *testing.T) {
 		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 		cfg := newConfig()
-		if err := cfg.parse(args); err != nil {
+		if _, err := cfg.parse(args); err != nil {
 			t.Errorf("%d: err = %v", i, err)
 		}
 	}
@@ -229,7 +229,7 @@ func TestConfigParsingConflictClusteringFlags(t *testing.T) {
 
 	for i, tt := range conflictArgs {
 		cfg := newConfig()
-		if err := cfg.parse(tt); !errors.Is(err, embed.ErrConflictBootstrapFlags) {
+		if _, err := cfg.parse(tt); !errors.Is(err, embed.ErrConflictBootstrapFlags) {
 			t.Errorf("%d: err = %v, want %v", i, err, embed.ErrConflictBootstrapFlags)
 		}
 	}
@@ -278,7 +278,7 @@ func TestConfigFileConflictClusteringFlags(t *testing.T) {
 		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 		cfg := newConfig()
-		if err := cfg.parse(args); !errors.Is(err, embed.ErrConflictBootstrapFlags) {
+		if _, err := cfg.parse(args); !errors.Is(err, embed.ErrConflictBootstrapFlags) {
 			t.Errorf("%d: err = %v, want %v", i, err, embed.ErrConflictBootstrapFlags)
 		}
 	}
@@ -320,7 +320,7 @@ func TestConfigParsingMissedAdvertiseClientURLsFlag(t *testing.T) {
 
 	for i, tt := range tests {
 		cfg := newConfig()
-		if err := cfg.parse(tt.args); !errors.Is(err, tt.werr) {
+		if _, err := cfg.parse(tt.args); !errors.Is(err, tt.werr) {
 			t.Errorf("%d: err = %v, want %v", i, err, tt.werr)
 		}
 	}
@@ -337,7 +337,7 @@ func TestConfigIsNewCluster(t *testing.T) {
 	for i, tt := range tests {
 		cfg := newConfig()
 		args := []string{"--initial-cluster-state", tests[i].state}
-		err := cfg.parse(args)
+		_, err := cfg.parse(args)
 		require.NoErrorf(t, err, "#%d: unexpected clusterState.Set error: %v", i, err)
 		if g := cfg.ec.IsNewCluster(); g != tt.wIsNew {
 			t.Errorf("#%d: isNewCluster = %v, want %v", i, g, tt.wIsNew)
@@ -385,7 +385,7 @@ func TestConfigFileElectionTimeout(t *testing.T) {
 		args := []string{fmt.Sprintf("--config-file=%s", tmpfile.Name())}
 
 		cfg := newConfig()
-		if err := cfg.parse(args); err == nil || !strings.Contains(err.Error(), tt.errStr) {
+		if _, err := cfg.parse(args); err == nil || !strings.Contains(err.Error(), tt.errStr) {
 			t.Errorf("%d: Wrong err = %v", i, err)
 		}
 	}
@@ -434,7 +434,7 @@ func TestParseFeatureGateFlags(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := newConfig()
-			err := cfg.parse(tc.args)
+			_, err := cfg.parse(tc.args)
 			if tc.expectErr {
 				require.Errorf(t, err, "expect parse error")
 				return
@@ -579,7 +579,7 @@ func TestConfigFileDeprecatedOptions(t *testing.T) {
 
 			// Parse config
 			cfg := newConfig()
-			err = cfg.parse([]string{fmt.Sprintf("--config-file=%s", tmpfile.Name())})
+			_, err = cfg.parse([]string{fmt.Sprintf("--config-file=%s", tmpfile.Name())})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -41,12 +41,33 @@ var (
 )
 
 func startEtcdOrProxyV2(args []string) {
+	err := startEtcdOrProxyV2Error(args)
+	switch {
+	case err == nil:
+		osutil.Exit(exitCodeOK)
+
+	case errorspkg.Is(err, ErrArgumentError):
+		fmt.Println(err)
+		osutil.Exit(exitCodeBadArgs)
+	case errorspkg.Is(err, ErrGeneralError):
+		fmt.Println(err)
+		osutil.Exit(exitCodeGeneral)
+	default:
+		fmt.Println(err)
+		osutil.Exit(exitCodeGeneral)
+	}
+}
+
+func startEtcdOrProxyV2Error(args []string) error {
 	grpc.EnableTracing = false
 
 	cfg := newConfig()
 	defaultInitialCluster := cfg.ec.InitialCluster
 
-	err := cfg.parse(args[1:])
+	shouldExit, err := cfg.parse(args[1:])
+	if shouldExit {
+		return nil
+	}
 	lg := cfg.ec.GetLogger()
 	// If we failed to parse the whole configuration, print the error using
 	// preferably the resolved logger from the config,
@@ -57,7 +78,7 @@ func startEtcdOrProxyV2(args []string) {
 		lg, zapError = logutil.CreateDefaultZapLogger(zap.InfoLevel)
 		if zapError != nil {
 			fmt.Printf("error creating zap logger %v", zapError)
-			os.Exit(1)
+			return fmt.Errorf("%w: error creating zap logger %v", ErrGeneralError, zapError)
 		}
 	}
 	lg.Info("Running: ", zap.Strings("args", args))
@@ -66,7 +87,10 @@ func startEtcdOrProxyV2(args []string) {
 		if errorspkg.Is(err, embed.ErrUnsetAdvertiseClientURLsFlag) {
 			lg.Warn("advertise client URLs are not set", zap.Error(err))
 		}
-		os.Exit(1)
+		if errorspkg.Is(err, ErrArgumentError) {
+			return err
+		}
+		return fmt.Errorf("%w: failed to verify flags %v", ErrArgumentError, err)
 	}
 
 	cfg.ec.SetupGlobalLoggers()
@@ -138,7 +162,7 @@ func startEtcdOrProxyV2(args []string) {
 			)
 			lg.Warn("do not reuse discovery token; generate a new one to bootstrap a cluster")
 
-			os.Exit(1)
+			return fmt.Errorf("%w: discovery failed %v", ErrGeneralError, err)
 		}
 
 		if strings.Contains(err.Error(), "include") && strings.Contains(err.Error(), "--initial-cluster") {
@@ -152,9 +176,10 @@ func startEtcdOrProxyV2(args []string) {
 			if cfg.ec.InitialCluster == cfg.ec.InitialClusterFromName(cfg.ec.Name) && len(cfg.ec.DiscoveryCfg.Endpoints) == 0 {
 				lg.Warn("V3 discovery settings (i.e., --discovery-token, --discovery-endpoints) are not set")
 			}
-			os.Exit(1)
+			return fmt.Errorf("%w: failed to start %v", ErrGeneralError, err)
 		}
-		lg.Fatal("discovery failed", zap.Error(err))
+		lg.Error("discovery failed", zap.Error(err))
+		return fmt.Errorf("%w: discovery failed %v", ErrGeneralError, err)
 	}
 
 	osutil.HandleInterrupts(lg)
@@ -168,12 +193,13 @@ func startEtcdOrProxyV2(args []string) {
 
 	select {
 	case lerr := <-errc:
-		// fatal out on listener errors
-		lg.Fatal("listener failed", zap.Error(lerr))
+		// exit on listener errors
+		lg.Error("listener failed", zap.Error(lerr))
+		return fmt.Errorf("%w: listener failed %v", ErrGeneralError, lerr)
 	case <-stopped:
 	}
 
-	osutil.Exit(0)
+	return nil
 }
 
 // startEtcd runs StartEtcd in addition to hooks needed for standalone etcd.

--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -78,7 +78,7 @@ func startEtcdOrProxyV2Error(args []string) error {
 		lg, zapError = logutil.CreateDefaultZapLogger(zap.InfoLevel)
 		if zapError != nil {
 			fmt.Printf("error creating zap logger %v", zapError)
-			return fmt.Errorf("%w: error creating zap logger %v", ErrGeneralError, zapError)
+			return fmt.Errorf("%w: error creating zap logger %w", ErrGeneralError, zapError)
 		}
 	}
 	lg.Info("Running: ", zap.Strings("args", args))
@@ -90,7 +90,7 @@ func startEtcdOrProxyV2Error(args []string) error {
 		if errorspkg.Is(err, ErrArgumentError) {
 			return err
 		}
-		return fmt.Errorf("%w: failed to verify flags %v", ErrArgumentError, err)
+		return fmt.Errorf("%w: failed to verify flags %w", ErrArgumentError, err)
 	}
 
 	cfg.ec.SetupGlobalLoggers()
@@ -162,7 +162,7 @@ func startEtcdOrProxyV2Error(args []string) error {
 			)
 			lg.Warn("do not reuse discovery token; generate a new one to bootstrap a cluster")
 
-			return fmt.Errorf("%w: discovery failed %v", ErrGeneralError, err)
+			return fmt.Errorf("%w: discovery failed %w", ErrGeneralError, err)
 		}
 
 		if strings.Contains(err.Error(), "include") && strings.Contains(err.Error(), "--initial-cluster") {
@@ -176,10 +176,10 @@ func startEtcdOrProxyV2Error(args []string) error {
 			if cfg.ec.InitialCluster == cfg.ec.InitialClusterFromName(cfg.ec.Name) && len(cfg.ec.DiscoveryCfg.Endpoints) == 0 {
 				lg.Warn("V3 discovery settings (i.e., --discovery-token, --discovery-endpoints) are not set")
 			}
-			return fmt.Errorf("%w: failed to start %v", ErrGeneralError, err)
+			return fmt.Errorf("%w: failed to start %w", ErrGeneralError, err)
 		}
 		lg.Error("discovery failed", zap.Error(err))
-		return fmt.Errorf("%w: discovery failed %v", ErrGeneralError, err)
+		return fmt.Errorf("%w: discovery failed %w", ErrGeneralError, err)
 	}
 
 	osutil.HandleInterrupts(lg)
@@ -195,7 +195,7 @@ func startEtcdOrProxyV2Error(args []string) error {
 	case lerr := <-errc:
 		// exit on listener errors
 		lg.Error("listener failed", zap.Error(lerr))
-		return fmt.Errorf("%w: listener failed %v", ErrGeneralError, lerr)
+		return fmt.Errorf("%w: listener failed %w", ErrGeneralError, lerr)
 	case <-stopped:
 	}
 

--- a/server/etcdmain/exit.go
+++ b/server/etcdmain/exit.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdmain
+
+import "errors"
+
+const (
+	exitCodeOK      = 0
+	exitCodeGeneral = 1
+	exitCodeBadArgs = 2
+)
+
+var (
+
+	ErrGeneralError  = errors.New("general error")
+	ErrArgumentError = errors.New("bad argument")
+)


### PR DESCRIPTION
What\n- funnel startEtcdOrProxyV2 exit paths through a single osutil.Exit call\n- convert config parsing help/version/flag exits into exit errors\n- add a small exit code helper for etcdmain\n\n## Why\nFollow-up to #21032 (step 2 after #21062) to unify exit calls.\n\n## Testing\n- not run (not requested)