### PR TITLE
client/pkg/transport: add dynamic trust root reloading for TLSInfo

### DIFF
--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -136,6 +136,13 @@ func newListenConfig(sopts *SocketOpts) net.ListenConfig {
 	return lc
 }
 
+// CertPoolProvider exposes the currently trusted CA bundle for a TLS handshake.
+// Implementations must be safe for concurrent use because multiple handshakes
+// can consult the provider at the same time.
+type CertPoolProvider interface {
+	GetCertPool() *x509.CertPool
+}
+
 type TLSInfo struct {
 	// CertFile is the _server_ cert, it will also be used as a _client_ certificate if ClientCertFile is empty
 	CertFile string
@@ -179,6 +186,10 @@ type TLSInfo struct {
 	// should be left nil. In that case, tls.X509KeyPair will be used.
 	parseFunc func([]byte, []byte) (tls.Certificate, error)
 
+	// dynamicTrustRoots is kept unexported so TLSInfo stays a data-only config
+	// unless callers explicitly opt into live trust-root lookup via the setter.
+	dynamicTrustRoots CertPoolProvider
+
 	// AllowedCN is a CN which must be provided by a client.
 	//
 	// Deprecated: use AllowedCNs instead.
@@ -215,6 +226,14 @@ func (info TLSInfo) String() string {
 
 func (info TLSInfo) Empty() bool {
 	return info.CertFile == "" && info.KeyFile == ""
+}
+
+// SetDynamicTrustRoots installs a live trust-root source for future handshakes.
+// Callers must set the provider before copying TLSInfo or building a tls.Config;
+// configs that have already been created keep using the provider captured at
+// construction time.
+func (info *TLSInfo) SetDynamicTrustRoots(provider CertPoolProvider) {
+	info.dynamicTrustRoots = provider
 }
 
 func SelfCert(lg *zap.Logger, dirpath string, hosts []string, selfSignedCertValidity uint, additionalUsages ...x509.ExtKeyUsage) (TLSInfo, error) {
@@ -516,6 +535,132 @@ func (info TLSInfo) baseConfig() (*tls.Config, error) {
 	return cfg, nil
 }
 
+// applyDynamicClientTrustRoots switches client verification to provider-backed
+// trust roots while preserving any existing post-verification checks.
+func (info TLSInfo) applyDynamicClientTrustRoots(cfg *tls.Config) error {
+	if info.dynamicTrustRoots == nil || cfg.InsecureSkipVerify {
+		return nil
+	}
+
+	var verifyAllowedConnection func(tls.ConnectionState) error
+	if cfg.VerifyPeerCertificate != nil {
+		if info.AllowedCN != "" && len(info.AllowedCNs) > 0 {
+			return fmt.Errorf("AllowedCN and AllowedCNs are mutually exclusive (cn=%q, cns=%q)", info.AllowedCN, info.AllowedCNs)
+		}
+		if info.AllowedHostname != "" && len(info.AllowedHostnames) > 0 {
+			return fmt.Errorf("AllowedHostname and AllowedHostnames are mutually exclusive (hostname=%q, hostnames=%q)", info.AllowedHostname, info.AllowedHostnames)
+		}
+		if info.AllowedCN != "" && info.AllowedHostname != "" {
+			return fmt.Errorf("AllowedCN and AllowedHostname are mutually exclusive (cn=%q, hostname=%q)", info.AllowedCN, info.AllowedHostname)
+		}
+		if len(info.AllowedCNs) > 0 && len(info.AllowedHostnames) > 0 {
+			return fmt.Errorf("AllowedCNs and AllowedHostnames are mutually exclusive (cns=%q, hostnames=%q)", info.AllowedCNs, info.AllowedHostnames)
+		}
+
+		if info.AllowedCN != "" {
+			verifyAllowedConnection = func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 || info.AllowedCN != cs.PeerCertificates[0].Subject.CommonName {
+					return errors.New("client certificate authentication failed")
+				}
+				return nil
+			}
+		}
+		if info.AllowedHostname != "" {
+			verifyAllowedConnection = func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 || cs.PeerCertificates[0].VerifyHostname(info.AllowedHostname) != nil {
+					return errors.New("client certificate authentication failed")
+				}
+				return nil
+			}
+		}
+		if len(info.AllowedCNs) > 0 {
+			verifyAllowedConnection = func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 {
+					return errors.New("client certificate authentication failed")
+				}
+				for _, allowedCN := range info.AllowedCNs {
+					if allowedCN == cs.PeerCertificates[0].Subject.CommonName {
+						return nil
+					}
+				}
+				return errors.New("client certificate authentication failed")
+			}
+		}
+		if len(info.AllowedHostnames) > 0 {
+			verifyAllowedConnection = func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 {
+					return errors.New("client certificate authentication failed")
+				}
+				for _, allowedHostname := range info.AllowedHostnames {
+					if cs.PeerCertificates[0].VerifyHostname(allowedHostname) == nil {
+						return nil
+					}
+				}
+				return errors.New("client certificate authentication failed")
+			}
+		}
+	}
+	previousVerifyConnection := cfg.VerifyConnection
+
+	// The built-in verifier always consults cfg.RootCAs, so opt-in dynamic
+	// roots must replace that path with per-handshake verification.
+	cfg.InsecureSkipVerify = true
+	cfg.VerifyPeerCertificate = nil
+	cfg.VerifyConnection = func(cs tls.ConnectionState) error {
+		if err := info.verifyDynamicServerCertificate(cs, cfg.ServerName); err != nil {
+			return err
+		}
+		if previousVerifyConnection != nil {
+			if err := previousVerifyConnection(cs); err != nil {
+				return err
+			}
+		}
+		if verifyAllowedConnection != nil {
+			if err := verifyAllowedConnection(cs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// verifyDynamicServerCertificate reruns server verification for one handshake
+// against the latest trust roots exposed by the provider.
+func (info TLSInfo) verifyDynamicServerCertificate(cs tls.ConnectionState, fallbackServerName string) error {
+	if len(cs.PeerCertificates) == 0 {
+		return errors.New("tls: server sent no certificates")
+	}
+
+	serverName := cs.ServerName
+	if serverName == "" {
+		serverName = fallbackServerName
+	}
+	if serverName == "" {
+		return errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
+	}
+	if host, _, err := net.SplitHostPort(serverName); err == nil && host != "" {
+		serverName = host
+	}
+	roots := info.dynamicTrustRoots.GetCertPool()
+	if roots == nil {
+		return errors.New("tls: dynamic trust root provider returned a nil cert pool")
+	}
+
+	intermediates := x509.NewCertPool()
+	for _, cert := range cs.PeerCertificates[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	_, err := cs.PeerCertificates[0].Verify(x509.VerifyOptions{
+		DNSName:       serverName,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Roots:         roots,
+	})
+	return err
+}
+
 // cafiles returns a list of CA file paths.
 func (info TLSInfo) cafiles() []string {
 	cs := make([]string, 0)
@@ -551,9 +696,24 @@ func (info TLSInfo) ServerConfig() (*tls.Config, error) {
 		}
 		cfg.ClientCAs = cp
 	}
-
 	// "h2" NextProtos is necessary for enabling HTTP2 for go's HTTP server
 	cfg.NextProtos = []string{"h2"}
+
+	if info.dynamicTrustRoots != nil && cfg.ClientAuth == tls.RequireAndVerifyClientCert {
+		baseCfg := cfg.Clone()
+		baseCfg.GetConfigForClient = nil
+
+		// Prime the listener with the most recent trust roots so the config
+		// exposed by ServerConfig matches what the next handshake will evaluate.
+		cfg.ClientCAs = info.dynamicTrustRoots.GetCertPool()
+		cfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			clone := baseCfg.Clone()
+			// Each new handshake must fetch trust roots again so CA rotation
+			// does not require rebuilding the listener.
+			clone.ClientCAs = info.dynamicTrustRoots.GetCertPool()
+			return clone, nil
+		}
+	}
 
 	return cfg, nil
 }
@@ -583,6 +743,9 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 
 	if info.selfCert {
 		cfg.InsecureSkipVerify = true
+	}
+	if err := info.applyDynamicClientTrustRoots(cfg); err != nil {
+		return nil, err
 	}
 
 	if info.EmptyCN {

--- a/client/pkg/transport/listener_dynamic_root_test.go
+++ b/client/pkg/transport/listener_dynamic_root_test.go
@@ -1,0 +1,408 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+type mutableCertPoolProvider struct {
+	mu       sync.RWMutex
+	certPool *x509.CertPool
+}
+
+func newMutableCertPoolProvider(certPool *x509.CertPool) *mutableCertPoolProvider {
+	return &mutableCertPoolProvider{certPool: certPool}
+}
+
+func (p *mutableCertPoolProvider) GetCertPool() *x509.CertPool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.certPool
+}
+
+func (p *mutableCertPoolProvider) SetCertPool(certPool *x509.CertPool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.certPool = certPool
+}
+
+func TestServerConfig_DynamicRootCAsPreservesHTTP2ALPN(t *testing.T) {
+	serverTLSInfo, err := createSelfCert(t)
+	require.NoError(t, err)
+
+	serverTLSInfo.ClientCertAuth = true
+	serverTLSInfo.Logger = zaptest.NewLogger(t)
+	serverTLSInfo.SetDynamicTrustRoots(newMutableCertPoolProvider(x509.NewCertPool()))
+
+	cfg, err := serverTLSInfo.ServerConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.GetConfigForClient)
+	require.Contains(t, cfg.NextProtos, "h2")
+
+	helloCfg, err := cfg.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, helloCfg)
+	require.Contains(t, helloCfg.NextProtos, "h2")
+}
+
+func TestServerConfig_DynamicRootCAsAcceptsNewClientCAOnNewHandshake(t *testing.T) {
+	serverTLSInfo, err := createSelfCert(t)
+	require.NoError(t, err)
+
+	clientCA1, err := createSelfCertEx(t, "127.0.0.1", x509.ExtKeyUsageClientAuth)
+	require.NoError(t, err)
+	clientCA2, err := createSelfCertEx(t, "127.0.0.1", x509.ExtKeyUsageClientAuth)
+	require.NoError(t, err)
+
+	provider := newMutableCertPoolProvider(mustCertPoolFromFile(t, clientCA1.CertFile))
+
+	serverTLSInfo.ClientCertAuth = true
+	serverTLSInfo.Logger = zaptest.NewLogger(t)
+	serverTLSInfo.SetDynamicTrustRoots(provider)
+
+	ln := mustNewTLSListener(t, serverTLSInfo)
+	defer ln.Close()
+
+	rootCAs := mustCertPoolFromFile(t, serverTLSInfo.CertFile)
+
+	clientConn1 := mustDialTLS(t, ln.Addr().String(), &tls.Config{
+		Certificates: []tls.Certificate{mustLoadKeyPair(t, clientCA1.CertFile, clientCA1.KeyFile)},
+		RootCAs:      rootCAs,
+	})
+	serverConn1 := mustAcceptConn(t, ln)
+	clientConn1.Close()
+	serverConn1.Close()
+
+	provider.SetCertPool(mustCertPoolFromFile(t, clientCA2.CertFile))
+
+	clientConn2 := mustDialTLS(t, ln.Addr().String(), &tls.Config{
+		Certificates: []tls.Certificate{mustLoadKeyPair(t, clientCA2.CertFile, clientCA2.KeyFile)},
+		RootCAs:      rootCAs,
+	})
+	serverConn2 := mustAcceptConn(t, ln)
+	clientConn2.Close()
+	serverConn2.Close()
+}
+
+func TestClientConfig_DynamicRootCAsAcceptsNewServerCAOnNewHandshake(t *testing.T) {
+	serverCA1, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+	serverCA2, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+
+	stableCertFile, stableKeyFile := mustWriteStableTLSFiles(t, serverCA1.CertFile, serverCA1.KeyFile)
+	serverInfo := &TLSInfo{
+		CertFile: stableCertFile,
+		KeyFile:  stableKeyFile,
+		Logger:   zaptest.NewLogger(t),
+	}
+
+	ln := mustNewTLSListener(t, serverInfo)
+	defer ln.Close()
+
+	provider := newMutableCertPoolProvider(mustCertPoolFromFile(t, serverCA1.CertFile))
+	clientInfo := TLSInfo{ServerName: "127.0.0.1"}
+	clientInfo.SetDynamicTrustRoots(provider)
+
+	clientCfg, err := clientInfo.ClientConfig()
+	require.NoError(t, err)
+
+	clientConn1 := mustDialTLS(t, ln.Addr().String(), clientCfg)
+	serverConn1 := mustAcceptConn(t, ln)
+	clientConn1.Close()
+	serverConn1.Close()
+
+	// Replacing the files under the same paths mirrors how operators rotate
+	// server identities without changing listener configuration.
+	mustReplaceTLSFiles(t, serverCA2.CertFile, serverCA2.KeyFile, stableCertFile, stableKeyFile)
+	provider.SetCertPool(mustCertPoolFromFile(t, serverCA2.CertFile))
+
+	clientConn2 := mustDialTLS(t, ln.Addr().String(), clientCfg)
+	serverConn2 := mustAcceptConn(t, ln)
+	require.Equal(t, mustLoadCertificate(t, serverCA2.CertFile).Raw, clientConn2.ConnectionState().PeerCertificates[0].Raw)
+	clientConn2.Close()
+	serverConn2.Close()
+
+	mustReplaceTLSFiles(t, serverCA1.CertFile, serverCA1.KeyFile, stableCertFile, stableKeyFile)
+	_, err = tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", ln.Addr().String(), clientCfg)
+	require.Error(t, err)
+}
+
+func TestDynamicRootCAs_DoesNotBreakExistingConnection(t *testing.T) {
+	serverCA1, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+	serverCA2, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+
+	stableCertFile, stableKeyFile := mustWriteStableTLSFiles(t, serverCA1.CertFile, serverCA1.KeyFile)
+	serverInfo := &TLSInfo{
+		CertFile: stableCertFile,
+		KeyFile:  stableKeyFile,
+		Logger:   zaptest.NewLogger(t),
+	}
+
+	ln := mustNewTLSListener(t, serverInfo)
+	defer ln.Close()
+
+	provider := newMutableCertPoolProvider(mustCertPoolFromFile(t, serverCA1.CertFile))
+	clientInfo := TLSInfo{ServerName: "127.0.0.1"}
+	clientInfo.SetDynamicTrustRoots(provider)
+
+	clientCfg, err := clientInfo.ClientConfig()
+	require.NoError(t, err)
+
+	clientConn1 := mustDialTLS(t, ln.Addr().String(), clientCfg)
+	defer clientConn1.Close()
+	serverConn1 := mustAcceptConn(t, ln)
+	defer serverConn1.Close()
+
+	requirePayloadTransfer(t, clientConn1, serverConn1, "ping-ca1")
+	requirePayloadTransfer(t, serverConn1, clientConn1, "pong-ca1")
+
+	mustReplaceTLSFiles(t, serverCA2.CertFile, serverCA2.KeyFile, stableCertFile, stableKeyFile)
+	provider.SetCertPool(mustCertPoolFromFile(t, serverCA2.CertFile))
+
+	// Existing TLS sessions should stay alive because only future handshakes
+	// consult the rotated trust roots.
+	requirePayloadTransfer(t, clientConn1, serverConn1, "ping-ca2")
+	requirePayloadTransfer(t, serverConn1, clientConn1, "pong-ca2")
+
+	clientConn2 := mustDialTLS(t, ln.Addr().String(), clientCfg)
+	serverConn2 := mustAcceptConn(t, ln)
+	require.Equal(t, mustLoadCertificate(t, serverCA2.CertFile).Raw, clientConn2.ConnectionState().PeerCertificates[0].Raw)
+	clientConn2.Close()
+	serverConn2.Close()
+}
+
+func TestDynamicRootCAs_NilPreservesExistingBehavior(t *testing.T) {
+	t.Run("client-config", func(t *testing.T) {
+		serverCA1, err := createSelfCertEx(t, "127.0.0.1")
+		require.NoError(t, err)
+		serverCA2, err := createSelfCertEx(t, "127.0.0.1")
+		require.NoError(t, err)
+
+		stableCertFile, stableKeyFile := mustWriteStableTLSFiles(t, serverCA1.CertFile, serverCA1.KeyFile)
+		serverInfo := &TLSInfo{
+			CertFile: stableCertFile,
+			KeyFile:  stableKeyFile,
+			Logger:   zaptest.NewLogger(t),
+		}
+
+		ln := mustNewTLSListener(t, serverInfo)
+		defer ln.Close()
+
+		clientInfo := TLSInfo{
+			ServerName:    "127.0.0.1",
+			TrustedCAFile: serverCA1.CertFile,
+		}
+		clientCfg, err := clientInfo.ClientConfig()
+		require.NoError(t, err)
+
+		clientConn := mustDialTLS(t, ln.Addr().String(), clientCfg)
+		serverConn := mustAcceptConn(t, ln)
+		clientConn.Close()
+		serverConn.Close()
+
+		mustReplaceTLSFiles(t, serverCA2.CertFile, serverCA2.KeyFile, stableCertFile, stableKeyFile)
+
+		_, err = tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", ln.Addr().String(), clientCfg)
+		require.Error(t, err)
+	})
+}
+
+func TestDynamicRootCAs_StripsPortFromFallbackServerName(t *testing.T) {
+	serverCA, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+
+	serverInfo := &TLSInfo{
+		CertFile: serverCA.CertFile,
+		KeyFile:  serverCA.KeyFile,
+		Logger:   zaptest.NewLogger(t),
+	}
+
+	ln := mustNewTLSListener(t, serverInfo)
+	defer ln.Close()
+
+	provider := newMutableCertPoolProvider(mustCertPoolFromFile(t, serverCA.CertFile))
+	clientInfo := TLSInfo{ServerName: "127.0.0.1"}
+	clientInfo.SetDynamicTrustRoots(provider)
+
+	clientCfg, err := clientInfo.ClientConfig()
+	require.NoError(t, err)
+
+	clientConn := mustDialTLS(t, ln.Addr().String(), clientCfg)
+	defer clientConn.Close()
+	serverConn := mustAcceptConn(t, ln)
+	defer serverConn.Close()
+
+	cs := clientConn.ConnectionState()
+	cs.ServerName = ""
+	require.NoError(t, clientInfo.verifyDynamicServerCertificate(cs, "127.0.0.1:2379"))
+}
+
+func TestDynamicRootCAs_PreservesHostnameVerification(t *testing.T) {
+	serverCA, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+
+	serverInfo := &TLSInfo{
+		CertFile: serverCA.CertFile,
+		KeyFile:  serverCA.KeyFile,
+		Logger:   zaptest.NewLogger(t),
+	}
+
+	ln := mustNewTLSListener(t, serverInfo)
+	defer ln.Close()
+
+	provider := newMutableCertPoolProvider(mustCertPoolFromFile(t, serverCA.CertFile))
+	clientInfo := TLSInfo{ServerName: "127.0.0.2"}
+	clientInfo.SetDynamicTrustRoots(provider)
+
+	clientCfg, err := clientInfo.ClientConfig()
+	require.NoError(t, err)
+
+	_, err = tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", ln.Addr().String(), clientCfg)
+	require.Error(t, err)
+}
+
+func TestDynamicRootCAs_NilProviderPoolFailsHandshake(t *testing.T) {
+	serverCA, err := createSelfCertEx(t, "127.0.0.1")
+	require.NoError(t, err)
+
+	serverInfo := &TLSInfo{
+		CertFile: serverCA.CertFile,
+		KeyFile:  serverCA.KeyFile,
+		Logger:   zaptest.NewLogger(t),
+	}
+
+	ln := mustNewTLSListener(t, serverInfo)
+	defer ln.Close()
+
+	clientInfo := TLSInfo{ServerName: "127.0.0.1"}
+	clientInfo.SetDynamicTrustRoots(newMutableCertPoolProvider(nil))
+
+	clientCfg, err := clientInfo.ClientConfig()
+	require.NoError(t, err)
+
+	_, err = tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", ln.Addr().String(), clientCfg)
+	require.Error(t, err)
+}
+
+func mustNewTLSListener(t *testing.T, info *TLSInfo) net.Listener {
+	t.Helper()
+
+	ln, err := NewListener("127.0.0.1:0", "https", info)
+	require.NoError(t, err)
+	return ln
+}
+
+func mustDialTLS(t *testing.T, addr string, cfg *tls.Config) *tls.Conn {
+	t.Helper()
+
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", addr, cfg)
+	require.NoError(t, err)
+	return conn
+}
+
+func mustAcceptConn(t *testing.T, ln net.Listener) net.Conn {
+	t.Helper()
+
+	conn, err := ln.Accept()
+	require.NoError(t, err)
+	return conn
+}
+
+func requirePayloadTransfer(t *testing.T, writer net.Conn, reader net.Conn, payload string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	require.NoError(t, writer.SetDeadline(deadline))
+	require.NoError(t, reader.SetDeadline(deadline))
+
+	_, err := writer.Write([]byte(payload))
+	require.NoError(t, err)
+
+	buf := make([]byte, len(payload))
+	_, err = io.ReadFull(reader, buf)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(buf))
+}
+
+func mustWriteStableTLSFiles(t *testing.T, certFile string, keyFile string) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	stableCertFile := filepath.Join(dir, "cert.pem")
+	stableKeyFile := filepath.Join(dir, "key.pem")
+	mustReplaceTLSFiles(t, certFile, keyFile, stableCertFile, stableKeyFile)
+	return stableCertFile, stableKeyFile
+}
+
+func mustReplaceTLSFiles(t *testing.T, srcCertFile string, srcKeyFile string, dstCertFile string, dstKeyFile string) {
+	t.Helper()
+
+	certBytes, err := os.ReadFile(srcCertFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dstCertFile, certBytes, 0o600))
+
+	keyBytes, err := os.ReadFile(srcKeyFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dstKeyFile, keyBytes, 0o600))
+}
+
+func mustCertPoolFromFile(t *testing.T, certFile string) *x509.CertPool {
+	t.Helper()
+
+	pemBytes, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+
+	certPool := x509.NewCertPool()
+	require.True(t, certPool.AppendCertsFromPEM(pemBytes))
+	return certPool
+}
+
+func mustLoadKeyPair(t *testing.T, certFile string, keyFile string) tls.Certificate {
+	t.Helper()
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+	return cert
+}
+
+func mustLoadCertificate(t *testing.T, certFile string) *x509.Certificate {
+	t.Helper()
+
+	pemBytes, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(pemBytes)
+	require.NotNil(t, block)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}


