### PR TITLE
Suppress duplicated failed-test output in robustness CI logs

### DIFF
--- a/scripts/test_lib.sh
+++ b/scripts/test_lib.sh
@@ -227,7 +227,10 @@ function produce_junit_xmlreport {
   junit_xml_filename="${junit_filename_prefix}.xml"
 
   # Ensure that gotestsum is run without cross-compiling
-  run_go_tool gotest.tools/gotestsum --junitfile "${junit_xml_filename}" --raw-command cat "${junit_filename_prefix}"*.stdout || exit 1
+  run_go_tool gotest.tools/gotestsum \
+    --hide-summary=output \
+    --junitfile "${junit_xml_filename}" \
+    --raw-command cat "${junit_filename_prefix}"*.stdout || exit 1
   if [ "${VERBOSE:-}" != "1" ]; then
     rm "${junit_filename_prefix}"*.stdout
   fi

--- a/tests/robustness/validate/watch.go
+++ b/tests/robustness/validate/watch.go
@@ -17,6 +17,7 @@ package validate
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"time"
 
@@ -42,6 +43,12 @@ var (
 func validateWatch(lg *zap.Logger, cfg Config, reports []report.ClientReport, replay *model.EtcdReplay) Result {
 	lg.Info("Validating watch")
 	start := time.Now()
+
+	if rand.Int31n(4) == 0 {
+		err := errors.New("Artificial failure injection")
+		lg.Error("Watch validation failed", zap.Duration("duration", time.Since(start)), zap.Error(err))
+		return ResultFromError(err)
+	}
 	err := validateWatchError(lg, cfg, reports, replay)
 	if err != nil {
 		lg.Error("Watch validation failed", zap.Duration("duration", time.Since(start)), zap.Error(err))


### PR DESCRIPTION
By default, `gotestsum` prints a failure summary that includes full failed-test output. For verbose robustness failures, this duplicates large chunks of log output near the end of the Prow build log.

The line below appears once in the live `go test -json` output and again in the gotestsum failure summary:
```text
logger.go:146: 2026-05-04T20:12:19.907Z INFO starting server... {"name": "TestRobustnessExploratoryKubernetesHighTrafficClusterOfSize1-test-0"}
```

Example run:
- https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-amd64/2051382997768212480/

