### PR TITLE
etcdserver: fix cannot promote member from follower when auth is enabled

### DIFF
--- a/server/etcdserver/api/etcdhttp/peer.go
+++ b/server/etcdserver/api/etcdhttp/peer.go
@@ -21,14 +21,16 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/etcdserver/api"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
 	"go.etcd.io/etcd/server/v3/lease/leasehttp"
-
-	"go.uber.org/zap"
 )
 
 const (
@@ -135,7 +137,14 @@ func (h *peerMemberPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	resp, err := h.server.PromoteMember(r.Context(), id)
+	// reconstruct gRPC metadata from HTTP header (if present) so admin check can pass
+	ctx := r.Context()
+	if tok := r.Header.Get("Authorization"); tok != "" {
+		md := metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: tok})
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+
+	resp, err := h.server.PromoteMember(ctx, id)
 	if err != nil {
 		switch err {
 		case membership.ErrIDNotFound:


### PR DESCRIPTION
Fixes #20757

## What this PR does

When auth is enabled and a `member promote` request is submitted to a
follower node, the follower forwards the request to the leader via the
peer HTTP API. The `Authorization` header from the original client
request was not being propagated into the gRPC metadata context of the
forwarded call. As a result, the leader's auth middleware rejected the
request with `auth: user name is empty`, causing the operation to fail
and timeout.

This backports the fix from #20792 (merged to main and release-3.6
via #20874) to the `release-3.5` branch.

## Changes
- Propagate `Authorization` header into gRPC metadata context before
  calling `PromoteMember` in `peerMemberPromoteHandler`

## How to reproduce the bug
1. Start a 2-member etcd cluster with auth enabled
2. Add a learner member
3. Send a `member promote` request to the follower endpoint
4. Without fix: fails with `auth: user name is empty`
5. With fix: promote succeeds