### PR TITLE
Keep the `--snapshot-count` flag

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -163,9 +163,7 @@ type Config struct {
 	//revive:disable-next-line:var-naming
 	WalDir string `json:"wal-dir"`
 
-	// SnapshotCount is the number of committed transactions that trigger a snapshot to disk.
-	// TODO: remove it in 3.7.
-	// Deprecated: Will be decommissioned in v3.7.
+	// SnapshotCount is the number of committed transactions that trigger a snapshot.
 	SnapshotCount uint64 `json:"snapshot-count"`
 
 	// SnapshotCatchUpEntries is the number of entires for a slow follower
@@ -619,7 +617,7 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	fs.UintVar(&cfg.MaxSnapFiles, "max-snapshots", cfg.MaxSnapFiles, "Maximum number of snapshot files to retain (0 is unlimited). Deprecated in v3.6 and will be decommissioned in v3.8.")
 	fs.UintVar(&cfg.MaxWalFiles, "max-wals", cfg.MaxWalFiles, "Maximum number of wal files to retain (0 is unlimited).")
 	fs.StringVar(&cfg.Name, "name", cfg.Name, "Human-readable name for this member.")
-	fs.Uint64Var(&cfg.SnapshotCount, "snapshot-count", cfg.SnapshotCount, "Number of committed transactions to trigger a snapshot to disk. Deprecated in v3.6 and will be decommissioned in v3.7.")
+	fs.Uint64Var(&cfg.SnapshotCount, "snapshot-count", cfg.SnapshotCount, "Number of committed transactions to trigger a snapshot.")
 	fs.UintVar(&cfg.TickMs, "heartbeat-interval", cfg.TickMs, "Time (in milliseconds) of a heartbeat interval.")
 	fs.UintVar(&cfg.ElectionMs, "election-timeout", cfg.ElectionMs, "Time (in milliseconds) for an election to timeout.")
 	fs.BoolVar(&cfg.InitialElectionTickAdvance, "initial-election-tick-advance", cfg.InitialElectionTickAdvance, "Whether to fast-forward initial election ticks on boot for faster election.")

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -58,8 +58,6 @@ var (
 	}
 
 	deprecatedFlags = map[string]string{
-		// TODO: remove in 3.7.
-		"snapshot-count": "--snapshot-count is deprecated in 3.6 and will be decommissioned in 3.7.",
 		"max-snapshots":  "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.8.",
 		"v2-deprecation": "--v2-deprecation is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input.",
 	}

--- a/server/etcdmain/config_test.go
+++ b/server/etcdmain/config_test.go
@@ -560,8 +560,7 @@ func TestConfigFileDeprecatedOptions(t *testing.T) {
 				MaxSnapFiles:  5,
 			},
 			expectedFlags: map[string]struct{}{
-				"snapshot-count": {},
-				"max-snapshots":  {},
+				"max-snapshots": {},
 			},
 		},
 	}

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -57,7 +57,7 @@ Member:
   --wal-dir ''
     Path to the dedicated wal directory.
   --snapshot-count '10000'
-    Number of committed transactions to trigger a snapshot to disk. Deprecated in v3.6 and will be decommissioned in v3.7.
+    Number of committed transactions to trigger a snapshot.
   --heartbeat-interval '100'
     Time (in milliseconds) of a heartbeat interval.
   --election-timeout '1000'

--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -677,11 +677,6 @@ func TestEtcdDeprecatedFlags(t *testing.T) {
 		expectedMsg string
 	}{
 		{
-			name:        "snapshot-count",
-			args:        append(commonArgs, "--snapshot-count=100"),
-			expectedMsg: "--snapshot-count is deprecated in 3.6 and will be decommissioned in 3.7",
-		},
-		{
 			name:        "max-snapshots",
 			args:        append(commonArgs, "--max-snapshots=10"),
 			expectedMsg: "--max-snapshots is deprecated in 3.6 and will be decommissioned in 3.8",


### PR DESCRIPTION
We won't generate v2 snapshot files in 3.8 anymore, but etcd is still generating snapshot periodically and will keep this behaviour. During etcd generating snapshot, it does the following two things:
1. generate a snapshot entry in WAL file
2. purge old raft entries

So we need to keep the flag `--snapshot-count` so that users can configure how frequently the snapshot is generated.

cc @fuweid @ivanvc @jberkus @serathius 


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
