### PR TITLE
wal: close files on Open and Create error paths

### DIFF
--- a/client/pkg/fileutil/purge.go
+++ b/client/pkg/fileutil/purge.go
@@ -74,6 +74,9 @@ func purgeFile(lg *zap.Logger, dirname string, suffix string, max uint, interval
 					}
 				}
 				if err = os.Remove(f); err != nil {
+					if l != nil {
+						l.Close()
+					}
 					lg.Error("failed to remove file", zap.String("path", f), zap.Error(err))
 					errC <- err
 					return

--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -97,7 +97,7 @@ type WAL struct {
 // Create creates a WAL ready for appending records. The given metadata is
 // recorded at the head of each WAL file, and can be retrieved with ReadAll
 // after the file is Open.
-func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
+func Create(lg *zap.Logger, dirpath string, metadata []byte) (_ *WAL, err error) {
 	if Exist(dirpath) {
 		return nil, os.ErrExist
 	}
@@ -109,20 +109,20 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 	// keep temporary wal directory so WAL initialization appears atomic
 	tmpdirpath := filepath.Clean(dirpath) + ".tmp"
 	if fileutil.Exist(tmpdirpath) {
-		if err := os.RemoveAll(tmpdirpath); err != nil {
-			return nil, err
+		if rmErr := os.RemoveAll(tmpdirpath); rmErr != nil {
+			return nil, rmErr
 		}
 	}
 	defer os.RemoveAll(tmpdirpath)
 
-	if err := fileutil.CreateDirAll(lg, tmpdirpath); err != nil {
+	if mkErr := fileutil.CreateDirAll(lg, tmpdirpath); mkErr != nil {
 		lg.Warn(
 			"failed to create a temporary WAL directory",
 			zap.String("tmp-dir-path", tmpdirpath),
 			zap.String("dir-path", dirpath),
-			zap.Error(err),
+			zap.Error(mkErr),
 		)
-		return nil, err
+		return nil, mkErr
 	}
 
 	p := filepath.Join(tmpdirpath, walName(0, 0))
@@ -135,6 +135,11 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 		)
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			f.Close()
+		}
+	}()
 	if _, err = f.Seek(0, io.SeekEnd); err != nil {
 		lg.Warn(
 			"failed to seek an initial WAL file",
@@ -191,7 +196,6 @@ func Create(lg *zap.Logger, dirpath string, metadata []byte) (*WAL, error) {
 			w.cleanupWAL(lg)
 		}
 	}()
-
 	// directory was renamed; sync parent dir to persist rename
 	pdir, perr := fileutil.OpenDir(filepath.Dir(w.dir))
 	if perr != nil {
@@ -348,6 +352,7 @@ func Open(lg *zap.Logger, dirpath string, snap *walpb.Snapshot) (*WAL, error) {
 		return nil, fmt.Errorf("openAtIndex failed: %w", err)
 	}
 	if w.dirFile, err = fileutil.OpenDir(w.dir); err != nil {
+		w.Close()
 		return nil, fmt.Errorf("fileutil.OpenDir failed: %w", err)
 	}
 	return w, nil


### PR DESCRIPTION
Fix resource leaks in WAL Open and Create error handling.

`fileutil.purgeFile` already closes the flock when `os.Remove` fails on current `main`, so that hunk is no longer in this PR.

#### 1. `wal.Open`: FD + goroutine leak when `OpenDir` fails

**Call chain:** `Open` → `openAtIndex` (succeeds, allocating file locks in `w.locks`, a `filePipeline` goroutine in `w.fp`, and a pre-allocated temp file) → `fileutil.OpenDir(w.dir)` (fails)

**Trigger:** Any filesystem error on the WAL directory between `openAtIndex` completing and `OpenDir` (e.g., directory removed by concurrent process, permission change, or FD exhaustion).

**Leak:** `w.locks` (locked WAL segment FDs), `w.fp` (goroutine + pre-allocated temp file) are never released. The `return nil, err` discards `w` without calling `w.Close()`.

**Fix:** Call `w.Close()` before returning the error.

#### 2. `wal.Create`: Locked FD leak on early error paths

**Call chain:** `Create` → `createNewWALFile` (succeeds, returns locked file `f`) → `f.Seek` / `Preallocate` / `newFileEncoder` / `saveCrc` / `encode` / `SaveSnapshot` (any fails)

**Trigger:** Disk full during Preallocate, I/O error during seek, or encoding failure.

**Leak:** The locked file `f` is never closed. While `defer os.RemoveAll(tmpdirpath)` removes the file from disk, the FD and advisory lock remain held.

**Fix:** Use a named return and a deferred closure that calls `f.Close()` when returning an error. Duplicate close after `renameWAL` takes ownership is harmless per `os.File.Close`.
