### PR TITLE
Update changelog to cover go version update

### DIFF
--- a/CHANGELOG/CHANGELOG-3.4.md
+++ b/CHANGELOG/CHANGELOG-3.4.md
@@ -1,6 +1,13 @@
 
-
 Previous change logs can be found at [CHANGELOG-3.3](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.3.md).
+
+---
+
+## v3.4.42 (TBC)
+
+### Dependencies
+
+- Compile binaries using [go 1.24.13](https://github.com/etcd-io/etcd/pull/21266).
 
 ---
 

--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -1,6 +1,13 @@
 
-
 Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.4.md).
+
+---
+
+## v3.5.28 (TBC)
+
+### Dependencies
+
+- Compile binaries using [go 1.24.13](https://github.com/etcd-io/etcd/pull/21258).
 
 ---
 

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -1,6 +1,13 @@
 
-
 Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md).
+
+---
+
+## v3.6.9 (TBC)
+
+### Dependencies
+
+- Compile binaries using [go 1.24.13](https://github.com/etcd-io/etcd/pull/21257).
 
 ---
 


### PR DESCRIPTION
- [main](https://github.com/etcd-io/etcd/tree/main): go v1.25.7 - https://github.com/etcd-io/etcd/pull/21256

- [release-3.6](https://github.com/etcd-io/etcd/tree/release-3.6): go v1.24.13 -https://github.com/etcd-io/etcd/pull/21257

- [release-3.5](https://github.com/etcd-io/etcd/tree/release-3.5): go v1.24.13 - https://github.com/etcd-io/etcd/pull/21258

- [release-3.4](https://github.com/etcd-io/etcd/tree/release-3.5): go v1.24.13 - https://github.com/etcd-io/etcd/pull/21266

Link to #21254 

cc @ivanvc @ahrtr 