### PR TITLE
[release-3.5] Don't reuse same ReadIndex

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -2235,38 +2235,18 @@ func TestIsActive(t *testing.T) {
 }
 
 func TestRequestCurrentIndex_LeaderChangedRace(t *testing.T) {
-	lg := zaptest.NewLogger(t)
-
-	s := &EtcdServer{
-		lgMu:     new(sync.RWMutex),
-		lg:       lg,
-		stopping: make(chan struct{}),
-		Cfg: config.ServerConfig{
-			TickMs:        100,
-			ElectionTicks: 10,
-		},
-	}
-
-	s.r = raftNode{
-		raftNodeConfig: raftNodeConfig{
-			Node: newNodeNop(),
-		},
-		readStateC: make(chan raft.ReadState, 1),
-	}
-
-	requestID := uint64(12345)
-	requestIDBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(requestIDBytes, requestID)
-
-	leaderChangedNotifier := make(chan struct{})
-	close(leaderChangedNotifier)
+	s, _ := setupTestRequestCurrentIndex(t)
 
 	for i := 0; i < 100; i++ {
-		s.r.readStateC <- raft.ReadState{
-			Index:      100,
-			RequestCtx: requestIDBytes,
-		}
-		index, err := s.requestCurrentIndex(leaderChangedNotifier, requestID)
+		s.r.readStateC <- raft.ReadState{Index: 100}
+
+		s.leaderChangedMu.Lock()
+		leaderChangedNotifier := s.leaderChanged
+		close(leaderChangedNotifier)
+		s.leaderChanged = make(chan struct{})
+		s.leaderChangedMu.Unlock()
+
+		index, err := s.requestCurrentIndex(leaderChangedNotifier)
 		require.ErrorIs(t, err, ErrLeaderChanged)
 		require.Equal(t, uint64(0), index)
 
@@ -2276,4 +2256,193 @@ func TestRequestCurrentIndex_LeaderChangedRace(t *testing.T) {
 		default:
 		}
 	}
+}
+
+func TestRequestCurrentIndex_UniqueRequestID(t *testing.T) {
+	s, mockRaft := setupTestRequestCurrentIndex(t)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.leaderChangedMu.Lock()
+		leaderChanged := s.leaderChanged
+		s.leaderChangedMu.Unlock()
+		s.requestCurrentIndex(leaderChanged)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(mockRaft.getRequests()) >= 2
+	}, time.Second, 100*time.Millisecond)
+
+	s.leaderChangedMu.Lock()
+	close(s.leaderChanged)
+	s.leaderChangedMu.Unlock()
+	wg.Wait()
+
+	seen := make(map[uint64]bool)
+	for _, id := range mockRaft.getRequests() {
+		require.Falsef(t, seen[id], "Found duplicate request ID: %d", id)
+		seen[id] = true
+	}
+}
+
+func TestRequestCurrentIndex_Success(t *testing.T) {
+	s, mockRaft := setupTestRequestCurrentIndex(t)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var index uint64
+	var err error
+	go func() {
+		defer wg.Done()
+		s.leaderChangedMu.Lock()
+		leaderChanged := s.leaderChanged
+		s.leaderChangedMu.Unlock()
+		index, err = s.requestCurrentIndex(leaderChanged)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(mockRaft.getRequests()) == 1
+	}, time.Second, 100*time.Millisecond)
+
+	reqID := mockRaft.getRequests()[0]
+	reqIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(reqIDBytes, reqID)
+
+	s.r.readStateC <- raft.ReadState{
+		Index:      100,
+		RequestCtx: reqIDBytes,
+	}
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), index)
+	require.Lenf(t, mockRaft.getRequests(), 1, "Expected exactly 1 ReadIndex request")
+}
+
+func TestRequestCurrentIndex_WrongRequestID(t *testing.T) {
+	s, mockRaft := setupTestRequestCurrentIndex(t)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var index uint64
+	var err error
+	go func() {
+		defer wg.Done()
+		s.leaderChangedMu.Lock()
+		leaderChanged := s.leaderChanged
+		s.leaderChangedMu.Unlock()
+		index, err = s.requestCurrentIndex(leaderChanged)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(mockRaft.getRequests()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	wrongReqIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(wrongReqIDBytes, 99999)
+
+	s.r.readStateC <- raft.ReadState{
+		Index:      100,
+		RequestCtx: wrongReqIDBytes,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	requests := mockRaft.getRequests()
+	require.Lenf(t, requests, 1, "Expected exactly 1 ReadIndex request")
+
+	reqID := requests[0]
+	reqIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(reqIDBytes, reqID)
+
+	s.r.readStateC <- raft.ReadState{
+		Index:      99,
+		RequestCtx: reqIDBytes,
+	}
+	wg.Wait()
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(99), index)
+	require.Lenf(t, mockRaft.getRequests(), 1, "Expected exactly 1 ReadIndex request")
+}
+
+func TestRequestCurrentIndex_DelayedResponse(t *testing.T) {
+	s, mockRaft := setupTestRequestCurrentIndex(t)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var index uint64
+	var err error
+	go func() {
+		defer wg.Done()
+		s.leaderChangedMu.Lock()
+		leaderChanged := s.leaderChanged
+		s.leaderChangedMu.Unlock()
+		index, err = s.requestCurrentIndex(leaderChanged)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(mockRaft.getRequests()) >= 3
+	}, 2*time.Second, 100*time.Millisecond)
+	requests := mockRaft.getRequests()
+
+	reqID := requests[1]
+	reqIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(reqIDBytes, reqID)
+
+	select {
+	case s.r.readStateC <- raft.ReadState{
+		Index:      100,
+		RequestCtx: reqIDBytes,
+	}:
+	case <-time.After(time.Second):
+		t.Fatal("timed out sending read state")
+	}
+	wg.Wait()
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), index)
+}
+
+func setupTestRequestCurrentIndex(t *testing.T) (*EtcdServer, *testRaftNode) {
+	mockRaft := &testRaftNode{}
+	s := &EtcdServer{
+		lgMu:               new(sync.RWMutex),
+		lg:                 zaptest.NewLogger(t),
+		reqIDGen:           idutil.NewGenerator(0, time.Time{}),
+		firstCommitInTermC: make(chan struct{}),
+		leaderChanged:      make(chan struct{}),
+		r: raftNode{
+			raftNodeConfig: raftNodeConfig{
+				Node: mockRaft,
+			},
+			readStateC: make(chan raft.ReadState, 1),
+		},
+	}
+	return s, mockRaft
+}
+
+type testRaftNode struct {
+	raft.Node
+	mu                sync.Mutex
+	readIndexRequests []uint64
+}
+
+func (m *testRaftNode) ReadIndex(ctx context.Context, rctx []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(rctx) == 8 {
+		m.readIndexRequests = append(m.readIndexRequests, binary.BigEndian.Uint64(rctx))
+	}
+	return nil
+}
+
+func (m *testRaftNode) getRequests() []uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	res := make([]uint64, len(m.readIndexRequests))
+	copy(res, m.readIndexRequests)
+	return res
 }

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -15,7 +15,6 @@
 package etcdserver
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -813,7 +812,6 @@ func (s *EtcdServer) Watchable() mvcc.WatchableKV { return s.KV() }
 
 func (s *EtcdServer) linearizableReadLoop() {
 	for {
-		requestId := s.reqIDGen.Next()
 		leaderChangedNotifier := s.LeaderChangedNotify()
 		select {
 		case <-leaderChangedNotifier:
@@ -833,7 +831,7 @@ func (s *EtcdServer) linearizableReadLoop() {
 		s.readNotifier = nextnr
 		s.readMu.Unlock()
 
-		confirmedIndex, err := s.requestCurrentIndex(leaderChangedNotifier, requestId)
+		confirmedIndex, err := s.requestCurrentIndex(leaderChangedNotifier)
 		if isStopped(err) {
 			return
 		}
@@ -868,8 +866,11 @@ func isStopped(err error) bool {
 	return err == raft.ErrStopped || err == ErrStopped
 }
 
-func (s *EtcdServer) requestCurrentIndex(leaderChangedNotifier <-chan struct{}, requestId uint64) (uint64, error) {
-	err := s.sendReadIndex(requestId)
+func (s *EtcdServer) requestCurrentIndex(leaderChangedNotifier <-chan struct{}) (uint64, error) {
+	requestIDs := map[uint64]struct{}{}
+	requestID := s.reqIDGen.Next()
+	requestIDs[requestID] = struct{}{}
+	err := s.sendReadIndex(requestID)
 	if err != nil {
 		return 0, err
 	}
@@ -892,19 +893,16 @@ func (s *EtcdServer) requestCurrentIndex(leaderChangedNotifier <-chan struct{}, 
 				return 0, ErrLeaderChanged
 			default:
 			}
-			requestIdBytes := uint64ToBigEndianBytes(requestId)
-			gotOwnResponse := bytes.Equal(rs.RequestCtx, requestIdBytes)
-			if !gotOwnResponse {
+			responseID := uint64(0)
+			if len(rs.RequestCtx) == 8 {
+				responseID = binary.BigEndian.Uint64(rs.RequestCtx)
+			}
+			if _, ok := requestIDs[responseID]; !ok {
 				// a previous request might time out. now we should ignore the response of it and
 				// continue waiting for the response of the current requests.
-				responseId := uint64(0)
-				if len(rs.RequestCtx) == 8 {
-					responseId = binary.BigEndian.Uint64(rs.RequestCtx)
-				}
 				lg.Warn(
 					"ignored out-of-date read index response; local node read indexes queueing up and waiting to be in sync with leader",
-					zap.Uint64("sent-request-id", requestId),
-					zap.Uint64("received-request-id", responseId),
+					zap.Uint64("received-request-id", responseID),
 				)
 				slowReadIndex.Inc()
 				continue
@@ -917,7 +915,9 @@ func (s *EtcdServer) requestCurrentIndex(leaderChangedNotifier <-chan struct{}, 
 		case <-firstCommitInTermNotifier:
 			firstCommitInTermNotifier = s.FirstCommitInTermNotify()
 			lg.Info("first commit in current term: resending ReadIndex request")
-			err := s.sendReadIndex(requestId)
+			requestID = s.reqIDGen.Next()
+			requestIDs[requestID] = struct{}{}
+			err := s.sendReadIndex(requestID)
 			if err != nil {
 				return 0, err
 			}
@@ -926,10 +926,12 @@ func (s *EtcdServer) requestCurrentIndex(leaderChangedNotifier <-chan struct{}, 
 		case <-retryTimer.C:
 			lg.Warn(
 				"waiting for ReadIndex response took too long, retrying",
-				zap.Uint64("sent-request-id", requestId),
+				zap.Uint64("sent-request-id", requestID),
 				zap.Duration("retry-timeout", readIndexRetryTime),
 			)
-			err := s.sendReadIndex(requestId)
+			requestID = s.reqIDGen.Next()
+			requestIDs[requestID] = struct{}{}
+			err := s.sendReadIndex(requestID)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
Backport of https://github.com/etcd-io/etcd/pull/21399 to release-3.5 branch

Ref https://github.com/etcd-io/etcd/issues/20418

/assign @ahrtr @fuweid