### PR TITLE
Add release description for 3.6.8 patch release.

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,6 +6,8 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.41 (TBC)
 
+This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+
 ### Package `clientv3`
 
 - [Remove the use of grpc-go's Metadata field](https://github.com/etcd-io/etcd/pull/21243)
@@ -1456,4 +1458,3 @@ Note: **v3.5 will deprecate `etcd --log-package-levels` flag for `capnslog`**; `
 - [Rebase etcd image from Alpine to Debian](https://github.com/etcd-io/etcd/pull/10805) to improve security and maintenance effort for etcd release.
 
 ---
-

--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -6,7 +6,7 @@ Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/
 
 ## v3.4.41 (TBC)
 
-This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv), [CVE-2025-61732](https://github.com/advisories/GHSA-8jvr-vh7g-f8gx), and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
 
 ### Package `clientv3`
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,7 +6,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.27 (TBC)
 
-This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv), [CVE-2025-61732](https://github.com/advisories/GHSA-8jvr-vh7g-f8gx), and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
 
 ### Package `clientv3`
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,8 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.27 (TBC)
 
+This update release preserves the endpoint Metadata field, although it will not be passed to grpc-go.  It also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+
 ### Package `clientv3`
 
 - [Remove the use of grpc-go's Metadata field](https://github.com/etcd-io/etcd/pull/21242)
@@ -808,4 +810,3 @@ Note that any `etcd_debugging_*` metrics are experimental and subject to change.
 
 
 ---
-

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,7 +6,7 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.8 (TBC)
 
-This update release preserves upgrade compatability for many users.  Two flags are preserved, and etcd will still accept the endpoint Metadata field, although it will not be passed to grpc-go.  This patch also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+This update release preserves upgrade compatability for many users.  Two flags are preserved, and etcd will still accept the endpoint Metadata field, although it will not be passed to grpc-go.  This patch also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv), [CVE-2025-61732](https://github.com/advisories/GHSA-8jvr-vh7g-f8gx), and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
 
 ### etcd server
 

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,6 +6,8 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.8 (TBC)
 
+This update release preserves upgrade compatability for many users.  Two flags are preserved, and etcd will still accept the endpoint Metadata field, although it will not be passed to grpc-go.  This patch also includes a golang update in order to prevent security vulnerabilities [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv) and [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x).
+
 ### etcd server
 
 - [Postpone removal of the --max-snapshots flag from v3.7 to v3.8](https://github.com/etcd-io/etcd/pull/21161)


### PR DESCRIPTION
@ivanvc 

Just adds a narrative description to the patch release; otherwise some of the changes are hard to understand.
