### PR TITLE
etcdmain,embed: document JSON/YAML config integer requirement for duration fields

### DIFF
--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -157,6 +157,13 @@ func init() {
 }
 
 // Config holds the arguments for configuring an etcd server.
+//
+// Note: time.Duration fields in this struct are unmarshalled from JSON/YAML
+// as integer nanoseconds (e.g. 600000000000 for 10 minutes). Human-readable
+// duration strings such as "10m" are only accepted by the equivalent
+// command-line flags, not by the configuration file.
+// This is a [known Go standard library limitation](https://github.com/golang/go/issues/10275)
+// where time.Duration is unmarshaled as a plain integer.
 type Config struct {
 	Name string `json:"name"`
 	Dir  string `json:"data-dir"`

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -41,6 +41,10 @@ var (
 
   etcd --config-file
     Path to the server configuration file. Note that if a configuration file is provided, other command line flags and environment variables will be ignored.
+    Duration-typed fields (for example --heartbeat-interval, --election-timeout,
+    --watch-progress-notify-interval) must be specified as integer nanoseconds
+    in the JSON/YAML file (e.g. 600000000000 for 10m); human-readable strings
+    such as "10m" are only accepted on the command line.
 
   etcd gateway
     Run the stateless pass-through etcd TCP connection forwarding proxy.


### PR DESCRIPTION
## What this PR does

The `--watch-progress-notify-interval` flag accepts human-readable strings (e.g. `"10m"`) via `flag.DurationVar` on the command line, but reading the same field from a JSON or YAML config file fails with an unmarshalling error because `time.Duration` (int64) only accepts integer values in nanoseconds.

This was decided to be addressed via documentation (see discussion in #20342).

This PR adds notes in two places:

1. **`server/etcdmain/help.go`** — adds a note to the `--watch-progress-notify-interval` help text explaining that config files require an integer in nanoseconds.
2. **`server/embed/config.go`** — expands the `WatchProgressNotifyInterval` struct comment to document the same limitation.

Fixes #20342