### PR TITLE
robustness: add default interval handling for WatchConfig

### DIFF
--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -137,7 +137,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 				Client:      c,
 				KeyStore:    keyStore,
 				Finish:      finish,
-				WatchConfig: profile.WatchConfig,
+				WatchConfig: normalizeWatchConfig(profile.WatchConfig),
 			})
 		}(c)
 	}
@@ -152,7 +152,7 @@ func SimulateTraffic(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2
 				Client:      c,
 				KeyStore:    keyStore,
 				Finish:      finish,
-				WatchConfig: profile.WatchConfig,
+				WatchConfig: normalizeWatchConfig(profile.WatchConfig),
 			})
 		}(c)
 	}
@@ -380,6 +380,15 @@ type RunWatchLoopParam struct {
 	KeyStore            *keyStore
 	Finish              <-chan struct{}
 	options.WatchConfig // Embedded: Interval and RevisionOffset
+}
+
+// normalizeWatchConfig returns a copy of the config with validated values.
+// If Interval is <= 0, it's set to DefaultWatchInterval.
+func normalizeWatchConfig(cfg options.WatchConfig) options.WatchConfig {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultWatchInterval
+	}
+	return cfg
 }
 
 type Traffic interface {


### PR DESCRIPTION
Add normalizeWatchConfig helper to ensure Interval is set to DefaultWatchInterval when it's 0 or negative.

This prevents time.After() from firing immediately and overwhelming the system with continuous watch spawns.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
