### PR TITLE
scripts/test.sh: Fix unbound variable error when RUN_ARG is empty

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -111,9 +111,9 @@ fi
 
 log_callout "Running with ${COMMON_TEST_FLAGS[*]}"
 
-RUN_ARG=()
+RUN_ARG=""
 if [ -n "${TESTCASE:-}" ]; then
-  RUN_ARG=("-run=${TESTCASE}")
+  RUN_ARG="-run=${TESTCASE}"
 fi
 
 function build_pass {
@@ -131,7 +131,7 @@ function unit_pass {
                  -failfast \
                  -timeout="${TIMEOUT:-3m}" \
                  "${COMMON_TEST_FLAGS[@]}" \
-                 "${RUN_ARG[@]}" \
+                 $RUN_ARG \
                  "$@"
 }
 
@@ -140,7 +140,7 @@ function integration_extra {
     run_go_tests_expanding_packages ./tests/integration/v2store/... \
                                     -timeout="${TIMEOUT:-5m}" \
                                     "${COMMON_TEST_FLAGS[@]}" \
-                                    "${RUN_ARG[@]}" \
+                                    $RUN_ARG \
                                     "$@"
   else
     log_warning "integration_extra ignored when PKG is specified"
@@ -153,7 +153,7 @@ function integration_pass {
                -failfast \
                -timeout="${TIMEOUT:-15m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               $RUN_ARG \
                "$@"
 
   run_go_tests ./tests/common/... \
@@ -162,7 +162,7 @@ function integration_pass {
                -tags=integration \
                -timeout="${TIMEOUT:-15m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               $RUN_ARG \
                "$@"
 
   integration_extra "$@"
@@ -171,22 +171,22 @@ function integration_pass {
 function e2e_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu do not have any impact.
   run_go_tests_expanding_packages ./tests/e2e/... \
-                                    -timeout="${TIMEOUT:-30m}" \
-                                    "${RUN_ARG[@]}" \
-                                    "$@"
+                                  -timeout="${TIMEOUT:-30m}" \
+                                  $RUN_ARG \
+                                  "$@"
   run_go_tests_expanding_packages ./tests/common/... \
-                                    -tags=e2e \
-                                    -timeout="${TIMEOUT:-30m}" \
-                                    "${RUN_ARG[@]}" \
-                                    "$@"
+                                  -tags=e2e \
+                                  -timeout="${TIMEOUT:-30m}" \
+                                  $RUN_ARG \
+                                  "$@"
 }
 
 function robustness_pass {
   # e2e tests are running pre-build binary. Settings like --race,-cover,-cpu does not have any impact.
   run_go_tests ./tests/robustness \
-                 -timeout="${TIMEOUT:-30m}" \
-                 "${RUN_ARG[@]}" \
-                 "$@"
+               -timeout="${TIMEOUT:-30m}" \
+               $RUN_ARG \
+               "$@"
 }
 
 function integration_e2e_pass {
@@ -221,7 +221,7 @@ function grpcproxy_integration_pass {
                -tags=cluster_proxy \
                -timeout="${TIMEOUT:-30m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               $RUN_ARG \
                "$@"
 }
 
@@ -230,7 +230,7 @@ function grpcproxy_e2e_pass {
                -tags=cluster_proxy \
                -timeout="${TIMEOUT:-30m}" \
                "${COMMON_TEST_FLAGS[@]}" \
-               "${RUN_ARG[@]}" \
+               $RUN_ARG \
                "$@"
 }
 


### PR DESCRIPTION
# Fix: Handle empty RUN_ARG array in test.sh to prevent "unbound variable" error

Fixes #21124

## Problem

When running `make test` or `make test-unit` without setting the `TESTCASE` environment variable, the script fails with:

```
./scripts/test.sh: line 130: RUN_ARG[@]: unbound variable
make: *** [test-unit] Error 1
```

This occurs because:
1. The `RUN_ARG` array is initialized as empty when `TESTCASE` is not set: `RUN_ARG=()`
2. The script uses `set -o nounset` (line 55) for strict error checking
3. In bash 3.2+ (especially on macOS), expanding an empty array `"${RUN_ARG[@]}"` under `set -o nounset` triggers an "unbound variable" error

## Solution

Changed `RUN_ARG` from an array to a string. This is the simplest and most elegant solution:

- Changed `RUN_ARG=()` to `RUN_ARG=""`
- Changed `RUN_ARG=("-run=${TESTCASE}")` to `RUN_ARG="-run=${TESTCASE}"`
- Changed `"${RUN_ARG[@]}"` to `$RUN_ARG` in all function calls

When `RUN_ARG` is an empty string, `$RUN_ARG` expands to nothing (no error), and when it has a value, it expands correctly. This ensures compatibility with bash 3.2+ while maintaining strict error checking with `set -o nounset`.

## Changes

Changed `RUN_ARG` from array to string in `scripts/test.sh`:
- Line 114: Changed `RUN_ARG=()` to `RUN_ARG=""`
- Line 116: Changed `RUN_ARG=("-run=${TESTCASE}")` to `RUN_ARG="-run=${TESTCASE}"`
- Updated 9 functions to use `$RUN_ARG` instead of `"${RUN_ARG[@]}"`:
  - `unit_pass`
  - `integration_extra`
  - `integration_pass` (2 call sites)
  - `e2e_pass` (2 call sites)
  - `robustness_pass`
  - `grpcproxy_integration_pass`
  - `grpcproxy_e2e_pass`

## Testing

Tested with:
- ✅ `make test-unit` (without TESTCASE) - now works
- ✅ `make test-unit TESTCASE="TestName"` - still works as expected
- ✅ Bash syntax validation: `bash -n scripts/test.sh` - passes

## Compatibility

- ✅ Compatible with bash 3.2+ (including macOS default bash)
- ✅ Maintains `set -o nounset` strict error checking
- ✅ No functional changes - `TESTCASE` remains optional
- ✅ All existing test functionality preserved

## Related

- Fixes the issue where `make test` fails on macOS/bash 3.2
- Ensures that developers can run tests without needing to set `TESTCASE`, which was the intended behavior based on the script's documentation
- Maintains backward compatibility with all bash versions (3.2+)
