### PR TITLE
fix: Move sync_go_toolchain_directive.sh to scripts/fix/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ verify-grpc-experimental:
 
 .PHONY: sync-toolchain-directive
 sync-toolchain-directive:
-	./scripts/sync_go_toolchain_directive.sh
+	./scripts/fix/sync_go_toolchain_directive.sh
 
 .PHONY: markdown-diff-lint
 markdown-diff-lint:

--- a/scripts/fix/sync_go_toolchain_directive.sh
+++ b/scripts/fix/sync_go_toolchain_directive.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+
 # Copyright 2025 The etcd Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +22,13 @@
 
 set -euo pipefail
 
-source ./scripts/test_lib.sh
+ETCD_ROOT_DIR=${ETCD_ROOT_DIR:-$(git rev-parse --show-toplevel)}
+source "${ETCD_ROOT_DIR}/scripts/test_lib.sh"
+
+log_callout "Syncing Go toolchain directive"
 
 TARGET_GO_VERSION="${TARGET_GO_VERSION:-"$(cat "${ETCD_ROOT_DIR}/.go-version")"}"
-find . -name 'go.mod' -exec go mod edit -toolchain=go"${TARGET_GO_VERSION}" {} \;
-go work edit -toolchain=go"${TARGET_GO_VERSION}"
+run find "${ETCD_ROOT_DIR}" -name 'go.mod' -exec go mod edit -toolchain=go"${TARGET_GO_VERSION}" {} \;
+run go work edit -toolchain=go"${TARGET_GO_VERSION}"
+
+log_success "Go toolchain directive synced"

--- a/scripts/verify_go_versions.sh
+++ b/scripts/verify_go_versions.sh
@@ -67,7 +67,7 @@ done < <(find . -name 'go.mod')
 
 if [[ "${toolchain_out_of_sync}" == "true" ]]; then
     log_error
-    log_error "Please run scripts/sync_go_toolchain_directive.sh or update .go-version to rectify this error"
+    log_error "Please run make sync-toolchain-directive or update .go-version to rectify this error"
 fi
 
 if [[ "${go_line_violation}" == "true" ]]; then


### PR DESCRIPTION
- Move sync_go_toolchain_directive.sh to scripts/fix/ directory
- Add ETCD_ROOT_DIR support for dynamic path resolution
- Integrate with test_lib.sh for consistent logging
- Add log_callout and log_success messages
- Keep original script name with underscore convention
- Maintain Makefile backward compatibility
- Verified: bash syntax check, shellcheck -x passed
