### PR TITLE
Consolidate gofail check in integration tests

### DIFF
--- a/tests/framework/integration/testing.go
+++ b/tests/framework/integration/testing.go
@@ -83,6 +83,12 @@ func BeforeTestExternal(t testutil.TB) {
 	BeforeTest(t, WithoutSkipInShort(), WithoutGoLeakDetection())
 }
 
+func SkipIfNoGoFail(t testutil.TB) {
+	if len(gofail.List()) == 0 {
+		t.Skip("please run 'make gofail-enable' before running the test")
+	}
+}
+
 func BeforeTest(t testutil.TB, opts ...TestOption) {
 	t.Helper()
 	options := newTestOptions(opts...)
@@ -100,9 +106,7 @@ func BeforeTest(t testutil.TB, opts ...TestOption) {
 	}
 
 	if options.failpoint != nil && len(options.failpoint.name) != 0 {
-		if len(gofail.List()) == 0 {
-			t.Skip("please run 'make gofail-enable' before running the test")
-		}
+		SkipIfNoGoFail(t)
 		require.NoError(t, gofail.Enable(options.failpoint.name, options.failpoint.payload))
 		t.Cleanup(func() {
 			require.NoError(t, gofail.Disable(options.failpoint.name))

--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -1540,9 +1540,7 @@ func TestV3NoEventsLostOnCompact(t *testing.T) {
 		t.Skip("grpc proxy currently does not support requesting progress notifications")
 	}
 	integration.BeforeTest(t)
-	if len(gofail.List()) == 0 {
-		t.Skip("please run 'make gofail-enable' before running the test")
-	}
+	integration.SkipIfNoGoFail(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 


### PR DESCRIPTION
Split from PR https://github.com/etcd-io/etcd/pull/21122

Changes:

- Consolidate the duplicate code of gofail checks into a dedicated function.
- Move the check from `TestV3LeaseKeepAliveForwardingCatchError`  function level into test case level because only two cases actually need that.

