### PR TITLE
ci: set top-level permissions for antithesis-verify workflow

### DIFF
--- a/.github/workflows/antithesis-verify.yml
+++ b/.github/workflows/antithesis-verify.yml
@@ -1,6 +1,9 @@
 ---
 name: Verify Antithesis Docker Compose Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines
2. If you used AI tools in preparing your PR, please disclose this
-->

## Summary

Add explicit `permissions: contents: read` at the workflow level in `.github/workflows/antithesis-verify.yml` to restrict the default `GITHUB_TOKEN` to read-only access, following the principle of least privilege.

Fixes #21469

## Changes

- Added top-level `permissions: contents: read` to the `antithesis-verify.yml` workflow

## Why

The OpenSSF Scorecard `Token-Permissions` check flagged this workflow for not defining top-level permissions:

```
Warn: no topLevel permission defined: .github/workflows/antithesis-verify.yml:1
```

This change improves the repository's OpenSSF Scorecard score with no functional impact, as the workflow only checks out code and runs local Docker builds.