### PR TITLE
[3.5] server: fix isLearner metric not set after snapshot

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -543,6 +543,13 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		cl.SetStore(st)
 		cl.SetBackend(be)
 		cl.Recover(api.UpdateCapability)
+		if m := cl.Member(id); m != nil {
+			if m.IsLearner {
+				isLearner.Set(1)
+			} else {
+				isLearner.Set(0)
+			}
+		}
 		if cl.Version() != nil && !cl.Version().LessThan(semver.Version{Major: 3}) && !beExist {
 			os.RemoveAll(bepath)
 			return nil, fmt.Errorf("database file (%v) of the backend is missing", bepath)
@@ -1432,6 +1439,14 @@ func (s *EtcdServer) applySnapshot(ep *etcdProgress, apply *apply) {
 	lg.Info("restoring cluster configuration")
 
 	s.cluster.Recover(api.UpdateCapability)
+
+	if m := s.cluster.Member(s.ID()); m != nil {
+		if m.IsLearner {
+			isLearner.Set(1)
+		} else {
+			isLearner.Set(0)
+		}
+	}
 
 	lg.Info("restored cluster configuration")
 	lg.Info("removing old peers from network")


### PR DESCRIPTION
## Summary

Backport of the fix for #17175 to `release-3.5`. The original fix (#17176) was merged to `main` but the previous backport attempt (#17266) was closed without merging.

After a learner node receives a snapshot (or restarts after one), the `etcd_server_is_learner` Prometheus metric stays at `0` instead of being set to `1`. This happens because the conf change entries that originally set the metric have been compacted into the snapshot, so `applyConfChange` is never called for them.

### Changes

- Set the `isLearner` metric right after `Recover()` in `NewServer()` (server startup/restart path)
- Set the `isLearner` metric right after `Recover()` in `applySnapshot()` (snapshot receive path)

This is a simpler approach than the `main` fix — instead of moving the metric into the membership package, we just update it at the two call sites in `server.go`. Both of the reporter's reproduction cases (learner joining after snapshot, learner restarting after snapshot) are covered.

Fixes #17175