### PR TITLE
Add --keys-only option for mvcc range

### DIFF
--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -27,6 +27,7 @@ type RangeOptions struct {
 	Limit int64
 	Rev   int64
 	Count bool
+	Key   bool
 }
 
 type RangeResult struct {


### PR DESCRIPTION
Part of #20386 

We need the option so that the mvcc can perform --keys-only operation on the backend side.