### PR TITLE
[release-3.5] Print the endpoint the grpc request was actually sent to in unary int…

### DIFF
--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -41,6 +42,8 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		ctx = withVersion(ctx)
 		grpcOpts, retryOpts := filterCallOptions(opts)
+		var p peer.Peer
+		grpcOpts = append(grpcOpts, grpc.Peer(&p))
 		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts)
 		// short circuit for simplicity, and avoiding allocations.
 		if callOpts.max == 0 {
@@ -63,6 +66,7 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 			c.GetLogger().Warn(
 				"retrying of unary invoker failed",
 				zap.String("target", cc.Target()),
+				zap.String("peer", p.String()),
 				zap.Uint("attempt", attempt),
 				zap.Error(lastErr),
 			)


### PR DESCRIPTION

Backport https://github.com/etcd-io/etcd/pull/21376 to 3.5
