### PR TITLE
Fix data inconsistency when a transaction includes a range request with a specified revision

### DIFF
--- a/server/etcdserver/api/v3rpc/validationfuzz_test.go
+++ b/server/etcdserver/api/v3rpc/validationfuzz_test.go
@@ -175,7 +175,7 @@ func execTransaction(t *testing.T, req *pb.RequestOp) {
 		Success: []*pb.RequestOp{req},
 	}
 
-	_, _, err := txn.Txn(ctx, zaptest.NewLogger(t), request, false, s, &lease.FakeLessor{})
+	_, _, err := txn.Txn(ctx, zaptest.NewLogger(t), request, false, s, &lease.FakeLessor{}, false)
 	if err != nil {
 		t.Skipf("Application erroring. %s", err.Error())
 	}

--- a/server/etcdserver/apply/apply.go
+++ b/server/etcdserver/apply/apply.go
@@ -38,33 +38,16 @@ func Apply(lg *zap.Logger, e *raftpb.Entry, uberApply UberApplier, w wait.Wait, 
 	}
 
 	needResult := w.IsRegistered(id)
+	wrapper := &InternalRaftRequestWrapper{
+		InternalRaftRequest: &raftReq,
+		SkipRangeExecution:  !needResult && raftReq.Txn != nil,
+	}
 	if needResult || !noSideEffect(&raftReq) {
-		if !needResult && raftReq.Txn != nil {
-			removeNeedlessRangeReqs(raftReq.Txn)
-		}
-		return uberApply.Apply(&raftReq, shouldApplyV3), id
+		return uberApply.Apply(wrapper, shouldApplyV3), id
 	}
 	return nil, id
 }
 
 func noSideEffect(r *pb.InternalRaftRequest) bool {
 	return r.Range != nil || r.AuthUserGet != nil || r.AuthRoleGet != nil || r.AuthStatus != nil
-}
-
-func removeNeedlessRangeReqs(txn *pb.TxnRequest) {
-	f := func(ops []*pb.RequestOp) []*pb.RequestOp {
-		j := 0
-		for i := 0; i < len(ops); i++ {
-			if _, ok := ops[i].Request.(*pb.RequestOp_RequestRange); ok {
-				continue
-			}
-			ops[j] = ops[i]
-			j++
-		}
-
-		return ops[:j]
-	}
-
-	txn.Success = f(txn.Success)
-	txn.Failure = f(txn.Failure)
 }

--- a/server/etcdserver/apply/auth.go
+++ b/server/etcdserver/apply/auth.go
@@ -40,7 +40,7 @@ func newAuthApplierV3(as auth.AuthStore, base applierV3, lessor lease.Lessor) *a
 	return &authApplierV3{applierV3: base, as: as, lessor: lessor}
 }
 
-func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
+func (aa *authApplierV3) Apply(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
 	aa.mu.Lock()
 	defer aa.mu.Unlock()
 	if r.Header != nil {
@@ -49,7 +49,7 @@ func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membersh
 		aa.authInfo.Username = r.Header.Username
 		aa.authInfo.Revision = r.Header.AuthRevision
 	}
-	if needAdminPermission(r) {
+	if needAdminPermission(r.InternalRaftRequest) {
 		if err := aa.as.IsAdminPermitted(&aa.authInfo); err != nil {
 			aa.authInfo.Username = ""
 			aa.authInfo.Revision = 0
@@ -114,11 +114,11 @@ func (aa *authApplierV3) DeleteRange(r *pb.DeleteRangeRequest) (*pb.DeleteRangeR
 	return aa.applierV3.DeleteRange(r)
 }
 
-func (aa *authApplierV3) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
+func (aa *authApplierV3) Txn(rt *pb.TxnRequest, skipRangeExecution bool) (*pb.TxnResponse, *traceutil.Trace, error) {
 	if err := CheckTxnAuth(aa.as, &aa.authInfo, aa.lessor, rt); err != nil {
 		return nil, nil, err
 	}
-	return aa.applierV3.Txn(rt)
+	return aa.applierV3.Txn(rt, skipRangeExecution)
 }
 
 func CheckTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, rt *pb.TxnRequest) error {

--- a/server/etcdserver/apply/auth_test.go
+++ b/server/etcdserver/apply/auth_test.go
@@ -45,7 +45,7 @@ func dummyIndexWaiter(_ uint64) <-chan struct{} {
 	return ch
 }
 
-func dummyApplyFunc(_ *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result {
+func dummyApplyFunc(_ *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3) *Result {
 	return &Result{}
 }
 
@@ -180,36 +180,36 @@ func setAuthInfo(authApplier *authApplierV3, userName string) {
 func TestAuthApplierV3_Apply(t *testing.T) {
 	tcs := []struct {
 		name         string
-		request      *pb.InternalRaftRequest
+		request      *InternalRaftRequestWrapper
 		expectResult *Result
 	}{
 		{
 			name: "request does not need admin permission",
-			request: &pb.InternalRaftRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 				Header: &pb.RequestHeader{},
-			},
+			}},
 			expectResult: &Result{},
 		},
 		{
 			name: "request needs admin permission but permission denied",
-			request: &pb.InternalRaftRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 				Header: &pb.RequestHeader{
 					Username: userReadOnly,
 				},
 				AuthEnable: &pb.AuthEnableRequest{},
-			},
+			}},
 			expectResult: &Result{
 				Err: auth.ErrPermissionDenied,
 			},
 		},
 		{
 			name: "request needs admin permission and permitted",
-			request: &pb.InternalRaftRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 				Header: &pb.RequestHeader{
 					Username: userRoot,
 				},
 				AuthEnable: &pb.AuthEnableRequest{},
-			},
+			}},
 			expectResult: &Result{},
 		},
 	}
