### PR TITLE
grpcproxy: return io.EOF at end of server-streaming RPCs

### DIFF
--- a/server/proxy/grpcproxy/adapter/chan_stream.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream.go
@@ -158,7 +158,7 @@ func newPipeStream(ctx context.Context, ssHandler func(chanServerStream) error) 
 		if err == nil {
 			// nil means the handler completed successfully;
 			// the gRPC ClientStream contract requires io.EOF:
-			// https://github.com/grpc/grpc-go/blob/master/stream.go#L140-L148
+			// https://github.com/grpc/grpc-go/blob/v1.80.0/stream.go#L139-L147
 			err = io.EOF
 		}
 		select {

--- a/server/proxy/grpcproxy/adapter/chan_stream.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream.go
@@ -16,6 +16,7 @@ package adapter
 
 import (
 	"context"
+	"io"
 	"maps"
 
 	"google.golang.org/grpc"
@@ -139,7 +140,8 @@ func (s *chanStream) RecvMsg(m any) error {
 }
 
 func newPipeStream(ctx context.Context, ssHandler func(chanServerStream) error) chanClientStream {
-	// ch1 is buffered so server can send error on close
+	// ch1 is buffered so the server can deliver a terminal status
+	// (real error or io.EOF) after the handler returns.
 	ch1, ch2 := make(chan any, 1), make(chan any)
 	headerc, trailerc := make(chan metadata.MD, 1), make(chan metadata.MD, 1)
 
@@ -152,12 +154,17 @@ func newPipeStream(ctx context.Context, ssHandler func(chanServerStream) error) 
 	ss := chanServerStream{headerc, trailerc, srv, nil}
 
 	go func() {
-		if err := ssHandler(ss); err != nil {
-			select {
-			case srv.sendc <- err:
-			case <-sctx.Done():
-			case <-cctx.Done():
-			}
+		err := ssHandler(ss)
+		if err == nil {
+			// nil means the handler completed successfully;
+			// the gRPC ClientStream contract requires io.EOF:
+			// https://github.com/grpc/grpc-go/blob/master/stream.go#L140-L148
+			err = io.EOF
+		}
+		select {
+		case srv.sendc <- err:
+		case <-sctx.Done():
+		case <-cctx.Done():
 		}
 		scancel()
 		ccancel()

--- a/server/proxy/grpcproxy/adapter/chan_stream_test.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestPipeStream_HandlerSuccessReturnsEOF verifies that when a server-streaming
+// handler completes successfully (returns nil), the client receives io.EOF from
+// RecvMsg. This matches the gRPC ClientStream contract:
+//
+//	"It returns io.EOF when the stream completes successfully."
+//	https://github.com/grpc/grpc-go/blob/master/stream.go
+func TestPipeStream_HandlerSuccessReturnsEOF(t *testing.T) {
+	cs := newPipeStream(context.Background(), func(ss chanServerStream) error {
+		ss.SendMsg("msg1") //nolint:staticcheck
+		ss.SendMsg("msg2") //nolint:staticcheck
+		return nil
+	})
+
+	var v any
+
+	if err := cs.RecvMsg(&v); err != nil {
+		t.Fatalf("RecvMsg() = %v, want nil", err)
+	}
+	if v != "msg1" {
+		t.Fatalf("RecvMsg() got %v, want msg1", v)
+	}
+
+	if err := cs.RecvMsg(&v); err != nil {
+		t.Fatalf("RecvMsg() = %v, want nil", err)
+	}
+	if v != "msg2" {
+		t.Fatalf("RecvMsg() got %v, want msg2", v)
+	}
+
+	if err := cs.RecvMsg(&v); !errors.Is(err, io.EOF) {
+		t.Fatalf("RecvMsg() = %v, want io.EOF (per gRPC ClientStream contract)", err)
+	}
+}
+
+// TestPipeStream_HandlerErrorPropagated verifies that when a handler returns a
+// non-nil error, the client receives that exact error from RecvMsg.
+func TestPipeStream_HandlerErrorPropagated(t *testing.T) {
+	handlerErr := errors.New("handler failed")
+	cs := newPipeStream(context.Background(), func(ss chanServerStream) error {
+		ss.SendMsg("partial") //nolint:staticcheck
+		return handlerErr
+	})
+
+	var v any
+
+	if err := cs.RecvMsg(&v); err != nil {
+		t.Fatalf("RecvMsg() = %v, want nil", err)
+	}
+	if v != "partial" {
+		t.Fatalf("RecvMsg() got %v, want partial", v)
+	}
+
+	if err := cs.RecvMsg(&v); !errors.Is(err, handlerErr) {
+		t.Fatalf("RecvMsg() = %v, want %v", err, handlerErr)
+	}
+}

--- a/server/proxy/grpcproxy/adapter/chan_stream_test.go
+++ b/server/proxy/grpcproxy/adapter/chan_stream_test.go
@@ -26,31 +26,31 @@ import (
 // RecvMsg. This matches the gRPC ClientStream contract:
 //
 //	"It returns io.EOF when the stream completes successfully."
-//	https://github.com/grpc/grpc-go/blob/master/stream.go
+//	https://github.com/grpc/grpc-go/blob/v1.80.0/stream.go#L139-L147
 func TestPipeStream_HandlerSuccessReturnsEOF(t *testing.T) {
 	cs := newPipeStream(context.Background(), func(ss chanServerStream) error {
-		ss.SendMsg("msg1") //nolint:staticcheck
-		ss.SendMsg("msg2") //nolint:staticcheck
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			ss.SendMsg("msg1") //nolint:staticcheck
+			ss.SendMsg("msg2") //nolint:staticcheck
+		}()
+		<-done
 		return nil
 	})
 
+	for _, want := range []string{"msg1", "msg2"} {
+		var v any
+		if err := cs.RecvMsg(&v); err != nil { //nolint:staticcheck
+			t.Fatalf("RecvMsg() = %v, want nil", err)
+		}
+		if v != want {
+			t.Fatalf("RecvMsg() got %v, want %s", v, want)
+		}
+	}
+
 	var v any
-
-	if err := cs.RecvMsg(&v); err != nil {
-		t.Fatalf("RecvMsg() = %v, want nil", err)
-	}
-	if v != "msg1" {
-		t.Fatalf("RecvMsg() got %v, want msg1", v)
-	}
-
-	if err := cs.RecvMsg(&v); err != nil {
-		t.Fatalf("RecvMsg() = %v, want nil", err)
-	}
-	if v != "msg2" {
-		t.Fatalf("RecvMsg() got %v, want msg2", v)
-	}
-
-	if err := cs.RecvMsg(&v); !errors.Is(err, io.EOF) {
+	if err := cs.RecvMsg(&v); !errors.Is(err, io.EOF) { //nolint:staticcheck
 		t.Fatalf("RecvMsg() = %v, want io.EOF (per gRPC ClientStream contract)", err)
 	}
 }
@@ -60,20 +60,24 @@ func TestPipeStream_HandlerSuccessReturnsEOF(t *testing.T) {
 func TestPipeStream_HandlerErrorPropagated(t *testing.T) {
 	handlerErr := errors.New("handler failed")
 	cs := newPipeStream(context.Background(), func(ss chanServerStream) error {
-		ss.SendMsg("partial") //nolint:staticcheck
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			ss.SendMsg("partial") //nolint:staticcheck
+		}()
+		<-done
 		return handlerErr
 	})
 
 	var v any
-
-	if err := cs.RecvMsg(&v); err != nil {
+	if err := cs.RecvMsg(&v); err != nil { //nolint:staticcheck
 		t.Fatalf("RecvMsg() = %v, want nil", err)
 	}
 	if v != "partial" {
 		t.Fatalf("RecvMsg() got %v, want partial", v)
 	}
 
-	if err := cs.RecvMsg(&v); !errors.Is(err, handlerErr) {
+	if err := cs.RecvMsg(&v); !errors.Is(err, handlerErr) { //nolint:staticcheck
 		t.Fatalf("RecvMsg() = %v, want %v", err, handlerErr)
 	}
 }

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -184,6 +184,25 @@ func TestMaintenanceSnapshotCancel(t *testing.T) {
 	}
 }
 
+// TestMaintenanceSnapshotFromServerClient verifies that snapshot streams created
+// by Member.ServerClient (in-process adapter path) complete successfully.
+func TestMaintenanceSnapshotFromServerClient(t *testing.T) {
+	integration.BeforeTest(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	srvClient := clus.Members[0].ServerClient
+	require.NotNilf(t, srvClient, "Member.ServerClient must be initialized")
+
+	rc, err := srvClient.Snapshot(t.Context())
+	require.NoError(t, err)
+	defer rc.Close()
+
+	_, err = io.Copy(io.Discard, rc)
+	require.NoErrorf(t, err, "snapshot stream should terminate cleanly")
+}
+
 // TestMaintenanceSnapshotWithVersionTimeout ensures that SnapshotWithVersion function
 // returns corresponding context errors when context timeout happened before snapshot reading
 func TestMaintenanceSnapshotWithVersionTimeout(t *testing.T) {


### PR DESCRIPTION
## Summary

When a server-streaming handler completes successfully (returns nil), `newPipeStream` skips sending any terminal status and immediately cancels both contexts. The client's `RecvMsg` returns `context.Canceled` instead of `io.EOF`, violating the [`ClientStream.RecvMsg` contract](https://github.com/grpc/grpc-go/blob/master/stream.go#L140-L148).

This is a prerequisite for https://github.com/etcd-io/etcd/pull/21631 otherwise for RangeStream, the `grpcproxy-integration` [tests fail](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21631/pull-etcd-grpcproxy-integration-amd64/2045149583989805056) with `context canceled` instead of clean EOF.

## Test plan

- Added unit tests for `newPipeStream` verifying `io.EOF` on success and error propagation on failure
- Tests fail against the old code (`context.Canceled` instead of `io.EOF`)