### PR TITLE
robustness: save report data before validation

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -76,15 +76,16 @@ func main() {
 	choice := rand.IntN(len(traffics))
 	tf := traffics[choice]
 	lg.Info("Traffic", zap.String("Type", trafficNames[choice]))
-	r := report.TestReport{Logger: lg, ServersDataPath: etcdetcdDataPaths, Traffic: &report.TrafficDetail{ExpectUniqueRevision: tf.ExpectUniqueRevision()}}
+	r := report.NewTestReport(lg, reportPath, etcdetcdDataPaths, &report.TrafficDetail{ExpectUniqueRevision: tf.ExpectUniqueRevision()})
 	defer func() {
-		if err = r.Report(reportPath); err != nil {
+		if err = r.SaveEtcdData(); err != nil {
 			lg.Error("Failed to save traffic generation report", zap.Error(err))
 		}
 	}()
 
 	lg.Info("Start traffic generation", zap.Duration("duration", duration), zap.String("base-time", baseTime.UTC().Format("2006-01-02T15:04:05.000000Z0700")))
-	r.Client, err = runTraffic(ctx, lg, tf, hosts, baseTime, duration)
+	clientReports, err := runTraffic(ctx, lg, tf, hosts, baseTime, duration)
+	r.SetClientReports(clientReports)
 	if err != nil {
 		lg.Error("Failed to generate traffic")
 		panic(err)

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -88,40 +88,39 @@ func TestRobustnessRegression(t *testing.T) {
 }
 
 func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenarios.TestScenario, c *e2e.EtcdProcessCluster) {
-	serverDataPaths := report.ServerDataPaths(c)
-	r := report.TestReport{
-		Logger:          lg,
-		ServersDataPath: serverDataPaths,
-		Traffic:         &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()},
-	}
+	r := report.NewTestReport(lg, testResultsDirectory(t), report.ServerDataPaths(c), &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()})
 	// t.Failed() returns false during panicking. We need to forcibly
 	// save data on panicking.
 	// Refer to: https://github.com/golang/go/issues/49929
 	panicked := true
 	defer func() {
-		_, persistResults := os.LookupEnv("PERSIST_RESULTS")
-		shouldReport := t.Failed() || panicked || persistResults
-		if shouldReport {
-			path := testResultsDirectory(t)
-			if err := r.Report(path); err != nil {
-				t.Error(err)
-			}
+		if err := r.Finalize(shouldKeepReport(t, panicked)); err != nil {
+			t.Error(err)
 		}
 	}()
-	r.Client = runScenario(ctx, t, s, lg, c)
+	clientReports := runScenario(ctx, t, s, lg, c)
+	r.SetClientReports(clientReports)
+	if err := r.SaveEtcdData(); err != nil {
+		t.Error(err)
+	}
 	persistedRequests, err := report.PersistedRequestsCluster(lg, c)
 	if err != nil {
 		t.Error(err)
 	}
 
 	validateConfig := validate.Config{ExpectRevisionUnique: s.Traffic.ExpectUniqueRevision()}
-	result := validate.ValidateAndReturnVisualize(lg, validateConfig, r.Client, persistedRequests, 5*time.Minute)
-	r.Visualize = result.Linearization.Visualize
+	result := validate.ValidateAndReturnVisualize(lg, validateConfig, clientReports, persistedRequests, 5*time.Minute)
+	r.SetVisualizer(result.Linearization.Visualize)
 	err = result.Error()
 	if err != nil {
 		t.Error(err)
 	}
 	panicked = false
+}
+
+func shouldKeepReport(t *testing.T, panicked bool) bool {
+	_, persistResults := os.LookupEnv("PERSIST_RESULTS")
+	return t.Failed() || panicked || persistResults
 }
 
 func runScenario(ctx context.Context, t *testing.T, s scenarios.TestScenario, lg *zap.Logger, clus *e2e.EtcdProcessCluster) (reports []report.ClientReport) {

--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -27,43 +27,100 @@ import (
 )
 
 type TestReport struct {
-	Logger          *zap.Logger
-	Cluster         *e2e.EtcdProcessCluster
-	ServersDataPath map[string]string
-	Client          []ClientReport
-	Visualize       func(lg *zap.Logger, path string) error
-	Traffic         *TrafficDetail
+	logger          *zap.Logger
+	reportPath      string
+	serverDataPaths map[string]string
+	clientReports   []ClientReport
+	visualize       func(lg *zap.Logger, path string) error
+	traffic         *TrafficDetail
+	dataSaved       bool
 }
 
-func (r *TestReport) Report(path string) error {
-	r.Logger.Info("Saving robustness test report", zap.String("path", path))
-	err := os.RemoveAll(path)
-	if err != nil {
-		r.Logger.Error("Failed to remove report dir", zap.Error(err))
+func NewTestReport(lg *zap.Logger, reportPath string, serverDataPaths map[string]string, traffic *TrafficDetail) *TestReport {
+	return &TestReport{
+		logger:          lg,
+		reportPath:      reportPath,
+		serverDataPaths: serverDataPaths,
+		traffic:         traffic,
 	}
-	for server, dataPath := range r.ServersDataPath {
+}
+
+func (r *TestReport) SetClientReports(reports []ClientReport) {
+	r.clientReports = reports
+}
+
+func (r *TestReport) SetVisualizer(visualize func(lg *zap.Logger, path string) error) {
+	r.visualize = visualize
+}
+
+func (r *TestReport) SaveEtcdData() error {
+	path, err := r.reportPathOrError()
+	if err != nil {
+		return err
+	}
+	r.logger.Info("Saving robustness test report", zap.String("path", path))
+	err = os.RemoveAll(path)
+	if err != nil {
+		r.logger.Error("Failed to remove report dir", zap.Error(err))
+	}
+	for server, dataPath := range r.serverDataPaths {
 		serverReportPath := filepath.Join(path, fmt.Sprintf("server-%s", server))
-		r.Logger.Info("Saving member data dir", zap.String("member", server), zap.String("data-dir", dataPath), zap.String("path", serverReportPath))
+		r.logger.Info("Saving member data dir", zap.String("member", server), zap.String("data-dir", dataPath), zap.String("path", serverReportPath))
 		if err := os.CopyFS(serverReportPath, os.DirFS(dataPath)); err != nil {
 			return err
 		}
 	}
-	if r.Client != nil {
-		if err := persistClientReports(r.Logger, path, r.Client); err != nil {
+	if r.clientReports != nil {
+		if err := persistClientReports(r.logger, path, r.clientReports); err != nil {
 			return err
 		}
 	}
-	if r.Traffic != nil {
-		if err := persistTrafficDetail(r.Logger, path, *r.Traffic); err != nil {
+	if r.traffic != nil {
+		if err := persistTrafficDetail(r.logger, path, *r.traffic); err != nil {
 			return err
 		}
 	}
-	if r.Visualize != nil {
-		if err := r.Visualize(r.Logger, filepath.Join(path, "history.html")); err != nil {
-			return err
-		}
-	}
+	r.dataSaved = true
 	return nil
+}
+
+func (r *TestReport) SaveVisualization() error {
+	if r.visualize == nil {
+		return fmt.Errorf("cannot save report visualization: visualizer is not set")
+	}
+	path, err := r.reportPathOrError()
+	if err != nil {
+		return err
+	}
+	return r.visualize(r.logger, filepath.Join(path, "history.html"))
+}
+
+func (r *TestReport) Finalize(keep bool) error {
+	if !r.dataSaved {
+		return nil
+	}
+	path, err := r.reportPathOrError()
+	if err != nil {
+		return err
+	}
+	if !keep {
+		r.logger.Info("Removing robustness test report", zap.String("path", path))
+		return os.RemoveAll(path)
+	}
+	r.logger.Info("Keeping robustness test report", zap.String("path", path))
+	if r.visualize == nil {
+		r.logger.Info("No visualization available to be saved", zap.String("path", path))
+		return nil
+	}
+	r.logger.Info("Adding visualization to test report", zap.String("path", path))
+	return r.SaveVisualization()
+}
+
+func (r *TestReport) reportPathOrError() (string, error) {
+	if r.reportPath == "" {
+		return "", fmt.Errorf("report path is not set")
+	}
+	return r.reportPath, nil
 }
 
 func ServerDataPaths(c *e2e.EtcdProcessCluster) map[string]string {


### PR DESCRIPTION
Robustness reports used to be saved only when validation failed, that can leave no client or server artifacts to reproduce the run locally for debugging if the validation got killed by OOM on CI.

This commit proposes that we save artifacts immediately after scenario traffic completes (before validation starts).

Successful runs remove the per-test report directory unless PERSIST_RESULTS is set.
