### PR TITLE
[release-3.5] server/etcdserver/api/v3rpc: run metrics interceptors before handlers

### DIFF
--- a/server/etcdserver/api/v3rpc/grpc.go
+++ b/server/etcdserver/api/v3rpc/grpc.go
@@ -44,16 +44,16 @@ func Server(s *etcdserver.EtcdServer, tls *tls.Config, interceptor grpc.UnarySer
 	}
 	chainUnaryInterceptors := []grpc.UnaryServerInterceptor{
 		newLogUnaryInterceptor(s),
-		newUnaryInterceptor(s),
 		grpc_prometheus.UnaryServerInterceptor,
+		newUnaryInterceptor(s),
 	}
 	if interceptor != nil {
 		chainUnaryInterceptors = append(chainUnaryInterceptors, interceptor)
 	}
 
 	chainStreamInterceptors := []grpc.StreamServerInterceptor{
-		newStreamInterceptor(s),
 		grpc_prometheus.StreamServerInterceptor,
+		newStreamInterceptor(s),
 	}
 
 	if s.Cfg.ExperimentalEnableDistributedTracing {


### PR DESCRIPTION
Followup to https://github.com/etcd-io/etcd/pull/21325#issuecomment-3938503821

Backport https://github.com/etcd-io/etcd/pull/21325 to 3.5

cc @fuweid 
