### PR TITLE
[release-3.6] Remove flag --max-snapshots in 3.8 rather than 3.7

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -219,8 +219,8 @@ type Config struct {
 	SnapshotCatchUpEntries uint64 `json:"snapshot-catchup-entries"`
 
 	// MaxSnapFiles is the maximum number of snapshot files.
-	// TODO: remove it in 3.7.
-	// Deprecated: Will be removed in v3.7.
+	// TODO: remove it in 3.8.
+	// Deprecated: Will be removed in v3.8.
 	MaxSnapFiles uint `json:"max-snapshots"`
 	//revive:disable-next-line:var-naming
 	MaxWalFiles uint `json:"max-wals"`
@@ -771,7 +771,7 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 		"listen-metrics-urls",
 		"List of URLs to listen on for the metrics and health endpoints.",
 	)
-	fs.UintVar(&cfg.MaxSnapFiles, "max-snapshots", cfg.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.7.")
+	fs.UintVar(&cfg.MaxSnapFiles, "max-snapshots", cfg.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.8.")
 	fs.UintVar(&cfg.MaxWalFiles, "max-wals", cfg.MaxWalFiles, "Maximum number of wal files to retain (0 is unlimited).")
 	fs.StringVar(&cfg.Name, "name", cfg.Name, "Human-readable name for this member.")
 	fs.Uint64Var(&cfg.SnapshotCount, "snapshot-count", cfg.SnapshotCount, "Number of committed transactions to trigger a snapshot to disk. Deprecated in v3.6 and will be decommissioned in v3.7.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -60,7 +60,7 @@ var (
 	deprecatedFlags = map[string]string{
 		// TODO: remove in 3.7.
 		"snapshot-count": "--snapshot-count is deprecated in 3.6 and will be decommissioned in 3.7.",
-		"max-snapshots":  "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.7.",
+		"max-snapshots":  "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.8.",
 		"v2-deprecation": "--v2-deprecation is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input.",
 		"experimental-compact-hash-check-enabled":           "--experimental-compact-hash-check-enabled is deprecated in 3.6 and will be decommissioned in 3.7. Use '--feature-gates=CompactHashCheck=true' instead.",
 		"experimental-compact-hash-check-time":              "--experimental-compact-hash-check-time is deprecated in 3.6 and will be decommissioned in 3.7. Use '--compact-hash-check-time' instead.",

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -72,7 +72,7 @@ Member:
   --listen-client-http-urls ''
     List of URLs to listen on for http only client traffic. Enabling this flag removes http services from --listen-client-urls.
   --max-snapshots '` + strconv.Itoa(embed.DefaultMaxSnapshots) + `'
-    Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.7.
+    Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.8.
   --max-wals '` + strconv.Itoa(embed.DefaultMaxWALs) + `'
     Maximum number of wal files to retain (0 is unlimited).
   --memory-mlock

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -684,7 +684,7 @@ func TestEtcdDeprecatedFlags(t *testing.T) {
 		{
 			name:        "max-snapshots",
 			args:        append(commonArgs, "--max-snapshots=10"),
-			expectedMsg: "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.7",
+			expectedMsg: "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.8",
 		},
 		{
 			name:        "v2-deprecation",


### PR DESCRIPTION
We still need to generate the v2 snapshot files in 3.7 to keep backward compatible with 3.6. We plan to remove this flag in v3.8.

Backport https://github.com/etcd-io/etcd/pull/21160 to 3.6.

cc @fuweid @ivanvc  @jberkus @serathius 


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
