### PR TITLE
enable linter for deprecated functions

### DIFF
--- a/api/etcdserverpb/raft_internal_stringer.go
+++ b/api/etcdserverpb/raft_internal_stringer.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	proto "github.com/golang/protobuf/proto"
+	proto "github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 )
 
 // InternalRaftStringer implements custom proto Stringer:

--- a/client/pkg/transport/timeout_transport.go
+++ b/client/pkg/transport/timeout_transport.go
@@ -39,7 +39,7 @@ func NewTimeoutTransport(info TLSInfo, dialtimeoutd, rdtimeoutd, wtimeoutd time.
 		tr.MaxIdleConnsPerHost = 1024
 	}
 
-	tr.Dial = (&rwTimeoutDialer{
+	tr.Dial = (&rwTimeoutDialer{ //nolint:staticcheck // TODO: remove for a supported version
 		Dialer: net.Dialer{
 			Timeout:   dialtimeoutd,
 			KeepAlive: 30 * time.Second,

--- a/client/pkg/transport/timeout_transport_test.go
+++ b/client/pkg/transport/timeout_transport_test.go
@@ -37,7 +37,7 @@ func TestNewTimeoutTransport(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(remoteAddr))
 
 	defer srv.Close()
-	conn, err := tr.Dial("tcp", srv.Listener.Addr().String())
+	conn, err := tr.Dial("tcp", srv.Listener.Addr().String()) //nolint:staticcheck // TODO: remove for a supported version
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -331,7 +331,7 @@ func (c *Client) dial(creds grpccredentials.TransportCredentials, dopts ...grpc.
 		defer cancel() // TODO: Is this right for cases where grpc.WithBlock() is not set on the dial options?
 	}
 	target := fmt.Sprintf("%s://%p/%s", resolver.Schema, c, authority(c.endpoints[0]))
-	conn, err := grpc.DialContext(dctx, target, opts...)
+	conn, err := grpc.DialContext(dctx, target, opts...) //nolint:staticcheck // TODO: remove for a supported version
 	if err != nil {
 		return nil, err
 	}

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -103,12 +103,12 @@ func TestDialTimeout(t *testing.T) {
 		{
 			Endpoints:   []string{"http://254.0.0.1:12345"},
 			DialTimeout: 2 * time.Second,
-			DialOptions: []grpc.DialOption{grpc.WithBlock()},
+			DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		},
 		{
 			Endpoints:   []string{"http://254.0.0.1:12345"},
 			DialTimeout: time.Second,
-			DialOptions: []grpc.DialOption{grpc.WithBlock()},
+			DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 			Username:    "abc",
 			Password:    "def",
 		},

--- a/client/v3/naming/resolver/resolver.go
+++ b/client/v3/naming/resolver/resolver.go
@@ -113,7 +113,7 @@ func convertToGRPCEndpoint(ups map[string]*endpoints.Update) []gresolver.Endpoin
 			Addresses: []gresolver.Address{
 				{
 					Addr:     up.Endpoint.Addr,
-					Metadata: up.Endpoint.Metadata,
+					Metadata: up.Endpoint.Metadata, //nolint:staticcheck // TODO: remove for a supported version
 				},
 			},
 		}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -832,7 +832,7 @@ func (e *Etcd) grpcGatewayDial(splitHTTP bool) (grpcDial func(ctx context.Contex
 	}
 
 	return func(ctx context.Context) (*grpc.ClientConn, error) {
-		conn, err := grpc.DialContext(ctx, addr, opts...)
+		conn, err := grpc.DialContext(ctx, addr, opts...) //nolint:staticcheck // TODO: remove for a supported version
 		if err != nil {
 			sctx.lg.Error("grpc gateway failed to dial", zap.String("addr", addr), zap.Error(err))
 			return nil, err

--- a/server/etcdmain/grpc_proxy_logger.go
+++ b/server/etcdmain/grpc_proxy_logger.go
@@ -22,8 +22,8 @@ import (
 	"slices"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb" //nolint:staticcheck // TODO: remove for a supported version
+	"github.com/golang/protobuf/proto"  //nolint:staticcheck // TODO: remove for a supported version
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/peer"

--- a/server/etcdserver/api/etcdhttp/types/errors_test.go
+++ b/server/etcdserver/api/etcdhttp/types/errors_test.go
@@ -38,8 +38,8 @@ func TestHTTPErrorWriteTo(t *testing.T) {
 		t.Errorf("HTTP status code %d, want %d", rr.Code, wcode)
 	}
 
-	if !reflect.DeepEqual(wheader, rr.HeaderMap) {
-		t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader)
+	if !reflect.DeepEqual(wheader, rr.HeaderMap) { //nolint:staticcheck // TODO: remove for a supported version
+		t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader) //nolint:staticcheck // TODO: remove for a supported version
 	}
 
 	gbody := rr.Body.String()

--- a/server/etcdserver/api/etcdhttp/version_test.go
+++ b/server/etcdserver/api/etcdhttp/version_test.go
@@ -45,7 +45,7 @@ func TestServeVersion(t *testing.T) {
 	if g := rw.Body.String(); g != string(w) {
 		t.Fatalf("body = %q, want %q", g, string(w))
 	}
-	if ct := rw.HeaderMap.Get("Content-Type"); ct != "application/json" {
+	if ct := rw.HeaderMap.Get("Content-Type"); ct != "application/json" { //nolint:staticcheck // TODO: remove for a supported version
 		t.Errorf("contet-type header = %s, want %s", ct, "application/json")
 	}
 }

--- a/server/etcdserver/api/v2error/error_test.go
+++ b/server/etcdserver/api/v2error/error_test.go
@@ -42,8 +42,8 @@ func TestErrorWriteTo(t *testing.T) {
 			"X-Etcd-Index": {"1"},
 		})
 
-		if !reflect.DeepEqual(wheader, rr.HeaderMap) {
-			t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader)
+		if !reflect.DeepEqual(wheader, rr.HeaderMap) { //nolint:staticcheck // TODO: remove for a supported version
+			t.Errorf("HTTP headers %v, want %v", rr.HeaderMap, wheader) //nolint:staticcheck // TODO: remove for a supported version
 		}
 	}
 }

--- a/server/etcdserver/api/v3rpc/codec.go
+++ b/server/etcdserver/api/v3rpc/codec.go
@@ -14,7 +14,7 @@
 
 package v3rpc
 
-import "github.com/golang/protobuf/proto"
+import "github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 
 type codec struct{}
 

--- a/server/etcdserver/api/v3rpc/grpc.go
+++ b/server/etcdserver/api/v3rpc/grpc.go
@@ -43,7 +43,7 @@ var (
 
 func Server(s *etcdserver.EtcdServer, tls *tls.Config, interceptor grpc.UnaryServerInterceptor, gopts ...grpc.ServerOption) *grpc.Server {
 	var opts []grpc.ServerOption
-	opts = append(opts, grpc.CustomCodec(&codec{}))
+	opts = append(opts, grpc.CustomCodec(&codec{})) //nolint:staticcheck // TODO: remove for a supported version
 	if tls != nil {
 		opts = append(opts, grpc.Creds(credentials.NewTransportCredential(tls)))
 	}

--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -590,7 +590,7 @@ func HashByRev(ctx context.Context, cid types.ID, cc *http.Client, url string, r
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Etcd-Cluster-ID", cid.String())
-	req.Cancel = ctx.Done()
+	req.Cancel = ctx.Done() //nolint:staticcheck // TODO: remove for a supported version
 
 	resp, err := cc.Do(req)
 	if err != nil {

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"github.com/prometheus/client_golang/prometheus"
 	ptestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"

--- a/server/etcdserver/txn/util.go
+++ b/server/etcdserver/txn/util.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"

--- a/server/lease/leasehttp/http.go
+++ b/server/lease/leasehttp/http.go
@@ -172,7 +172,7 @@ func RenewHTTP(ctx context.Context, id lease.LeaseID, url string, rt http.RoundT
 		return -1, err
 	}
 	req.Header.Set("Content-Type", "application/protobuf")
-	req.Cancel = ctx.Done()
+	req.Cancel = ctx.Done() //nolint:staticcheck // TODO: remove for a supported version
 
 	resp, err := cc.Do(req)
 	if err != nil {

--- a/server/proxy/grpcproxy/adapter/chan_stream.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream.go
@@ -46,9 +46,9 @@ func (ss *chanServerStream) SendHeader(md metadata.MD) error {
 		ss.headerc = nil
 		ss.headers = nil
 		return nil
-	case <-ss.Context().Done():
+	case <-ss.Context().Done(): //nolint:staticcheck // TODO: remove for a supported version
 	}
-	return ss.Context().Err()
+	return ss.Context().Err() //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (ss *chanServerStream) SetHeader(md metadata.MD) error {

--- a/server/proxy/grpcproxy/adapter/election_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/election_client_adapter.go
@@ -58,24 +58,24 @@ type es2ecClientStream struct{ chanClientStream }
 type es2ecServerStream struct{ chanServerStream }
 
 func (s *es2ecClientStream) Send(rr *v3electionpb.LeaderRequest) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *es2ecClientStream) Recv() (*v3electionpb.LeaderResponse, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*v3electionpb.LeaderResponse), nil
 }
 
 func (s *es2ecServerStream) Send(rr *v3electionpb.LeaderResponse) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *es2ecServerStream) Recv() (*v3electionpb.LeaderRequest, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*v3electionpb.LeaderRequest), nil

--- a/server/proxy/grpcproxy/adapter/lease_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/lease_client_adapter.go
@@ -60,24 +60,24 @@ type ls2lcClientStream struct{ chanClientStream }
 type ls2lcServerStream struct{ chanServerStream }
 
 func (s *ls2lcClientStream) Send(rr *pb.LeaseKeepAliveRequest) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ls2lcClientStream) Recv() (*pb.LeaseKeepAliveResponse, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.LeaseKeepAliveResponse), nil
 }
 
 func (s *ls2lcServerStream) Send(rr *pb.LeaseKeepAliveResponse) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ls2lcServerStream) Recv() (*pb.LeaseKeepAliveRequest, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.LeaseKeepAliveRequest), nil

--- a/server/proxy/grpcproxy/adapter/maintenance_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/maintenance_client_adapter.go
@@ -70,24 +70,24 @@ type ss2scClientStream struct{ chanClientStream }
 type ss2scServerStream struct{ chanServerStream }
 
 func (s *ss2scClientStream) Send(rr *pb.SnapshotRequest) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ss2scClientStream) Recv() (*pb.SnapshotResponse, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.SnapshotResponse), nil
 }
 
 func (s *ss2scServerStream) Send(rr *pb.SnapshotResponse) error {
-	return s.SendMsg(rr)
+	return s.SendMsg(rr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ss2scServerStream) Recv() (*pb.SnapshotRequest, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.SnapshotRequest), nil

--- a/server/proxy/grpcproxy/adapter/watch_client_adapter.go
+++ b/server/proxy/grpcproxy/adapter/watch_client_adapter.go
@@ -45,24 +45,24 @@ type ws2wcClientStream struct{ chanClientStream }
 type ws2wcServerStream struct{ chanServerStream }
 
 func (s *ws2wcClientStream) Send(wr *pb.WatchRequest) error {
-	return s.SendMsg(wr)
+	return s.SendMsg(wr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ws2wcClientStream) Recv() (*pb.WatchResponse, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.WatchResponse), nil
 }
 
 func (s *ws2wcServerStream) Send(wr *pb.WatchResponse) error {
-	return s.SendMsg(wr)
+	return s.SendMsg(wr) //nolint:staticcheck // TODO: remove for a supported version
 }
 
 func (s *ws2wcServerStream) Recv() (*pb.WatchRequest, error) {
 	var v any
-	if err := s.RecvMsg(&v); err != nil {
+	if err := s.RecvMsg(&v); err != nil { //nolint:staticcheck // TODO: remove for a supported version
 		return nil, err
 	}
 	return v.(*pb.WatchRequest), nil

--- a/server/proxy/grpcproxy/cluster.go
+++ b/server/proxy/grpcproxy/cluster.go
@@ -143,7 +143,7 @@ func (cp *clusterProxy) membersFromUpdates() ([]*pb.Member, error) {
 	defer cp.umu.RUnlock()
 	mbs := make([]*pb.Member, 0, len(cp.umap))
 	for _, upt := range cp.umap {
-		m, err := decodeMeta(fmt.Sprint(upt.Metadata))
+		m, err := decodeMeta(fmt.Sprint(upt.Metadata)) //nolint:staticcheck // TODO: remove for a supported version
 		if err != nil {
 			return nil, err
 		}

--- a/server/storage/wal/version.go
+++ b/server/storage/wal/version.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 

--- a/server/storage/wal/version_test.go
+++ b/server/storage/wal/version_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/server/storage/wal/walpb/record_test.go
+++ b/server/storage/wal/walpb/record_test.go
@@ -17,14 +17,14 @@ package walpb
 import (
 	"testing"
 
-	"github.com/golang/protobuf/descriptor"
+	"github.com/golang/protobuf/descriptor" //nolint:staticcheck // TODO: remove for a supported version
 
 	"go.etcd.io/raft/v3/raftpb"
 )
 
 func TestSnapshotMetadataCompatibility(t *testing.T) {
-	_, snapshotMetadataMd := descriptor.ForMessage(&raftpb.SnapshotMetadata{})
-	_, snapshotMd := descriptor.ForMessage(&Snapshot{})
+	_, snapshotMetadataMd := descriptor.ForMessage(&raftpb.SnapshotMetadata{}) //nolint:staticcheck // TODO: remove for a supported version
+	_, snapshotMd := descriptor.ForMessage(&Snapshot{})                        //nolint:staticcheck // TODO: remove for a supported version
 	if len(snapshotMetadataMd.GetField()) != len(snapshotMd.GetField()) {
 		t.Errorf("Different number of fields in raftpb.SnapshotMetadata vs. walpb.Snapshot. " +
 			"They are supposed to be in sync.")

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -50,7 +50,7 @@ func newClient(t *testing.T, entpoints []string, cfg e2e.ClientConfig) *clientv3
 	ccfg := clientv3.Config{
 		Endpoints:   entpoints,
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	if tlscfg != nil {
 		ccfg.TLS, err = tlscfg.ClientConfig()

--- a/tests/e2e/v3_curl_kv_test.go
+++ b/tests/e2e/v3_curl_kv_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	protov1 "github.com/golang/protobuf/proto"
+	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	gw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -53,7 +53,7 @@ func NewEtcdctl(cfg ClientConfig, endpoints []string, opts ...config.ClientOptio
 		client, err := clientv3.New(clientv3.Config{
 			Endpoints:   ctl.endpoints,
 			DialTimeout: 5 * time.Second,
-			DialOptions: []grpc.DialOption{grpc.WithBlock()},
+			DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 			Username:    ctl.authConfig.Username,
 			Password:    ctl.authConfig.Password,
 			Token:       ctl.authConfig.Token,

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -726,7 +726,7 @@ func MustNewMember(t testutil.TB, mcfg MemberConfig) *Member {
 		m.MaxLearners = mcfg.MaxLearners
 	}
 	m.Metrics = mcfg.Metrics
-	m.V2Deprecation = config.V2_DEPR_DEFAULT
+	m.V2Deprecation = config.V2_DEPR_DEFAULT //nolint:staticcheck // TODO: remove for a supported version
 	m.GRPCServerRecorder = &grpctesting.GRPCRecorder{}
 
 	m.Logger, m.LogObserver = memberLogger(t, mcfg.Name)
@@ -897,7 +897,7 @@ func NewClientV3(m *Member) (*clientv3.Client, error) {
 	cfg := clientv3.Config{
 		Endpoints:          []string{m.GRPCURL},
 		DialTimeout:        5 * time.Second,
-		DialOptions:        []grpc.DialOption{grpc.WithBlock()},
+		DialOptions:        []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		MaxCallSendMsgSize: m.ClientMaxCallSendMsgSize,
 		MaxCallRecvMsgSize: m.ClientMaxCallRecvMsgSize,
 		Logger:             m.Logger.Named("client"),
@@ -1492,7 +1492,7 @@ func (c *Cluster) newClientCfg() (*clientv3.Config, error) {
 	cfg := &clientv3.Config{
 		Endpoints:          c.Endpoints(),
 		DialTimeout:        5 * time.Second,
-		DialOptions:        []grpc.DialOption{grpc.WithBlock()},
+		DialOptions:        []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		MaxCallSendMsgSize: c.Cfg.ClientMaxCallSendMsgSize,
 		MaxCallRecvMsgSize: c.Cfg.ClientMaxCallRecvMsgSize,
 	}

--- a/tests/integration/clientv3/connectivity/black_hole_test.go
+++ b/tests/integration/clientv3/connectivity/black_hole_test.go
@@ -49,7 +49,7 @@ func TestBalancerUnderBlackholeKeepAliveWatch(t *testing.T) {
 	ccfg := clientv3.Config{
 		Endpoints:            []string{eps[0]},
 		DialTimeout:          time.Second,
-		DialOptions:          []grpc.DialOption{grpc.WithBlock()},
+		DialOptions:          []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		DialKeepAliveTime:    time.Second,
 		DialKeepAliveTimeout: 500 * time.Millisecond,
 	}
@@ -175,7 +175,7 @@ func testBalancerUnderBlackholeNoKeepAlive(t *testing.T, op func(*clientv3.Clien
 	ccfg := clientv3.Config{
 		Endpoints:   []string{eps[0]},
 		DialTimeout: 1 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cli, err := integration.NewClient(t, ccfg)
 	require.NoError(t, err)

--- a/tests/integration/clientv3/connectivity/dial_test.go
+++ b/tests/integration/clientv3/connectivity/dial_test.go
@@ -60,7 +60,7 @@ func TestDialTLSExpired(t *testing.T) {
 	_, err = integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 3 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		TLS:         tls,
 	})
 	require.Truef(t, clientv3test.IsClientTimeout(err), "expected dial timeout error")
@@ -76,7 +76,7 @@ func TestDialTLSNoConfig(t *testing.T) {
 	c, err := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	})
 	defer func() {
 		if c != nil {
@@ -112,7 +112,7 @@ func testDialSetEndpoints(t *testing.T, setBefore bool) {
 	cfg := clientv3.Config{
 		Endpoints:   []string{eps[toKill]},
 		DialTimeout: 1 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cli, err := integration.NewClient(t, cfg)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestRejectOldCluster(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:        []string{clus.Members[0].GRPCURL, clus.Members[1].GRPCURL},
 		DialTimeout:      5 * time.Second,
-		DialOptions:      []grpc.DialOption{grpc.WithBlock()},
+		DialOptions:      []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		RejectOldCluster: true,
 	}
 	cli, err := integration.NewClient(t, cfg)

--- a/tests/integration/clientv3/connectivity/network_partition_test.go
+++ b/tests/integration/clientv3/connectivity/network_partition_test.go
@@ -122,7 +122,7 @@ func testBalancerUnderNetworkPartition(t *testing.T, op func(*clientv3.Client, c
 	ccfg := clientv3.Config{
 		Endpoints:   []string{eps[0]},
 		DialTimeout: 3 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cli, err := integration.NewClient(t, ccfg)
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestBalancerUnderNetworkPartitionLinearizableGetLeaderElection(t *testing.T
 	cli, err := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{eps[(lead+1)%2]},
 		DialTimeout: 2 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	})
 	require.NoError(t, err)
 	defer cli.Close()
@@ -279,7 +279,7 @@ func TestDropReadUnderNetworkPartition(t *testing.T) {
 	ccfg := clientv3.Config{
 		Endpoints:   eps,
 		DialTimeout: 10 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cli, err := integration.NewClient(t, ccfg)
 	require.NoError(t, err)

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -780,7 +780,7 @@ func TestKVForLearner(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:   []string{learnerEp},
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	// this client only has endpoint of the learner member
 	cli, err := integration.NewClient(t, cfg)
@@ -853,7 +853,7 @@ func TestBalancerSupportLearner(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:   []string{learnerEp},
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cli, err := integration.NewClient(t, cfg)
 	if err != nil {

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -432,7 +432,7 @@ func TestMaintenanceStatus(t *testing.T) {
 			}
 
 			t.Logf("Creating client...")
-			cli, err := integration.NewClient(t, clientv3.Config{Endpoints: eps, DialOptions: []grpc.DialOption{grpc.WithBlock()}})
+			cli, err := integration.NewClient(t, clientv3.Config{Endpoints: eps, DialOptions: []grpc.DialOption{grpc.WithBlock()}}) //nolint:staticcheck // TODO: remove for a supported version
 			require.NoError(t, err)
 			defer cli.Close()
 			t.Logf("Creating client [DONE]")

--- a/tests/integration/clientv3/mirror_auth_test.go
+++ b/tests/integration/clientv3/mirror_auth_test.go
@@ -54,7 +54,7 @@ func TestMirrorSync_Authenticated(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:   initialClient.Endpoints(),
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		Username:    "syncer",
 		Password:    "syncfoo",
 	}

--- a/tests/integration/clientv3/naming/resolver_test.go
+++ b/tests/integration/clientv3/naming/resolver_test.go
@@ -75,7 +75,7 @@ func testEtcdGRPCResolver(t *testing.T, lbPolicy string) {
 	}
 
 	// Create connection with provided lb policy
-	conn, err := grpc.Dial("etcd:///foo", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(b),
+	conn, err := grpc.Dial("etcd:///foo", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(b), //nolint:staticcheck // TODO: remove for a supported version
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%s"}`, lbPolicy)))
 	if err != nil {
 		t.Fatal("failed to connect to foo", err)

--- a/tests/integration/clientv3/user_test.go
+++ b/tests/integration/clientv3/user_test.go
@@ -60,7 +60,7 @@ func TestAddUserAfterDelete(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:   authapi.Endpoints(),
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cfg.Username, cfg.Password = "root", "123"
 	authed, err := integration.NewClient(t, cfg)
@@ -116,7 +116,7 @@ func TestUserErrorAuth(t *testing.T) {
 	cfg := clientv3.Config{
 		Endpoints:   authapi.Endpoints(),
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 	}
 	cfg.Username, cfg.Password = "wrong-id", "123"
 	_, err = integration.NewClient(t, cfg)

--- a/tests/integration/v3_failover_test.go
+++ b/tests/integration/v3_failover_test.go
@@ -93,7 +93,7 @@ func createClient(t *testing.T, cc *tls.Config, clus *integration.Cluster) (*cli
 	cli, err := integration.NewClient(t, clientv3.Config{
 		Endpoints:   clus.Endpoints(),
 		DialTimeout: 5 * time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		TLS:         cc,
 	})
 	if err != nil {

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -1578,7 +1578,7 @@ func TestTLSGRPCRejectSecureClient(t *testing.T) {
 	defer clus.Terminate(t)
 
 	clus.Members[0].ClientTLSInfo = &integration.TestTLSInfo
-	clus.Members[0].DialOptions = []grpc.DialOption{grpc.WithBlock()}
+	clus.Members[0].DialOptions = []grpc.DialOption{grpc.WithBlock()} //nolint:staticcheck // TODO: remove for a supported version
 	clus.Members[0].GRPCURL = strings.Replace(clus.Members[0].GRPCURL, "http://", "https://", 1)
 	client, err := integration.NewClientV3(clus.Members[0])
 	if client != nil || err == nil {
@@ -1727,7 +1727,7 @@ func testTLSReload(
 				continue
 			}
 			cli, cerr := integration.NewClient(t, clientv3.Config{
-				DialOptions: []grpc.DialOption{grpc.WithBlock()},
+				DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 				Endpoints:   []string{clus.Members[0].GRPCURL},
 				DialTimeout: time.Second,
 				TLS:         cc,

--- a/tests/integration/v3_tls_test.go
+++ b/tests/integration/v3_tls_test.go
@@ -66,7 +66,7 @@ func testTLSCipherSuites(t *testing.T, valid bool) {
 	cli, cerr := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
+		DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 		TLS:         cc,
 	})
 	if cli != nil {
@@ -129,7 +129,7 @@ func TestTLSMinMaxVersion(t *testing.T) {
 			cli, cerr := integration.NewClient(t, clientv3.Config{
 				Endpoints:   []string{clus.Members[0].GRPCURL},
 				DialTimeout: time.Second,
-				DialOptions: []grpc.DialOption{grpc.WithBlock()},
+				DialOptions: []grpc.DialOption{grpc.WithBlock()}, //nolint:staticcheck // TODO: remove for a supported version
 				TLS:         cc,
 			})
 			if cerr != nil {

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -85,7 +85,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - -SA1019 # TODO(fix) Using a deprecated function, variable, constant or field
         - -SA2002 # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
         - -QF1001 # TODO(fix) Apply De Morgan’s law
         - -QF1002 # TODO(fix) Convert untagged switch to tagged switch


### PR DESCRIPTION
enable the linter and just tag each exception with a TODO so we have identified the existing ones but we can gate to avoid adding new deprecated functions.


Fixes: https://github.com/etcd-io/etcd/issues/21101

/assign @serathius @siyuanfoundation @ahrtr 
