### PR TITLE
robustness: 20221 reproduction

### DIFF
--- a/tests/robustness/Makefile
+++ b/tests/robustness/Makefile
@@ -84,6 +84,11 @@ test-robustness-issue20221: /tmp/etcd-bc47e771-failpoints/bin
 	GO_TEST_FLAGS='-v -run=TestRobustnessRegression/Issue20221 -count 100 -failfast --bin-dir=/tmp/etcd-bc47e771-failpoints/bin' $(TOPLEVEL_MAKE) test-robustness && \
 	 echo "Failed to reproduce" || echo "Successful reproduction"
 
+.PHONY: test-robustness-issue20221-event
+test-robustness-issue20221-event: /tmp/etcd-44a094a2-failpoints/bin
+	GO_TEST_FLAGS='-v -run=TestRobustnessRegression/Issue20221-event -count 100 -failfast --bin-dir=/tmp/etcd-44a094a2-failpoints/bin' $(TOPLEVEL_MAKE) test-robustness && \
+	 echo "Failed to reproduce" || echo "Successful reproduction"
+
 # Etcd API usage by Kubernetes
 
 .PHONY: k8s-coverage
@@ -148,13 +153,26 @@ $(GOPATH)/bin/gofail: $(REPOSITORY_ROOT)/tools/mod/go.mod $(REPOSITORY_ROOT)/too
 	  $(MAKE) gofail-enable; \
 	  $(MAKE) build;
 
+/tmp/etcd-44a094a2-failpoints/bin: $(GOPATH)/bin/gofail
+	rm -rf /tmp/etcd-44a094a2-failpoints/
+	mkdir -p /tmp/etcd-44a094a2-failpoints/
+	cd /tmp/etcd-44a094a2-failpoints/; \
+	  git init; \
+	  git remote add origin https://github.com/etcd-io/etcd.git; \
+	  git fetch --depth 1 origin 44a094a20a7a0ac16cf88c9f21b6ca90e9f85cf5; \
+	  git checkout FETCH_HEAD; \
+	  cp -r $(REPOSITORY_ROOT)/tests/robustness/patches/removeVerifyModRevision . && \
+	  patch --fuzz=0 server/storage/mvcc/watchable_store.go ./removeVerifyModRevision/watchable_store.patch && \
+	  $(MAKE) gofail-enable; \
+	  $(MAKE) build;
+
 /tmp/etcd-release-3.7-failpoints/bin: $(GOPATH)/bin/gofail
 	rm -rf /tmp/etcd-release-3.7-failpoints/
 	mkdir -p /tmp/etcd-release-3.7-failpoints/
 	cd /tmp/etcd-release-3.7-failpoints/; \
-	  git clone --depth 1 --branch release-3.7 https://github.com/etcd-io/etcd.git .; \
-	  $(MAKE) gofail-enable; \
-	  $(MAKE) build;
+	git clone --depth 1 --branch release-3.7 https://github.com/etcd-io/etcd.git .; \
+	$(MAKE) gofail-enable; \
+	$(MAKE) build;
 
 /tmp/etcd-release-3.6-failpoints/bin: $(GOPATH)/bin/gofail
 	rm -rf /tmp/etcd-release-3.6-failpoints/

--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -316,6 +316,10 @@ func (c *RecordingClient) Endpoints() []string {
 	return c.client.Endpoints()
 }
 
