### PR TITLE
fix: use require.Eventually for metric checks in TestV3LeaseKeepAliveForwardingCatchError

### DIFF
--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -427,7 +427,9 @@ func TestV3LeaseKeepAliveForwardingCatchError(t *testing.T) {
 		require.Equal(t, rpctypes.ErrNoLeader.Error(), rpctypes.ErrorDesc(err))
 		// Skip metric check in proxy mode - metrics are recorded on the proxy, not the etcd server.
 		if !integration.ThroughProxy {
-			require.Equal(t, prevUnavailableCount+1, getLeaseKeepAliveMetric(t, follower, "Unavailable"))
+			require.Eventually(t, func() bool {
+				return getLeaseKeepAliveMetric(t, follower, "Unavailable") == prevUnavailableCount+1
+			}, 3*time.Second, 100*time.Millisecond)
 		}
 	})
 
@@ -462,7 +464,9 @@ func TestV3LeaseKeepAliveForwardingCatchError(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled)
 		} else {
 			require.Equal(t, rpctypes.ErrNoLeader.Error(), rpctypes.ErrorDesc(err))
-			require.Equal(t, prevUnavailableCount+1, getLeaseKeepAliveMetric(t, follower, "Unavailable"))
+			require.Eventually(t, func() bool {
+				return getLeaseKeepAliveMetric(t, follower, "Unavailable") == prevUnavailableCount+1
+			}, 3*time.Second, 100*time.Millisecond)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes a flaky test in `TestV3LeaseKeepAliveForwardingCatchError` by replacing `require.Equal` with `require.Eventually` for metric validation checks.

## Problem

The test was flaky due to a race condition between:
1. The gRPC server recording the `Unavailable` metric (asynchronously)
2. The test checking the metric value immediately after receiving the error response (synchronously)

The `grpc_server_handled_total` metric is updated after the RPC completes on the server side, but the client receives the error response before the metric is fully recorded.

## Solution

This change replaces `require.Equal` with `require.Eventually` (with 3s timeout and 100ms polling interval) for both affected subtests:
- `catches_NoLeader_error_with_WithRequireLeader`
- `catches_NoLeader_error_without_WithRequireLeader`

This pattern is already used in similar tests in the same file (`client_cancels_while_forwarding` and `forwarding_times_out`).

## Test Results

All tests pass locally with Go 1.26.0:
- ✅ `TestV3LeaseKeepAliveForwardingCatchError/forwarding_succeeds`
- ✅ `TestV3LeaseKeepAliveForwardingCatchError/catches_NoLeader_error_with_WithRequireLeader`
- ✅ `TestV3LeaseKeepAliveForwardingCatchError/catches_NoLeader_error_without_WithRequireLeader`
- ✅ All other `TestV3Lease*` tests

Fixes #21308