### PR TITLE
Improve `validateLinearizableOperationsAndVisualize` to respect timeout

### DIFF
--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -32,27 +32,49 @@ var (
 
 func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, operations []porcupine.Operation, timeout time.Duration) LinearizationResult {
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
-	start := time.Now()
 
 	model := model.NonDeterministicModel(keys)
-	check, info := porcupine.CheckOperationsVerbose(model, operations, timeout)
 	result := LinearizationResult{
-		Info:  info,
 		Model: model,
 	}
+
+	// Use the non-verbose path for the initial decision so timeout is respected.
+	initialLinearizationCheckStart := time.Now()
+	check := porcupine.CheckOperationsTimeout(model, operations, timeout)
+	initialLinearizationCheckDuration := time.Since(initialLinearizationCheckStart)
+
 	switch check {
 	case porcupine.Ok:
 		result.Status = Success
-		lg.Info("Linearization success", zap.Duration("duration", time.Since(start)))
+		lg.Info("Linearization success",
+			zap.Duration("duration", initialLinearizationCheckDuration),
+		)
 	case porcupine.Unknown:
 		result.Status = Failure
 		result.Message = "timed out"
 		result.Timeout = true
-		lg.Error("Linearization timed out", zap.Duration("duration", time.Since(start)))
+		lg.Error("Linearization timed out",
+			zap.Duration("duration", initialLinearizationCheckDuration),
+		)
 	case porcupine.Illegal:
+		// Once the fast path already proved the history illegal, rerun in verbose
+		// mode without timeout so we always capture a visualization report.
+		reportGenerationStart := time.Now()
+		reportCheck, info := porcupine.CheckOperationsVerbose(model, operations, 0)
+		reportGenerationDuration := time.Since(reportGenerationStart)
+		result.Info = info
 		result.Status = Failure
 		result.Message = "illegal"
-		lg.Error("Linearization illegal", zap.Duration("duration", time.Since(start)))
+		if reportCheck != porcupine.Illegal {
+			lg.Warn("Verbose illegal rerun returned unexpected result",
+				zap.String("timeout_check_result", string(check)),
+				zap.String("report_result", string(reportCheck)),
+			)
+		}
+		lg.Error("Linearization illegal",
+			zap.Duration("initial_run_duration", initialLinearizationCheckDuration),
+			zap.Duration("report_run_duration", reportGenerationDuration),
+		)
 	default:
 		result.Status = Failure
 		result.Message = "unknown"

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -18,6 +18,7 @@ package validate
 import (
 	"fmt"
 	"math/rand/v2"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -294,6 +295,48 @@ func keyValueRevision(key, value string, rev int64) model.KeyValue {
 	}
 }
 
+func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
+	timeout := time.Second
+	history := concurrentFailedPutsWithRead(t, 22)
+	keys := model.ModelKeys(history)
+
+	start := time.Now()
+	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, timeout)
+	elapsed := time.Since(start)
+
+	if !result.Timeout {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) timed out = false, message = %q", result.Message)
+	}
+	if result.Message != "timed out" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "timed out")
+	}
+	if elapsed > timeout+250*time.Millisecond {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) does not respect timeout: %v, timeout was %v", elapsed, timeout)
+	}
+}
+
+func TestValidateLinearizableOperationsIllegalGeneratesVisualization(t *testing.T) {
+	history := impossibleReadAfterSuccessfulPut()
+	keys := model.ModelKeys(history)
+
+	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, 100*time.Millisecond)
+	if result.Timeout {
+		t.Fatal("validateLinearizableOperationsAndVisualize(...) timed out unexpectedly")
+	}
+	if result.Message != "illegal" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "illegal")
+	}
+	if result.Status != Failure {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) status = %q, want %q", result.Status, Failure)
+	}
+	if len(result.Info.PartialLinearizations()) == 0 {
+		t.Fatal("validateLinearizableOperationsAndVisualize(...) produced no linearization info for illegal history")
+	}
+	if err := result.Visualize(zap.NewNop(), filepath.Join(t.TempDir(), "history.html")); err != nil {
+		t.Fatalf("result.Visualize(...): %v", err)
+	}
+}
+
 func BenchmarkValidateLinearizableOperations(b *testing.B) {
 	lg := zap.NewNop()
 	b.Run("SequentialSuccessPuts", func(b *testing.B) {
@@ -339,7 +382,8 @@ func sequentialSuccessPuts(count int, startRevision int64) []porcupine.Operation
 	return ops
 }
 
-func concurrentFailedPutsWithRead(b *testing.B, concurrencyCount int) []porcupine.Operation {
+func concurrentFailedPutsWithRead(tb testing.TB, concurrencyCount int) []porcupine.Operation {
+	tb.Helper()
 	ops := []porcupine.Operation{}
 	for i := 0; i < concurrencyCount; i++ {
 		ops = append(ops, porcupine.Operation{
@@ -353,7 +397,7 @@ func concurrentFailedPutsWithRead(b *testing.B, concurrencyCount int) []porcupin
 	replay := model.NewReplayFromOperations(ops)
 	state, err := replay.StateForRevision(int64(concurrencyCount) + 1)
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 	request := rangeRequest("key", "kez", 0, 0)
 	_, resp := state.Step(request)
@@ -383,6 +427,25 @@ func sequentialFailedPuts(count int, keyCount int) []porcupine.Operation {
 		})
 	}
 	return ops
+}
+
+func impossibleReadAfterSuccessfulPut() []porcupine.Operation {
+	return []porcupine.Operation{
+		{
+			ClientId: 0,
+			Input:    putRequest("key", "value"),
+			Output:   txnResponse(2, model.EtcdOperationResult{}),
+			Call:     0,
+			Return:   1,
+		},
+		{
+			ClientId: 1,
+			Input:    rangeRequest("key", "", 0, 0),
+			Output:   rangeResponse(1, keyValueRevision("key", "wrong", 9999)),
+			Call:     2,
+			Return:   3,
+		},
+	}
 }
 
 func backtrackingHeavy(b *testing.B) (ops []porcupine.Operation) {


### PR DESCRIPTION
`porcupine.CheckOperationsVerbose` will wait for all goroutines to finish in the conditional branch of `computeInfo` in the porcupine library, where as `porcupine.CheckOperationsTimeout` doesn't. During the wait, the timeout won't be respected. 

The proposed change is that we run `porcupine.CheckOperationsTimeout` to check if there is any linearizability issue first. If there is indeed an issue, we then run `porcupine.CheckOperationsVerbose` without timeout, to generate the report. 

PoC of timeout not being respected on existing branch: https://github.com/etcd-io/etcd/compare/main...henrybear327:etcd:robustness/porcupine_timeout_demo