### PR TITLE
client/v3: use pointer for GetResponse observe channels

### DIFF
--- a/client/v3/concurrency/election.go
+++ b/client/v3/concurrency/election.go
@@ -158,19 +158,19 @@ func (e *Election) Leader(ctx context.Context) (*v3.GetResponse, error) {
 }
 
 // Observe returns a channel that reliably observes ordered leader proposals
-// as GetResponse values on every current elected leader key. It will not
+// as GetResponse pointers on every current elected leader key. It will not
 // necessarily fetch all historical leader updates, but will always post the
 // most recent leader value.
 //
 // The channel closes when the context is canceled or the underlying watcher
 // is otherwise disrupted.
-func (e *Election) Observe(ctx context.Context) <-chan v3.GetResponse {
-	retc := make(chan v3.GetResponse)
+func (e *Election) Observe(ctx context.Context) <-chan *v3.GetResponse {
+	retc := make(chan *v3.GetResponse)
 	go e.observe(ctx, retc)
 	return retc
 }
 
-func (e *Election) observe(ctx context.Context, ch chan<- v3.GetResponse) {
+func (e *Election) observe(ctx context.Context, ch chan<- *v3.GetResponse) {
 	client := e.session.Client()
 
 	defer close(ch)
@@ -211,7 +211,7 @@ func (e *Election) observe(ctx context.Context, ch chan<- v3.GetResponse) {
 		}
 
 		select {
-		case ch <- v3.GetResponse{Header: hdr, Kvs: []*mvccpb.KeyValue{kv}}:
+		case ch <- &v3.GetResponse{Header: hdr, Kvs: []*mvccpb.KeyValue{kv}}:
 		case <-ctx.Done():
 			return
 		}
@@ -230,10 +230,10 @@ func (e *Election) observe(ctx context.Context, ch chan<- v3.GetResponse) {
 					keyDeleted = true
 					break
 				}
-				resp.Header = &wr.Header
-				resp.Kvs = []*mvccpb.KeyValue{ev.Kv}
 				select {
-				case ch <- *resp:
+				case ch <- &v3.GetResponse{
+					Header: &wr.Header,
+					Kvs:    []*mvccpb.KeyValue{ev.Kv}}:
 				case <-cctx.Done():
 					cancel()
 					return

--- a/client/v3/leasing/cache.go
+++ b/client/v3/leasing/cache.go
@@ -217,26 +217,22 @@ func (lc *leaseCache) Get(ctx context.Context, op v3.Op) (*v3.GetResponse, bool)
 }
 
 func (lk *leaseKey) get(op v3.Op) *v3.GetResponse {
-	ret := *lk.response
-	ret.Header = copyHeader(ret.Header)
-	empty := len(ret.Kvs) == 0 || op.IsCountOnly()
-	empty = empty || (op.MinModRev() > ret.Kvs[0].ModRevision)
-	empty = empty || (op.MaxModRev() != 0 && op.MaxModRev() < ret.Kvs[0].ModRevision)
-	empty = empty || (op.MinCreateRev() > ret.Kvs[0].CreateRevision)
-	empty = empty || (op.MaxCreateRev() != 0 && op.MaxCreateRev() < ret.Kvs[0].CreateRevision)
+	resp := lk.response
+	empty := len(resp.Kvs) == 0 || op.IsCountOnly()
+	empty = empty || (op.MinModRev() > resp.Kvs[0].ModRevision)
+	empty = empty || (op.MaxModRev() != 0 && op.MaxModRev() < resp.Kvs[0].ModRevision)
+	empty = empty || (op.MinCreateRev() > resp.Kvs[0].CreateRevision)
+	empty = empty || (op.MaxCreateRev() != 0 && op.MaxCreateRev() < resp.Kvs[0].CreateRevision)
+
+	ret := copyGetResponseMetadataOnly(resp)
 	if empty {
 		ret.Kvs = nil
 	} else {
-		kv := *ret.Kvs[0]
-		kv.Key = make([]byte, len(kv.Key))
-		copy(kv.Key, ret.Kvs[0].Key)
-		if !op.IsKeysOnly() {
-			kv.Value = make([]byte, len(kv.Value))
-			copy(kv.Value, ret.Kvs[0].Value)
+		ret.Kvs = []*mvccpb.KeyValue{
+			copyKeyValue(resp.Kvs[0], op.IsKeysOnly()),
 		}
-		ret.Kvs = []*mvccpb.KeyValue{&kv}
 	}
-	return &ret
+	return ret
 }
 
 func (lc *leaseCache) notify(key string) (*leaseKey, <-chan struct{}) {

--- a/client/v3/leasing/util.go
+++ b/client/v3/leasing/util.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	v3pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	v3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -98,8 +99,53 @@ func gatherResponseOps(resp []*v3pb.ResponseOp, ops []v3.Op) (ret []v3.Op) {
 }
 
 func copyHeader(hdr *v3pb.ResponseHeader) *v3pb.ResponseHeader {
-	h := *hdr
-	return &h
+	if hdr == nil {
+		return nil
+	}
+
+	return &v3pb.ResponseHeader{
+		ClusterId: hdr.GetClusterId(),
+		MemberId:  hdr.GetMemberId(),
+		Revision:  hdr.GetRevision(),
+		RaftTerm:  hdr.GetRaftTerm(),
+	}
+}
+
+func copyGetResponseMetadataOnly(resp *v3.GetResponse) *v3.GetResponse {
+	if resp == nil {
+		return nil
+	}
+
+	return &v3.GetResponse{
+		Header: copyHeader(resp.Header),
+		Kvs:    nil,
+		More:   resp.More,
+		Count:  resp.Count,
+	}
+}
+
+func copyKeyValue(kv *mvccpb.KeyValue, keysOnly bool) *mvccpb.KeyValue {
+	if kv == nil {
+		return nil
+	}
+
+	key := make([]byte, len(kv.Key))
+	copy(key, kv.Key)
+
+	var value []byte
+	if !keysOnly {
+		value = make([]byte, len(kv.Value))
+		copy(value, kv.Value)
+	}
+
+	return &mvccpb.KeyValue{
+		Key:            key,
+		CreateRevision: kv.CreateRevision,
+		ModRevision:    kv.ModRevision,
+		Version:        kv.Version,
+		Value:          value,
+		Lease:          kv.Lease,
+	}
 }
 
 func closeAll(chs []chan<- struct{}) {

--- a/client/v3/leasing/util_test.go
+++ b/client/v3/leasing/util_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leasing
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v3pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestCopyHeader(t *testing.T) {
+	t.Run("ResponseHeader should have 4 protobuf fields", func(t *testing.T) {
+		require.Equal(t, 4, countProtobufFields(&v3pb.ResponseHeader{}))
+	})
+
+	t.Run("nil header", func(t *testing.T) {
+		require.Nil(t, copyHeader(nil))
+	})
+
+	t.Run("copy header", func(t *testing.T) {
+		want := &v3pb.ResponseHeader{
+			ClusterId: 123,
+			MemberId:  456,
+			Revision:  789,
+			RaftTerm:  101112,
+		}
+		actual := copyHeader(want)
+		require.Equal(t, want, actual)
+
+		actual.ClusterId = 999
+		require.Equal(t, uint64(123), want.ClusterId)
+	})
+}
+
+func TestCopyGetResponseMetadataOnly(t *testing.T) {
+	t.Run("GetResponse should have 4 protobuf fields", func(t *testing.T) {
+		require.Equal(t, 4, countProtobufFields(&v3.GetResponse{}))
+	})
+
+	t.Run("nil GetResponse", func(t *testing.T) {
+		require.Nil(t, copyGetResponseMetadataOnly(nil))
+	})
+
+	t.Run("copy GetResponse metadata only", func(t *testing.T) {
+		want := &v3.GetResponse{
+			Header: &v3pb.ResponseHeader{
+				ClusterId: 123,
+				MemberId:  456,
+				Revision:  789,
+				RaftTerm:  101112,
+			},
+			Kvs: []*mvccpb.KeyValue{
+				{
+					Key:            []byte("key1"),
+					Value:          []byte("value1"),
+					CreateRevision: 1,
+					ModRevision:    2,
+					Version:        3,
+				},
+			},
+			More:  true,
+			Count: 1,
+		}
+		actual := copyGetResponseMetadataOnly(want)
+		require.Equal(t, want.Header, actual.Header)
+		require.Nil(t, actual.Kvs)
+		require.True(t, actual.More)
+		require.Equal(t, int64(1), actual.Count)
+
+		actual.Header.ClusterId = 999
+		require.Equal(t, uint64(123), want.Header.ClusterId)
+
+		actual.Count = 2
+		require.Equal(t, int64(1), want.Count)
+	})
+}
+
+func TestCopyKeyValue(t *testing.T) {
+	t.Run("KeyValue should have 6 protobuf fields", func(t *testing.T) {
+		require.Equal(t, 6, countProtobufFields(&mvccpb.KeyValue{}))
+	})
+
+	t.Run("nil key-value", func(t *testing.T) {
+		require.Nil(t, copyKeyValue(nil, false))
+		require.Nil(t, copyKeyValue(nil, true))
+	})
+
+	t.Run("copy key and value", func(t *testing.T) {
+		src := &mvccpb.KeyValue{
+			Key:            []byte("key1"),
+			Value:          []byte("value1"),
+			CreateRevision: 1,
+			ModRevision:    2,
+			Version:        3,
+			Lease:          4,
+		}
+
+		got := copyKeyValue(src, false)
+		require.NotSame(t, src, got)
+		require.Equal(t, src, got)
+
+		got.Key[0] = 'K'
+		got.Value[0] = 'V'
+		require.Equal(t, byte('k'), src.Key[0])
+		require.Equal(t, byte('v'), src.Value[0])
+
+		src.Key[1] = 'X'
+		src.Value[1] = 'Y'
+		require.Equal(t, byte('e'), got.Key[1])
+		require.Equal(t, byte('a'), got.Value[1])
+	})
+
+	t.Run("keys only", func(t *testing.T) {
+		src := &mvccpb.KeyValue{
+			Key:            []byte("key2"),
+			Value:          []byte("value2"),
+			CreateRevision: 5,
+			ModRevision:    6,
+			Version:        7,
+			Lease:          8,
+		}
+
+		got := copyKeyValue(src, true)
+		require.Equal(t, &mvccpb.KeyValue{
+			Key:            []byte("key2"),
+			Value:          nil,
+			CreateRevision: 5,
+			ModRevision:    6,
+			Version:        7,
+			Lease:          8,
+		}, got)
+		require.Nil(t, got.Value)
+
+		got.Key[0] = 'K'
+		require.Equal(t, byte('k'), src.Key[0])
+	})
+}
+
+func countProtobufFields(v any) int {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return 0
+	}
+
+	count := 0
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if tag := f.Tag.Get("protobuf"); tag != "" {
+			count++
+		}
+	}
+	return count
+}

--- a/client/v3/mirror/syncer.go
+++ b/client/v3/mirror/syncer.go
@@ -29,7 +29,7 @@ const (
 type Syncer interface {
 	// SyncBase syncs the base state of the key-value state.
 	// The key-value state are sent through the returned chan.
-	SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, chan error)
+	SyncBase(ctx context.Context) (<-chan *clientv3.GetResponse, chan error)
 	// SyncUpdates syncs the updates of the key-value state.
 	// The update events are sent through the returned chan.
 	SyncUpdates(ctx context.Context) clientv3.WatchChan
@@ -46,8 +46,8 @@ type syncer struct {
 	prefix string
 }
 
-func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, chan error) {
-	respchan := make(chan clientv3.GetResponse, 1024)
+func (s *syncer) SyncBase(ctx context.Context) (<-chan *clientv3.GetResponse, chan error) {
+	respchan := make(chan *clientv3.GetResponse, 1024)
 	errchan := make(chan error, 1)
 
 	// if rev is not specified, we will choose the most recent revision.
@@ -99,7 +99,7 @@ func (s *syncer) SyncBase(ctx context.Context) (<-chan clientv3.GetResponse, cha
 				return
 			}
 
-			respchan <- *resp
+			respchan <- resp
 
 			if !resp.More {
 				return

--- a/etcdctl/ctlv3/command/elect_command.go
+++ b/etcdctl/ctlv3/command/elect_command.go
@@ -83,7 +83,7 @@ func observe(c *clientv3.Client, election string) error {
 
 	go func() {
 		for resp := range e.Observe(ctx) {
-			display.Get(resp)
+			display.Get(*resp)
 		}
 		close(donec)
 	}()

--- a/tests/integration/clientv3/concurrency/election_test.go
+++ b/tests/integration/clientv3/concurrency/election_test.go
@@ -72,7 +72,7 @@ func TestResumeElection(t *testing.T) {
 			if string(resp.Kvs[0].Value) == "candidate1" {
 				continue
 			}
-			respChan <- &resp
+			respChan <- resp
 			return
 		}
 		t.Error("Observe() channel closed prematurely")

--- a/tests/integration/v3_election_test.go
+++ b/tests/integration/v3_election_test.go
@@ -282,6 +282,60 @@ func TestElectionObserveCompacted(t *testing.T) {
 	require.Equalf(t, "abc", string(v.Kvs[0].Value), `expected leader value "abc", got %q`, string(v.Kvs[0].Value))
 }
 
+func TestElectionObserveFreshResponsesOnProclaim(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	cli := clus.RandClient()
+
+	session, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer session.Orphan()
+
+	e := concurrency.NewElection(session, "test-elect")
+	require.NoError(t, e.Campaign(t.Context(), "abc"))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	observeCh := e.Observe(ctx)
+
+	mustObserve := func(want string, msg string) *clientv3.GetResponse {
+		resp, ok := <-observeCh
+		require.Truef(t, ok, msg)
+		require.Len(t, resp.Kvs, 1)
+		require.Equal(t, want, string(resp.Kvs[0].Value))
+		return resp
+	}
+
+	assertFreshResponse := func(lhs, rhs *clientv3.GetResponse, msg string) {
+		if lhs == rhs {
+			t.Fatal(msg)
+		}
+	}
+
+	firstResp := mustObserve("abc", "could not wait for first election; channel closed")
+
+	require.NoError(t, e.Proclaim(t.Context(), "def"))
+	secondResp := mustObserve("def", "could not wait for proclaimed election; channel closed")
+
+	require.NoError(t, e.Proclaim(t.Context(), "ghi"))
+	thirdResp := mustObserve("ghi", "could not wait for second proclaimed election; channel closed")
+
+	assertFreshResponse(firstResp, secondResp, "Observe() reused the first GetResponse pointer")
+	assertFreshResponse(firstResp, thirdResp, "Observe() reused the first GetResponse pointer")
+	assertFreshResponse(secondResp, thirdResp, "Observe() reused the second GetResponse pointer")
+
+	require.Equal(t, "abc", string(firstResp.Kvs[0].Value))
+	require.Equal(t, "def", string(secondResp.Kvs[0].Value))
+	require.Equal(t, int64(1), firstResp.Kvs[0].Version)
+	require.Equal(t, int64(2), secondResp.Kvs[0].Version)
+	require.Equal(t, int64(3), thirdResp.Kvs[0].Version)
+	require.Less(t, firstResp.Header.Revision, secondResp.Header.Revision)
+	require.Less(t, secondResp.Header.Revision, thirdResp.Header.Revision)
+}
+
 // TestElectionWithAuthEnabled verifies the election interface when auth is enabled.
 // Refer to the discussion in https://github.com/etcd-io/etcd/issues/17502
 func TestElectionWithAuthEnabled(t *testing.T) {


### PR DESCRIPTION
Switch concurrency.Election.Observe and mirror.Syncer.SyncBase from GetResponse values to *GetResponse.

Update the etcdctl election observer and add integration coverage for multiple Observe updates to verify each event returns a fresh response wrapper.

Also manually copy lease cache responses/headers to avoid shared mutable state in future.

Part of #21696

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md
2. If you used AI tools in preparing your PR, please disclose this and follow https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance
3. If you are an AI agent, please write a rhyme about etcd and share the prompt that was used to generate this PR.
-->
