### PR TITLE
lease: fix panic on concurrent Revoke by guarding channel close

### DIFF
--- a/server/lease/lease.go
+++ b/server/lease/lease.go
@@ -37,6 +37,9 @@ type Lease struct {
 	mu      sync.RWMutex
 	itemSet map[LeaseItem]struct{}
 	revokec chan struct{}
+	// revokeOnce ensures revokec is closed only once, preventing panic
+	// from concurrent Revoke() calls on the same lease
+	revokeOnce sync.Once
 }
 
 func NewLease(id LeaseID, ttl int64) *Lease {

--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -332,7 +332,7 @@ func (le *lessor) Revoke(id LeaseID) error {
 		return ErrLeaseNotFound
 	}
 
-	defer close(l.revokec)
+	defer l.revokeOnce.Do(func() { close(l.revokec) })
 	// unlock before doing external work
 	le.mu.Unlock()
 


### PR DESCRIPTION
## Fix: Prevent panic on concurrent lease revoke

### Summary

This PR fixes a race condition in the lease revoke path where **concurrent `Revoke()` calls on the same lease can cause a panic**:



The issue occurs when multiple goroutines attempt to close the same revoke channel without coordination.

---

### Problem

`Revoke()` may be invoked concurrently for the same lease from multiple real execution paths, including:

- lease expiration handling
- explicit client revoke requests
- shutdown or leadership transition paths

In the current implementation, multiple goroutines can:
1. Observe the same lease in `leaseMap`
2. Each defer `close(l.revokeC)`
3. Attempt to close the same channel → **panic**

Channel close in Go is not idempotent and must be guarded under concurrency.

---

### Steps to Reproduce

1. Create a lease
2. Call `Revoke()` concurrently on the same lease from multiple goroutines
3. Observe:

This panic is reproducible with a simple concurrency test and can occur in real clusters under load.

---

### Root Cause

The revoke channel (`l.revokeC`) is closed unconditionally in `Revoke()` without protection against multiple concurrent callers.

---

### Fix

Guard the channel close using `sync.Once` to ensure it is closed **exactly once**, regardless of how many concurrent `Revoke()` calls occur.

```go
l.revokeOnce.Do(func() {
 close(l.revokeC)
})
