### PR TITLE
Experimenting with making debug log level useful for debugging linearizability issues

### DIFF
--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -137,6 +137,7 @@ func (h *pipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(len(b)))
 
+	logRaftCommunication(h.lg, h.localID, m, types.ID(m.From), "receive")
 	if err := h.r.Process(context.TODO(), m); err != nil {
 		var writerErr writerToResponse
 		switch {

--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -96,6 +96,7 @@ func (p *pipeline) handle() {
 	for {
 		select {
 		case m := <-p.msgc:
+			logRaftCommunication(p.tr.Logger, p.tr.ID, m, p.peerID, "send")
 			start := time.Now()
 			err := p.post(pbutil.MustMarshal(&m))
 			end := time.Now()

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -201,6 +201,7 @@ func (cw *streamWriter) run() {
 			heartbeatc, msgc = nil, nil
 
 		case m := <-msgc:
+			logRaftCommunication(cw.lg, cw.localID, m, cw.peerID, "send")
 			err := enc.encode(&m)
 			if err == nil {
 				unflushed += m.Size()
@@ -497,6 +498,7 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 			cr.mu.Unlock()
 			return err
 		}
+		logRaftCommunication(cr.lg, cr.tr.ID, m, cr.peerID, "receive")
 
 		// gofail: var raftDropHeartbeat struct{}
 		// continue labelRaftDropHeartbeat

--- a/server/etcdserver/api/rafthttp/transport.go
+++ b/server/etcdserver/api/rafthttp/transport.go
@@ -16,6 +16,7 @@ package rafthttp
 
 import (
 	"context"
+	"encoding/binary"
 	"net/http"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
@@ -450,4 +452,41 @@ func (t *Transport) ActivePeers() (cnt int) {
 		}
 	}
 	return cnt
+}
+
+func logRaftCommunication(lg *zap.Logger, localID types.ID, m raftpb.Message, remote types.ID, direction string) {
+	if !lg.Core().Enabled(zap.DebugLevel) {
+		return
+	}
+	var requestID uint64
+	switch m.Type {
+	case raftpb.MsgBeat, raftpb.MsgHeartbeat, raftpb.MsgHeartbeatResp:
+		if len(m.Context) != 8 {
+			return
+		}
+		requestID = binary.BigEndian.Uint64(m.Context)
+	case raftpb.MsgReadIndex, raftpb.MsgReadIndexResp:
+		if len(m.Entries) > 0 && len(m.Entries[0].Data) == 8 {
+			requestID = binary.BigEndian.Uint64(m.Entries[0].Data)
+		}
+	case raftpb.MsgProp:
+		if len(m.Entries) > 0 {
+			r := pb.InternalRaftRequest{}
+			if err := r.Unmarshal(m.Entries[0].Data); err == nil {
+				requestID = r.Header.ID
+			}
+		}
+	default:
+	}
+	lg.Debug(
+		"Raft communication",
+		zap.String("direction", direction),
+		zap.String("message-type", m.Type.String()),
+		zap.String("local-member-id", localID.String()),
+		zap.String("remote-peer-id", remote.String()),
+		zap.Uint64("term", m.Term),
+		zap.Uint64("index", m.Index),
+		zap.Uint64("commit", m.Commit),
+		zap.Uint64("request-id", requestID),
+	)
 }

--- a/server/etcdserver/api/v3rpc/interceptor.go
+++ b/server/etcdserver/api/v3rpc/interceptor.go
@@ -77,139 +77,112 @@ func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 
 func newLogUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		lg := s.Logger()
+		debug := lg.Core().Enabled(zap.DebugLevel)
+		if debug {
+			logUnaryRequest(ctx, lg.Debug, info, req)
+		}
+
 		startTime := time.Now()
 		resp, err := handler(ctx, req)
-		lg := s.Logger()
-		if lg != nil { // acquire stats if debug level is enabled or RequestInfo is expensive
-			defer logUnaryRequestStats(ctx, lg, s.Cfg.WarningUnaryRequestDuration, info, startTime, req, resp)
+		duration := time.Since(startTime)
+
+		if duration > s.Cfg.WarningUnaryRequestDuration {
+			var fields []zap.Field
+			if !debug {
+				fields = requestLogFields(req)
+			}
+			logUnaryResponseStats(ctx, lg.Warn, duration, info, startTime, resp, fields...)
+		} else if debug {
+			logUnaryResponseStats(ctx, lg.Debug, duration, info, startTime, resp)
 		}
 		return resp, err
 	}
 }
 
-func logUnaryRequestStats(ctx context.Context, lg *zap.Logger, warnLatency time.Duration, info *grpc.UnaryServerInfo, startTime time.Time, req any, resp any) {
-	duration := time.Since(startTime)
-	var enabledDebugLevel, expensiveRequest bool
-	if lg.Core().Enabled(zap.DebugLevel) {
-		enabledDebugLevel = true
-	}
-	if duration > warnLatency {
-		expensiveRequest = true
-	}
-	if !enabledDebugLevel && !expensiveRequest {
-		return
-	}
-	remote := "No remote client info."
+func logUnaryRequest(ctx context.Context, log func(msg string, fields ...zap.Field), info *grpc.UnaryServerInfo, req any) {
+	remote := ""
 	peerInfo, ok := peer.FromContext(ctx)
 	if ok {
 		remote = peerInfo.Addr.String()
 	}
-	responseType := info.FullMethod
-	var reqCount, respCount int64
-	var reqSize, respSize int
-	var reqContent string
+	var size int
+	if msg, ok := req.(Sizer); ok {
+		size = msg.Size()
+	}
+	fields := []zap.Field{
+		zap.String("method", info.FullMethod),
+		zap.String("remote", remote),
+		zap.Int("size", size),
+	}
+	fields = append(fields, requestLogFields(req)...)
+	log("request", fields...)
+}
+
+type Sizer interface {
+	Size() int
+}
+
+func requestLogFields(req any) []zap.Field {
+	fields := []zap.Field{}
+	switch _req := req.(type) {
+	case *pb.RangeRequest:
+		fields = append(fields,
+			zap.String("range_begin", string(_req.GetKey())),
+			zap.String("range_end", string(_req.GetRangeEnd())),
+			zap.Int64("range_revision", _req.GetRevision()),
+			zap.Int64("range_limit", _req.GetLimit()),
+			zap.Bool("range_count_only", _req.GetCountOnly()),
+			zap.Bool("range_keys_only", _req.GetKeysOnly()),
+		)
+	case *pb.PutRequest:
+		fields = append(fields,
+			zap.String("put_key", string(_req.GetKey())),
+		)
+	case *pb.DeleteRangeRequest:
+		fields = append(fields,
+			zap.String("delete_range_begin", string(_req.GetKey())),
+			zap.String("delete_range_end", string(_req.GetRangeEnd())),
+		)
+	case *pb.TxnRequest:
+		fields = append(fields,
+			zap.Int("txn_compare_len", len(_req.GetCompare())),
+			zap.Int("txn_success_len", len(_req.GetSuccess())),
+			zap.Int("txn_failure_len", len(_req.GetFailure())),
+		)
+	default:
+	}
+	return fields
+}
+
+func logUnaryResponseStats(ctx context.Context, log func(msg string, fields ...zap.Field), duration time.Duration, info *grpc.UnaryServerInfo, startTime time.Time, resp any, fields ...zap.Field) {
+	var size int
+	if msg, ok := resp.(Sizer); ok {
+		size = msg.Size()
+	}
+	fields = append(fields,
+		zap.String("method", info.FullMethod),
+		zap.Duration("duration", duration),
+		zap.Int("size", size),
+	)
 	switch _resp := resp.(type) {
 	case *pb.RangeResponse:
-		_req, ok := req.(*pb.RangeRequest)
-		if ok {
-			reqCount = 0
-			reqSize = _req.Size()
-			reqContent = _req.String()
-		}
-		if _resp != nil {
-			respCount = _resp.GetCount()
-			respSize = _resp.Size()
-		}
+		fields = append(fields,
+			zap.Int("size", _resp.Size()),
+			zap.Int64("count", _resp.GetCount()),
+		)
 	case *pb.PutResponse:
-		_req, ok := req.(*pb.PutRequest)
-		if ok {
-			reqCount = 1
-			reqSize = _req.Size()
-			reqContent = pb.NewLoggablePutRequest(_req).String()
-			// redact value field from request content, see PR #9821
-		}
-		if _resp != nil {
-			respCount = 0
-			respSize = _resp.Size()
-		}
+		fields = append(fields,
+			zap.Int("size", _resp.Size()),
+		)
 	case *pb.DeleteRangeResponse:
-		_req, ok := req.(*pb.DeleteRangeRequest)
-		if ok {
-			reqCount = 0
-			reqSize = _req.Size()
-			reqContent = _req.String()
-		}
-		if _resp != nil {
-			respCount = _resp.GetDeleted()
-			respSize = _resp.Size()
-		}
+		fields = append(fields,
+			zap.Int64("delete_range_deleted", _resp.GetDeleted()),
+		)
 	case *pb.TxnResponse:
-		_req, ok := req.(*pb.TxnRequest)
-		if ok && _resp != nil {
-			if _resp.GetSucceeded() { // determine the 'actual' count and size of request based on success or failure
-				reqCount = int64(len(_req.GetSuccess()))
-				reqSize = 0
-				for _, r := range _req.GetSuccess() {
-					reqSize += r.Size()
-				}
-			} else {
-				reqCount = int64(len(_req.GetFailure()))
-				reqSize = 0
-				for _, r := range _req.GetFailure() {
-					reqSize += r.Size()
-				}
-			}
-			reqContent = pb.NewLoggableTxnRequest(_req).String()
-			// redact value field from request content, see PR #9821
-		}
-		if _resp != nil {
-			respCount = 0
-			respSize = _resp.Size()
-		}
 	default:
-		reqCount = -1
-		reqSize = -1
-		respCount = -1
-		respSize = -1
 	}
-
-	if enabledDebugLevel {
-		logGenericRequestStats(lg, startTime, duration, remote, responseType, reqCount, reqSize, respCount, respSize, reqContent)
-	} else if expensiveRequest {
-		logExpensiveRequestStats(lg, startTime, duration, remote, responseType, reqCount, reqSize, respCount, respSize, reqContent)
-	}
-}
-
-func logGenericRequestStats(lg *zap.Logger, startTime time.Time, duration time.Duration, remote string, responseType string,
-	reqCount int64, reqSize int, respCount int64, respSize int, reqContent string,
-) {
-	lg.Debug("request stats",
-		zap.Time("start time", startTime),
-		zap.Duration("time spent", duration),
-		zap.String("remote", remote),
-		zap.String("response type", responseType),
-		zap.Int64("request count", reqCount),
-		zap.Int("request size", reqSize),
-		zap.Int64("response count", respCount),
-		zap.Int("response size", respSize),
-		zap.String("request content", reqContent),
-	)
-}
-
-func logExpensiveRequestStats(lg *zap.Logger, startTime time.Time, duration time.Duration, remote string, responseType string,
-	reqCount int64, reqSize int, respCount int64, respSize int, reqContent string,
-) {
-	lg.Warn("request stats",
-		zap.Time("start time", startTime),
-		zap.Duration("time spent", duration),
-		zap.String("remote", remote),
-		zap.String("response type", responseType),
-		zap.Int64("request count", reqCount),
-		zap.Int("request size", reqSize),
-		zap.Int64("response count", respCount),
-		zap.Int("response size", respSize),
-		zap.String("request content", reqContent),
-	)
+	log("response", fields...)
 }
 
 func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor {

--- a/server/etcdserver/requestid/requestid.go
+++ b/server/etcdserver/requestid/requestid.go
@@ -1,0 +1,17 @@
+package requestid
+
+import "context"
+
+type requestIDKey struct{}
+
+func NewContext(ctx context.Context, requestID uint64) context.Context {
+	return context.WithValue(ctx, requestIDKey{}, requestID)
+}
+
+func FromContext(ctx context.Context) uint64 {
+	val := ctx.Value(requestIDKey{})
+	if val == nil {
+		return 0
+	}
+	return val.(uint64)
+}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2464,3 +2464,7 @@ func addFeatureGateMetrics(fg featuregate.FeatureGate, guageVec *prometheus.Gaug
 		guageVec.With(prometheus.Labels{"name": string(feature), "stage": string(featureSpec.PreRelease)}).Set(metricVal)
 	}
 }
+
+func (s *EtcdServer) RequestID() uint64 {
+	return s.reqIDGen.Next()
+}

--- a/server/etcdserver/util.go
+++ b/server/etcdserver/util.go
@@ -83,6 +83,7 @@ func longestConnected(tp rafthttp.Transporter, membs []types.ID) (types.ID, bool
 type notifier struct {
 	c   chan struct{}
 	err error
+	readIndexID uint64
 }
 
 func newNotifier() *notifier {
@@ -91,7 +92,8 @@ func newNotifier() *notifier {
 	}
 }
 
-func (nc *notifier) notify(err error) {
+func (nc *notifier) notify(err error, readIndexID uint64) {
 	nc.err = err
+	nc.readIndexID = readIndexID
 	close(nc.c)
 }

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -36,6 +36,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	apply2 "go.etcd.io/etcd/server/v3/etcdserver/apply"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
+	"go.etcd.io/etcd/server/v3/etcdserver/requestid"
 	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	"go.etcd.io/etcd/server/v3/features"
 	"go.etcd.io/etcd/server/v3/lease"
@@ -830,9 +831,15 @@ func (s *EtcdServer) processInternalRaftRequestOnce(ctx context.Context, r pb.In
 	if ci > ai+maxGapBetweenApplyAndCommitIndex {
 		return nil, errors.ErrTooManyRequests
 	}
+	lg := s.Logger()
+	requestID := requestid.FromContext(ctx)
+	if requestID == 0 {
+		lg.Warn("request ID not found in context, log correlation might not work, generating new")
+		requestID = s.reqIDGen.Next()
+	}
 
 	r.Header = &pb.RequestHeader{
-		ID: s.reqIDGen.Next(),
+		ID: requestID,
 	}
 
 	// check authinfo if it is not InternalAuthenticateRequest
@@ -877,6 +884,7 @@ func (s *EtcdServer) processInternalRaftRequestOnce(ctx context.Context, r pb.In
 	defer cancel()
 
 	span := trace.SpanFromContext(ctx)
+	lg.Debug("Send raft proposal", zap.String("request_type", reqType), zap.Uint64("request_id", requestID))
 	span.AddEvent("Send raft proposal")
 	err = s.r.Propose(cctx, data)
 	if err != nil {
@@ -890,6 +898,7 @@ func (s *EtcdServer) processInternalRaftRequestOnce(ctx context.Context, r pb.In
 	select {
 	case x := <-ch:
 		span.AddEvent("Receive raft result")
+		lg.Debug("Receive raft result", zap.String("request_type", reqType), zap.Uint64("request_id", requestID))
 		return x.(*apply2.Result), nil
 	case <-cctx.Done():
 		proposalsFailed.Inc()
@@ -997,7 +1006,7 @@ func (s *EtcdServer) linearizableReadLoop() {
 			return
 		}
 		if err != nil {
-			nr.notify(err)
+			nr.notify(err, requestID)
 			continue
 		}
 
@@ -1016,7 +1025,7 @@ func (s *EtcdServer) linearizableReadLoop() {
 			}
 		}
 		// unblock all l-reads requested at indices before confirmedIndex
-		nr.notify(nil)
+		nr.notify(nil, requestID)
 		trace.Step("applied index is now lower than readState.Index")
 
 		trace.LogAllStepsIfLong(traceThreshold)
@@ -1114,16 +1123,19 @@ func uint64ToBigEndianBytes(number uint64) []byte {
 }
 
 func (s *EtcdServer) sendReadIndex(requestIndex uint64) error {
+	lg := s.Logger()
+	timeout := s.Cfg.ReqTimeout()
+	lg.Debug("sending read index request", zap.Uint64("read-request-id", requestIndex), zap.Duration("timeout", timeout))
 	ctxToSend := uint64ToBigEndianBytes(requestIndex)
 
-	cctx, cancel := context.WithTimeout(context.Background(), s.Cfg.ReqTimeout())
+
+	cctx, cancel := context.WithTimeout(context.Background(), timeout)
 	err := s.r.ReadIndex(cctx, ctxToSend)
 	cancel()
 	if errorspkg.Is(err, raft.ErrStopped) {
 		return err
 	}
 	if err != nil {
-		lg := s.Logger()
 		lg.Warn("failed to get read index from Raft", zap.Error(err))
 		readIndexFailed.Inc()
 		return err
@@ -1149,6 +1161,8 @@ func (s *EtcdServer) linearizableReadNotify(ctx context.Context) error {
 	// wait for read state notification
 	select {
 	case <-nc.c:
+		requestID := requestid.FromContext(ctx)
+		s.Logger().Debug("linearizable read notify", zap.Uint64("read-index-id", nc.readIndexID), zap.Uint64("request-id", requestID))
 		return nc.err
 	case <-ctx.Done():
 		return ctx.Err()

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -1122,11 +1122,11 @@ func uint64ToBigEndianBytes(number uint64) []byte {
 	return byteResult
 }
 
-func (s *EtcdServer) sendReadIndex(requestIndex uint64) error {
+func (s *EtcdServer) sendReadIndex(requestID uint64) error {
 	lg := s.Logger()
 	timeout := s.Cfg.ReqTimeout()
-	lg.Debug("sending read index request", zap.Uint64("read-request-id", requestIndex), zap.Duration("timeout", timeout))
-	ctxToSend := uint64ToBigEndianBytes(requestIndex)
+	lg.Debug("sending read index request", zap.Uint64("read-request-id", requestID), zap.Duration("timeout", timeout))
+	ctxToSend := uint64ToBigEndianBytes(requestID)
 
 
 	cctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
Goal: Make debugging linearizability issues possible on upstream code without needing to have custom code in Antithesis.

Problem: How to incorporate logging and tracing

Before:
```
10:42:57 etcd1 | {"level":"debug","ts":"2026-03-01T10:42:57.113997+0100","caller":"v3rpc/interceptor.go:186","msg":"request stats","start time":"2026-03-01T10:42:57.113603+0100","time spent":"379.414µs","remote":"127.0.0.1:60676","response type":"/etcdserverpb.KV/Range","request count":0,"request size":3,"response count":0,"response size":28,"request content":"key:\"a\" "}
```

After
```
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.149692+0100","caller":"v3rpc/interceptor.go:124","msg":"request","method":"/etcdserverpb.KV/Range","request_id":3632606832826034696,"remote":"127.0.0.1:58622","size":3,"range_begin":"a","range_end":"","range_revision":0,"range_limit":0,"range_count_only":false,"range_keys_only":false}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.149723+0100","caller":"etcdserver/v3_server.go:1128","msg":"sending read index request","read-request-id":3632606832826034694,"timeout":"7s"}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.149779+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgReadIndex","local-member-id":"8211f1d0f64f3269","remote-peer-id":"fd422379fda50e48","term":0,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.149845+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgReadIndex","local-member-id":"fd422379fda50e48","remote-peer-id":"8211f1d0f64f3269","term":0,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.149903+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgHeartbeat","local-member-id":"fd422379fda50e48","remote-peer-id":"8211f1d0f64f3269","term":24,"index":0,"commit":71,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.149915+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgHeartbeat","local-member-id":"fd422379fda50e48","remote-peer-id":"91bc3c398fb3c146","term":24,"index":0,"commit":71,"request-id":3632606832826034694}
21:12:00 etcd2 | {"level":"debug","ts":"2026-03-01T21:12:00.149996+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgHeartbeat","local-member-id":"91bc3c398fb3c146","remote-peer-id":"fd422379fda50e48","term":24,"index":0,"commit":71,"request-id":3632606832826034694}
21:12:00 etcd2 | {"level":"debug","ts":"2026-03-01T21:12:00.150060+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgHeartbeatResp","local-member-id":"91bc3c398fb3c146","remote-peer-id":"fd422379fda50e48","term":24,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.149973+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgHeartbeat","local-member-id":"8211f1d0f64f3269","remote-peer-id":"fd422379fda50e48","term":24,"index":0,"commit":71,"request-id":3632606832826034694}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.150103+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgHeartbeatResp","local-member-id":"8211f1d0f64f3269","remote-peer-id":"fd422379fda50e48","term":24,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.150124+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgHeartbeatResp","local-member-id":"fd422379fda50e48","remote-peer-id":"91bc3c398fb3c146","term":24,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.150161+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"send","message-type":"MsgReadIndexResp","local-member-id":"fd422379fda50e48","remote-peer-id":"8211f1d0f64f3269","term":24,"index":71,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd3 | {"level":"debug","ts":"2026-03-01T21:12:00.150197+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgHeartbeatResp","local-member-id":"fd422379fda50e48","remote-peer-id":"8211f1d0f64f3269","term":24,"index":0,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.150239+0100","caller":"rafthttp/transport.go:481","msg":"Raft communication","direction":"receive","message-type":"MsgReadIndexResp","local-member-id":"8211f1d0f64f3269","remote-peer-id":"fd422379fda50e48","term":24,"index":71,"commit":0,"request-id":3632606832826034694}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.150285+0100","caller":"etcdserver/v3_server.go:1165","msg":"linearizable read notify","read-index-id":3632606832826034694,"request-id":3632606832826034696}
21:12:00 etcd1 | {"level":"debug","ts":"2026-03-01T21:12:00.150352+0100","caller":"v3rpc/interceptor.go:191","msg":"response","method":"/etcdserverpb.KV/Range","duration":"643.721µs","size":44,"request_id":3632606832826034696,"size":44,"count":1}

```

/cc @ahrtr @fuweid @AwesomePatrol 
Ref https://github.com/etcd-io/etcd/issues/20418