### PR TITLE
clientv3: address review feedback on RangeStream from #21358

### DIFF
--- a/client/v3/kv.go
+++ b/client/v3/kv.go
@@ -179,7 +179,7 @@ func (kv *kv) GetStream(ctx context.Context, key string, opts ...OpOption) (GetS
 			resp, err := c.Recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					respCh <- RangeStreamResponse{closeErr: err}
+					respCh <- RangeStreamResponse{closeErr: ContextError(ctx, err)}
 				}
 				return
 			}

--- a/client/v3/ordering/kv.go
+++ b/client/v3/ordering/kv.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"sync"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -73,6 +76,11 @@ func (kv *kvOrdering) Get(ctx context.Context, key string, opts ...clientv3.OpOp
 			return nil, err
 		}
 	}
+}
+
+// GetStream is not supported by kvOrdering.
+func (kv *kvOrdering) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
+	return nil, status.Error(codes.Unimplemented, "GetStream is not supported by kvOrdering")
 }
 
 func (kv *kvOrdering) Txn(ctx context.Context) clientv3.Txn {

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -464,6 +464,9 @@ func TestKVCompact(t *testing.T) {
 // rpctypes.ErrCompacted error from the server (matching Get's behavior),
 // rather than the raw gRPC status.
 func TestKVGetStreamCompactedError(t *testing.T) {
+	if integration.ThroughProxy {
+		t.Skip("RangeStream is not supported by the KV client adapter")
+	}
 	integration.BeforeTest(t)
 
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -460,6 +460,35 @@ func TestKVCompact(t *testing.T) {
 	}
 }
 
+// TestKVGetStreamCompactedError ensures GetStream surfaces the typed
+// rpctypes.ErrCompacted error from the server (matching Get's behavior),
+// rather than the raw gRPC status.
+func TestKVGetStreamCompactedError(t *testing.T) {
+	integration.BeforeTest(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	kv := clus.RandClient()
+	ctx := t.Context()
+
+	for i := 0; i < 5; i++ {
+		_, err := kv.Put(ctx, "foo", "bar")
+		require.NoError(t, err)
+	}
+	_, err := kv.Compact(ctx, 6)
+	require.NoError(t, err)
+
+	_, err = kv.Get(ctx, "foo", clientv3.WithRev(3))
+	require.ErrorIsf(t, err, rpctypes.ErrCompacted, "Get returned %T %v", err, err)
+
+	stream, err := kv.GetStream(ctx, "foo", clientv3.WithRev(3))
+	require.NoError(t, err)
+
+	_, err = clientv3.GetStreamToGetResponse(stream)
+	require.ErrorIsf(t, err, rpctypes.ErrCompacted, "GetStream returned %T %v", err, err)
+}
+
 // TestKVGetRetry ensures get will retry on disconnect.
 func TestKVGetRetry(t *testing.T) {
 	integration.BeforeTest(t)


### PR DESCRIPTION
Follow-up to https://github.com/etcd-io/etcd/pull/21358 addressing fuweid's review comments.

1. Wrap streaming Recv() errors with ContextError
2. Stub GetStream on the ordering KV wrapper