### PR TITLE
transport,embed: integrate CA hot-reload support

### DIFF
--- a/client/pkg/tlsutil/ca_reloader_test.go
+++ b/client/pkg/tlsutil/ca_reloader_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+// testCA holds a CA certificate and a leaf certificate signed by it for testing.
+type testCA struct {
+	caPEM   []byte           // PEM-encoded CA certificate
+	caCert  *x509.Certificate // Parsed CA certificate
+	caKey   *ecdsa.PrivateKey // CA private key
+	leafPEM []byte           // PEM-encoded leaf certificate signed by this CA
+	leaf    *x509.Certificate // Parsed leaf certificate
+}
+
+// generateTestCA creates a self-signed CA and a leaf certificate signed by it.
+// The leaf cert can be used to verify the CA is actually in the pool.
+func generateTestCA(t *testing.T) *testCA {
+	t.Helper()
+
+	// Generate CA key and cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caSerial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	caTemplate := x509.Certificate{
+		SerialNumber: caSerial,
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caDER, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	// Generate leaf cert signed by the CA
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	leafSerial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	leafTemplate := x509.Certificate{
+		SerialNumber: leafSerial,
+		Subject: pkix.Name{
+			CommonName: "test-leaf",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	leafDER, err := x509.CreateCertificate(rand.Reader, &leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+
+	return &testCA{
+		caPEM:   caPEM,
+		caCert:  caCert,
+		caKey:   caKey,
+		leafPEM: leafPEM,
+		leaf:    leaf,
+	}
+}
+
+// verifyLeaf checks if the leaf certificate validates against the given pool.
+func (tc *testCA) verifyLeaf(pool *x509.CertPool) error {
+	_, err := tc.leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	return err
+}
+
+func TestNewCAReloader(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ca := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	require.NotNil(t, reloader)
+
+	// Verify pool can validate certs signed by the CA
+	pool := reloader.GetCertPool()
+	require.NotNil(t, pool)
+	err = ca.verifyLeaf(pool)
+	require.NoError(t, err, "pool should validate leaf cert signed by loaded CA")
+}
+
+func TestNewCAReloader_InvalidFile(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Try to create CAReloader with non-existent file
+	_, err := NewCAReloader([]string{"/nonexistent/ca.crt"}, logger)
+	require.Error(t, err)
+}
+
+func TestNewCAReloader_InvalidCert(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Create temp dir and invalid CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, []byte("invalid cert data"), 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader - should fail because cert is invalid
+	_, err = NewCAReloader([]string{caFile}, logger)
+	require.Error(t, err)
+}
+
+func TestCAReloader_Reload(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Generate two different CAs with leaf certs
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca1.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader with short interval
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	reloader.WithInterval(50 * time.Millisecond)
+	reloader.Start()
+	t.Cleanup(func() { reloader.Stop() })
+
+	// Verify initial pool validates CA1's leaf cert
+	pool := reloader.GetCertPool()
+	require.NoError(t, ca1.verifyLeaf(pool), "initial pool should validate CA1 leaf")
+	require.Error(t, ca2.verifyLeaf(pool), "initial pool should NOT validate CA2 leaf")
+
+	// Update CA file to CA2
+	err = os.WriteFile(caFile, ca2.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Wait for reload
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify updated pool validates CA2's leaf cert but NOT CA1's
+	pool = reloader.GetCertPool()
+	require.NoError(t, ca2.verifyLeaf(pool), "reloaded pool should validate CA2 leaf")
+	require.Error(t, ca1.verifyLeaf(pool), "reloaded pool should NOT validate CA1 leaf")
+}
+
+func TestCAReloader_GracefulFallback(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ca := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader with short interval
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	reloader.WithInterval(50 * time.Millisecond)
+	reloader.Start()
+	t.Cleanup(func() { reloader.Stop() })
+
+	// Verify initial pool works
+	pool := reloader.GetCertPool()
+	require.NoError(t, ca.verifyLeaf(pool), "initial pool should validate leaf")
+
+	// Write invalid data to CA file
+	err = os.WriteFile(caFile, []byte("invalid cert data"), 0600)
+	require.NoError(t, err)
+
+	// Wait for reload attempt
+	time.Sleep(100 * time.Millisecond)
+
+	// Pool should still work (graceful fallback to previous valid pool)
+	pool = reloader.GetCertPool()
+	require.NoError(t, ca.verifyLeaf(pool), "pool should still validate leaf after failed reload")
+}
+
+func TestCAReloader_Concurrency(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Generate two different CAs for alternating writes
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca1.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader with short interval
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	reloader.WithInterval(10 * time.Millisecond)
+	reloader.Start()
+	t.Cleanup(func() { reloader.Stop() })
+
+	// Run concurrent reads and verify pool always validates at least one CA
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				pool := reloader.GetCertPool()
+				assert.NotNil(t, pool)
+				// Pool should validate either CA1 or CA2 (depending on reload state)
+				ca1Valid := ca1.verifyLeaf(pool) == nil
+				ca2Valid := ca2.verifyLeaf(pool) == nil
+				assert.True(t, ca1Valid || ca2Valid, "pool should validate at least one CA")
+			}
+		}()
+	}
+
+	// Also update the file concurrently
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 10; j++ {
+			caPEM := ca1.caPEM
+			if j%2 == 0 {
+				caPEM = ca2.caPEM
+			}
+			_ = os.WriteFile(caFile, caPEM, 0600)
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestCAReloader_Stop(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ca := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	reloader.WithInterval(10 * time.Millisecond)
+	reloader.Start()
+
+	// Stop should complete without hanging
+	done := make(chan struct{})
+	go func() {
+		reloader.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() did not complete in time")
+	}
+}
+
+func TestCAReloader_StopWithoutStart(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ca := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader but don't call Start()
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+
+	// Stop should complete without hanging even though Start was never called
+	done := make(chan struct{})
+	go func() {
+		reloader.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() without Start() should not deadlock")
+	}
+}
+
+func TestCAReloader_NoChangeNoReload(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ca := generateTestCA(t)
+
+	// Create temp dir and CA file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	err := os.WriteFile(caFile, ca.caPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader with short interval
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+	reloader.WithInterval(50 * time.Millisecond)
+	reloader.Start()
+	t.Cleanup(func() { reloader.Stop() })
+
+	// Verify initial pool works
+	pool := reloader.GetCertPool()
+	require.NoError(t, ca.verifyLeaf(pool), "initial pool should validate leaf")
+
+	// Wait for multiple reload cycles without changing file
+	time.Sleep(150 * time.Millisecond)
+
+	// Pool should still work and validate the same CA
+	pool = reloader.GetCertPool()
+	require.NoError(t, ca.verifyLeaf(pool), "pool should still validate leaf after no-op reload cycles")
+}
+
+func TestCAReloader_MultipleCAs(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Generate two CAs
+	ca1 := generateTestCA(t)
+	ca2 := generateTestCA(t)
+
+	// Create temp dir and write both CAs to the same file
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.crt")
+	combinedPEM := append(ca1.caPEM, ca2.caPEM...)
+	err := os.WriteFile(caFile, combinedPEM, 0600)
+	require.NoError(t, err)
+
+	// Create CAReloader
+	reloader, err := NewCAReloader([]string{caFile}, logger)
+	require.NoError(t, err)
+
+	// Pool should validate leaf certs from BOTH CAs
+	pool := reloader.GetCertPool()
+	require.NoError(t, ca1.verifyLeaf(pool), "pool should validate CA1 leaf")
+	require.NoError(t, ca2.verifyLeaf(pool), "pool should validate CA2 leaf")
+}

--- a/client/pkg/tlsutil/metrics.go
+++ b/client/pkg/tlsutil/metrics.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	caReloadSuccessTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd",
+		Subsystem: "tlsutil",
+		Name:      "ca_reload_success_total",
+		Help:      "Total number of successful CA certificate reloads.",
+	})
+
+	caReloadFailureTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd",
+		Subsystem: "tlsutil",
+		Name:      "ca_reload_failure_total",
+		Help:      "Total number of failed CA certificate reloads.",
+	})
+
+	caReloadDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "etcd",
+		Subsystem: "tlsutil",
+		Name:      "ca_reload_duration_seconds",
+		Help:      "Duration of CA certificate reload operations in seconds.",
+		// Buckets from 1ms to ~1s (reload should be fast, it's just file reads)
+		Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+	})
+)
+
+func init() {
+	prometheus.MustRegister(caReloadSuccessTotal)
+	prometheus.MustRegister(caReloadFailureTotal)
+	prometheus.MustRegister(caReloadDurationSeconds)
+}

