### PR TITLE
embed: add option for client listener

### DIFF
--- a/CHANGELOG/CHANGELOG-3.8.md
+++ b/CHANGELOG/CHANGELOG-3.8.md
@@ -3,3 +3,7 @@ Previous change logs can be found at [CHANGELOG-3.7](https://github.com/etcd-io/
 ---
 
 ## v3.8.0 (TBC)
+
+### Package `embed`
+
+[Add option for client listener](https://github.com/etcd-io/etcd/pull/21672)

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -241,6 +241,8 @@ type Config struct {
 	AdvertisePeerUrls, AdvertiseClientUrls                 []url.URL
 	//revive:enable:var-naming
 
+	ClientListeners, HTTPClientListeners map[url.URL]net.Listener
+
 	ClientTLSInfo transport.TLSInfo
 	ClientAutoTLS bool
 	PeerTLSInfo   transport.TLSInfo

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -449,11 +449,8 @@ func (e *Etcd) Close() {
 
 	for _, sctx := range e.sctxs {
 		sctx.cancel()
-	}
-
-	for i := range e.Clients {
-		if e.Clients[i] != nil {
-			e.Clients[i].Close()
+		if sctx.owned {
+			sctx.l.Close()
 		}
 	}
 
@@ -671,6 +668,7 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 
 	for _, u := range cfg.ListenClientUrls {
 		addr, secure, network := resolveURL(u)
+
 		sctx := sctxs[addr]
 		if sctx == nil {
 			sctx = newServeCtx(cfg.logger)
@@ -681,7 +679,9 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 		sctx.scheme = u.Scheme
 		sctx.addr = addr
 		sctx.network = network
+		sctx.owned = true
 	}
+
 	for _, u := range cfg.ListenClientHttpUrls {
 		addr, secure, network := resolveURL(u)
 
@@ -698,17 +698,57 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 		sctx.addr = addr
 		sctx.network = network
 		sctx.httpOnly = true
+		sctx.owned = true
+	}
+
+	for u, l := range cfg.ClientListeners {
+		addr, secure, network := resolveURL(u)
+
+		sctx := sctxs[addr]
+		if sctx != nil {
+			return nil, fmt.Errorf("cannot specify the URL %v in both ClientListeners and ListenClientUrls or ListenClientHttpUrls", &u)
+		}
+
+		sctx = newServeCtx(cfg.logger)
+		sctxs[addr] = sctx
+		sctx.secure = sctx.secure || secure
+		sctx.insecure = sctx.insecure || !secure
+		sctx.scheme = u.Scheme
+		sctx.addr = addr
+		sctx.network = network
+		sctx.l = l
+	}
+
+	for u, l := range cfg.HTTPClientListeners {
+		addr, secure, network := resolveURL(u)
+
+		sctx := sctxs[addr]
+		if sctx != nil {
+			return nil, fmt.Errorf("cannot specify the URL %v in both HTTPClientListeners and ClientListeners, ListenClientUrls, or ListenClientHttpUrls", &u)
+		}
+
+		sctx = newServeCtx(cfg.logger)
+		sctxs[addr] = sctx
+		sctx.secure = sctx.secure || secure
+		sctx.insecure = sctx.insecure || !secure
+		sctx.scheme = u.Scheme
+		sctx.addr = addr
+		sctx.network = network
+		sctx.httpOnly = true
+		sctx.l = l
 	}
 
 	for _, sctx := range sctxs {
-		if sctx.l, err = transport.NewListenerWithOpts(sctx.addr, sctx.scheme,
-			transport.WithSocketOpts(&cfg.SocketOpts),
-			transport.WithSkipTLSInfoCheck(true),
-		); err != nil {
-			return nil, err
+		if sctx.l == nil {
+			if sctx.l, err = transport.NewListenerWithOpts(sctx.addr, sctx.scheme,
+				transport.WithSocketOpts(&cfg.SocketOpts),
+				transport.WithSkipTLSInfoCheck(true),
+			); err != nil {
+				return nil, err
+			}
+			// net.Listener will rewrite ipv4 0.0.0.0 to ipv6 [::], breaking
+			// hosts that disable ipv6. So, use the address given by the user.
 		}
-		// net.Listener will rewrite ipv4 0.0.0.0 to ipv6 [::], breaking
-		// hosts that disable ipv6. So, use the address given by the user.
 
 		if fdLimit, fderr := runtimeutil.FDLimit(); fderr == nil {
 			if fdLimit <= reservedInternalFDNum {
@@ -722,7 +762,7 @@ func configureClientListeners(cfg *Config) (sctxs map[string]*serveCtx, err erro
 		}
 
 		defer func(sctx *serveCtx) {
-			if err == nil || sctx.l == nil {
+			if err == nil || sctx.l == nil || !sctx.owned {
 				return
 			}
 			sctx.l.Close()

--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -60,6 +60,7 @@ type serveCtx struct {
 	secure   bool
 	insecure bool
 	httpOnly bool
+	owned    bool
 
 	// ctx is used to control the grpc gateway. Terminate the grpc gateway
 	// by calling `cancel` when shutting down the etcd.

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -20,7 +20,9 @@
 package embed_test
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -30,6 +32,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
@@ -124,12 +128,14 @@ func TestEmbedEtcd(t *testing.T) {
 	}
 }
 
-func TestEmbedEtcdGracefulStopSecure(t *testing.T)   { testEmbedEtcdGracefulStop(t, true) }
-func TestEmbedEtcdGracefulStopInsecure(t *testing.T) { testEmbedEtcdGracefulStop(t, false) }
+func TestEmbedEtcdGracefulStopSecureUnix(t *testing.T)   { testEmbedEtcdGracefulStop(t, true, false) }
+func TestEmbedEtcdGracefulStopInsecureUnix(t *testing.T) { testEmbedEtcdGracefulStop(t, false, false) }
+func TestEmbedEtcdGracefulStopSecureMem(t *testing.T)    { testEmbedEtcdGracefulStop(t, true, true) }
+func TestEmbedEtcdGracefulStopInsecureMem(t *testing.T)  { testEmbedEtcdGracefulStop(t, false, true) }
 
 // testEmbedEtcdGracefulStop ensures embedded server stops
 // cutting existing transports.
-func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
+func testEmbedEtcdGracefulStop(t *testing.T, secure, listener bool) {
 	testutil.SkipTestIfShortMode(t, "Cannot start embedded cluster in --short tests")
 
 	cfg := embed.NewConfig()
@@ -140,6 +146,12 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 
 	urls := newEmbedURLs(secure, 2)
 	setupEmbedCfg(cfg, []url.URL{urls[0]}, []url.URL{urls[1]})
+	l := bufconn.Listen(10)
+	defer l.Close()
+	if listener {
+		cfg.ClientListeners = map[url.URL]net.Listener{urls[0]: l}
+		cfg.ListenClientUrls = nil
+	}
 
 	cfg.Dir = filepath.Join(t.TempDir(), "embed-etcd")
 
@@ -153,6 +165,11 @@ func testEmbedEtcdGracefulStop(t *testing.T, secure bool) {
 	if secure {
 		clientCfg.TLS, err = testTLSInfo.ClientConfig()
 		require.NoError(t, err)
+	}
+	if listener {
+		clientCfg.DialOptions = []grpc.DialOption{grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return l.DialContext(ctx)
+		})}
 	}
 	cli, err := integration.NewClient(t, clientCfg)
 	require.NoError(t, err)


### PR DESCRIPTION
Add an option to provide net.Listeners instead of listen addresses to the embed server. This allows custom transports (including in-memory transports). Applications include new security transports, graceful server restart, and hermetic testing.

In particular, I am trying to improve testing for software components that use etcd. An example of this is controller-runtime's [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest). In order to work around the listener limitation, envtest uses a [port picker to bind port 0](https://github.com/kubernetes-sigs/controller-runtime/blob/589525a057391c2be40fd0de7c31ad3bac69a5d7/pkg/internal/testing/controlplane/etcd.go#L120), and then immediately closes it. It then instructs etcd to bind the port that had been just bound. This has a race condition and is unreliable. It also requires polling for the port to be re-bound.

If the test constructor (e.g. envtest) just binds the listener and provides it directly to etcd, there is no race condition and etcd can be used immediately without polling. Connections will be queued until etcd is ready to accept them. For even better reliability, an in-memory transport such as https://github.com/iangudger/memnet could be used.

Updates etcd-io/etcd#10191
Updates etcd-io/etcd#17440