### PR TITLE
mvcc: rename RangeOptions.Count to CountOnly

### DIFF
--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -45,9 +45,9 @@ func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *
 
 	limit := rangeLimit(r)
 	ro := mvcc.RangeOptions{
-		Limit: limit,
-		Rev:   r.Revision,
-		Count: r.CountOnly,
+		Limit:     limit,
+		Rev:       r.Revision,
+		CountOnly: r.CountOnly,
 	}
 
 	rr, err := txnRead.Range(ctx, r.Key, mkGteRange(r.RangeEnd), ro)

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -24,9 +24,9 @@ import (
 )
 
 type RangeOptions struct {
-	Limit int64
-	Rev   int64
-	Count bool
+	Limit     int64
+	Rev       int64
+	CountOnly bool
 }
 
 type RangeResult struct {

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -207,7 +207,7 @@ func TestStoreRange(t *testing.T) {
 		},
 	}
 
-	ro := RangeOptions{Limit: 1, Rev: 0, Count: false}
+	ro := RangeOptions{Limit: 1, Rev: 0, CountOnly: false}
 	for i, tt := range tests {
 		s := newFakeStore(lg)
 		b := s.b.(*fakeBackend)
@@ -755,7 +755,7 @@ func TestConcurrentReadNotBlockingWrite(t *testing.T) {
 
 	// readTx2 simulates a short read request
 	readTx2 := s.Read(ConcurrentReadTxMode, traceutil.TODO())
-	ro := RangeOptions{Limit: 1, Rev: 0, Count: false}
+	ro := RangeOptions{Limit: 1, Rev: 0, CountOnly: false}
 	ret, err := readTx2.Range(t.Context(), []byte("foo"), nil, ro)
 	if err != nil {
 		t.Fatalf("failed to range: %v", err)

--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -80,7 +80,7 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 	if rev < tr.s.compactMainRev {
 		return &RangeResult{KVs: nil, Count: -1, Rev: 0}, ErrCompacted
 	}
-	if ro.Count {
+	if ro.CountOnly {
 		total := tr.s.kvindex.CountRevisions(key, end, rev)
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil


### PR DESCRIPTION
Align the server-side `mvcc.RangeOptions` field name with the client's `CountOnly` naming (client/v3 `WithCountOnly`/`IsCountOnly`, and the `RangeRequest.CountOnly` proto field). No behavior change.

This also removes the awkward `Count: r.CountOnly` mapping in `server/etcdserver/txn/range.go`.

Requested by @serathius in https://github.com/etcd-io/etcd/pull/21618.