### PR TITLE
[release-3.4] Get all Put related auth check into a separate function 'checkPutAuth'

### DIFF
--- a/etcdserver/apply_auth.go
+++ b/etcdserver/apply_auth.go
@@ -64,25 +64,34 @@ func (aa *authApplierV3) Apply(r *pb.InternalRaftRequest) *applyResult {
 }
 
 func (aa *authApplierV3) Put(txn mvcc.TxnWrite, r *pb.PutRequest) (*pb.PutResponse, *traceutil.Trace, error) {
-	if err := aa.as.IsPutPermitted(&aa.authInfo, r.Key); err != nil {
+	if err := checkPutAuth(aa.as, &aa.authInfo, aa.lessor, r); err != nil {
 		return nil, nil, err
 	}
 
-	if err := aa.checkLeasePuts(lease.LeaseID(r.Lease)); err != nil {
+	return aa.applierV3.Put(txn, r)
+}
+
+func checkPutAuth(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, r *pb.PutRequest) error {
+	if err := as.IsPutPermitted(ai, r.Key); err != nil {
+		return err
+	}
+
+	if err := checkLeasePuts(as, ai, lessor, lease.LeaseID(r.Lease)); err != nil {
 		// The specified lease is already attached with a key that cannot
 		// be written by this user. It means the user cannot revoke the
 		// lease so attaching the lease to the newly written key should
 		// be forbidden.
-		return nil, nil, err
+		return err
 	}
 
 	if r.PrevKv {
-		err := aa.as.IsRangePermitted(&aa.authInfo, r.Key, nil)
+		err := as.IsRangePermitted(ai, r.Key, nil)
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
 	}
-	return aa.applierV3.Put(txn, r)
+
+	return nil
 }
 
 func (aa *authApplierV3) Range(ctx context.Context, txn mvcc.TxnRead, r *pb.RangeRequest) (*pb.RangeResponse, error) {
@@ -178,30 +187,30 @@ func (aa *authApplierV3) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, error) {
 }
 
 func (aa *authApplierV3) LeaseRevoke(lc *pb.LeaseRevokeRequest) (*pb.LeaseRevokeResponse, error) {
-	if err := aa.checkLeasePuts(lease.LeaseID(lc.ID)); err != nil {
+	if err := checkLeasePuts(aa.as, &aa.authInfo, aa.lessor, lease.LeaseID(lc.ID)); err != nil {
 		return nil, err
 	}
 	return aa.applierV3.LeaseRevoke(lc)
 }
 
-func (aa *authApplierV3) checkLeasePuts(leaseID lease.LeaseID) error {
-	l := aa.lessor.Lookup(leaseID)
+func checkLeasePuts(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, leaseID lease.LeaseID) error {
+	l := lessor.Lookup(leaseID)
 	if l != nil {
-		return aa.checkLeasePutsKeys(l)
+		return checkLeasePutsKeys(as, ai, l)
 	}
 
 	return nil
 }
 
-func (aa *authApplierV3) checkLeasePutsKeys(l *lease.Lease) error {
+func checkLeasePutsKeys(as auth.AuthStore, ai *auth.AuthInfo, l *lease.Lease) error {
 	// early return for most-common scenario of either disabled auth or admin user.
 	// IsAdminPermitted also checks whether auth is enabled
-	if err := aa.as.IsAdminPermitted(&aa.authInfo); err == nil {
+	if err := as.IsAdminPermitted(ai); err == nil {
 		return nil
 	}
 
 	for _, key := range l.Keys() {
-		if err := aa.as.IsPutPermitted(&aa.authInfo, []byte(key)); err != nil {
+		if err := as.IsPutPermitted(ai, []byte(key)); err != nil {
 			return err
 		}
 	}

--- a/etcdserver/apply_auth_test.go
+++ b/etcdserver/apply_auth_test.go
@@ -18,16 +18,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/bcrypt"
+
 	"go.etcd.io/etcd/auth"
 	"go.etcd.io/etcd/auth/authpb"
 	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"go.etcd.io/etcd/lease"
-	"golang.org/x/crypto/bcrypt"
-
 	betesting "go.etcd.io/etcd/mvcc/backend"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestCheckLeasePutsKeys(t *testing.T) {
@@ -51,24 +50,24 @@ func TestCheckLeasePutsKeys(t *testing.T) {
 	defer as.AuthDisable()
 
 	aa := authApplierV3{as: as}
-	assert.NoError(t, aa.checkLeasePutsKeys(lease.NewLease(lease.LeaseID(1), 3600)), "auth is disabled, should allow puts")
+	assert.NoError(t, checkLeasePutsKeys(aa.as, &aa.authInfo, lease.NewLease(lease.LeaseID(1), 3600)), "auth is disabled, should allow puts")
 	assert.NoError(t, enableAuthAndCreateRoot(aa.as), "error while enabling auth")
 	aa.authInfo = auth.AuthInfo{Username: "root"}
-	assert.NoError(t, aa.checkLeasePutsKeys(lease.NewLease(lease.LeaseID(1), 3600)), "auth is enabled, should allow puts for root")
+	assert.NoError(t, checkLeasePutsKeys(aa.as, &aa.authInfo, lease.NewLease(lease.LeaseID(1), 3600)), "auth is enabled, should allow puts for root")
 
 	l := lease.NewLease(lease.LeaseID(1), 3600)
 	l.SetLeaseItem(lease.LeaseItem{Key: "a"})
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: 0}
-	assert.ErrorIs(t, aa.checkLeasePutsKeys(l), auth.ErrUserEmpty, "auth is enabled, should not allow bob, non existing at rev 0")
+	assert.ErrorIs(t, checkLeasePutsKeys(aa.as, &aa.authInfo, l), auth.ErrUserEmpty, "auth is enabled, should not allow bob, non existing at rev 0")
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: 1}
-	assert.ErrorIs(t, aa.checkLeasePutsKeys(l), auth.ErrAuthOldRevision, "auth is enabled, old revision")
+	assert.ErrorIs(t, checkLeasePutsKeys(aa.as, &aa.authInfo, l), auth.ErrAuthOldRevision, "auth is enabled, old revision")
 
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: aa.as.Revision()}
-	assert.ErrorIs(t, aa.checkLeasePutsKeys(l), auth.ErrPermissionDenied, "auth is enabled, bob does not have permissions, bob does not exist")
+	assert.ErrorIs(t, checkLeasePutsKeys(aa.as, &aa.authInfo, l), auth.ErrPermissionDenied, "auth is enabled, bob does not have permissions, bob does not exist")
 	_, err := aa.as.UserAdd(&pb.AuthUserAddRequest{Name: "bob", Options: &authpb.UserAddOptions{NoPassword: true}})
 	assert.NoError(t, err, "bob should be added without error")
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: aa.as.Revision()}
-	assert.ErrorIs(t, aa.checkLeasePutsKeys(l), auth.ErrPermissionDenied, "auth is enabled, bob exists yet does not have permissions")
+	assert.ErrorIs(t, checkLeasePutsKeys(aa.as, &aa.authInfo, l), auth.ErrPermissionDenied, "auth is enabled, bob exists yet does not have permissions")
 
 	// allow bob to access "a"
 	_, err = aa.as.RoleAdd(&pb.AuthRoleAddRequest{Name: "bobsrole"})
@@ -89,7 +88,7 @@ func TestCheckLeasePutsKeys(t *testing.T) {
 	assert.NoError(t, err, "bob should be granted bobsrole without error")
 
 	aa.authInfo = auth.AuthInfo{Username: "bob", Revision: aa.as.Revision()}
-	assert.NoError(t, aa.checkLeasePutsKeys(l), "bob should be able to access key 'a'")
+	assert.NoError(t, checkLeasePutsKeys(aa.as, &aa.authInfo, l), "bob should be able to access key 'a'")
 
 }
 


### PR DESCRIPTION

Partially backport https://github.com/etcd-io/etcd/pull/21680 to 3.4

cc. @fuweid @serathius 

edited by fuweid