### PR TITLE
fix race condition in updateCommittedIndex using CAS

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -799,8 +799,8 @@ func (s *EtcdServer) run() {
 		},
 		updateCommittedIndex: func(ci uint64) {
 			cci := s.getCommittedIndex()
-			if ci > cci {
-				s.setCommittedIndex(ci)
+			for ci > cci && !s.committedIndex.CompareAndSwap(cci, ci) {
+				cci = s.getCommittedIndex()
 			}
 		},
 	}


### PR DESCRIPTION
### What this PR does

Fix a potential race condition in `updateCommittedIndex` callback by using Compare-And-Swap (CAS) instead of check-then-act pattern.

### Why this change is needed

The previous implementation had a race condition:

```
// Before (race condition)
cci := s.getCommittedIndex()  // Step 1: read
if ci > cci {                  // Step 2: compare
    s.setCommittedIndex(ci)    // Step 3: write
}
```
In concurrent scenarios, this could cause the committed index to regress


Using CAS ensures atomic compare-and-swap:

// After (race-free)
cci := s.getCommittedIndex()
for ci > cci && !s.committedIndex.CompareAndSwap(cci, ci) {
    cci = s.getCommittedIndex()
}
 ensure the index only increases monotonically.

Signed-off-by: baycore <dxasu@qq.com>
