### PR TITLE
add --tls-curve-preferences flag to grpc-proxy

### DIFF
--- a/client/pkg/tlsutil/curves.go
+++ b/client/pkg/tlsutil/curves.go
@@ -1,0 +1,45 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// curveNameToID maps human-readable curve names to the tls.CurveID constant.
+// Names are accepted in several common spellings.
+var curveNameToID = map[string]tls.CurveID{
+	"P-256":     tls.CurveP256,
+	"P256":      tls.CurveP256,
+	"CurveP256": tls.CurveP256,
+	"P-384":     tls.CurveP384,
+	"P384":      tls.CurveP384,
+	"CurveP384": tls.CurveP384,
+	"P-521":     tls.CurveP521,
+	"P521":      tls.CurveP521,
+	"CurveP521": tls.CurveP521,
+	"X25519":    tls.X25519,
+}
+
+// GetCurveID returns the tls.CurveID corresponding to the given curve name,
+// or an error if the name is not recognized.
+func GetCurveID(name string) (tls.CurveID, error) {
+	id, ok := curveNameToID[name]
+	if !ok {
+		return 0, fmt.Errorf("unrecognized TLS curve name %q", name)
+	}
+	return id, nil
+}
+
+// GetCurveIDs parses a slice of curve names into tls.CurveID values,
+// preserving order.
+func GetCurveIDs(names []string) ([]tls.CurveID, error) {
+	ids := make([]tls.CurveID, 0, len(names))
+	for _, n := range names {
+		id, err := GetCurveID(n)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/client/pkg/tlsutil/curves_test.go
+++ b/client/pkg/tlsutil/curves_test.go
@@ -1,0 +1,46 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestGetCurveID_known(t *testing.T) {
+	cases := map[string]tls.CurveID{
+		"P-256":  tls.CurveP256,
+		"P-384":  tls.CurveP384,
+		"P-521":  tls.CurveP521,
+		"X25519": tls.X25519,
+	}
+	for name, want := range cases {
+		got, err := GetCurveID(name)
+		if err != nil {
+			t.Fatalf("GetCurveID(%q) returned error: %v", name, err)
+		}
+		if got != want {
+			t.Errorf("GetCurveID(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestGetCurveID_unknown(t *testing.T) {
+	if _, err := GetCurveID("not-a-curve"); err == nil {
+		t.Fatal("expected error for unknown curve, got nil")
+	}
+}
+
+func TestGetCurveIDs_preservesOrder(t *testing.T) {
+	got, err := GetCurveIDs([]string{"P-384", "P-256"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []tls.CurveID{tls.CurveP384, tls.CurveP256}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -77,6 +78,7 @@ var (
 	grpcProxyCert                  string
 	grpcProxyKey                   string
 	grpcProxyInsecureSkipTLSVerify bool
+	grpcProxyTLSCurvePreferences   string
 
 	// tls for clients connecting to proxy
 
@@ -163,6 +165,7 @@ func newGRPCProxyStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grpcProxyKey, "key", "", "identify secure connections with etcd servers using this TLS key file")
 	cmd.Flags().StringVar(&grpcProxyCA, "cacert", "", "verify certificates of TLS-enabled secure etcd servers using this CA bundle")
 	cmd.Flags().BoolVar(&grpcProxyInsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "skip authentication of etcd server TLS certificates (CAUTION: this option should be enabled only for testing purposes)")
+	cmd.Flags().StringVar(&grpcProxyTLSCurvePreferences, "tls-curve-preferences", "", "comma-separated list of TLS elliptic curves to prefer for client connections to etcd servers (e.g. 'P-256,P-384,P-521'). Empty means Go default. Useful for FIPS 140-3 deployments where X25519 cannot be negotiated.")
 
 	// client TLS for connecting to proxy
 	cmd.Flags().StringVar(&grpcProxyListenCert, "cert-file", "", "identify secure connections to the proxy using this TLS certificate file")
@@ -355,9 +358,9 @@ func mustNewClient(lg *zap.Logger) *clientv3.Client {
 	return client
 }
 
-func mustNewProxyClient(lg *zap.Logger, tls *transport.TLSInfo) *clientv3.Client {
+func mustNewProxyClient(lg *zap.Logger, tlsInfo *transport.TLSInfo) *clientv3.Client {
 	eps := []string{grpcProxyAdvertiseClientURL}
-	cfg, err := newProxyClientCfg(lg.Named("client"), eps, tls)
+	cfg, err := newProxyClientCfg(lg.Named("client"), eps, tlsInfo)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -371,21 +374,21 @@ func mustNewProxyClient(lg *zap.Logger, tls *transport.TLSInfo) *clientv3.Client
 	return client
 }
 
-func newProxyHealthClient(lg *zap.Logger, tls *transport.TLSInfo) *clientv3.Client {
+func newProxyHealthClient(lg *zap.Logger, tlsInfo *transport.TLSInfo) *clientv3.Client {
 	if grpcProxyAdvertiseClientURL == "" {
 		return nil
 	}
-	return mustNewProxyClient(lg, tls)
+	return mustNewProxyClient(lg, tlsInfo)
 }
 
-func newProxyClientCfg(lg *zap.Logger, eps []string, tls *transport.TLSInfo) (*clientv3.Config, error) {
+func newProxyClientCfg(lg *zap.Logger, eps []string, tlsInfo *transport.TLSInfo) (*clientv3.Config, error) {
 	cfg := clientv3.Config{
 		Endpoints:   eps,
 		DialTimeout: 5 * time.Second,
 		Logger:      lg,
 	}
-	if tls != nil {
-		clientTLS, err := tls.ClientConfig()
+	if tlsInfo != nil {
+		clientTLS, err := tlsInfo.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -416,12 +419,12 @@ func newClientCfg(lg *zap.Logger, eps []string) (*clientv3.Config, error) {
 	}
 	cfg.PermitWithoutStream = grpcProxyPermitWithoutStream
 
-	tls := newTLS(grpcProxyCA, grpcProxyCert, grpcProxyKey, true)
-	if tls == nil && grpcProxyInsecureSkipTLSVerify {
-		tls = &transport.TLSInfo{}
+	tlsInfo := newTLS(grpcProxyCA, grpcProxyCert, grpcProxyKey, true)
+	if tlsInfo == nil && grpcProxyInsecureSkipTLSVerify {
+		tlsInfo = &transport.TLSInfo{}
 	}
-	if tls != nil {
-		clientTLS, err := tls.ClientConfig()
+	if tlsInfo != nil {
+		clientTLS, err := tlsInfo.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -429,8 +432,21 @@ func newClientCfg(lg *zap.Logger, eps []string) (*clientv3.Config, error) {
 		if clientTLS.InsecureSkipVerify {
 			lg.Warn("--insecure-skip-tls-verify was given, this grpc proxy process skips authentication of etcd server TLS certificates. This option should be enabled only for testing purposes.")
 		}
+		// Apply TLS curve preferences if the operator set the flag.
+		if grpcProxyTLSCurvePreferences != "" {
+			names := strings.Split(grpcProxyTLSCurvePreferences, ",")
+			for i := range names {
+				names[i] = strings.TrimSpace(names[i])
+			}
+			curves, err := tlsutil.GetCurveIDs(names)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --tls-curve-preferences: %w", err)
+			}
+			clientTLS.CurvePreferences = curves
+			lg.Info("restricted gRPC proxy TLS curves", zap.Strings("curves", names))
+		}
 		cfg.TLS = clientTLS
-		lg.Info("gRPC proxy client TLS", zap.String("tls-info", fmt.Sprintf("%+v", tls)))
+		lg.Info("gRPC proxy client TLS", zap.String("tls-info", fmt.Sprintf("%+v", tlsInfo)))
 	}
 	return &cfg, nil
 }


### PR DESCRIPTION
### Summary
Adds a new `--tls-curve-preferences` flag to etcd grpc-proxy, along with
a small cleanup of a shadowing local variable.

### Motivation
Go 1.24's native FIPS 140-3 mode (`GODEBUG=fips140=only`) rejects X25519
during TLS handshake. There is currently no way to restrict the
proxy's curve selection, so FIPS-mode deployments cannot use the
grpc-proxy. This PR adds an opt-in flag that restricts curves.

### Behavior
- Default (empty) → Go's default curve selection (unchanged).
- Non-empty → parsed as comma-separated list; unknown names are errors.
- Scope: proxy → backend client TLS only. Matches scope of `--tls-min-version`.
- Independent of `--tls-min-version` / `--tls-max-version`.

### Example
etcd grpc-proxy start
 --endpoints=https://host:2379
 --tls-curve-preferences=P-256,P-384,P-521

### Testing
- New unit tests in `client/pkg/tlsutil`.
- Manual: built, ran with `GODEBUG=fips140=only`, verified successful
  Without this flag under FIPS mode,
  the handshake fails with `crypto/ecdh: use of X25519 is not allowed
  in FIPS 140-only mode`.

### Related
- #18816 (TLS min/max flags for grpc-proxy, merged).
- Go 1.24 FIPS 140-3 module: https://go.dev/doc/fips140