### PR TITLE
v3rpc: validate peer URLs in MemberUpdate like MemberAdd

### DIFF
--- a/server/etcdserver/api/v3rpc/member.go
+++ b/server/etcdserver/api/v3rpc/member.go
@@ -78,9 +78,14 @@ func (cs *ClusterServer) MemberRemove(ctx context.Context, r *pb.MemberRemoveReq
 }
 
 func (cs *ClusterServer) MemberUpdate(ctx context.Context, r *pb.MemberUpdateRequest) (*pb.MemberUpdateResponse, error) {
+	urls, err := types.NewURLs(r.PeerURLs)
+	if err != nil {
+		return nil, rpctypes.ErrGRPCMemberBadURLs
+	}
+
 	m := membership.Member{
 		ID:             types.ID(r.ID),
-		RaftAttributes: membership.RaftAttributes{PeerURLs: r.PeerURLs},
+		RaftAttributes: membership.RaftAttributes{PeerURLs: urls.StringSlice()},
 	}
 	membs, err := cs.server.UpdateMember(ctx, m)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `MemberAdd` validates peer URLs through `types.NewURLs()` before passing them to the server
- `MemberUpdate` passes the raw string slice directly without any validation
- This allows malformed URLs to be stored in the cluster membership

Found during code review.

## Fix
Validate peer URLs through `types.NewURLs()` in `MemberUpdate`, consistent with `MemberAdd`.

## Test plan
- [x] Existing v3rpc tests pass (`go test ./server/etcdserver/api/v3rpc/...`)