### PR TITLE
etcdutl: validate data file path instead of panic

### DIFF
--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -15,6 +15,7 @@
 package etcdutl
 
 import (
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,6 +29,19 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/wal"
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
 )
+
+// validateDataDir checks if the data directory's backend database file exists.
+func validateDataDir(dataDir string) error {
+	dbPath := datadir.ToBackendFileName(dataDir)
+	return validateFilePath(dbPath)
+}
+
+// validateFilePath checks if the specified file exists.
+// It returns an error encountered by os.Stat, such as os.ErrNotExist, os.ErrPermission, etc.
+func validateFilePath(filePath string) error {
+	_, err := os.Stat(filePath)
+	return err
+}
 
 // FlockTimeout is the duration to wait to obtain a file lock on db file.
 var FlockTimeout time.Duration

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -48,6 +48,9 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func DefragData(dataDir string) error {
+	if err := validateDataDir(dataDir); err != nil {
+		return err
+	}
 	b := backend.NewDefaultBackend(
 		GetLogger(),
 		datadir.ToBackendFileName(dataDir),

--- a/etcdutl/etcdutl/hashkv_command.go
+++ b/etcdutl/etcdutl/hashkv_command.go
@@ -54,6 +54,9 @@ type HashKV struct {
 }
 
 func calculateHashKV(dbPath string, rev int64) (HashKV, error) {
+	if err := validateFilePath(dbPath); err != nil {
+		return HashKV{}, err
+	}
 	b := backend.NewDefaultBackend(zap.NewNop(), dbPath, backend.WithTimeout(FlockTimeout))
 	defer b.Close()
 	// Since `etcdutl hashkv` only hashes the keyspace and ignores leases, we use a simple lessor to simplify the implementation.

--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -122,8 +122,10 @@ func (c *migrateConfig) finalize() error {
 }
 
 func migrateCommandFunc(c *migrateConfig) error {
-	dbPath := datadir.ToBackendFileName(c.dataDir)
-	be := backend.NewDefaultBackend(GetLogger(), dbPath, backend.WithTimeout(FlockTimeout))
+	if err := validateDataDir(c.dataDir); err != nil {
+		return err
+	}
+	be := backend.NewDefaultBackend(GetLogger(), datadir.ToBackendFileName(c.dataDir), backend.WithTimeout(FlockTimeout))
 	defer be.Close()
 
 	tx := be.BatchTx()

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -94,6 +94,9 @@ func SnapshotStatusCommandFunc(cmd *cobra.Command, args []string) {
 		err := fmt.Errorf("snapshot status requires exactly one argument")
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
+	if err := validateFilePath(args[0]); err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
 	printer := initPrinterFromCmd(cmd)
 
 	lg := GetLogger()


### PR DESCRIPTION
For https://github.com/etcd-io/etcd/pull/21201#discussion_r3247324152


run `etcdutl` with following sub-commands and args/flags, and ensure no panic returned.

  | Subcommand          | Parameter              | Error Type             | Exit Code | Panic? |
  |---------------------|------------------------|------------------------|-----------|--------|
  | defrag              | --data-dir=/non-existing   | ErrFileNotFound | 1        | No     |
  | migrate             | --data-dir=/non-existing  | ErrFileNotFound | 1        | No     |
  | hashkv              | filename             | ErrFileNotFound          | 1        | No     |
  | snapshot status     | filename             | ErrFileNotFound          | 1        | No     |
  | snapshot restore    | filename --data-dir=/non-existing | os.Stat error           | 1        | No     |