### PR TITLE
fix: align stale workflow inputs with actions/stale v10

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d #v10.1.1
         with:
-          days-until-stale: 90
-          days-until-close: 21
+          days-before-stale: 90
+          days-before-close: 21
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-labels: 'stage/tracked,help wanted'
-          exempt-projects: false
-          exempt-milestones: false
-          exempt-assignees: false
+          exempt-issue-labels: 'stage/tracked,help wanted'
+          exempt-pr-labels: 'stage/tracked,help wanted'
+          exempt-milestones: ''
+          exempt-assignees: ''
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed after 21 days if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed after 21 days if no further activity occurs. Thank you for your contributions.'
           close-issue-message: ''


### PR DESCRIPTION
Sorry for the misconfiguration in the previously added GitHub Action, which caused some settings not to take effect. This PR fixes the configuration issues.

Reference: [https://raw.githubusercontent.com/actions/stale/v10.1.1/action.yml](https://raw.githubusercontent.com/actions/stale/v10.1.1/action.yml)

Although there is some debate in [https://github.com/etcd-io/etcd/issues/21051](https://github.com/etcd-io/etcd/issues/21051), we should first ensure that the stale action works as intended.


Ref: https://github.com/etcd-io/etcd/issues/21051#issuecomment-3731349508
Ref: https://github.com/etcd-io/etcd/pull/19932
