### PR TITLE
[Robustness test] Fix data race by tracking detached watch goroutines (part 2-1)

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -186,9 +186,10 @@ func simulateTraffic(ctx context.Context, tf traffic.Traffic, hosts []string, cl
 			defer wg.Done()
 			defer c.Close()
 			tf.RunWatchLoop(ctx, traffic.RunWatchLoopParam{
-				Client:   c,
-				KeyStore: keyStore,
-				Finish:   finish,
+				Client:    c,
+				KeyStore:  keyStore,
+				Finish:    finish,
+				WaitGroup: &wg,
 			})
 		}(c)
 	}
@@ -199,9 +200,10 @@ func simulateTraffic(ctx context.Context, tf traffic.Traffic, hosts []string, cl
 			defer wg.Done()
 			defer c.Close()
 			tf.RunWatchLoop(ctx, traffic.RunWatchLoopParam{
-				Client:   c,
-				KeyStore: keyStore,
-				Finish:   finish,
+				Client:    c,
+				KeyStore:  keyStore,
+				Finish:    finish,
+				WaitGroup: &wg,
 			})
 		}(c)
 	}


### PR DESCRIPTION
Root cause: `RunWatchLoop()` spawned detached goroutines that were not tracked by the main `sync.WaitGroup`.

When the parent `SimulateTraffic` is about to exit and calls `wg.Done()`, it will unblocked immediately, allowing Reports() to read from the history while detached goroutines were still writing to it since not all of them have been terminated.

Fixes https://github.com/etcd-io/etcd/issues/21132

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
