### PR TITLE
client/v3: fix double resolver update in EtcdManualResolver.Build

### DIFF
--- a/client/v3/internal/resolver/resolver.go
+++ b/client/v3/internal/resolver/resolver.go
@@ -45,13 +45,13 @@ func (r *EtcdManualResolver) Build(target resolver.Target, cc resolver.ClientCon
 	if r.serviceConfig.Err != nil {
 		return nil, r.serviceConfig.Err
 	}
-	res, err := r.Resolver.Build(target, cc, opts)
-	if err != nil {
-		return nil, err
-	}
-	// Populates endpoints stored in r into ClientConn (cc).
-	r.updateState()
-	return res, nil
+	// Seed the initial state before the underlying manual.Resolver is built so
+	// that gRPC receives a single resolver update with both the endpoints and
+	// the round_robin ServiceConfig. Otherwise Build would emit an empty first
+	// update and updateState a second one, forcing gRPC to switch balancers
+	// mid-connection and tear down an in-flight SubConn. See issue #21660.
+	r.InitialState(r.buildState())
+	return r.Resolver.Build(target, cc, opts)
 }
 
 func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
@@ -61,18 +61,21 @@ func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
 
 func (r EtcdManualResolver) updateState() {
 	if getCC(r) != nil {
-		eps := make([]resolver.Endpoint, len(r.endpoints))
-		for i, ep := range r.endpoints {
-			addr, serverName := endpoint.Interpret(ep)
-			eps[i] = resolver.Endpoint{Addresses: []resolver.Address{
-				{Addr: addr, ServerName: serverName},
-			}}
-		}
-		state := resolver.State{
-			Endpoints:     eps,
-			ServiceConfig: r.serviceConfig,
-		}
-		r.UpdateState(state)
+		r.UpdateState(r.buildState())
+	}
+}
+
+func (r EtcdManualResolver) buildState() resolver.State {
+	eps := make([]resolver.Endpoint, len(r.endpoints))
+	for i, ep := range r.endpoints {
+		addr, serverName := endpoint.Interpret(ep)
+		eps[i] = resolver.Endpoint{Addresses: []resolver.Address{
+			{Addr: addr, ServerName: serverName},
+		}}
+	}
+	return resolver.State{
+		Endpoints:     eps,
+		ServiceConfig: r.serviceConfig,
 	}
 }
 

--- a/client/v3/internal/resolver/resolver_test.go
+++ b/client/v3/internal/resolver/resolver_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// recordingClientConn is a test implementation of resolver.ClientConn that
+// records every UpdateState call so tests can assert on the number and
+// contents of the updates that gRPC would have observed.
+type recordingClientConn struct {
+	resolver.ClientConn
+
+	mu     sync.Mutex
+	states []resolver.State
+}
+
+func (c *recordingClientConn) UpdateState(s resolver.State) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states = append(c.states, s)
+	return nil
+}
+
+func (c *recordingClientConn) ReportError(error) {}
+
+func (c *recordingClientConn) NewAddress([]resolver.Address) {}
+
+func (c *recordingClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
+	// Return a non-nil ParseResult with no error. The resolver only checks
+	// Err and passes the ParseResult pointer through; tests can observe its
+	// presence on the forwarded resolver.State.
+	return &serviceconfig.ParseResult{}
+}
+
+func (c *recordingClientConn) snapshot() []resolver.State {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]resolver.State, len(c.states))
+	copy(out, c.states)
+	return out
+}
+
+// TestBuildSendsSingleUpdateWithServiceConfig is a regression test for
+// https://github.com/etcd-io/etcd/issues/21660. Build must emit exactly one
+// resolver update, and that update must already carry the round_robin
+// ServiceConfig alongside the configured endpoints. Before the fix, Build
+// ran the embedded manual.Resolver.Build first and then pushed the endpoints
+// and ServiceConfig via a follow-up UpdateState call, which made gRPC
+// switch balancers mid-connection.
+func TestBuildSendsSingleUpdateWithServiceConfig(t *testing.T) {
+	r := New("127.0.0.1:2379", "127.0.0.2:2379")
+	cc := &recordingClientConn{}
+
+	if _, err := r.Build(resolver.Target{}, cc, resolver.BuildOptions{}); err != nil {
+		t.Fatalf("Build returned unexpected error: %v", err)
+	}
+
+	states := cc.snapshot()
+	if len(states) != 1 {
+		t.Fatalf("expected exactly 1 UpdateState call, got %d", len(states))
+	}
+
+	got := states[0]
+	if got.ServiceConfig == nil {
+		t.Fatalf("expected ServiceConfig to be set on the initial update")
+	}
+	if got.ServiceConfig.Err != nil {
+		t.Fatalf("unexpected ServiceConfig parse error: %v", got.ServiceConfig.Err)
+	}
+	if len(got.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints on the initial update, got %d", len(got.Endpoints))
+	}
+}
+
+// TestSetEndpointsAfterBuild verifies SetEndpoints continues to propagate
+// updates once the resolver has been built.
+func TestSetEndpointsAfterBuild(t *testing.T) {
+	r := New("127.0.0.1:2379")
+	cc := &recordingClientConn{}
+
+	if _, err := r.Build(resolver.Target{}, cc, resolver.BuildOptions{}); err != nil {
+		t.Fatalf("Build returned unexpected error: %v", err)
+	}
+
+	r.SetEndpoints([]string{"127.0.0.1:2379", "127.0.0.2:2379", "127.0.0.3:2379"})
+
+	states := cc.snapshot()
+	if len(states) != 2 {
+		t.Fatalf("expected 2 UpdateState calls (Build + SetEndpoints), got %d", len(states))
+	}
+	if n := len(states[1].Endpoints); n != 3 {
+		t.Fatalf("expected 3 endpoints after SetEndpoints, got %d", n)
+	}
+	if states[1].ServiceConfig == nil {
+		t.Fatalf("SetEndpoints update should carry the ServiceConfig")
+	}
+}

