### PR TITLE
wal,etcdserver: fsync WAL backup before truncate, check lease checkpoint error

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -402,7 +402,12 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 				return lease.ErrNotPrimary
 			}
 
-			srv.raftRequestOnce(ctx, pb.InternalRaftRequest{LeaseCheckpoint: cp})
+			_, err := srv.raftRequestOnce(ctx, pb.InternalRaftRequest{LeaseCheckpoint: cp})
+			if err != nil {
+				srv.lg.Warn("failed to checkpoint lease",
+					zap.Error(err))
+				return err
+			}
 			return nil
 		})
 	}

--- a/server/storage/wal/repair.go
+++ b/server/storage/wal/repair.go
@@ -83,6 +83,11 @@ func Repair(lg *zap.Logger, dirpath string) bool {
 				return false
 			}
 
+			if err = fileutil.Fsync(bf); err != nil {
+				lg.Warn("failed to fsync backup", zap.String("path", brokenName), zap.Error(err))
+				return false
+			}
+
 			if err = f.Truncate(lastOffset); err != nil {
 				lg.Warn("failed to truncate", zap.String("path", f.Name()), zap.Error(err))
 				return false


### PR DESCRIPTION
## Summary
- **WAL Repair** (`server/storage/wal/repair.go`): `io.Copy` writes the backup file, then `Truncate` destroys the original data, but the backup is never fsynced. A power loss after truncate but before the OS flushes the backup to disk loses both copies.
- **Lease checkpoint** (`server/etcdserver/server.go`): The error from `raftRequestOnce` is discarded and the checkpointer callback always returns nil. Failed raft proposals silently lose checkpoint data.

Found during code review.

## Fix
- Fsync the backup file before truncating the original WAL file
- Check and return the error from `raftRequestOnce` in the lease checkpoint callback

## Test plan
- [x] Existing WAL tests pass (`go test ./server/storage/wal/...`)
- [x] Server package builds successfully (`go build ./server/etcdserver/...`)