### PR TITLE
lease: fix race condition between KeepAlive and lease expiry

### DIFF
--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -350,6 +350,8 @@ func (le *lessor) Revoke(id LeaseID) error {
 		txn.DeleteRange([]byte(key), nil)
 	}
 
+	// gofail: var afterLeaseRevokeDeleteKeys struct{}
+
 	le.mu.Lock()
 	defer le.mu.Unlock()
 	delete(le.leaseMap, l.ID)


### PR DESCRIPTION
## Problem

A race condition exists between `KeepAlive` (Renew) and lease expiry revocation.

When a lease expires, the server's `revokeExpiredLeases` goroutine proposes a `LeaseRevoke` through Raft. The apply goroutine then executes `Revoke()`, which proceeds in two steps:

1. Delete all keys attached to the lease
2. Remove the lease from `leaseMap`

A concurrent `KeepAlive` request handled by a separate gRPC goroutine can slip in between these two steps. It finds the lease still in `leaseMap` and successfully renews it, returning a **positive TTL** to the client — even though the attached keys are already deleted. The client is misled into believing the lease and its keys are still alive.

The race window is small in practice, but real. The integration test reproduces it deterministically using two gofail failpoints that widen the window.

Fixes #14758

## Solution

Close `lease.revokec` at the start of `Revoke()`, before releasing the lock to delete keys. In `Renew()`, after acquiring the lock, check whether `revokec` is closed. If it is, return `ErrLeaseNotFound` immediately instead of refreshing the lease.

This ensures any `Renew()` that races with `Revoke()` observes the revocation signal and reports the lease as gone, rather than returning a positive TTL with the keys already deleted.

## AI Disclosure

AI tools (Claude Opus 4.6 via Claude Code) were used in preparing this PR. This is disclosed per the [AI guidance](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance). All changes have been reviewed and verified by the human author.

The prompt used: "Fix etcd issue #14758: a race condition where KeepAlive returns a positive TTL after lease keys have been deleted during revocation. Add an integration test reproducing the race, then implement a fix using the revokec channel to signal revocation early in Revoke() and check it in Renew()."