### PR TITLE
[release-3.6] etcdutl: validate data file path instead of panic

### DIFF
--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -16,6 +16,7 @@ package etcdutl
 
 import (
 	"errors"
+	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -28,6 +29,19 @@ import (
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
 	"go.etcd.io/raft/v3/raftpb"
 )
+
+// validateDataDir checks if the data directory's backend database file exists.
+func validateDataDir(dataDir string) error {
+	dbPath := datadir.ToBackendFileName(dataDir)
+	return validateFilePath(dbPath)
+}
+
+// validateFilePath checks if the specified file exists.
+// It returns an error encountered by os.Stat, such as os.ErrNotExist, os.ErrPermission, etc.
+func validateFilePath(filePath string) error {
+	_, err := os.Stat(filePath)
+	return err
+}
 
 func GetLogger() *zap.Logger {
 	config := logutil.DefaultZapLoggerConfig

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -50,8 +50,13 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func DefragData(dataDir string) error {
-	var be backend.Backend
-	lg := GetLogger()
+	var (
+		be backend.Backend
+		lg = GetLogger()
+	)
+	if err := validateDataDir(dataDir); err != nil {
+		return err
+	}
 	bch := make(chan struct{})
 	dbDir := datadir.ToBackendFileName(dataDir)
 	go func() {

--- a/etcdutl/etcdutl/hashkv_command.go
+++ b/etcdutl/etcdutl/hashkv_command.go
@@ -54,6 +54,9 @@ type HashKV struct {
 }
 
 func calculateHashKV(dbPath string, rev int64) (HashKV, error) {
+	if err := validateFilePath(dbPath); err != nil {
+		return HashKV{}, err
+	}
 	cfg := backend.DefaultBackendConfig(zap.NewNop())
 	cfg.Path = dbPath
 	b := backend.New(cfg)

--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -122,6 +122,9 @@ func (c *migrateConfig) finalize() error {
 }
 
 func migrateCommandFunc(c *migrateConfig) error {
+	if err := validateDataDir(c.dataDir); err != nil {
+		return err
+	}
 	dbPath := datadir.ToBackendFileName(c.dataDir)
 	be := backend.NewDefaultBackend(GetLogger(), dbPath)
 	defer be.Close()

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -94,6 +94,9 @@ func SnapshotStatusCommandFunc(cmd *cobra.Command, args []string) {
 		err := fmt.Errorf("snapshot status requires exactly one argument")
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
+	if err := validateFilePath(args[0]); err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
 	printer := initPrinterFromCmd(cmd)
 
 	lg := GetLogger()


### PR DESCRIPTION
Part of #21761 

  | # | command | Test Input | Behavior | Exit Code |
  |---|---|---|---|---|
  | 1 | `etcdutl defrag --data-dir <dir>` | `/tmp/non-existing-dir` | Error | 1 |
  | 2 | `etcdutl migrate --data-dir <dir>` | `/tmp/non-existing-dir` | Error | 1 |
  | 3 | `etcdutl hashkv <filename>` | `/tmp/non-existing-file` | Error | 1 |
  | 4 | `etcdutl snapshot status <filename>` | `/tmp/non-existing-file` | Error | 1 |
  | 5 | `etcdutl snapshot restore <filename>` | `/tmp/non-existing-file` | Error | 1 |