### PR TITLE
fix: resolve revive unexported-return in pkg/flags and pkg/wait

### DIFF
--- a/pkg/flags/uint32.go
+++ b/pkg/flags/uint32.go
@@ -21,8 +21,8 @@ import (
 
 type uint32Value uint32
 
-// NewUint32Value creates an uint32 instance with the provided value.
-func NewUint32Value(v uint32) *uint32Value {
+// NewUint32Value creates a flag.Value for an uint32 variable.
+func NewUint32Value(v uint32) flag.Value {
 	val := new(uint32Value)
 	*val = uint32Value(v)
 	return val

--- a/pkg/wait/wait_time.go
+++ b/pkg/wait/wait_time.go
@@ -35,7 +35,7 @@ type timeList struct {
 	m                   map[uint64]chan struct{}
 }
 
-func NewTimeList() *timeList {
+func NewTimeList() WaitTime {
 	return &timeList{m: make(map[uint64]chan struct{})}
 }
 


### PR DESCRIPTION
This change resolves revive `unexported-return` violations by ensuring that
exported constructors do not return unexported concrete types.

- flags.NewUint32Value now returns `flag.Value` instead of `*uint32Value`
- wait.NewTimeList now returns `WaitTime` instead of `*timeList`

The underlying implementations (`uint32Value`, `timeList`) remain unexported,
preserving encapsulation while keeping the public API surface stable.

No behavioral changes are introduced. Existing usages continue to work since
the returned interfaces are already the expected abstraction at call sites.

This is part of the incremental `unexported-return` cleanup tracked in #18370.