### PR TITLE
etcdutl: add context-aware timeout to hash command with exit 124

### DIFF
--- a/etcdutl/etcdutl/bucket_command.go
+++ b/etcdutl/etcdutl/bucket_command.go
@@ -15,10 +15,14 @@
 package etcdutl
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,6 +31,7 @@ import (
 	"go.etcd.io/etcd/api/v3/authpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/cobrautl"
 	"go.etcd.io/etcd/server/v3/lease/leasepb"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
@@ -252,15 +257,52 @@ func getHashCommandFunc(_ *cobra.Command, args []string) {
 		lg.Fatal("db file not exist", zap.String("path", dp))
 	}
 
-	hash, err := getHash(dp)
-	if err != nil {
-		lg.Fatal("failed to get hash", zap.Error(err))
+	hash, err := runHashWithTimeout(dp, FlockTimeout)
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		fmt.Fprintf(os.Stderr, "timed out waiting for the database lock on %s\n", dp)
+		os.Exit(ExitTimeout)
+	case err != nil:
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	default:
+		fmt.Printf("db path: %s\nHash: %d\n", dp, hash)
 	}
-	fmt.Printf("db path: %s\nHash: %d\n", dp, hash)
+}
+
+// runHashWithTimeout runs getHash in a goroutine and returns the hash, or
+// context.DeadlineExceeded if timeout elapses before the operation completes.
+// Pass timeout=0 to wait indefinitely.
+func runHashWithTimeout(dbPath string, timeout time.Duration) (uint32, error) {
+	type result struct {
+		hash uint32
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		h, err := getHash(dbPath)
+		ch <- result{h, err}
+	}()
+
+	if timeout <= 0 {
+		r := <-ch
+		return r.hash, r.err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case r := <-ch:
+		return r.hash, r.err
+	}
 }
 
 func getHash(dbPath string) (hash uint32, err error) {
-	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	// No bbolt flock timeout: we rely on the caller's context (via runHashWithTimeout)
+	// to bound the overall wait. Passing a bbolt timeout would cause NewDefaultBackend
+	// to panic on ErrTimeout instead of returning a clean error.
+	b := backend.NewDefaultBackend(zap.NewNop(), dbPath)
 	defer b.Close()
 	return b.Hash(schema.DefaultIgnores)
 }

