### PR TITLE
robustness: implement cluster client endpoint switching

### DIFF
--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -316,6 +316,10 @@ func (c *RecordingClient) Endpoints() []string {
 	return c.client.Endpoints()
 }
 
+func (c *RecordingClient) SetEndpoints(endpoints ...string) {
+	c.client.SetEndpoints(endpoints...)
+}
+
 func (c *RecordingClient) Watch(ctx context.Context, key string, rev int64, withPrefix bool, withProgressNotify bool, withPrevKV bool) clientv3.WatchChan {
 	request := model.WatchRequest{
 		Key:                key,

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -224,6 +224,12 @@ func SimulateWatchTraffic(ctx context.Context, wg *sync.WaitGroup, profile *Watc
 			defer c.Close()
 			tf.RunWatchLoop(ctx, c, baseParam)
 		}(c)
+
+		if profile.EndpointSwitchPeriod != nil {
+			wg.Go(func() {
+				runEndpointSwitchLoop(ctx, c, endpoints, *profile.EndpointSwitchPeriod, baseParam.Finish)
+			})
+		}
 	}
 	for range profile.ClusterClientCount {
 		c, err := clientSet.NewClient(endpoints)
@@ -236,6 +242,12 @@ func SimulateWatchTraffic(ctx context.Context, wg *sync.WaitGroup, profile *Watc
 			defer c.Close()
 			tf.RunWatchLoop(ctx, c, baseParam)
 		}(c)
+
+		if profile.EndpointSwitchPeriod != nil {
+			wg.Go(func() {
+				runEndpointSwitchLoop(ctx, c, endpoints, *profile.EndpointSwitchPeriod, baseParam.Finish)
+			})
+		}
 	}
 	return nil
 }
@@ -377,9 +389,10 @@ type KeyValue struct {
 }
 
 type Watch struct {
-	MemberClientCount   int
-	ClusterClientCount  int
-	RevisionOffsetRange Range
+	MemberClientCount    int
+	ClusterClientCount   int
+	RevisionOffsetRange  Range
+	EndpointSwitchPeriod *time.Duration
 }
 
 type Compaction struct {
@@ -493,4 +506,17 @@ func CheckEmptyDatabaseAtStart(ctx context.Context, lg *zap.Logger, endpoints []
 		break
 	}
 	return nil
+}
+
+func runEndpointSwitchLoop(ctx context.Context, c *client.RecordingClient, endpoints []string, period time.Duration, finish <-chan struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-finish:
+			return
+		case <-time.After(period):
+			c.SetEndpoints(endpoints...)
+		}
+	}
 }


### PR DESCRIPTION
Introduce optional cluster client endpoint switching. 

This would allow us to test out the client reconnection behaviors, such as the resumable guarantee for watches. 

Used in https://github.com/etcd-io/etcd/pull/21472