### PR TITLE
refactor: filter range results

### DIFF
--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -82,20 +82,16 @@ func rangeLimit(r *pb.RangeRequest) int64 {
 
 func filterRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest) {
 	if r.MaxModRevision != 0 {
-		f := func(kv *mvccpb.KeyValue) bool { return kv.ModRevision > r.MaxModRevision }
-		pruneKVs(rr, f)
+		pruneKVs(rr, func(kv *mvccpb.KeyValue) bool { return kv.ModRevision > r.MaxModRevision })
 	}
 	if r.MinModRevision != 0 {
-		f := func(kv *mvccpb.KeyValue) bool { return kv.ModRevision < r.MinModRevision }
-		pruneKVs(rr, f)
+		pruneKVs(rr, func(kv *mvccpb.KeyValue) bool { return kv.ModRevision < r.MinModRevision })
 	}
 	if r.MaxCreateRevision != 0 {
-		f := func(kv *mvccpb.KeyValue) bool { return kv.CreateRevision > r.MaxCreateRevision }
-		pruneKVs(rr, f)
+		pruneKVs(rr, func(kv *mvccpb.KeyValue) bool { return kv.CreateRevision > r.MaxCreateRevision })
 	}
 	if r.MinCreateRevision != 0 {
-		f := func(kv *mvccpb.KeyValue) bool { return kv.CreateRevision < r.MinCreateRevision }
-		pruneKVs(rr, f)
+		pruneKVs(rr, func(kv *mvccpb.KeyValue) bool { return kv.CreateRevision < r.MinCreateRevision })
 	}
 }
 


### PR DESCRIPTION
Simplifies the filterRangeResults function by removing the early return guard that creates maintenance risk Replaces multiple if statements with a declarative filter approach

Test suite: https://github.com/etcd-io/etcd/blob/4412e98bf63c7d16ff112a28a946620735fc9a79/tests/common/kv_test.go#L137-L140