--- a/etcdutl/etcdutl/bucket_command.go
+++ b/etcdutl/etcdutl/bucket_command.go
@@ -15,10 +15,13 @@
 package etcdutl
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,6 +30,7 @@ import (
 	"go.etcd.io/etcd/api/v3/authpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/pkg/v3/cobrautl"
 	"go.etcd.io/etcd/server/v3/lease/leasepb"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
@@ -252,14 +256,51 @@ func getHashCommandFunc(_ *cobra.Command, args []string) {
 		lg.Fatal("db file not exist", zap.String("path", dp))
 	}
 
-	hash, err := getHash(dp)
-	if err != nil {
-		lg.Fatal("failed to get hash", zap.Error(err))
+	hash, err := runHashWithTimeout(dp, FlockTimeout)
+	switch {
+	case err == context.DeadlineExceeded:
+		fmt.Fprintf(os.Stderr, "timed out waiting for the database lock on %s\n", dp)
+		os.Exit(ExitTimeout)
+	case err != nil:
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	default:
+		fmt.Printf("db path: %s\nHash: %d\n", dp, hash)
 	}
-	fmt.Printf("db path: %s\nHash: %d\n", dp, hash)
+}
+
+// runHashWithTimeout runs getHash in a goroutine and returns the hash, or
+// context.DeadlineExceeded if timeout elapses before the operation completes.
+// Pass timeout=0 to wait indefinitely.
+func runHashWithTimeout(dbPath string, timeout time.Duration) (uint32, error) {
+	type result struct {
+		hash uint32
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		h, err := getHash(dbPath)
+		ch <- result{h, err}
+	}()
+
+	if timeout <= 0 {
+		r := <-ch
+		return r.hash, r.err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case r := <-ch:
+		return r.hash, r.err
+	}
 }
 
 func getHash(dbPath string) (hash uint32, err error) {
-	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	// No bbolt flock timeout: we rely on the caller's context (via runHashWithTimeout)
+	// to bound the overall wait. Passing a bbolt timeout would cause NewDefaultBackend
+	// to panic on ErrTimeout instead of returning a clean error.
+	b := backend.NewDefaultBackend(zap.NewNop(), dbPath)
 	return b.Hash(schema.DefaultIgnores)
 }

--- a/etcdutl/etcdutl/bucket_command_test.go
+++ b/etcdutl/etcdutl/bucket_command_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutl
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+)
+
+// TestRunHashWithTimeout_Success verifies that runHashWithTimeout returns the
+// correct hash when the database is available within the timeout.
+func TestRunHashWithTimeout_Success(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// Create and close an empty db so getHash can open it.
+	b := backend.NewDefaultBackend(zap.NewNop(), dbPath)
+	b.Close()
+
+	_, err := runHashWithTimeout(dbPath, 5*time.Second)
+	assert.NilError(t, err)
+}
+
+// TestRunHashWithTimeout_Timeout verifies that runHashWithTimeout returns
+// context.DeadlineExceeded when the database lock cannot be acquired within
+// the given timeout. This is the core fix for
+// https://github.com/etcd-io/etcd/issues/20276.
+func TestRunHashWithTimeout_Timeout(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "locked.db")
+
+	// Create the db file.
+	b := backend.NewDefaultBackend(zap.NewNop(), dbPath)
+	b.Close()
+
+	// Hold an exclusive bbolt lock so that getHash blocks waiting for it.
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{})
+	assert.NilError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = runHashWithTimeout(dbPath, 200*time.Millisecond)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestRunHashWithTimeout_ZeroTimeout verifies that passing timeout=0 causes
+// runHashWithTimeout to wait indefinitely (no deadline), succeeding once the
+// db is available. We simulate this with an immediately available db.
+func TestRunHashWithTimeout_ZeroTimeout(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test_zero.db")
+
+	b := backend.NewDefaultBackend(zap.NewNop(), dbPath)
+	b.Close()
+
+	_, err := runHashWithTimeout(dbPath, 0)
+	assert.NilError(t, err)
+}

--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -32,6 +32,9 @@ import (
 // FlockTimeout is the duration to wait to obtain a file lock on db file.
 var FlockTimeout time.Duration
 
+// ExitTimeout is the exit code when a command times out, matching the GNU timeout convention.
+const ExitTimeout = 124
+
 func GetLogger() *zap.Logger {
 	config := logutil.DefaultZapLoggerConfig
 	config.Encoding = "console"


### PR DESCRIPTION
Fixes #20276

## Problem

`etcdutl hash` hangs indefinitely when the bbolt db is locked by another process. The root cause is two-fold:

1. `backend.NewDefaultBackend` calls `zap.Logger.Panic` (not `return err`) when `bolt.Open` fails — so the existing `--timeout` flock mechanism panics the process rather than returning cleanly.
2. When `--timeout 0`, bbolt blocks forever and the process never returns.

## Fix

- Runs `getHash` in a goroutine and selects on a `context.WithTimeout` deadline, bounded by the existing `--timeout` root flag
- Exits with code **124** on timeout (GNU `timeout(1)` convention)
- Exits with code **1** on actual errors, printing a message that clearly distinguishes timeout from failure
- Removes the bbolt-level flock timeout from `getHash` to prevent the panic path; the context deadline is the sole timeout mechanism

## Tests

Three new unit tests in `bucket_command_test.go`:

| Test | What it covers |
|---|---|
| `TestRunHashWithTimeout_Success` | db available, returns without error |
| `TestRunHashWithTimeout_Timeout` | db held locked by a second `bolt.Open`, verifies `context.DeadlineExceeded` — directly reproduces #20276 |
| `TestRunHashWithTimeout_ZeroTimeout` | `timeout=0` means no deadline, succeeds on unlocked db |

```
go test ./etcdutl/... -run TestRunHash -v
--- PASS: TestRunHashWithTimeout_Success (0.03s)
--- PASS: TestRunHashWithTimeout_Timeout (0.21s)
--- PASS: TestRunHashWithTimeout_ZeroTimeout (0.02s)
```