### PR TITLE
wal: fix ReadAll silently losing ErrSnapshotNotFound

### DIFF
--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -581,9 +581,10 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 
 	if w.tail() != nil {
 		// create encoder (chain crc with the decoder), enable appending
-		w.encoder, err = newFileEncoder(w.tail().File, w.decoder.LastCRC())
-		if err != nil {
-			return nil, state, nil, err
+		var encoderErr error
+		w.encoder, encoderErr = newFileEncoder(w.tail().File, w.decoder.LastCRC())
+		if encoderErr != nil {
+			return nil, state, nil, encoderErr
 		}
 	}
 	w.decoder = nil


### PR DESCRIPTION
## Summary
- In `ReadAll`, when the WAL is opened in write mode (via `wal.Open`), `err` is set to `ErrSnapshotNotFound` at line 570 when no matching snapshot is found
- At line 584, `newFileEncoder` reuses the same named return variable `err`, overwriting `ErrSnapshotNotFound` with nil on success
- This causes `ReadAll` to silently return success instead of the expected `ErrSnapshotNotFound`
- The `Verify` function correctly handles this by returning `ErrSnapshotNotFound` independently of any encoder setup

Found during code review.

## Fix
Use a separate variable (`encoderErr`) for the encoder error so the snapshot match status is preserved in the return value.

## Test plan
- [x] Existing WAL unit tests pass (`go test ./server/storage/wal/...`)