### PR TITLE
[3.4] etcdserver: add learner check to readyz

### DIFF
--- a/etcdserver/api/etcdhttp/health.go
+++ b/etcdserver/api/etcdhttp/health.go
@@ -50,6 +50,7 @@ type ServerHealth interface {
 	Range(context.Context, *pb.RangeRequest) (*pb.RangeResponse, error)
 	Config() etcdserver.ServerConfig
 	AuthStore() auth.AuthStore
+	IsLearner() bool
 }
 
 type serverHealthV2V3 interface {
@@ -283,6 +284,8 @@ func installReadyzEndpoints(mux *http.ServeMux, server ServerHealth) {
 	reg.Register("serializable_read", readCheck(server, true))
 	// linearizable_read check would be replaced by read_index check in 3.6
 	reg.Register("linearizable_read", readCheck(server, false))
+	// check if local is learner
+	reg.Register("non_learner", learnerCheck(server))
 	reg.InstallHttpEndpoints(mux)
 }
 
@@ -451,5 +454,14 @@ func readCheck(srv ServerHealth, serializable bool) func(ctx context.Context) er
 		ctx = srv.AuthStore().WithRoot(ctx)
 		_, err := srv.Range(ctx, &pb.RangeRequest{KeysOnly: true, Limit: 1, Serializable: serializable})
 		return err
+	}
+}
+
+func learnerCheck(srv ServerHealth) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if srv.IsLearner() {
+			return fmt.Errorf("not supported for learner")
+		}
+		return nil
 	}
 }

--- a/etcdserver/api/etcdhttp/health_test.go
+++ b/etcdserver/api/etcdhttp/health_test.go
@@ -41,6 +41,7 @@ type fakeHealthServer struct {
 	linearizableReadError error
 	missingLeader         bool
 	authStore             auth.AuthStore
+	isLearner             bool
 }
 
 func (s *fakeHealthServer) Range(_ context.Context, req *pb.RangeRequest) (*pb.RangeResponse, error) {
@@ -61,6 +62,10 @@ func (s *fakeHealthServer) Leader() types.ID {
 	return types.ID(raft.None)
 }
 
+func (s *fakeHealthServer) IsLearner() bool {
+	return s.isLearner
+}
+
 func (s *fakeHealthServer) AuthStore() auth.AuthStore { return s.authStore }
 
 func (s *fakeHealthServer) ClientCertAuthEnabled() bool { return false }
@@ -75,6 +80,7 @@ type healthTestCase struct {
 	alarms        []*pb.AlarmMember
 	apiError      error
 	missingLeader bool
+	isLearner     bool
 }
 
 func TestHealthHandler(t *testing.T) {
@@ -183,6 +189,11 @@ func TestHttpSubPath(t *testing.T) {
 			name:             "/readyz/non_exist 404",
 			healthCheckURL:   "/readyz/non_exist",
 			expectStatusCode: http.StatusNotFound,
+		},
+		{
+			name:             "/readyz/learner ok",
+			healthCheckURL:   "/readyz/non_learner",
+			expectStatusCode: http.StatusOK,
 		},
 	}
 	for _, tt := range tests {
@@ -333,6 +344,42 @@ func TestLinearizableReadCheck(t *testing.T) {
 				linearizableReadError: tt.apiError,
 				authStore:             auth.NewAuthStore(logger, be, nil, 0),
 			}
+			HandleHealth(mux, s)
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+			checkHttpResponse(t, ts, tt.healthCheckURL, tt.expectStatusCode, tt.inResult, tt.notInResult)
+			checkMetrics(t, tt.healthCheckURL, "linearizable_read", tt.expectStatusCode)
+		})
+	}
+}
+
+func TestLearnerReadyCheck(t *testing.T) {
+	be, _ := betesting.NewDefaultTmpBackend()
+	defer be.Close()
+	tests := []healthTestCase{
+		{
+			name:             "readyz normal",
+			healthCheckURL:   "/readyz",
+			expectStatusCode: http.StatusOK,
+			isLearner:        false,
+		},
+		{
+			name:             "not ready because member is learner",
+			healthCheckURL:   "/readyz",
+			expectStatusCode: http.StatusServiceUnavailable,
+			isLearner:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			logger := zaptest.NewLogger(t)
+			s := &fakeHealthServer{
+				linearizableReadError: tt.apiError,
+				authStore:             auth.NewAuthStore(logger, be, nil, 0),
+			}
+			s.isLearner = tt.isLearner
 			HandleHealth(mux, s)
 			ts := httptest.NewServer(mux)
 			defer ts.Close()


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/19086
I found this PR got backported to `3.5` https://github.com/etcd-io/etcd/pull/19280 but not to 3.4
