### PR TITLE
fix(etcdutl): add missing Close() calls in defrag and bucket commands

### DIFF
--- a/etcdutl/etcdutl/bucket_command.go
+++ b/etcdutl/etcdutl/bucket_command.go
@@ -261,5 +261,6 @@ func getHashCommandFunc(_ *cobra.Command, args []string) {
 
 func getHash(dbPath string) (hash uint32, err error) {
 	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 	return b.Hash(schema.DefaultIgnores)
 }

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -52,6 +52,7 @@ func DefragData(dataDir string) error {
 		GetLogger(),
 		datadir.ToBackendFileName(dataDir),
 		backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 
 	return b.Defrag()
 }

--- a/etcdutl/etcdutl/hashkv_command.go
+++ b/etcdutl/etcdutl/hashkv_command.go
@@ -55,8 +55,10 @@ type HashKV struct {
 
 func calculateHashKV(dbPath string, rev int64) (HashKV, error) {
 	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
+	defer b.Close()
 	// Since `etcdutl hashkv` only hashes the keyspace and ignores leases, we use a simple lessor to simplify the implementation.
 	st := mvcc.NewStore(zap.NewNop(), b, &SimpleLessor{}, mvcc.StoreConfig{})
+	defer st.Close()
 	hst := mvcc.NewHashStorage(zap.NewNop(), st)
 
 	h, _, err := hst.HashByRev(rev)


### PR DESCRIPTION
## Summary
This PR adds missing  calls after  in two etcdutl commands, following the same pattern as #21686 (hashkv_command.go).

## Changes
-  in  — added 
-  in  — added 

## Context
As noted by @ahrtr in https://github.com/etcd-io/etcd/pull/21686#issuecomment-4342830143, other etcdutl commands also need similar fixes. This PR addresses the remaining commands that were missing the Close() call.

## Checklist
- [x] DCO sign-off included
- [ ] Tests pass (pending CI)

Signed-off-by: goingforstudying-ctrl <goingforstudying-ctrl@users.noreply.github.com>