### PR TITLE
fix: Fix snapshot transfer error propagation

### DIFF
--- a/server/etcdserver/api/snap/message.go
+++ b/server/etcdserver/api/snap/message.go
@@ -17,9 +17,6 @@ package snap
 import (
 	"io"
 
-	"google.golang.org/protobuf/proto"
-
-	"go.etcd.io/etcd/pkg/v3/ioutil"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -41,8 +38,8 @@ type Message struct {
 func NewMessage(rs *raftpb.Message, rc io.ReadCloser, rcSize int64) *Message {
 	return &Message{
 		Message:    rs,
-		ReadCloser: ioutil.NewExactReadCloser(rc, rcSize),
-		TotalSize:  int64(proto.Size(rs)) + rcSize,
+		ReadCloser: rc,
+		TotalSize:  int64(rs.Size()) + rcSize,
 		closeC:     make(chan bool, 1),
 	}
 }

--- a/server/etcdserver/snapshot_merge.go
+++ b/server/etcdserver/snapshot_merge.go
@@ -76,9 +76,9 @@ func newSnapshotReaderCloser(lg *zap.Logger, snapshot backend.Snapshot) io.ReadC
 			)
 		}
 		pw.CloseWithError(err)
-		err = snapshot.Close()
-		if err != nil {
-			lg.Panic("failed to close database snapshot", zap.Error(err))
+		closeErr := snapshot.Close()
+		if closeErr != nil {
+			lg.Panic("failed to close database snapshot", zap.Error(closeErr))
 		}
 	}()
 	return pr


### PR DESCRIPTION

Removes ExactReadCloser wrapper that was causing spurious 'ioutil: short read' errors when snapshot transfer is interrupted.

Fixes #21418
