### PR TITLE
tests: migrate ctl_v3_kv_test.go to common testing framework

### DIFF
--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -15,12 +15,10 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,22 +27,11 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestCtlV3PutTimeout(t *testing.T) { testCtl(t, putTest, withDefaultDialTimeout()) }
 func TestCtlV3PutClientTLSFlagByEnv(t *testing.T) {
 	testCtl(t, putTest, withCfg(*e2e.NewConfigClientTLS()), withFlagByEnv())
 }
-func TestCtlV3PutIgnoreValue(t *testing.T) { testCtl(t, putTestIgnoreValue) }
-func TestCtlV3PutIgnoreLease(t *testing.T) { testCtl(t, putTestIgnoreLease) }
 
-func TestCtlV3GetTimeout(t *testing.T) { testCtl(t, getTest, withDefaultDialTimeout()) }
-
-func TestCtlV3GetFormat(t *testing.T)             { testCtl(t, getFormatTest) }
-func TestCtlV3GetRev(t *testing.T)                { testCtl(t, getRevTest) }
-func TestCtlV3GetMinMaxCreateModRev(t *testing.T) { testCtl(t, getMinMaxCreateModRevTest) }
-func TestCtlV3GetKeysOnly(t *testing.T)           { testCtl(t, getKeysOnlyTest) }
-func TestCtlV3GetCountOnly(t *testing.T)          { testCtl(t, getCountOnlyTest) }
-
-func TestCtlV3DelTimeout(t *testing.T) { testCtl(t, delTest, withDefaultDialTimeout()) }
+func TestCtlV3GetFormat(t *testing.T) { testCtl(t, getFormatTest) }
 
 func TestCtlV3TimeoutWhenNoProcessListensOnEndpoint(t *testing.T) {
 	e2e.BeforeTest(t)
@@ -135,74 +122,6 @@ func putTest(cx ctlCtx) {
 	}
 }
 
