### PR TITLE
Codeflash/optimize

### DIFF
--- a/server/etcdserver/api/v2store/event.go
+++ b/server/etcdserver/api/v2store/event.go
@@ -34,16 +34,21 @@ type Event struct {
 }
 
 func newEvent(action string, key string, modifiedIndex, createdIndex uint64) *Event {
-	n := &NodeExtern{
-		Key:           key,
-		ModifiedIndex: modifiedIndex,
-		CreatedIndex:  createdIndex,
+	// Allocate Event and NodeExtern together to reduce heap allocations from 2 to 1.
+	type eventWithNode struct {
+		event Event
+		node  NodeExtern
 	}
-
-	return &Event{
-		Action: action,
-		Node:   n,
+	en := &eventWithNode{
+		event: Event{Action: action},
+		node: NodeExtern{
+			Key:           key,
+			ModifiedIndex: modifiedIndex,
+			CreatedIndex:  createdIndex,
+		},
 	}
+	en.event.Node = &en.node
+	return &en.event
 }
 
 func (e *Event) IsCreated() bool {

--- a/server/etcdserver/api/v2store/store.go
+++ b/server/etcdserver/api/v2store/store.go
@@ -275,7 +275,7 @@ func (s *store) CompareAndSwap(nodePath string, prevValue string, prevIndex uint
 		reportWriteFailure(CompareAndSwap)
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -350,7 +350,7 @@ func (s *store) Delete(nodePath string, dir, recursive bool) (*Event, error) {
 		reportWriteFailure(Delete)
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -411,7 +411,7 @@ func (s *store) CompareAndDelete(nodePath string, prevValue string, prevIndex ui
 		reportWriteFailure(CompareAndDelete)
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 
 	n, err := s.internalGet(nodePath)
 	if err != nil { // if the node does not exist, return error
@@ -454,7 +454,7 @@ func (s *store) Watch(key string, recursive, stream bool, sinceIndex uint64) (Wa
 	s.worldLock.RLock()
 	defer s.worldLock.RUnlock()
 
-	key = path.Clean(path.Join("/", key))
+	key = path.Join("/", key)
 	if sinceIndex == 0 {
 		sinceIndex = s.CurrentIndex + 1
 	}
@@ -523,7 +523,7 @@ func (s *store) Update(nodePath string, newValue string, expireOpts TTLOptionSet
 		reportWriteFailure(Update)
 	}()
 
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -587,7 +587,7 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 		nodePath += "/" + fmt.Sprintf("%020s", strconv.FormatUint(nextIndex, 10))
 	}
 
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
@@ -662,7 +662,7 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 
 // InternalGet gets the node of the given nodePath.
 func (s *store) internalGet(nodePath string) (*node, *v2error.Error) {
-	nodePath = path.Clean(path.Join("/", nodePath))
+	nodePath = path.Join("/", nodePath)
 
 	walkFunc := func(parent *node, name string) (*node, *v2error.Error) {
 		if !parent.IsDir() {

--- a/server/etcdserver/api/v2store/store.go
+++ b/server/etcdserver/api/v2store/store.go
@@ -32,6 +32,20 @@ import (
 // The default version to set when the store is first initialized.
 const defaultVersion = 2
 
+// normalizePath ensures the path starts with "/" and is clean.
+// It avoids allocation when the path is already normalized (common case).
+func normalizePath(p string) string {
+	if len(p) > 0 && p[0] == '/' && !strings.Contains(p, "//") && !strings.Contains(p, "/.") {
+		// Fast path: already starts with "/" and has no double-slashes or dots.
+		// Strip trailing slash if present (except for root "/").
+		if len(p) > 1 && p[len(p)-1] == '/' {
+			return p[:len(p)-1]
+		}
+		return p
+	}
+	return path.Join("/", p)
+}
+
 var minExpireTime time.Time
 
 func init() {
@@ -275,7 +289,7 @@ func (s *store) CompareAndSwap(nodePath string, prevValue string, prevIndex uint
 		reportWriteFailure(CompareAndSwap)
 	}()
 
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -350,7 +364,7 @@ func (s *store) Delete(nodePath string, dir, recursive bool) (*Event, error) {
 		reportWriteFailure(Delete)
 	}()
 
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -411,7 +425,7 @@ func (s *store) CompareAndDelete(nodePath string, prevValue string, prevIndex ui
 		reportWriteFailure(CompareAndDelete)
 	}()
 
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 
 	n, err := s.internalGet(nodePath)
 	if err != nil { // if the node does not exist, return error
@@ -454,7 +468,7 @@ func (s *store) Watch(key string, recursive, stream bool, sinceIndex uint64) (Wa
 	s.worldLock.RLock()
 	defer s.worldLock.RUnlock()
 
-	key = path.Join("/", key)
+	key = normalizePath(key)
 	if sinceIndex == 0 {
 		sinceIndex = s.CurrentIndex + 1
 	}
@@ -523,7 +537,7 @@ func (s *store) Update(nodePath string, newValue string, expireOpts TTLOptionSet
 		reportWriteFailure(Update)
 	}()
 
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
 		return nil, v2error.NewError(v2error.EcodeRootROnly, "/", s.CurrentIndex)
@@ -587,7 +601,7 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 		nodePath += "/" + fmt.Sprintf("%020s", strconv.FormatUint(nextIndex, 10))
 	}
 
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 
 	// we do not allow the user to change "/"
 	if s.readonlySet.Contains(nodePath) {
@@ -662,7 +676,7 @@ func (s *store) internalCreate(nodePath string, dir bool, value string, unique, 
 
 // InternalGet gets the node of the given nodePath.
 func (s *store) internalGet(nodePath string) (*node, *v2error.Error) {
-	nodePath = path.Join("/", nodePath)
+	nodePath = normalizePath(nodePath)
 
 	walkFunc := func(parent *node, name string) (*node, *v2error.Error) {
 		if !parent.IsDir() {

--- a/server/etcdserver/api/v2store/store.go
+++ b/server/etcdserver/api/v2store/store.go
@@ -469,17 +469,32 @@ func (s *store) Watch(key string, recursive, stream bool, sinceIndex uint64) (Wa
 
 // walk walks all the nodePath and apply the walkFunc on each directory
 func (s *store) walk(nodePath string, walkFunc func(prev *node, component string) (*node, *v2error.Error)) (*node, *v2error.Error) {
-	components := strings.Split(nodePath, "/")
-
 	curr := s.Root
 	var err *v2error.Error
 
-	for i := 1; i < len(components); i++ {
-		if len(components[i]) == 0 { // ignore empty string
-			return curr, nil
+	// Iterate over path components without allocating a []string via strings.Split.
+	// Skip leading slash.
+	for len(nodePath) > 0 {
+		// Skip leading slashes.
+		if nodePath[0] == '/' {
+			nodePath = nodePath[1:]
+			continue
+		}
+		// Find the next slash.
+		idx := strings.IndexByte(nodePath, '/')
+		var component string
+		if idx < 0 {
+			component = nodePath
+			nodePath = ""
+		} else {
+			component = nodePath[:idx]
+			nodePath = nodePath[idx+1:]
+		}
+		if len(component) == 0 {
+			continue
 		}
 
-		curr, err = walkFunc(curr, components[i])
+		curr, err = walkFunc(curr, component)
 		if err != nil {
 			return nil, err
 		}

--- a/server/etcdserver/api/v2store/watcher_hub.go
+++ b/server/etcdserver/api/v2store/watcher_hub.go
@@ -122,18 +122,20 @@ func (wh *watcherHub) add(e *Event) {
 func (wh *watcherHub) notify(e *Event) {
 	e = wh.EventHistory.addEvent(e) // add event into the eventHistory
 
-	segments := strings.Split(e.Node.Key, "/")
-
-	currPath := "/"
-
 	// walk through all the segments of the path and notify the watchers
 	// if the path is "/foo/bar", it will notify watchers with path "/",
 	// "/foo" and "/foo/bar"
-
-	for _, segment := range segments {
-		currPath = path.Join(currPath, segment)
-		// notify the watchers who interests in the changes of current path
-		wh.notifyWatchers(e, currPath, false)
+	//
+	// Iterate without strings.Split to avoid allocating a []string slice.
+	key := e.Node.Key
+	wh.notifyWatchers(e, "/", false)
+	for i := 1; i < len(key); i++ {
+		if key[i] == '/' {
+			wh.notifyWatchers(e, key[:i], false)
+		}
+	}
+	if len(key) > 1 {
+		wh.notifyWatchers(e, key, false)
 	}
 }
 

--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -16,9 +16,10 @@ package txn
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"math"
-	"sort"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -112,27 +113,41 @@ func sortRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest, lg *zap.Logger) 
 	}
 
 	if !isDefaultOrdering(r.SortTarget, sortOrder) {
-		var sorter sort.Interface
-		switch {
-		case r.SortTarget == pb.RangeRequest_KEY:
-			sorter = &kvSortByKey{&kvSort{rr.KVs}}
-		case r.SortTarget == pb.RangeRequest_VERSION:
-			sorter = &kvSortByVersion{&kvSort{rr.KVs}}
-		case r.SortTarget == pb.RangeRequest_CREATE:
-			sorter = &kvSortByCreate{&kvSort{rr.KVs}}
-		case r.SortTarget == pb.RangeRequest_MOD:
-			sorter = &kvSortByMod{&kvSort{rr.KVs}}
-		case r.SortTarget == pb.RangeRequest_VALUE:
-			sorter = &kvSortByValue{&kvSort{rr.KVs}}
+		// Use slices.SortFunc to avoid heap-allocating sort.Interface wrappers.
+		// For descending order, we negate the comparison function instead of
+		// wrapping with sort.Reverse (which allocates another interface).
+		var cmpFunc func(a, b mvccpb.KeyValue) int
+		switch r.SortTarget {
+		case pb.RangeRequest_KEY:
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return bytes.Compare(a.Key, b.Key)
+			}
+		case pb.RangeRequest_VERSION:
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return cmp.Compare(a.Version, b.Version)
+			}
+		case pb.RangeRequest_CREATE:
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return cmp.Compare(a.CreateRevision, b.CreateRevision)
+			}
+		case pb.RangeRequest_MOD:
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return cmp.Compare(a.ModRevision, b.ModRevision)
+			}
+		case pb.RangeRequest_VALUE:
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return bytes.Compare(a.Value, b.Value)
+			}
 		default:
 			lg.Panic("unexpected sort target", zap.Int32("sort-target", int32(r.SortTarget)))
 		}
-		switch {
-		case sortOrder == pb.RangeRequest_ASCEND:
-			sort.Sort(sorter)
-		case sortOrder == pb.RangeRequest_DESCEND:
-			sort.Sort(sort.Reverse(sorter))
+		if sortOrder == pb.RangeRequest_DESCEND {
+			ascFunc := cmpFunc
+			cmpFunc = func(a, b mvccpb.KeyValue) int {
+				return ascFunc(b, a)
+			}
 		}
+		slices.SortFunc(rr.KVs, cmpFunc)
 	}
 }
 
@@ -177,41 +192,3 @@ func pruneKVs(rr *mvcc.RangeResult, isPrunable func(*mvccpb.KeyValue) bool) {
 	rr.KVs = rr.KVs[:j]
 }
 
-type kvSort struct{ kvs []mvccpb.KeyValue }
-
-func (s *kvSort) Swap(i, j int) {
-	t := s.kvs[i]
-	s.kvs[i] = s.kvs[j]
-	s.kvs[j] = t
-}
-func (s *kvSort) Len() int { return len(s.kvs) }
-
-type kvSortByKey struct{ *kvSort }
-
-func (s *kvSortByKey) Less(i, j int) bool {
-	return bytes.Compare(s.kvs[i].Key, s.kvs[j].Key) < 0
-}
-
-type kvSortByVersion struct{ *kvSort }
-
-func (s *kvSortByVersion) Less(i, j int) bool {
-	return (s.kvs[i].Version - s.kvs[j].Version) < 0
-}
-
-type kvSortByCreate struct{ *kvSort }
-
-func (s *kvSortByCreate) Less(i, j int) bool {
-	return (s.kvs[i].CreateRevision - s.kvs[j].CreateRevision) < 0
-}
-
-type kvSortByMod struct{ *kvSort }
-
-func (s *kvSortByMod) Less(i, j int) bool {
-	return (s.kvs[i].ModRevision - s.kvs[j].ModRevision) < 0
-}
-
-type kvSortByValue struct{ *kvSort }
-
-func (s *kvSortByValue) Less(i, j int) bool {
-	return bytes.Compare(s.kvs[i].Value, s.kvs[j].Value) < 0
-}

--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -113,6 +113,13 @@ func sortRangeResults(rr *mvcc.RangeResult, r *pb.RangeRequest, lg *zap.Logger) 
 	}
 
 	if !isDefaultOrdering(r.SortTarget, sortOrder) {
+		// Fast path: KEY DESCEND only needs a reverse since storage returns
+		// keys in ascending lexicographic order. This is O(n) vs O(n log n).
+		if r.SortTarget == pb.RangeRequest_KEY && sortOrder == pb.RangeRequest_DESCEND {
+			slices.Reverse(rr.KVs)
+			return
+		}
+
 		// Use slices.SortFunc to avoid heap-allocating sort.Interface wrappers.
 		// For descending order, we negate the comparison function instead of
 		// wrapping with sort.Reverse (which allocates another interface).

--- a/server/storage/mvcc/index.go
+++ b/server/storage/mvcc/index.go
@@ -120,6 +120,9 @@ func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int) (revs []
 		}
 		return []Revision{rev}, 1
 	}
+	if limit > 0 {
+		revs = make([]Revision, 0, limit)
+	}
 	ti.unsafeVisit(key, end, func(ki *keyIndex) bool {
 		if rev, _, _, err := ki.get(ti.lg, atRev); err == nil {
 			if limit <= 0 || len(revs) < limit {

--- a/server/storage/mvcc/key_index.go
+++ b/server/storage/mvcc/key_index.go
@@ -158,7 +158,7 @@ func (ki *keyIndex) get(lg *zap.Logger, atRev int64) (modified, created Revision
 		return Revision{}, Revision{}, 0, ErrRevisionNotFound
 	}
 
-	n := g.walk(func(rev Revision) bool { return rev.Main > atRev })
+	n := g.findRevisionIndex(atRev)
 	if n != -1 {
 		return g.revs[n], g.created, g.ver - int64(len(g.revs)-n-1), nil
 	}
@@ -256,16 +256,6 @@ func (ki *keyIndex) keep(atRev int64, available map[Revision]struct{}) {
 }
 
 func (ki *keyIndex) doCompact(atRev int64, available map[Revision]struct{}) (genIdx int, revIndex int) {
-	// walk until reaching the first revision smaller or equal to "atRev",
-	// and add the revision to the available map
-	f := func(rev Revision) bool {
-		if rev.Main <= atRev {
-			available[rev] = struct{}{}
-			return false
-		}
-		return true
-	}
-
 	genIdx, g := 0, &ki.generations[0]
 	// find first generation includes atRev or created after atRev
 	for genIdx < len(ki.generations)-1 {
@@ -276,7 +266,12 @@ func (ki *keyIndex) doCompact(atRev int64, available map[Revision]struct{}) (gen
 		g = &ki.generations[genIdx]
 	}
 
-	revIndex = g.walk(f)
+	// Use binary search to find the last revision with Main <= atRev,
+	// and add it to the available map
+	revIndex = g.findRevisionIndex(atRev)
+	if revIndex != -1 {
+		available[g.revs[revIndex]] = struct{}{}
+	}
 
 	return genIdx, revIndex
 }
@@ -293,18 +288,18 @@ func (ki *keyIndex) findGeneration(rev int64) *generation {
 	cg := lastg
 
 	for cg >= 0 {
-		if len(ki.generations[cg].revs) == 0 {
+		g := &ki.generations[cg]
+		if len(g.revs) == 0 {
 			cg--
 			continue
 		}
-		g := ki.generations[cg]
 		if cg != lastg {
 			if tomb := g.revs[len(g.revs)-1].Main; tomb <= rev {
 				return nil
 			}
 		}
 		if g.revs[0].Main <= rev {
-			return &ki.generations[cg]
+			return g
 		}
 		cg--
 	}
@@ -312,7 +307,7 @@ func (ki *keyIndex) findGeneration(rev int64) *generation {
 }
 
 func (ki *keyIndex) Less(bki *keyIndex) bool {
-	return bytes.Compare(ki.key, bki.key) == -1
+	return bytes.Compare(ki.key, bki.key) < 0
 }
 
 func (ki *keyIndex) equal(b *keyIndex) bool {
@@ -365,6 +360,27 @@ func (g *generation) walk(f func(rev Revision) bool) int {
 		}
 	}
 	return -1
+}
+
+// findRevisionIndex uses binary search to find the index of the last revision
+// with Main <= atRev. Returns -1 if no such revision exists.
+// This is an optimized alternative to walk for the common case of searching
+// by main revision.
+func (g *generation) findRevisionIndex(atRev int64) int {
+	// Binary search for the last revision where Main <= atRev.
+	// Revisions are sorted in ascending order by Main.
+	lo, hi := 0, len(g.revs)-1
+	result := -1
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		if g.revs[mid].Main <= atRev {
+			result = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return result
 }
 
 func (g *generation) String() string {


### PR DESCRIPTION

# Optimization Session Handoff

## Domain
Deep (multi-dimensional profiling)

## Branch
`codeflash/optimize`

## Status
Complete - ready for review

## Changes Made

### server/storage/mvcc/key_index.go
1. Added `findRevisionIndex` method: O(log n) binary search replacement for O(n) linear `walk` in revision lookup
2. Updated `get` to use `findRevisionIndex` instead of `walk`
3. Updated `doCompact` to use `findRevisionIndex` instead of `walk`
4. Fixed value copy in `findGeneration` (pointer instead of struct copy)
5. Changed `Less` to use `< 0` instead of `== -1`

### server/storage/mvcc/index.go
1. Pre-allocate revs slice in `Revisions` when limit is known

### server/etcdserver/txn/range.go
1. Replaced sort.Interface-based sorting with slices.SortFunc (eliminates 3 allocs per sorted range)
2. Added KEY DESCEND fast path using slices.Reverse instead of full sort (O(n) vs O(n log n))
3. Used cmp.Compare for numeric comparisons

### server/etcdserver/api/v2store/store.go
1. Replaced strings.Split in walk() with zero-allocation slash-delimited iteration
2. Removed redundant path.Clean wrapping path.Join calls
3. Added normalizePath() fast-path that avoids path.Join allocation for already-clean paths

### server/etcdserver/api/v2store/event.go
1. Colocated Event and NodeExtern in single heap allocation

### server/etcdserver/api/v2store/watcher_hub.go
1. Replaced strings.Split + path.Join in notify() with zero-allocation substring iteration

## Key Results

### storage/mvcc (from prior session)
- Range queries: 1.5x-3.3x faster
- Index compaction: 1.2x-2.6x faster
- Index get (key lookup): 1.5x faster
- 4 fewer allocations per limited range query

### etcdserver/txn (this session)
- Sort-related allocations reduced by 3 per sorted range request (630->627, 629->627)
- KEY DESCEND uses O(n) reverse instead of O(n log n) sort

### etcdserver/api/v2store (this session)
- BenchmarkStoreSet128Bytes: 1240 B/op -> 544 B/op (-56.1%), 27 allocs -> 8 allocs (-70.4%)
- ns/op improved from ~1776ns to ~1212ns (1.47x faster, median)

## Tests
All tests pass. `TestRangeSecObserve` is pre-existing flaky (fails with count>1 on main too).

## Remaining Opportunities
- Protobuf unmarshal (`KeyValue.Unmarshal`) is ~14% of Range CPU; consider vtprotobuf or lazy deserialization
- bbolt Cursor.search is 38% of Range alloc objects (external dependency)
- runtime.growslice is 23% of Range CPU (storage layer slice growth)
- v2store: node.Repr (9.3%) and NodeExtern.loadInternalNode (6.2%) still allocate per operation
- Backend writeback benchmarks show ~400k allocs/op; could benefit from buffer pooling



| benchmark                                      | package                | before_ns | after_ns | speedup | before_allocs | after_allocs | status |
|-----------------------------------------------|------------------------|----------:|---------:|--------:|--------------:|-------------:|--------|
| BenchmarkIndexCompact1                        | storage/mvcc           | 525.6     | 200      | 2.63x   | 2             | 3            | kept   |
| BenchmarkIndexCompact100                      | storage/mvcc           | 18555     | 14865    | 1.25x   | 12            | 12           | kept   |
| BenchmarkIndexGet                             | storage/mvcc           | 5476      | 3654     | 1.50x   | 0             | 0            | kept   |
| BenchmarkIndexPut                             | storage/mvcc           | 4175      | 3396     | 1.23x   | 3             | 3            | kept   |
| BenchmarkRange/keys_100/no_sort_no_limit      | etcdserver/txn         | 171698    | 85633    | 2.01x   | 627           | 627          | kept   |
| BenchmarkRange/keys_100/no_sort_limit_10      | etcdserver/txn         | 26319     | 13090    | 2.01x   | 90            | 86           | kept   |
| BenchmarkRange/keys_100/key_ascend_limit_10   | etcdserver/txn         | 25555     | 13164    | 1.94x   | 90            | 86           | kept   |
| BenchmarkRange/keys_1000/no_sort_no_limit     | etcdserver/txn         | 1699573   | 1099734  | 1.55x   | 6031          | 6031         | kept   |
| BenchmarkRange/keys_1000/no_sort_limit_10     | etcdserver/txn         | 69695     | 39916    | 1.75x   | 90            | 86           | kept   |
| BenchmarkRange/keys_10000/no_sort_no_limit    | etcdserver/txn         | 28818465  | 12687227 | 2.27x   | 70038         | 70038        | kept   |
| BenchmarkRange/keys_10000/no_sort_limit_10    | etcdserver/txn         | 1086151   | 325630   | 3.34x   | 101           | 97           | kept   |
| BenchmarkRange/keys_10000/key_ascend_limit_10 | etcdserver/txn         | 957333    | 447380   | 2.14x   | 101           | 97           | kept   |
| BenchmarkRange/keys_100/key_descend_limit_10  | etcdserver/txn         | -         | -        | -       | 630           | 627          | kept   |
| BenchmarkRange/keys_100/create_ascend_limit_10| etcdserver/txn         | -         | -        | -       | 629           | 627          | kept   |
| BenchmarkStoreSet128Bytes                     | etcdserver/api/v2store | 1776      | 1212     | 1.47x   | 27            | 8            | kept   |