--- a/tools/check-grpc-experimental/allowlist.txt
+++ b/tools/check-grpc-experimental/allowlist.txt
@@ -10,9 +10,11 @@ resolver.BuildOptions
 resolver.Builder
 resolver.ClientConn
 resolver.Endpoint
+resolver.Endpoints
 resolver.ParseServiceConfig
 resolver.ResolveNowOptions
 resolver.Resolver
+resolver.ServiceConfig
 resolver.State
 resolver.Target
 resolver.URL


### PR DESCRIPTION
Fixes #21660.

## Background

`EtcdManualResolver.Build` used to invoke the embedded `manual.Resolver.Build` first and only then push the endpoints plus the `round_robin` `ServiceConfig` via a follow-up `updateState` call. gRPC therefore observed an initial resolver state *without* the `ServiceConfig` and a second update shortly after that carried it, which forced gRPC to switch load balancers mid-connection and tear down the in-flight `SubChannel`. The warning visible in client logs was:

```
[core] [Channel #2 SubChannel #5] grpc: addrConn.createTransport failed to connect to
{Addr: "127.0.0.1:2379", ...}. Err: connection error: desc = "transport: Error while dialing:
dial tcp 127.0.0.1:2379: operation was canceled"
```

Every new `grpc.ClientConn` (every `newClient`, every per-endpoint `maintenance.Status` / `HashKV` / etc.) paid for a throwaway TCP dial and TLS handshake on top of the noise in the logs. The root cause was flagged in the issue by @zyriljamez and the proposed ordering change was endorsed by @ahrtr.

## Fix

Seed the initial resolver state via `manual.Resolver.InitialState` *before* calling `manual.Resolver.Build`. That way the underlying resolver dispatches the first `UpdateState` to the `ClientConn` itself, already carrying the endpoints and the `round_robin` `ServiceConfig` as one atomic update, and the `updateState` trailer is no longer needed on the Build path.

```go
r.serviceConfig = cc.ParseServiceConfig(...)
r.InitialState(r.buildState())
return r.Resolver.Build(target, cc, opts)
```

A small `buildState` helper is extracted so that `updateState` (used by `SetEndpoints`) keeps sharing the exact same state construction.

## Before / after

- **Before**: two resolver updates per `Build` (empty initial + ServiceConfig second); gRPC balancer switch; `addrConn.createTransport ... operation was canceled` warnings; one wasted TCP dial + TLS handshake per client.
- **After**: one resolver update per `Build`, already carrying endpoints and ServiceConfig; no balancer switch; no warnings; no wasted dial.

## Tests

Added `client/v3/internal/resolver/resolver_test.go` with:
- `TestBuildSendsSingleUpdateWithServiceConfig` — asserts `Build` forwards exactly one `UpdateState` call and that call already carries both the endpoints and the `ServiceConfig`.
- `TestSetEndpointsAfterBuild` — asserts `SetEndpoints` keeps propagating updates through the shared `buildState` path.

```
$ go test ./client/v3/internal/resolver/... -race
ok  	go.etcd.io/etcd/client/v3/internal/resolver	1.706s
$ golangci-lint run ./client/v3/internal/resolver/...
0 issues.
$ go test ./client/v3/...
ok  	go.etcd.io/etcd/client/v3	... (all packages pass)
```

cc @ahrtr for review — the approach here matches the sequencing change you endorsed on the issue.