### PR TITLE
add beforeRangeStreamChunk gofail point

### DIFF
--- a/server/etcdserver/v3_server.go
+++ b/server/etcdserver/v3_server.go
@@ -219,6 +219,7 @@ func (s *EtcdServer) rangeStream(ctx context.Context, r *pb.RangeRequest, rs pb.
 	count := int64(0)
 	var headerRev int64
 	for {
+		// gofail: var beforeRangeStreamChunk struct{}
 		resp, _, err := txn.Range(ctx, s.Logger(), s.KV(), r, false)
 		if err != nil {
 			return err

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -42,6 +42,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
+	gofail "go.etcd.io/gofail/runtime"
 )
 
 // TestV3PutOverwrite puts a key with the v3 api to a random Cluster member,
@@ -1771,6 +1772,7 @@ func TestV3RangeStreamWriteBetweenChunks(t *testing.T) {
 	}
 
 	integration.BeforeTest(t)
+	integration.SkipIfNoGoFail(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
@@ -1787,6 +1789,10 @@ func TestV3RangeStreamWriteBetweenChunks(t *testing.T) {
 		require.NoError(t, err)
 		pinnedRev = resp.Header.Revision
 	}
+
+	// Sleep between chunks to prevent gRPC queueing.
+	require.NoError(t, gofail.Enable("beforeRangeStreamChunk", `sleep("1s")`))
+	defer func() { require.NoError(t, gofail.Disable("beforeRangeStreamChunk")) }()
 
 	stream, err := kvc.RangeStream(t.Context(), &pb.RangeRequest{
 		Key:      []byte("k00"),


### PR DESCRIPTION
It seems like gRPC queues chunks so the put isn't actually lnterleaved between the chunk calls as server could have already processed them but it's just backlogged because client has a pause on calling `Recv()`