### PR TITLE
[Draft] Range-free Compaction

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -366,6 +366,7 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 	mvccStoreConfig := mvcc.StoreConfig{
 		CompactionBatchLimit:    cfg.CompactionBatchLimit,
 		CompactionSleepInterval: cfg.CompactionSleepInterval,
+		CompactionRangeFree:     srv.FeatureEnabled(features.RangeFreeCompaction),
 	}
 	srv.kv = mvcc.New(srv.Logger(), srv.be, srv.lessor, mvccStoreConfig)
 	srv.corruptionChecker = newCorruptionChecker(cfg.Logger, srv, srv.kv.HashStorage())

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -79,6 +79,9 @@ const (
 	// beta: v3.7
 	// main PR: https://github.com/etcd-io/etcd/pull/20589
 	FastLeaseKeepAlive featuregate.Feature = "FastLeaseKeepAlive"
+
+	// RangeFreeCompaction enables etcdserver to compact wihtout iterating over db.
+	RangeFreeCompaction featuregate.Feature = "RangeFreeCompaction"
 )
 
 var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -90,6 +93,7 @@ var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LeaseCheckpointPersist:       {Default: false, PreRelease: featuregate.Alpha},
 	SetMemberLocalAddr:           {Default: false, PreRelease: featuregate.Alpha},
 	FastLeaseKeepAlive:           {Default: true, PreRelease: featuregate.Beta},
