### PR TITLE
lease: Client should stop sending keepAlive requests after recv channel closed

### DIFF
--- a/client/v3/ctx.go
+++ b/client/v3/ctx.go
@@ -25,6 +25,8 @@ import (
 
 // WithRequireLeader requires client requests to only succeed
 // when the cluster has a leader.
+// The leader check is performed by interceptors created by
+// newUnaryInterceptor and newStreamInterceptor.
 func WithRequireLeader(ctx context.Context) context.Context {
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok { // no outgoing metadata ctx key, create one


### PR DESCRIPTION
If a lease client sets this `withRequireLeader` and closes its receive channel due to no leader, it should also stop sending more keepAlive requests to the server (it  wouldn't have a channel to receive response anyway).

I extended the existing test function `TestLeaseWithRequireLeader` to verify this update and it now has two test cases:
- "lease stays alive with mixed keepAlives"
- "lease expires when both keepAlives require leader"

Also fixed the bug of `newIdx`. Surprisingly this wasn't caught for the past 9-ish years.