-func putTestIgnoreValue(cx ctlCtx) {
-	require.NoError(cx.t, ctlV3Put(cx, "foo", "bar", ""))
-	require.NoError(cx.t, ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}))
-	require.NoError(cx.t, ctlV3Put(cx, "foo", "", "", "--ignore-value"))
-	require.NoError(cx.t, ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}))
-}
-
-func putTestIgnoreLease(cx ctlCtx) {
-	leaseID, err := ctlV3LeaseGrant(cx, 10)
-	if err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3LeaseGrant error (%v)", err)
-	}
-	if err := ctlV3Put(cx, "foo", "bar", leaseID); err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3Put error (%v)", err)
-	}
-	if err := ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar"}); err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3Get error (%v)", err)
-	}
-	if err := ctlV3Put(cx, "foo", "bar1", "", "--ignore-lease"); err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3Put error (%v)", err)
-	}
-	if err := ctlV3Get(cx, []string{"foo"}, kv{"foo", "bar1"}); err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3Get error (%v)", err)
-	}
-	if err := ctlV3LeaseRevoke(cx, leaseID); err != nil {
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3LeaseRevok error (%v)", err)
-	}
-	if err := ctlV3Get(cx, []string{"key"}); err != nil { // expect no output
-		cx.t.Fatalf("putTestIgnoreLease: ctlV3Get error (%v)", err)
-	}
-}
-
-func getTest(cx ctlCtx) {
-	var (
-		kvs    = []kv{{"key1", "val1"}, {"key2", "val2"}, {"key3", "val3"}}
-		revkvs = []kv{{"key3", "val3"}, {"key2", "val2"}, {"key1", "val1"}}
-	)
-	for i := range kvs {
-		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
-			cx.t.Fatalf("getTest #%d: ctlV3Put error (%v)", i, err)
-		}
-	}
-
-	tests := []struct {
-		args []string
-
-		wkv []kv
-	}{
-		{[]string{"key1"}, []kv{{"key1", "val1"}}},
-		{[]string{"", "--prefix"}, kvs},
-		{[]string{"", "--from-key"}, kvs},
-		{[]string{"key", "--prefix"}, kvs},
-		{[]string{"key", "--prefix", "--limit=2"}, kvs[:2]},
-		{[]string{"key", "--prefix", "--order=ASCEND", "--sort-by=MODIFY"}, kvs},
-		{[]string{"key", "--prefix", "--order=ASCEND", "--sort-by=VERSION"}, kvs},
-		{[]string{"key", "--prefix", "--sort-by=CREATE"}, kvs}, // ASCEND by default
-		{[]string{"key", "--prefix", "--order=DESCEND", "--sort-by=CREATE"}, revkvs},
-		{[]string{"key", "--prefix", "--order=DESCEND", "--sort-by=KEY"}, revkvs},
-	}
-	for i, tt := range tests {
-		if err := ctlV3Get(cx, tt.args, tt.wkv...); err != nil {
-			if cx.dialTimeout > 0 && !isGRPCTimedout(err) {
-				cx.t.Errorf("getTest #%d: ctlV3Get error (%v)", i, err)
-			}
-		}
-	}
-}
-
 func getFormatTest(cx ctlCtx) {
 	require.NoError(cx.t, ctlV3Put(cx, "abc", "123", ""))
 
@@ -230,151 +149,6 @@ func getFormatTest(cx ctlCtx) {
 			cx.t.Errorf("#%d: error (%v)", i, err)
 		}
 		assert.Contains(cx.t, strings.Join(lines, "\n"), tt.wstr)
-	}
-}
-
-func getRevTest(cx ctlCtx) {
-	kvs := []kv{{"key", "val1"}, {"key", "val2"}, {"key", "val3"}}
-	for i := range kvs {
-		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
-			cx.t.Fatalf("getRevTest #%d: ctlV3Put error (%v)", i, err)
-		}
-	}
-
-	tests := []struct {
-		args []string
-
-		wkv []kv
-	}{
-		{[]string{"key", "--rev", "2"}, kvs[:1]},
-		{[]string{"key", "--rev", "3"}, kvs[1:2]},
-		{[]string{"key", "--rev", "4"}, kvs[2:]},
-	}
-
-	for i, tt := range tests {
-		if err := ctlV3Get(cx, tt.args, tt.wkv...); err != nil {
-			cx.t.Errorf("getTest #%d: ctlV3Get error (%v)", i, err)
-		}
-	}
-}
-
-func getMinMaxCreateModRevTest(cx ctlCtx) {
-	kvs := []kv{ //     revision:   store | key create | key modify
-		{"key1", "val1"}, //     2         2           2
-		{"key2", "val2"}, //     3         3           3
-		{"key1", "val3"}, //     4         2           4
-		{"key4", "val4"}, //     5         5           5
-	}
-	for i := range kvs {
-		if err := ctlV3Put(cx, kvs[i].key, kvs[i].val, ""); err != nil {
-			cx.t.Fatalf("getRevTest #%d: ctlV3Put error (%v)", i, err)
-		}
-	}
-
-	tests := []struct {
-		args []string
-
-		wkv []kv
-	}{
-		{[]string{"key", "--prefix", "--max-create-rev", "3"}, []kv{kvs[1], kvs[2]}},
-		{[]string{"key", "--prefix", "--min-create-rev", "3"}, []kv{kvs[1], kvs[3]}},
-		{[]string{"key", "--prefix", "--max-mod-rev", "3"}, []kv{kvs[1]}},
-		{[]string{"key", "--prefix", "--min-mod-rev", "4"}, kvs[2:]},
-	}
-
-	for i, tt := range tests {
-		if err := ctlV3Get(cx, tt.args, tt.wkv...); err != nil {
-			cx.t.Errorf("getMinModRevTest #%d: ctlV3Get error (%v)", i, err)
-		}
-	}
-}
-
-func getKeysOnlyTest(cx ctlCtx) {
-	require.NoError(cx.t, ctlV3Put(cx, "key", "val", ""))
-	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--keys-only", "key"}...)
-	require.NoError(cx.t, e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "key"})
-	require.NoError(cx.t, err)
-	require.NotContainsf(cx.t, lines, "val", "got value but passed --keys-only")
-}
-
-func getCountOnlyTest(cx ctlCtx) {
-	cmdArgs := append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 0"}))
-	require.NoError(cx.t, ctlV3Put(cx, "key", "val", ""))
-	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 1"}))
-	require.NoError(cx.t, ctlV3Put(cx, "key1", "val", ""))
-	require.NoError(cx.t, ctlV3Put(cx, "key1", "val", ""))
-	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 2"}))
-	require.NoError(cx.t, ctlV3Put(cx, "key2", "val", ""))
-	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key", "--prefix", "--write-out=fields"}...)
-	require.NoError(cx.t, e2e.SpawnWithExpects(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\" : 3"}))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	cmdArgs = append(cx.PrefixArgs(), []string{"get", "--count-only", "key3", "--prefix", "--write-out=fields"}...)
-	lines, err := e2e.SpawnWithExpectLines(ctx, cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "\"Count\""})
-	require.NoError(cx.t, err)
-	require.NotContains(cx.t, lines, "\"Count\" : 3")
-}
-
-func delTest(cx ctlCtx) {
-	tests := []struct {
-		puts []kv
-		args []string
-
-		deletedNum int
-	}{
-		{ // delete all keys
-			[]kv{{"foo1", "bar"}, {"foo2", "bar"}, {"foo3", "bar"}},
-			[]string{"", "--prefix"},
-			3,
-		},
-		{ // delete all keys
-			[]kv{{"foo1", "bar"}, {"foo2", "bar"}, {"foo3", "bar"}},
-			[]string{"", "--from-key"},
-			3,
-		},
-		{
-			[]kv{{"this", "value"}},
-			[]string{"that"},
-			0,
-		},
-		{
-			[]kv{{"sample", "value"}},
-			[]string{"sample"},
-			1,
-		},
-		{
-			[]kv{{"key1", "val1"}, {"key2", "val2"}, {"key3", "val3"}},
-			[]string{"key", "--prefix"},
-			3,
-		},
-		{
-			[]kv{{"zoo1", "bar"}, {"zoo2", "bar2"}, {"zoo3", "bar3"}},
-			[]string{"zoo1", "--from-key"},
-			3,
-		},
-	}
-
-	for i, tt := range tests {
-		for j := range tt.puts {
-			if err := ctlV3Put(cx, tt.puts[j].key, tt.puts[j].val, ""); err != nil {
-				cx.t.Fatalf("delTest #%d-%d: ctlV3Put error (%v)", i, j, err)
-			}
-		}
-		if err := ctlV3Del(cx, tt.args, tt.deletedNum); err != nil {
-			if cx.dialTimeout > 0 && !isGRPCTimedout(err) {
-				cx.t.Fatalf("delTest #%d: ctlV3Del error (%v)", i, err)
-			}
-		}
 	}
 }
 

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -152,26 +152,10 @@ func getFormatTest(cx ctlCtx) {
 	}
 }
 