+	RangeFreeCompaction:          {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func NewDefaultServerFeatureGate(name string, lg *zap.Logger) featuregate.FeatureGate {

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -640,7 +640,7 @@ func TestIndexCompactAndKeep(t *testing.T) {
 			j = int64(len(afterCompacts)) - 1
 		}
 
-		am := ti.Compact(i)
+		am, _ := ti.Compact(i)
 		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
 
 		keep := ti.Keep(i)
@@ -663,7 +663,7 @@ func TestIndexCompactAndKeep(t *testing.T) {
 			j = int64(len(afterCompacts)) - 1
 		}
 
-		am := ti.Compact(i)
+		am, _ := ti.Compact(i)
 		require.Equalf(t, afterCompacts[j].compacted, am, "#%d: compact(%d) != expected", i, i)
 
 		keep := ti.Keep(i)

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -17,6 +17,7 @@ package mvcc
 import (
 	"encoding/binary"
 	"fmt"
+	"sort"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -27,7 +28,7 @@ import (
 
 func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyValueHash, error) {
 	totalStart := time.Now()
-	keep := s.kvindex.Compact(compactMainRev)
+	keep, _ := s.kvindex.Compact(compactMainRev)
 	indexCompactionPauseMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
 
 	totalStart = time.Now()
@@ -97,4 +98,125 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 			return KeyValueHash{}, fmt.Errorf("interrupted due to stop signal")
 		}
 	}
+}
+
+func (s *store) scheduleCompactionRangeFree(compactMainRev, prevCompactRev int64) (KeyValueHash, error) {
+	totalStart := time.Now()
+	// Use Compact to get revisions to delete and perform index compaction
+	keep, toDelete := s.kvindex.Compact(compactMainRev)
+	indexCompactionPauseMs.Observe(float64(time.Since(totalStart) / time.Millisecond))
+
+	totalStart = time.Now()
+	defer func() { dbCompactionTotalMs.Observe(float64(time.Since(totalStart) / time.Millisecond)) }()
+	keyCompactions := 0
+	defer func() { dbCompactionKeysCounter.Add(float64(keyCompactions)) }()
+	defer func() { dbCompactionLast.Set(float64(time.Now().Unix())) }()
+
+	batchNum := s.cfg.CompactionBatchLimit
+	h := newKVHasher(prevCompactRev, compactMainRev, keep)
+
+	// Convert toDelete map to sorted slice for deterministic iteration
+	revs := make([]Revision, 0, len(toDelete))
+	for rev := range toDelete {
+		revs = append(revs, rev)
+	}
+	// Sort revisions by main and sub revision
+	sort.Slice(revs, func(i, j int) bool {
+		if revs[i].Main != revs[j].Main {
+			return revs[i].Main < revs[j].Main
+		}
+		return revs[i].Sub < revs[j].Sub
+	})
+
+	// Start a goroutine to compute hash in parallel using ReadTx
+	kvHashCh := make(chan KeyValueHash, 1)
+	// The underlying bbolt read tx should be able to see all the revisions at the moment,
+	// including the revisions that will be deleted in compaction.
+	readTx := s.b.ReadTx()
+	readTx.RLock()
+	go func(ch chan<- KeyValueHash) {
+		defer readTx.RUnlock()
+		end := make([]byte, 8)
+		binary.BigEndian.PutUint64(end, uint64(compactMainRev+1))
+		last := make([]byte, 8+1+8)
+
+		for {
+			keys, values := readTx.UnsafeRange(schema.Key, last, end, int64(batchNum))
+
+			for i := range keys {
+				h.WriteKeyValue(keys[i], values[i])
+			}
+
+			// last batch
+			if len(keys) < batchNum {
+				break
+			}
+
+			// update last
+			rev := BytesToRev(keys[len(keys)-1])
+			last = RevToBytes(Revision{Main: rev.Main, Sub: rev.Sub + 1}, last)
+			readTx = s.b.ReadTx()
+		}
+
+		ch <- h.Hash()
+	}(kvHashCh)
+
+	// Process deletions in batches
+	deletedCount := 0
+	start := time.Now()
+	tx := s.b.BatchTx()
+	tx.LockOutsideApply()
+	// gofail: var compactAfterAcquiredBatchTxLock struct{}
+	keyBytes := make([]byte, 8+1+8)
+
+	for _, rev := range revs {
+		// Delete the revision directly
+		RevToBytes(rev, keyBytes)
+		tx.UnsafeDelete(schema.Key, keyBytes)
+		keyCompactions++
+		deletedCount++
+
+		// Commit in batches
+		if deletedCount%batchNum == 0 {
+			tx.Unlock()
+			// gofail: var compactBeforeCommitBatch struct{}
+			s.b.ForceCommit()
+			// gofail: var compactAfterCommitBatch struct{}
+			dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
+
+			select {
+			case <-time.After(s.cfg.CompactionSleepInterval):
+			case <-s.stopc:
+				return KeyValueHash{}, fmt.Errorf("interrupted due to stop signal")
+			}
+
+			// Start a new batch
+			start = time.Now()
+			tx = s.b.BatchTx()
+			tx.LockOutsideApply()
+		}
+	}
+
+	// gofail: var compactBeforeSetFinishedCompact struct{}
+	UnsafeSetFinishedCompact(tx, compactMainRev)
+	tx.Unlock()
+	dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
+	// gofail: var compactAfterSetFinishedCompact struct{}
+
+	// Wait for hash computation to complete
+	hash := <-kvHashCh
+
+	size, sizeInUse := s.b.Size(), s.b.SizeInUse()
+	s.lg.Info(
+		"finished scheduled compaction",
+		zap.Int64("compact-revision", compactMainRev),
+		zap.Duration("took", time.Since(totalStart)),
+		zap.Int("number-of-keys-compacted", keyCompactions),
+		zap.Uint32("hash", hash.Hash),
+		zap.Int64("current-db-size-bytes", size),
+		zap.String("current-db-size", humanize.Bytes(uint64(size))),
+		zap.Int64("current-db-size-in-use-bytes", sizeInUse),
+		zap.String("current-db-size-in-use", humanize.Bytes(uint64(sizeInUse))),
+	)
+	return hash, nil
 }


### PR DESCRIPTION
Try to resolve #21284 
This PR introduces a new compaction implementation that parallelly does calculating kvhash and deleting obsolete revision to reduce the time required for etcdserver compaction.

What is changed:
- add a new FeatureGate CompactionRangeFree.
- change interface of Index. The second parameter `map[Revision]struct{}` to return means the set of revisions to delete.
- change `compact` method of `keyIndex`
- add a new `scheduleCompactionRangeFree` method for `*store`

To address the suggestions in the review https://github.com/etcd-io/etcd/issues/21284#issuecomment-3896125745

> In particular, we must ensure that deleted K/V pairs are still included when calculating the hash; otherwise, it may generate false alarms.

Before starting to delete revisions, a new `ReadTx()` is obtained. The underlying bbolt read tx should be able to see all the revisions at that moment, including the revisions that will be deleted in compaction. 

> what happens if the hash calculation triggered by compaction has not finished before the next compaction starts? These edge cases need to be carefully handled.

For the moment, I choose to wait for hash calculation done in the compaction logic, by doing `hash := <-kvHashCh` before returning. So there should not be overlap of different hash calculation.
There certainly is room for optimization. We could make compaction not wait hash calculation finished, and just return a `<-chan KeyValueHash` and let other component wait for the result, for example, HashStorage.