### PR TITLE
Add a nil guard for e2e process Kill

### DIFF
--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -274,6 +274,9 @@ func (ep *EtcdServerProcess) Logs() LogsExpect {
 
 func (ep *EtcdServerProcess) Kill() error {
 	ep.cfg.lg.Info("killing server...", zap.String("name", ep.cfg.Name))
+	if ep.proc == nil {
+		return nil
+	}
 	return ep.proc.Signal(syscall.SIGKILL)
 }
 


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.

Fix: #21129
```
go.etcd.io/etcd/pkg/v3/expect.(*ExpectProcess).Signal(0x0, {0x10222c8, 0x1014538})
```
0x0 indicates that the `ExpectProcess` struct is nil.