### PR DESCRIPTION
Summary: enable CA hot-reload without forcing file-backed reloading.

Proposal can be found in https://github.com/etcd-io/etcd/issues/11555#issuecomment-4237224766.

Refs #21156
Refs #21157
Refs #21158

**Disclaimer #1:** I relied on two different agentic implementations to support me in the validation and documentation of my proposal, and the coding of this PR. The tests are fully generated by those agents in adversarial mode, ie had them fight until they agreed. This work took several days and dozens of prompts, after realizing #21156 and #21157 didn't fit my specific needs, namely to hot reload CA directly from SPIRE (SPIFFE) in embed mode, without file-backed TLS info.

**Disclaimer #2:** I sign commits with sigstore's gitsign which is unverified by GitHub :(

**Disclaimer #3:** couldn't `make verify`:
```shell
PASSES="bom" ./scripts/test.sh
Running with --race
Starting at: Mon Apr 13 16:15:44 WEST 2026

'bom' started at Mon Apr 13 16:15:44 WEST 2026
Checking bill of materials...
% 'cp' 'go.sum' 'go.sum.tmp'
% 'cp' 'go.mod' 'go.mod.tmp'
% (cd tools/mod && 'go' 'install' 'github.com/appscodelabs/license-bill-of-materials')
% '[REDACTED]/go/bin/license-bill-of-materials' '--override-file' './bill-of-materials.override.json' './...' './api/...' './cache/...' './client/pkg/...' './client/v3/...' './etcdctl/...' './etcdutl/...' './pkg/...' './server/...' './tests/...'
% 'cp' 'go.sum.tmp' 'go.sum'
% 'cp' 'go.mod.tmp' 'go.mod'
21,29d20
< 		"project": "github.com/antithesishq/antithesis-sdk-go",
< 		"licenses": [
< 			{
< 				"type": "MIT License",
< 				"confidence": 1
< 			}
< 		]
< 	},
< 	{
modularized licenses do not match given bill of materials
FAIL: 'bom' FAILED at Mon Apr 13 16:15:51 WEST 2026
gmake: *** [Makefile:110: verify-bom] Error 255
```

`make test-unit`:
```shell
(...)
ok  	go.etcd.io/etcd/client/pkg/v3/transport	(cached)

'unit' PASSED and completed at Mon Apr 13 16:20:03 WEST 2026
SUCCESS
```