### PR TITLE
mvcc: add WithTotalCount optimization for Range

### DIFF
--- a/server/etcdserver/apply/backend.go
+++ b/server/etcdserver/apply/backend.go
@@ -56,7 +56,7 @@ func (a *applierV3backend) DeleteRange(dr *pb.DeleteRangeRequest) (*pb.DeleteRan
 }
 
 func (a *applierV3backend) Range(r *pb.RangeRequest) (*pb.RangeResponse, *traceutil.Trace, error) {
-	return mvcctxn.Range(context.TODO(), a.options.Logger, a.options.KV, r)
+	return mvcctxn.Range(context.TODO(), a.options.Logger, a.options.KV, r, true)
 }
 
 func (a *applierV3backend) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {

--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -29,7 +29,7 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
-func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) (resp *pb.RangeResponse, trace *traceutil.Trace, err error) {
+func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest, withTotalCount bool) (resp *pb.RangeResponse, trace *traceutil.Trace, err error) {
 	ctx, trace = traceutil.EnsureTrace(ctx, lg, "range")
 	defer func(start time.Time) {
 		success := err == nil
@@ -37,18 +37,19 @@ func Range(ctx context.Context, lg *zap.Logger, kv mvcc.KV, r *pb.RangeRequest) 
 	}(time.Now())
 	txnRead := kv.Read(mvcc.ConcurrentReadTxMode, trace)
 	defer txnRead.End()
-	resp, err = executeRange(ctx, lg, txnRead, r)
+	resp, err = executeRange(ctx, lg, txnRead, r, withTotalCount)
 	return resp, trace, err
 }
 
