### PR TITLE
etcdserver: prevent panic when two snapshots arrive in quick succession

### DIFF
--- a/tests/e2e/ctl_v3_snapshot_test.go
+++ b/tests/e2e/ctl_v3_snapshot_test.go
@@ -462,7 +462,7 @@ func TestBreakConsistentIndexNewerThanSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	err = member.Start(ctx)
 	require.Error(t, err)
-	_, err = member.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "failed to find database snapshot file (snap: snapshot file doesn't exist)"})
+	_, err = member.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: "snap: snapshot file doesn't exist"})
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
fixes: https://github.com/etcd-io/etcd/issues/18055

#### Approach

OpenSnapshotBackend now calls `ReserveDBSnapshot` to mark the snapshot index as "in-use" before attempting to access the file. Concurrent calls to `ReleaseSnapDBs` (triggered by incoming newer snapshots) check this reservation map and explicitly skip deletion for any reserved indices. This guarantees that the snapshot file currently being applied is protected from deletion, even if a newer snapshot arrives and triggers a cleanup during the apply process.

This PR implements an in-memory reservation mechanism rather than file locking because:

1. Both the apply path [OpenSnapshotBackend](https://github.com/etcd-io/etcd/blob/main/server/storage/backend.go#L57-L72) and the cleanup path [ReleaseSnapDBs](https://github.com/etcd-io/etcd/blob/main/server/etcdserver/api/snap/snapshotter.go#L259-L291) operate on the same `*Snapshotter` instance, allowing in-memory coordination.

2. File locking (`flock`) behaves differently across platforms (Linux, Windows) and filesystems (NFS), while in-memory coordination is consistent everywhere. (`contributing.md` mentions only Linux is supported, but the Makefile does include Windows builds.)

3. [OpenSnapshotBackend](https://github.com/etcd-io/etcd/blob/main/server/storage/backend.go#L59-L73) renames the snapshot file; it is my understanding that file locks do not survive renames on many systems.

4. The reservation is a simple map lookup protected by `RWMutex`, with `Reserve`/`Release` co-located in one function using `defer`.

The fix adds a `reserved` map to track snapshots currently being applied, and [ReleaseSnapDBs](https://github.com/etcd-io/etcd/blob/main/server/etcdserver/api/snap/snapshotter.go#L259-L291) skips deletion of any reserved snapshots.
