### PR TITLE
Update kubernetes patches used in etcd-k8s coverage tests

### DIFF
--- a/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0002-Add-kubernetesEtcdContractTracker.patch
@@ -90,10 +90,10 @@ index 00000000000..c16eecb20fa
 +	return k.Interface.OptimisticDelete(ctx, key, expectedRevision, opts)
 +}
 diff --git a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
-index 53fc9f97a70..8870369d471 100644
+index 6b60601a784..235850a44f2 100644
 --- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
 +++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
-@@ -351,8 +351,16 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
+@@ -354,8 +354,16 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
  		TLS:                  tlsConfig,
  		Logger:               etcd3ClientLogger,
  	}

--- a/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
+++ b/tests/robustness/coverage/patches/kubernetes/0004-Configure-cmd-tests.patch
@@ -5,7 +5,7 @@ Subject: [PATCH 4/4] Configure cmd tests
 
 
 diff --git a/hack/lib/etcd.sh b/hack/lib/etcd.sh
-index 6e99d244c80..62af49e3e5c 100755
+index 15c4e59bba9..a22e8d04775 100755
 --- a/hack/lib/etcd.sh
 +++ b/hack/lib/etcd.sh
 @@ -25,6 +25,8 @@ ETCD_PORT=${ETCD_PORT:-2379}
@@ -21,10 +21,10 @@ index 6e99d244c80..62af49e3e5c 100755
    else
      ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
    fi
--  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=${ETCD_LOGLEVEL} 2> \"${ETCD_LOGFILE}\" >/dev/null"
--  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level="${ETCD_LOGLEVEL}" 2> "${ETCD_LOGFILE}" >/dev/null &
-+  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --log-level=${ETCD_LOGLEVEL} --enable-distributed-tracing --distributed-tracing-address=\"0.0.0.0:4317\" --distributed-tracing-service-name=\"etcd\" --distributed-tracing-sampling-rate=1000000 2> \"${ETCD_LOGFILE}\" >/dev/null"
-+  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --log-level="${ETCD_LOGLEVEL}" --enable-distributed-tracing --distributed-tracing-address="192.168.32.1:4317" --distributed-tracing-service-name="etcd" --distributed-tracing-sampling-rate=1000000 2> "${ETCD_LOGFILE}" >/dev/null &
+-  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --listen-peer-urls http://localhost:0 --log-level=${ETCD_LOGLEVEL} 2> \"${ETCD_LOGFILE}\" >/dev/null"
+-  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --listen-peer-urls "http://localhost:0" --log-level="${ETCD_LOGLEVEL}" 2> "${ETCD_LOGFILE}" >/dev/null &
++  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --listen-peer-urls http://localhost:0 --log-level=${ETCD_LOGLEVEL} --enable-distributed-tracing --distributed-tracing-address=\"192.168.32.1:4317\" --distributed-tracing-service-name=\"etcd\" --distributed-tracing-sampling-rate=1000000 2> \"${ETCD_LOGFILE}\" >/dev/null"
++  etcd --advertise-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --data-dir "${ETCD_DIR}" --listen-client-urls "${KUBE_INTEGRATION_ETCD_URL}" --listen-peer-urls "http://localhost:0" --log-level="${ETCD_LOGLEVEL}" --enable-distributed-tracing --distributed-tracing-address="192.168.32.1:4317" --distributed-tracing-service-name="etcd" --distributed-tracing-sampling-rate=1000000 2> "${ETCD_LOGFILE}" >/dev/null &
    ETCD_PID=$!
  
    echo "Waiting for etcd to come up."


### PR DESCRIPTION
Same as https://github.com/etcd-io/etcd/pull/20766 before.

First seen in: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-k8s-coverage-amd64/2029151506988535808

/cc @serathius 