### PR TITLE
robustness: exercise RangeStream in traffic mix.

### DIFF
--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -113,6 +113,30 @@ func (c *RecordingClient) Range(ctx context.Context, start, end string, revision
 	return resp, err
 }
 
+func (c *RecordingClient) RangeStream(ctx context.Context, start, end string, revision, limit int64) (*clientv3.GetResponse, error) {
+	ops := []clientv3.OpOption{}
+	if end != "" {
+		ops = append(ops, clientv3.WithRange(end))
+	}
+	if revision != 0 {
+		ops = append(ops, clientv3.WithRev(revision))
+	}
+	if limit != 0 {
+		ops = append(ops, clientv3.WithLimit(limit))
+	}
+	c.kvMux.Lock()
+	defer c.kvMux.Unlock()
+	callTime := time.Since(c.baseTime)
+	stream, err := c.client.GetStream(ctx, start, ops...)
+	var resp *clientv3.GetResponse
+	if err == nil {
+		resp, err = clientv3.GetStreamToGetResponse(stream)
+	}
+	returnTime := time.Since(c.baseTime)
+	c.kvOperations.AppendRange(start, end, revision, limit, callTime, returnTime, resp, err)
+	return resp, err
+}
+
 func (c *RecordingClient) Put(ctx context.Context, key, value string, _ ...clientv3.OpOption) (*clientv3.PutResponse, error) {
 	c.kvMux.Lock()
 	defer c.kvMux.Unlock()

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -37,9 +37,11 @@ var (
 		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
-			{Choice: List, Weight: 15},
+			{Choice: List, Weight: 8},
+			{Choice: ListStream, Weight: 7},
 			{Choice: StaleGet, Weight: 10},
-			{Choice: StaleList, Weight: 10},
+			{Choice: StaleList, Weight: 5},
+			{Choice: StaleListStream, Weight: 5},
 			{Choice: Delete, Weight: 5},
 			{Choice: MultiOpTxn, Weight: 10},
 			{Choice: PutWithLease, Weight: 5},
@@ -54,9 +56,11 @@ var (
 		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
-			{Choice: List, Weight: 15},
+			{Choice: List, Weight: 8},
+			{Choice: ListStream, Weight: 7},
 			{Choice: StaleGet, Weight: 10},
-			{Choice: StaleList, Weight: 10},
+			{Choice: StaleList, Weight: 5},
+			{Choice: StaleListStream, Weight: 5},
 			{Choice: MultiOpTxn, Weight: 10},
 			{Choice: Put, Weight: 40},
 		},
@@ -85,17 +89,19 @@ func (t etcdTraffic) ExpectUniqueRevision() bool {
 type etcdRequestType string
 
 const (
-	Get           etcdRequestType = "get"
-	StaleGet      etcdRequestType = "staleGet"
-	List          etcdRequestType = "list"
-	StaleList     etcdRequestType = "staleList"
-	Put           etcdRequestType = "put"
-	Delete        etcdRequestType = "delete"
-	MultiOpTxn    etcdRequestType = "multiOpTxn"
-	PutWithLease  etcdRequestType = "putWithLease"
-	LeaseRevoke   etcdRequestType = "leaseRevoke"
-	CompareAndSet etcdRequestType = "compareAndSet"
-	Defragment    etcdRequestType = "defragment"
+	Get             etcdRequestType = "get"
+	StaleGet        etcdRequestType = "staleGet"
+	List            etcdRequestType = "list"
+	StaleList       etcdRequestType = "staleList"
+	ListStream      etcdRequestType = "listStream"
+	StaleListStream etcdRequestType = "staleListStream"
+	Put             etcdRequestType = "put"
+	Delete          etcdRequestType = "delete"
+	MultiOpTxn      etcdRequestType = "multiOpTxn"
+	PutWithLease    etcdRequestType = "putWithLease"
+	LeaseRevoke     etcdRequestType = "leaseRevoke"
+	CompareAndSet   etcdRequestType = "compareAndSet"
+	Defragment      etcdRequestType = "defragment"
 )
 
 func (t etcdTraffic) Name() string {
@@ -230,6 +236,19 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 	case StaleList:
 		var resp *clientv3.GetResponse
 		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit)
+		if resp != nil {
+			rev = resp.Header.Revision
+		}
+	case ListStream:
+		var resp *clientv3.GetResponse
+		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit)
+		if resp != nil {
+			c.keyStore.SyncKeys(resp)
+			rev = resp.Header.Revision
+		}
+	case StaleListStream:
+		var resp *clientv3.GetResponse
+		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit)
 		if resp != nil {
 			rev = resp.Header.Revision
 		}


### PR DESCRIPTION
Adds RangeStream to the robustness traffic mix. Assembled response is recorded via AppendRange so the linearizability checker enforces snapshot equivalence with unary Range.