### PR TITLE
lease: Fix incorrect gRPC Unavailable on client cancel during LeaseKeepAlive forwarding

### DIFF
--- a/server/etcdserver/api/v3rpc/lease.go
+++ b/server/etcdserver/api/v3rpc/lease.go
@@ -22,7 +22,6 @@ import (
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/lease"
 )
@@ -98,11 +97,12 @@ func (ls *LeaseServer) LeaseKeepAlive(stream pb.Lease_LeaseKeepAliveServer) (err
 	select {
 	case err = <-errc:
 	case <-stream.Context().Done():
-		// the only server-side cancellation is noleader for now.
+		// We end up here due to:
+		// 1. Client cancellation
+		// 2. Server cancellation: the client ctx is wrapped with WithRequireLeader,
+		//		monitorLeader() detects no leader and thus cancels this stream with ErrGRPCNoLeader.
+		// 3. Server cancellation: the server is shutting down.
 		err = stream.Context().Err()
-		if errors.Is(err, context.Canceled) {
-			err = rpctypes.ErrGRPCNoLeader
-		}
 	}
 	return err
 }

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -51,6 +51,7 @@ var toGRPCErrorMap = map[error]error{
 	errors.ErrNoLeader:                   rpctypes.ErrGRPCNoLeader,
 	errors.ErrNotLeader:                  rpctypes.ErrGRPCNotLeader,
 	errors.ErrLeaderChanged:              rpctypes.ErrGRPCLeaderChanged,
+	errors.ErrCanceled:                   rpctypes.ErrGRPCCanceled,
 	errors.ErrStopped:                    rpctypes.ErrGRPCStopped,
 	errors.ErrTimeout:                    rpctypes.ErrGRPCTimeout,
 	errors.ErrTimeoutDueToLeaderFail:     rpctypes.ErrGRPCTimeoutDueToLeaderFail,

--- a/server/lease/leasehttp/http.go
+++ b/server/lease/leasehttp/http.go
@@ -172,8 +172,8 @@ func RenewHTTP(ctx context.Context, id lease.LeaseID, url string, rt http.RoundT
 	if err != nil {
 		return -1, err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/protobuf")
-	req.Cancel = ctx.Done() //nolint:staticcheck // TODO: remove for a supported version
 
 	resp, err := cc.Do(req)
 	if err != nil {


### PR DESCRIPTION
Follow-up to the previous reproduction PR https://github.com/etcd-io/etcd/pull/21050. Refer there for full context.