### PR TITLE
clientv3: don't log warn/error for expected context cancellation on shutdown

### DIFF
--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -65,6 +65,14 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 			if lastErr == nil {
 				return nil
 			}
+			if isContextError(lastErr) {
+				if ctx.Err() != nil {
+					// parent context is done (e.g. client.Close()), this is expected
+					return lastErr
+				}
+				// callCtx deadline or cancellation, retry without logging
+				continue
+			}
 			c.GetLogger().Warn(
 				"retrying of unary invoker failed",
 				zap.String("target", cc.Target()),
@@ -73,14 +81,6 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 				zap.Uint("attempt", attempt),
 				zap.Error(lastErr),
 			)
-			if isContextError(lastErr) {
-				if ctx.Err() != nil {
-					// its the context deadline or cancellation.
-					return lastErr
-				}
-				// its the callCtx deadline or cancellation, in which case try again.
-				continue
-			}
 			if c.shouldRefreshToken(lastErr, callOpts) {
 				gtErr := c.refreshToken(ctx)
 				if gtErr != nil {
@@ -117,7 +117,9 @@ func (c *Client) streamClientInterceptor(optFuncs ...retryOption) grpc.StreamCli
 		// (see https://github.com/etcd-io/etcd/issues/11954 for more).
 		err := c.getToken(ctx)
 		if err != nil {
-			c.GetLogger().Error("clientv3/retry_interceptor: getToken failed", zap.Error(err))
+			if !isContextError(err) || ctx.Err() == nil {
+				c.GetLogger().Error("clientv3/retry_interceptor: getToken failed", zap.Error(err))
+			}
 			return nil, err
 		}
 		grpcOpts, retryOpts := filterCallOptions(opts)
@@ -131,7 +133,9 @@ func (c *Client) streamClientInterceptor(optFuncs ...retryOption) grpc.StreamCli
 		}
 		newStreamer, err := streamer(ctx, desc, cc, method, grpcOpts...)
 		if err != nil {
-			c.GetLogger().Error("streamer failed to create ClientStream", zap.Error(err))
+			if !isContextError(err) || ctx.Err() == nil {
+				c.GetLogger().Error("streamer failed to create ClientStream", zap.Error(err))
+			}
 			return nil, err // TODO(mwitkow): Maybe dial and transport errors should be retriable?
 		}
 		retryingStreamer := &serverStreamingRetryingStream{


### PR DESCRIPTION
Fixes #21643

When `client.Close()` is called, the context gets canceled and any in-flight or retried calls fail with `codes.Canceled`. This is completely expected, but the retry interceptor was logging these at Warn/Error level:

```
WARN clientv3/retry_interceptor: retrying of unary invoker failed
ERROR clientv3/retry_interceptor: getToken failed
ERROR clientv3/retry_interceptor: streamer failed to create ClientStream
```

These entries fire during normal application shutdown and aren't actionable. Three changes:

1. **`"retrying of unary invoker failed"` (Warn)**: move the `isContextError` check before the log. If the parent context is done, return immediately without logging. If it's a call-level context timeout, continue retrying without logging (it's already retried). Only log Warn for genuine non-context errors.

2. **`"getToken failed"` (Error)**: skip the Error log if the error is a context error and the parent context is already canceled.

3. **`"streamer failed to create ClientStream"` (Error)**: same treatment.

The behavior for actual failures (non-context errors) is unchanged.