### PR TITLE
etcdctl: Split SaveWithVersion and client io

### DIFF
--- a/client/v3/snapshot/v3_snapshot.go
+++ b/client/v3/snapshot/v3_snapshot.go
@@ -47,10 +47,51 @@ func hasChecksum(n int64) bool {
 // the selected node.
 // Etcd <v3.6 will return "" as version.
 func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, dbPath string) (string, error) {
+	partpath := dbPath + ".part"
+	defer func() {
+		err := os.RemoveAll(partpath)
+		if err != nil {
+			lg.Error("Failed to cleanup .part file", zap.Error(err))
+		}
+	}()
+
+	f, err := os.OpenFile(partpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileutil.PrivateFileMode)
+	if err != nil {
+		return "", fmt.Errorf("could not open %s (%w)", partpath, err)
+	}
+	lg.Info("created temporary db file", zap.String("path", partpath))
+
+	version, err := SaveWithVersionStream(ctx, lg, cfg, f)
+	if err != nil {
+		_ = f.Close()
+		return version, err
+	}
+
+	if err := fileutil.Fsync(f); err != nil {
+		_ = f.Close()
+		return version, fmt.Errorf("could not fsync snapshot: %w", err)
+	}
+
+	if err := f.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return version, fmt.Errorf("could not close file descriptor: %w", err)
+	}
+
+	if err := os.Rename(partpath, dbPath); err != nil {
+		return version, fmt.Errorf("could not rename %s to %s (%w)", partpath, dbPath, err)
+	}
+
+	lg.Info("saved", zap.String("path", dbPath))
+	return version, nil
+}
+
+// SaveWithVersionStream fetches an etcd snapshot and writes it to the provided writer.
+// It does NOT fsync or close the writer, which makes it safe for stdout and other streams.
+func SaveWithVersionStream(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, w io.Writer) (string, error) {
 	cfg.Logger = lg.Named("client")
 	if len(cfg.Endpoints) != 1 {
 		return "", fmt.Errorf("snapshot must be requested to one selected node, not multiple %v", cfg.Endpoints)
 	}
+
 	cli, err := clientv3.New(cfg)
 	if err != nil {
 		return "", err
@@ -61,26 +102,6 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 			lg.Error("Failed to close client", zap.Error(err))
 		}
 	}()
-
-	partpath := dbPath + ".part"
-	defer func() {
-		err = os.RemoveAll(partpath)
-		if err != nil {
-			lg.Error("Failed to cleanup .part file", zap.Error(err))
-		}
-	}()
-
-	f, err := os.OpenFile(partpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileutil.PrivateFileMode)
-	if err != nil {
-		return "", fmt.Errorf("could not open %s (%w)", partpath, err)
-	}
-	defer func() {
-		err = f.Close()
-		if err != nil && !errors.Is(err, os.ErrClosed) {
-			lg.Error("Could not close file descriptor", zap.Error(err))
-		}
-	}()
-	lg.Info("created temporary db file", zap.String("path", partpath))
 
 	start := time.Now()
 	resp, err := cli.SnapshotWithVersion(ctx)
@@ -93,21 +114,18 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 			lg.Error("Could not close snapshot stream", zap.Error(err))
 		}
 	}()
+
 	lg.Info("fetching snapshot", zap.String("endpoint", cfg.Endpoints[0]))
+
 	var size int64
-	size, err = io.Copy(f, resp.Snapshot)
+	size, err = io.Copy(w, resp.Snapshot)
 	if err != nil {
 		return resp.Version, fmt.Errorf("could not write snapshot: %w", err)
 	}
 	if !hasChecksum(size) {
 		return resp.Version, fmt.Errorf("sha256 checksum not found [bytes: %d]", size)
 	}
-	if err = fileutil.Fsync(f); err != nil {
-		return resp.Version, fmt.Errorf("could not fsync snapshot: %w", err)
-	}
-	if err = f.Close(); err != nil {
-		return resp.Version, fmt.Errorf("could not close file descriptor: %w", err)
-	}
+
 	lg.Info("fetched snapshot",
 		zap.String("endpoint", cfg.Endpoints[0]),
 		zap.String("size", humanize.Bytes(uint64(size))),
@@ -115,9 +133,5 @@ func SaveWithVersion(ctx context.Context, lg *zap.Logger, cfg clientv3.Config, d
 		zap.String("etcd-version", resp.Version),
 	)
 
-	if err = os.Rename(partpath, dbPath); err != nil {
-		return resp.Version, fmt.Errorf("could not rename %s to %s (%w)", partpath, dbPath, err)
-	}
-	lg.Info("saved", zap.String("path", dbPath))
 	return resp.Version, nil
 }


### PR DESCRIPTION
This commit splits the SaveWithVersion for snapshots into one part that takes care of opening, flushing, and closing the file while SaveWithVersionStream handles loading the snapshot and copying it to an io.Writer.

This allows the CLI to call SaveWithVersionStream and write the snapshot to StdOut.

Writing the snapshot to StdOut allows for secure, on-the-fly compression and encryption of the snapshot without first saving it to a filesystem.

Closes #16242

---

This is my first public MR in go. Feedback how to improve the MR highly welcome.
