### PR TITLE
etcdserver: propagate get() errors through doSerialize

### DIFF
--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1574,3 +1574,22 @@ func TestAddFeatureGateMetrics(t *testing.T) {
 	err := ptestutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), "etcd_server_feature_enabled")
 	require.NoErrorf(t, err, "unexpected metric collection result: \n%s", err)
 }
+// TestDoSerializeGetErrorPropagated tests that doSerialize propagates errors returned by the get function.
+func TestDoSerializeGetErrorPropagated(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+
+	srv := &EtcdServer{
+		lgMu:      new(sync.RWMutex),
+		lg:        lg,
+		Cfg:       config.ServerConfig{Logger: lg},
+		authStore: auth.NewAuthStore(lg, schema.NewAuthBackend(lg, be), nil, 0),
+	}
+
+	chk := func(*auth.AuthInfo) error { return nil }
+	get := func() error { return mvcc.ErrCompacted }
+
+	err := srv.doSerialize(t.Context(), chk, get)
+	require.ErrorIs(t, err, mvcc.ErrCompacted)
+}

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -144,7 +144,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		return s.authStore.IsRangePermitted(ai, r.Key, r.RangeEnd)
 	}
 
-	get := func() { resp, _, err = txn.Range(ctx, s.Logger(), s.KV(), r) }
+	get := func() error { resp, _, err = txn.Range(ctx, s.Logger(), s.KV(), r); return err }
 	if serr := s.doSerialize(ctx, chk, get); serr != nil {
 		err = serr
 		return nil, err
@@ -222,8 +222,9 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 			requestDurationSec.WithLabelValues("ReadonlyTxn", strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
 		}(time.Now())
 
-		get := func() {
+		get := func() error {
 			resp, _, err = txn.Txn(ctx, s.Logger(), r, s.Cfg.ServerFeatureGate.Enabled(features.TxnModeWriteWithSharedBuffer), s.KV(), s.lessor)
+			return err
 		}
 		if serr := s.doSerialize(ctx, chk, get); serr != nil {
 			return nil, serr
@@ -890,8 +891,8 @@ func (s *EtcdServer) raftRequest(ctx context.Context, r pb.InternalRaftRequest) 
 	return result.Resp, nil
 }
 
-// doSerialize handles the auth logic, with permissions checked by "chk", for a serialized request "get". Returns a non-nil error on authentication failure.
-func (s *EtcdServer) doSerialize(ctx context.Context, chk func(*auth.AuthInfo) error, get func()) error {
+// doSerialize handles the auth logic, with permissions checked by "chk", for a serialized request "get". Returns a non-nil error on authentication failure or if get returns an error.
+func (s *EtcdServer) doSerialize(ctx context.Context, chk func(*auth.AuthInfo) error, get func() error) error {
 	trace := traceutil.Get(ctx)
 	ai, err := s.AuthInfoFromCtx(ctx)
 	if err != nil {
@@ -906,7 +907,9 @@ func (s *EtcdServer) doSerialize(ctx context.Context, chk func(*auth.AuthInfo) e
 	}
 	trace.Step("get authentication metadata")
 	// fetch response for serialized request
-	get()
+	if err = get(); err != nil {
+		return err
+	}
 	// check for stale token revision in case the auth store was updated while
 	// the request has been handled.
 	if ai.Revision != 0 && ai.Revision != s.authStore.Revision() {


### PR DESCRIPTION
## Summary

Fixes an incorrect error message under a race condition.

The race:

1. Client has an auth token with `Revision: N`
2. Client sends a serializable `Range` with an old specific revision that has since been compacted → `get()` returns `mvcc.ErrCompacted`
3. Concurrently, any auth operation (add user, role change, etc.) advances the auth store to revision `N+1`

**Before the fix:** `doSerialize` ignores the `ErrCompacted` from `get()`, reaches the stale-token check, sees `ai.Revision (N) != authStore.Revision() (N+1)`, and returns `auth.ErrAuthOldRevision`. The client is told to re-authenticate — wrong diagnosis. The compaction error is silently dropped.

**After the fix:** `get()` returns `ErrCompacted`, `doSerialize` returns it immediately, skipping the stale check entirely. The client gets the correct, actionable error.

## Test added

`TestDoSerializeGetErrorPropagated` in `server/etcdserver/server_test.go` constructs a minimal `EtcdServer` with auth disabled (so `AuthInfoFromCtx` returns nil and `chk` trivially passes), calls `doSerialize` with a `get` that returns `mvcc.ErrCompacted`, and asserts `errors.Is(err, mvcc.ErrCompacted)`.

## Historical context

The `get func()` signature (no error return) was intentional in the original design. `doSerialize` had an explicit retry loop to solve a TOCTOU problem:

1. Get auth info at revision N
2. Check permissions
3. Call `get()` — result captured via closure
4. If auth store had advanced to N+1 by the time `get()` finished → retry from step 1
5. Loop until auth is stable, then return

In that model, `get()` could be called multiple times, the caller already held the result via closure, and error propagation from `get()` was deliberately the caller's responsibility.

In 2018 ([95095f840](https://github.com/etcd-io/etcd/commit/95095f8406ce1bfc938237babf13a7ac36f73c6c)), the loop was removed because `ErrAuthOldRevision` from `chk()` would always repeat — the retry was pointless. The `get func()` signature was left unchanged even though the entire rationale for it had been removed.

This change completes that refactor: with no retry loop, `doSerialize` should propagate `get()` errors directly rather than relying on the caller's closure.

## AI disclosure

AI tools (Claude) were used to assist in preparing this PR. All changes have been reviewed and tested by the author.