### PR TITLE
scripts: fix SC2268 shellcheck warning in test_lib.sh

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -497,7 +497,7 @@ function git_assert_branch_in_sync {
   if [ -n "${branch}" ]; then
     ref_local=$(run git rev-parse "${branch}")
     ref_origin=$(run git rev-parse "origin/${branch}")
-    if [ "x${ref_local}" != "x${ref_origin}" ]; then
+    if [ "${ref_local}" != "${ref_origin}" ]; then
       log_error "In workspace '$(pwd)' the branch: ${branch} diverges from the origin."
       log_error "Consider cleaning up / renaming this directory or (cd $(pwd) && git reset --hard origin/${branch})"
       return 2


### PR DESCRIPTION
Remove x-prefix pattern in comparison that is no longer needed in modern shells as per shellcheck SC2268.

Fixes #21710 