### PR TITLE
Fix broken `eqErrGRPC` helper function in integration tests

### DIFF
--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -673,6 +673,7 @@ func TestV3PutIgnoreValue(t *testing.T) {
 		{ // put failure for non-existent key
 			func() error {
 				preq := newPutReq()
+				preq.Value = nil
 				preq.IgnoreValue = true
 				_, err := kvc.Put(t.Context(), preq)
 				return err
@@ -1176,8 +1177,8 @@ func TestV3TooLargeRequest(t *testing.T) {
 
 	kvc := integration.ToGRPC(clus.RandClient()).KV
 
-	// 2MB request value
-	largeV := make([]byte, 2*1024*1024)
+	// Must exceed MaxRequestBytes (1.5MB) but stay under gRPC MaxRecvMsgSize (2MB)
+	largeV := make([]byte, 1624*1024)
 	preq := &pb.PutRequest{Key: []byte("foo"), Value: largeV}
 
 	_, err := kvc.Put(t.Context(), preq)
@@ -2166,6 +2167,9 @@ func TestGRPCStreamRequireLeader(t *testing.T) {
 
 // TestV3LargeRequests ensures that configurable MaxRequestBytes works as intended.
 func TestV3LargeRequests(t *testing.T) {
+	if integration.ThroughProxy {
+		t.Skip("grpcproxy does not propagate MaxRequestBytes to its internal gRPC client connection")
+	}
 	integration.BeforeTest(t)
 	tests := []struct {
 		maxRequestBytes uint
@@ -2269,7 +2273,91 @@ func TestV3AdditionalGRPCOptions(t *testing.T) {
 }
 
 func eqErrGRPC(err1 error, err2 error) bool {
-	return !(err1 == nil && err2 != nil) || err1.Error() == err2.Error()
+	if err1 == nil && err2 == nil {
+		return true
+	}
+	if err1 == nil || err2 == nil {
+		return false
+	}
+	s1 := mustGRPCStatus(err1)
+	s2 := mustGRPCStatus(err2)
+	return s1.Code() == s2.Code() && s1.Message() == s2.Message()
+}
+
+func mustGRPCStatus(err error) *status.Status {
+	s, ok := status.FromError(err)
+	if ok {
+		return s
+	}
+	// In grpcproxy mode, ToGRPC adapters bypass the gRPC wire so errors
+	// arrive as rpctypes.EtcdError instead of gRPC status errors.
+	var etcdErr rpctypes.EtcdError
+	if errors.As(err, &etcdErr) {
+		return status.New(etcdErr.Code(), etcdErr.Error())
+	}
+	panic(fmt.Sprintf("eqErrGRPC: not a gRPC status error: %T %v", err, err))
+}
+
+func TestEqErrGRPC(t *testing.T) {
+	tests := []struct {
+		name     string
+		err1     error
+		err2     error
+		expected bool
+	}{
+		{
+			name:     "same error - same object",
+			err1:     rpctypes.ErrGRPCLeaseExist,
+			err2:     rpctypes.ErrGRPCLeaseExist,
+			expected: true,
+		},
+		{
+			name:     "wire reconstruction - same code and message",
+			err1:     status.Error(codes.FailedPrecondition, "etcdserver: lease already exists"),
+			err2:     rpctypes.ErrGRPCLeaseExist,
+			expected: true,
+		},
+		{
+			name:     "same code, different message",
+			err1:     status.Error(codes.FailedPrecondition, "error A"),
+			err2:     status.Error(codes.FailedPrecondition, "error B"),
+			expected: false,
+		},
+		{
+			name:     "different code, same message",
+			err1:     status.Error(codes.FailedPrecondition, "same message"),
+			err2:     status.Error(codes.NotFound, "same message"),
+			expected: false,
+		},
+		{
+			name:     "different code, different message",
+			err1:     rpctypes.ErrGRPCLeaseExist,
+			err2:     rpctypes.ErrGRPCLeaseNotFound,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := eqErrGRPC(tt.err1, tt.err2); result != tt.expected {
+				t.Errorf("eqErrGRPC(%v, %v) = %v, want %v", tt.err1, tt.err2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEqErrGRPCHandlesEtcdError(t *testing.T) {
+	require.True(t, eqErrGRPC(rpctypes.ErrUserEmpty, rpctypes.ErrGRPCUserEmpty))
+	require.False(t, eqErrGRPC(rpctypes.ErrUserEmpty, rpctypes.ErrGRPCPermissionDenied))
+}
+
+func TestEqErrGRPCPanicsOnPlainError(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("eqErrGRPC should panic on plain error")
+		}
+	}()
+	eqErrGRPC(errors.New("plain error"), rpctypes.ErrGRPCUserEmpty)
 }
 
 // waitForRestart tries a range request until the client's server responds.

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -1065,6 +1065,7 @@ func TestV3LeaseRecoverKeyWithMultipleLease(t *testing.T) {
 	clus.Members[0].Stop(t)
 	clus.Members[0].Restart(t)
 	clus.WaitMembersForLeader(t, clus.Members)
+	clus.Members[0].WaitStarted(t)
 	for i, leaseID := range leaseIDs {
 		if !leaseExist(t, clus, leaseID) {
 			t.Errorf("#%d: unexpected lease not exists", i)


### PR DESCRIPTION
The test helper function `eqErrGRPC` has always been flawed since introduced in 2016. 

```go
func eqErrGRPC(err1 error, err2 error) bool {
	return !(err1 == nil && err2 != nil) || err1.Error() == err2.Error()
}
```

When the first argument was non-nil (usually the case in tests), it will always return true. This has made all error assertions using this helper effectively no-ops.

**Changes:**
- Replace broken implementation with correct gRPC status comparison using `status.FromError()`
- Handle `rpctypes.EtcdError` so `eqErrGRPC` works in grpcproxy mode where `ToGRPC` adapters bypass the gRPC wire
- Handle nil errors (both nil → equal, one nil → not equal)
- Add unit tests covering code/message permutations and edge cases

**Pre-existing test bugs exposed by the fix:**
- `TestV3PutIgnoreValue`: sent `IgnoreValue=true` with a non-empty `Value` field, causing `ErrGRPCValueProvided` instead of the expected `ErrGRPCKeyNotFound`. Fixed by clearing `Value`.
- `TestV3TooLargeRequest`: sent a 2MB value which exceeded the gRPC `MaxRecvMsgSize` (`MaxRequestBytes` 1.5MB + 512KB overhead = 2MB), causing gRPC `ResourceExhausted` instead of etcd's `ErrGRPCRequestTooLarge`. Fixed by reducing the value size to stay under the gRPC transport limit.
- `TestV3LeaseRecoverKeyWithMultipleLease`: after server restart, `leaseExist()` used the old client which hadn't reconnected yet. The broken `eqErrGRPC` masked the connection error by returning true. Fixed by adding `WaitStarted` to ensure client connectivity before checking leases.
- `TestV3LargeRequests`: skipped in grpcproxy mode as the proxy does not propagate custom `MaxRequestBytes` to its internal gRPC client connection.