### PR TITLE
fix(etcdutl): initialize FlockTimeout to 10s so hash doesn't block forever

### DIFF
--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -30,7 +30,10 @@ import (
 )
 
 // FlockTimeout is the duration to wait to obtain a file lock on db file.
-var FlockTimeout time.Duration
+// Initialized to the ctl.go --timeout flag default so commands invoked
+// through code paths that skip flag parsing (tests, library use) don't
+// block forever on a locked db file. Issue 20276.
+var FlockTimeout = 10 * time.Second
 
 func GetLogger() *zap.Logger {
 	config := logutil.DefaultZapLoggerConfig


### PR DESCRIPTION
Refs etcd-io/etcd#20276.

## Problem

`etcdutl`'s package-level `FlockTimeout` defaulted to Go's zero value, which `bbolt` treats as "block indefinitely". The `--timeout` flag default in `ctl.go` `init()` is `10 * time.Second`, but code paths that reach `FlockTimeout` without flag parsing (direct library use, some test harnesses, or commands invoked before the flag is wired up) keep the zero value and make `etcdutl hash`, `listBucket`, `defrag`, and `hashkv` all block forever on a db file in use by an active etcd.

## Fix

Initialize `FlockTimeout` to `10 * time.Second` at the package level so the default never degrades. `ctl.go`'s `DurationVar` continues to override it as before; tests and library callers now get the same sane default.

## Test

`go test ./etcdutl/...` passes locally.