### PR TITLE
[release-3.5] Fix read access via PrevKv or lease attachment in a Put request in etcd transactions bypass RBAC authorization checks

### DIFF
--- a/server/etcdserver/apply_auth.go
+++ b/server/etcdserver/apply_auth.go
@@ -116,7 +116,7 @@ func (aa *authApplierV3) DeleteRange(txn mvcc.TxnWrite, r *pb.DeleteRangeRequest
 	return aa.applierV3.DeleteRange(txn, r)
 }
 
-func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.RequestOp) error {
+func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, reqs []*pb.RequestOp) error {
 	for _, requ := range reqs {
 		switch tv := requ.Request.(type) {
 		case *pb.RequestOp_RequestRange:
@@ -133,10 +133,9 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			if err := as.IsPutPermitted(ai, tv.RequestPut.Key); err != nil {
+			if err := checkPutAuth(as, ai, lessor, tv.RequestPut); err != nil {
 				return err
 			}
-
 		case *pb.RequestOp_RequestDeleteRange:
 			if tv.RequestDeleteRange == nil {
 				continue
@@ -158,7 +157,7 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			err := checkTxnAuth(as, ai, tv.RequestTxn)
+			err := checkTxnAuth(as, ai, lessor, tv.RequestTxn)
 			if err != nil {
 				return err
 			}
@@ -168,20 +167,20 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 	return nil
 }
 
-func checkTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, rt *pb.TxnRequest) error {
+func checkTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, rt *pb.TxnRequest) error {
 	for _, c := range rt.Compare {
 		if err := as.IsRangePermitted(ai, c.Key, c.RangeEnd); err != nil {
 			return err
 		}
 	}
-	if err := checkTxnReqsPermission(as, ai, rt.Success); err != nil {
+	if err := checkTxnReqsPermission(as, ai, lessor, rt.Success); err != nil {
 		return err
 	}
-	return checkTxnReqsPermission(as, ai, rt.Failure)
+	return checkTxnReqsPermission(as, ai, lessor, rt.Failure)
 }
 
 func (aa *authApplierV3) Txn(ctx context.Context, rt *pb.TxnRequest) (*pb.TxnResponse, *traceutil.Trace, error) {
-	if err := checkTxnAuth(aa.as, &aa.authInfo, rt); err != nil {
+	if err := checkTxnAuth(aa.as, &aa.authInfo, aa.lessor, rt); err != nil {
 		return nil, nil, err
 	}
 	return aa.applierV3.Txn(ctx, rt)

--- a/server/etcdserver/apply_auth_txn_test.go
+++ b/server/etcdserver/apply_auth_txn_test.go
@@ -25,6 +25,7 @@ import (
 	"go.etcd.io/etcd/api/v3/authpb"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/server/v3/auth"
+	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/mvcc/backend"
 	betesting "go.etcd.io/etcd/server/v3/mvcc/backend/testing"
 )
@@ -386,7 +387,7 @@ func TestCheckTxnAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := checkTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, tt.txnRequest)
+			err := checkTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, &lease.FakeLessor{}, tt.txnRequest)
 			assert.Equal(t, tt.err, err)
 		})
 	}

--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -169,7 +169,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		var resp *pb.TxnResponse
 		var err error
 		chk := func(ai *auth.AuthInfo) error {
-			return checkTxnAuth(s.authStore, ai, r)
+			return checkTxnAuth(s.authStore, ai, s.lessor, r)
 		}
 
 		defer func(start time.Time) {

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -1094,3 +1094,53 @@ func TestReadWithPrevKvInTXN(t *testing.T) {
 	require.Error(t, err)
 	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }
+
+func TestPutWithLeaseInTXN(t *testing.T) {
+	BeforeTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "fop",
+		},
+	}
+	anonCli := toGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	t.Log("Create a lease and attach it to a key which the user1 doesn't have permission to write")
+	leaseResp, err := rootc.Grant(t.Context(), 90)
+	require.NoError(t, err)
+	leaseID := leaseResp.ID
+	_, err = rootc.Put(t.Context(), "eoo", "bar", clientv3.WithLease(leaseID))
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithLease(leaseID))).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
+}

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -234,6 +234,7 @@ type user struct {
 	name     string
 	password string
 	role     string
+	perm     string
 	key      string
 	end      string
 }
@@ -370,8 +371,15 @@ func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
 			continue
 		}
 
+		permType := authpb.READWRITE
+		if len(user.perm) > 0 {
+			val, ok := authpb.Permission_Type_value[strings.ToUpper(user.perm)]
+			if ok {
+				permType = authpb.Permission_Type(val)
+			}
+		}
 		perm := &authpb.Permission{
-			PermType: authpb.READWRITE,
+			PermType: permType,
 			Key:      []byte(user.key),
 			RangeEnd: []byte(user.end),
 		}
@@ -1039,4 +1047,50 @@ func TestV3AuthCompact(t *testing.T) {
 
 	_, err = rootCli.Compact(ctx, 1, clientv3.WithCompactPhysical())
 	require.NoError(t, err)
+}
+
+func TestReadWithPrevKvInTXN(t *testing.T) {
+	BeforeTest(t)
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "zoo",
+		},
+	}
+	anonCli := toGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := NewClient(t, clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	_, err = rootc.Put(t.Context(), "foo", "bar")
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithPrevKV())).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/21677 to release-3.5

cc @fuweid @serathius 