### PR TITLE
server: allow non-admin maintenance status

### DIFF
--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -367,7 +367,7 @@ func (ams *authMaintenanceServer) Alarm(ctx context.Context, ar *pb.AlarmRequest
 }
 
 func (ams *authMaintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (*pb.StatusResponse, error) {
-	if err := ams.isPermitted(ctx); err != nil {
+	if err := ams.requireAuthInfo(ctx); err != nil {
 		return nil, togRPCError(err)
 	}
 

--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -166,7 +166,7 @@ func TestStatusWithRootAuth(t *testing.T) {
 }
 
 func TestStatusWithUserAuth(t *testing.T) {
-	testStatusWithAuth(t, false, true, WithAuth("user0", "user0Pass"))
+	testStatusWithAuth(t, false, false, WithAuth("user0", "user0Pass"))
 }
 
 func testStatusWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {


### PR DESCRIPTION
Fixes #21663

Maintenance.Status currently uses the admin-only authorization path, while MemberList and AlarmList only require an authenticated caller. This regressed authenticated non-admin health/status probes after the CVE-2026-33413 auth hardening.

This change switches Status to the same authenticated-caller check used for non-mutating maintenance reads, preserving the unauthenticated rejection while allowing authenticated non-admin users to fetch local member status.

Tests:
- go test -tags=integration ./tests/common -run 'TestStatusWith(NoAuth|InvalidAuth|RootAuth|UserAuth)$' -count=1\n- go test -race -tags=integration ./tests/common -run 'TestStatusWith(NoAuth|InvalidAuth|RootAuth|UserAuth)$' -count=1