### PR TITLE
model: changed MemberID from uint64 to string for consistent logs

### DIFF
--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -116,8 +117,8 @@ func (h *AppendableHistory) AppendLeaseGrant(start, end time.Duration, resp *cli
 	var revision int64
 	var MemberID uint64
 	if resp != nil && resp.ResponseHeader != nil {
-		revision = resp.ResponseHeader.Revision
-		MemberID = resp.ResponseHeader.MemberId
+		revision = resp.Revision
+		MemberID = resp.MemberId
 	}
 	h.appendSuccessful(request, start, end, leaseGrantResponseWithMemberID(revision, MemberID))
 }
@@ -387,7 +388,7 @@ func rangeResponseWithMemberID(kvs []*mvccpb.KeyValue, count int64, revision int
 			},
 		}
 	}
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Range: &result, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Range: &result, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func failedResponse(err error) MaybeEtcdResponse {
@@ -407,7 +408,7 @@ func putResponse(revision int64) MaybeEtcdResponse {
 }
 
 func putResponseWithMemberID(revision int64, MemberID uint64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: []EtcdOperationResult{{}}}, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: []EtcdOperationResult{{}}}, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func deleteRequest(key string) EtcdRequest {
@@ -419,7 +420,7 @@ func deleteResponse(deleted int64, revision int64) MaybeEtcdResponse {
 }
 
 func deleteResponseWithMemberID(deleted int64, revision int64, MemberID uint64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: []EtcdOperationResult{{Deleted: deleted}}}, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: []EtcdOperationResult{{Deleted: deleted}}}, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func compareRevisionAndPutRequest(key string, expectedRevision int64, value string) EtcdRequest {
@@ -474,7 +475,7 @@ func txnResponse(result []EtcdOperationResult, succeeded bool, revision int64) M
 }
 
 func txnResponseWithMemberID(result []EtcdOperationResult, succeeded bool, revision int64, MemberID uint64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: result, Failure: !succeeded}, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{Txn: &TxnResponse{Results: result, Failure: !succeeded}, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func putWithLeaseRequest(key, value string, leaseID int64) EtcdRequest {
@@ -490,7 +491,7 @@ func leaseGrantResponse(revision int64) MaybeEtcdResponse {
 }
 
 func leaseGrantResponseWithMemberID(revision int64, MemberID uint64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{LeaseGrant: &LeaseGrantReponse{}, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{LeaseGrant: &LeaseGrantReponse{}, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func leaseRevokeRequest(leaseID int64) EtcdRequest {
@@ -502,7 +503,7 @@ func leaseRevokeResponse(revision int64) MaybeEtcdResponse {
 }
 
 func leaseRevokeResponseWithMemberID(revision int64, MemberID uint64) MaybeEtcdResponse {
-	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{LeaseRevoke: &LeaseRevokeResponse{}, Revision: revision, MemberID: MemberID}}
+	return MaybeEtcdResponse{EtcdResponse: EtcdResponse{LeaseRevoke: &LeaseRevokeResponse{}, Revision: revision, MemberID: strconv.FormatUint(MemberID, 16)}}
 }
 
 func defragmentRequest() EtcdRequest {

--- a/tests/robustness/model/types.go
+++ b/tests/robustness/model/types.go
@@ -147,7 +147,7 @@ type EtcdResponse struct {
 	Compact     *CompactResponse
 	ClientError string
 	Revision    int64
-	MemberID    uint64
+	MemberID    string
 }
 
 func Match(r1, r2 MaybeEtcdResponse) bool {
@@ -160,8 +160,8 @@ func Match(r1, r2 MaybeEtcdResponse) bool {
 		r2Revision = r2.PersistedRevision
 	}
 
-	r1.EtcdResponse.MemberID = 0
-	r2.EtcdResponse.MemberID = 0
+	r1.MemberID = ""
+	r2.MemberID = ""
 
 	return (r1.Persisted && r1.PersistedRevision == 0) || (r2.Persisted && r2.PersistedRevision == 0) || ((r1.Persisted || r2.Persisted) && (r1.Error != "" || r2.Error != "" || r1Revision == r2Revision)) || reflect.DeepEqual(r1, r2)
 }


### PR DESCRIPTION
# Convert MemberID to hex string in robustness model

## Issue #21211

The `EtcdResponse.MemberID` field was defined as `uint64`, but etcd's `types.ID` type has a custom `String()` method that formats IDs as hexadecimal strings:

```go
// From client/pkg/types/id.go
type ID uint64

func (i ID) String() string {
	return strconv.FormatUint(uint64(i), 16)
}
```

This caused inconsistency in the robustness test model:
- Etcd internally represents member IDs as hex strings (e.g., `"8e9e05c52164694d"`)
- The model was storing them as raw `uint64` values
- Logs and comparisons showed decimal numbers instead of hex strings
- Made debugging harder and broke alignment with etcd's standard ID representation

## Solution

Changed `EtcdResponse.MemberID` from `uint64` to `string` and updated all response builders to convert member IDs to hexadecimal format using `strconv.FormatUint(MemberID, 16)`.

## Changes

### `tests/robustness/model/types.go`
- Changed `MemberID` field type from `uint64` to `string`
- Updated `Match()` function to use empty string comparison (`""`) instead of zero value (`0`)

### `tests/robustness/model/history.go`
- Added `strconv` import
- Updated all response builder functions to convert `uint64` member IDs to hex strings:
  - `rangeResponseWithMemberID()`
  - `putResponseWithMemberID()`
  - `deleteResponseWithMemberID()`
  - `txnResponseWithMemberID()`
  - `leaseGrantResponseWithMemberID()`
  - `leaseRevokeResponseWithMemberID()`

## Impact

- Member IDs now consistently appear as hexadecimal strings in robustness test logs
- Aligns model behavior with etcd's standard ID representation throughout the codebase
- Improves debugging and log analysis by matching the format used in production etcd
