### PR TITLE
pkg: fix revive unexported-return in flags and wait

### DIFF
--- a/pkg/flags/uint32.go
+++ b/pkg/flags/uint32.go
@@ -19,27 +19,27 @@ import (
 	"strconv"
 )
 
-type uint32Value uint32
+type Uint32Value uint32
 
 // NewUint32Value creates an uint32 instance with the provided value.
-func NewUint32Value(v uint32) *uint32Value {
-	val := new(uint32Value)
-	*val = uint32Value(v)
+func NewUint32Value(v uint32) *Uint32Value {
+	val := new(Uint32Value)
+	*val = Uint32Value(v)
 	return val
 }
 
 // Set parses a command line uint32 value.
 // Implements "flag.Value" interface.
-func (i *uint32Value) Set(s string) error {
+func (i *Uint32Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 32)
-	*i = uint32Value(v)
+	*i = Uint32Value(v)
 	return err
 }
 
-func (i *uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 // Uint32FromFlag return the uint32 value of a flag with the given name
 func Uint32FromFlag(fs *flag.FlagSet, name string) uint32 {
-	val := *fs.Lookup(name).Value.(*uint32Value)
+	val := *fs.Lookup(name).Value.(*Uint32Value)
 	return uint32(val)
 }

--- a/pkg/flags/uint32_test.go
+++ b/pkg/flags/uint32_test.go
@@ -52,7 +52,7 @@ func TestUint32Value(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var val uint32Value
+			var val Uint32Value
 			err := val.Set(tc.s)
 
 			if tc.expectError {

--- a/pkg/wait/wait_time.go
+++ b/pkg/wait/wait_time.go
@@ -29,17 +29,17 @@ var closec chan struct{}
 
 func init() { closec = make(chan struct{}); close(closec) }
 
-type timeList struct {
+type TimeList struct {
 	l                   sync.Mutex
 	lastTriggerDeadline uint64
 	m                   map[uint64]chan struct{}
 }
 
-func NewTimeList() *timeList {
-	return &timeList{m: make(map[uint64]chan struct{})}
+func NewTimeList() *TimeList {
+	return &TimeList{m: make(map[uint64]chan struct{})}
 }
 
-func (tl *timeList) Wait(deadline uint64) <-chan struct{} {
+func (tl *TimeList) Wait(deadline uint64) <-chan struct{} {
 	tl.l.Lock()
 	defer tl.l.Unlock()
 	if tl.lastTriggerDeadline >= deadline {
@@ -53,7 +53,7 @@ func (tl *timeList) Wait(deadline uint64) <-chan struct{} {
 	return ch
 }
 
-func (tl *timeList) Trigger(deadline uint64) {
+func (tl *TimeList) Trigger(deadline uint64) {
 	tl.l.Lock()
 	defer tl.l.Unlock()
 	tl.lastTriggerDeadline = deadline


### PR DESCRIPTION
This PR fixes revive `unexported-return` lint violations in the pkg module.

Changes:
- Exported the concrete types returned by exported constructors in:
  - pkg/flags
  - pkg/wait
- Updated internal references accordingly.
- Ensured revive passes for the affected packages.
- Verified unit, integration, release, and e2e tests pass locally.

This follows the incremental cleanup approach discussed in #18370.
