### PR TITLE
cache: Passive notification for consistent read

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -244,23 +244,34 @@ func (c *Cache) waitTillRevision(ctx context.Context, rev int64) error {
 	c.progressRequestor.add()
 	defer c.progressRequestor.remove()
 
-	ticker := time.NewTicker(revisionPollInterval)
-	defer ticker.Stop()
-	timeout := time.After(c.cfg.WaitTimeout)
+	startTime := time.Now()
 
-	// TODO: rewrite from periodic polling to passive notification
-	for {
-		if c.store.LatestRev() >= rev {
-			return nil
-		}
+	timeoutCh := time.After(c.cfg.WaitTimeout)
+	go func() {
 		select {
-		case <-ticker.C:
-		case <-timeout:
-			return ErrCacheTimeout
+		case <-timeoutCh:
+			c.store.revCond.Broadcast()
 		case <-ctx.Done():
+			c.store.revCond.Broadcast()
+		}
+	}()
+
+	c.store.mu.RLock()
+	defer c.store.mu.RUnlock()
+
+	for c.store.latest.rev < rev {
+		if time.Since(startTime) >= c.cfg.WaitTimeout {
+			return ErrCacheTimeout
+		}
+
+		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+
+		c.store.revCond.Wait()
 	}
+
+	return nil
 }
 
 // Close cancels the private context and blocks until all goroutines return.

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -733,7 +734,9 @@ func TestWaitTillRevision(t *testing.T) {
 	t.Run("cache_already_caught_up", func(t *testing.T) {
 		c, _ := newCacheForWaitTest(10, 10, newTestProgressRequestor())
 
-		if err := c.waitTillRevision(context.Background(), 10); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := c.waitTillRevision(ctx, 10); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -805,14 +808,16 @@ func TestWaitTillRevision(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		c, _ := newCacheForWaitTest(10, 5, newTestProgressRequestor())
+		synctest.Test(t, func(t *testing.T) {
+			c, _ := newCacheForWaitTest(10, 5, newTestProgressRequestor())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		err := c.waitTillRevision(ctx, 10)
-		if !errors.Is(err, ErrCacheTimeout) {
-			t.Fatalf("got %v, want ErrCacheTimeout", err)
-		}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			err := c.waitTillRevision(ctx, 10)
+			if !errors.Is(err, ErrCacheTimeout) {
+				t.Fatalf("got %v, want ErrCacheTimeout", err)
+			}
+		})
 	})
 }
 

--- a/cache/config.go
+++ b/cache/config.go
@@ -16,8 +16,6 @@ package cache
 
 import "time"
 
-const revisionPollInterval = 50 * time.Millisecond
-
 type Config struct {
 	// PerWatcherBufferSize caps each watcher’s buffered channel.
 	// Bigger values tolerate brief client slow-downs at the cost of extra memory.

--- a/cache/store.go
+++ b/cache/store.go
@@ -32,6 +32,7 @@ var ErrNotReady = fmt.Errorf("cache: store not ready")
 // reads at historical revisions can be served until they fall out of the window.
 type store struct {
 	mu      sync.RWMutex
+	revCond *sync.Cond // revCond is broadcast whenever latest.rev changes
 	degree  int
 	latest  snapshot              // latest is the mutable working snapshot
 	history ringBuffer[*snapshot] // history stores immutable cloned snapshots
@@ -39,11 +40,14 @@ type store struct {
 
 func newStore(degree int, historyCapacity int) *store {
 	tree := btree.New[*kvItem](degree, kvItemLess)
-	return &store{
+	s := &store{
 		degree:  degree,
 		latest:  snapshot{rev: 0, tree: tree},
 		history: *newRingBuffer(historyCapacity, func(s *snapshot) int64 { return s.rev }),
 	}
+	// Use RLocker so waiters hold read lock, allowing concurrent reads and non-blocking writes
+	s.revCond = sync.NewCond(s.mu.RLocker())
+	return s
 }
 
 type kvItem struct {
@@ -113,6 +117,7 @@ func (s *store) Restore(kvs []*mvccpb.KeyValue, rev int64) {
 	s.history.RebaseHistory()
 	s.latest.rev = rev
 	s.history.Append(newClonedSnapshot(rev, s.latest.tree))
+	s.revCond.Broadcast()
 }
 
 func (s *store) Apply(resp clientv3.WatchResponse) error {
@@ -142,6 +147,7 @@ func (s *store) applyProgressNotifyLocked(revision int64) {
 		return
 	}
 	s.latest.rev = revision
+	s.revCond.Broadcast()
 }
 
 func (s *store) applyEventsLocked(events []*clientv3.Event) error {
@@ -162,6 +168,7 @@ func (s *store) applyEventsLocked(events []*clientv3.Event) error {
 		}
 		s.latest.rev = rev
 		s.history.Append(newClonedSnapshot(rev, s.latest.tree))
+		s.revCond.Broadcast()
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, waitTillRevision used a ticker to poll every 50ms to check if the cache had caught up to the required revision. This approach was inefficient as it resulted in unnecessary wake-ups and delays.

This change introduces a sync.Cond on the store that broadcasts whenever the revision advances, allowing waiting goroutines to be notified immediately when the cache catches up.

Part of #19371 