### PR TITLE
[release-3.5] etcdutl: validate data file path instead of panic

### DIFF
--- a/etcdutl/etcdutl/backup_command.go
+++ b/etcdutl/etcdutl/backup_command.go
@@ -24,6 +24,7 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/pkg/v3/cobrautl"
 	"go.etcd.io/etcd/pkg/v3/idutil"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	"go.etcd.io/etcd/raft/v3/raftpb"
@@ -68,7 +69,9 @@ func NewBackupCommand() *cobra.Command {
 }
 
 func doBackup(cmd *cobra.Command, args []string) {
-	HandleBackup(withV3, dataDir, backupDir, walDir, backupWalDir)
+	if err := HandleBackup(withV3, dataDir, backupDir, walDir, backupWalDir); err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
 }
 
 type desiredCluster struct {
@@ -102,6 +105,10 @@ func newDesiredCluster() desiredCluster {
 // HandleBackup handles a request that intends to do a backup.
 func HandleBackup(withV3 bool, srcDir string, destDir string, srcWAL string, destWAL string) error {
 	lg := GetLogger()
+
+	if err := validateDataDir(srcDir); err != nil {
+		return err
+	}
 
 	srcSnap := datadir.ToSnapDir(srcDir)
 	destSnap := datadir.ToSnapDir(destDir)

--- a/etcdutl/etcdutl/common.go
+++ b/etcdutl/etcdutl/common.go
@@ -15,11 +15,27 @@
 package etcdutl
 
 import (
+	"os"
+
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
+	"go.etcd.io/etcd/server/v3/datadir"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+// validateDataDir checks if the data directory's backend database file exists.
+func validateDataDir(dataDir string) error {
+	dbPath := datadir.ToBackendFileName(dataDir)
+	return validateFilePath(dbPath)
+}
+
+// validateFilePath checks if the specified file exists.
+// It returns an error encountered by os.Stat, such as os.ErrNotExist, os.ErrPermission, etc.
+func validateFilePath(filePath string) error {
+	_, err := os.Stat(filePath)
+	return err
+}
 
 func GetLogger() *zap.Logger {
 	config := logutil.DefaultZapLoggerConfig

--- a/etcdutl/etcdutl/defrag_command.go
+++ b/etcdutl/etcdutl/defrag_command.go
@@ -50,8 +50,13 @@ func defragCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 func DefragData(dataDir string) error {
-	var be backend.Backend
-	lg := GetLogger()
+	var (
+		be backend.Backend
+		lg = GetLogger()
+	)
+	if err := validateDataDir(dataDir); err != nil {
+		return err
+	}
 	bch := make(chan struct{})
 	dbDir := datadir.ToBackendFileName(dataDir)
 	go func() {

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -109,6 +109,9 @@ func SnapshotStatusCommandFunc(cmd *cobra.Command, args []string) {
 		err := fmt.Errorf("snapshot status requires exactly one argument")
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, err)
 	}
+	if err := validateFilePath(args[0]); err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
 	printer := initPrinterFromCmd(cmd)
 
 	lg := GetLogger()


### PR DESCRIPTION
Part of #21761 

| # | Subcommand | Test Input | Behavior | Exit Code |
  |---|---|---|---|---|
  | 1 | `etcdutl backup --data-dir <dir>` | `/tmp/non-existing-dir` | Error | 1 |
  | 2 | `etcdutl check v2store --data-dir <dir>` | `/tmp/non-existing-dir` | Error | 1 |
  | 3 | `etcdutl defrag --data-dir <dir>` | `/tmp/non-existing-dir` | Error | 1 |
  | 4 | `etcdutl snapshot status <filename>` | `/tmp/non-existing-file` | Error | 1 |
  | 5 | `etcdutl snapshot restore <filename>` | `/tmp/non-existing-file` | Error | 1 |