### PR TITLE
robustness: drop delete revision tracking in watchRevisions

### DIFF
--- a/tests/robustness/validate/patch_history.go
+++ b/tests/robustness/validate/patch_history.go
@@ -32,7 +32,7 @@ type patchArgs struct {
 }
 
 func patchLinearizableOperations(operations []porcupine.Operation, reports []report.ClientReport, persistedRequests []model.EtcdRequest) []porcupine.Operation {
-	putRevision, delRevision := watchRevisions(reports)
+	putRevision := watchRevisions(reports)
 	persistedPutCount := countPersistedPuts(persistedRequests)
 	clientPutCount := countClientPuts(reports)
 
@@ -56,7 +56,6 @@ func patchLinearizableOperations(operations []porcupine.Operation, reports []rep
 			clientCount:    c,
 			persistedCount: persistedDeleteCount[opts],
 			returnTime:     delReturnTime[opts],
-			revision:       delRevision[opts],
 		}
 	}
 
@@ -65,9 +64,8 @@ func patchLinearizableOperations(operations []porcupine.Operation, reports []rep
 	)
 }
 
-func watchRevisions(reports []report.ClientReport) (map[model.PutOptions]int64, map[model.DeleteOptions]int64) {
+func watchRevisions(reports []report.ClientReport) map[model.PutOptions]int64 {
 	putRevisions := map[model.PutOptions]int64{}
-	delRevisions := map[model.DeleteOptions]int64{}
 
 	for _, client := range reports {
 		for _, watch := range client.Watch {
@@ -87,7 +85,7 @@ func watchRevisions(reports []report.ClientReport) (map[model.PutOptions]int64, 
 			}
 		}
 	}
-	return putRevisions, delRevisions
+	return putRevisions
 }
 
 func patchOperations(


### PR DESCRIPTION
Delete operation revisions are now determined from watch events generated by lease revocation rather than being tracked separately in watchRevisions().
This simplifies the patching logic by removing the delRevision map and associated cleanup code.
