### PR TITLE
Update 3.6 changelog to cover the two flags deprecation changes

### DIFF
--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,6 +6,11 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.8 (TBC)
 
+### etcd server
+
+- [Postpone removal of the --max-snapshots flag from v3.7 to v3.8](https://github.com/etcd-io/etcd/pull/21161)
+- [Revoke the deprecation of the `--snapshot-count` flag](https://github.com/etcd-io/etcd/pull/21163)
+
 ### Dependencies
 
 - Bump [golang.org/x/crypto to 0.45.0 to address CVE-2025-47914, and CVE-2025-58181](https://github.com/etcd-io/etcd/pull/21037).


### PR DESCRIPTION
Link to ,
- https://github.com/etcd-io/etcd/pull/21161
- https://github.com/etcd-io/etcd/pull/21163
- https://github.com/etcd-io/etcd/issues/20187

cc @fuweid @ivanvc @jberkus @serathius 

Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
