### PR TITLE
[release-3.6] tests: Change max retries when removing a member from a cluster to reduce flakiness

### DIFF
--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"maps"
@@ -847,19 +846,21 @@ func (epc *EtcdProcessCluster) CloseProc(ctx context.Context, finder func(EtcdPr
 		return fmt.Errorf("failed to find member ID: %w", err)
 	}
 
+	sleepDuration := 500 * time.Millisecond
+	maxRetries := int((2 * etcdserver.HealthInterval) / sleepDuration)
 	memberRemoved := false
-	for i := 0; i < 10; i++ {
+	for i := 0; i < maxRetries; i++ {
 		_, err := memberCtl.MemberRemove(ctx, memberID)
 		if err != nil && strings.Contains(err.Error(), "member not found") {
 			memberRemoved = true
 			break
 		}
 
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(sleepDuration)
 	}
 
 	if !memberRemoved {
-		return errors.New("failed to remove member after 10 tries")
+		return fmt.Errorf("failed to remove member after %d tries", maxRetries)
 	}
 
 	epc.lg.Info("successfully removed member", zap.String("acurl", proc.Config().ClientURL))


### PR DESCRIPTION
Cherry pick of #20840 on release-3.6.

#20840: tests: Change max retries when removing a member from a