### PR TITLE
Fix race between read index and leader change

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -16,6 +16,7 @@ package etcdserver
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	errorspkg "errors"
 	"fmt"
@@ -1573,4 +1574,52 @@ func TestAddFeatureGateMetrics(t *testing.T) {
 	`
 	err := ptestutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), "etcd_server_feature_enabled")
 	require.NoErrorf(t, err, "unexpected metric collection result: \n%s", err)
+}
+
+func TestRequestCurrentIndex_LeaderChangedRace(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+
+	s := &EtcdServer{
+		lgMu:              new(sync.RWMutex),
+		lg:                lg,
+		stopping:          make(chan struct{}),
+		firstCommitInTerm: notify.NewNotifier(),
+		Cfg: config.ServerConfig{
+			TickMs:        100,
+			ElectionTicks: 10,
+		},
+	}
+	s.memberID = 1
+	s.lead.Store(1)
+	s.term.Store(2)
+
+	s.r = raftNode{
+		raftNodeConfig: raftNodeConfig{
+			Node: newNodeNop(),
+		},
+		readStateC: make(chan raft.ReadState, 1),
+	}
+
+	requestID := uint64(12345)
+	requestIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(requestIDBytes, requestID)
+
+	leaderChangedNotifier := make(chan struct{})
+	close(leaderChangedNotifier)
+
+	for i := 0; i < 100; i++ {
+		s.r.readStateC <- raft.ReadState{
+			Index:      100,
+			RequestCtx: requestIDBytes,
+		}
+		index, err := s.requestCurrentIndex(leaderChangedNotifier, requestID)
+		require.ErrorIs(t, err, errors.ErrLeaderChanged)
+		require.Equal(t, uint64(0), index)
+
+		// Clear the readStateC channel for the next iteration,
+		select {
+		case <-s.r.readStateC:
+		default:
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/etcd-io/etcd/issues/20418

/assign @ahrtr @fuweid 

Fix is to guarantee that we prioritize reading from `leaderChangedNotifier` over `readStateC`

https://onecat.medium.com/golang-select-behavior-13a5cd77ae94