### PR TITLE
scripts: include tests/common in coverage pass

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -352,6 +352,9 @@ function cov_pass {
   # integration_cluster_proxy
   run_for_module "tests" go_test "./integration/..." "parallel" "pkg_to_coverprofileflag integration_cluster_proxy" \
       -tags cluster_proxy -timeout=30m "${gocov_build_flags[@]}" || failed="$failed integration_cluster_proxy"
+  # integration_common
+  run_for_module "tests" go_test "./common/..." "parallel" "pkg_to_coverprofileflag integration_common" \
+      -tags=integration -timeout=30m "${gocov_build_flags[@]}" "$@" || failed="$failed integration_common"
 
   local cover_out_file="${coverdir}/all.coverprofile"
   merge_cov "${coverdir}"


### PR DESCRIPTION
`tests/common/...` was not included in `cov_pass`, so client/v3 wrappers exercised only via the common test suite had no coverage reported even though the tests run in regular CI. 

Discovered while working on https://github.com/etcd-io/etcd/pull/21358#issuecomment-3954961806, and showed 0% coverage on newly added code.