-func ctlV3Put(cx ctlCtx, key, value, leaseID string, flags ...string) error {
-	skipValue := false
-	skipLease := false
-	for _, f := range flags {
-		if f == "--ignore-value" {
-			skipValue = true
-		}
-		if f == "--ignore-lease" {
-			skipLease = true
-		}
-	}
-	cmdArgs := append(cx.PrefixArgs(), "put", key)
-	if !skipValue {
-		cmdArgs = append(cmdArgs, value)
-	}
-	if leaseID != "" && !skipLease {
+func ctlV3Put(cx ctlCtx, key, value, leaseID string) error {
+	cmdArgs := append(cx.PrefixArgs(), "put", key, value)
+	if leaseID != "" {
 		cmdArgs = append(cmdArgs, "--lease", leaseID)
-	}
-	if len(flags) != 0 {
-		cmdArgs = append(cmdArgs, flags...)
 	}
 	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: "OK"})
 }

--- a/tests/e2e/ctl_v3_kv_test.go
+++ b/tests/e2e/ctl_v3_kv_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -145,8 +145,3 @@ func ctlV3LeaseKeepAlive(cx ctlCtx, leaseID string) error {
 	}
 	return proc.Stop()
 }
-
-func ctlV3LeaseRevoke(cx ctlCtx, leaseID string) error {
-	cmdArgs := append(cx.PrefixArgs(), "lease", "revoke", leaseID)
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: fmt.Sprintf("lease %s revoked", leaseID)})
-}