@@ -229,147 +229,147 @@ func TestAuthApplierV3_Apply(t *testing.T) {
 func TestAuthApplierV3_AdminPermission(t *testing.T) {
 	tcs := []struct {
 		name                  string
-		request               *pb.InternalRaftRequest
+		request               *InternalRaftRequestWrapper
 		adminPermissionNeeded bool
 	}{
 		{
 			name:                  "Range does not need admin permission",
-			request:               &pb.InternalRaftRequest{Range: &pb.RangeRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Range: &pb.RangeRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "Put does not need admin permission",
-			request:               &pb.InternalRaftRequest{Put: &pb.PutRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Put: &pb.PutRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "DeleteRange does not need admin permission",
-			request:               &pb.InternalRaftRequest{DeleteRange: &pb.DeleteRangeRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{DeleteRange: &pb.DeleteRangeRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "Txn does not need admin permission",
-			request:               &pb.InternalRaftRequest{Txn: &pb.TxnRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "Compaction does not need admin permission",
-			request:               &pb.InternalRaftRequest{Compaction: &pb.CompactionRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Compaction: &pb.CompactionRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "LeaseGrant does not need admin permission",
-			request:               &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "LeaseRevoke does not need admin permission",
-			request:               &pb.InternalRaftRequest{LeaseRevoke: &pb.LeaseRevokeRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseRevoke: &pb.LeaseRevokeRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "Alarm does not need admin permission",
-			request:               &pb.InternalRaftRequest{Alarm: &pb.AlarmRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Alarm: &pb.AlarmRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "LeaseCheckpoint does not need admin permission",
-			request:               &pb.InternalRaftRequest{LeaseCheckpoint: &pb.LeaseCheckpointRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseCheckpoint: &pb.LeaseCheckpointRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "Authenticate does not need admin permission",
-			request:               &pb.InternalRaftRequest{Authenticate: &pb.InternalAuthenticateRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Authenticate: &pb.InternalAuthenticateRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "ClusterVersionSet does not need admin permission",
-			request:               &pb.InternalRaftRequest{ClusterVersionSet: &membershippb.ClusterVersionSetRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{ClusterVersionSet: &membershippb.ClusterVersionSetRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "ClusterMemberAttrSet does not need admin permission",
-			request:               &pb.InternalRaftRequest{ClusterMemberAttrSet: &membershippb.ClusterMemberAttrSetRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{ClusterMemberAttrSet: &membershippb.ClusterMemberAttrSetRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "DowngradeInfoSet does not need admin permission",
-			request:               &pb.InternalRaftRequest{DowngradeInfoSet: &membershippb.DowngradeInfoSetRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{DowngradeInfoSet: &membershippb.DowngradeInfoSetRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "AuthUserGet does not need admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserGet: &pb.AuthUserGetRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserGet: &pb.AuthUserGetRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "AuthRoleGet does not need admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleGet: &pb.AuthRoleGetRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleGet: &pb.AuthRoleGetRequest{}}},
 			adminPermissionNeeded: false,
 		},
 		{
 			name:                  "AuthEnable needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthEnable: &pb.AuthEnableRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthEnable: &pb.AuthEnableRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthDisable needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthDisable: &pb.AuthDisableRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthDisable: &pb.AuthDisableRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserAdd needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserAdd: &pb.AuthUserAddRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserAdd: &pb.AuthUserAddRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserDelete needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserDelete: &pb.AuthUserDeleteRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserDelete: &pb.AuthUserDeleteRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserChangePassword needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserChangePassword: &pb.AuthUserChangePasswordRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserChangePassword: &pb.AuthUserChangePasswordRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserGrantRole needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserGrantRole: &pb.AuthUserGrantRoleRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserGrantRole: &pb.AuthUserGrantRoleRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserRevokeRole needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserRevokeRole: &pb.AuthUserRevokeRoleRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserRevokeRole: &pb.AuthUserRevokeRoleRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthUserList needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthUserList: &pb.AuthUserListRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthUserList: &pb.AuthUserListRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthRoleList needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleList: &pb.AuthRoleListRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleList: &pb.AuthRoleListRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthRoleAdd needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleAdd: &pb.AuthRoleAddRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleAdd: &pb.AuthRoleAddRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthRoleDelete needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleDelete: &pb.AuthRoleDeleteRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleDelete: &pb.AuthRoleDeleteRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthRoleGrantPermission needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleGrantPermission: &pb.AuthRoleGrantPermissionRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleGrantPermission: &pb.AuthRoleGrantPermissionRequest{}}},
 			adminPermissionNeeded: true,
 		},
 		{
 			name:                  "AuthRoleRevokePermission needs admin permission",
-			request:               &pb.InternalRaftRequest{AuthRoleRevokePermission: &pb.AuthRoleRevokePermissionRequest{}},
+			request:               &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{AuthRoleRevokePermission: &pb.AuthRoleRevokePermissionRequest{}}},
 			adminPermissionNeeded: true,
 		},
 	}
@@ -653,7 +653,7 @@ func TestAuthApplierV3_Txn(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			setAuthInfo(authApplier, tc.userName)
-			_, _, err := authApplier.Txn(tc.request)
+			_, _, err := authApplier.Txn(tc.request, false)
 			require.Equalf(t, tc.expectError, err, "Range returned unexpected error (or lack thereof), expected: %v, got: %v", tc.expectError, err)
 		})
 	}

--- a/server/etcdserver/apply/backend.go
+++ b/server/etcdserver/apply/backend.go
@@ -43,7 +43,7 @@ func newApplierV3Backend(opts ApplierOptions) applierV3 {
 	}
 }
 
-func (a *applierV3backend) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
+func (a *applierV3backend) Apply(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result {
 	return applyFunc(r, shouldApplyV3)
 }
 
@@ -59,8 +59,8 @@ func (a *applierV3backend) Range(r *pb.RangeRequest) (*pb.RangeResponse, *traceu
 	return mvcctxn.Range(context.TODO(), a.options.Logger, a.options.KV, r, true)
 }
 
-func (a *applierV3backend) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
-	return mvcctxn.Txn(context.TODO(), a.options.Logger, rt, a.options.TxnModeWriteWithSharedBuffer, a.options.KV, a.options.Lessor)
+func (a *applierV3backend) Txn(rt *pb.TxnRequest, skipRangeExecution bool) (*pb.TxnResponse, *traceutil.Trace, error) {
+	return mvcctxn.Txn(context.TODO(), a.options.Logger, rt, a.options.TxnModeWriteWithSharedBuffer, a.options.KV, a.options.Lessor, skipRangeExecution)
 }
 
 func (a *applierV3backend) Compaction(compaction *pb.CompactionRequest) (*pb.CompactionResponse, <-chan struct{}, *traceutil.Trace, error) {

--- a/server/etcdserver/apply/capped.go
+++ b/server/etcdserver/apply/capped.go
@@ -34,11 +34,11 @@ func (a *applierV3Capped) Put(_ *pb.PutRequest) (*pb.PutResponse, *traceutil.Tra
 	return nil, nil, errors.ErrNoSpace
 }
 
-func (a *applierV3Capped) Txn(r *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
+func (a *applierV3Capped) Txn(r *pb.TxnRequest, skipRangeExecution bool) (*pb.TxnResponse, *traceutil.Trace, error) {
 	if a.q.Cost(r) > 0 {
 		return nil, nil, errors.ErrNoSpace
 	}
-	return a.applierV3.Txn(r)
+	return a.applierV3.Txn(r, skipRangeExecution)
 }
 
 func (a *applierV3Capped) LeaseGrant(_ *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error) {

--- a/server/etcdserver/apply/corrupt.go
+++ b/server/etcdserver/apply/corrupt.go
@@ -38,7 +38,7 @@ func (a *applierV3Corrupt) DeleteRange(_ *pb.DeleteRangeRequest) (*pb.DeleteRang
 	return nil, nil, errors.ErrCorrupt
 }
 
-func (a *applierV3Corrupt) Txn(_ *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
+func (a *applierV3Corrupt) Txn(_ *pb.TxnRequest, _ bool) (*pb.TxnResponse, *traceutil.Trace, error) {
 	return nil, nil, errors.ErrCorrupt
 }
 

--- a/server/etcdserver/apply/interface.go
+++ b/server/etcdserver/apply/interface.go
@@ -33,16 +33,24 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
+// InternalRaftRequestWrapper carries per-apply metadata for an InternalRaftRequest.
+type InternalRaftRequestWrapper struct {
+	*pb.InternalRaftRequest
+	// SkipRangeExecution skips execution of range requests inside a txn for
+	// members that do not need the response; validation via checkRange still runs.
+	SkipRangeExecution bool
+}
+
 // applierV3 is the interface for processing V3 raft messages
 type applierV3 interface {
 	// Apply executes the generic portion of application logic for the current applier, but
 	// delegates the actual execution to the applyFunc method.
-	Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result
+	Apply(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3, applyFunc applyFunc) *Result
 
 	Put(p *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error)
 	Range(r *pb.RangeRequest) (*pb.RangeResponse, *traceutil.Trace, error)
 	DeleteRange(dr *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, *traceutil.Trace, error)
-	Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error)
+	Txn(rt *pb.TxnRequest, skipRangeExecution bool) (*pb.TxnResponse, *traceutil.Trace, error)
 	Compaction(compaction *pb.CompactionRequest) (*pb.CompactionResponse, <-chan struct{}, *traceutil.Trace, error)
 
 	LeaseGrant(lc *pb.LeaseGrantRequest) (*pb.LeaseGrantResponse, error)
@@ -115,4 +123,4 @@ type Result struct {
 	Trace *traceutil.Trace
 }
 
-type applyFunc func(*pb.InternalRaftRequest, membership.ShouldApplyV3) *Result
+type applyFunc func(*InternalRaftRequestWrapper, membership.ShouldApplyV3) *Result

--- a/server/etcdserver/apply/quota.go
+++ b/server/etcdserver/apply/quota.go
@@ -42,9 +42,9 @@ func (a *quotaApplierV3) Put(p *pb.PutRequest) (*pb.PutResponse, *traceutil.Trac
 	return resp, trace, err
 }
 
-func (a *quotaApplierV3) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
+func (a *quotaApplierV3) Txn(rt *pb.TxnRequest, skipRangeExecution bool) (*pb.TxnResponse, *traceutil.Trace, error) {
 	ok := a.q.Available(rt)
-	resp, trace, err := a.applierV3.Txn(rt)
+	resp, trace, err := a.applierV3.Txn(rt, skipRangeExecution)
 	if err == nil && !ok {
 		err = errors.ErrNoSpace
 	}

--- a/server/etcdserver/apply/uber_applier.go
+++ b/server/etcdserver/apply/uber_applier.go
@@ -28,7 +28,7 @@ import (
 )
 
 type UberApplier interface {
-	Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result
+	Apply(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3) *Result
 }
 
 type uberApplier struct {
@@ -79,7 +79,7 @@ func (a *uberApplier) restoreAlarms() {
 	}
 }
 
-func (a *uberApplier) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result {
+func (a *uberApplier) Apply(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3) *Result {
 	// We first execute chain of Apply() calls down the hierarchy:
 	// (i.e. CorruptApplier -> CappedApplier -> Auth -> Quota -> Backend),
 	// then dispatch() unpacks the request to a specific method (like Put),
@@ -90,15 +90,15 @@ func (a *uberApplier) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.
 
 // dispatch translates the request (r) into appropriate call (like Put) on
 // the underlying applyV3 object.
-func (a *uberApplier) dispatch(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *Result {
+func (a *uberApplier) dispatch(r *InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3) *Result {
 	op := "unknown"
 	ar := &Result{}
 	defer func(start time.Time) {
 		success := ar.Err == nil || errors.Is(ar.Err, mvcc.ErrCompacted)
 		txn.ApplySecObserve("v3", op, success, time.Since(start))
-		txn.WarnOfExpensiveRequest(a.lg, a.warningApplyDuration, start, &pb.InternalRaftStringer{Request: r}, ar.Resp, ar.Err)
+		txn.WarnOfExpensiveRequest(a.lg, a.warningApplyDuration, start, &pb.InternalRaftStringer{Request: r.InternalRaftRequest}, ar.Resp, ar.Err)
 		if !success {
-			txn.WarnOfFailedRequest(a.lg, start, &pb.InternalRaftStringer{Request: r}, ar.Resp, ar.Err)
+			txn.WarnOfFailedRequest(a.lg, start, &pb.InternalRaftStringer{Request: r.InternalRaftRequest}, ar.Resp, ar.Err)
 		}
 	}(time.Now())
 
@@ -139,7 +139,7 @@ func (a *uberApplier) dispatch(r *pb.InternalRaftRequest, shouldApplyV3 membersh
 		ar.Resp, ar.Trace, ar.Err = a.applyV3.DeleteRange(r.DeleteRange)
 	case r.Txn != nil:
 		op = "Txn"
-		ar.Resp, ar.Trace, ar.Err = a.applyV3.Txn(r.Txn)
+		ar.Resp, ar.Trace, ar.Err = a.applyV3.Txn(r.Txn, r.SkipRangeExecution)
 	case r.Compaction != nil:
 		op = "Compaction"
 		ar.Resp, ar.Physc, ar.Trace, ar.Err = a.applyV3.Compaction(r.Compaction)

--- a/server/etcdserver/apply/uber_applier_test.go
+++ b/server/etcdserver/apply/uber_applier_test.go
@@ -83,55 +83,55 @@ func defaultUberApplier(t *testing.T) UberApplier {
 func TestUberApplier_Alarm_Corrupt(t *testing.T) {
 	tcs := []struct {
 		name        string
-		request     *pb.InternalRaftRequest
+		request     *InternalRaftRequestWrapper
 		expectError error
 	}{
 		{
 			name:        "Put request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{Put: &pb.PutRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Put: &pb.PutRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "Range request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{Range: &pb.RangeRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Range: &pb.RangeRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "DeleteRange request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{DeleteRange: &pb.DeleteRangeRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{DeleteRange: &pb.DeleteRangeRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "Txn request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{Txn: &pb.TxnRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "Compaction request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{Compaction: &pb.CompactionRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Compaction: &pb.CompactionRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "LeaseGrant request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 		{
 			name:        "LeaseRevoke request returns ErrCorrupt after alarm CORRUPT is activated",
-			request:     &pb.InternalRaftRequest{LeaseRevoke: &pb.LeaseRevokeRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseRevoke: &pb.LeaseRevokeRequest{}}},
 			expectError: errors.ErrCorrupt,
 		},
 	}
 
 	ua := defaultUberApplier(t)
-	result := ua.Apply(&pb.InternalRaftRequest{
+	result := ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 		Header: &pb.RequestHeader{},
 		Alarm: &pb.AlarmRequest{
 			Action:   pb.AlarmRequest_ACTIVATE,
 			MemberID: memberID,
 			Alarm:    pb.AlarmType_CORRUPT,
 		},
-	}, membership.ApplyBoth)
+	}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	require.NoError(t, result.Err)
 
@@ -148,17 +148,17 @@ func TestUberApplier_Alarm_Corrupt(t *testing.T) {
 func TestUberApplier_Alarm_Quota(t *testing.T) {
 	tcs := []struct {
 		name        string
-		request     *pb.InternalRaftRequest
+		request     *InternalRaftRequestWrapper
 		expectError error
 	}{
 		{
 			name:        "Put request returns ErrCorrupt after alarm NOSPACE is activated",
-			request:     &pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}},
 			expectError: errors.ErrNoSpace,
 		},
 		{
 			name: "Txn request cost > 0 returns ErrCorrupt after alarm NOSPACE is activated",
-			request: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
 				Success: []*pb.RequestOp{
 					{
 						Request: &pb.RequestOp_RequestPut{
@@ -168,12 +168,12 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}}},
 			expectError: errors.ErrNoSpace,
 		},
 		{
 			name: "Txn request cost = 0 is still allowed after alarm NOSPACE is activated",
-			request: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
 				Success: []*pb.RequestOp{
 					{
 						Request: &pb.RequestOp_RequestRange{
@@ -183,12 +183,12 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}}},
 			expectError: nil,
 		},
 		{
 			name: "Txn request cost = 0 in both branches is still allowed after alarm NOSPACE is activated",
-			request: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
+			request: &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Txn: &pb.TxnRequest{
 				Compare: []*pb.Compare{
 					{
 						Key:         []byte(key),
@@ -215,25 +215,25 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}}},
 			expectError: nil,
 		},
 		{
 			name:        "LeaseGrant request returns ErrCorrupt after alarm NOSPACE is activated",
-			request:     &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}},
+			request:     &InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{LeaseGrant: &pb.LeaseGrantRequest{}}},
 			expectError: errors.ErrNoSpace,
 		},
 	}
 
 	ua := defaultUberApplier(t)
-	result := ua.Apply(&pb.InternalRaftRequest{
+	result := ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 		Header: &pb.RequestHeader{},
 		Alarm: &pb.AlarmRequest{
 			Action:   pb.AlarmRequest_ACTIVATE,
 			MemberID: memberID,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, membership.ApplyBoth)
+	}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	require.NoError(t, result.Err)
 
@@ -249,33 +249,33 @@ func TestUberApplier_Alarm_Quota(t *testing.T) {
 // TestUberApplier_Alarm_Deactivate tests the applier should be able to apply after alarm is deactivated
 func TestUberApplier_Alarm_Deactivate(t *testing.T) {
 	ua := defaultUberApplier(t)
-	result := ua.Apply(&pb.InternalRaftRequest{
+	result := ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 		Header: &pb.RequestHeader{},
 		Alarm: &pb.AlarmRequest{
 			Action:   pb.AlarmRequest_ACTIVATE,
 			MemberID: memberID,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, membership.ApplyBoth)
+	}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	require.NoError(t, result.Err)
 
-	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}, membership.ApplyBoth)
+	result = ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	require.Equalf(t, errors.ErrNoSpace, result.Err, "Apply: got %v, expect: %v", result.Err, errors.ErrNoSpace)
 
-	result = ua.Apply(&pb.InternalRaftRequest{
+	result = ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{
 		Header: &pb.RequestHeader{},
 		Alarm: &pb.AlarmRequest{
 			Action:   pb.AlarmRequest_DEACTIVATE,
 			MemberID: memberID,
 			Alarm:    pb.AlarmType_NOSPACE,
 		},
-	}, membership.ApplyBoth)
+	}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	require.NoError(t, result.Err)
 
-	result = ua.Apply(&pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}, membership.ApplyBoth)
+	result = ua.Apply(&InternalRaftRequestWrapper{InternalRaftRequest: &pb.InternalRaftRequest{Put: &pb.PutRequest{Key: []byte(key)}}}, membership.ApplyBoth)
 	require.NotNil(t, result)
 	assert.NoError(t, result.Err)
 }

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -139,7 +139,7 @@ func TestApplyRepeat(t *testing.T) {
 
 type uberApplierMock struct{}
 
-func (uberApplierMock) Apply(r *pb.InternalRaftRequest, shouldApplyV3 membership.ShouldApplyV3) *apply2.Result {
+func (uberApplierMock) Apply(r *apply2.InternalRaftRequestWrapper, shouldApplyV3 membership.ShouldApplyV3) *apply2.Result {
 	return &apply2.Result{}
 }
 

--- a/server/etcdserver/txn/txn.go
+++ b/server/etcdserver/txn/txn.go
@@ -29,7 +29,7 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWithSharedBuffer bool, kv mvcc.KV, lessor lease.Lessor) (txnResp *pb.TxnResponse, trace *traceutil.Trace, err error) {
+func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWithSharedBuffer bool, kv mvcc.KV, lessor lease.Lessor, skipRangeExecution bool) (txnResp *pb.TxnResponse, trace *traceutil.Trace, err error) {
 	ctx, trace = traceutil.EnsureTrace(ctx, lg, "transaction")
 	isWrite := !IsTxnReadonly(rt)
 	// When the transaction contains write operations, we use ReadTx instead of
@@ -68,7 +68,7 @@ func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWit
 	} else {
 		txnWrite = mvcc.NewReadOnlyTxnWrite(txnRead)
 	}
-	txnResp, err = txn(ctx, lg, txnWrite, rt, isWrite, txnPath)
+	txnResp, err = txn(ctx, lg, txnWrite, rt, isWrite, txnPath, skipRangeExecution)
 	txnWrite.End()
 
 	trace.AddField(
@@ -78,9 +78,9 @@ func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWit
 	return txnResp, trace, err
 }
 
-func txn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt *pb.TxnRequest, isWrite bool, txnPath []bool) (*pb.TxnResponse, error) {
+func txn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt *pb.TxnRequest, isWrite bool, txnPath []bool, skipRangeExecution bool) (*pb.TxnResponse, error) {
 	txnResp, _ := newTxnResp(rt, txnPath)
-	_, err := executeTxn(ctx, lg, txnWrite, rt, txnPath, txnResp)
+	_, err := executeTxn(ctx, lg, txnWrite, rt, txnPath, txnResp, skipRangeExecution)
 	if err != nil {
 		if isWrite {
 			// CAUTION: When a txn performing write operations starts, we always expect it to be successful.
@@ -132,7 +132,7 @@ func newTxnResp(rt *pb.TxnRequest, txnPath []bool) (txnResp *pb.TxnResponse, txn
 	return txnResp, txnCount
 }
 
-func executeTxn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt *pb.TxnRequest, txnPath []bool, tresp *pb.TxnResponse) (txns int, err error) {
+func executeTxn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt *pb.TxnRequest, txnPath []bool, tresp *pb.TxnResponse, skipRangeExecution bool) (txns int, err error) {
 	trace := traceutil.Get(ctx)
 	reqs := rt.Success
 	if !txnPath[0] {
@@ -147,9 +147,20 @@ func executeTxn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt 
 				traceutil.Field{Key: "req_type", Value: "range"},
 				traceutil.Field{Key: "range_begin", Value: string(tv.RequestRange.Key)},
 				traceutil.Field{Key: "range_end", Value: string(tv.RequestRange.RangeEnd)})
-			resp, err := executeRange(ctx, lg, txnWrite, tv.RequestRange, true)
-			if err != nil {
-				return 0, fmt.Errorf("applyTxn: failed Range: %w", err)
+			var resp *pb.RangeResponse
+			if skipRangeExecution {
+				rev := txnWrite.Rev()
+				if len(txnWrite.Changes()) > 0 {
+					rev++
+				}
+				resp = &pb.RangeResponse{
+					Header: &pb.ResponseHeader{Revision: rev},
+				}
+			} else {
+				resp, err = executeRange(ctx, lg, txnWrite, tv.RequestRange, true)
+				if err != nil {
+					return 0, fmt.Errorf("applyTxn: failed Range: %w", err)
+				}
 			}
 			respi.(*pb.ResponseOp_ResponseRange).ResponseRange = resp
 			trace.StopSubTrace()
@@ -173,7 +184,7 @@ func executeTxn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt 
 			respi.(*pb.ResponseOp_ResponseDeleteRange).ResponseDeleteRange = resp
 		case *pb.RequestOp_RequestTxn:
 			resp := respi.(*pb.ResponseOp_ResponseTxn).ResponseTxn
-			applyTxns, err := executeTxn(ctx, lg, txnWrite, tv.RequestTxn, txnPath[1:], resp)
+			applyTxns, err := executeTxn(ctx, lg, txnWrite, tv.RequestTxn, txnPath[1:], resp, skipRangeExecution)
 			if err != nil {
 				// don't wrap the error. It's a recursive call and err should be already wrapped
 				return 0, err

--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -223,7 +223,7 @@ func TestCheckTxn(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			_, _, err := Txn(ctx, zaptest.NewLogger(t), tc.txn, false, s, lessor)
+			_, _, err := Txn(ctx, zaptest.NewLogger(t), tc.txn, false, s, lessor, false)
 
 			gotErr := ""
 			if err != nil {
@@ -302,6 +302,76 @@ func setup(t *testing.T, setup testSetup) (mvcc.KV, lease.Lessor) {
 	return s, lessor
 }
 
+func TestSkippedRangeExecutionResponseHeaderRevision(t *testing.T) {
+	tests := []struct {
+		name string
+		txn  *pb.TxnRequest
+	}{
+		{
+			name: "range before write",
+			txn: &pb.TxnRequest{
+				Success: []*pb.RequestOp{
+					{
+						Request: &pb.RequestOp_RequestRange{
+							RequestRange: &pb.RangeRequest{Key: []byte("foo")},
+						},
+					},
+					{
+						Request: &pb.RequestOp_RequestPut{
+							RequestPut: &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "range after write",
+			txn: &pb.TxnRequest{
+				Success: []*pb.RequestOp{
+					{
+						Request: &pb.RequestOp_RequestPut{
+							RequestPut: &pb.PutRequest{Key: []byte("foo"), Value: []byte("bar")},
+						},
+					},
+					{
+						Request: &pb.RequestOp_RequestRange{
+							RequestRange: &pb.RangeRequest{Key: []byte("foo")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			lg := zaptest.NewLogger(t)
+			normalKV, normalLessor := setup(t, testSetup{})
+			skippedKV, skippedLessor := setup(t, testSetup{})
+
+			normalResp, _, err := Txn(ctx, lg, tt.txn, false, normalKV, normalLessor, false)
+			require.NoError(t, err)
+			skippedResp, _, err := Txn(ctx, lg, tt.txn, false, skippedKV, skippedLessor, true)
+			require.NoError(t, err)
+
+			var normalRangeHeader, skippedRangeHeader *pb.ResponseHeader
+			for i, resp := range normalResp.Responses {
+				rangeResp := resp.GetResponseRange()
+				if rangeResp == nil {
+					continue
+				}
+				normalRangeHeader = rangeResp.Header
+				skippedRangeHeader = skippedResp.Responses[i].GetResponseRange().Header
+				break
+			}
+			require.NotNil(t, normalRangeHeader)
+			require.NotNil(t, skippedRangeHeader)
+			require.Equal(t, normalRangeHeader.Revision, skippedRangeHeader.Revision)
+		})
+	}
+}
+
 func TestReadonlyTxnError(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	defer betesting.Close(t, b)
@@ -328,7 +398,7 @@ func TestReadonlyTxnError(t *testing.T) {
 		},
 	}
 
-	_, _, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{})
+	_, _, err := Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}, false)
 	if err == nil || !strings.Contains(err.Error(), "applyTxn: failed Range: rangeKeys: context cancelled: context canceled") {
 		t.Fatalf("Expected context canceled error, got %v", err)
 	}
@@ -371,7 +441,7 @@ func TestWriteTxnPanicWithoutApply(t *testing.T) {
 	// we verify the following properties below:
 	// 1. server panics after a write txn aply fails (invariant: server should never try to move on from a failed write)
 	// 2. no writes from the txn are applied to the backend (invariant: failed write should have no side-effect on DB state besides panic)
-	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}) }, "Expected panic in Txn with writes")
+	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}, false) }, "Expected panic in Txn with writes")
 	dbHashAfter, err := computeFileHash(bePath)
 	require.NoErrorf(t, err, "failed to compute DB file hash after txn")
 	require.Equalf(t, dbHashBefore, dbHashAfter, "mismatch in DB hash before and after failed write txn")

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -363,7 +363,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		}(time.Now())
 
 		get := func() {
-			resp, _, err = txn.Txn(ctx, s.Logger(), r, s.Cfg.ServerFeatureGate.Enabled(features.TxnModeWriteWithSharedBuffer), s.KV(), s.lessor)
+			resp, _, err = txn.Txn(ctx, s.Logger(), r, s.Cfg.ServerFeatureGate.Enabled(features.TxnModeWriteWithSharedBuffer), s.KV(), s.lessor, false)
 		}
 		if serr := s.doSerialize(ctx, chk, get); serr != nil {
 			return nil, serr

--- a/tests/e2e/txn_range_consistency_test.go
+++ b/tests/e2e/txn_range_consistency_test.go
@@ -27,8 +27,7 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-// TestReproduce18667 reproduces the issue: https://github.com/etcd-io/etcd/issues/18667.
-func TestReproduce18667(t *testing.T) {
+func TestTxnRangeConsistency(t *testing.T) {
 	e2e.BeforeTest(t)
 
 	ctx := t.Context()
@@ -71,15 +70,6 @@ func TestReproduce18667(t *testing.T) {
 		cli = newClient(t, clus.Procs[idx].EndpointsGRPC(), e2e.ClientConfig{})
 		resp, err := cli.Get(ctx, "k2")
 		require.NoError(t, err)
-		// TODO: All members are supposed to have the same key/value pair k2:v2.
-		// However, the issue https://github.com/etcd-io/etcd/issues/18667
-		// hasn't been resolved yet, so some members hold the wrong data
-		// "k2:foo". Once the issue is fixed, we should remove the if-else
-		// branch below, and all member should have consistent data k2:v2.
-		if i == 0 {
-			assert.Equal(t, "v2", string(resp.Kvs[0].Value))
-		} else {
-			assert.Equal(t, "foo", string(resp.Kvs[0].Value))
-		}
+		assert.Equal(t, "v2", string(resp.Kvs[0].Value))
 	}
 }

--- a/tests/integration/txn_range_consistency_test.go
+++ b/tests/integration/txn_range_consistency_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/tests/v3/framework/integration"
+)
+
+func TestTxnRangeRequestConsistency(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3})
+	defer clus.Terminate(t)
+
+	kvc := integration.ToGRPC(clus.Client(0)).KV
+
+	_, err := kvc.Put(t.Context(), &pb.PutRequest{Key: []byte("key"), Value: []byte("val")})
+	require.NoError(t, err)
+
+	_, err = kvc.Compact(t.Context(), &pb.CompactionRequest{Revision: 2})
+	require.NoError(t, err)
+
+	txn := &pb.TxnRequest{
+		Success: []*pb.RequestOp{
+			{
+				Request: &pb.RequestOp_RequestRange{
+					RequestRange: &pb.RangeRequest{
+						Key:      []byte("key"),
+						Revision: 1,
+					},
+				},
+			},
+			{
+				Request: &pb.RequestOp_RequestPut{
+					RequestPut: &pb.PutRequest{
+						Key:   []byte("should-not-exist"),
+						Value: []byte("inconsistent"),
+					},
+				},
+			},
+		},
+	}
+	_, err = kvc.Txn(t.Context(), txn)
+	require.ErrorContains(t, err, "mvcc: required revision has been compacted")
+
+	for i := range clus.Members {
+		resp, err := clus.Client(i).Get(t.Context(), "should-not-exist")
+		require.NoError(t, err)
+		require.Equalf(t, int64(0), resp.Count, "member %d should not have the key", i)
+	}
+}


### PR DESCRIPTION
Remove the optimization that removes range requests from read-only txns. This ensures all cluster members execute the same validation and maintain consistent data.

Closes #18667