### PR TITLE
v3rpc: add lightweight request audit logging

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -133,6 +133,11 @@ type ServerConfig struct {
 
 	WarningApplyDuration        time.Duration
 	WarningUnaryRequestDuration time.Duration
+	// ExperimentalLogRequestPath enables lightweight request logging of all unary gRPC requests.
+	// When set to a file path, request entries are written to this dedicated file in JSON format.
+	ExperimentalLogRequestPath string
+	// ExperimentalLogRequestRotationConfigJSON configures log rotation for the request log file.
+	ExperimentalLogRequestRotationConfigJSON string
 
 	StrictReconfigCheck bool
 

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -379,6 +379,13 @@ type Config struct {
 	// WarningUnaryRequestDuration is the time duration after which a warning is generated if applying
 	// unary request takes more time than this value.
 	WarningUnaryRequestDuration time.Duration `json:"warning-unary-request-duration"`
+	// ExperimentalLogRequestPath enables lightweight request logging of all unary gRPC requests.
+	// When set to a file path, request entries (method, key, client IP, duration) are written
+	// to this dedicated file in JSON format, without expensive proto serialization.
+	ExperimentalLogRequestPath string `json:"experimental-log-request-path"`
+	// ExperimentalLogRequestRotationConfigJSON configures log rotation for the request log file.
+	// Defaults to MaxSize=100(MB), MaxAge=7(days), MaxBackups=5, LocalTime=false(UTC), Compress=false.
+	ExperimentalLogRequestRotationConfigJSON string `json:"experimental-log-request-rotation-config-json"`
 	// MaxLearners sets a limit to the number of learner members that can exist in the cluster membership.
 	MaxLearners int `json:"max-learners"`
 
@@ -758,6 +765,8 @@ func (cfg *Config) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&cfg.DowngradeCheckTime, "downgrade-check-time", cfg.DowngradeCheckTime, "Duration of time between two downgrade status checks.")
 	fs.DurationVar(&cfg.WarningApplyDuration, "warning-apply-duration", cfg.WarningApplyDuration, "Time duration after which a warning is generated if watch progress takes more time.")
 	fs.DurationVar(&cfg.WarningUnaryRequestDuration, "warning-unary-request-duration", cfg.WarningUnaryRequestDuration, "Time duration after which a warning is generated if a unary request takes more time.")
+	fs.StringVar(&cfg.ExperimentalLogRequestPath, "experimental-log-request-path", cfg.ExperimentalLogRequestPath, "Enable lightweight request logging for all unary gRPC requests. When set to a file path, request entries are written to this dedicated file in JSON format.")
+	fs.StringVar(&cfg.ExperimentalLogRequestRotationConfigJSON, "experimental-log-request-rotation-config-json", cfg.ExperimentalLogRequestRotationConfigJSON, "Configures log rotation for the request log file. Default: MaxSize=100(MB), MaxAge=7(days), MaxBackups=5, LocalTime=false(UTC), Compress=false.")
 	fs.BoolVar(&cfg.MemoryMlock, "memory-mlock", cfg.MemoryMlock, "Enable to enforce etcd pages (in particular bbolt) to stay in RAM.")
 	fs.UintVar(&cfg.BootstrapDefragThresholdMegabytes, "bootstrap-defrag-threshold-megabytes", 0, "Enable the defrag during etcd server bootstrap on condition that it will free at least the provided threshold of disk space. Needs to be set to non-zero value to take effect.")
 	fs.IntVar(&cfg.MaxLearners, "max-learners", membership.DefaultMaxLearners, "Sets the maximum number of learners that can be available in the cluster membership.")

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -228,6 +228,8 @@ func StartEtcd(inCfg *Config) (e *Etcd, err error) {
 		DowngradeCheckTime:                cfg.DowngradeCheckTime,
 		WarningApplyDuration:              cfg.WarningApplyDuration,
 		WarningUnaryRequestDuration:       cfg.WarningUnaryRequestDuration,
+		ExperimentalLogRequestPath:               cfg.ExperimentalLogRequestPath,
+		ExperimentalLogRequestRotationConfigJSON: cfg.ExperimentalLogRequestRotationConfigJSON,
 		MemoryMlock:                       cfg.MemoryMlock,
 		BootstrapDefragThresholdMegabytes: cfg.BootstrapDefragThresholdMegabytes,
 		MaxLearners:                       cfg.MaxLearners,

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -262,6 +262,10 @@ Logging:
     Configures log rotation if enabled with a JSON logger config. MaxSize(MB), MaxAge(days,0=no limit), MaxBackups(0=no limit), LocalTime(use computers local time), Compress(gzip)".
   --warning-unary-request-duration '300ms'
     Set time duration after which a warning is logged if a unary request takes more than this duration.
+  --experimental-log-request-path ''
+    Enable lightweight request logging for all unary gRPC requests. When set to a file path, request entries are written to this dedicated file in JSON format.
+  --experimental-log-request-rotation-config-json '{"maxsize": 100, "maxage": 7, "maxbackups": 5, "localtime": false, "compress": false}'
+    Configures log rotation for the request log file. Default: MaxSize=100(MB), MaxAge=7(days), MaxBackups=5, LocalTime=false(UTC), Compress=false.
 
 Distributed tracing:
   --enable-distributed-tracing 'false'

--- a/server/etcdserver/api/v3rpc/interceptor.go
+++ b/server/etcdserver/api/v3rpc/interceptor.go
@@ -37,6 +37,7 @@ import (
 const (
 	maxNoLeaderCnt = 3
 	snapshotMethod = "/etcdserverpb.Maintenance/Snapshot"
+	maxLogKeys     = 10
 )
 
 type streamsMap struct {
@@ -82,14 +83,25 @@ func newLogUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerIntercepto
 		resp, err := handler(ctx, req)
 		lg := s.Logger()
 		if lg != nil { // acquire stats if debug level is enabled or RequestInfo is expensive
-			defer logUnaryRequestStats(ctx, lg, s.Cfg.WarningUnaryRequestDuration, info, startTime, req, resp)
+			defer logUnaryRequestStats(ctx, lg, s.Cfg.WarningUnaryRequestDuration, s.RequestLogger(), info, startTime, req, resp)
 		}
 		return resp, err
 	}
 }
 
-func logUnaryRequestStats(ctx context.Context, lg *zap.Logger, warnLatency time.Duration, info *grpc.UnaryServerInfo, startTime time.Time, req any, resp any) {
+func logUnaryRequestStats(ctx context.Context, lg *zap.Logger, warnLatency time.Duration, requestLogger *zap.Logger, info *grpc.UnaryServerInfo, startTime time.Time, req any, resp any) {
 	duration := time.Since(startTime)
+
+	// Lightweight request logging path - O(1) field extraction, no proto.Size or .String()
+	if requestLogger != nil {
+		remote := "No remote client info."
+		peerInfo, ok := peer.FromContext(ctx)
+		if ok {
+			remote = peerInfo.Addr.String()
+		}
+		logLightweightRequestInfo(requestLogger, info.FullMethod, remote, duration, req)
+	}
+
 	var enabledDebugLevel, expensiveRequest bool
 	if lg.Core().Enabled(zap.DebugLevel) {
 		enabledDebugLevel = true
@@ -211,6 +223,63 @@ func logExpensiveRequestStats(lg *zap.Logger, startTime time.Time, duration time
 		zap.Int("response size", respSize),
 		zap.String("request content", reqContent),
 	)
+}
+
+// logLightweightRequestInfo logs a unary request with only O(1) fields at info level.
+// It avoids expensive proto serialization (proto.Size, .String) that the debug-level
+// and slow-request paths use.
+func logLightweightRequestInfo(lg *zap.Logger, method string, remote string, duration time.Duration, req any) {
+	fields := []zap.Field{
+		zap.String("method", method),
+		zap.String("remote", remote),
+		zap.Duration("time_spent", duration),
+	}
+
+	switch r := req.(type) {
+	case *pb.RangeRequest:
+		fields = append(fields, zap.ByteString("key", r.Key))
+		if len(r.RangeEnd) > 0 {
+			fields = append(fields, zap.ByteString("range_end", r.RangeEnd))
+		}
+	case *pb.PutRequest:
+		fields = append(fields, zap.ByteString("key", r.Key))
+	case *pb.DeleteRangeRequest:
+		fields = append(fields, zap.ByteString("key", r.Key))
+		if len(r.RangeEnd) > 0 {
+			fields = append(fields, zap.ByteString("range_end", r.RangeEnd))
+		}
+	case *pb.TxnRequest:
+		if len(r.Compare) > 0 {
+			count := len(r.Compare)
+			if count > maxLogKeys {
+				count = maxLogKeys
+			}
+			keys := make([]string, 0, count)
+			var rangeEnds []string
+			for i := 0; i < len(r.Compare) && i < maxLogKeys; i++ {
+				keys = append(keys, string(r.Compare[i].Key))
+				if len(r.Compare[i].RangeEnd) > 0 {
+					if rangeEnds == nil {
+						rangeEnds = make([]string, 0, count)
+					}
+					rangeEnds = append(rangeEnds, string(r.Compare[i].RangeEnd))
+				}
+			}
+			fields = append(fields, zap.Strings("compare_keys", keys))
+			if len(rangeEnds) > 0 {
+				fields = append(fields, zap.Strings("compare_range_ends", rangeEnds))
+			}
+			if len(r.Compare) > maxLogKeys {
+				fields = append(fields, zap.Int("truncated", len(r.Compare)-maxLogKeys))
+			}
+		}
+	case *pb.LeaseGrantRequest:
+		fields = append(fields, zap.Int64("ttl", r.TTL), zap.Int64("lease_id", int64(r.ID)))
+	case *pb.LeaseRevokeRequest:
+		fields = append(fields, zap.Int64("lease_id", int64(r.ID)))
+	}
+
+	lg.Info("request info", fields...)
 }
 
 func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor {

--- a/server/etcdserver/api/v3rpc/interceptor_test.go
+++ b/server/etcdserver/api/v3rpc/interceptor_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3rpc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+func newTestLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.InfoLevel)
+	return zap.New(core), logs
+}
+
+// findField returns the zap.Field with the given key, or false if not found.
+func findField(entry observer.LoggedEntry, key string) (zap.Field, bool) {
+	for _, f := range entry.Context {
+		if f.Key == key {
+			return f, true
+		}
+	}
+	return zap.Field{}, false
+}
+
+// stringVal extracts a string value from a String or ByteString field.
+func stringVal(f zap.Field) string {
+	switch f.Type {
+	case zapcore.StringType:
+		return f.String
+	case zapcore.ByteStringType:
+		return string(f.Interface.([]byte))
+	default:
+		return ""
+	}
+}
+
+func TestLogLightweightRequestInfo_RangeRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.RangeRequest{Key: []byte("/registry/pods"), RangeEnd: []byte("/registry/pods0")}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Range", "10.0.0.1:34567", 5*time.Millisecond, req)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	require.Equal(t, "request info", entry.Message)
+	require.Equal(t, zap.InfoLevel, entry.Level)
+
+	f, ok := findField(entry, "method")
+	require.True(t, ok)
+	require.Equal(t, "/etcdserverpb.KV/Range", stringVal(f))
+
+	f, ok = findField(entry, "remote")
+	require.True(t, ok)
+	require.Equal(t, "10.0.0.1:34567", stringVal(f))
+
+	f, ok = findField(entry, "key")
+	require.True(t, ok)
+	require.Equal(t, "/registry/pods", stringVal(f))
+
+	f, ok = findField(entry, "range_end")
+	require.True(t, ok)
+	require.Equal(t, "/registry/pods0", stringVal(f))
+}
+
+func TestLogLightweightRequestInfo_RangeRequestNoRangeEnd(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.RangeRequest{Key: []byte("/registry/pods")}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Range", "10.0.0.1:34567", 5*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	_, ok := findField(entry, "key")
+	require.True(t, ok)
+	_, ok = findField(entry, "range_end")
+	require.False(t, ok, "range_end should not be logged when empty")
+}
+
+func TestLogLightweightRequestInfo_PutRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.PutRequest{Key: []byte("/registry/secrets/my-secret"), Value: []byte("sensitive-data")}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Put", "10.0.0.2:34568", 10*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	f, ok := findField(entry, "key")
+	require.True(t, ok)
+	require.Equal(t, "/registry/secrets/my-secret", stringVal(f))
+
+	_, ok = findField(entry, "value")
+	require.False(t, ok, "value should not be logged for PutRequest")
+}
+
+func TestLogLightweightRequestInfo_DeleteRangeRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.DeleteRangeRequest{Key: []byte("/registry/pods"), RangeEnd: []byte("/registry/pods0")}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/DeleteRange", "10.0.0.3:34569", 3*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	f, ok := findField(entry, "key")
+	require.True(t, ok)
+	require.Equal(t, "/registry/pods", stringVal(f))
+
+	f, ok = findField(entry, "range_end")
+	require.True(t, ok)
+	require.Equal(t, "/registry/pods0", stringVal(f))
+}
+
+func TestLogLightweightRequestInfo_TxnRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.TxnRequest{
+		Compare: []*pb.Compare{
+			{Key: []byte("/key1"), RangeEnd: []byte("/key10")},
+			{Key: []byte("/key2")},
+		},
+	}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Txn", "10.0.0.4:34570", 15*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	_, ok := findField(entry, "compare_keys")
+	require.True(t, ok)
+	_, ok = findField(entry, "compare_range_ends")
+	require.True(t, ok)
+}
+
+func TestLogLightweightRequestInfo_TxnRequestNoCompare(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.TxnRequest{}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Txn", "10.0.0.4:34570", 1*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	_, ok := findField(entry, "compare_keys")
+	require.False(t, ok, "compare_keys should not be logged when empty")
+}
+
+func TestLogLightweightRequestInfo_TxnRequestTruncated(t *testing.T) {
+	lg, logs := newTestLogger()
+	const totalCompares = 15
+	compares := make([]*pb.Compare, totalCompares)
+	for i := 0; i < totalCompares; i++ {
+		compares[i] = &pb.Compare{Key: []byte(fmt.Sprintf("/key%d", i)), RangeEnd: []byte(fmt.Sprintf("/key%d-end", i))}
+	}
+	req := &pb.TxnRequest{Compare: compares}
+	logLightweightRequestInfo(lg, "/etcdserverpb.KV/Txn", "10.0.0.4:34570", 15*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	_, ok := findField(entry, "compare_keys")
+	require.True(t, ok)
+	_, ok = findField(entry, "compare_range_ends")
+	require.True(t, ok)
+
+	truncatedField, ok := findField(entry, "truncated")
+	require.True(t, ok, "truncated field should be present when compares exceed maxLogKeys")
+	require.Equal(t, int64(totalCompares-maxLogKeys), truncatedField.Integer)
+}
+
+func TestLogLightweightRequestInfo_LeaseGrantRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.LeaseGrantRequest{TTL: 60, ID: 12345}
+	logLightweightRequestInfo(lg, "/etcdserverpb.Lease/LeaseGrant", "10.0.0.5:34571", 1*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	f, ok := findField(entry, "ttl")
+	require.True(t, ok)
+	require.Equal(t, int64(60), f.Integer)
+
+	f, ok = findField(entry, "lease_id")
+	require.True(t, ok)
+	require.Equal(t, int64(12345), f.Integer)
+}
+
+func TestLogLightweightRequestInfo_LeaseRevokeRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.LeaseRevokeRequest{ID: 12345}
+	logLightweightRequestInfo(lg, "/etcdserverpb.Lease/LeaseRevoke", "10.0.0.5:34571", 1*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	f, ok := findField(entry, "lease_id")
+	require.True(t, ok)
+	require.Equal(t, int64(12345), f.Integer)
+}
+
+func TestLogLightweightRequestInfo_UnknownRequest(t *testing.T) {
+	lg, logs := newTestLogger()
+	req := &pb.AuthUserAddRequest{Name: "test-user"}
+	logLightweightRequestInfo(lg, "/etcdserverpb.Auth/UserAdd", "10.0.0.6:34572", 2*time.Millisecond, req)
+
+	entry := logs.All()[0]
+	f, ok := findField(entry, "method")
+	require.True(t, ok)
+	require.Equal(t, "/etcdserverpb.Auth/UserAdd", stringVal(f))
+
+	f, ok = findField(entry, "remote")
+	require.True(t, ok)
+	require.Equal(t, "10.0.0.6:34572", stringVal(f))
+
+	_, ok = findField(entry, "key")
+	require.False(t, ok)
+}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -31,6 +31,8 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/membershippb"
@@ -221,6 +223,9 @@ type EtcdServer struct {
 	lgMu *sync.RWMutex
 	lg   *zap.Logger
 
+	requestLogger   *zap.Logger
+	requestLoggerWS *zapcore.BufferedWriteSyncer
+
 	w wait.Wait
 
 	read *read.Read
@@ -328,6 +333,36 @@ func NewServer(cfg config.ServerConfig) (srv *EtcdServer, err error) {
 		consistIndex:          b.storage.backend.ci,
 		firstCommitInTerm:     notify.NewNotifier(),
 		clusterVersionChanged: notify.NewNotifier(),
+	}
+
+	// Initialize request logger if path is configured
+	if cfg.ExperimentalLogRequestPath != "" {
+		// Default rotation config
+		ljCfg := lumberjack.Logger{
+			Filename:   cfg.ExperimentalLogRequestPath,
+			MaxSize:    100, // MB
+			MaxBackups: 5,
+			MaxAge:     7, // days
+		}
+		// User-provided rotation config overrides defaults (Filename is never overridden)
+		if cfg.ExperimentalLogRequestRotationConfigJSON != "" {
+			if err := json.Unmarshal([]byte(cfg.ExperimentalLogRequestRotationConfigJSON), &ljCfg); err != nil {
+				return nil, fmt.Errorf("failed to parse request log rotation config: %w", err)
+			}
+			ljCfg.Filename = cfg.ExperimentalLogRequestPath
+		}
+		ws := &zapcore.BufferedWriteSyncer{
+			WS:            zapcore.AddSync(&ljCfg),
+			Size:          256 * 1024, // 256 KB
+			FlushInterval: time.Second,
+		}
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			ws,
+			zap.InfoLevel,
+		)
+		srv.requestLogger = zap.New(core)
+		srv.requestLoggerWS = ws
 	}
 
 	addFeatureGateMetrics(cfg.ServerFeatureGate, serverFeatureEnabled)
@@ -444,6 +479,11 @@ func (s *EtcdServer) Logger() *zap.Logger {
 	l := s.lg
 	s.lgMu.RUnlock()
 	return l
+}
+
+// RequestLogger returns the dedicated logger for request logging, or nil if disabled.
+func (s *EtcdServer) RequestLogger() *zap.Logger {
+	return s.requestLogger
 }
 
 func (s *EtcdServer) Config() config.ServerConfig {
@@ -940,6 +980,9 @@ func (s *EtcdServer) ensureLeadership() bool {
 // Cleanup removes allocated objects by EtcdServer.NewServer in
 // situation that EtcdServer::Start was not called (that takes care of cleanup).
 func (s *EtcdServer) Cleanup() {
+	if s.requestLoggerWS != nil {
+		s.requestLoggerWS.Stop()
+	}
 	// kv, lessor and backend can be nil if running without v3 enabled
 	// or running unit tests.
 	if s.lessor != nil {


### PR DESCRIPTION
## Summary

Add `--experimental-log-request-path` flag to enable lightweight request logging for all unary gRPC requests. When a file path is provided, request entries (method, key, client IP, duration) are written to this dedicated file in JSON format, without expensive proto serialization (`proto.Size`, `.String()`).

This fills the critical gap between:
- `--log-level=debug`: logs all requests but with heavy serialization, unsuitable for production.
- `--warning-unary-request-duration`: only logs slow requests.

By writing to a **dedicated file** (similar to Nginx's `access.log`), this feature provides a clean, isolated stream of request events for operators to analyze, without polluting or being drowned out by etcd's main operational logs.

## Goals

Currently, operators cannot answer the following questions without enabling debug-level logging (which is O(n) per request and unsuitable for production):
- “Who deleted this key?”
- “Which client is generating high QPS on a specific key?”
- “What changes happened around the time of an incident?”

This is especially critical for requests made directly via `etcdctl` or the v3 gRPC API, which bypass the Kubernetes API Server and its audit logging mechanisms.

This PR aims to make these questions answerable with minimal overhead (O(1) per request).

## Non-goals

To keep this PR focused and lightweight, the following are explicitly **out of scope**:
- **Compliance Audit System**: This is not a PCI-DSS/SOX compliant audit log. It does not provide tamper-proof storage, cryptographic signing, or guaranteed delivery.
- **Log Forwarding Pipeline**: We are not building a log shipping pipeline (buffering, backpressure, routing). Operators should use existing log shippers (e.g., Fluentd, Vector, Promtail) to collect and forward the generated log files to their SIEM/audit systems.
- **Request Content Logging**: `PutRequest` values are excluded for privacy and payload size reasons. Full request/response bodies remain at the `debug` level.
- **Stream RPC Coverage**: `Watch` and `LeaseKeepAlive` are out of scope for this initial implementation.
- **Real-time Alerting**: This feature logs requests; alerting based on these logs is an external concern.

## Key Design

- **O(1) field extraction** per request type — no `proto.Size()` or `.String()` calls
- **Buffered async I/O** — `zapcore.BufferedWriteSyncer` (256 KB buffer, 1s flush) ensures log writes never block the gRPC request path
- **Built-in log rotation** — uses `lumberjack` with sensible defaults (MaxSize=100 MB, MaxBackups=5, MaxAge=7 days), configurable via `--experimental-log-request-rotation-config-json`
- **Info level** — written to a dedicated file, won't flood etcd's main operational logs
- **Defaults to disabled** — zero overhead when off
- **TxnRequest truncation** — logs at most 10 compare keys per entry (`maxLogKeys`), with a `truncated` field showing the omitted count, to prevent oversized log entries
- **PutRequest** — key only, value is never logged (matches existing `NewLoggablePutRequest` redaction)
- **Stream requests** — out of scope for this PR

## Flags

| Flag | Type | Default | Description |
|------|------|---------|-------------|
| `--experimental-log-request-path` | string | `””` (disabled) | File path for the dedicated request log. When set, lightweight request logging is enabled. |
| `--experimental-log-request-rotation-config-json` | string | `{“maxsize”:100,”maxage”:7,”maxbackups”:5,”localtime”:false,”compress”:false}` | Log rotation configuration for the request log file. |

## Approach

Building on the established pattern from [PR #13236](https://github.com/etcd-io/etcd/pull/13236) (new flag → `ServerConfig` → gRPC interceptor), this PR adds a lightweight request logging path within the existing `zap` framework.

It uses a dedicated `zap.Logger` instance backed by a `zapcore.BufferedWriteSyncer` wrapping a `lumberjack.Logger`. Writes go to an in-memory 256 KB buffer and return immediately — the gRPC handler never waits for disk I/O. A background goroutine flushes the buffer to disk at most once per second. Log rotation is handled automatically by `lumberjack` (size-based rotation with configurable limits).

This ensures O(1) field extraction, no value logging, and no proto marshaling, keeping the performance overhead strictly minimal. If the log file write blocks or fails, it will not block the main etcd request path (best-effort delivery).

## AI Assistance

AI tools (Claude Code) were used for code review feedback analysis and PR description drafting. All code was reviewed and verified by the author.

## Test Plan

- [x] Unit tests for `logLightweightRequestInfo` with all request types (including TxnRequest truncation)
- [x] Integration tests (1 known flaky test unrelated to this change)
- [x] Build passes
- [ ] Manual verification with etcd server
- [ ] CI passes