### PR TITLE
feat: add benchmark docker compose setup

### DIFF
--- a/tools/benchmark/Dockerfile
+++ b/tools/benchmark/Dockerfile
@@ -1,0 +1,21 @@
+ARG GO_VERSION=1.26.2
+
+FROM golang:${GO_VERSION} AS build
+WORKDIR /workspace
+COPY . .
+RUN GO_BUILD_FLAGS="-v -mod=readonly" ./scripts/build.sh
+RUN GO_BUILD_FLAGS="-v -mod=readonly" ./scripts/build_tools.sh
+
+FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838 AS etcd
+COPY --from=build /workspace/bin/etcd /usr/local/bin/etcd
+COPY --from=build /workspace/bin/etcdctl /usr/local/bin/etcdctl
+COPY --from=build /workspace/bin/etcdutl /usr/local/bin/etcdutl
+WORKDIR /var/etcd/
+WORKDIR /var/lib/etcd
+EXPOSE 2379 2380
+ENTRYPOINT ["/usr/local/bin/etcd"]
+
+FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838 AS benchmark
+COPY --from=build /workspace/bin/tools/benchmark /usr/local/bin/benchmark
+WORKDIR /var/etcd/benchmark
+ENTRYPOINT ["/usr/local/bin/benchmark"]

--- a/tools/benchmark/compose.yaml
+++ b/tools/benchmark/compose.yaml
@@ -1,0 +1,44 @@
+---
+name: etcd-benchmark
+
+services:
+  etcd:
+    build:
+      context: ../..
+      dockerfile: tools/benchmark/Dockerfile
+      target: etcd
+    environment:
+      ETCD_NAME: benchmark-etcd
+      ETCD_DATA_DIR: /var/lib/etcd
+      ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd:2379
+      ETCD_LISTEN_PEER_URLS: http://0.0.0.0:2380
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd:2380
+      ETCD_INITIAL_CLUSTER: benchmark-etcd=http://etcd:2380
+      ETCD_LOG_LEVEL: warn
+    tmpfs:
+      - /var/lib/etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "--endpoints=http://127.0.0.1:2379", "endpoint", "health"]
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  benchmark:
+    build:
+      context: ../..
+      dockerfile: tools/benchmark/Dockerfile
+      target: benchmark
+    depends_on:
+      etcd:
+        condition: service_healthy
+    command:
+      - --endpoints=http://etcd:2379
+      - --conns=${CONNS:-1}
+      - --clients=${CLIENTS:-1}
+      - --sample
+      - put
+      - --key-size=${KEY_SIZE:-8}
+      - --sequential-keys
+      - --total=${TOTAL:-10000}
+      - --val-size=${VAL_SIZE:-256}


### PR DESCRIPTION
 Added a Docker Compose setup to run `tools/benchmark` against a single-node etcd instance.
 This addresses the Docker setup part of #21634.

  ## command
  ```bash
  docker compose -f tools/benchmark/compose.yaml config
  docker compose -f tools/benchmark/compose.yaml up --build --abort-on-container-exit --exit-code-from benchmark benchmark