### PR TITLE
add grpc healthcheck option for clientv3

### DIFF
--- a/client/v3/example_healthcheck_test.go
+++ b/client/v3/example_healthcheck_test.go
@@ -1,0 +1,1 @@
+../../tests/integration/clientv3/examples/example_healthcheck_test.go

--- a/client/v3/healthcheck/healthcheck.go
+++ b/client/v3/healthcheck/healthcheck.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"google.golang.org/grpc"
+	// Register the gRPC client's health check implementation via its init().
+	// It sets internal.HealthCheckFunc = clientHealthCheck, which is required
+	// for the client-side healthCheckConfig (see GRPCClientHealthCheckOptions)
+	// to perform health checks against the server.
+	_ "google.golang.org/grpc/health"
+)
+
+func GRPCClientHealthCheckOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithDisableServiceConfig(),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`),
+	}
+}

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
-	_ "google.golang.org/grpc/health"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/healthcheck"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -62,10 +62,7 @@ func TestFailoverOnDefrag(t *testing.T) {
 				e2e.WithServerFeatureGate("StopGRPCServiceOnDefrag", true),
 				e2e.WithGoFailEnabled(true),
 			},
-			gRPCDialOptions: []grpc.DialOption{
-				grpc.WithDisableServiceConfig(),
-				grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`),
-			},
+			gRPCDialOptions:        healthcheck.GRPCClientHealthCheckOptions(),
 			expectedMinQPS:         20,
 			expectedMaxFailureRate: 0.01,
 		},
@@ -76,10 +73,7 @@ func TestFailoverOnDefrag(t *testing.T) {
 				e2e.WithServerFeatureGate("StopGRPCServiceOnDefrag", false),
 				e2e.WithGoFailEnabled(true),
 			},
-			gRPCDialOptions: []grpc.DialOption{
-				grpc.WithDisableServiceConfig(),
-				grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`),
-			},
+			gRPCDialOptions:        healthcheck.GRPCClientHealthCheckOptions(),
 			expectedMinQPS:         20,
 			expectedMinFailureRate: 0.25,
 		},
@@ -100,10 +94,7 @@ func TestFailoverOnDefrag(t *testing.T) {
 				e2e.WithServerFeatureGate("StopGRPCServiceOnDefrag", true),
 				e2e.WithGoFailEnabled(true),
 			},
-			gRPCDialOptions: []grpc.DialOption{
-				grpc.WithDisableServiceConfig(),
-				grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`),
-			},
+			gRPCDialOptions:        healthcheck.GRPCClientHealthCheckOptions(),
 			expectedMinQPS:         20,
 			expectedMaxFailureRate: 0.01,
 		},
@@ -114,10 +105,7 @@ func TestFailoverOnDefrag(t *testing.T) {
 				e2e.WithServerFeatureGate("StopGRPCServiceOnDefrag", false),
 				e2e.WithGoFailEnabled(true),
 			},
-			gRPCDialOptions: []grpc.DialOption{
-				grpc.WithDisableServiceConfig(),
-				grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`),
-			},
+			gRPCDialOptions:        healthcheck.GRPCClientHealthCheckOptions(),
 			expectedMinQPS:         20,
 			expectedMinFailureRate: 0.25,
 		},

--- a/tests/integration/clientv3/examples/example_healthcheck_test.go
+++ b/tests/integration/clientv3/examples/example_healthcheck_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/healthcheck"
+)
+
+func mockHealthCheck() {
+	fmt.Println("")
+}
+
+func Example_grpcClientHealthCheck() {
+	forUnitTestsRunInMockedContext(mockHealthCheck, func() {
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   exampleEndpoints(),
+			DialTimeout: dialTimeout,
+			DialOptions: healthcheck.GRPCClientHealthCheckOptions(),
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cli.Close()
+
+		_, err = cli.Put(context.TODO(), "foo", "bar")
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
+	// Output:
+}


### PR DESCRIPTION
continuation of #18882

not quite sure if we should
- forbid client visiting learner's HealthCheck service. It seems no harm for clients detecting leaner's health.
- register HealthCheck service for grpc proxy. Perhaps it should be in another PR.

