### PR TITLE
txn: fix range benchmark to enable WithTotalCount

### DIFF
--- a/server/etcdserver/txn/range_bench_test.go
+++ b/server/etcdserver/txn/range_bench_test.go
@@ -97,7 +97,7 @@ func BenchmarkRange(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for b.Loop() {
-					_, _, err := Range(ctx, zap.NewNop(), s, req, false)
+					_, _, err := Range(ctx, zap.NewNop(), s, req, true)
 					if err != nil {
 						b.Fatal(err)
 					}


### PR DESCRIPTION
Fix range benchmark to pass `withTotalCount=true` instead of `false`. Typo from https://github.com/etcd-io/etcd/pull/21618/changes#r3103627859