### PR TITLE
embed: make tracing exporter TLS configurable instead of hardcoded insecure

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -399,6 +399,10 @@ type Config struct {
 	// DistributedTracingSamplingRatePerMillion is the number of samples to collect per million spans.
 	// Defaults to 0.
 	DistributedTracingSamplingRatePerMillion int `json:"distributed-tracing-sampling-rate"`
+	// DistributedTracingInsecure disables transport security for the tracing
+	// exporter's gRPC connection. Defaults to true for backward compatibility.
+	// Set to false when the OpenTelemetry Collector endpoint requires TLS.
+	DistributedTracingInsecure bool `json:"distributed-tracing-insecure"`
 
 	// Logger is logger options: currently only supports "zap".
 	// "capnslog" is removed in v3.5.
@@ -562,8 +566,9 @@ func NewConfig() *Config {
 		MemoryMlock:        false,
 		MaxLearners:        membership.DefaultMaxLearners,
 
-		DistributedTracingAddress:     DefaultDistributedTracingAddress,
-		DistributedTracingServiceName: DefaultDistributedTracingServiceName,
+		DistributedTracingAddress:      DefaultDistributedTracingAddress,
+		DistributedTracingServiceName:  DefaultDistributedTracingServiceName,
+		DistributedTracingInsecure:     true,
 
 		CompactHashCheckTime: DefaultCompactHashCheckTime,
 
@@ -733,6 +738,7 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.DistributedTracingServiceName, "distributed-tracing-service-name", cfg.DistributedTracingServiceName, "Configures service name for distributed tracing to be used to define service name for OpenTelemetry Tracing (if enabled with enable-distributed-tracing flag). 'etcd' is the default service name. Use the same service name for all instances of etcd.")
 	fs.StringVar(&cfg.DistributedTracingServiceInstanceID, "distributed-tracing-instance-id", "", "Configures service instance ID for distributed tracing to be used to define service instance ID key for OpenTelemetry Tracing (if enabled with enable-distributed-tracing flag). There is no default value set. This ID must be unique per etcd instance.")
 	fs.IntVar(&cfg.DistributedTracingSamplingRatePerMillion, "distributed-tracing-sampling-rate", 0, "Number of samples to collect per million spans for OpenTelemetry Tracing (if enabled with enable-distributed-tracing flag).")
+	fs.BoolVar(&cfg.DistributedTracingInsecure, "distributed-tracing-insecure", true, "Disable transport security for the distributed tracing exporter's gRPC connection. Set to false when the OpenTelemetry Collector requires TLS.")
 
 	// auth
 	fs.StringVar(&cfg.AuthToken, "auth-token", cfg.AuthToken, "Specify auth token specific options.")

--- a/server/embed/config_tracing.go
+++ b/server/embed/config_tracing.go
@@ -49,10 +49,13 @@ type tracingExporter struct {
 }
 
 func newTracingExporter(ctx context.Context, cfg *Config) (*tracingExporter, error) {
-	exporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithInsecure(),
+	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.DistributedTracingAddress),
-	)
+	}
+	if cfg.DistributedTracingInsecure {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+	exporter, err := otlptracegrpc.New(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- The tracing exporter unconditionally uses `otlptracegrpc.WithInsecure()`, which disables transport security for the gRPC connection to the OpenTelemetry Collector
- This overrides any TLS configuration that might be set via OpenTelemetry SDK environment variables
- There is no way for operators to enable TLS on the tracing exporter connection

Found during code review.

## Fix
Add a `DistributedTracingInsecure` config field (default `true` for backward compatibility) and a corresponding `--distributed-tracing-insecure` flag. When set to `false`, the exporter will use TLS (either from system defaults or OTEL SDK env vars).

## Test plan
- [x] Existing embed tests pass (`go test ./server/embed/...`)