### PR TITLE
Documentation: update contributor-guide pages and postmortem

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,4 +1,4 @@
-This directory includes etcd project internal documentation for new and existing contributors.
+This directory includes the etcd project's internal documentation for new and existing contributors.
 
-For user and developer documentation please go to [etcd.io](https://etcd.io/),
-which is developed in [website](https://github.com/etcd-io/website/) repo.
+For user and developer documentation, please go to [etcd.io](https://etcd.io/),
+which is developed in the [website](https://github.com/etcd-io/website/) repo.

--- a/Documentation/contributor-guide/community-membership.md
+++ b/Documentation/contributor-guide/community-membership.md
@@ -2,11 +2,11 @@
 
 This doc outlines the various responsibilities of contributor roles in etcd.
 
-| Role       | Responsibilities                             | Requirements                                                  | Defined by                    |
-|------------|----------------------------------------------|---------------------------------------------------------------|-------------------------------|
-| Member     | Active contributor in the community          | Sponsored by 2 reviewers and multiple contributions           | etcd GitHub org member        |
-| Reviewer   | Review contributions from other members      | History of review and authorship                              | [OWNERS] file reviewer entry  |
-| Maintainer | Set direction and priorities for the project | Demonstrated responsibility and excellent technical judgement | [OWNERS] file approver entry  |
+| Role       | Responsibilities                             | Requirements                                                  | Defined by                   |
+| ---------- | -------------------------------------------- | ------------------------------------------------------------- | ---------------------------- |
+| Member     | Active contributor in the community          | Sponsored by 2 reviewers and multiple contributions           | etcd GitHub org member       |
+| Reviewer   | Review contributions from other members      | History of review and authorship                              | [OWNERS] file reviewer entry |
+| Maintainer | Set direction and priorities for the project | Demonstrated responsibility and excellent technical judgement | [OWNERS] file approver entry |
 
 ## New contributors
 
@@ -24,7 +24,7 @@ below.
 
 ## Member
 
-Members are continuously active contributors to the community.  They can have
+Members are continuously active contributors to the community. They can have
 issues and PRs assigned to them. Members are expected to remain active
 contributors to the community.
 
@@ -33,11 +33,11 @@ contributors to the community.
 ### Member requirements
 
 - Enabled [two-factor authentication] on their GitHub account
-- Have made multiple contributions to the project or community.  Contribution may include, but is not limited to:
+- Have made multiple contributions to the project or community. Contribution may include, but is not limited to:
   - Authoring or reviewing PRs on GitHub. At least one PR must be **merged**.
   - Filing or commenting on issues on GitHub
   - Contributing to community discussions (e.g. meetings, Slack, email discussion
-      forums, Stack Overflow)
+    forums, Stack Overflow)
 - Subscribed to [etcd-dev@googlegroups.com](https://groups.google.com/g/etcd-dev)
 - Have read the [contributor guide]
 - Sponsored by two active maintainers or reviewers.
@@ -59,7 +59,7 @@ contributors to the community.
   - Addresses bugs or issues discovered after code is accepted
 
 **Note:** Members who frequently contribute code are expected to proactively
-perform code reviews and work towards becoming a *reviewer*.
+perform code reviews and work towards becoming a _reviewer_.
 
 ## Reviewers
 
@@ -69,11 +69,11 @@ the codebase and software engineering principles. Their LGTM counts towards
 merging a code change into the project. A reviewer is generally on the ladder towards
 maintainership.
 
-**Defined by:** *reviewers* entry in the [OWNERS] file.
+**Defined by:** _reviewers_ entry in the [OWNERS] file.
 
 ### Reviewer requirements
 
-- member for at least 3 months.
+- Member for at least 3 months.
 - Primary reviewer for at least 5 PRs to the codebase.
 - Reviewed or contributed at least 20 substantial PRs to the codebase.
 - Knowledgeable about the codebase.
@@ -101,7 +101,7 @@ are committed to the long-term success of a project. Maintainership is about bui
 trust with the current maintainers and being a person that they can
 depend on to make decisions in the best interest of the project in a consistent manner.
 
-**Defined by:** *approvers* entry in the [OWNERS] file.
+**Defined by:** _approvers_ entry in the [OWNERS] file.
 
 ### Maintainer requirements
 
@@ -117,7 +117,7 @@ depend on to make decisions in the best interest of the project in a consistent 
 - To become a maintainer send an email with your candidacy to <etcd-maintainers-private@googlegroups.com>
   - Ensure your sponsors are @mentioned in the email
   - Include a list of contributions representative of your work on the project.
-  - Existing maintainers vote will privately and respond to the email with either acceptance or feedback for suggested improvement.
+  - Existing maintainers will privately vote and respond to the email with either acceptance or feedback for suggested improvements.
 - With your membership approved you are expected to:
   - Open a PR and add an entry to the [OWNERS] file
   - Request to be added to the <etcd-maintainers@googlegroups.com> and <etcd-maintainers-private@googlegroups.com> mailing lists
@@ -126,7 +126,7 @@ depend on to make decisions in the best interest of the project in a consistent 
   - Request access to `etcd-development` GCP project where we publish releases
   - Request access to passwords shared between maintainers
   - Request cncf service desk access by emailing <projects@cncf.io>
-  - Raise cncf service desk ticket to be addded to [cncf-etcd-maintainers mailing list](https://lists.cncf.io/g/cncf-etcd-maintainers/directory)
+  - Raise CNCF service desk ticket to be added to [cncf-etcd-maintainers mailing list](https://lists.cncf.io/g/cncf-etcd-maintainers/directory)
 
 ### Maintainer responsibilities and privileges
 
@@ -161,7 +161,7 @@ Retiring maintainers must:
 - Open a PR and move to emeritus approvers in the [OWNERS] file
 - Open a PR to be removed from the [etcd-maintainer teams of the etcd-io organization in GitHub](https://github.com/orgs/etcd-io/teams/maintainers-etcd)
 - Remove their access to `etcd-development` GCP project where we publish releases
-- Raise cncf service desk ticket to be removed as a [cncf-etcd-maintainers mailing list](https://lists.cncf.io/g/cncf-etcd-maintainers/directory) admin
+- Raise CNCF service desk ticket to be removed as a [cncf-etcd-maintainers mailing list](https://lists.cncf.io/g/cncf-etcd-maintainers/directory) admin
 - Request to be removed as a member of the [etcd-maintainers](https://groups.google.com/g/etcd-maintainers) and [etcd-maintainers-private](https://groups.google.com/g/etcd-maintainers-private) Google groups
 
 ## Acknowledgements

--- a/Documentation/contributor-guide/dependency_management.md
+++ b/Documentation/contributor-guide/dependency_management.md
@@ -17,10 +17,10 @@
 
 ## Main branch
 
-The dependabot is enabled & [configured](https://github.com/etcd-io/etcd/blob/main/.github/dependabot.yml) to
-manage dependencies for etcd `main` branch. But dependabot doesn't work well for multi-module repository like `etcd`,
+Dependabot is enabled and [configured](https://github.com/etcd-io/etcd/blob/main/.github/dependabot.yml) to
+manage dependencies for the etcd `main` branch. However, dependabot doesn't work well for a multi-module repository like `etcd`,
 see [dependabot-core/issues/6678](https://github.com/dependabot/dependabot-core/issues/6678).
-Usually, human intervention is required each time when dependabot automatically opens some PRs to bump dependencies.
+Usually, human intervention is required each time dependabot automatically opens PRs to bump dependencies.
 Please see the guidance below.
 
 ### Dependencies used in workflows
@@ -45,7 +45,7 @@ in the following order,
 - go.etcd.io/etcd/tests/v3
 - go.etcd.io/etcd/v3
 - go.etcd.io/etcd/tools/v3
-For more details about etcd Golang modules, please check <https://etcd.io/docs/next/dev-internal/modules>
+  For more details about etcd Golang modules, please check <https://etcd.io/docs/next/dev-internal/modules>
 
 Note the module `go.etcd.io/etcd/tools/v3` doesn't depend on any other modules, nor by any other modules, so it doesn't matter when to bump dependencies for it.
 
@@ -68,7 +68,7 @@ git add .
 git commit --signoff -m "dependency: bump github.com/spf13/cobra from 1.6.1 to 1.7.0"
 ```
 
-Please close the related PRs which were automatically opened by dependabot. 
+Please close the related PRs which were automatically opened by dependabot.
 
 When you bump multiple dependencies in one PR, it's recommended to create a separate commit for each dependency. But it isn't a must; for example,
 you can get all dependencies bumping for the module `go.etcd.io/etcd/tools/v3` included in one commit.
@@ -137,7 +137,7 @@ Please refer to [build(deps): bump arduino/setup-protoc from 1.3.0 to 2.0.0](htt
 
 ### Rotation worksheet
 
-The dependabot scheduling interval is weekly; it means dependabot will automatically raise a bunch of PRs per week.
+The dependabot scheduling interval is weekly; this means dependabot will automatically raise a number of PRs per week.
 Usually, human intervention is required each time. We have a [rotation worksheet](https://docs.google.com/spreadsheets/d/1jodHIO7Dk2VWTs1IRnfMFaRktS9IH8XRyifOnPdSY8I/edit#gid=1394774387),
 and everyone is welcome to participate; you just need to register your name in the worksheet.
 
@@ -187,7 +187,7 @@ release is v3.6.0, so etcd 3.6.0 depends on raft v3.6.0.
 Please see the table below:
 
 | etcd versions | bbolt versions | raft versions |
-|---------------|----------------|---------------|
+| ------------- | -------------- | ------------- |
 | 3.4.x         | v1.3.x         | N/A           |
 | 3.5.x         | v1.3.x         | N/A           |
 | 3.6.x         | v1.4.x         | v3.6.x        |

--- a/Documentation/contributor-guide/features.md
+++ b/Documentation/contributor-guide/features.md
@@ -1,4 +1,4 @@
-# Features 
+# Features
 
 This document provides an overview of etcd features and general development guidelines for adding and deprecating them. The project maintainers can override these guidelines per the need of the project following the project governance.
 
@@ -9,15 +9,17 @@ The etcd features fall into three stages: Alpha, Beta, and GA.
 ### Alpha
 
 Any new feature is usually added as an Alpha feature. An Alpha feature is characterized as below:
+
 - Might be buggy due to a lack of user testing. Enabling the feature may not work as expected.
 - Disabled by default.
 - Support for such a feature may be dropped at any time without notice
-    - Feature-related issues may be given lower priorities.
-    - It can be removed in the next minor or major release without following the feature deprecation policy unless it graduates to a more stable stage.
+  - Feature-related issues may be given lower priorities.
+  - It can be removed in the next minor or major release without following the feature deprecation policy unless it graduates to a more stable stage.
 
 ### Beta
 
 A Beta feature is characterized as below:
+
 - Supported as part of the supported releases of etcd.
 - Enabled by default.
 - Discontinuation of support must follow the feature deprecation policy.
@@ -25,6 +27,7 @@ A Beta feature is characterized as below:
 ### GA
 
 A GA feature is characterized as below:
+
 - Supported as part of the supported releases of etcd.
 - Always enabled; you cannot disable it. The corresponding feature gate is no longer needed.
 - Discontinuation of support must follow the feature deprecation policy.
@@ -33,26 +36,27 @@ A GA feature is characterized as below:
 
 ### Adding a new feature
 
-Any new enhancements to the etcd are typically added as an Alpha feature. 
+Any new enhancements to etcd are typically added as an Alpha feature.
 
 etcd follows the Kubernetes [KEP process](https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/0000-kep-process/README.md) for new enhancements. The general development requirements are listed below. They can be somewhat flexible depending on the scope of the feature and review discussions and will evolve over time.
+
 - Open a [KEP](https://github.com/kubernetes/enhancements/issues) issue
-    - It must provide a clear need for the proposed feature.
-    - It should list development work items as checkboxes. There must be one work item towards future graduation to Beta.
-    - Label the issue with `/sig etcd`.
-    - Keep the issue open for tracking purposes until a decision is made on graduation.
-- Open a [KEP](https://github.com/kubernetes/enhancements) Pull Request (PR). 
-    - The KEP template can be simplified for etcd.
-    - It must provide clear graduation criteria for each stage.
-    - The KEP doc should reside in [keps/sig-etcd](https://github.com/kubernetes/enhancements/tree/master/keps/sig-etcd/)
+  - It must provide a clear need for the proposed feature.
+  - It should list development work items as checkboxes. There must be one work item towards future graduation to Beta.
+  - Label the issue with `/sig etcd`.
+  - Keep the issue open for tracking purposes until a decision is made on graduation.
+- Open a [KEP](https://github.com/kubernetes/enhancements) Pull Request (PR).
+  - The KEP template can be simplified for etcd.
+  - It must provide clear graduation criteria for each stage.
+  - The KEP doc should reside in [keps/sig-etcd](https://github.com/kubernetes/enhancements/tree/master/keps/sig-etcd/)
 - Open Pull Requests (PRs) in [etcd](https://github.com/etcd-io/etcd)
-    - Provide unit tests. Integration tests are also recommended as possible.
-    - Provide robust e2e test coverage. If the feature being added is complicated or quickly needed, maintainers can decide to go with e2e tests for basic coverage initially and have robust coverage added at a later time before the feature graduation to the stable feature.
-    - Provide logs for proper debugging.
-    - Provide metrics and benchmarks as needed.
-    - Add an Alpha [feature gate](https://etcd.io/docs/v3.6/feature-gates/).
-    - Any code changes or configuration flags related to the implementation of the feature must be gated with the feature gate e.g. `if cfg.ServerFeatureGate.Enabled(features.FeatureName)`.
-    - Add a CHANGELOG entry.
+  - Provide unit tests. Integration tests are also recommended as possible.
+  - Provide robust e2e test coverage. If the feature being added is complicated or quickly needed, maintainers can decide to go with e2e tests for basic coverage initially and have robust coverage added at a later time before the feature graduation to the stable feature.
+  - Provide logs for proper debugging.
+  - Provide metrics and benchmarks as needed.
+  - Add an Alpha [feature gate](https://etcd.io/docs/v3.6/feature-gates/).
+  - Any code changes or configuration flags related to the implementation of the feature must be gated with the feature gate e.g. `if cfg.ServerFeatureGate.Enabled(features.FeatureName)`.
+  - Add a CHANGELOG entry.
 - At least two maintainers must approve the KEP and related code changes.
 
 ### Graduating a feature to the next stage
@@ -62,6 +66,7 @@ It is important that features don't get stuck in one stage. They should be revis
 #### Provide implementation
 
 If a feature is found ready for graduation to the next stage, open a Pull Request (PR) with the following changes.
+
 - Update the feature `PreRelease` stage in `server/features/etcd_features.go`.
 - Update the status in the original KEP issue.
 
@@ -70,18 +75,21 @@ At least two maintainers must approve the work. Patch releases should not be con
 ### Deprecating a feature
 
 #### Alpha
+
 Alpha features can be removed without going through the deprecation process.
+
 - Remove the feature gate in `server/features/etcd_features.go`, and clean up all relevant code.
 - Close the original KEP issue with reasons to drop the feature.
 
 #### Beta and GA
+
 As the project evolves, a Beta/GA feature may sometimes need to be deprecated and removed. Such a situation should be handled using the steps below:
 
 - A Beta/GA feature can only be deprecated after at least 2 minor or major releases.
 - Update original KEP issue if it has not been closed or create a new etcd issue with reasons and steps to deprecate the feature.
 - Add the feature deprecation documentation in the release notes and feature gates documentation of the next minor/major release.
 - In the next minor/major release, set the feature gate to `{Default: false, PreRelease: featuregate.Deprecated, LockedToDefault: false}` in `server/features/etcd_features.go`. Deprecated feature gates must respond with a warning when used.
-    - If the feature has GAed, and the original gated codes has been cleaned up, add the disablement codes back with the feature gate.
+  - If the feature has GAed, and the original gated codes has been cleaned up, add the disablement codes back with the feature gate.
 - In the minor/major release after the next, set the feature gate to `{Default: false, PreRelease: featuregate.Deprecated, LockedToDefault: true}` in `server/features/etcd_features.go`, and start cleaning the code.
 
 At least two maintainers must approve the work. Patch releases should not be considered for deprecation.

--- a/Documentation/contributor-guide/local_cluster.md
+++ b/Documentation/contributor-guide/local_cluster.md
@@ -23,21 +23,21 @@ Use `etcdctl` to interact with the running cluster:
 
 1. Store an example key-value pair in the cluster:
 
-    ```
-      $ ./etcdctl put foo bar
-      OK
-    ```
+   ```
+     $ ./etcdctl put foo bar
+     OK
+   ```
 
-    If OK is printed, storing the key-value pair is successful.
+   If OK is printed, storing the key-value pair is successful.
 
 2. Retrieve the value of `foo`:
 
-    ```
-    $ ./etcdctl get foo
-    bar
-    ```
+   ```
+   $ ./etcdctl get foo
+   bar
+   ```
 
-    If `bar` is returned, interaction with the etcd cluster is working as expected.
+   If `bar` is returned, interaction with the etcd cluster is working as expected.
 
 ## Local multi-member cluster
 
@@ -47,18 +47,19 @@ A `Procfile` at the base of the etcd git repository is provided to easily config
 
 1. Install `goreman` to control Procfile-based applications:
 
-    ```
-    $ go install github.com/mattn/goreman@latest
-    ```
-   The installation will place executables in the $GOPATH/bin. If $GOPATH environment variable is not set, the tool will be installed into the $HOME/go/bin. Make sure that $PATH is set accordingly in your environment.
+   ```
+   $ go install github.com/mattn/goreman@latest
+   ```
+
+   The installation will place executables in the $GOPATH/bin. If the $GOPATH environment variable is not set, the tool will be installed into the $HOME/go/bin. Make sure that $PATH is set accordingly in your environment.
 
 2. Start a cluster with `goreman` using etcd's stock Procfile:
 
-    ```
-    $ goreman -f Procfile start
-    ```
+   ```
+   $ goreman -f Procfile start
+   ```
 
-    The members start running. They listen on `localhost:2379`, `localhost:22379`, and `localhost:32379` respectively for client requests.
+   The members start running. They listen on `localhost:2379`, `localhost:22379`, and `localhost:32379` respectively for client requests.
 
 ### Interacting with the cluster
 
@@ -66,29 +67,30 @@ Use `etcdctl` to interact with the running cluster:
 
 1. Print the list of members:
 
-    ```
-    $ etcdctl --write-out=table --endpoints=localhost:2379 member list
-    ```
-    The list of etcd members is displayed as follows:
+   ```
+   $ etcdctl --write-out=table --endpoints=localhost:2379 member list
+   ```
 
-    ```
-    +------------------+---------+--------+------------------------+------------------------+
-    |        ID        | STATUS  |  NAME  |       PEER ADDRS       |      CLIENT ADDRS      |
-    +------------------+---------+--------+------------------------+------------------------+
-    | 8211f1d0f64f3269 | started | infra1 | http://127.0.0.1:2380  | http://127.0.0.1:2379  |
-    | 91bc3c398fb3c146 | started | infra2 | http://127.0.0.1:22380 | http://127.0.0.1:22379 |
-    | fd422379fda50e48 | started | infra3 | http://127.0.0.1:32380 | http://127.0.0.1:32379 |
-    +------------------+---------+--------+------------------------+------------------------+
-    ```
+   The list of etcd members is displayed as follows:
+
+   ```
+   +------------------+---------+--------+------------------------+------------------------+
+   |        ID        | STATUS  |  NAME  |       PEER ADDRS       |      CLIENT ADDRS      |
+   +------------------+---------+--------+------------------------+------------------------+
+   | 8211f1d0f64f3269 | started | infra1 | http://127.0.0.1:2380  | http://127.0.0.1:2379  |
+   | 91bc3c398fb3c146 | started | infra2 | http://127.0.0.1:22380 | http://127.0.0.1:22379 |
+   | fd422379fda50e48 | started | infra3 | http://127.0.0.1:32380 | http://127.0.0.1:32379 |
+   +------------------+---------+--------+------------------------+------------------------+
+   ```
 
 2. Store an example key-value pair in the cluster:
 
-    ```
-    $ etcdctl put foo bar
-    OK
-    ```
+   ```
+   $ etcdctl put foo bar
+   OK
+   ```
 
-    If OK is printed, storing the key-value pair is successful.
+   If OK is printed, storing the key-value pair is successful.
 
 ### Testing fault tolerance
 
@@ -96,55 +98,56 @@ To exercise etcd's fault tolerance, kill a member and attempt to retrieve the ke
 
 1. Identify the process name of the member to be stopped.
 
-    The `Procfile` lists the properties of the multi-member cluster. For example, consider the member with the process name, `etcd2`.
+   The `Procfile` lists the properties of the multi-member cluster. For example, consider the member with the process name, `etcd2`.
 
 2. Stop the member:
 
-    ```
-    # kill etcd2
-    $ goreman run stop etcd2
-    ```
+   ```
+   # kill etcd2
+   $ goreman run stop etcd2
+   ```
 
 3. Store a key:
 
-    ```
-    $ etcdctl put key hello
-    OK
-    ```
+   ```
+   $ etcdctl put key hello
+   OK
+   ```
 
-4.  Retrieve the key that is stored in the previous step:
+4. Retrieve the key that is stored in the previous step:
 
-    ```
-    $ etcdctl get key
-    hello
-    ```
+   ```
+   $ etcdctl get key
+   hello
+   ```
 
 5. Retrieve a key from the stopped member:
 
-    ```
-    $ etcdctl --endpoints=localhost:22379 get key
-    ```
+   ```
+   $ etcdctl --endpoints=localhost:22379 get key
+   ```
 
-    The command should display an error caused by connection failure:
+   The command should display an error caused by connection failure:
 
-    ```
-    2017/06/18 23:07:35 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 127.0.0.1:22379: getsockopt: connection refused"; Reconnecting to "localhost:22379"
-    Error:  grpc: timed out trying to connect
-    ```
+   ```
+   2017/06/18 23:07:35 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 127.0.0.1:22379: getsockopt: connection refused"; Reconnecting to "localhost:22379"
+   Error:  grpc: timed out trying to connect
+   ```
+
 6. Restart the stopped member:
 
-    ```
-    $ goreman run restart etcd2
-    ```
+   ```
+   $ goreman run restart etcd2
+   ```
 
 7. Get the key from the restarted member:
 
-    ```
-    $ etcdctl --endpoints=localhost:22379 get key
-    hello
-    ```
+   ```
+   $ etcdctl --endpoints=localhost:22379 get key
+   hello
+   ```
 
-    Restarting the member re-establishs the connection. `etcdctl` will now be able to retrieve the key successfully. To learn more about interacting with etcd, read [interacting with etcd section][interacting].
+   Restarting the member re-establishs the connection. `etcdctl` will now be able to retrieve the key successfully. To learn more about interacting with etcd, read [interacting with etcd section][interacting].
 
 [clustering]: https://etcd.io/docs/latest/op-guide/clustering/
 [interacting]: https://etcd.io/docs/latest/dev-guide/interacting_v3/

--- a/Documentation/contributor-guide/logging.md
+++ b/Documentation/contributor-guide/logging.md
@@ -1,33 +1,33 @@
 # Logging Conventions
 
-etcd uses the [zap][zap] library for logging application output categorized into *levels*. A log message's level is determined according to these conventions:
+etcd uses the [zap][zap] library for logging application output categorized into _levels_. A log message's level is determined according to these conventions:
 
-* Debug: Everything is still fine, but even common operations may be logged, and less helpful but more quantity of notices. Usually not used in production.
-  * Examples:
-    * Send a normal message to a remote peer
-    * Write a log entry to disk
+- Debug: Everything is still fine, but even common operations may be logged, and less helpful but more numerous notices. Usually not used in production.
+  - Examples:
+    - Send a normal message to a remote peer
+    - Write a log entry to disk
 
-* Info: Normal, working log information, everything is fine, but helpful notices for auditing or common operations. Should rather not be logged more frequently than once per a few seconds in a normal server's operation.
-  * Examples:
-    * Startup configuration
-    * Start to do a snapshot
+- Info: Normal, working log information; everything is fine, but helpful notices for auditing or common operations. Should not be logged more frequently than once every few seconds during normal server operation.
+  - Examples:
+    - Startup configuration
+    - Start to do a snapshot
 
-* Warning: (Hopefully) Temporary conditions that may cause errors, but may work fine. A replica disappearing (that may reconnect) is a warning.
-  * Examples:
-    * Failure to send a raft message to a remote peer
-    * Failure to receive heartbeat message within the configured election timeout
+- Warning: (Hopefully) Temporary conditions that may cause errors, but may work fine. A replica disappearing (that may reconnect) is a warning.
+  - Examples:
+    - Failure to send a raft message to a remote peer
+    - Failure to receive heartbeat message within the configured election timeout
 
-* Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost.
-  * Examples:
-    * Failure to allocate disk space for WAL
+- Error: Data has been lost, a request has failed for a bad reason, or a required resource has been lost.
+  - Examples:
+    - Failure to allocate disk space for WAL
 
-* Panic: Unrecoverable or unexpected error situation that requires stopping execution.
-  * Examples:
-    * Failure to create the database
+- Panic: Unrecoverable or unexpected error situation that requires stopping execution.
+  - Examples:
+    - Failure to create the database
 
-* Fatal: Unrecoverable or unexpected error situation that requires immediate exit. Mostly used in the test.
-  * Examples:
-    * Failure to find the data directory
-    * Failure to run a test function
+- Fatal: Unrecoverable or unexpected error situation that requires immediate exit. Mostly used in the test.
+  - Examples:
+    - Failure to find the data directory
+    - Failure to run a test function
 
 [zap]: https://github.com/uber-go/zap

--- a/Documentation/contributor-guide/modules.md
+++ b/Documentation/contributor-guide/modules.md
@@ -1,43 +1,42 @@
 # Golang modules
 
 The etcd project (since version 3.5) is organized into multiple
-[golang modules](https://golang.org/ref/mod) hosted  in a [single repository](https://golang.org/ref/mod#vcs-dir).
+[golang modules](https://golang.org/ref/mod) hosted in a [single repository](https://golang.org/ref/mod#vcs-dir).
 
 ![modules graph](modules.svg)
 
 There are the following modules:
 
-  - **go.etcd.io/etcd/api/v3** - contains API definitions
-  (like protos & proto-generated libraries) that defines communication protocol
+- **go.etcd.io/etcd/api/v3** - contains API definitions
+  (like protos and proto-generated libraries) that define the communication protocol
   between etcd clients and servers.
 
-  - **go.etcd.io/etcd/pkg/v3** - a collection of utility packages used by etcd
+- **go.etcd.io/etcd/pkg/v3** - a collection of utility packages used by etcd
   without being specific to etcd itself. A package belongs here
   only if it could possibly be moved out into its own repository in the future.
   Please avoid adding here code that has a lot of dependencies on its own, as
   they automatically become dependencies of the client library
   (that we want to keep lightweight).
 
-  - **go.etcd.io/etcd/client/v3** - client library used to contact etcd over
+- **go.etcd.io/etcd/client/v3** - client library used to contact etcd over
   the network (grpc). Recommended for all new usage of etcd.
 
-  - **go.etcd.io/raft/v3** - implementation of distributed consensus
-  protocol. Should have no etcd specific code. Hosted in a separate repository:
+- **go.etcd.io/raft/v3** - implementation of distributed consensus
+  protocol. Should have no etcd-specific code. Hosted in a separate repository:
   https://github.com/etcd-io/raft.
 
-  - **go.etcd.io/etcd/server/v3** - etcd implementation.
+- **go.etcd.io/etcd/server/v3** - etcd implementation.
   The code in this package is internal to etcd and should not be consumed
   by external projects. The package layout and API can change within the minor versions.
 
-  - **go.etcd.io/etcd/etcdctl/v3** - a command line tool to access and manage etcd.
+- **go.etcd.io/etcd/etcdctl/v3** - a command line tool to access and manage etcd.
 
-  - **go.etcd.io/etcd/tests/v3** - a module that contains all integration tests of etcd.
-    Notice: All unit tests (fast and not requiring cross-module dependencies)
-    should be kept in the local modules of the code under the test.
+- **go.etcd.io/etcd/tests/v3** - a module that contains all integration tests of etcd.
+  Notice: All unit tests (fast and not requiring cross-module dependencies)
+  should be kept in the local modules of the code under the test.
 
-  - **go.etcd.io/bbolt** - implementation of persistent b-tree.
-    Hosted in a separate repository: https://github.com/etcd-io/bbolt.
-
+- **go.etcd.io/bbolt** - implementation of persistent b-tree.
+  Hosted in a separate repository: https://github.com/etcd-io/bbolt.
 
 ### Operations
 
@@ -45,18 +44,22 @@ There are the following modules:
    `go.etcd.io/etcd/client/v3@v3.5.10` must depend on `go.etcd.io/etcd/api/v3@v3.5.10`.
 
    The consistent updating of versions can be performed using:
+
    ```shell script
    % DRY_RUN=false TARGET_VERSION="v3.5.10" ./scripts/release_mod.sh update_versions
    ```
+
 2. The released modules should be tagged according to https://golang.org/ref/mod#vcs-version rules,
    i.e. each module should get its own tag.
    The tagging can be performed using:
+
    ```shell script
    % DRY_RUN=false REMOTE_REPO="origin" ./scripts/release_mod.sh push_mod_tags
    ```
 
 3. All etcd modules should depend on the same versions of underlying dependencies.
    This can be verified using:
+
    ```shell script
    % PASSES="dep" ./test.sh
    ```
@@ -64,6 +67,7 @@ There are the following modules:
 4. The go.mod files must not contain dependencies not being used and must
    conform to `go mod tidy` format.
    This is being verified by:
+
    ```
    % PASSES="mod_tidy" ./test.sh
    ```
@@ -81,11 +85,12 @@ As a North Star, we would like to evaluate etcd modules towards the following mo
 ![modules graph](modules-future.svg)
 
 This assumes:
-  - Splitting etcdmigrate/etcdadm out of etcdctl binary.
-    Thanks to this etcdctl would become clearly a command-line wrapper
-    around network client API,
-    while etcdmigrate/etcdadm would support direct physical operations on the
-    etcd storage files.
-  - Splitting etcd-proxy out of ./etcd binary, as it contains more experimental code
-    so carries additional risk & dependencies.
-  - Deprecation of support for v2 protocol.
+
+- Splitting etcdmigrate/etcdadm out of etcdctl binary.
+  Thanks to this etcdctl would become clearly a command-line wrapper
+  around network client API,
+  while etcdmigrate/etcdadm would support direct physical operations on the
+  etcd storage files.
+- Splitting etcd-proxy out of ./etcd binary, as it contains more experimental code
+  so carries additional risk and dependencies.
+- Deprecation of support for the v2 protocol.

--- a/Documentation/contributor-guide/prow_jobs.md
+++ b/Documentation/contributor-guide/prow_jobs.md
@@ -4,39 +4,39 @@
 
 [Prow](https://docs.prow.k8s.io/docs/) is a Kubernetes based CI/CD system. Jobs can be triggered by various types of events and report their status to many different services. Prow provides GitHub automation through policy enforcement and chat-ops via `/command` interactions on pull requests (e.g., `/test`, `/approve`, `/retest`), enabling contributors to trigger jobs and manage workflows directly from GitHub comments.
 
-When a user comments `/ok-to-test`or `/retest,` on a Pull Request, GitHub sends a webhook to Prow's Kubernetes cluster. Visit this [site](https://docs.prow.k8s.io/docs/life-of-a-prow-job/) to further understand the lifecycle of a Prow job.
+When a user comments `/ok-to-test` or `/retest` on a Pull Request, GitHub sends a webhook to Prow's Kubernetes cluster. Visit this [site](https://docs.prow.k8s.io/docs/life-of-a-prow-job/) to further understand the lifecycle of a Prow job.
 This is where you can find all etcd Prow jobs [status](https://prow.k8s.io/?repo=etcd-io%2Fetcd)
 
 ## 2. How Prow is used for etcd Testing
 
-etcd's CI is managed by [kubernetes/test-infra](https://github.com/kubernetes/test-infra), running Prow.
+etcd's CI is managed by [kubernetes/test-infra](https://github.com/kubernetes/test-infra), which runs Prow.
 
-When a pull request is submitted, or a `/command` is issued, the CI of etcd which managed by [kubernetes/test-infra](https://github.com/kubernetes/test-infra) uses Prow to run the tests. You can view all supported Prow [commands](https://prow.k8s.io/command-help).
+When a pull request is submitted or a `/command` is issued, the CI for etcd, managed by [kubernetes/test-infra](https://github.com/kubernetes/test-infra), uses Prow to run the tests. You can view all supported Prow [commands](https://prow.k8s.io/command-help).
 
-### Jobs Types
+### Job Types
 
 The jobs [configuration](https://github.com/kubernetes/test-infra/tree/master/config/jobs/etcd) for etcd. Please see [ProwJob](https://docs.prow.k8s.io/docs/jobs/) docs for more info.
 
 There are 3 different job types:
 
-- Recurring jobs that regularly run etcd performance benchmarks, specifically targeting the put API, for the amd64 architecture.[etcd-benchmarks-periodics.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-benchmarks-periodic.yaml)
-- Presubmits jobs: Run on pull requests before code is merged, ensuring new changes do not break the build or tests. [etcd-operator-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-presubmits.yaml)
-- Postsubmits run after merging the etcd-io/etcd-operator code: [etcd-operator-postsubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-operator-postsubmits.yaml)
-- Periodic jobs are jobs that run automatically on a fixed schedule (such as every 4 hours, once a day, etc.), regardless of code changes or pull requests. They’re designed to continuously check the stability, compatibility, or performance of the project over time. [etcd-periodics.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-periodics.yaml)
-- Builds the etcd project for all main and release branches before merging any PR. [etcd-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-presubmits.yaml)
-- This file defines jobs that run automatically after code is merged (postsubmit) into the main or release branches of the etcd repository (etcd-io/etcd). [etcd-postsubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-postsubmits.yaml)
-- Test pull requests for the etcd-io/raft repository on certain branches (main and release-3.6)[etcd-raft-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-raft-presubmits.yaml)
-- Checks markdown formatting for website changes [etcd-website-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-website-presubmits.yaml).
-- This file contains jobs that run after code is merged into the etcd-io/protodoc repository. [protodoc-presubmit.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/protodoc-postsubmits.yaml)
-- This file defines jobs that run on pull requests (before merge) for the etcd-io/protodoc repository.[protodoc-postsubmit.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/protodoc-presubmits.yaml)
+- Recurring jobs that regularly run etcd performance benchmarks, specifically targeting the put API, for the amd64 architecture. [etcd-benchmarks-periodics.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-benchmarks-periodic.yaml)
+- Presubmit jobs: Run on pull requests before code is merged, ensuring new changes do not break the build or tests. [etcd-operator-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-presubmits.yaml)
+- Postsubmit jobs: Run after merging the etcd-io/etcd-operator code. [etcd-operator-postsubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-operator-postsubmits.yaml)
+- Periodic jobs: Run automatically on a fixed schedule (such as every 4 hours, once a day, etc.), regardless of code changes or pull requests. They’re designed to continuously check the stability, compatibility, or performance of the project over time. [etcd-periodics.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-periodics.yaml)
+- Build jobs: Build the etcd project for all main and release branches before merging any PR. [etcd-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-presubmits.yaml)
+- Postsubmit definitions: Jobs that run automatically after code is merged (postsubmit) into the main or release branches of the etcd repository (etcd-io/etcd). [etcd-postsubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-postsubmits.yaml)
+- Test jobs: Test pull requests for the etcd-io/raft repository on certain branches (main and release-3.6). [etcd-raft-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-raft-presubmits.yaml)
+- Website checks: Checks markdown formatting for website changes. [etcd-website-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/etcd-website-presubmits.yaml).
+- Protodoc postsubmit: This file contains jobs that run after code is merged into the etcd-io/protodoc repository. [protodoc-presubmit.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/protodoc-postsubmits.yaml)
+- Protodoc presubmit: This file defines jobs that run on pull requests (before merge) for the etcd-io/protodoc repository. [protodoc-postsubmit.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/etcd/protodoc-presubmits.yaml)
 
-As an example, `pull-etcd-e2e-amd64` is one of the [presubmits](https://github.com/kubernetes/test-infra/blob/b21a1d3a72d5715ea7c9234cade21751847cfbe5/config/jobs/etcd/etcd-presubmits.yaml#L193). The job automatically runs end-to-end (e2e) tests on the amd64 architecture for every pull request to the etcd repository targeting the main, release-3.6, release-3.5, or release-3.4 branches. This is an example to its dashboard result [graph](https://prow.k8s.io/?repo=etcd-io%2Fetcd&type=presubmit&job=pull-etcd-e2e-amd64).
+As an example, `pull-etcd-e2e-amd64` is one of the [presubmits](https://github.com/kubernetes/test-infra/blob/b21a1d3a72d5715ea7c9234cade21751847cfbe5/config/jobs/etcd/etcd-presubmits.yaml#L193). The job automatically runs end-to-end (e2e) tests on the amd64 architecture for every pull request to the etcd repository targeting the main, release-3.6, release-3.5, or release-3.4 branches. This is an example; see its dashboard result [graph](https://prow.k8s.io/?repo=etcd-io%2Fetcd&type=presubmit&job=pull-etcd-e2e-amd64).
 
 Refer to [the test-infra Job Types documentation](https://github.com/kubernetes/test-infra/tree/master/config/jobs#job-types) to learn more about them.
 
 ### How to Trigger Prow Running Tests
 
-These tests can be triggered when you leave a comment, like `/ok-to-test` (only triggered by an etcd-io member) or `/retest`, in PR [example](https://github.com/etcd-io/etcd/pull/20733#issuecomment-3341443205). `/ok-to-test` allows Prow to run tests on a pull request from a first-time contributor. `/retest` tells Prow to rerun any failed or flaky joobs on the pull request, useful if a previous test failed due to a transient issue.
+These tests can be triggered when you leave a comment, like `/ok-to-test` (only triggered by an etcd-io member) or `/retest`, in a PR (for example: https://github.com/etcd-io/etcd/pull/20733#issuecomment-3341443205). `/ok-to-test` allows Prow to run tests on a pull request from a first-time contributor. `/retest` tells Prow to rerun any failed or flaky jobs on the pull request, useful if a previous test failed due to a transient issue.
 
 You can find all supported [commands](https://prow.k8s.io/command-help).
 
@@ -49,7 +49,7 @@ Test-infra's Prow exposes Grafana dashboards to provide visibility into build re
 
 It is useful for a few reasons:
 
-1. Tuning resources: By drilling into each build-run, you can determine realistic memory & CPU requests and limits for that job‑type. This helps avoid waste or avoid failed builds hitting resource limits.
+1. Tuning resources: By drilling into each build-run, you can determine realistic memory and CPU requests and limits for that job‑type. This helps avoid waste or failed builds hitting resource limits.
 
 2. Spotting anomalies: If one build suddenly used 8 GiB while normally this job uses 1 GiB, it may indicate a regression or mis‑configuration.
 

--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -24,7 +24,7 @@ All release version numbers follow the format of [semantic versioning 2.0.0](htt
 
 - Ensure the relevant [milestone](https://github.com/etcd-io/etcd/milestones) on GitHub is complete. All referenced issues should be closed or moved elsewhere.
 - Ensure the latest [upgrade documentation](https://etcd.io/docs/next/upgrades) is available.
-- Bump [hardcoded MinClusterVerion in the repository](https://github.com/etcd-io/etcd/blob/v3.4.15/version/version.go#L29), if necessary.
+  -- Bump [hardcoded MinClusterVersion in the repository](https://github.com/etcd-io/etcd/blob/v3.4.15/version/version.go#L29), if necessary.
 - Add feature capability maps for the new version, if necessary.
 
 ### Patch version release
@@ -32,11 +32,11 @@ All release version numbers follow the format of [semantic versioning 2.0.0](htt
 - To request a backport, developers submit cherry-pick PRs targeting the release branch. The commits should not include merge commits. The commits should be restricted to bug fixes and security patches.
 - The cherrypick PRs should target the appropriate release branch (`base:release-<major>-<minor>`). The k8s infra cherry pick robot `/cherrypick <branch>` PR chatops command may be used to automatically generate cherrypick PRs.
 - The release patch manager reviews the cherrypick PRs. Please discuss carefully what is backported to the patch release. Each patch release should be strictly better than its predecessor.
-- The release patch manager will cherry-pick these commits starting from the oldest one into stable branch.
+- The release patch manager will cherry-pick these commits starting from the oldest one into the stable branch.
 
 ## Write a release note
 
-- Write an introduction for the new release. For example, what major bug we fix, what new features we introduce, or what performance improvement we make.
+- Write an introduction for the new release. For example, what major bugs were fixed, what new features were introduced, or what performance improvements were made.
 - Put `[GH XXXX]` at the head of the change line to reference the Pull Request that introduces the change. Moreover, add a link on it to jump to the Pull Request.
 - Find PRs with the `release-note` label and explain them in the `NEWS` file, as a straightforward summary of changes for end-users.
 
@@ -55,11 +55,12 @@ The etcd project aims to release a new patch version if any of the following con
 
 There are some prerequisites, which should be done before the release process. These are one-time operations,
 which don't need to be executed before releasing each version.
+
 1. Generate a GPG key and add it to your GitHub account. Refer to the links on [settings](https://github.com/settings/keys).
-2. Ensure you have a Linux machine, on which the git, Golang, and docker have been installed.
-    - Ensure the Golang version matches the version defined in `.go-version` file.
-    - Ensure non-privileged users can run docker commands, refer to the [Linux postinstall](https://docs.docker.com/engine/install/linux-postinstall/).
-    - Ensure there is at least 5GB of free space on your Linux machine.
+2. Ensure you have a Linux machine, on which git, Golang, and docker have been installed.
+   - Ensure the Golang version matches the version defined in the `.go-version` file.
+   - Ensure non-privileged users can run docker commands; refer to the [Linux postinstall](https://docs.docker.com/engine/install/linux-postinstall/).
+   - Ensure there is at least 5 GB of free space on your Linux machine.
 3. Install gsutil, refer to [gsutil_install](https://cloud.google.com/storage/docs/gsutil_install). When asked about cloud project to use, pick `etcd-development`.
 4. Authenticate the image registry, refer to [Authentication methods](https://cloud.google.com/container-registry/docs/advanced-authentication).
    - `gcloud auth login`
@@ -100,9 +101,9 @@ On the day of the release:
    under project `etcd-development`, and images are pushed to `quay.io` and `gcr.io`.
    - It is advisable to do a dry run before the actual release. This will create a `/tmp` directory. Do **NOT** forget to remove this directory before the actual release.
 
-      ```bash
-      DRY_RUN=true BRANCH=${BRANCH} ./scripts/release.sh ${VERSION}
-      ```
+     ```bash
+     DRY_RUN=true BRANCH=${BRANCH} ./scripts/release.sh ${VERSION}
+     ```
 
 4. Publish the release page on GitHub
    - Open the **draft** release URL shown by the release script
@@ -130,12 +131,12 @@ On the day of the release:
 6. Update the changelog to reflect the correct release date.
 7. Paste the release link to the issue raised in Step 1 and close the issue.
 8. Raise a follow-up `kubernetes/org` pull request to return the GitHub release team to empty, least privilege state.
-9. Crease a new stable branch through `git push origin release-${VERSION_MAJOR}.${VERSION_MINOR}` if this is a new major or minor stable release.
+9. Create a new stable branch through `git push origin release-${VERSION_MAJOR}.${VERSION_MINOR}` if this is a new major or minor stable release.
 10. Re-generate a new password for quay.io if needed (e.g. shared to a contributor who isn't in the release team, and we should rotate the password at least once every 3 months).
 11. Bump the new etcd release in Kubernetes, refer to [Bump etcd Version in Kubernetes](bump_etcd_version_k8s.md).
 
-- For etcd 3.6 patches, bump it to Kubernetes 1.34 and all newer minor versions (including `master` branch)
-- For etcd 3.5 patches, bump it to Kubernetes 1.33 and all older supported versions
+- For etcd 3.6 patches, bump it to Kubernetes 1.34 and all newer minor versions (including the `master` branch).
+- For etcd 3.5 patches, bump it to Kubernetes 1.33 and all older supported versions.
 
 #### Release known issues
 

--- a/Documentation/contributor-guide/reporting_bugs.md
+++ b/Documentation/contributor-guide/reporting_bugs.md
@@ -8,7 +8,7 @@ To make the bug report accurate and easy to understand, please try to create bug
 
 - Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please include the steps that might lead to the problem. If possible, please attach the affected etcd data dir and stack trace to the bug report.
 
-- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on etcd is out of scope, but we are happy to provide guidance in the right direction or help with using etcd itself.
+- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down bug fixes if too many dependencies are involved in a bug report. Debugging external systems that rely on etcd is out of scope, but we are happy to provide guidance in the right direction or help with using etcd itself.
 
 - Unique. Do not duplicate existing bug reports.
 
@@ -22,19 +22,19 @@ We might ask for further information to locate a bug. A duplicated bug report wi
 
 ### How to get a stack trace
 
-``` bash
+```bash
 $ kill -QUIT $PID
 ```
 
 ### How to get the etcd version
 
-``` bash
+```bash
 $ etcd --version
 ```
 
 ### How to get etcd configuration and log when it runs as systemd service ‘etcd2.service’
 
-``` bash
+```bash
 $ sudo systemctl cat etcd2
 $ sudo journalctl -u etcd2
 ```

--- a/Documentation/contributor-guide/triage_prs.md
+++ b/Documentation/contributor-guide/triage_prs.md
@@ -9,8 +9,9 @@ A PR can have various labels, milestones, reviewers, etc. The detailed list of l
 https://github.com/kubernetes/kubernetes/labels
 
 Following are a few example searches on PR for convenience:
-* [Open PRS for milestone etcd-v3.6](https://github.com/etcd-io/etcd/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Aetcd-v3.6)
-* [PRs under investigation](https://github.com/etcd-io/etcd/labels/Investigating)
+
+- [Open PRS for milestone etcd-v3.6](https://github.com/etcd-io/etcd/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+milestone%3Aetcd-v3.6)
+- [PRs under investigation](https://github.com/etcd-io/etcd/labels/Investigating)
 
 ## Scope
 
@@ -18,14 +19,15 @@ These guidelines serve as a primary document for managing PRs and review policy 
 
 ## Ensure tests are run
 
-The etcd project use Kubernetes Prow and GitHub Actions to run tests. To ensure all required tests run if a pull request is ready for testing and still has the `needs-ok-to-test` label then please comment on the pull request `/ok-to-test`.
+The etcd project uses Kubernetes Prow and GitHub Actions to run tests. To ensure all required tests run, if a pull request is ready for testing and still has the `needs-ok-to-test` label, then please comment on the pull request `/ok-to-test`.
 
 ## Handle inactive PRs
-Poke PR owner if review comments are not addressed in 15 days. If the PR owner does not reply in 90 days, update the PR with a new commit if possible. If not, inactive PR should be closed after 180 days.
+
+Poke the PR owner if review comments are not addressed in 15 days. If the PR owner does not reply in 90 days, update the PR with a new commit if possible. If not, the inactive PR should be closed after 180 days.
 
 ## Poke reviewer if needed
 
-Reviewers are responsive in a timely fashion, but considering everyone is busy, give them some time after requesting a review if a quick response is not provided. If the response is not provided in 10 days, feel free to contact them via adding a comment in the PR or sending an email or message on Slack.
+Reviewers are generally responsive, but considering everyone is busy, give them some time after requesting a review before following up. If no response is provided in 10 days, feel free to contact them by adding a comment in the PR or sending an email or message on Slack.
 
 ## Verify important labels are in place
 
@@ -41,21 +43,21 @@ PRs should get at least two approvals (/lgtm or GitHub review approval) before m
 
 Notes:
 
-* Approvals should come from a maintainer, reviewer, or submodule owner familiar with the relevant code or area.
-* If there’s disagreement, maintainers should discuss and agree before merging.
+- Approvals should come from a maintainer, reviewer, or submodule owner familiar with the relevant code or area.
+- If there’s disagreement, maintainers should discuss and agree before merging.
 
 ### Exceptions for Less Impactful PRs
 
 For low-risk changes — such as:
 
-* CI workflows
-* Documentation
-* Comments
+- CI workflows
+- Documentation
+- Comments
 
 The rule can be relaxed:
 
-* One approval is generally enough.
+- One approval is generally enough.
 
 However:
 
-* If the author is a maintainer, they should still get approval from another maintainer, reviewer, or submodule owner, even for minor changes.
+- If the author is a maintainer, they should still get approval from another maintainer, reviewer, or submodule owner, even for minor changes.

--- a/Documentation/postmortems/v3.5-data-inconsistency.md
+++ b/Documentation/postmortems/v3.5-data-inconsistency.md
@@ -1,122 +1,125 @@
 # v3.5 data inconsistency postmortem
 
 |         |            |
-|---------|------------|
+| ------- | ---------- |
 | Authors | serathius@ |
 | Date    | 2022-04-20 |
 | Status  | published  |
 
 ## Summary
 
-|         |                                                                                                                                                                                                                               |
-|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Summary | Code refactor in v3.5.0 resulted in consistent index not being saved atomically. Independent crash could lead to committed transactions are not reflected on all the members.                                                 |
-| Impact  | No user reported problems in production as triggering the issue required frequent crashes, however issue was critical enough to motivate a public statement. Main impact comes from loosing user trust into etcd reliability. |
+|         |                                                                                                                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Summary | Code refactor in v3.5.0 resulted in the consistent index not being saved atomically. An independent crash could lead to committed transactions not being reflected on all members.                                                   |
+| Impact  | No users reported problems in production as triggering the issue required frequent crashes; however, the issue was critical enough to motivate a public statement. The main impact comes from losing user trust in etcd reliability. |
 
 ## Background
 
-etcd v3 state is preserved on disk in two forms write ahead log (WAL) and database state (DB).
-etcd v3.5 also still maintains v2 state, however it's deprecated and not relevant to the issue in this postmortem.
+etcd v3 state is preserved on disk in two forms: the write-ahead log (WAL) and the database state (DB).
+etcd v3.5 also still maintains v2 state; however, it's deprecated and not relevant to the issue in this postmortem.
 
-WAL stores history of changes for etcd state and database represents state at one point. 
-To know which point of history database is representing, it stores consistent index (CI).
-It's a special metadata field that points to last entry in WAL that it has seen.
+WAL stores the history of changes for etcd state and the database represents state at a single point.
+To know which point of history the database represents, it stores the consistent index (CI).
+It's a metadata field that points to the last entry in the WAL that it has seen.
 
-When etcd is updating database state, it replays entries from WAL and updates the consistent index to point to new entry.
-This operation is required to be [atomic](https://en.wikipedia.org/wiki/Atomic_commit). 
-A partial fail would mean that database and WAL would no longer match, so some entries would be either skipped (if only CI is updated) or executed twice (if only changes are applied).
-This is especially important for distributed system like etcd, where there are multiple cluster members, each applying the WAL entries to their database.
-Correctness of the system depends on assumption that every member of the cluster, while replying WAL entries, will reach the same state.
+When etcd updates the database state, it replays entries from the WAL and updates the consistent index to point to the new entry.
+This operation must be [atomic](https://en.wikipedia.org/wiki/Atomic_commit).
+A partial failure would mean that the database and WAL would no longer match, so some entries would either be skipped (if only CI is updated) or executed twice (if only changes are applied).
+This is especially important for a distributed system like etcd, where multiple cluster members each apply WAL entries to their database.
+Correctness of the system depends on the assumption that every member of the cluster, while replaying WAL entries, will reach the same state.
 
 ## Root cause
 
-To simplify managing consistency index, etcd has introduced backend hooks in https://github.com/etcd-io/etcd/pull/12855.
-Goal was to ensure that consistency index is always updated, by automatically triggering update during commit.
-Implementation was as follows, before applying the WAL entries, etcd updated in memory value of consistent index. 
-As part of transaction commit process, a database hook would read the value of consistent index and store it to database. 
+To simplify managing the consistency index, etcd introduced backend hooks in https://github.com/etcd-io/etcd/pull/12855.
+The goal was to ensure that the consistency index is always updated by automatically triggering an update during commit.
+The implementation was as follows: before applying the WAL entries, etcd updated the in-memory value of the consistent index.
+As part of the transaction commit process, a database hook would read the value of the consistent index and store it to the database.
 
-Problem is that in memory value of consistent index is shared, and there might be other in flight transactions apart from serial WAL apply flow.
-So if we imagine scenario:
-1. etcd server starts an apply workflow, and it just sets a new consistent index value.
-2. The periodic commit is triggered, and it executes the backend hook and saves consistent index from apply workflow.
-3. etcd server finished an apply workflow, saves new changes and saves same value of consistent index again.
+The problem is that the in-memory value of the consistent index is shared, and there might be other in-flight transactions apart from the serial WAL apply flow.
+Consider the scenario:
 
-Between second and third point there is a very small window where consistent index is increased without applying entry from WAL.
+1. The etcd server starts an apply workflow and sets a new consistent index value.
+2. A periodic commit is triggered, and it executes the backend hook and saves the consistent index from the apply workflow.
+3. The etcd server finishes the apply workflow, saves new changes and saves the same value of the consistent index again.
+
+Between the second and third points there is a small window where the consistent index is increased without applying the corresponding entry from the WAL.
 
 ## Trigger
 
-If etcd crashed after consistency index is saved, but before to apply workflow finished it would lead to data inconsistency.
-When recovering the data etcd would skip executing changes from failed apply workflow, assuming they have been already executed.
+If etcd crashed after the consistent index is saved but before the apply workflow finished, it would lead to data inconsistency.
+When recovering the data, etcd would skip executing changes from the failed apply workflow, assuming they had already been executed.
 
-This follows the issue reports and code used to reproduce the issue where trigger was etcd crashing under high request load.
-Etcd v3.5.0 was released with bug (https://github.com/etcd-io/etcd/pull/13505) that could cause etcd to crash that was fixed in v3.5.1.
-Apart from that all reports described etcd running under high memory pressure, causing it to go out of memory from time to time.
-Reproduction run etcd under high stress and randomly killed one of the members using SIGKILL signal (not recoverable immediate process death). 
+This is consistent with issue reports and the code used to reproduce the issue where the trigger was etcd crashing under high request load.
+Etcd v3.5.0 was released with a bug (https://github.com/etcd-io/etcd/pull/13505) that could cause etcd to crash; this was fixed in v3.5.1.
+Additionally, reports described etcd running under high memory pressure, causing it to OOM from time to time.
+To reproduce, we ran etcd under high stress and randomly killed one of the members using SIGKILL (an immediate, non-recoverable process death).
 
 ## Detection
 
-For single member cluster it is totally undetectable. 
-There is no mechanism or tool for verifying that state database matches WAL.  
+For a single-member cluster it is undetectable.
+There is no mechanism or tool for verifying that the database state matches the WAL.
 
-In cluster with multiple members it would mean that one of the members that crashed, will missing changes from failed apply workflow.
-This means that it will have different state of database and will return different hash via `HashKV` grpc call.
+In a cluster with multiple members it would mean that one of the members that crashed will be missing changes from the failed apply workflow.
+This means that it will have a different database state and will return a different hash via the `HashKV` gRPC call.
 
-There is an automatic mechanism to detect data inconsistency. 
+There is an automatic mechanism to detect data inconsistency.
 It can be executed during etcd start via `--experimental-initial-corrupt-check` and periodically via `--experimental-corrupt-check-time`.
-Both checks however have a flaw, they depend on `HashKV` grpc method, which might fail causing the check to pass.
+Both checks, however, have a flaw: they depend on the `HashKV` gRPC method, which might fail, causing the check to pass incorrectly.
 
-In multi member etcd cluster, each member can run with different performance and be at different stage of applying the WAL log.
+In a multi-member etcd cluster, each member can run with different performance and be at a different stage of applying the WAL log.
 Comparing database hashes between multiple etcd members requires all hashes to be calculated at the same change.
-This is done by requesting hash for the same `revision` (version of key value store). 
-However, it will not work if the provided revision is not available on the members.
-This can happen on very slow members, or in cases where corruption has lead revision numbers to diverge.
+This is done by requesting a hash for the same `revision` (version of the key-value store).
+However, it will not work if the provided revision is not available on all members.
+This can happen on very slow members, or in cases where corruption has led to diverging revision numbers.
 
-This means that for this issue, the corrupt check is only reliable during etcd start just after etcd crashes.
+This means that for this issue, the corrupt check is only reliable during etcd start just after a crash.
 
 ## Impact
 
-We are not aware any cases of users reporting a data corruption in production environment.
+We are not aware of any cases of users reporting data corruption in production environments.
 
-However, issue was critical enough to motivate a public statement. 
-Main impact comes from loosing user trust into etcd reliability.
+However, the issue was critical enough to motivate a public statement.
+The main impact comes from losing user trust in etcd reliability.
 
 ## Lessons learned
 
 ### What went well
 
-* Multiple maintainers were able to work effectively on reproducing and fixing the issue. As they are in different timezones, there was always someone working on the issue.
-* When fixing the main data inconsistency we have found multiple other edge cases that could lead to data corruption (https://github.com/etcd-io/etcd/issues/13514, https://github.com/etcd-io/etcd/issues/13922, https://github.com/etcd-io/etcd/issues/13937).
+- Multiple maintainers were able to work effectively on reproducing and fixing the issue. As they are in different timezones, there was always someone working on the issue.
+- When fixing the main data inconsistency we found multiple other edge cases that could lead to data corruption (https://github.com/etcd-io/etcd/issues/13514, https://github.com/etcd-io/etcd/issues/13922, https://github.com/etcd-io/etcd/issues/13937).
 
 ### What went wrong
 
-* No users enable data corruption detection as it is still an experimental feature introduced in v3.3. All reported cases where detected manually making it almost impossible to reproduce.
-* etcd has functional tests designed to detect such problems, however they are unmaintained, flaky and are missing crucial scenarios.
-* etcd v3.5 release was not qualified as comprehensive as previous ones. Older maintainers run manual qualification process that is no longer known or executed.
-* etcd apply code is so complicated that fixing the data inconsistency took almost 2 weeks and multiple tries. Fix needed to be so complicated that we needed to develop automatic validation for it (https://github.com/etcd-io/etcd/pull/13885).
-* etcd v3.5 was recommended for production without enough insight on the production adoption. Production ready recommendations based on after some internal feedback... to get diverse usage, but the user's hold on till someone else will discover issues.
+- No users enabled data corruption detection as it is still an experimental feature introduced in v3.3. All reported cases were detected manually, making them almost impossible to reproduce.
+- etcd has functional tests designed to detect such problems; however, they are unmaintained, flaky, and missing crucial scenarios.
+- the etcd v3.5 release was not qualified as comprehensively as previous ones. Older maintainers ran a manual qualification process that is no longer documented or executed.
+- The etcd apply code is complex; fixing the data inconsistency took almost two weeks and multiple attempts. The fix required additional automatic validation (https://github.com/etcd-io/etcd/pull/13885).
+- etcd v3.5 was recommended for production without sufficient insight on production adoption. Production-ready recommendations were based on limited internal feedback and did not capture diverse usage patterns.
 
 ### Where we got lucky
 
-* We reproduced the issue using etcd functional only because weird partition setup on workstation. Functional tests store etcd data under `/tmp` usually mounted to in memory filesystem. Problem was reproduced only because one of the maintainers has `/tmp` mounted to standard disk.
+- We reproduced the issue using functional tests only because of a non-standard partition setup on a workstation. Functional tests store etcd data under `/tmp`, which is usually mounted to an in-memory filesystem. The problem was reproduced only because one of the maintainers had `/tmp` mounted to a standard disk.
 
 ## Action items
 
-Action items should directly address items listed in lessons learned. 
+Action items should directly address the items listed in lessons learned.
 We should double down on things that went well, fix things that went wrong, and stop depending on luck.
 
-Action fall under three types, and we should have at least one item per type. Types:
-* Prevent - Prevent similar issues from occurring. In this case, what testing we should introduce to find data inconsistency issues before release, preventing publishing broken release.
-* Detect - Be more effective in detecting when similar issues occur. In this case, improve mechanism to detect data inconsistency issue so users will be automatically informed.
-* Mitigate - Reduce time to recovery for users. In this case, how we ensure that users are able to quickly fix data inconsistency.
+Action items fall under three types, and we should have at least one item per type. Types:
+
+- Prevent - Prevent similar issues from occurring. In this case, what testing we should introduce to find data inconsistency issues before release, preventing publishing broken release.
+- Detect - Be more effective in detecting when similar issues occur. In this case, improve mechanism to detect data inconsistency issue so users will be automatically informed.
+- Mitigate - Reduce time to recovery for users. In this case, how we ensure that users are able to quickly fix data inconsistency.
 
 Actions should not be restricted to fixing the immediate issues and also propose long term strategic improvements.
-To reflect this action items should have assigned priority: 
-* P0 - Critical for reliability of the v3.5 release. Should be prioritized this over all other work and backported to v3.5.
-* P1 - Important for long term success of the project. Blocks v3.6 release.
-* P2 - Stretch  goals that would be nice to have for v3.6, however should not be blocking.
+To reflect this action items should have assigned priority:
+
+- P0 - Critical for reliability of the v3.5 release. Should be prioritized this over all other work and backported to v3.5.
+- P1 - Important for long term success of the project. Blocks v3.6 release.
+- P2 - Stretch goals that would be nice to have for v3.6, however should not be blocking.
 
 | Action Item                                                                         | Type     | Priority | Bug                                          | Status |
-|-------------------------------------------------------------------------------------|----------|----------|----------------------------------------------|--------|
+| ----------------------------------------------------------------------------------- | -------- | -------- | -------------------------------------------- | ------ |
 | etcd testing can reproduce historical data inconsistency issues                     | Prevent  | P0       | https://github.com/etcd-io/etcd/issues/14045 | DONE   |
 | etcd detects data corruption by default                                             | Detect   | P0       | https://github.com/etcd-io/etcd/issues/14039 | DONE   |
 | etcd testing is high quality, easy to maintain and expand                           | Prevent  | P1       | https://github.com/etcd-io/etcd/issues/13637 |        |
@@ -131,7 +134,7 @@ To reflect this action items should have assigned priority:
 ## Timeline
 
 | Date       | Event                                                                                                                 |
-|------------|-----------------------------------------------------------------------------------------------------------------------|
+| ---------- | --------------------------------------------------------------------------------------------------------------------- |
 | 2021-05-08 | Pull request that caused data corruption was merged - https://github.com/etcd-io/etcd/pull/12855                      |
 | 2021-06-16 | Release v3.5.0 with data corruption was published - https://github.com/etcd-io/etcd/releases/tag/v3.5.0               |
 | 2021-12-01 | Report of data corruption - https://github.com/etcd-io/etcd/issues/13514                                              |


### PR DESCRIPTION
What: Update multiple documentation files to clarify contributor guidance, processes, and postmortem details. Changes include updates and typo fixes in the contributor guide, improvements to onboarding examples, and enhancements to the v3.5 postmortem.

Files changed:

Documentation/README.md
Documentation/contributor-guide/community-membership.md Documentation/contributor-guide/dependency_management.md Documentation/contributor-guide/features.md
Documentation/contributor-guide/local_cluster.md
Documentation/contributor-guide/logging.md
Documentation/contributor-guide/modules.md
Documentation/contributor-guide/prow_jobs.md
Documentation/contributor-guide/release.md
Documentation/contributor-guide/reporting_bugs.md
Documentation/contributor-guide/triage_prs.md
Documentation/postmortems/v3.5-data-inconsistency.md

Why: Improve clarity and consistency for contributors, reduce friction during reviews, and capture lessons from the v3.5 incident to help prevent regressions.

Signed-off-by: Ahmed Madbouly ahmedmadbouly186@gmail.com