+func (c *RecordingClient) SetEndpoints(endpoints ...string) {
+	c.client.SetEndpoints(endpoints...)
+}
+
 func (c *RecordingClient) Watch(ctx context.Context, key string, rev int64, withPrefix bool, withProgressNotify bool, withPrevKV bool) clientv3.WatchChan {
 	request := model.WatchRequest{
 		Key:                key,

--- a/tests/robustness/patches/removeVerifyModRevision/watchable_store.patch
+++ b/tests/robustness/patches/removeVerifyModRevision/watchable_store.patch
@@ -1,0 +1,35 @@
+diff --git a/server/storage/mvcc/watchable_store.go b/server/storage/mvcc/watchable_store.go
+index 1996ee6..ed9fe1c 100644
+--- a/server/storage/mvcc/watchable_store.go
++++ b/server/storage/mvcc/watchable_store.go
+@@ -15,14 +15,12 @@
+ package mvcc
+ 
+ import (
+-	"fmt"
+ 	"sync"
+ 	"time"
+ 
+ 	"go.uber.org/zap"
+ 
+ 	"go.etcd.io/etcd/api/v3/mvccpb"
+-	"go.etcd.io/etcd/client/pkg/v3/verify"
+ 	clientv3 "go.etcd.io/etcd/client/v3"
+ 	"go.etcd.io/etcd/pkg/v3/traceutil"
+ 	"go.etcd.io/etcd/server/v3/lease"
+@@ -610,15 +608,6 @@ func (w *watcher) send(wr WatchResponse) bool {
+ 		wr.Events = ne
+ 	}
+ 
+-	verify.Verify(func() {
+-		if w.startRev > 0 {
+-			for _, ev := range wr.Events {
+-				if ev.Kv.ModRevision < w.startRev {
+-					panic(fmt.Sprintf("Event.ModRevision(%d) is less than the w.startRev(%d) for watchID: %d", ev.Kv.ModRevision, w.startRev, w.id))
+-				}
+-			}
+-		}
+-	})
+ 
+ 	// if all events are filtered out, we should send nothing.
+ 	if !progressEvent && len(wr.Events) == 0 {

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -322,6 +322,28 @@ func Regression(t *testing.T) []TestScenario {
 			e2e.WithSnapshotCatchUpEntries(10),
 		),
 	})
+	clusterClientSwitchingInterval := 500 * time.Millisecond
+	scenarios = append(scenarios, TestScenario{
+		Name:      "Issue20221-event",
+		Failpoint: failpoint.BlackholeUntilSnapshot,
+		Profile: traffic.Profile{
+			KeyValue: &traffic.KeyValueHigh,
+			Watch: &traffic.Watch{
+				MemberClientCount:    6,
+				ClusterClientCount:   2,
+				RevisionOffsetRange:  traffic.Range{Min: 10, Max: 100},
+				EndpointSwitchPeriod: &clusterClientSwitchingInterval,
+			},
+		},
+		Traffic: traffic.EtcdPut,
+		Cluster: *e2e.NewConfig(
+			e2e.WithSnapshotCount(10),
+			e2e.WithPeerProxy(true),
+			e2e.WithIsPeerTLS(true),
+			e2e.WithWatchProcessNotifyInterval(10*time.Millisecond),
+			e2e.WithSnapshotCatchUpEntries(10),
+		),
+	})
 	if v.Compare(version.V3_5) >= 0 {
 		opts := []e2e.EPClusterOption{
 			e2e.WithSnapshotCount(100),

--- a/tests/robustness/traffic/traffic.go
+++ b/tests/robustness/traffic/traffic.go
@@ -224,6 +224,12 @@ func SimulateWatchTraffic(ctx context.Context, wg *sync.WaitGroup, profile *Watc
 			defer c.Close()
 			tf.RunWatchLoop(ctx, c, baseParam)
 		}(c)
+
+		if profile.EndpointSwitchPeriod != nil {
+			wg.Go(func() {
+				runEndpointSwitchLoop(ctx, c, endpoints, *profile.EndpointSwitchPeriod, baseParam.Finish)
+			})
+		}
 	}
 	for range profile.ClusterClientCount {
 		c, err := clientSet.NewClient(endpoints)
@@ -236,6 +242,12 @@ func SimulateWatchTraffic(ctx context.Context, wg *sync.WaitGroup, profile *Watc
 			defer c.Close()
 			tf.RunWatchLoop(ctx, c, baseParam)
 		}(c)
+
+		if profile.EndpointSwitchPeriod != nil {
+			wg.Go(func() {
+				runEndpointSwitchLoop(ctx, c, endpoints, *profile.EndpointSwitchPeriod, baseParam.Finish)
+			})
+		}
 	}
 	return nil
 }
@@ -377,9 +389,10 @@ type KeyValue struct {
 }
 
 type Watch struct {
-	MemberClientCount   int
-	ClusterClientCount  int
-	RevisionOffsetRange Range
+	MemberClientCount    int
+	ClusterClientCount   int
+	RevisionOffsetRange  Range
+	EndpointSwitchPeriod *time.Duration
 }
 
 type Compaction struct {
@@ -493,4 +506,17 @@ func CheckEmptyDatabaseAtStart(ctx context.Context, lg *zap.Logger, endpoints []
 		break
 	}
 	return nil
+}
+
+func runEndpointSwitchLoop(ctx context.Context, c *client.RecordingClient, endpoints []string, period time.Duration, finish <-chan struct{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-finish:
+			return
+		case <-time.After(period):
+			c.SetEndpoints(endpoints...)
+		}
+	}
 }


### PR DESCRIPTION
Targeting bug fix https://github.com/etcd-io/etcd/pull/20281

The idea is that we have a watch that was connected to a peer A, and have received event there. Due to cluster client switching the connection to a different peer, with the blackholeUntilSnapshot failpoint enabled, by chance it would connect to a peer that is blackholed and lags behind. In this case, due to the bug, we could get a revision that is in the past, as seen in the log.

```
    logger.go:146: 2026-03-11T16:11:25.397Z     ERROR   Broke watch guarantee   {"guarantee": "resumable", "client": 20, "request": {"Key":"key","Revision":1593,"WithPrefix":true,"WithProgressNotify":true,"WithPrevKV":true}, "got-event": {"Type":"put-operation","Key":"key76","Value":{"Value":"1981"},"Revision":1571,"PrevValue":{"Value":{"Value":"1976"},"ModRevision":1567,"Version":23}}, "want-event": {"Type":"put-operation","Key":"key80","Value":{"Value":"2010"},"Revision":1593}}
```