### PR TITLE
[release-3.6] Fix read access via PrevKv or lease attachment in a Put request in etcd transactions bypass RBAC authorization checks

### DIFF
--- a/server/etcdserver/apply/apply_auth.go
+++ b/server/etcdserver/apply/apply_auth.go
@@ -114,29 +114,29 @@ func (aa *authApplierV3) DeleteRange(r *pb.DeleteRangeRequest) (*pb.DeleteRangeR
 }
 
 func (aa *authApplierV3) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
-	if err := CheckTxnAuth(aa.as, &aa.authInfo, rt); err != nil {
+	if err := CheckTxnAuth(aa.as, &aa.authInfo, aa.lessor, rt); err != nil {
 		return nil, nil, err
 	}
 	return aa.applierV3.Txn(rt)
 }
 
-func CheckTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, rt *pb.TxnRequest) error {
-	return checkTxnPermission(as, ai, rt)
+func CheckTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, rt *pb.TxnRequest) error {
+	return checkTxnPermission(as, ai, lessor, rt)
 }
 
-func checkTxnPermission(as auth.AuthStore, ai *auth.AuthInfo, rt *pb.TxnRequest) error {
+func checkTxnPermission(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, rt *pb.TxnRequest) error {
 	for _, c := range rt.Compare {
 		if err := as.IsRangePermitted(ai, c.Key, c.RangeEnd); err != nil {
 			return err
 		}
 	}
-	if err := checkTxnReqsPermission(as, ai, rt.Success); err != nil {
+	if err := checkTxnReqsPermission(as, ai, lessor, rt.Success); err != nil {
 		return err
 	}
-	return checkTxnReqsPermission(as, ai, rt.Failure)
+	return checkTxnReqsPermission(as, ai, lessor, rt.Failure)
 }
 
-func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.RequestOp) error {
+func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, reqs []*pb.RequestOp) error {
 	for _, requ := range reqs {
 		switch tv := requ.Request.(type) {
 		case *pb.RequestOp_RequestRange:
@@ -153,10 +153,9 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			if err := as.IsPutPermitted(ai, tv.RequestPut.Key); err != nil {
+			if err := checkPutAuth(as, ai, lessor, tv.RequestPut); err != nil {
 				return err
 			}
-
 		case *pb.RequestOp_RequestDeleteRange:
 			if tv.RequestDeleteRange == nil {
 				continue
@@ -178,7 +177,7 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			err := checkTxnPermission(as, ai, tv.RequestTxn)
+			err := checkTxnPermission(as, ai, lessor, tv.RequestTxn)
 			if err != nil {
 				return err
 			}

--- a/server/etcdserver/apply/apply_auth_test.go
+++ b/server/etcdserver/apply/apply_auth_test.go
@@ -1048,7 +1048,7 @@ func TestCheckTxnAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, tt.txnRequest)
+			err := CheckTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, &lease.FakeLessor{}, tt.txnRequest)
 			assert.Equal(t, tt.err, err)
 		})
 	}

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -174,7 +174,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		var resp *pb.TxnResponse
 		var err error
 		chk := func(ai *auth.AuthInfo) error {
-			return apply2.CheckTxnAuth(s.authStore, ai, r)
+			return apply2.CheckTxnAuth(s.authStore, ai, s.lessor, r)
 		}
 
 		defer func(start time.Time) {

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -188,6 +189,7 @@ type user struct {
 	name     string
 	password string
 	role     string
+	perm     string
 	key      string
 	end      string
 }
@@ -379,8 +381,15 @@ func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
 			continue
 		}
 
+		permType := authpb.READWRITE
+		if len(user.perm) > 0 {
+			val, ok := authpb.Permission_Type_value[strings.ToUpper(user.perm)]
+			if ok {
+				permType = authpb.Permission_Type(val)
+			}
+		}
 		perm := &authpb.Permission{
-			PermType: authpb.READWRITE,
+			PermType: permType,
 			Key:      []byte(user.key),
 			RangeEnd: []byte(user.end),
 		}
@@ -484,6 +493,52 @@ func TestV3AuthNestedTxnPermissionDenied(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Kvs, 1)
 	require.Equal(t, resp.Kvs[0].Value, []byte("bar"))
+}
+
+func TestReadWithPrevKvInTXN(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "zoo",
+		},
+	}
+	anonCli := integration.ToGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := integration.NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := integration.NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	_, err = rootc.Put(t.Context(), "foo", "bar")
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithPrevKV())).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }
 
 func TestV3AuthOldRevConcurrent(t *testing.T) {

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -541,6 +541,56 @@ func TestReadWithPrevKvInTXN(t *testing.T) {
 	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }
 
+func TestPutWithLeaseInTXN(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "fop",
+		},
+	}
+	anonCli := integration.ToGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := integration.NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := integration.NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	t.Log("Create a lease and attach it to a key which the user1 doesn't have permission to write")
+	leaseResp, err := rootc.Grant(t.Context(), 90)
+	require.NoError(t, err)
+	leaseID := leaseResp.ID
+	_, err = rootc.Put(t.Context(), "eoo", "bar", clientv3.WithLease(leaseID))
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithLease(leaseID))).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
+}
+
 func TestV3AuthOldRevConcurrent(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/21677 to release-3.6

cc @fuweid @serathius 