### PR TITLE
rafthttp: close response body on io.ReadAll error in stream dial

### DIFF
--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -630,6 +630,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 	case http.StatusPreconditionFailed:
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
+			resp.Body.Close()
 			cr.picker.unreachable(u)
 			return nil, err
 		}


### PR DESCRIPTION
In `streamReader.dial()`, when the HTTP response has status `StatusPreconditionFailed`, the code reads the response body via `io.ReadAll`. If `io.ReadAll` returns an error, the function returns without closing `resp.Body`, leaking the underlying TCP connection.

Every other error path in this switch statement properly closes the response body (via `httputil.GracefulClose`), but this one was missed.

This fix adds `resp.Body.Close()` before returning on the `io.ReadAll` error path to prevent the connection leak. Using `resp.Body.Close()` directly (rather than `httputil.GracefulClose`) is intentional, since `io.ReadAll` already failed, attempting to drain the body via `io.Copy(io.Discard, resp.Body)` inside `GracefulClose` could also fail or hang.

A prior merged fix [PR #5120](https://github.com/etcd-io/etcd/pull/5120) addressed the same class of issue (response body leak) in `cluster_util.go`.
