### PR TITLE
v3rpc: return Unavailable instead of Unknown for ErrNotPrimary

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -36,6 +36,7 @@ var (
 	ErrGRPCLeaseNotFound    = status.Error(codes.NotFound, "etcdserver: requested lease not found")
 	ErrGRPCLeaseExist       = status.Error(codes.FailedPrecondition, "etcdserver: lease already exists")
 	ErrGRPCLeaseTTLTooLarge = status.Error(codes.OutOfRange, "etcdserver: too large lease TTL")
+	ErrGRPCLeaseNotPrimary  = status.Error(codes.Unavailable, "etcdserver: not primary lessor")
 
 	ErrGRPCWatchCanceled = status.Error(codes.Canceled, "etcdserver: watch canceled")
 
@@ -113,6 +114,7 @@ var (
 		ErrorDesc(ErrGRPCLeaseNotFound):    ErrGRPCLeaseNotFound,
 		ErrorDesc(ErrGRPCLeaseExist):       ErrGRPCLeaseExist,
 		ErrorDesc(ErrGRPCLeaseTTLTooLarge): ErrGRPCLeaseTTLTooLarge,
+		ErrorDesc(ErrGRPCLeaseNotPrimary):  ErrGRPCLeaseNotPrimary,
 
 		ErrorDesc(ErrGRPCMemberExist):            ErrGRPCMemberExist,
 		ErrorDesc(ErrGRPCPeerURLExist):           ErrGRPCPeerURLExist,
@@ -181,6 +183,7 @@ var (
 	ErrLeaseNotFound    = Error(ErrGRPCLeaseNotFound)
 	ErrLeaseExist       = Error(ErrGRPCLeaseExist)
 	ErrLeaseTTLTooLarge = Error(ErrGRPCLeaseTTLTooLarge)
+	ErrLeaseNotPrimary  = Error(ErrGRPCLeaseNotPrimary)
 
 	ErrMemberExist            = Error(ErrGRPCMemberExist)
 	ErrPeerURLExist           = Error(ErrGRPCPeerURLExist)

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -71,6 +71,7 @@ var toGRPCErrorMap = map[error]error{
 	lease.ErrLeaseNotFound:    rpctypes.ErrGRPCLeaseNotFound,
 	lease.ErrLeaseExists:      rpctypes.ErrGRPCLeaseExist,
 	lease.ErrLeaseTTLTooLarge: rpctypes.ErrGRPCLeaseTTLTooLarge,
+	lease.ErrNotPrimary:       rpctypes.ErrGRPCLeaseNotPrimary,
 
 	auth.ErrRootUserNotExist:     rpctypes.ErrGRPCRootUserNotExist,
 	auth.ErrRootRoleNotExist:     rpctypes.ErrGRPCRootRoleNotExist,

--- a/server/etcdserver/api/v3rpc/util_test.go
+++ b/server/etcdserver/api/v3rpc/util_test.go
@@ -27,6 +27,17 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
+func TestLeaseNotPrimaryReturnsUnavailable(t *testing.T) {
+	err := togRPCError(lease.ErrNotPrimary)
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if s.Code() != codes.Unavailable {
+		t.Errorf("expected codes.Unavailable, got %v", s.Code())
+	}
+}
+
 func TestGRPCError(t *testing.T) {
 	tt := []struct {
 		err error

--- a/server/etcdserver/api/v3rpc/util_test.go
+++ b/server/etcdserver/api/v3rpc/util_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
 
@@ -33,6 +34,7 @@ func TestGRPCError(t *testing.T) {
 	}{
 		{err: mvcc.ErrCompacted, exp: rpctypes.ErrGRPCCompacted},
 		{err: mvcc.ErrFutureRev, exp: rpctypes.ErrGRPCFutureRev},
+		{err: lease.ErrNotPrimary, exp: rpctypes.ErrGRPCLeaseNotPrimary},
 		{err: context.Canceled, exp: context.Canceled},
 		{err: context.DeadlineExceeded, exp: context.DeadlineExceeded},
 		{err: errors.New("foo"), exp: status.Error(codes.Unknown, "foo")},

--- a/tests/integration/v3_lease_test.go
+++ b/tests/integration/v3_lease_test.go
@@ -1228,3 +1228,49 @@ func leaseExist(t *testing.T, clus *integration.Cluster, leaseID int64) bool {
 
 	return true
 }
+
+// TestV3LeaseKeepAliveReturnsUnavailableOnLeaderLoss verifies that when a
+// lease keepalive fails because the leader is lost, the client receives
+// codes.Unavailable so it can distinguish this transient error from permanent
+// failures and retry on another member.
+//
+// This exercises the gRPC error mapping for leadership-related lease errors
+// (ErrNotPrimary, ErrNoLeader) which should all surface as Unavailable.
+func TestV3LeaseKeepAliveReturnsUnavailableOnLeaderLoss(t *testing.T) {
+	integration.BeforeTest(t)
+	leader, follower, anotherFollower := setupLeaseForwardingCluster(t)
+	leaderClient := integration.ToGRPC(leader.Client).Lease
+	followerClient := integration.ToGRPC(follower.Client).Lease
+
+	grantResp, err := leaderClient.LeaseGrant(t.Context(), &pb.LeaseGrantRequest{TTL: 30})
+	require.NoError(t, err)
+	leaseID := grantResp.ID
+
+	// Verify keepalive works while leader is up.
+	keepAliveClient, err := followerClient.LeaseKeepAlive(t.Context())
+	require.NoError(t, err)
+	defer keepAliveClient.CloseSend()
+
+	require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+	resp, err := keepAliveClient.Recv()
+	require.NoError(t, err)
+	require.Positive(t, resp.TTL)
+
+	// Stop leader and other follower so the remaining follower cannot
+	// forward the renewal.
+	leader.Stop(t)
+	anotherFollower.Stop(t)
+
+	// Send another keepalive. The follower should return Unavailable.
+	require.NoError(t, keepAliveClient.Send(&pb.LeaseKeepAliveRequest{ID: leaseID}))
+	_, err = keepAliveClient.Recv()
+	require.Error(t, err)
+
+	if integration.ThroughProxy {
+		// grpcproxy doesn't propagate the specific error code.
+		require.ErrorIs(t, err, context.Canceled)
+	} else {
+		require.Equalf(t, codes.Unavailable, status.Code(err),
+			"expected Unavailable on leader loss, got %v: %v", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
When `LeaseRenew` returns `lease.ErrNotPrimary` (e.g. after a leader switch), the error was not mapped in `toGRPCErrorMap`, causing `togRPCError` to fall through to `status.Error(codes.Unknown, err.Error())`. Clients seeing `Unknown` (code 2) do not know to retry.

This adds `ErrGRPCLeaseNotPrimary` with `codes.Unavailable` (14) and maps `lease.ErrNotPrimary` to it, so clients receive a retryable status code. This is consistent with how `ErrLeaderChanged` and `ErrNoLeader` are already mapped to `codes.Unavailable`.

Changes:
- `api/v3rpc/rpctypes/error.go`: add `ErrGRPCLeaseNotPrimary`, `ErrLeaseNotPrimary`, and the `errStringToError` mapping
- `server/etcdserver/api/v3rpc/util.go`: add `lease.ErrNotPrimary` to `toGRPCErrorMap`
- `server/etcdserver/api/v3rpc/util_test.go`: add test case

Tests pass:
```
ok  go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc (TestGRPCError)
ok  go.etcd.io/etcd/api/v3/v3rpc/rpctypes (TestConvert)
```

Fixes #21671