--- a/client/pkg/tlsutil/tlsutil.go
+++ b/client/pkg/tlsutil/tlsutil.go
@@ -15,11 +15,22 @@
 package tlsutil
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
 )
+
+// Note: sync is still needed for sync.WaitGroup and sync.Once
+
+var errNoCertsLoaded = errors.New("no certificates were loaded from CA files")
 
 // NewCertPool creates x509 certPool with provided CA files.
 func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
@@ -70,4 +81,174 @@ func NewCert(certfile, keyfile string, parseFunc func([]byte, []byte) (tls.Certi
 		return nil, err
 	}
 	return &tlsCert, nil
+}
+
+// DefaultCAReloadInterval is the default interval for checking CA file changes.
+const DefaultCAReloadInterval = 10 * time.Second
+
+// caState holds the current CA pool and file hashes for atomic swapping.
+type caState struct {
+	pool   *x509.CertPool
+	hashes [][32]byte
+}
+
+// CAReloader manages dynamic reloading of CA certificate pools.
+// It periodically checks for file changes and updates the cached pool.
+// Reads are lock-free using atomic.Pointer (RCU pattern).
+type CAReloader struct {
+	caFiles  []string
+	state    atomic.Pointer[caState]
+	interval time.Duration
+	logger   *zap.Logger
+
+	wg       sync.WaitGroup
+	stopc    chan struct{}
+	stopOnce sync.Once
+}
+
+// NewCAReloader creates a new CAReloader for the given CA files.
+// It performs an initial load of the CA files and returns an error if loading fails.
+// Call Start() to begin the background polling goroutine.
+func NewCAReloader(caFiles []string, logger *zap.Logger) (*CAReloader, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	r := &CAReloader{
+		caFiles:  caFiles,
+		interval: DefaultCAReloadInterval,
+		logger:   logger,
+		stopc:    make(chan struct{}),
+	}
+
+	// Initialize with empty state
+	r.state.Store(&caState{})
+
+	// Perform initial load - must succeed
+	if _, err := r.reload(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// WithInterval sets the polling interval for checking CA file changes.
+func (r *CAReloader) WithInterval(d time.Duration) *CAReloader {
+	r.interval = d
+	return r
+}
+
+// Start begins the background goroutine that periodically checks for CA file changes.
+func (r *CAReloader) Start() {
+	r.wg.Add(1)
+	go r.run()
+}
+
+// Stop stops the background polling goroutine and waits for it to finish.
+// It is safe to call Stop multiple times.
+// It is also safe to call Stop without having called Start.
+func (r *CAReloader) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stopc)
+	})
+	r.wg.Wait()
+}
+
+// GetCertPool returns the currently cached CA certificate pool.
+// This method is lock-free and safe for concurrent use.
+func (r *CAReloader) GetCertPool() *x509.CertPool {
+	return r.state.Load().pool
+}
+
+// run is the background goroutine that periodically checks for CA file changes.
+func (r *CAReloader) run() {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	r.logger.Info("starting CA certificate poll",
+		zap.Duration("interval", r.interval),
+		zap.Strings("ca-files", r.caFiles),
+	)
+
+	for {
+		select {
+		case <-ticker.C:
+			if _, err := r.reload(); err != nil {
+				r.logger.Warn("failed to reload CA certificates, using cached pool",
+					zap.Strings("ca-files", r.caFiles),
+					zap.Error(err),
+				)
+			}
+		case <-r.stopc:
+			r.logger.Info("stopping CA certificate poll")
+			return
+		}
+	}
+}
+
+// reload reads the CA files from disk and updates the cached pool if changed.
+// Returns (changed bool, err error) where changed indicates if the pool was updated.
+func (r *CAReloader) reload() (bool, error) {
+	start := time.Now()
+
+	// Compute hashes of all CA file contents
+	newHashes := make([][32]byte, len(r.caFiles))
+	for i, caFile := range r.caFiles {
+		data, err := os.ReadFile(caFile)
+		if err != nil {
+			caReloadFailureTotal.Inc()
+			return false, err
+		}
+		newHashes[i] = sha256.Sum256(data)
+	}
+
+	// Check if any file has changed (lock-free read)
+	current := r.state.Load()
+	changed := len(current.hashes) != len(newHashes)
+	if !changed {
+		for i := range newHashes {
+			if current.hashes[i] != newHashes[i] {
+				changed = true
+				break
+			}
+		}
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	// Parse the new CA pool
+	pool, err := NewCertPool(r.caFiles)
+	if err != nil {
+		caReloadFailureTotal.Inc()
+		return false, err
+	}
+
+	// Ensure we actually parsed some certificates.
+	// pem.Decode returns nil for invalid PEM data, so NewCertPool
+	// may return an empty pool without error. We treat an empty pool
+	// as an error to enable graceful fallback to the previous pool.
+	if len(r.caFiles) > 0 && pool.Equal(x509.NewCertPool()) {
+		caReloadFailureTotal.Inc()
+		return false, errNoCertsLoaded
+	}
+
+	// Atomically swap to new state (RCU pattern)
+	r.state.Store(&caState{
+		pool:   pool,
+		hashes: newHashes,
+	})
+
+	// Record metrics for successful reload
+	caReloadSuccessTotal.Inc()
+	caReloadDurationSeconds.Observe(time.Since(start).Seconds())
+
+	r.logger.Info("reloaded CA certificates",
+		zap.Strings("ca-files", r.caFiles),
+	)
+
+	return true, nil
 }

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -259,6 +259,20 @@ type Config struct {
 	//revive:disable-next-line:var-naming
 	TlsMaxVersion string `json:"tls-max-version"`
 
+	// PeerTLSReloadCA enables dynamic reloading of peer trusted CA certificates.
+	// When enabled, the CA certificates specified in peer-trusted-ca-file are
+	// periodically reloaded, enabling zero-downtime CA rotation.
+	PeerTLSReloadCA bool `json:"peer-tls-reload-ca"`
+
+	// ClientTLSReloadCA enables dynamic reloading of client trusted CA certificates.
+	// When enabled, the CA certificates specified in trusted-ca-file are
+	// periodically reloaded, enabling zero-downtime CA rotation.
+	ClientTLSReloadCA bool `json:"client-tls-reload-ca"`
+
+	// TLSCAReloadInterval is the interval for checking CA file changes.
+	// Default is 10 seconds.
+	TLSCAReloadInterval time.Duration `json:"tls-ca-reload-interval"`
+
 	ClusterState          string `json:"initial-cluster-state"`
 	DNSCluster            string `json:"discovery-srv"`
 	DNSClusterServiceName string `json:"discovery-srv-name"`
@@ -705,6 +719,9 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&cfg.PeerTLSInfo.SkipClientSANVerify, "peer-skip-client-san-verification", false, "Skip verification of SAN field in client certificate for peer connections.")
 	fs.StringVar(&cfg.TlsMinVersion, "tls-min-version", string(tlsutil.TLSVersion12), "Minimum TLS version supported by etcd. Possible values: TLS1.2, TLS1.3.")
 	fs.StringVar(&cfg.TlsMaxVersion, "tls-max-version", string(tlsutil.TLSVersionDefault), "Maximum TLS version supported by etcd. Possible values: TLS1.2, TLS1.3 (empty defers to Go).")
+	fs.BoolVar(&cfg.PeerTLSReloadCA, "peer-tls-reload-ca", false, "Enable dynamic reloading of peer trusted CA certificates.")
+	fs.BoolVar(&cfg.ClientTLSReloadCA, "client-tls-reload-ca", false, "Enable dynamic reloading of client trusted CA certificates.")
+	fs.DurationVar(&cfg.TLSCAReloadInterval, "tls-ca-reload-interval", tlsutil.DefaultCAReloadInterval, "Interval for checking CA file changes when CA reload is enabled.")
 
 	fs.Var(
 		flags.NewUniqueURLsWithExceptions("*", "*"),

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -226,6 +226,12 @@ Security:
     Minimum TLS version supported by etcd. Possible values: TLS1.2, TLS1.3.
   --tls-max-version ''
     Maximum TLS version supported by etcd. Possible values: TLS1.2, TLS1.3 (empty will be auto-populated by Go).
+  --peer-tls-reload-ca 'false'
+    Enable dynamic reloading of peer trusted CA certificates.
+  --client-tls-reload-ca 'false'
+    Enable dynamic reloading of client trusted CA certificates.
+  --tls-ca-reload-interval '10s'
+    Interval for checking CA file changes when CA reload is enabled.
 
 Auth:
   --auth-token 'simple'


### PR DESCRIPTION
## Summary

Integrate CAReloader into the transport layer for both server and client TLS configurations. Add server flags to enable the feature.

## Changes

**Transport layer:**
- Add `CAReloader` field to `TLSInfo` for dynamic CA updates
- Server: use `VerifyConnection` callback with dynamic CA pool
- Client: use `DialTLSContext` to inject fresh RootCAs per connection

**Server flags:**
- `--peer-tls-reload-ca`: Enable dynamic reloading of peer trusted CA certificates
- `--client-tls-reload-ca`: Enable dynamic reloading of client trusted CA certificates  
- `--tls-ca-reload-interval`: Interval for checking CA file changes (default 10s)

**Lifecycle management:**
- `Etcd` struct owns CAReloader lifecycle
- Reloaders created in `StartEtcd()` before listener configuration
- Cleanup in `Etcd.Close()`

The feature is disabled by default and must be explicitly enabled.

## Background

This PR is a split of #21074 into smaller, reviewable pieces as requested by maintainers.

## Stacking

This PR is part of a stacked PR series for CA hot-reload support (issue #11555):

1. #21156 - `tlsutil: add CAReloader` ← **must be merged first**
2. **This PR** - `transport,embed: integrate CA hot-reload support`
3. #21158 - `tests: add CA rotation integration test`

Please review #21156 first.

---

Part 2 of 3 for CA hot-reload support.
Replaces #21074 (split into smaller PRs)
Partially fixes #11555

Signed-off-by: Amir Omidi <amir@aaomidi.com>