### PR TITLE
etcdserver: set etcd_cluster_version version metric in Recover()

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -297,6 +297,7 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 			"set cluster version from store",
 			zap.String("cluster-version", version.Cluster(c.version.String())),
 		)
+		ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(c.version.String())}).Set(1)
 	}
 }
 


### PR DESCRIPTION
### Summary

Fixes #18805

During a rolling deployment of etcd 3.6.0 (deploying the same version again, not an upgrade) we see 
```
Host 1: starting etcd server - cluster-version: to_be_decided 
Host 1: set cluster version from store - cluster-version: 3.6 
...
Host 2: starting etcd server - cluster-version: to_be_decided 
Host 2: set cluster version from store - cluster-version: 3.6 
...
Host 3: starting etcd server - cluster-version: to_be_decided 
Host 3: set cluster version from store - cluster-version: 3.6 
...
```
And so on. However, once the rolling-deploy is complete, we find that the cluster_version metric is not being emitted:

```
root@etcd-host-2:/# curl -s localhost:2379/metrics | grep "server_version"
'server_version' label with current version.
etcd_server_version{server_version="3.6.0"} 1
root@etcd-host-2:/# curl -s localhost:2379/metrics | grep "cluster_version"
root@etcd-host-2:/#
```

It appears we are missing the call to actually set the metric once we determine it in the recover() path, via applySnapshot().

### Background
We are experiencing this ourselves in production, and came across #18805 which appears was never resolved. It appears the only places that emit this metric are in `Start()` if `s.ClusterVersion()` is non-nil then. According to our logs, it is `nil` then on startup, given we see the `to_be_decided` message from this branch in `server.go`:
```
	if s.ClusterVersion() != nil {
		lg.Info(
			"starting etcd server",
			zap.String("local-member-id", s.MemberID().String()),
			zap.String("local-server-version", version.Version),
			zap.String("cluster-id", s.Cluster().ID().String()),
			zap.String("cluster-version", version.Cluster(s.ClusterVersion().String())),
		)
		membership.ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(s.ClusterVersion().String())}).Set(1)
	} else {
		lg.Info(
			"starting etcd server",
			zap.String("local-member-id", s.MemberID().String()),
			zap.String("local-server-version", version.Version),
			zap.String("cluster-version", "to_be_decided"), <--- this is what we see in the logs
		)
	}
```

The only other place this gets set today is in `SetVersion` from `cluster.go` which handles going between versions, if I'm not mistaken:
```
if oldVer != nil {
	ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(oldVer.String())}).Set(0)
}
ClusterVersionMetrics.With(prometheus.Labels{"cluster_version": version.Cluster(ver.String())}).Set(1)
```

And `SetVersion` is only called when the leader (via `monitorClusterVersions()`) determines the version should change, like if we did an upgrade, and in `err := monitor.UpdateClusterVersionIfNeeded()`.

So the bug is just that we're missing the steady-state case where we need to restore the version.