### PR TITLE
fix TestKVGet skip masking non-stream coverage

### DIFF
--- a/tests/common/kv_test.go
+++ b/tests/common/kv_test.go
@@ -136,9 +136,9 @@ func TestKVGet(t *testing.T) {
 					{name: "Get third version of 'c' by its revision", begin: "c", options: config.GetOptions{Revision: int(firstRev) + 5}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 1, Kvs: []*mvccpb.KeyValue{kvC}}},
 					{name: "Get the latest version of 'c'", begin: "c", wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 1, Kvs: []*mvccpb.KeyValue{kvC}}},
 					{name: "all KVs with mininum mod revision sorted by mod revision", begin: "", options: config.GetOptions{Prefix: true, MinModRevision: int(firstRev) + 3, SortBy: clientv3.SortByModRevision}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: allKvs[2:]}},
-					{name: "all KVs with maximum mod revision, sorted by key descending", begin: "", options: config.GetOptions{Prefix: true, MaxModRevision: int(firstRev) + 4, Order: clientv3.SortDescend, SortBy: clientv3.SortByKey}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: reversedKvs[:2]}},
+					{name: "all KVs with maximum mod revision, sorted by key descending", begin: "", options: config.GetOptions{Prefix: true, MaxModRevision: int(firstRev) + 4, Order: clientv3.SortDescend, SortBy: clientv3.SortByKey}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: reversedKvs[4:]}},
 					{name: "all KVs with minimum create revision, sorted by version, descending", begin: "", options: config.GetOptions{Prefix: true, MinCreateRevision: int(firstRev) + 3, Order: clientv3.SortDescend, SortBy: clientv3.SortByVersion}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: allKvs[2:]}},
-					{name: "all KVs with maximimum create revision, sorted by value", begin: "", options: config.GetOptions{Prefix: true, MaxCreateRevision: int(firstRev) + 6, Order: clientv3.SortDescend, SortBy: clientv3.SortByValue}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: allKvs[:4]}},
+					{name: "all KVs with maximimum create revision, sorted by value", begin: "", options: config.GetOptions{Prefix: true, MaxCreateRevision: int(firstRev) + 6, Order: clientv3.SortDescend, SortBy: clientv3.SortByValue}, wantResponse: &clientv3.GetResponse{Header: currentHeader, Count: 6, Kvs: kvsByValueDesc[1:5]}},
 				}
 				testsWithKeysOnly := make([]testcase, 0, len(tests))
 				for _, otc := range tests {
@@ -155,7 +155,7 @@ func TestKVGet(t *testing.T) {
 					t.Run(tt.name, func(t *testing.T) {
 						for _, stream := range []bool{true, false} {
 							t.Run(fmt.Sprintf("Stream=%v", stream), func(t *testing.T) {
-								if !supportsGetStream || !rangeStreamSupports(tt.options) {
+								if stream && (!supportsGetStream || !rangeStreamSupports(tt.options)) {
 									t.Skip("Stream not supported")
 								}
 								opts := tt.options


### PR DESCRIPTION
Stream subtest should only skip on stream=true instead of unconditionally, this was a regression caused by my rangestream change.

In the meantime, https://github.com/etcd-io/etcd/pull/21227 merged without the test running due to the regression. There are two incorrect tests that need to be updated.

Discovered while working on https://github.com/etcd-io/etcd/pull/21747

Using the values before as the source of truth: https://github.com/etcd-io/etcd/commit/a5161279ea68a89c10db85924c0148cc0f028880, manually verified 2 test failures.

1.  `reversedKvs := []*mvccpb.KeyValue{kvFop, kvFooAbc, kvFoo, kvC, kvB, kvA}`

 "all KVs with maximum mod revision, sorted by key descending" -> `[]*mvccpb.KeyValue{kvB, kvA}`

This should be `reversedKVs[4:]` instead of `reveresdKVs[:2]`

2. `allKvs := []*mvccpb.KeyValue{kvA, kvB, kvC, kvFoo, kvFooAbc, kvFop}`
    `kvsByValueDesc := []*mvccpb.KeyValue{kvFop, kvFoo, kvC, kvA, kvB, kvFooAbc}`

"all KVs with maximimum create revision, sorted by value" -> `[]*mvccpb.KeyValue{kvFoo, kvC, kvA, kvB}`

`allKvs[:4]` doesn't sort by value. `kvsByValueDesc[1:5]` has this sorted.




