### PR TITLE
server: add riscv64 to supported architectures

### DIFF
--- a/server/etcdmain/etcd.go
+++ b/server/etcdmain/etcd.go
@@ -237,7 +237,7 @@ func checkSupportArch() {
 	// To add a new platform, check https://github.com/etcd-io/website/blob/main/content/en/docs/${VERSION}/op-guide/supported-platform.md.
 	// The ${VERSION} is the etcd version, e.g. v3.5, v3.6 etc.
 	switch runtime.GOARCH {
-	case "amd64", "arm64", "ppc64le", "s390x":
+	case "amd64", "arm64", "ppc64le", "s390x", "riscv64":
 		return
 	}
 	// unsupported arch only configured via environment variable


### PR DESCRIPTION
This PR adds `riscv64` to the list of officially supported architectures in `checkSupportArch()`, alongside the existing amd64, arm64, ppc64le, and s390x entries.

Currently, running etcd on riscv64 requires setting the `ETCD_UNSUPPORTED_ARCH` environment variable as a workaround. This one-line change removes that friction for RISC-V users.

Go supports riscv64 as a first-class target since Go 1.14, and etcd builds and runs correctly on native riscv64 hardware. I verified this using [RISE riscv64 runners](https://gitlab.com/riseproject/riscv64-ci-images) (GitHub-hosted runners with the `ubuntu-24.04-riscv` label, provided by the RISE Project): [successful CI run](https://github.com/gounthar/etcd/actions/runs/23348956185).

The RISC-V ecosystem has matured considerably, with multiple production boards available (SiFive HiFive, StarFive VisionFive 2, Milk-V Pioneer, SpacemiT K1, etc.) and major Linux distributions shipping riscv64 packages.

Ref #21509