### PR TITLE
Remove the use of grpc-go's Metadata field

### DIFF
--- a/client/v3/naming/endpoints/endpoints.go
+++ b/client/v3/naming/endpoints/endpoints.go
@@ -29,11 +29,8 @@ type Endpoint struct {
 	// Since etcd 3.1
 	Addr string
 
-	// Metadata is the information associated with Addr, which may be used
-	// to make load balancing decision.
+	// Metadata is the information associated with Addr.
 	// Since etcd 3.1
-	//
-	// Deprecated: The field is deprecated and will be removed in 3.7.
 	Metadata any
 }
 

--- a/client/v3/naming/resolver/resolver.go
+++ b/client/v3/naming/resolver/resolver.go
@@ -112,8 +112,7 @@ func convertToGRPCEndpoint(ups map[string]*endpoints.Update) []gresolver.Endpoin
 		ep := gresolver.Endpoint{
 			Addresses: []gresolver.Address{
 				{
-					Addr:     up.Endpoint.Addr,
-					Metadata: up.Endpoint.Metadata, //nolint:staticcheck // TODO: remove for a supported version
+					Addr: up.Endpoint.Addr,
 				},
 			},
 		}


### PR DESCRIPTION
We also revoke the deprecation of the Metadata field, Users can store whatever information related to each endpoint. We just don't need to pass the value to grpc-go's Metadata.

Link to https://github.com/etcd-io/etcd/issues/15145

Read https://docs.google.com/document/d/14pPPyQkJ8NvPZSM6Pe1Wr0BDHAsw_Xcp0mepoSVTQHs/edit?tab=t.0 

cc @dfawley @fuweid @serathius 