### PR TITLE
Time all stages of robustness tests using t.Run

### DIFF
--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -60,7 +60,7 @@ func validateReports(lg *zap.Logger, serversDataPath map[string]string, reports 
 	assertResult(validate.ResultFromError(err), "Loaded persisted requests")
 
 	validateConfig := validate.Config{ExpectRevisionUnique: tf.ExpectUniqueRevision}
-	result := validate.ValidateAndReturnVisualize(lg, validateConfig, reports, persistedRequests, 5*time.Minute)
+	result := validate.ValidateAndReturnVisualize(validate.NewTimerLogger(lg), validateConfig, reports, persistedRequests, 5*time.Minute)
 	assertResult(result.Assumptions, "Validation assumptions fulfilled")
 	if result.Linearization.Timeout {
 		assert.Unreachable("Linearization timeout", nil)

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -241,7 +241,7 @@ func TestValidateSerializableOperations(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			replay := model.NewReplay(tc.persistedRequests)
-			result := validateSerializableOperations(zaptest.NewLogger(t), tc.operations, replay)
+			result := ResultFromError(validateSerializableOperations(zaptest.NewLogger(t), tc.operations, replay))
 			if result.Message != tc.expectError {
 				t.Errorf("validateSerializableOperations(...), got: %q, want: %q", result.Message, tc.expectError)
 			}
@@ -391,7 +391,7 @@ func shuffleHistory(history []porcupine.Operation, shuffleCount int) [][]porcupi
 
 func validateShuffles(b *testing.B, lg *zap.Logger, shuffles [][]porcupine.Operation, duration time.Duration) {
 	for i := 0; i < len(shuffles); i++ {
-		result := validateLinearizableOperationsAndVisualize(lg, shuffles[i], duration)
+		result := validateLinearizableOperations(lg, shuffles[i], duration)
 		if err := result.Error(); err != nil {
 			b.Fatalf("Not linearizable: %v", err)
 		}

--- a/tests/robustness/validate/timer.go
+++ b/tests/robustness/validate/timer.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type TimerLogger interface {
+	Run(string, func(TimerLogger))
+	Logger() *zap.Logger
+}
+
+func NewTimerLogger(lg *zap.Logger) TimerLogger {
+	return &flatTimerLogger{lg}
+}
+
+type flatTimerLogger struct {
+	lg *zap.Logger
+}
+
+func (t *flatTimerLogger) Run(name string, run func(t TimerLogger)) {
+	t.lg.Info("Start " + name)
+	start := time.Now()
+	run(t)
+	t.lg.Info("End "+name, zap.Duration("duration", time.Since(start)))
+}
+
+func (t *flatTimerLogger) Logger() *zap.Logger {
+	return t.lg
+}

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -48,7 +48,7 @@ func TestDataReports(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			result := ValidateAndReturnVisualize(zaptest.NewLogger(t), Config{}, reports, persistedRequests, 5*time.Minute)
+			result := ValidateAndReturnVisualize(&flatTimerLogger{lg}, Config{}, reports, persistedRequests, 5*time.Minute)
 			err = result.Error()
 			if err != nil {
 				t.Error(err)
@@ -175,7 +175,7 @@ func TestValidateAndReturnVisualize(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			lg := zaptest.NewLogger(t)
-			result := ValidateAndReturnVisualize(lg, Config{}, tc.reports, tc.persistedRequests, 5*time.Second)
+			result := ValidateAndReturnVisualize(&flatTimerLogger{lg}, Config{}, tc.reports, tc.persistedRequests, 5*time.Second)
 
 			if tc.expectError != "" {
 				require.ErrorContains(t, result.Error(), tc.expectError)
@@ -1978,7 +1978,7 @@ func TestValidateWatch(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			replay := model.NewReplay(tc.persistedRequests)
-			result := validateWatch(zaptest.NewLogger(t), tc.config, tc.reports, replay)
+			result := ResultFromError(validateWatch(zaptest.NewLogger(t), tc.config, tc.reports, replay))
 			if result.Message != tc.expectError {
 				t.Errorf("validateWatch(...), got: %q, want: %q", result.Message, tc.expectError)
 			}

--- a/tests/robustness/validate/watch.go
+++ b/tests/robustness/validate/watch.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
@@ -39,18 +38,7 @@ var (
 	errBrokeFilter       = errors.New("event not matching watch filter")
 )
 
-func validateWatch(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) Result {
-	lg.Info("Validating watch")
-	start := time.Now()
-	err := validateWatchError(lg, cfg, reports, replay)
-	if err != nil {
-		lg.Error("Watch validation failed", zap.Duration("duration", time.Since(start)), zap.Error(err))
-	}
-	lg.Info("Watch validation success", zap.Duration("duration", time.Since(start)))
-	return ResultFromError(err)
-}
-
-func validateWatchError(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) error {
+func validateWatch(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) error {
 	// Validate etcd watch properties defined in https://etcd.io/docs/v3.6/learning/api_guarantees/#watch-apis
 	for _, r := range reports {
 		err := validateFilter(lg, r)


### PR DESCRIPTION
Thanks to junit reading subtest this should allow to see timings in Testgrid.

/cc @henrybear327 