-func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *pb.RangeRequest) (*pb.RangeResponse, error) {
+func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *pb.RangeRequest, withTotalCount bool) (*pb.RangeResponse, error) {
 	trace := traceutil.Get(ctx)
 
 	limit := rangeLimit(r)
 	ro := mvcc.RangeOptions{
-		Limit:     limit,
-		Rev:       r.Revision,
-		CountOnly: r.CountOnly,
+		Limit:          limit,
+		Rev:            r.Revision,
+		CountOnly:      r.CountOnly,
+		WithTotalCount: withTotalCount,
 	}
 
 	rr, err := txnRead.Range(ctx, r.Key, mkGteRange(r.RangeEnd), ro)

--- a/server/etcdserver/txn/range_bench_test.go
+++ b/server/etcdserver/txn/range_bench_test.go
@@ -97,7 +97,7 @@ func BenchmarkRange(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for b.Loop() {
-					_, _, err := Range(ctx, zap.NewNop(), s, req)
+					_, _, err := Range(ctx, zap.NewNop(), s, req, false)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/server/etcdserver/txn/txn.go
+++ b/server/etcdserver/txn/txn.go
@@ -147,7 +147,7 @@ func executeTxn(ctx context.Context, lg *zap.Logger, txnWrite mvcc.TxnWrite, rt 
 				traceutil.Field{Key: "req_type", Value: "range"},
 				traceutil.Field{Key: "range_begin", Value: string(tv.RequestRange.Key)},
 				traceutil.Field{Key: "range_end", Value: string(tv.RequestRange.RangeEnd)})
-			resp, err := executeRange(ctx, lg, txnWrite, tv.RequestRange)
+			resp, err := executeRange(ctx, lg, txnWrite, tv.RequestRange, true)
 			if err != nil {
 				return 0, fmt.Errorf("applyTxn: failed Range: %w", err)
 			}

--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -268,7 +268,7 @@ func TestCheckRange(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
-			_, _, err := Range(ctx, zaptest.NewLogger(t), s, tc.op.GetRequestRange())
+			_, _, err := Range(ctx, zaptest.NewLogger(t), s, tc.op.GetRequestRange(), true)
 
 			gotErr := ""
 			if err != nil {

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -144,7 +144,7 @@ func (s *EtcdServer) Range(ctx context.Context, r *pb.RangeRequest) (*pb.RangeRe
 		return s.authStore.IsRangePermitted(ai, r.Key, r.RangeEnd)
 	}
 
-	get := func() { resp, _, err = txn.Range(ctx, s.Logger(), s.KV(), r) }
+	get := func() { resp, _, err = txn.Range(ctx, s.Logger(), s.KV(), r, true) }
 	if serr := s.doSerialize(ctx, chk, get); serr != nil {
 		err = serr
 		return nil, err

--- a/server/storage/mvcc/index.go
+++ b/server/storage/mvcc/index.go
@@ -24,7 +24,7 @@ import (
 type index interface {
 	Get(key []byte, atRev int64) (rev, created Revision, ver int64, err error)
 	Range(key, end []byte, atRev int64) ([][]byte, []Revision)
-	Revisions(key, end []byte, atRev int64, limit int) ([]Revision, int)
+	Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int)
 	CountRevisions(key, end []byte, atRev int64) int
 	Put(key []byte, rev Revision)
 	Tombstone(key []byte, rev Revision) error
@@ -109,7 +109,7 @@ func (ti *treeIndex) unsafeVisit(key, end []byte, f func(ki *keyIndex) bool) {
 // Revisions returns limited number of revisions from key(included) to end(excluded)
 // at the given rev. The returned slice is sorted in the order of key. There is no limit if limit <= 0.
 // The second return parameter isn't capped by the limit and reflects the total number of revisions.
-func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int) (revs []Revision, total int) {
+func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) (revs []Revision, total int) {
 	ti.RLock()
 	defer ti.RUnlock()
 
@@ -125,10 +125,17 @@ func (ti *treeIndex) Revisions(key, end []byte, atRev int64, limit int) (revs []
 			if limit <= 0 || len(revs) < limit {
 				revs = append(revs, rev)
 			}
-			total++
+			if withTotalCount {
+				total++
+			} else if limit > 0 && len(revs) >= limit {
+				return false
+			}
 		}
 		return true
 	})
+	if !withTotalCount {
+		total = len(revs)
+	}
 	return revs, total
 }
 

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -223,7 +223,7 @@ func TestIndexRevision(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		revs, _ := ti.Revisions(tt.key, tt.end, tt.atRev, tt.limit)
+		revs, _ := ti.Revisions(tt.key, tt.end, tt.atRev, tt.limit, true)
 		if !reflect.DeepEqual(revs, tt.wrevs) {
 			t.Errorf("#%d limit %d: revs = %+v, want %+v", i, tt.limit, revs, tt.wrevs)
 		}

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -234,6 +234,66 @@ func TestIndexRevision(t *testing.T) {
 	}
 }
 
+func TestIndexRevisionsWithTotalCount(t *testing.T) {
+	allKeys := [][]byte{[]byte("foo"), []byte("foo1"), []byte("foo2"), []byte("foo2"), []byte("foo1"), []byte("foo")}
+	allRevs := []Revision{{Main: 1}, {Main: 2}, {Main: 3}, {Main: 4}, {Main: 5}, {Main: 6}}
+
+	ti := newTreeIndex(zaptest.NewLogger(t))
+	for i := range allKeys {
+		ti.Put(allKeys[i], allRevs[i])
+	}
+
+	// Range [foo, fop) @ rev 6 matches 3 keys: foo, foo1, foo2.
+	tests := []struct {
+		key, end   []byte
+		atRev      int64
+		limit      int
+		withTotalCount bool
+		wrevs      []Revision
+		wtotal     int
+	}{
+		// withTotalCount=true with limit returns the full total
+		{
+			[]byte("foo"), []byte("fop"), 6, 1, true,
+			[]Revision{{Main: 6}}, 3,
+		},
+		// withTotalCount=false with limit caps total at len(revs)
+		{
+			[]byte("foo"), []byte("fop"), 6, 1, false,
+			[]Revision{{Main: 6}}, 1,
+		},
+		// withTotalCount=false with limit larger than matches returns full total
+		{
+			[]byte("foo"), []byte("fop"), 6, 10, false,
+			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+		},
+		// withTotalCount=false without limit returns full total
+		{
+			[]byte("foo"), []byte("fop"), 6, 0, false,
+			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+		},
+		// withTotalCount=true without limit returns full total
+		{
+			[]byte("foo"), []byte("fop"), 6, 0, true,
+			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+		},
+		// withTotalCount=false with no matches
+		{
+			[]byte("bar"), []byte("baz"), 6, 5, false,
+			nil, 0,
+		},
+	}
+	for i, tt := range tests {
+		revs, total := ti.Revisions(tt.key, tt.end, tt.atRev, tt.limit, tt.withTotalCount)
+		if !reflect.DeepEqual(revs, tt.wrevs) {
+			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
+		}
+		if total != tt.wtotal {
+			t.Errorf("#%d: total = %d, want %d", i, total, tt.wtotal)
+		}
+	}
+}
+
 func TestIndexCompactAndKeep(t *testing.T) {
 	maxRev := int64(20)
 

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -245,52 +245,85 @@ func TestIndexRevisionsWithTotalCount(t *testing.T) {
 
 	// Range [foo, fop) @ rev 6 matches 3 keys: foo, foo1, foo2.
 	tests := []struct {
-		key, end   []byte
-		atRev      int64
-		limit      int
+		name           string
+		key, end       []byte
+		atRev          int64
+		limit          int
 		withTotalCount bool
-		wrevs      []Revision
-		wtotal     int
+		wrevs          []Revision
+		wtotal         int
 	}{
-		// withTotalCount=true with limit returns the full total
 		{
-			[]byte("foo"), []byte("fop"), 6, 1, true,
-			[]Revision{{Main: 6}}, 3,
+			name:           "withTotalCount=true with limit returns the full total",
+			key:            []byte("foo"),
+			end:            []byte("fop"),
+			atRev:          6,
+			limit:          1,
+			withTotalCount: true,
+			wrevs:          []Revision{{Main: 6}},
+			wtotal:         3,
 		},
-		// withTotalCount=false with limit caps total at len(revs)
 		{
-			[]byte("foo"), []byte("fop"), 6, 1, false,
-			[]Revision{{Main: 6}}, 1,
+			name:           "withTotalCount=false with limit caps total at len(revs)",
+			key:            []byte("foo"),
+			end:            []byte("fop"),
+			atRev:          6,
+			limit:          1,
+			withTotalCount: false,
+			wrevs:          []Revision{{Main: 6}},
+			wtotal:         1,
 		},
-		// withTotalCount=false with limit larger than matches returns full total
 		{
-			[]byte("foo"), []byte("fop"), 6, 10, false,
-			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+			name:           "withTotalCount=false with limit larger than matches returns full total",
+			key:            []byte("foo"),
+			end:            []byte("fop"),
+			atRev:          6,
+			limit:          10,
+			withTotalCount: false,
+			wrevs:          []Revision{{Main: 6}, {Main: 5}, {Main: 4}},
+			wtotal:         3,
 		},
-		// withTotalCount=false without limit returns full total
 		{
-			[]byte("foo"), []byte("fop"), 6, 0, false,
-			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+			name:           "withTotalCount=false without limit returns full total",
+			key:            []byte("foo"),
+			end:            []byte("fop"),
+			atRev:          6,
+			limit:          0,
+			withTotalCount: false,
+			wrevs:          []Revision{{Main: 6}, {Main: 5}, {Main: 4}},
+			wtotal:         3,
 		},
-		// withTotalCount=true without limit returns full total
 		{
-			[]byte("foo"), []byte("fop"), 6, 0, true,
-			[]Revision{{Main: 6}, {Main: 5}, {Main: 4}}, 3,
+			name:           "withTotalCount=true without limit returns full total",
+			key:            []byte("foo"),
+			end:            []byte("fop"),
+			atRev:          6,
+			limit:          0,
+			withTotalCount: true,
+			wrevs:          []Revision{{Main: 6}, {Main: 5}, {Main: 4}},
+			wtotal:         3,
 		},
-		// withTotalCount=false with no matches
 		{
-			[]byte("bar"), []byte("baz"), 6, 5, false,
-			nil, 0,
+			name:           "withTotalCount=false with no matches",
+			key:            []byte("bar"),
+			end:            []byte("baz"),
+			atRev:          6,
+			limit:          5,
+			withTotalCount: false,
+			wrevs:          nil,
+			wtotal:         0,
 		},
 	}
-	for i, tt := range tests {
-		revs, total := ti.Revisions(tt.key, tt.end, tt.atRev, tt.limit, tt.withTotalCount)
-		if !reflect.DeepEqual(revs, tt.wrevs) {
-			t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.wrevs)
-		}
-		if total != tt.wtotal {
-			t.Errorf("#%d: total = %d, want %d", i, total, tt.wtotal)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			revs, total := ti.Revisions(tt.key, tt.end, tt.atRev, tt.limit, tt.withTotalCount)
+			if !reflect.DeepEqual(revs, tt.wrevs) {
+				t.Errorf("revs = %+v, want %+v", revs, tt.wrevs)
+			}
+			if total != tt.wtotal {
+				t.Errorf("total = %d, want %d", total, tt.wtotal)
+			}
+		})
 	}
 }
 

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -24,9 +24,10 @@ import (
 )
 
 type RangeOptions struct {
-	Limit     int64
-	Rev       int64
-	CountOnly bool
+	Limit          int64
+	Rev            int64
+	CountOnly      bool
+	WithTotalCount bool
 }
 
 type RangeResult struct {

--- a/server/storage/mvcc/kv_test.go
+++ b/server/storage/mvcc/kv_test.go
@@ -237,7 +237,7 @@ func testKVRangeLimit(t *testing.T, f rangeFunc) {
 		{100, 3, kvs},
 	}
 	for i, tt := range tests {
-		r, err := f(s, []byte("foo"), []byte("foo3"), RangeOptions{Limit: tt.limit})
+		r, err := f(s, []byte("foo"), []byte("foo3"), RangeOptions{Limit: tt.limit, WithTotalCount: true})
 		if err != nil {
 			t.Fatalf("#%d: range error (%v)", i, err)
 		}

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -1027,7 +1027,7 @@ type fakeIndex struct {
 	indexCompactRespc     chan map[Revision]struct{}
 }
 
-func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int) ([]Revision, int) {
+func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int) {
 	_, rev := i.Range(key, end, atRev)
 	if len(rev) >= limit {
 		rev = rev[:limit]

--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -85,7 +85,7 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
-	revpairs, total := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit))
+	revpairs, total := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit), ro.WithTotalCount)
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil


### PR DESCRIPTION
Add WithTotalCount flag to RangeOptions so treeIndex.Revisions() can skip counting all matching keys when only a limited page is needed. Reduces per-page cost from O(total_keys) to O(limit) when the caller opts out of the full total.

This is an option that will only be used by RangeStream. Important for RangeStream as we do not want to traverse the entire tree on each chunk.


