### PR TITLE
etcdctl: add --stream flag to get command

### DIFF
--- a/etcdctl/ctlv3/command/get_command.go
+++ b/etcdctl/ctlv3/command/get_command.go
@@ -39,6 +39,7 @@ var (
 	getMaxCreateRev int64
 	getMinModRev    int64
 	getMaxModRev    int64
+	getStream       bool
 )
 
 // NewGetCommand returns the cobra command for "get".
@@ -64,6 +65,7 @@ func NewGetCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&getMaxCreateRev, "max-create-rev", 0, "Maximum create revision")
 	cmd.Flags().Int64Var(&getMinModRev, "min-mod-rev", 0, "Minimum modification revision")
 	cmd.Flags().Int64Var(&getMaxModRev, "max-mod-rev", 0, "Maximum modification revision")
+	cmd.Flags().BoolVar(&getStream, "stream", false, "Use the RangeStream RPC")
 
 	cmd.RegisterFlagCompletionFunc("consistency", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"l", "s"}, cobra.ShellCompDirectiveDefault
@@ -82,7 +84,20 @@ func NewGetCommand() *cobra.Command {
 func getCommandFunc(cmd *cobra.Command, args []string) {
 	key, opts := getGetOp(args)
 	ctx, cancel := commandCtx(cmd)
-	resp, err := mustClientFromCmd(cmd).Get(ctx, key, opts...)
+	client := mustClientFromCmd(cmd)
+	var (
+		resp *clientv3.GetResponse
+		err  error
+	)
+	if getStream {
+		var stream clientv3.GetStreamChan
+		stream, err = client.GetStream(ctx, key, opts...)
+		if err == nil {
+			resp, err = clientv3.GetStreamToGetResponse(stream)
+		}
+	} else {
+		resp, err = client.Get(ctx, key, opts...)
+	}
 	cancel()
 	if err != nil {
 		cobrautl.ExitWithError(cobrautl.ExitError, err)

--- a/tests/common/integration_test.go
+++ b/tests/common/integration_test.go
@@ -25,7 +25,6 @@ import (
 func init() {
 	testRunner = framework.IntegrationTestRunner
 	clusterTestCases = integrationClusterTestCases
-	supportsGetStream = true
 }
 
 func integrationClusterTestCases() []testCase {

--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -30,6 +30,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/etcdserver/txn"
 	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/interfaces"
 	"go.etcd.io/etcd/tests/v3/framework/testutils"
 )
 
@@ -59,6 +60,14 @@ func TestKVPut(t *testing.T) {
 }
 
 func TestKVGet(t *testing.T) {
+	testKVGet(t, false)
+}
+
+func TestKVGetStream(t *testing.T) {
+	testKVGet(t, true)
+}
+
+func testKVGet(t *testing.T, stream bool) {
 	testRunner.BeforeTest(t)
 	for _, tc := range clusterTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
@@ -67,6 +76,10 @@ func TestKVGet(t *testing.T) {
 			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
 			defer clus.Close()
 			cc := testutils.MustClient(clus.Client())
+
+			if stream && !clusterSupportsGetStream(ctx, t, clus) {
+				t.Skip("RangeStream is not supported by this cluster")
+			}
 
 			testutils.ExecuteUntil(ctx, t, func() {
 				resp, err := cc.Get(ctx, "", config.GetOptions{Prefix: true})
@@ -153,20 +166,16 @@ func TestKVGet(t *testing.T) {
 				}
 				for _, tt := range slices.Concat(tests, testsWithKeysOnly) {
 					t.Run(tt.name, func(t *testing.T) {
-						for _, stream := range []bool{true, false} {
-							t.Run(fmt.Sprintf("Stream=%v", stream), func(t *testing.T) {
-								if stream && (!supportsGetStream || !rangeStreamSupports(tt.options)) {
-									t.Skip("Stream not supported")
-								}
-								opts := tt.options
-								opts.Stream = stream
-								resp, err := cc.Get(ctx, tt.begin, opts)
-								require.NoErrorf(t, err, "count not get key %q, err: %s", tt.begin, err)
-								resp.Header.MemberId = 0
-								resp.Header.RaftTerm = 0
-								assert.Equal(t, tt.wantResponse, resp)
-							})
+						if stream && !rangeStreamSupports(tt.options) {
+							t.Skip("options not supported by RangeStream")
 						}
+						opts := tt.options
+						opts.Stream = stream
+						resp, err := cc.Get(ctx, tt.begin, opts)
+						require.NoErrorf(t, err, "count not get key %q, err: %s", tt.begin, err)
+						resp.Header.MemberId = 0
+						resp.Header.RaftTerm = 0
+						assert.Equal(t, tt.wantResponse, resp)
 					})
 				}
 			})
@@ -182,6 +191,18 @@ func createKV(key, val string, createRev, modRev, ver int64) *mvccpb.KeyValue {
 		ModRevision:    modRev,
 		Version:        ver,
 	}
+}
+
+// clusterSupportsGetStream probes every cluster member with a RangeStream RPC and returns false if any member rejects it.
+func clusterSupportsGetStream(ctx context.Context, t *testing.T, clus interfaces.Cluster) bool {
+	for _, m := range clus.Members() {
+		_, err := m.Client().Get(ctx, "probe", config.GetOptions{Stream: true})
+		if err != nil {
+			t.Logf("member does not support RangeStream: %v", err)
+			return false
+		}
+	}
+	return true
 }
 
 // rangeStreamSupports reports whether the server's RangeStream RPC accepts a

--- a/tests/common/main_test.go
+++ b/tests/common/main_test.go
@@ -22,9 +22,8 @@ import (
 )
 
 var (
-	testRunner        intf.TestRunner
-	clusterTestCases  func() []testCase
-	supportsGetStream bool
+	testRunner       intf.TestRunner
+	clusterTestCases func() []testCase
 )
 
 func TestMain(m *testing.M) {

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -103,9 +103,6 @@ func (ctl *EtcdctlV3) DowngradeCancel(ctx context.Context) error {
 }
 
 func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) (*clientv3.GetResponse, error) {
-	if o.Stream {
-		return nil, fmt.Errorf("etcdctl has no RangeStream command; Stream=true is not supported by the e2e backend")
-	}
 	var args []string
 	if o.Timeout != 0 {
 		args = append(args, fmt.Sprintf("--command-timeout=%s", o.Timeout))
@@ -151,6 +148,9 @@ func (ctl *EtcdctlV3) Get(ctx context.Context, key string, o config.GetOptions) 
 	}
 	if o.MinModRevision != 0 {
 		args = append(args, fmt.Sprintf("--min-mod-rev=%d", o.MinModRevision))
+	}
+	if o.Stream {
+		args = append(args, "--stream")
 	}
 	switch o.SortBy {
 	case clientv3.SortByCreateRevision:


### PR DESCRIPTION
Add --stream flag. Also removes the supportsGetStream variable since e2e now supports getStream.

e2e tests now exercise the streaming path ([TestKVGet](https://github.com/etcd-io/etcd/blob/9c420dfa0eb7b05c61aa6257af714f70026ac26e/tests/common/kv_test.go#L61)) so no new tests were added.