### PR TITLE
[WIP] Range Stream benchmarks

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -640,6 +640,10 @@ func (s *kvStub) Compact(ctx context.Context, rev int64, _ ...clientv3.CompactOp
 	return nil, nil
 }
 
+func (s *kvStub) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	return nil, errors.New("GetStream not implemented")
+}
+
 func (s *kvStub) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
 	return clientv3.OpResponse{}, nil
 }

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/dustin/go-humanize v1.0.1
+	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
@@ -22,7 +23,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/client/v3/kv.go
+++ b/client/v3/kv.go
@@ -16,7 +16,10 @@ package clientv3
 
 import (
 	"context"
+	"errors"
+	"io"
 
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"google.golang.org/grpc"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -27,6 +30,7 @@ type (
 	CompactResponse pb.CompactionResponse
 	PutResponse     pb.PutResponse
 	GetResponse     pb.RangeResponse
+	GetStreamChan   <-chan RangeStreamResponse
 	DeleteResponse  pb.DeleteRangeResponse
 	TxnResponse     pb.TxnResponse
 )
@@ -48,6 +52,15 @@ type KV interface {
 	// When passed WithSort(), the keys will be sorted.
 	Get(ctx context.Context, key string, opts ...OpOption) (*GetResponse, error)
 
+	// RangeStream retrieves keys.
+	// By default, will return the value for "key", if any.
+	// When passed WithRange(end), will return the keys in the range [key, end).
+	// When passed WithFromKey(), returns keys greater than or equal to key.
+	// When passed WithRev(rev) with rev > 0, retrieves keys at the given revision;
+	// if the required revision is compacted, the request will fail with ErrCompacted .
+	// When passed WithLimit(limit), the number of returned keys is bounded by limit.
+	GetStream(ctx context.Context, key string, opts ...OpOption) (GetStreamChan, error)
+
 	// Delete deletes a key, or optionally using WithRange(end), [key, end).
 	Delete(ctx context.Context, key string, opts ...OpOption) (*DeleteResponse, error)
 
@@ -63,6 +76,35 @@ type KV interface {
 
 	// Txn creates a transaction.
 	Txn(ctx context.Context) Txn
+}
+
+// RangeStreamResponse holds a single chunk from a RangeStream RPC. Kvs is
+// disjoint per chunk; Header, More, and Count are populated only on the
+// final chunk.
+//
+// On a non-EOF stream error, the final value sent on the channel is a
+// terminal RangeStreamResponse with RangeResponse == nil and a non-nil
+// Err().
+type RangeStreamResponse struct {
+	*pb.RangeResponse
+	closeErr error
+}
+
+// Err returns the error value if this RangeStreamResponse is the terminal
+// error response for a stream that failed mid-flight.
+func (r *RangeStreamResponse) Err() error {
+	return r.closeErr
+}
+
+func GetStreamToGetResponse(stream GetStreamChan) (*GetResponse, error) {
+	resp := &pb.RangeResponse{}
+	for r := range stream {
+		if err := r.Err(); err != nil {
+			return nil, err
+		}
+		proto.Merge(resp, r.RangeResponse)
+	}
+	return (*GetResponse)(resp), nil
 }
 
 type OpResponse struct {
@@ -122,6 +164,29 @@ func (kv *kv) Put(ctx context.Context, key, val string, opts ...OpOption) (*PutR
 func (kv *kv) Get(ctx context.Context, key string, opts ...OpOption) (*GetResponse, error) {
 	r, err := kv.Do(ctx, OpGet(key, opts...))
 	return r.get, ContextError(ctx, err)
+}
+
+func (kv *kv) GetStream(ctx context.Context, key string, opts ...OpOption) (GetStreamChan, error) {
+	op := OpGet(key, opts...)
+	c, err := kv.remote.RangeStream(ctx, op.toRangeRequest(), kv.callOpts...)
+	if err != nil {
+		return nil, ContextError(ctx, err)
+	}
+	respCh := make(chan RangeStreamResponse, 1)
+	go func() {
+		defer close(respCh)
+		for {
+			resp, err := c.Recv()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					respCh <- RangeStreamResponse{closeErr: err}
+				}
+				return
+			}
+			respCh <- RangeStreamResponse{RangeResponse: resp.RangeResponse}
+		}
+	}()
+	return respCh, nil
 }
 
 func (kv *kv) Delete(ctx context.Context, key string, opts ...OpOption) (*DeleteResponse, error) {

--- a/client/v3/leasing/kv.go
+++ b/client/v3/leasing/kv.go
@@ -91,6 +91,11 @@ func (lkv *leasingKV) Put(ctx context.Context, key, val string, opts ...v3.OpOpt
 	return lkv.put(ctx, v3.OpPut(key, val, opts...))
 }
 
+// GetStream is not supported by leasingKV.
+func (lkv *leasingKV) GetStream(ctx context.Context, key string, opts ...v3.OpOption) (v3.GetStreamChan, error) {
+	return nil, status.Error(codes.Unimplemented, "GetStream is not supported by leasingKV")
+}
+
 func (lkv *leasingKV) Delete(ctx context.Context, key string, opts ...v3.OpOption) (*v3.DeleteResponse, error) {
 	return lkv.delete(ctx, v3.OpDelete(key, opts...))
 }

--- a/client/v3/namespace/kv.go
+++ b/client/v3/namespace/kv.go
@@ -17,6 +17,9 @@ package namespace
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -62,6 +65,11 @@ func (kv *kvPrefix) Get(ctx context.Context, key string, opts ...clientv3.OpOpti
 	get := r.Get()
 	kv.unprefixGetResponse(get)
 	return get, nil
+}
+
+// GetStream is not supported by kvPrefix.
+func (kv *kvPrefix) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	return nil, status.Error(codes.Unimplemented, "GetStream is not supported by kvPrefix")
 }
 
 func (kv *kvPrefix) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {

--- a/server/etcdserver/api/v3discovery/discovery_test.go
+++ b/server/etcdserver/api/v3discovery/discovery_test.go
@@ -748,6 +748,10 @@ func (fkv *fakeBaseKV) Get(ctx context.Context, key string, opts ...clientv3.OpO
 	return nil, nil
 }
 
+func (fkv *fakeBaseKV) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	return nil, nil
+}
+
 func (fkv *fakeBaseKV) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
 	return nil, nil
 }

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -25,6 +25,7 @@ import (
 func init() {
 	testRunner = framework.IntegrationTestRunner
 	clusterTestCases = integrationClusterTestCases
+	supportsGetStream = true
 }
 
 func integrationClusterTestCases() []testCase {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -27,6 +27,7 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
@@ -153,11 +154,20 @@ func TestKVGet(t *testing.T) {
 				}
 				for _, tt := range slices.Concat(tests, testsWithKeysOnly) {
 					t.Run(tt.name, func(t *testing.T) {
-						resp, err := cc.Get(ctx, tt.begin, tt.options)
-						require.NoErrorf(t, err, "count not get key %q, err: %s", tt.begin, err)
-						resp.Header.MemberId = 0
-						resp.Header.RaftTerm = 0
-						assert.Equal(t, tt.wantResponse, resp)
+						for _, stream := range []bool{true, false} {
+							t.Run(fmt.Sprintf("Stream=%v", stream), func(t *testing.T) {
+								if !supportsGetStream || !rangeStreamSupports(tt.options) {
+									t.Skip("Stream not supported")
+								}
+								opts := tt.options
+								opts.Stream = stream
+								resp, err := cc.Get(ctx, tt.begin, opts)
+								require.NoErrorf(t, err, "count not get key %q, err: %s", tt.begin, err)
+								resp.Header.MemberId = 0
+								resp.Header.RaftTerm = 0
+								assert.Equal(t, tt.wantResponse, resp)
+							})
+						}
 					})
 				}
 			})
@@ -173,6 +183,23 @@ func createKV(key, val string, createRev, modRev, ver int64) *mvccpb.KeyValue {
 		ModRevision:    modRev,
 		Version:        ver,
 	}
+}
+
+// rangeStreamSupports reports whether the server's RangeStream RPC accepts a
+// request with these options, mirroring v3rpc.checkRangeStreamRequest.
+func rangeStreamSupports(o config.GetOptions) bool {
+	if !txn.IsDefaultOrdering(
+		etcdserverpb.RangeRequest_SortTarget(o.SortBy),
+		etcdserverpb.RangeRequest_SortOrder(o.Order),
+	) {
+		return false
+	}
+	return !txn.HasRevisionFilters(&etcdserverpb.RangeRequest{
+		MinModRevision:    int64(o.MinModRevision),
+		MaxModRevision:    int64(o.MaxModRevision),
+		MinCreateRevision: int64(o.MinCreateRevision),
+		MaxCreateRevision: int64(o.MaxCreateRevision),
+	})
 }
 
 func dropValue(s []*mvccpb.KeyValue) []*mvccpb.KeyValue {

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	testRunner       intf.TestRunner
-	clusterTestCases func() []testCase
+	testRunner        intf.TestRunner
+	clusterTestCases  func() []testCase
+	supportsGetStream bool
 )
 
 func TestMain(m *testing.M) {

--- a/tests/framework/config/client.go
+++ b/tests/framework/config/client.go
@@ -43,6 +43,7 @@ type GetOptions struct {
 	MaxModRevision    int
 	MinCreateRevision int
 	MaxCreateRevision int
+	Stream            bool
 }
 
 type PutOptions struct {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -104,6 +104,9 @@ func (ctl *EtcdctlV3) DowngradeCancel(ctx context.Context) error {
 }
 
 func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) (*clientv3.GetResponse, error) {
+	if o.Stream {
+		return nil, fmt.Errorf("etcdctl has no RangeStream command; Stream=true is not supported by the e2e backend")
+	}
 	var args []string
 	if o.Timeout != 0 {
 		args = append(args, fmt.Sprintf("--command-timeout=%s", o.Timeout))

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -230,6 +230,13 @@ func (c integrationClient) Get(ctx context.Context, key string, o config.GetOpti
 	if o.MinModRevision != 0 {
 		clientOpts = append(clientOpts, clientv3.WithMinModRev(int64(o.MinModRevision)))
 	}
+	if o.Stream {
+		stream, err := c.Client.GetStream(ctx, key, clientOpts...)
+		if err != nil {
+			return nil, err
+		}
+		return clientv3.GetStreamToGetResponse(stream)
+	}
 	return c.Client.Get(ctx, key, clientOpts...)
 }
 

--- a/tests/integration/clientv3/examples/example_kv_test.go
+++ b/tests/integration/clientv3/examples/example_kv_test.go
@@ -192,6 +192,110 @@ func ExampleKV_getSortedPrefix() {
 	// key_0 : value
 }
 
+func mockKVGetStream() {
+	fmt.Println("key_0 : value")
+	fmt.Println("key_1 : value")
+	fmt.Println("key_2 : value")
+	fmt.Println("count: 3, more: false")
+}
+
+func ExampleKV_getStream() {
+	forUnitTestsRunInMockedContext(mockKVGetStream, func() {
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   exampleEndpoints(),
+			DialTimeout: dialTimeout,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cli.Close()
+
+		for i := 0; i < 3; i++ {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			_, err = cli.Put(ctx, fmt.Sprintf("key_%d", i), "value")
+			cancel()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		stream, err := cli.GetStream(ctx, "key", clientv3.WithPrefix())
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Header, More, and Count are populated only on the final chunk, and
+		// only when the stream completes without error. Track the latest
+		// chunk to read them, the same way they appear on a unary Get response.
+		var last clientv3.RangeStreamResponse
+		for chunk := range stream {
+			if err := chunk.Err(); err != nil {
+				log.Fatal(err)
+			}
+			for _, ev := range chunk.Kvs {
+				fmt.Printf("%s : %s\n", ev.Key, ev.Value)
+			}
+			last = chunk
+		}
+		fmt.Printf("count: %d, more: %v\n", last.Count, last.More)
+	})
+	// Output:
+	// key_0 : value
+	// key_1 : value
+	// key_2 : value
+	// count: 3, more: false
+}
+
+func mockKVGetStreamToGetResponse() {
+	fmt.Println("count: 3")
+	fmt.Println("key_0 : value")
+	fmt.Println("key_1 : value")
+	fmt.Println("key_2 : value")
+}
+
+func ExampleKV_getStreamToGetResponse() {
+	forUnitTestsRunInMockedContext(mockKVGetStreamToGetResponse, func() {
+		cli, err := clientv3.New(clientv3.Config{
+			Endpoints:   exampleEndpoints(),
+			DialTimeout: dialTimeout,
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cli.Close()
+
+		for i := 0; i < 3; i++ {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			_, err = cli.Put(ctx, fmt.Sprintf("key_%d", i), "value")
+			cancel()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		stream, err := cli.GetStream(ctx, "key", clientv3.WithPrefix())
+		if err != nil {
+			log.Fatal(err)
+		}
+		resp, err := clientv3.GetStreamToGetResponse(stream)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("count: %d\n", resp.Count)
+		for _, ev := range resp.Kvs {
+			fmt.Printf("%s : %s\n", ev.Key, ev.Value)
+		}
+	})
+	// Output:
+	// count: 3
+	// key_0 : value
+	// key_1 : value
+	// key_2 : value
+}
+
 func mockKVDelete() {
 	fmt.Println("Deleted all keys: true")
 }

--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -216,6 +216,10 @@ func (c *RecordingClient) Defragment(ctx context.Context) (*clientv3.DefragmentR
 	return resp, err
 }
 
+func (c *RecordingClient) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	panic("not implemented")
+}
+
 func (c *RecordingClient) Compact(ctx context.Context, rev int64, _ ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
 	c.kvMux.Lock()
 	defer c.kvMux.Unlock()


### PR DESCRIPTION
Moving benchmarks to this branch

## Benchmark Results

### Setup

- etcd single node on localhost
- All modes accumulate full results in client memory for fair comparison
- Client peak memory: max `HeapInuse` sampled at 1ms via `runtime.ReadMemStats`
- Server peak memory: max `go_memstats_heap_inuse_bytes` from `/metrics` sampled at 50ms

### Small values (100-byte values, 1 client, 10 iterations)

All comparisons relative to **Stream (count once)**.

#### 100k keys (~10 MB total data)

| Mode | Latency | Client Mem | Server Mem | Throughput |
|---|---|---|---|---|
| Stream (count once) | 0.10s | 38 MB | 52 MB | 117 MB/s |
| Single-shot unary | 0.10s | 54 MB (1.4x worse) | 110 MB (2.1x worse) | 114 MB/s |
| Paginated unary (10k) | 0.15s (1.5x worse) | 38 MB | 52 MB | 90 MB/s (1.3x worse) |
| Stream (count always) | 0.13s (1.3x worse) | 39 MB | 51 MB | 88 MB/s (1.3x worse) |

#### 500k keys (~50 MB total data)

| Mode | Latency | Client Mem | Server Mem | Throughput |
|---|---|---|---|---|
| Stream (count once) | 0.64s | 141 MB | 190 MB | 98 MB/s |
| Single-shot unary | 0.60s | 253 MB (1.8x worse) | 498 MB (2.6x worse) | 98 MB/s |
| Paginated unary (10k) | 1.68s (2.6x worse) | 140 MB | 179 MB | 33 MB/s (2.9x worse) |
| Stream (count always) | 1.95s (3.0x worse) | 141 MB | 175 MB | 34 MB/s (2.9x worse) |

#### 1M keys (~100 MB total data)

| Mode | Latency | Client Mem | Server Mem | Throughput |
|---|---|---|---|---|
| Stream (count once) | 1.37s | 271 MB | 348 MB | 90 MB/s |
| Single-shot unary | 1.39s | 494 MB (1.8x worse) | 1000 MB (2.9x worse) | 89 MB/s |
| Paginated unary (10k) | 5.44s (4.0x worse) | 269 MB | 339 MB | 22 MB/s (4.2x worse) |
| Stream (count always) | 6.78s (4.9x worse) | 270 MB | 329 MB | 19 MB/s (4.8x worse) |

#### 2M keys (~200 MB total data)

| Mode | Latency | Throughput |
|---|---|---|
| Stream (count once) | 2.76s | 86 MB/s |
| Single-shot unary | 2.79s | 85 MB/s |
| Paginated unary (10k) | 19.21s (7.0x worse) | 12 MB/s (6.9x worse) |
| Stream (count always) | 23.27s (8.4x worse) | 10 MB/s (8.4x worse) |

### Large values (10k keys x 100KB values, ~1 GB total data)

#### 1 client, 1 iteration

| Mode | Latency | Client Mem | Server Mem | Throughput |
|---|---|---|---|---|
| Stream (count once) | 0.48s | 1.01 GB | 1.03 GB | 1.99 GB/s |
| Single-shot unary | 1.38s (2.9x worse) | 2.92 GB (2.9x worse) | 2.47 GB (2.4x worse) | 710 MB/s (2.8x worse) |

#### 5 clients, 50 iterations

| Mode | P50 Latency | P90 Latency | Client Mem | Server Mem | Throughput |
|---|---|---|---|---|---|
| Stream | 1.81s | 8.33s | 5.01 GB | 1.06 GB | 383 MB/s |
| Single-shot | 28.30s (15.6x worse) | 42.12s (5.1x worse) | 13.91 GB (2.8x worse) | 16.78 GB (15.8x worse) | 37 MB/s (10.5x worse) |

With concurrent clients and large values, single-shot collapses: 5 in-flight ~1 GB responses overwhelm both client and server memory, causing GC thrashing. Stream stays comfortable at ~1 GB server memory since chunks are sent and freed incrementally.

### Key observations

1. **Stream matches single-shot on latency and throughput for small values** while using 1.8x less client memory and 2.9x less server memory at 1M keys.
2. **With large values, stream wins on every metric** — 2.9x faster, 2.9x less client memory, 2.4x less server memory.
3. **Under concurrency with large values, stream's advantage explodes** — 15.6x faster latency, 15.8x less server memory. Single-shot's memory footprint causes GC thrashing and swapping.
4. **Paginated unary has no advantages** — slower than stream at every size (1.5x at 100k, 7x at 2M), with the gap growing superlinearly due to per-RPC overhead compounding across hundreds of pages.
5. **Count-always is expensive** — computing total count on every chunk via O(n) b-tree scan makes stream count-always slower than paginated at 1M+ keys. Counting once at the start is critical.
