### PR TITLE
transport,backend: fix unchecked errors in SelfCert and Hash

### DIFF
--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -321,8 +321,13 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 		)
 		return info, err
 	}
-	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	certOut.Close()
+	if err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		certOut.Close()
+		return info, err
+	}
+	if err = certOut.Close(); err != nil {
+		return info, err
+	}
 
 	info.Logger.Info("created cert file", zap.String("path", certPath))
 
@@ -339,8 +344,13 @@ func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertVali
 		)
 		return info, err
 	}
-	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
-	keyOut.Close()
+	if err = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}); err != nil {
+		keyOut.Close()
+		return info, err
+	}
+	if err = keyOut.Close(); err != nil {
+		return info, err
+	}
 	info.Logger.Info("created key file", zap.String("path", keyPath))
 	return SelfCert(lg, dirpath, hosts, selfSignedCertValidity)
 }

--- a/server/storage/backend/backend.go
+++ b/server/storage/backend/backend.go
@@ -413,13 +413,15 @@ func (b *backend) Hash(ignores func(bucketName, keyName []byte) bool) (uint32, e
 				return fmt.Errorf("cannot get hash of bucket %s", next)
 			}
 			h.Write(next)
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				if ignores != nil && !ignores(next, k) {
 					h.Write(k)
 					h.Write(v)
 				}
 				return nil
-			})
+			}); err != nil {
+				return err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- **SelfCert** (`client/pkg/transport/listener.go`): `pem.Encode` and `Close()` errors are discarded for both the certificate and key files. If the disk is full, truncated PEM files are silently written. On the next call, `SelfCert` finds the corrupt files via `os.Stat` and returns `TLSInfo` pointing at them.
- **Hash** (`server/storage/backend/backend.go`): The error return from `ForEach` is ignored. The `defragdb` function in the same file correctly checks the `ForEach` error.

Found during code review.

## Fix
- Check errors from `pem.Encode` and `Close` for both cert and key files in `SelfCert`
- Check and propagate the `ForEach` error in `Hash`

## Test plan
- [x] Existing transport tests pass (`go test ./client/pkg/transport/...`)
- [x] Existing backend tests pass (`go test ./server/storage/backend/...`)