### PR TITLE
Do not load v2 snapshot on bootstrap

### DIFF
--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -15,7 +15,6 @@
 package etcdutl
 
 import (
-	"errors"
 	"time"
 
 	"go.uber.org/zap"
@@ -23,11 +22,9 @@ import (
 
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
 	"go.etcd.io/etcd/server/v3/storage/wal"
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
-	"go.etcd.io/raft/v3/raftpb"
 )
 
 // FlockTimeout is the duration to wait to obtain a file lock on db file.
@@ -45,30 +42,15 @@ func GetLogger() *zap.Logger {
 }
 
 func getLatestWALSnap(lg *zap.Logger, dataDir string) (walpb.Snapshot, error) {
-	snapshot, err := getLatestV2Snapshot(lg, dataDir)
+	walPath := datadir.ToWALDir(dataDir)
+	walSnaps, err := wal.ValidSnapshotEntries(lg, walPath)
 	if err != nil {
 		return walpb.Snapshot{}, err
 	}
 
-	var walsnap walpb.Snapshot
-	if snapshot != nil {
-		walsnap.Index, walsnap.Term = snapshot.Metadata.Index, snapshot.Metadata.Term
+	if len(walSnaps) > 0 {
+		lastIdx := len(walSnaps) - 1
+		return walSnaps[lastIdx], nil
 	}
-	return walsnap, nil
-}
-
-func getLatestV2Snapshot(lg *zap.Logger, dataDir string) (*raftpb.Snapshot, error) {
-	walPath := datadir.ToWALDir(dataDir)
-	walSnaps, err := wal.ValidSnapshotEntries(lg, walPath)
-	if err != nil {
-		return nil, err
-	}
-
-	ss := snap.New(lg, datadir.ToSnapDir(dataDir))
-	snapshot, err := ss.LoadNewestAvailable(walSnaps)
-	if err != nil && !errors.Is(err, snap.ErrNoSnapshot) {
-		return nil, err
-	}
-
-	return snapshot, nil
+	return walpb.Snapshot{}, nil
 }

--- a/etcdutl/etcdutl/common_test.go
+++ b/etcdutl/etcdutl/common_test.go
@@ -67,35 +67,6 @@ func TestGetLatestWalSnap(t *testing.T) {
 			},
 			expectedLatestWALSnap: walpb.Snapshot{Index: 35, Term: 5},
 		},
-		{
-			name: "there are orphan snapshot records in wal file",
-			walSnaps: []walpb.Snapshot{
-				{Index: 10, Term: 2},
-				{Index: 20, Term: 3},
-				{Index: 30, Term: 4},
-				{Index: 45, Term: 5},
-				{Index: 55, Term: 6},
-			},
-			snapshots: []raftpb.Snapshot{
-				{Metadata: raftpb.SnapshotMetadata{Index: 10, Term: 2}},
-				{Metadata: raftpb.SnapshotMetadata{Index: 20, Term: 3}},
-				{Metadata: raftpb.SnapshotMetadata{Index: 30, Term: 4}},
-			},
-			expectedLatestWALSnap: walpb.Snapshot{Index: 30, Term: 4},
-		},
-		{
-			name: "wal snapshot records do not match the snapshot files at all",
-			walSnaps: []walpb.Snapshot{
-				{Index: 10, Term: 2},
-				{Index: 20, Term: 3},
-				{Index: 30, Term: 4},
-			},
-			snapshots: []raftpb.Snapshot{
-				{Metadata: raftpb.SnapshotMetadata{Index: 40, Term: 5}},
-				{Metadata: raftpb.SnapshotMetadata{Index: 50, Term: 6}},
-			},
-			expectedLatestWALSnap: walpb.Snapshot{},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -137,7 +108,8 @@ func TestGetLatestWalSnap(t *testing.T) {
 			walSnap, err := getLatestWALSnap(lg, dataDir)
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expectedLatestWALSnap, walSnap)
+			require.Equal(t, tc.expectedLatestWALSnap.Term, walSnap.Term)
+			require.Equal(t, tc.expectedLatestWALSnap.Index, walSnap.Index)
 		})
 	}
 }

--- a/server/etcdserver/bootstrap_test.go
+++ b/server/etcdserver/bootstrap_test.go
@@ -190,8 +190,7 @@ func TestBootstrapBackend(t *testing.T) {
 			}
 
 			haveWAL := wal.Exist(cfg.WALDir())
-			ss := snap.New(cfg.Logger, cfg.SnapDir())
-			backend, err := bootstrapBackend(cfg, haveWAL, ss)
+			backend, err := bootstrapBackend(cfg, haveWAL)
 			defer t.Cleanup(func() {
 				backend.Close()
 			})


### PR DESCRIPTION
Link to https://github.com/etcd-io/etcd/issues/20187

In this PR, we don't load v2 snapshot files (*.snap) anymore, instead we just pick the latest snapshot entry from WAL. We don't need the raftpb.Snapshot.Data anymore, so it's correct to just read the latest snapshot entry from WAL.

The end goal is to completely get rid of v2 snapshot, which means we don't read v2 snapshot, nor write it. But in order to be compatible with 3.6, we still need to write v2 snapshot. This PR just stops reading v2 snapshot, so that it's safe to completely remove it in 3.8.

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
