### PR TITLE
client/v3: fix revive unexported-return issues

### DIFF
--- a/client/v3/concurrency/stm.go
+++ b/client/v3/concurrency/stm.go
@@ -65,15 +65,16 @@ type stmOptions struct {
 	prefetch []string
 }
 
-type stmOption func(*stmOptions)
+// STMOption configures STM.
+type STMOption func(*stmOptions)
 
 // WithIsolation specifies the transaction isolation level.
-func WithIsolation(lvl Isolation) stmOption {
+func WithIsolation(lvl Isolation) STMOption {
 	return func(so *stmOptions) { so.iso = lvl }
 }
 
 // WithAbortContext specifies the context for permanently aborting the transaction.
-func WithAbortContext(ctx context.Context) stmOption {
+func WithAbortContext(ctx context.Context) STMOption {
 	return func(so *stmOptions) { so.ctx = ctx }
 }
 
@@ -81,12 +82,12 @@ func WithAbortContext(ctx context.Context) stmOption {
 // If an STM transaction will unconditionally fetch a set of keys, prefetching
 // those keys will save the round-trip cost from requesting each key one by one
 // with Get().
-func WithPrefetch(keys ...string) stmOption {
+func WithPrefetch(keys ...string) STMOption {
 	return func(so *stmOptions) { so.prefetch = append(so.prefetch, keys...) }
 }
 
 // NewSTM initiates a new STM instance, using serializable snapshot isolation by default.
-func NewSTM(c *v3.Client, apply func(STM) error, so ...stmOption) (*v3.TxnResponse, error) {
+func NewSTM(c *v3.Client, apply func(STM) error, so ...STMOption) (*v3.TxnResponse, error) {
 	opts := &stmOptions{ctx: c.Ctx()}
 	for _, f := range so {
 		f(opts)

--- a/client/v3/ordering/kv.go
+++ b/client/v3/ordering/kv.go
@@ -31,7 +31,7 @@ type kvOrdering struct {
 	revMu              sync.RWMutex
 }
 
-func NewKV(kv clientv3.KV, orderViolationFunc OrderViolationFunc) *kvOrdering {
+func NewKV(kv clientv3.KV, orderViolationFunc OrderViolationFunc) clientv3.KV {
 	return &kvOrdering{kv, orderViolationFunc, 0, sync.RWMutex{}}
 }
 


### PR DESCRIPTION
Part of #18370

Fix the `unexported-return` revive lint violations in the `client/v3` module.

Changes:
- `ordering.NewKV()` now returns `clientv3.KV` instead of `*kvOrdering`
- Export `stmOption` as `STMOption` so that `WithIsolation()`, `WithAbortContext()`, `WithPrefetch()`, and `NewSTM()` no longer return/accept an unexported type