### PR TITLE
docs: mark Kubernetes etcd image build step as deprecated

### DIFF
--- a/Documentation/contributor-guide/bump_etcd_version_k8s.md
+++ b/Documentation/contributor-guide/bump_etcd_version_k8s.md
@@ -53,6 +53,8 @@ You can refer to the guide [here](https://github.com/kubernetes/community/blob/m
 
 ### Build etcd image
 
+> **Deprecated:** Kubernetes now uses the officially released etcd images, and does not require building the legacy image from `cluster/images/etcd` for normal version bumps. This section is kept for reference until that legacy path is removed from the Kubernetes repository.
+>
 > Reference: [link 1](https://github.com/kubernetes/kubernetes/pull/131105) [link 2](https://github.com/kubernetes/kubernetes/pull/131126)
 
 1. In `build/dependencies.yaml`, update the `version` of `etcd-image` to the new version. Update `golang: etcd release version` if necessary.


### PR DESCRIPTION
Addresses etcd-io/etcd#20945.

The `Build etcd image` subsection in `Documentation/contributor-guide/bump_etcd_version_k8s.md` documents a legacy flow based on `kubernetes/kubernetes/cluster/images/etcd`.

Kubernetes now uses the officially released etcd images, so this step is no longer required for normal version bumps. This PR keeps the content, but clearly marks it as deprecated until the legacy path is removed upstream.