### PR TITLE
RangeStream benchmarks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/coreos/go-semver v0.3.1
 	github.com/dustin/go-humanize v1.0.1
+	github.com/golang/protobuf v1.5.4
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.3
@@ -54,7 +55,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect

--- a/tools/benchmark/cmd/range.go
+++ b/tools/benchmark/cmd/range.go
@@ -22,12 +22,18 @@ import (
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/spf13/cobra"
 	"golang.org/x/time/rate"
 
+	etcdserverpb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	v3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/report"
 )
+
+// k8sWatchCachePageSize matches the default page size used by the Kubernetes
+// watch cache when paginating List requests against etcd.
+const k8sWatchCachePageSize = 10000
 
 // rangeCmd represents the range command
 var rangeCmd = &cobra.Command{
@@ -43,6 +49,9 @@ var (
 	rangeConsistency string
 	rangeLimit       int64
 	rangeCountOnly   bool
+	rangeStream      bool
+	rangePaginate    bool
+	rangePrefix      bool
 )
 
 func init() {
@@ -52,18 +61,29 @@ func init() {
 	rangeCmd.Flags().StringVar(&rangeConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
 	rangeCmd.Flags().Int64Var(&rangeLimit, "limit", 0, "Maximum number of results to return from range request (0 is no limit)")
 	rangeCmd.Flags().BoolVar(&rangeCountOnly, "count-only", false, "Only returns the count of keys")
+	rangeCmd.Flags().BoolVar(&rangeStream, "stream", false, "Use RangeStream instead of unary Range")
+	rangeCmd.Flags().BoolVar(&rangePaginate, "paginate", false, "Use paginated unary range with 10k-key pages")
+	rangeCmd.Flags().BoolVar(&rangePrefix, "prefix", false, "Range over all keys with the given key as prefix")
 }
 
 func rangeFunc(cmd *cobra.Command, args []string) {
-	if len(args) == 0 || len(args) > 2 {
+	if len(args) > 2 || (len(args) == 0 && !rangePrefix) {
 		fmt.Fprintln(os.Stderr, cmd.Usage())
 		os.Exit(1)
 	}
 
-	k := args[0]
+	key := ""
 	end := ""
+	if len(args) >= 1 {
+		key = args[0]
+	}
 	if len(args) == 2 {
 		end = args[1]
+	}
+
+	if rangePaginate && rangeLimit > 0 {
+		fmt.Fprintln(os.Stderr, "--paginate and --limit are mutually exclusive")
+		os.Exit(1)
 	}
 
 	if rangeConsistency == "l" {
@@ -80,22 +100,58 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 	}
 	limit := rate.NewLimiter(rate.Limit(rangeRate), 1)
 
-	requests := make(chan v3.Op, totalClients)
+	requests := make(chan struct{}, totalClients)
 	clients := mustCreateClients(totalClients, totalConns)
 
 	bar = pb.New(rangeTotal)
 	bar.Start()
+
+	var baseOpts []v3.OpOption
+	if rangeLimit > 0 {
+		baseOpts = append(baseOpts, v3.WithLimit(rangeLimit))
+	}
+	if rangeCountOnly {
+		baseOpts = append(baseOpts, v3.WithCountOnly())
+	}
+	if rangeConsistency == "s" {
+		baseOpts = append(baseOpts, v3.WithSerializable())
+	}
+	if rangePrefix {
+		if rangePaginate {
+			// Pin the prefix's range end once. Otherwise WithPrefix would
+			// re-derive it from the advancing start key on every page.
+			baseOpts = append(baseOpts, v3.WithRange(v3.GetPrefixRangeEnd(key)))
+			if key == "" {
+				key = "\x00"
+			}
+		} else {
+			baseOpts = append(baseOpts, v3.WithPrefix())
+		}
+	} else if end != "" {
+		baseOpts = append(baseOpts, v3.WithRange(end))
+	}
 
 	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {
 			defer wg.Done()
-			for op := range requests {
+			for range requests {
 				limit.Wait(context.Background())
-
 				st := time.Now()
-				_, err := c.Do(context.Background(), op)
+				var err error
+				switch {
+				case rangeStream:
+					var stream v3.GetStreamChan
+					stream, err = c.GetStream(context.Background(), key, baseOpts...)
+					if err == nil {
+						_, err = v3.GetStreamToGetResponse(stream)
+					}
+				case rangePaginate:
+					err = paginatedRange(c, key, k8sWatchCachePageSize, baseOpts)
+				default:
+					_, err = c.Get(context.Background(), key, baseOpts...)
+				}
 				r.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
 				bar.Increment()
 			}
@@ -104,15 +160,7 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 
 	go func() {
 		for i := 0; i < rangeTotal; i++ {
-			opts := []v3.OpOption{v3.WithRange(end), v3.WithLimit(rangeLimit)}
-			if rangeCountOnly {
-				opts = append(opts, v3.WithCountOnly())
-			}
-			if rangeConsistency == "s" {
-				opts = append(opts, v3.WithSerializable())
-			}
-			op := v3.OpGet(k, opts...)
-			requests <- op
+			requests <- struct{}{}
 		}
 		close(requests)
 	}()
@@ -122,4 +170,28 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 	close(r.Results())
 	bar.Finish()
 	fmt.Printf("%s", <-rc)
+}
+
+func paginatedRange(c *v3.Client, key string, pageSize int64, baseOpts []v3.OpOption) error {
+	merged := &etcdserverpb.RangeResponse{}
+	var rev int64
+	for {
+		opts := append([]v3.OpOption{v3.WithLimit(pageSize)}, baseOpts...)
+		if rev != 0 {
+			opts = append(opts, v3.WithRev(rev))
+		}
+		resp, err := c.Get(context.Background(), key, opts...)
+		if err != nil {
+			return err
+		}
+		if rev == 0 {
+			rev = resp.Header.Revision
+		}
+		proto.Merge(merged, (*etcdserverpb.RangeResponse)(resp))
+		if !resp.More || len(resp.Kvs) == 0 {
+			return nil
+		}
+		last := resp.Kvs[len(resp.Kvs)-1].Key
+		key = string(append(last, '\x00'))
+	}
 }


### PR DESCRIPTION
## Benchmark Results

`bench range` over an etcd seeded with N sequential keys × value-size, three modes:

- **Single-shot unary** — one Range RPC, full response in one message (existing path)
- **Stream** — `RangeStream` consumed via `GetStreamToGetResponse` (new)
- **Paginated unary** — repeated bounded Range RPCs with page=10000 (current Kubernetes LIST behavior)

Each mode runs against a fresh etcd (seed once, restart between modes) so RSS is isolated per-mode. Multipliers are vs Stream.

Testing across a broad range of data, on data shapes where paginated's 10k fixed count is similar to our default per chunk max configuration (1.5 MB) in rangestream, performance is similar. However, at both ends, small values large count and large values small count, paginated starts to lag behind in either memory or throughput. 

### Single client

| shape         | mode      | p50              | p90              | peak memory         |
|---------------|-----------|------------------|------------------|------------------|
| 100k × 100B   | unary     | 0.093s (1.14×)   | 0.098s (1.15×)   |  199 MB (1.83×)  |
|               | **stream**| **0.081s**       | **0.086s**       | **109 MB**       |
|               | paginated | 0.121s (1.49×)   | 0.128s (1.49×)   |  106 MB (0.97×)  |
| 500k × 100B   | unary     | 0.585s (1.09×)   | 0.657s (1.19×)   |  822 MB (2.56×)  |
|               | **stream**| **0.537s**       | **0.555s**       | **321 MB**       |
|               | paginated | 1.408s (2.62×)   | 1.454s (2.62×)   |  316 MB (0.98×)  |
| 1M × 100B     | unary     | 1.267s (1.05×)   | 1.351s (0.98×)   | 1663 MB (2.79×)  |
|               | **stream**| **1.205s**       | **1.382s**       | **596 MB**       |
|               | paginated | 4.838s (4.02×)   | 5.293s (3.83×)   |  589 MB (0.99×)  |
| 10k × 100KB   | unary     | 1.102s (3.06×)   | 2.598s (6.35×)   | 6610 MB (6.10×)  |
|               | **stream**| **0.360s**       | **0.409s**       | **1084 MB**      |
|               | paginated | 1.190s (3.31×)   | 3.080s (7.53×)   | 7698 MB (7.10×)  |

### 5 concurrent clients

| shape         | mode      | p50               | p90                | peak memory           |
|---------------|-----------|-------------------|--------------------|--------------------|
| 50k × 5KB     | unary     | 0.738s (1.54×)    | 1.946s (3.81×)     |  5464 MB (8.92×)   |
|               | **stream**| **0.480s**        | **0.511s**         | **613 MB**         |
|               | paginated | 0.459s (0.96×)    | 0.739s (1.45×)     |  1389 MB (2.27×)   |
| 10k × 30KB    | unary     | 0.681s (1.81×)    | 1.938s (4.19×)     |  6383 MB (14.67×)  |
|               | **stream**| **0.376s**        | **0.463s**         | **435 MB**         |
|               | paginated | 0.445s (1.18×)    | 0.904s (1.95×)     |  6109 MB (14.04×)  |
| 10k × 100KB   | unary     | 22.555s (18.26×)  | 57.802s (41.46×)   | 10941 MB (8.97×)   |
|               | **stream**| **1.235s**        | **1.394s**         | **1219 MB**        |
|               | paginated | 39.986s (32.37×)  | 122.138s (87.62×)  | 10940 MB (8.97×)   |


