### PR TITLE
Reduce WatchTimeout to 500ms

### DIFF
--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -35,7 +35,7 @@ import (
 var (
 	DefaultLeaseTTL         int64 = 7200
 	RequestTimeout                = 200 * time.Millisecond
-	WatchTimeout                  = time.Second
+	WatchTimeout                  = 500 * time.Millisecond
 	MultiOpTxnOpCount             = 4
 	DefaultCompactionPeriod       = 200 * time.Millisecond
 	DefaultWatchInterval          = 250 * time.Millisecond


### PR DESCRIPTION
An attempt to reduce flake for robustness test on CI.


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
