### PR TITLE
robustness: improve log message for watch Reliable guarantee failures

### DIFF
--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -1467,6 +1467,114 @@ func TestValidateWatch(t *testing.T) {
 			},
 		},
 		{
+			name: "Reliable - event below requested watch revision with prefix - fail",
+			reports: []report.ClientReport{
+				{
+					Watch: []model.WatchOperation{
+						{
+							Request: model.WatchRequest{
+								WithPrefix: true,
+								Revision:   100,
+							},
+							Responses: []model.WatchResponse{
+								{
+									Events: []model.WatchEvent{
+										putWatchEvent("a", "1", 2, true),
+										putWatchEvent("b", "2", 3, true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			persistedRequests: []model.EtcdRequest{
+				putRequest("a", "1"),
+				putRequest("b", "2"),
+			},
+			expectError: errBrokeReliable.Error(),
+		},
+		{
+			name: "Reliable - event below requested watch revision - fail",
+			reports: []report.ClientReport{
+				{
+					Watch: []model.WatchOperation{
+						{
+							Request: model.WatchRequest{
+								Key:      "a",
+								Revision: 100,
+							},
+							Responses: []model.WatchResponse{
+								{
+									Events: []model.WatchEvent{
+										putWatchEvent("a", "1", 2, true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			persistedRequests: []model.EtcdRequest{
+				putRequest("a", "1"),
+			},
+			expectError: errBrokeReliable.Error(),
+		},
+		{
+			name: "Reliable - events at and above requested watch revision with prefix - pass",
+			reports: []report.ClientReport{
+				{
+					Watch: []model.WatchOperation{
+						{
+							Request: model.WatchRequest{
+								WithPrefix: true,
+								Revision:   2,
+							},
+							Responses: []model.WatchResponse{
+								{
+									Events: []model.WatchEvent{
+										putWatchEvent("a", "1", 2, true),
+										putWatchEvent("b", "2", 3, true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			persistedRequests: []model.EtcdRequest{
+				putRequest("a", "1"),
+				putRequest("b", "2"),
+			},
+			expectError: "",
+		},
+		{
+			name: "Reliable - events at and above requested watch revision - pass",
+			reports: []report.ClientReport{
+				{
+					Watch: []model.WatchOperation{
+						{
+							Request: model.WatchRequest{
+								Key:      "a",
+								Revision: 2,
+							},
+							Responses: []model.WatchResponse{
+								{
+									Events: []model.WatchEvent{
+										putWatchEvent("a", "1", 2, true),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			persistedRequests: []model.EtcdRequest{
+				putRequest("a", "1"),
+			},
+			expectError: "",
+		},
+		{
 			name: "Resumable - watch revision from middle event - pass",
 			reports: []report.ClientReport{
 				{


### PR DESCRIPTION
Previously, `errBrokeReliable` made it difficult to diagnose cases where a received event's revision was lower than the revision specified in the watch request. 

This commit adds an explicit detail to the log message clarifying the cause of the failure.

```
logger.go:146: 2026-02-25T23:39:02.437+0800 INFO    Validating watch
logger.go:146: 2026-02-25T23:39:02.437+0800 ERROR   Broke watch guarantee   {"guarantee": "reliable", "client": 19, "detail": "received event below requested watch revision", "event-revision": 381, "request-revision": 1000322}
```