### PR TITLE
tests/common: fix flaky TestKVGet by zeroing non-deterministic RaftTerm

### DIFF
--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -97,7 +97,6 @@ func TestKVGet(t *testing.T) {
 				currentHeader := &etcdserverpb.ResponseHeader{
 					ClusterId: currentResp.Header.ClusterId,
 					Revision:  currentResp.Header.Revision,
-					RaftTerm:  currentResp.Header.RaftTerm,
 				}
 
 				type testcase struct {
@@ -157,6 +156,7 @@ func TestKVGet(t *testing.T) {
 						resp, err := cc.Get(ctx, tt.begin, tt.options)
 						require.NoErrorf(t, err, "count not get key %q, err: %s", tt.begin, err)
 						resp.Header.MemberId = 0
+						resp.Header.RaftTerm = 0
 						assert.Equal(t, tt.wantResponse, resp)
 					})
 				}


### PR DESCRIPTION
## Summary

- `TestKVGet` captures a reference header snapshot and compares subsequent Get responses against it using `assert.Equal`. `RaftTerm` can change between requests, causing non-deterministic test failures.
- Zero out `RaftTerm` on actual responses before comparison (matching the existing `MemberId` zeroing pattern) and remove it from the expected header constructor.

## Presubmits

Checked presubmits on [sig-etcd-presubmits testgrid](https://testgrid.k8s.io/sig-etcd-presubmits#pull-etcd-integration-1-cpu-amd64). `TestKVGet` has been flaking — last 3 failure samples all fail with `RaftTerm` mismatch:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-integration-1-cpu-amd64/2040527381617184768
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-integration-1-cpu-amd64/2042489768314408960
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/directory/pull-etcd-integration-1-cpu-amd64/2044978225955737600

Failure:
```
--- FAIL: TestKVGet/PeerAutoTLS_and_ClientAutoTLS/Range_covering_all_keys_->_all_KVs (0.38s)
    kv_test.go:160:
        Diff:
        --- Expected
        +++ Actual
        @@ -5,3 +5,3 @@
           Revision: (int64) 9,
        -  RaftTerm: (uint64) 2,
        +  RaftTerm: (uint64) 3,
```

Discovered while working on https://github.com/etcd-io/etcd/pull/21618 and seeing the flake.