### PR TITLE
[release-3.4] Fix read access via PrevKv or lease attachment in a Put request in etcd transactions bypass RBAC authorization checks

### DIFF
--- a/etcdserver/apply_auth.go
+++ b/etcdserver/apply_auth.go
@@ -115,7 +115,7 @@ func (aa *authApplierV3) DeleteRange(txn mvcc.TxnWrite, r *pb.DeleteRangeRequest
 	return aa.applierV3.DeleteRange(txn, r)
 }
 
-func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.RequestOp) error {
+func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, reqs []*pb.RequestOp) error {
 	for _, requ := range reqs {
 		switch tv := requ.Request.(type) {
 		case *pb.RequestOp_RequestRange:
@@ -132,10 +132,9 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			if err := as.IsPutPermitted(ai, tv.RequestPut.Key); err != nil {
+			if err := checkPutAuth(as, ai, lessor, tv.RequestPut); err != nil {
 				return err
 			}
-
 		case *pb.RequestOp_RequestDeleteRange:
 			if tv.RequestDeleteRange == nil {
 				continue
@@ -157,7 +156,7 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 				continue
 			}
 
-			err := checkTxnAuth(as, ai, tv.RequestTxn)
+			err := checkTxnAuth(as, ai, lessor, tv.RequestTxn)
 			if err != nil {
 				return err
 			}
@@ -167,20 +166,20 @@ func checkTxnReqsPermission(as auth.AuthStore, ai *auth.AuthInfo, reqs []*pb.Req
 	return nil
 }
 
-func checkTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, rt *pb.TxnRequest) error {
+func checkTxnAuth(as auth.AuthStore, ai *auth.AuthInfo, lessor lease.Lessor, rt *pb.TxnRequest) error {
 	for _, c := range rt.Compare {
 		if err := as.IsRangePermitted(ai, c.Key, c.RangeEnd); err != nil {
 			return err
 		}
 	}
-	if err := checkTxnReqsPermission(as, ai, rt.Success); err != nil {
+	if err := checkTxnReqsPermission(as, ai, lessor, rt.Success); err != nil {
 		return err
 	}
-	return checkTxnReqsPermission(as, ai, rt.Failure)
+	return checkTxnReqsPermission(as, ai, lessor, rt.Failure)
 }
 
 func (aa *authApplierV3) Txn(rt *pb.TxnRequest) (*pb.TxnResponse, error) {
-	if err := checkTxnAuth(aa.as, &aa.authInfo, rt); err != nil {
+	if err := checkTxnAuth(aa.as, &aa.authInfo, aa.lessor, rt); err != nil {
 		return nil, err
 	}
 	return aa.applierV3.Txn(rt)

--- a/etcdserver/apply_auth_txn_test.go
+++ b/etcdserver/apply_auth_txn_test.go
@@ -25,6 +25,7 @@ import (
 	"go.etcd.io/etcd/auth"
 	"go.etcd.io/etcd/auth/authpb"
 	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
+	"go.etcd.io/etcd/lease"
 	betesting "go.etcd.io/etcd/mvcc/backend"
 )
 
@@ -385,7 +386,7 @@ func TestCheckTxnAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := checkTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, tt.txnRequest)
+			err := checkTxnAuth(as, &auth.AuthInfo{Username: "foo", Revision: 8}, &lease.FakeLessor{}, tt.txnRequest)
 			assert.Equal(t, tt.err, err)
 		})
 	}

--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -159,7 +159,7 @@ func (s *EtcdServer) Txn(ctx context.Context, r *pb.TxnRequest) (*pb.TxnResponse
 		var resp *pb.TxnResponse
 		var err error
 		chk := func(ai *auth.AuthInfo) error {
-			return checkTxnAuth(s.authStore, ai, r)
+			return checkTxnAuth(s.authStore, ai, s.lessor, r)
 		}
 
 		defer func(start time.Time) {

--- a/integration/v3_auth_test.go
+++ b/integration/v3_auth_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/etcd/auth/authpb"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -206,6 +207,7 @@ type user struct {
 	name     string
 	password string
 	role     string
+	perm     string
 	key      string
 	end      string
 }
@@ -342,8 +344,15 @@ func authSetupUsers(t *testing.T, auth pb.AuthClient, users []user) {
 			continue
 		}
 
+		permType := authpb.READWRITE
+		if len(user.perm) > 0 {
+			val, ok := authpb.Permission_Type_value[strings.ToUpper(user.perm)]
+			if ok {
+				permType = authpb.Permission_Type(val)
+			}
+		}
 		perm := &authpb.Permission{
-			PermType: authpb.READWRITE,
+			PermType: permType,
 			Key:      []byte(user.key),
 			RangeEnd: []byte(user.end),
 		}
@@ -1005,4 +1014,49 @@ func TestV3AuthCompact(t *testing.T) {
 
 	_, err = rootCli.Compact(ctx, 1, clientv3.WithCompactPhysical())
 	require.NoError(t, err)
+}
+
+func TestReadWithPrevKvInTXN(t *testing.T) {
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "zoo",
+		},
+	}
+	anonCli := toGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := clientv3.New(clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := clientv3.New(clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	_, err = rootc.Put(t.Context(), "foo", "bar")
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithPrevKV())).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }

--- a/integration/v3_auth_test.go
+++ b/integration/v3_auth_test.go
@@ -1060,3 +1060,52 @@ func TestReadWithPrevKvInTXN(t *testing.T) {
 	require.Error(t, err)
 	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
 }
+
+func TestPutWithLeaseInTXN(t *testing.T) {
+	clus := NewClusterV3(t, &ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	users := []user{
+		{
+			name:     "user1",
+			password: "user1-123",
+			role:     "role1",
+			perm:     "write",
+			key:      "foo",
+			end:      "fop",
+		},
+	}
+	anonCli := toGRPC(clus.Client(0))
+	authSetupUsers(t, anonCli.Auth, users)
+	authSetupRoot(t, anonCli.Auth)
+
+	rootc, err := clientv3.New(clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "root",
+		Password:  "123",
+	})
+	require.NoError(t, err)
+	defer rootc.Close()
+
+	userc, err := clientv3.New(clientv3.Config{
+		Endpoints: clus.Client(0).Endpoints(),
+		Username:  "user1",
+		Password:  "user1-123",
+	})
+	require.NoError(t, err)
+	defer userc.Close()
+
+	t.Log("Create a lease and attach it to a key which the user1 doesn't have permission to write")
+	leaseResp, err := rootc.Grant(t.Context(), 90)
+	require.NoError(t, err)
+	leaseID := leaseResp.ID
+	_, err = rootc.Put(t.Context(), "eoo", "bar", clientv3.WithLease(leaseID))
+	require.NoError(t, err)
+
+	_, err = userc.Txn(t.Context()).
+		Then(clientv3.OpPut("foo", "new", clientv3.WithLease(leaseID))).
+		Commit()
+
+	require.Error(t, err)
+	require.Truef(t, eqErrGRPC(err, rpctypes.ErrGRPCPermissionDenied), "got %v, expected %v", err, rpctypes.ErrGRPCPermissionDenied)
+}


### PR DESCRIPTION
Backport https://github.com/etcd-io/etcd/pull/21677 to release-3.4

cc @fuweid @serathius 