### PR TITLE
[release-3.5] etcdserver: fix cannot promote with auth from follower

### DIFF
--- a/server/etcdserver/api/etcdhttp/peer.go
+++ b/server/etcdserver/api/etcdhttp/peer.go
@@ -21,12 +21,14 @@ import (
 	"strconv"
 	"strings"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/etcdserver/api"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
 	"go.etcd.io/etcd/server/v3/lease/leasehttp"
+	"google.golang.org/grpc/metadata"
 
 	"go.uber.org/zap"
 )
@@ -135,7 +137,14 @@ func (h *peerMemberPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	resp, err := h.server.PromoteMember(r.Context(), id)
+	// reconstruct gRPC metadata from HTTP header (if present) so admin check can pass
+	ctx := r.Context()
+	if token := r.Header.Get("Authorization"); token != "" {
+		md := metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: token})
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+
+	resp, err := h.server.PromoteMember(ctx, id)
 	if err != nil {
 		switch err {
 		case membership.ErrIDNotFound:

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -25,9 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/coreos/go-semver/semver"
 	"go.uber.org/zap"
@@ -340,6 +342,20 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	if err != nil {
 		return nil, err
 	}
+
+	// add the auth token via HTTP header if present in gRPC metadata
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		ts, ok := md[rpctypes.TokenFieldNameGRPC]
+		if !ok {
+			ts, ok = md[rpctypes.TokenFieldNameSwagger]
+		}
+
+		if ok && len(ts) > 0 {
+			token := ts[0]
+			req.Header.Set("Authorization", token)
+		}
+	}
+
 	req = req.WithContext(ctx)
 	resp, err := cc.Do(req)
 	if err != nil {

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -93,6 +94,14 @@ func TestCtlV3MemberUpdateClientAutoTLS(t *testing.T) {
 }
 func TestCtlV3MemberUpdatePeerTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(*e2e.NewConfigPeerTLS()))
+}
+
+func TestCtlV3MemberPromoteWithAuthFromLeader(t *testing.T) {
+	testCtl(t, memberPromoteWithAuth(false), withTestTimeout(30*time.Second))
+}
+
+func TestCtlV3MemberPromoteWithAuthFromFollower(t *testing.T) {
+	testCtl(t, memberPromoteWithAuth(true), withTestTimeout(30*time.Second))
 }
 
 func memberListTest(cx ctlCtx) {
@@ -415,5 +424,46 @@ func ensureAllMembersFromV3StoreAreVotingMembers(t *testing.T, dataDir string) {
 
 	for _, m := range members {
 		require.Falsef(t, m.IsLearner, "member is still learner: %+v", m)
+	}
+}
+
+func memberPromoteWithAuth(fromFollower bool) func(cx ctlCtx) {
+	return func(cx ctlCtx) {
+		// Add a regular member
+		_, err := cx.epc.StartNewProc(nil, false, cx.t)
+		require.NoError(cx.t, err)
+
+		var learnerID uint64
+		var addErr error
+		for {
+			// Add a learner once the cluster is healthy
+			learnerID, addErr = cx.epc.StartNewProc(nil, true, cx.t)
+			if addErr != nil {
+				if strings.Contains(addErr.Error(), "etcdserver: unhealthy cluster") {
+					time.Sleep(1 * time.Second)
+					continue
+				}
+			}
+			break
+		}
+		require.NoError(cx.t, addErr)
+
+		leaderIdx := cx.epc.WaitLeader(cx.t)
+		followerIdx := (leaderIdx + 1) % len(cx.epc.Procs)
+
+		require.NoError(cx.t, authEnable(cx))
+		cx.user, cx.pass = "root", "root"
+
+		if fromFollower {
+			_, err = cx.epc.Procs[followerIdx].
+				Etcdctl(e2e.ClientNonTLS, false, false).
+				MemberPromoteWithAuth(learnerID, cx.user, cx.pass)
+		} else {
+			_, err = cx.epc.Procs[leaderIdx].
+				Etcdctl(e2e.ClientNonTLS, false, false).
+				MemberPromoteWithAuth(learnerID, cx.user, cx.pass)
+		}
+
+		require.NoError(cx.t, err)
 	}
 }

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -183,6 +183,15 @@ func (ctl *Etcdctl) MemberPromote(id uint64) (*clientv3.MemberPromoteResponse, e
 	return &resp, err
 }
 
+func (ctl *Etcdctl) MemberPromoteWithAuth(id uint64, username, password string) (*clientv3.MemberPromoteResponse, error) {
+	if ctl.v2 {
+		panic("Unsupported method for v2")
+	}
+	var resp clientv3.MemberPromoteResponse
+	err := ctl.spawnJsonCmd(&resp, "member", "promote", fmt.Sprintf("%x", id), "--user", fmt.Sprintf("%s:%s", username, password))
+	return &resp, err
+}
+
 func (ctl *Etcdctl) Compact(rev int64) (*clientv3.CompactResponse, error) {
 	if ctl.v2 {
 		panic("Unsupported method for v2")


### PR DESCRIPTION
Manual backport of the fix for https://github.com/etcd-io/etcd/issues/20757 to release-3.5.

### Changes

- Includes the original fix from https://github.com/etcd-io/etcd/pull/20792 (by @xUser5000)
- Adjust the original e2e test for compatibility with release-3.5
- Add helper function `MemberPromoteWithAuth` to `etcdctl` for tests

Fixes https://github.com/etcd-io/etcd/issues/20757