--- a/tests/e2e/ctl_v3_lease_test.go
+++ b/tests/e2e/ctl_v3_lease_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 

--- a/tests/framework/config/client.go
+++ b/tests/framework/config/client.go
@@ -46,8 +46,10 @@ type GetOptions struct {
 }
 
 type PutOptions struct {
-	LeaseID clientv3.LeaseID
-	Timeout time.Duration
+	LeaseID     clientv3.LeaseID
+	Timeout     time.Duration
+	IgnoreValue bool
+	IgnoreLease bool
 }
 
 type DeleteOptions struct {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -227,9 +227,16 @@ func parseFieldsGetResponse(lines []string) (*clientv3.GetResponse, error) {
 func (ctl *EtcdctlV3) Put(ctx context.Context, key, value string, opts config.PutOptions) (*clientv3.PutResponse, error) {
 	resp := clientv3.PutResponse{}
 	args := []string{}
-	args = append(args, "put", key, value)
-	if opts.LeaseID != 0 {
+	if opts.IgnoreValue {
+		args = append(args, "put", key, "--ignore-value")
+	} else {
+		args = append(args, "put", key, value)
+	}
+	if opts.LeaseID != 0 && !opts.IgnoreLease {
 		args = append(args, "--lease", strconv.FormatInt(int64(opts.LeaseID), 16))
+	}
+	if opts.IgnoreLease {
+		args = append(args, "--ignore-lease")
 	}
 	if opts.Timeout != 0 {
 		args = append(args, fmt.Sprintf("--command-timeout=%s", opts.Timeout))

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -240,8 +240,14 @@ func (c integrationClient) Put(ctx context.Context, key, value string, opts conf
 		defer cancel()
 	}
 	var clientOpts []clientv3.OpOption
-	if opts.LeaseID != 0 {
+	if opts.LeaseID != 0 && !opts.IgnoreLease {
 		clientOpts = append(clientOpts, clientv3.WithLease(opts.LeaseID))
+	}
+	if opts.IgnoreValue {
+		clientOpts = append(clientOpts, clientv3.WithIgnoreValue())
+	}
+	if opts.IgnoreLease {
+		clientOpts = append(clientOpts, clientv3.WithIgnoreLease())
 	}
 	return c.Client.Put(ctx, key, value, clientOpts...)
 }


### PR DESCRIPTION
## Summary
- Migrate `PutIgnoreValue`, `PutIgnoreLease`, `Get` (with rev, keys-only, count-only, min/max create/mod rev), and `Delete` tests from `tests/e2e/ctl_v3_kv_test.go` to the common testing framework in `tests/common/kv_test.go`
- Add `IgnoreValue` and `IgnoreLease` fields to `config.PutOptions` and implement support in both e2e (etcdctl) and integration client backends
- Retain e2e-specific tests (`GetFormat`, `GetRevokedCRL`, `PutClientTLSFlagByEnv`) that depend on etcdctl output format or TLS-specific behavior

## Test plan
- [x] Verify `TestKVPutIgnoreValue` passes with both `e2e` and `integration` build tags
- [x] Verify `TestKVPutIgnoreLease` passes with both `e2e` and `integration` build tags
- [x] Verify remaining e2e-specific tests (`TestCtlV3GetFormat`, `TestCtlV3GetRevokedCRL`, `TestCtlV3PutClientTLSFlagByEnv`) still pass
- [x] Verify existing common tests (`TestKVPut`, `TestKVGet`, `TestKVDelete`) are unaffected

Fixes #20550