### PR TITLE
fix(etcdutl): add missing Close() calls in calculateHashKV

### DIFF
--- a/etcdutl/etcdutl/bucket_command.go
+++ b/etcdutl/etcdutl/bucket_command.go
@@ -261,5 +261,6 @@ func getHashCommandFunc(_ *cobra.Command, args []string) {
 
 func getHash(dbPath string) (hash uint32, err error) {
 	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 	return b.Hash(schema.DefaultIgnores)
 }

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -52,6 +52,7 @@ func DefragData(dataDir string) error {
 		GetLogger(),
 		datadir.ToBackendFileName(dataDir),
 		backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 
 	return b.Defrag()
 }

--- a/etcdutl/etcdutl/hashkv_command.go
+++ b/etcdutl/etcdutl/hashkv_command.go
@@ -55,8 +55,10 @@ type HashKV struct {
 
 func calculateHashKV(dbPath string, rev int64) (HashKV, error) {
 	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 	// Since `etcdutl hashkv` only hashes the keyspace and ignores leases, we use a simple lessor to simplify the implementation.
 	st := mvcc.NewStore(zap.NewNop(), b, &SimpleLessor{}, mvcc.StoreConfig{})
+	defer st.Close()
 	hst := mvcc.NewHashStorage(zap.NewNop(), st)
 
 	h, _, err := hst.HashByRev(rev)


### PR DESCRIPTION
## Summary
The etcdutl hashkv command hangs indefinitely when run against a db file that is locked by another etcd process. This happens because calculateHashKV opens a backend and mvcc store but never closes them, leaving the file lock held.

## Changes
- Add defer b.Close() to close the backend after hashing
- Add defer st.Close() to close the mvcc store after hashing

These changes ensure the boltdb file lock is released promptly, allowing the command to complete (or fail with a timeout error) instead of hanging forever.

Fixes #20276