### PR TITLE
mvcc: synchronize watch progress notifications with event stream

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -515,13 +515,9 @@ func (s *watchableStore) progressIfSync(watchers map[WatchID]*watcher, responseW
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rev := s.rev()
 	// Any watcher unsynced?
 	for _, w := range watchers {
 		if _, ok := s.synced.watchers[w]; !ok {
-			return false
-		}
-		if rev < w.startRev {
 			return false
 		}
 	}
@@ -532,6 +528,9 @@ func (s *watchableStore) progressIfSync(watchers map[WatchID]*watcher, responseW
 	// notification will be broadcasted client-side if required
 	// (see dispatchEvent in client/v3/watch.go)
 	for _, w := range watchers {
+		// Use the watcher's minRev - 1 to ensure that we don't send a progress
+		// notification for a revision that hasn't been notified yet via notify().
+		rev := w.minRev - 1
 		w.send(WatchResponse{WatchID: responseWatchID, Revision: rev})
 		return true
 	}


### PR DESCRIPTION
Addresses #15220. Ensure that progress notifications do not lead the event stream by using the watcher's minRev instead of the store's current revision. This prevents 'Stale View' scenarios in Kubernetes controllers. Synthesized by Nexus v16 Global Sovereign Rescue.