### PR TITLE
etcdserver: optimize range request with KEY ASCEND sorting

### DIFF
--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -17,6 +17,7 @@ package txn
 import (
 	"bytes"
 	"context"
+	"math"
 	"sort"
 	"time"
 
@@ -67,17 +68,26 @@ func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *
 
 func rangeLimit(r *pb.RangeRequest) int64 {
 	limit := r.Limit
-	if r.SortOrder != pb.RangeRequest_NONE ||
-		r.MinModRevision != 0 || r.MaxModRevision != 0 ||
-		r.MinCreateRevision != 0 || r.MaxCreateRevision != 0 {
-		// fetch everything; sort and truncate afterwards
+	if !isDefaultOrdering(r.SortTarget, r.SortOrder) || hasRevisionFilters(r) {
 		limit = 0
 	}
-	if limit > 0 {
-		// fetch one extra for 'more' flag
+	if limit > 0 && limit < math.MaxInt64 {
 		limit = limit + 1
 	}
 	return limit
+}
+
+func isDefaultOrdering(sortTarget pb.RangeRequest_SortTarget, sortOrder pb.RangeRequest_SortOrder) bool {
+	// Since current mvcc.Range implementation returns results
+	// sorted by keys in lexiographically ascending order,
+	// don't re-sort when target is 'KEY' and order is ASCEND
+	return sortOrder == pb.RangeRequest_NONE ||
+		(sortTarget == pb.RangeRequest_KEY && sortOrder == pb.RangeRequest_ASCEND)
+}
+
+func hasRevisionFilters(r *pb.RangeRequest) bool {
+	return r.MinModRevision != 0 || r.MaxModRevision != 0 ||
+		r.MinCreateRevision != 0 || r.MaxCreateRevision != 0
 }
 
 func filterRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest) {
@@ -102,17 +112,10 @@ func filterRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest) {
 func sortRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest, lg *zap.Logger) {
 	sortOrder := r.SortOrder
 	if r.SortTarget != pb.RangeRequest_KEY && sortOrder == pb.RangeRequest_NONE {
-		// Since current mvcc.Range implementation returns results
-		// sorted by keys in lexiographically ascending order,
-		// sort ASCEND by default only when target is not 'KEY'
 		sortOrder = pb.RangeRequest_ASCEND
-	} else if r.SortTarget == pb.RangeRequest_KEY && sortOrder == pb.RangeRequest_ASCEND {
-		// Since current mvcc.Range implementation returns results
-		// sorted by keys in lexiographically ascending order,
-		// don't re-sort when target is 'KEY' and order is ASCEND
-		sortOrder = pb.RangeRequest_NONE
 	}
-	if sortOrder != pb.RangeRequest_NONE {
+
+	if !isDefaultOrdering(r.SortTarget, sortOrder) {
 		var sorter sort.Interface
 		switch {
 		case r.SortTarget == pb.RangeRequest_KEY:


### PR DESCRIPTION

This PR optimizes range request handling by passing the limit to the backend when sorting by key in ascending order, as the backend already returns keys in this order. This avoids fetching all keys and then truncating in memory.

```
goos: windows
goarch: amd64
pkg: go.etcd.io/etcd/server/v3/etcdserver/txn
cpu: Intel(R) Core(TM) 5 120U

                                            │        old.txt        │              new.txt               │
                                            │         sec/op        │   sec/op      vs base              │
--------------------------------------------------------------------------------------------------------
RangeLimitOptimization/KeyAscendLimit100_10k/Old       3.056m ± 0%       26.93μ ± 0%   -99.12% (p=0.000)
RangeLimitOptimization/KeyAscendLimit100_100k/Old     16.639m ± 0%       27.11μ ± 0%   -99.84% (p=0.000)
RangeLimitOptimization/KeyAscendLimit100_1m/Old     168.512m ± 0%       25.22μ ± 0%   -99.99% (p=0.000)
RangeLimitOptimization/KeyAscendLimit1000_10k/Old     2.412m ± 0%      256.44μ ± 0%   -89.37% (p=0.000)
geomean                                        14.274m              49.52μ         -99.65%
```

Closes #20745
