### PR TITLE
Leverage StepContext to mitigate linearization timeout issue in Robustness test

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -106,3 +106,5 @@ require (
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/anishathalye/porcupine => github.com/henrybear327/porcupine v0.0.0-20260506075837-cd3def88aca3

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,7 +1,5 @@
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
-github.com/anishathalye/porcupine v1.1.0 h1:jkMLqDejaWqvhvjxYKyqwQO3d1Jw+/08wHiIw0O4wcU=
-github.com/anishathalye/porcupine v1.1.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/antithesishq/antithesis-sdk-go v0.4.3 h1:a2hGdDogClzHzFu20r1z0tzD6zwSWUipiaerAjZVP90=
 github.com/antithesishq/antithesis-sdk-go v0.4.3/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -56,6 +54,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajR
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
+github.com/henrybear327/porcupine v0.0.0-20260506075837-cd3def88aca3 h1:8Mjo8E9bXtODNGP3/surqPqFBepLgMGGkPfJirDLsoE=
+github.com/henrybear327/porcupine v0.0.0-20260506075837-cd3def88aca3/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -44,8 +45,15 @@ var DeterministicModel = func(keys []string) porcupine.Model {
 		Init: func() any {
 			return freshEtcdState(keys)
 		},
-		Step: func(st any, in any, out any) (bool, any) {
-			return st.(EtcdState).apply(in.(EtcdRequest), out.(EtcdResponse))
+		StepContext: func(ctx context.Context, st any, in any, out any) (bool, any) {
+			if ctx.Err() != nil {
+				return false, nil
+			}
+			ok, newState := st.(EtcdState).apply(in.(EtcdRequest), out.(EtcdResponse))
+			if ctx.Err() != nil {
+				return false, nil
+			}
+			return ok, newState
 		},
 		Equal: func(st1, st2 any) bool {
 			return st1.(EtcdState).Equal(st2.(EtcdState))

--- a/tests/robustness/model/deterministic_test.go
+++ b/tests/robustness/model/deterministic_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"context"
 	"math/rand"
 	"slices"
 	"testing"
@@ -32,7 +33,7 @@ func TestModelDeterministic(t *testing.T) {
 			model := DeterministicModel(keys)
 			state := model.Init()
 			for _, op := range tc.operations {
-				ok, newState := model.Step(state, op.req, op.resp.EtcdResponse)
+				ok, newState := model.StepContext(context.Background(), state, op.req, op.resp.EtcdResponse)
 				if op.expectFailure == ok {
 					t.Logf("state: %v", state)
 					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.expectFailure, ok, model.DescribeOperation(op.req, op.resp.EtcdResponse))

--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -32,8 +33,8 @@ var NonDeterministicModel = func(keys []string) porcupine.Model {
 		Init: func() any {
 			return nonDeterministicState{freshEtcdState(keys)}
 		},
-		Step: func(st any, in any, out any) (bool, any) {
-			return st.(nonDeterministicState).apply(in.(EtcdRequest), out.(MaybeEtcdResponse))
+		StepContext: func(ctx context.Context, st any, in any, out any) (bool, any) {
+			return st.(nonDeterministicState).applyContext(ctx, in.(EtcdRequest), out.(MaybeEtcdResponse))
 		},
 		Equal: func(st1, st2 any) bool {
 			return st1.(nonDeterministicState).Equal(st2.(nonDeterministicState))
@@ -145,49 +146,85 @@ func compareStates(first, second EtcdState) int {
 	return 0
 }
 
-func (states nonDeterministicState) apply(request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
+func (states nonDeterministicState) applyContext(ctx context.Context, request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
+	if ctx.Err() != nil {
+		return false, nil
+	}
 	var newStates nonDeterministicState
 	switch {
 	case response.Error != "":
-		newStates = states.applyFailedRequest(request)
+		newStates = states.applyFailedRequestContext(ctx, request)
 	case response.Persisted && response.PersistedRevision == 0:
-		newStates = states.applyPersistedRequest(request)
+		newStates = states.applyPersistedRequestContext(ctx, request)
 	case response.Persisted && response.PersistedRevision != 0:
-		newStates = states.applyPersistedRequestWithRevision(request, response.PersistedRevision)
+		newStates = states.applyPersistedRequestWithRevisionContext(ctx, request, response.PersistedRevision)
 	default:
-		newStates = states.applyRequestWithResponse(request, response.EtcdResponse)
+		newStates = states.applyRequestWithResponseContext(ctx, request, response.EtcdResponse)
+	}
+	if ctx.Err() != nil {
+		return false, nil
 	}
 	return len(newStates) > 0, newStates
 }
 
-// applyFailedRequest returns both the original states and states with applied request. It considers both cases, request was persisted and request was lost.
-func (states nonDeterministicState) applyFailedRequest(request EtcdRequest) nonDeterministicState {
+// applyFailedRequestContext returns both the original states and states with applied request. It considers both cases, request was persisted and request was lost.
+func (states nonDeterministicState) applyFailedRequestContext(ctx context.Context, request EtcdRequest) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states)*2)
 	for _, s := range states {
+		if ctx.Err() != nil {
+			return nil
+		}
 		newStates = append(newStates, s)
 		newState, _ := s.Step(request)
+		if ctx.Err() != nil {
+			return nil
+		}
 		if !newState.Equal(s) {
+			if ctx.Err() != nil {
+				return nil
+			}
 			newStates = append(newStates, newState)
 		}
 	}
 	return newStates
 }
 
-// applyPersistedRequest applies request to all possible states.
-func (states nonDeterministicState) applyPersistedRequest(request EtcdRequest) nonDeterministicState {
+// applyPersistedRequestContext applies request to all possible states.
+func (states nonDeterministicState) applyPersistedRequestContext(ctx context.Context, request EtcdRequest) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if ctx.Err() != nil {
+			return nil
+		}
 		newState, _ := s.Step(request)
+		if ctx.Err() != nil {
+			return nil
+		}
 		newStates = append(newStates, newState)
 	}
 	return newStates
 }
 
-// applyPersistedRequestWithRevision applies request to all possible states, but leaves only states that would return proper revision.
-func (states nonDeterministicState) applyPersistedRequestWithRevision(request EtcdRequest, responseRevision int64) nonDeterministicState {
+// applyPersistedRequestWithRevisionContext applies request to all possible states, but leaves only states that would return proper revision.
+func (states nonDeterministicState) applyPersistedRequestWithRevisionContext(ctx context.Context, request EtcdRequest, responseRevision int64) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if ctx.Err() != nil {
+			return nil
+		}
 		newState, modelResponse := s.Step(request)
+		if ctx.Err() != nil {
+			return nil
+		}
 		if modelResponse.Revision == responseRevision {
 			newStates = append(newStates, newState)
 		}
@@ -195,12 +232,24 @@ func (states nonDeterministicState) applyPersistedRequestWithRevision(request Et
 	return newStates
 }
 
-// applyRequestWithResponse applies request to all possible states, but leaves only state that would return proper response.
-func (states nonDeterministicState) applyRequestWithResponse(request EtcdRequest, response EtcdResponse) nonDeterministicState {
+// applyRequestWithResponseContext applies request to all possible states, but leaves only state that would return proper response.
+func (states nonDeterministicState) applyRequestWithResponseContext(ctx context.Context, request EtcdRequest, response EtcdResponse) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if ctx.Err() != nil {
+			return nil
+		}
 		newState, modelResponse := s.Step(request)
+		if ctx.Err() != nil {
+			return nil
+		}
 		if Match(modelResponse, MaybeEtcdResponse{EtcdResponse: response}) {
+			if ctx.Err() != nil {
+				return nil
+			}
 			newStates = append(newStates, newState)
 		}
 	}

--- a/tests/robustness/model/non_deterministic_test.go
+++ b/tests/robustness/model/non_deterministic_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -330,7 +331,7 @@ func TestModelNonDeterministic(t *testing.T) {
 			model := NonDeterministicModel(keys)
 			state := model.Init()
 			for _, op := range tc.operations {
-				ok, newState := model.Step(state, op.req, op.resp)
+				ok, newState := model.StepContext(context.Background(), state, op.req, op.resp)
 				if ok != !op.expectFailure {
 					t.Logf("state: %v", state)
 					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.expectFailure, ok, model.DescribeOperation(op.req, op.resp))
@@ -347,6 +348,31 @@ func TestModelNonDeterministic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestModelNonDeterministicStepContextCancellation(t *testing.T) {
+	model := NonDeterministicModel([]string{"key"})
+	state := model.Init()
+	request := putRequest("key", "1")
+	response := failedResponse(errors.New("failed"))
+
+	ok, nextState := model.StepContext(context.Background(), state, request, response)
+	if !ok {
+		t.Fatal("expected uncanceled context to allow state expansion")
+	}
+	if got := len(nextState.(nonDeterministicState)); got != 2 {
+		t.Fatalf("expected failed request to expand into 2 states, got %d", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, nextState = model.StepContext(ctx, state, request, response)
+	if ok {
+		t.Fatal("expected canceled context to stop state expansion")
+	}
+	if got := len(nextState.(nonDeterministicState)); got != 0 {
+		t.Fatalf("expected canceled context to return no states, got %d", got)
 	}
 }
 

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -294,6 +294,73 @@ func keyValueRevision(key, value string, rev int64) model.KeyValue {
 	}
 }
 
+func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
+	timeout := time.Second
+	const failedPutCount = 17
+	// Repeat the range read to make the final applyRequestWithResponse step slow.
+	const rangeReadCount = 3072
+
+	history := []porcupine.Operation{}
+	for i := 0; i < failedPutCount; i++ {
+		history = append(history, porcupine.Operation{
+			ClientId: i,
+			Input:    putRequest(fmt.Sprintf("failed%03d", i), "value"),
+			Output:   errorResponse(fmt.Errorf("timeout")),
+			Call:     int64(i),
+			Return:   int64(failedPutCount + i),
+		})
+	}
+
+	rangeOperations := make([]model.EtcdOperation, 0, rangeReadCount)
+	for i := 0; i < rangeReadCount; i++ {
+		rangeOperations = append(rangeOperations, model.EtcdOperation{
+			Type: model.RangeOperation,
+			Range: model.RangeOptions{
+				Start: "failed",
+				End:   "faile~",
+			},
+		})
+	}
+	readRequest := model.EtcdRequest{
+		Type: model.Txn,
+		Txn: &model.TxnRequest{
+			OperationsOnSuccess: rangeOperations,
+		},
+	}
+
+	// Each failed put can be lost or persisted, so the large read-only
+	// transaction reaches applyRequestWithResponse with many possible states in
+	// a single Step call.
+	replay := model.NewReplayFromOperations(history)
+	state, err := replay.StateForRevision(failedPutCount + 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, readResponse := state.Step(readRequest)
+	history = append(history, porcupine.Operation{
+		ClientId: failedPutCount,
+		Input:    readRequest,
+		Output:   readResponse,
+		Call:     int64(2 * failedPutCount),
+		Return:   int64(2*failedPutCount + 1),
+	})
+	keys := model.ModelKeys(history)
+
+	start := time.Now()
+	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, timeout)
+	elapsed := time.Since(start)
+
+	if !result.Timeout {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) timed out = false, message = %q", result.Message)
+	}
+	if result.Message != "timed out" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "timed out")
+	}
+	if elapsed > timeout+250*time.Millisecond {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) does not respect timeout: %v, timeout was %v", elapsed, timeout)
+	}
+}
+
 func BenchmarkValidateLinearizableOperations(b *testing.B) {
 	lg := zap.NewNop()
 	b.Run("SequentialSuccessPuts", func(b *testing.B) {


### PR DESCRIPTION
We have been seeing quite some examples during the robustness test debugging that the linearization timeout isn't respected.

The root cause is that the porcupine `Step` interface currently doesn't have a way to propagate timeout information to the interface implementation. Under certain condition as mentioned in https://github.com/anishathalye/porcupine/issues/44, we can run into situations that the validation timeout is not respected, causing the robustness test CI to fail (timeout or OOM).

This PR attempts to resolve this by switching to using the new `StepContext` interface.

We can only merge this PR after https://github.com/anishathalye/porcupine/pull/45 is merged. Currently, the PR is based on my commit for testing purposes.

Additional context: https://github.com/etcd-io/etcd/pull/21606