### PR TITLE
Remove obsolete k8s feature gate

### DIFF
--- a/tests/robustness/coverage/kind-with-tracing.yaml
+++ b/tests/robustness/coverage/kind-with-tracing.yaml
@@ -1,8 +1,6 @@
 ---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  "APIServerTracing": true
 nodes:
   - role: control-plane
     extraMounts:


### PR DESCRIPTION
It was deleted in https://github.com/kubernetes/kubernetes/pull/138907

/cc @serathius 