### PR TITLE
client/v3: check lease freshness before serving cached reads, fix EvictRange bug

### DIFF
--- a/client/v3/concurrency/session.go
+++ b/client/v3/concurrency/session.go
@@ -16,6 +16,7 @@ package concurrency
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -35,6 +36,8 @@ type Session struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	donec  <-chan struct{}
+
+	lastKeepAlive atomic.Int64
 }
 
 // NewSession gets the leased session for a client.
@@ -64,6 +67,8 @@ func NewSession(client *v3.Client, opts ...SessionOption) (*Session, error) {
 	donec := make(chan struct{})
 	s := &Session{client: client, opts: ops, id: id, ctx: ctx, cancel: cancel, donec: donec}
 
+	s.lastKeepAlive.Store(time.Now().UnixNano())
+
 	// keep the lease alive until client error or cancelled context
 	go func() {
 		defer func() {
@@ -71,7 +76,7 @@ func NewSession(client *v3.Client, opts ...SessionOption) (*Session, error) {
 			cancel()
 		}()
 		for range keepAlive {
-			// eat messages until keep alive channel closes
+			s.lastKeepAlive.Store(time.Now().UnixNano())
 		}
 	}()
 
@@ -95,6 +100,13 @@ func (s *Session) Ctx() context.Context {
 // Done returns a channel that closes when the lease is orphaned, expires, or
 // is otherwise no longer being refreshed.
 func (s *Session) Done() <-chan struct{} { return s.donec }
+
+// IsLeaseValid reports whether the session's lease is likely still
+// valid on the server, based on the time since the last keepalive ack.
+func (s *Session) IsLeaseValid() bool {
+	last := time.Unix(0, s.lastKeepAlive.Load())
+	return time.Since(last) < time.Duration(s.opts.ttl)*time.Second
+}
 
 // Orphan ends the refresh for the session lease. This is useful
 // in case the state of the client connection is indeterminate (revoke

--- a/client/v3/leasing/cache.go
+++ b/client/v3/leasing/cache.go
@@ -183,12 +183,10 @@ func (lc *leaseCache) Evict(key string) (rev int64) {
 }
 
 func (lc *leaseCache) EvictRange(key, end string) {
-	lc.mu.Lock()
-	defer lc.mu.Unlock()
 	for k := range lc.entries {
 		if inRange(k, key, end) {
-			delete(lc.entries, key)
-			lc.revokes[key] = time.Now()
+			delete(lc.entries, k)
+			lc.revokes[k] = time.Now()
 		}
 	}
 }

--- a/client/v3/leasing/kv.go
+++ b/client/v3/leasing/kv.go
@@ -299,7 +299,7 @@ func (lkv *leasingKV) get(ctx context.Context, op v3.Op) (*v3.GetResponse, error
 		r, err := lkv.kv.Do(ctx, op)
 		return r.Get(), err
 	}
-	if !lkv.readySession() {
+	if !lkv.readySession() || !lkv.session.IsLeaseValid() {
 		return do()
 	}
 

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -1800,3 +1800,77 @@ func waitForExpireAck(t *testing.T, kv clientv3.KV) {
 	}
 	t.Fatalf("waited too long to acknlowedge lease expiration")
 }
+
+func TestLeasingGetChecksForExpiration(t *testing.T) {
+	integration.BeforeTest(t)
+
+	ttl := 6
+
+	// There's no way to partition a client from the server, so use multiple
+	// servers and shut down a single server to partition the client from the
+	// system.
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, UseBridge: true})
+	defer clus.Terminate(t)
+
+	// Try to make sure server 0 is not the leader
+	if clus.Members[0].Server.Leader() == clus.Members[0].Server.MemberID() {
+		err := clus.Members[0].Server.MoveLeader(context.TODO(),
+			clus.Members[0].Server.Lead(),
+			uint64(clus.Members[1].Server.MemberID()))
+		if err != nil {
+			panic(err)
+		}
+	}
+	time.Sleep(2 * time.Second)
+
+	leaderID := clus.Members[0].Server.Leader()
+	if leaderID == clus.Members[0].Server.MemberID() {
+		panic("test wants 0 to not be leader")
+	}
+
+	// This client will get partitioned away from the system (by killing the
+	// node it's connected to).
+	lkv0, closeLKV0, err := leasing.NewKV(clus.Client(0), "pfx/", concurrency.WithTTL(ttl))
+	require.NoError(t, err)
+	defer closeLKV0()
+
+	lkv1, closeLKV1, err := leasing.NewKV(clus.Client(1), "pfx/")
+	require.NoError(t, err)
+	defer closeLKV1()
+
+	if _, err = lkv0.Put(context.TODO(), "k", "abc"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = lkv0.Get(context.TODO(), "k"); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(6500 * time.Millisecond)
+	clus.Members[0].Stop(t)
+
+	if _, err = lkv1.Put(context.TODO(), "k", "def"); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := lkv1.Get(context.TODO(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Kvs) != 1 || string(resp.Kvs[0].Value) != "def" {
+		t.Fatalf(`expected "k"->"def" from lkv1, got response %+v`, resp)
+	}
+
+	go func() {
+		// Eventually bring back the server so the disconnected client can
+		// finish its last `Get()`.
+		time.Sleep(1 * time.Second)
+		clus.Members[0].Restart(t)
+	}()
+	cachedResp, err := lkv0.Get(context.TODO(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cachedResp.Kvs) != 1 || string(cachedResp.Kvs[0].Value) != "def" {
+		t.Fatalf(`expected "k"->"def", got response %+v`, cachedResp)
+	}
+}


### PR DESCRIPTION
The leasing layer claims linearizable reads via lease-based escape, but never actually checks the lease is valid before serving from cache. Adds the missing freshness check. Cannot be fully safe under unbounded clock drift, which matches what the package docs already imply about lease-based mechanisms.

Also fixes `EvictRange` using the loop parameter `key` instead of the loop variable `k`.

Test case from @upamanyus in #19091 / #19092.

Fixes #19091