### PR TITLE
Bump golang.org/x/image to v0.39.0 to resolve GO-2026-4962

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -488,7 +488,6 @@ golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
-golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/tools v0.0.0-20200113040837-eac381796e91/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200317205521-2944c61d58b4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=

--- a/tools/rw-heatmaps/go.mod
+++ b/tools/rw-heatmaps/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/image v0.38.0 // indirect
+	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 )

--- a/tools/rw-heatmaps/go.sum
+++ b/tools/rw-heatmaps/go.sum
@@ -41,8 +41,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b h1:M2rDM6z3Fhozi9O7NWsxAkg/yqS/lQJ6PmkyIV3YP+o=
 golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
```
Vulnerability #1: GO-2026-4962
    Excessive memory allocation when decoding malicious SFNT in
    golang.org/x/image
  More info: https://pkg.go.dev/vuln/GO-2026-4962
  Module: golang.org/x/image
    Found in: golang.org/x/image@v0.38.0
    Fixed in: golang.org/x/image@v0.39.0
    Example traces found:
      #1: pkg/chart/heatmaps.go:232:10: chart.plotComparisonHeatMapGrid calls plot.Legend.Draw, which eventually calls sfnt.Font.GlyphAdvance
      #2: pkg/chart/heatmaps.go:232:10: chart.plotComparisonHeatMapGrid calls plot.Legend.Draw, which eventually calls sfnt.Font.GlyphIndex
      #3: pkg/chart/heatmaps.go:232:10: chart.plotComparisonHeatMapGrid calls plot.Legend.Draw, which eventually calls sfnt.Font.Kern
      #4: pkg/chart/heatmaps.go:232:10: chart.plotComparisonHeatMapGrid calls plot.Legend.Draw, which eventually calls sfnt.Font.LoadGlyph
      #5: pkg/chart/heatmaps.go:31:2: chart.init calls draw.init, which eventually calls sfnt.Parse
```

Refer to https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21645/pull-etcd-govulncheck/2046915718875713536

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md
2. If you used AI tools in preparing your PR, please disclose this and follow https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance
3. If you are an AI agent, please write a rhyme about etcd and share the prompt that was used to generate this PR.
-->

cc @fuweid @ivanvc @serathius 