### PR TITLE
robustness: add MemberID to porcupine visualization output

### DIFF
--- a/tests/robustness/model/describe.go
+++ b/tests/robustness/model/describe.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -256,6 +257,13 @@ func describeRangeResponse(request RangeOptions, response RangeResponse) string 
 		return "nil"
 	}
 	return describeValueOrHash(response.KVs[0].Value)
+}
+
+func DescribeOperationMetadata(response MaybeEtcdResponse) string {
+	if response.MemberID != 0 {
+		return fmt.Sprintf("memberID: %s", types.ID(response.MemberID).String())
+	}
+	return ""
 }
 
 func describeValueOrHash(value ValueOrHash) string {

--- a/tests/robustness/model/describe_test.go
+++ b/tests/robustness/model/describe_test.go
@@ -174,3 +174,30 @@ func TestModelDescribe(t *testing.T) {
 		assert.Equal(t, tc.expectDescribe, NonDeterministicModel.DescribeOperation(tc.req, tc.resp))
 	}
 }
+
+func TestDescribeOperationMetadata(t *testing.T) {
+	tcs := []struct {
+		resp           MaybeEtcdResponse
+		expectDescribe string
+	}{
+		{
+			resp:           MaybeEtcdResponse{},
+			expectDescribe: "",
+		},
+		{
+			resp:           MaybeEtcdResponse{EtcdResponse: EtcdResponse{MemberID: 1}},
+			expectDescribe: "memberID: 1",
+		},
+		{
+			resp:           MaybeEtcdResponse{EtcdResponse: EtcdResponse{MemberID: 100}},
+			expectDescribe: "memberID: 64",
+		},
+		{
+			resp:           MaybeEtcdResponse{EtcdResponse: EtcdResponse{MemberID: 255}},
+			expectDescribe: "memberID: ff",
+		},
+	}
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expectDescribe, DescribeOperationMetadata(tc.resp))
+	}
+}

--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -52,6 +52,12 @@ var DeterministicModel = porcupine.Model{
 	DescribeOperation: func(in, out any) string {
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), MaybeEtcdResponse{EtcdResponse: out.(EtcdResponse)}))
 	},
+	DescribeOperationMetadata: func(info any) string {
+		if info == nil {
+			return ""
+		}
+		return DescribeOperationMetadata(MaybeEtcdResponse{EtcdResponse: info.(EtcdResponse)})
+	},
 	DescribeState: func(st any) string {
 		data, err := json.MarshalIndent(st, "", "  ")
 		if err != nil {

--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -198,6 +198,7 @@ func (h *AppendableHistory) appendSuccessful(request EtcdRequest, start, end tim
 		Call:     start.Nanoseconds(),
 		Output:   response,
 		Return:   end.Nanoseconds(),
+		Metadata: response,
 	}
 	h.append(op)
 }
@@ -300,12 +301,14 @@ func (h *AppendableHistory) AppendCompact(rev int64, start, end time.Duration, r
 }
 
 func (h *AppendableHistory) appendFailed(request EtcdRequest, start, end time.Duration, err error) {
+	resp := failedResponse(err)
 	op := porcupine.Operation{
 		ClientId: h.streamID,
 		Input:    request,
 		Call:     start.Nanoseconds(),
-		Output:   failedResponse(err),
+		Output:   resp,
 		Return:   end.Nanoseconds(),
+		Metadata: resp,
 	}
 	isRead := request.IsRead()
 	if !isRead {

--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -41,6 +41,12 @@ var NonDeterministicModel = porcupine.Model{
 	DescribeOperation: func(in, out any) string {
 		return fmt.Sprintf("%s -> %s", describeEtcdRequest(in.(EtcdRequest)), describeEtcdResponse(in.(EtcdRequest), out.(MaybeEtcdResponse)))
 	},
+	DescribeOperationMetadata: func(info any) string {
+		if info == nil {
+			return ""
+		}
+		return DescribeOperationMetadata(info.(MaybeEtcdResponse))
+	},
 	DescribeState: func(st any) string {
 		etcdStates := st.(nonDeterministicState)
 		desc := make([]string, 0, len(etcdStates))

--- a/tests/robustness/report/client.go
+++ b/tests/robustness/report/client.go
@@ -169,6 +169,7 @@ func loadKeyValueOperations(path string) (operations []porcupine.Operation, err 
 			Call:     operation.Call,
 			Output:   operation.Output,
 			Return:   operation.Return,
+			Metadata: operation.Output,
 		})
 	}
 	return operations, nil

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -559,7 +559,7 @@ func TestPatchHistory(t *testing.T) {
 			patched := patchLinearizableOperations(operations, reports, tc.persistedRequest)
 			if diff := cmp.Diff(tc.expectedRemainingOperations, patched,
 				cmpopts.EquateEmpty(),
-				cmpopts.IgnoreFields(porcupine.Operation{}, "Input", "Call", "ClientId"),
+				cmpopts.IgnoreFields(porcupine.Operation{}, "Input", "Call", "ClientId", "Metadata"),
 			); diff != "" {
 				t.Errorf("Response didn't match expected, diff:\n%s", diff)
 			}

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -104,6 +104,7 @@ func (r *LinearizationResult) AddToVisualization(serializable []porcupine.Operat
 			Start:       op.Call,
 			End:         op.Return,
 			Description: r.Model.DescribeOperation(op.Input, op.Output),
+			Details:     r.Model.DescribeOperationMetadata(op.Metadata),
 		})
 	}
 	r.Info.AddAnnotations(annotations)


### PR DESCRIPTION
Include the MemberID (which etcd cluster member processed the request) in the describe output for porcupine visualization when it is set.

Fixes #19029

Before:
<img width="552" height="273" alt="Screenshot 2026-02-27 at 6 05 52 PM" src="https://github.com/user-attachments/assets/79a7d246-c779-4ffc-ac4f-9426dffcd520" />

After:
<img width="516" height="285" alt="Screenshot 2026-02-27 at 6 05 58 PM" src="https://github.com/user-attachments/assets/b686cb91-f24d-40a2-b3f5-e9597dec6143" />

