### PR TITLE
cache: Add on-demand progress notification from cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -101,6 +101,11 @@ func New(client *clientv3.Client, prefix string, opts ...Option) (*Cache, error)
 	return cache, nil
 }
 
+func (c *Cache) RequestProgress(_ context.Context) error {
+	c.demux.BroadcastProgress()
+	return nil
+}
+
 // Watch registers a cache-backed watcher for a given key or prefix.
 // It returns a WatchChan that streams WatchResponses containing events.
 func (c *Cache) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {

--- a/cache/demux.go
+++ b/cache/demux.go
@@ -163,6 +163,22 @@ func (d *demux) LatestRev() int64 {
 	return d.maxRev
 }
 
+func (d *demux) BroadcastProgress() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.maxRev == 0 {
+		return
+	}
+	resp := clientv3.WatchResponse{
+		Header: etcdserverpb.ResponseHeader{
+			Revision: d.maxRev,
+		},
+	}
+	for w := range d.activeWatchers {
+		w.enqueueResponse(resp)
+	}
+}
+
 func (d *demux) updateStoreLocked(resp clientv3.WatchResponse) {
 	if resp.IsProgressNotify() {
 		d.maxRev = resp.Header.Revision

--- a/cache/demux_test.go
+++ b/cache/demux_test.go
@@ -336,6 +336,84 @@ func TestSlowWatcherResync(t *testing.T) {
 	}
 }
 
+func TestBroadcastProgress(t *testing.T) {
+	t.Run("sends progress to active watchers", func(t *testing.T) {
+		d := newDemux(16, 10*time.Millisecond)
+		d.Init(1)
+		d.maxRev = 10
+
+		w1 := newWatcher(8, nil)
+		w2 := newWatcher(8, nil)
+		d.Register(w1, 0)
+		d.Register(w2, 0)
+
+		d.BroadcastProgress()
+
+		resps1 := readResponses(t, w1, 1)
+		require.Truef(t, resps1[0].IsProgressNotify(), "expected progress notify")
+		require.Equal(t, int64(10), resps1[0].Header.Revision)
+
+		resps2 := readResponses(t, w2, 1)
+		require.Truef(t, resps2[0].IsProgressNotify(), "expected progress notify")
+		require.Equal(t, int64(10), resps2[0].Header.Revision)
+	})
+
+	t.Run("is no-op when maxRev is zero", func(t *testing.T) {
+		d := newDemux(16, 10*time.Millisecond)
+		d.Init(1)
+
+		w := newWatcher(8, nil)
+		d.Register(w, 0)
+
+		d.maxRev = 0
+		d.BroadcastProgress()
+		select {
+		case <-w.respCh:
+			t.Fatal("expected no response when maxRev is 0")
+		default:
+		}
+	})
+
+	t.Run("sends progress only to active watchers", func(t *testing.T) {
+		d := newDemux(16, 10*time.Millisecond)
+		d.Init(1)
+		d.maxRev = 10
+
+		active := newWatcher(8, nil)
+		lagging := newWatcher(8, nil)
+		d.Register(active, 0) // startingRev becomes maxRev+1 => active
+		d.Register(lagging, 5)
+
+		d.BroadcastProgress()
+
+		activeResps := readResponses(t, active, 1)
+		require.Truef(t, activeResps[0].IsProgressNotify(), "expected progress notify for active watcher")
+		require.Equal(t, int64(10), activeResps[0].Header.Revision)
+
+		select {
+		case <-lagging.respCh:
+			t.Fatal("expected no progress notify for lagging watcher")
+		default:
+		}
+	})
+}
+
+func readResponses(t *testing.T, w *watcher, count int) []clientv3.WatchResponse {
+	t.Helper()
+	responses := make([]clientv3.WatchResponse, 0, count)
+
+	for i := 0; i < count; i++ {
+		select {
+		case resp := <-w.respCh:
+			responses = append(responses, resp)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for response %d/%d (got %d)", i+1, count, len(responses))
+		}
+	}
+
+	return responses
+}
+
 func respWithEventRevs(revs ...int64) clientv3.WatchResponse {
 	events := make([]*clientv3.Event, 0, len(revs))
 	for _, r := range revs {

--- a/tests/integration/cache_test.go
+++ b/tests/integration/cache_test.go
@@ -488,7 +488,7 @@ func TestCacheWithPrefixWatch(t *testing.T) {
 	}
 }
 
-func TestCacheWatchPrefixProgressNotify(t *testing.T) {
+func TestCacheServerRequestProgress(t *testing.T) {
 	if integration.ThroughProxy {
 		t.Skip("grpc proxy currently does not support requesting progress notifications")
 	}
@@ -543,6 +543,74 @@ func TestCacheWatchPrefixProgressNotify(t *testing.T) {
 		}
 	case <-wctx.Done():
 		t.Fatalf("timed out waiting for progress notification: %v", wctx.Err())
+	}
+}
+
+func TestCacheRequestProgress(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	t.Cleanup(func() { clus.Terminate(t) })
+	client := clus.Client(0)
+
+	ctx := t.Context()
+
+	c, err := cache.New(client, "/foo")
+	if err != nil {
+		t.Fatalf("cache.New: %v", err)
+	}
+	t.Cleanup(c.Close)
+	if err := c.WaitReady(ctx); err != nil {
+		t.Fatalf("cache.WaitReady: %v", err)
+	}
+
+	wctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	watchCh := c.Watch(wctx, "/foo", clientv3.WithPrefix())
+
+	// Write some keys under the watched prefix so the cache advances.
+	var latestRev int64
+	for i := 0; i < 3; i++ {
+		resp, err := client.Put(ctx, fmt.Sprintf("/foo/key-%d", i), "v")
+		if err != nil {
+			t.Fatalf("Put(/foo/key-%d): %v", i, err)
+		}
+		latestRev = resp.Header.Revision
+	}
+
+	// Drain the event responses so the watcher is caught up.
+	// Events may be batched into fewer responses, so count total events.
+	totalEvents := 0
+	for totalEvents < 3 {
+		select {
+		case resp := <-watchCh:
+			if resp.Canceled {
+				t.Fatalf("unexpected canceled response: %v", resp.CancelReason)
+			}
+			totalEvents += len(resp.Events)
+		case <-wctx.Done():
+			t.Fatalf("timed out waiting for events, got %d/3", totalEvents)
+		}
+	}
+
+	// Call RequestProgress on the cache — this should deliver a progress
+	// notification to the watcher with the cache's current revision.
+	if err := c.RequestProgress(ctx); err != nil {
+		t.Fatalf("RequestProgress: %v", err)
+	}
+
+	select {
+	case resp, ok := <-watchCh:
+		if !ok {
+			t.Fatalf("expected watch response, got closed")
+		}
+		if !resp.IsProgressNotify() {
+			t.Fatalf("expected progress notify, got %d events", len(resp.Events))
+		}
+		if resp.Header.Revision < latestRev {
+			t.Fatalf("progress revision %d < latest rev %d", resp.Header.Revision, latestRev)
+		}
+	case <-wctx.Done():
+		t.Fatalf("timed out waiting for progress notification from RequestProgress")
 	}
 }
 


### PR DESCRIPTION
Add Cache.RequestProgress() method that mirrors the etcd Watcher.RequestProgress API but is served entirely from the cache. It broadcasts a progress notification at the cache's current revision to all active local watchers.

Also, used AI for writing tests.

Part of #19371
