### PR TITLE
Fix TestCacheLaggingWatcher flake

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -409,3 +409,8 @@ func (c *Cache) validateRange(startKey, endKey []byte) error {
 		return nil
 	}
 }
+
+// WaitForNextResync blocks until the next resync loop iteration is complete.
+func (c *Cache) WaitForNextResync(ctx context.Context) error {
+	return c.demux.WaitForNextResync(ctx)
+}


### PR DESCRIPTION
Fix is pretty simple, just provide a reliable way to wait for resync loop to execute.

Fixes https://github.com/etcd-io/etcd/issues/20852

Superseeds https://github.com/etcd-io/etcd/pull/21130

Before
```
go test -c ./tests/integration && stress ./integration.test --test.run TestCacheLaggingWatcher/pipeline_overflow | grep "runs so far"
5s: 408 runs so far, 29 failures (7.11%)
10s: 856 runs so far, 72 failures (8.41%)
15s: 1291 runs so far, 100 failures (7.75%)
20s: 1729 runs so far, 133 failures (7.69%)
25s: 2160 runs so far, 180 failures (8.33%)
30s: 2605 runs so far, 223 failures (8.56%)
35s: 3037 runs so far, 255 failures (8.40%)
40s: 3459 runs so far, 282 failures (8.15%)
45s: 3882 runs so far, 317 failures (8.17%)
50s: 4306 runs so far, 360 failures (8.36%)
55s: 4738 runs so far, 390 failures (8.23%)
1m0s: 5168 runs so far, 429 failures (8.30%)
```

After
```
go test -c ./tests/integration && stress ./integration.test --test.run TestCacheLaggingWatcher/pipeline_overflow
5s: 411 runs so far, 0 failures
10s: 837 runs so far, 0 failures
15s: 1267 runs so far, 0 failures
20s: 1695 runs so far, 0 failures
25s: 2127 runs so far, 0 failures
30s: 2558 runs so far, 0 failures
35s: 2989 runs so far, 0 failures
40s: 3413 runs so far, 0 failures
45s: 3845 runs so far, 0 failures
50s: 4274 runs so far, 0 failures
55s: 4699 runs so far, 0 failures
1m0s: 5168 runs so far, 0 failures
```
/cc @ivanvc @zhijun42 @apullo777 @MadhavJivrajani 
