### PR TITLE
snap: write snapshots atomically and cleanup broken snapshots

### DIFF
--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -60,8 +60,6 @@ func New(lg *zap.Logger, dir string) *Snapshotter {
 		lg = zap.NewNop()
 	}
 
-	cleanupBrokenSnapshots(dir, 1, lg)
-
 	return &Snapshotter{
 		lg:  lg,
 		dir: dir,

--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -59,9 +59,40 @@ func New(lg *zap.Logger, dir string) *Snapshotter {
 	if lg == nil {
 		lg = zap.NewNop()
 	}
+
+	cleanupBrokenSnapshots(dir, 1, lg)
+
 	return &Snapshotter{
 		lg:  lg,
 		dir: dir,
+	}
+}
+
+// Clean up stale broken snapshot files left behind by crashes during snapshot creation.
+// Keep only the most recent broken snapshot to avoid unbounded disk usage.
+func cleanupBrokenSnapshots(dir string, keep int, lg *zap.Logger) {
+	files, err := filepath.Glob(filepath.Join(dir, "*.snap.broken"))
+	if err != nil {
+		lg.Warn("failed to list broken snapshots", zap.Error(err))
+		return
+	}
+	if len(files) <= keep {
+		return
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		fi, err1 := os.Stat(files[i])
+		fj, err2 := os.Stat(files[j])
+		if err1 != nil || err2 != nil {
+			return files[i] > files[j] // fallback deterministic order
+		}
+		return fi.ModTime().After(fj.ModTime())
+	})
+
+	for _, f := range files[keep:] {
+		if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+			lg.Warn("failed to remove broken snapshot", zap.String("path", f), zap.Error(err))
+		}
 	}
 }
 
@@ -85,18 +116,26 @@ func (s *Snapshotter) save(snapshot *raftpb.Snapshot) error {
 	}
 	snapMarshallingSec.Observe(time.Since(start).Seconds())
 
-	spath := filepath.Join(s.dir, fname)
+	finalPath := filepath.Join(s.dir, fname)
+	tmpPath := finalPath + ".tmp"
 
 	fsyncStart := time.Now()
-	err = pioutil.WriteAndSyncFile(spath, d, 0o666)
+	err = pioutil.WriteAndSyncFile(tmpPath, d, 0o666)
 	snapFsyncSec.Observe(time.Since(fsyncStart).Seconds())
 
 	if err != nil {
-		s.lg.Warn("failed to write a snap file", zap.String("path", spath), zap.Error(err))
-		rerr := os.Remove(spath)
-		if rerr != nil {
-			s.lg.Warn("failed to remove a broken snap file", zap.String("path", spath), zap.Error(rerr))
-		}
+		s.lg.Warn("failed to write a temp snap file", zap.String("path", tmpPath), zap.Error(err))
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		s.lg.Warn("failed to rename temp snap file",
+			zap.String("tmp-path", tmpPath),
+			zap.String("final-path", finalPath),
+			zap.Error(err),
+		)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 

--- a/tests/e2e/reproduce_20732_test.go
+++ b/tests/e2e/reproduce_20732_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// TestIssue20732 reproduces etcd-io/etcd#20732 where repeated crashes during
+// snapshot creation could accumulate *.snap.broken files and exhaust disk space.
+func TestIssue20732(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	ctx := t.Context()
+
+	cfg := e2e.NewConfig(
+		e2e.WithClusterSize(1),
+		e2e.WithSnapshotCount(1), // snapshot very frequently
+		e2e.WithKeepDataDir(true),
+		e2e.WithLogLevel("debug"),
+	)
+
+	epc, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(cfg))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, epc.Close())
+	}()
+
+	proc := epc.Procs[0]
+
+	t.Log("Step 1: Repeatedly trigger snapshot and crash etcd")
+
+	for round := 0; round < 5; round++ {
+		t.Logf("Round %d: write data to trigger snapshot", round)
+
+		for i := 0; i < 10; i++ {
+			_, err := proc.Etcdctl().Put(
+				ctx,
+				fmt.Sprintf("key-%d-%d", round, i),
+				"value",
+				config.PutOptions{},
+			)
+			require.NoError(t, err)
+		}
+
+		t.Log("Killing etcd process abruptly")
+		require.NoError(t, proc.Kill())
+
+		t.Log("Restarting etcd with same data-dir")
+		require.NoError(t, proc.Restart(ctx))
+	}
+
+	t.Log("Step 2: Verify broken snapshots do not accumulate")
+
+	snapDir := filepath.Join(
+		proc.Config().DataDirPath,
+		"member",
+		"snap",
+	)
+
+	broken, err := filepath.Glob(filepath.Join(snapDir, "*.snap.broken"))
+	require.NoError(t, err)
+
+	require.LessOrEqual(
+		t,
+		len(broken),
+		1,
+		"expected at most one broken snapshot, found %d: %v",
+		len(broken),
+		broken,
+	)
+}


### PR DESCRIPTION
## Problem

etcd writes snapshots directly to the final `.snap` file_toggle during snapshot creation. If the process crashes or is killed while writing the snapshot, a partially written file can be left behind. On the next startup, such files are renamed to `.snap.broken` and never cleaned up, allowing broken snapshots to accumulate indefinitely and eventually exhaust disk space.

## Solution

This PR improves snapshot robustness by:
- Writing snapshots to a temporary file and atomically renaming it to the final `.snap` file on success.
- Removing temporary files on failure.
- Cleaning up stale `.snap.broken` files on startup, keeping only the most recent one to avoid unbounded disk usage.

## Impact

- Prevents creation of new broken snapshot files.
- Avoids disk exhaustion caused by repeated crashes during snapshot creation.
- Improves etcd resilience under disk pressure and frequent restarts.

## Tests

- Existing snapshotter tests pass.
- Snapshot writing path validated with atomic rename semantics.

Fixes #20732
