### PR TITLE
Workaround long-running Porcupine Step

### DIFF
--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -19,9 +19,22 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync/atomic"
 
 	"github.com/anishathalye/porcupine"
 )
+
+// LinearizationDeadlineTripped is set when linearization validation exceeds
+// its timeout.
+//
+// Porcupine currently does not propagate its timeout to the model Step
+// callback. A single non-deterministic Step can take seconds or minutes, so
+// CheckOperationsVerbose may not return promptly after its timeout expires.
+// Until etcd depends on a Porcupine version with timeout propagation, validation
+// uses this atomic flag to let Step and its helpers return early.
+//
+// See https://github.com/anishathalye/porcupine/pull/45 and https://github.com/etcd-io/etcd/pull/21715.
+var LinearizationDeadlineTripped atomic.Int32
 
 // NonDeterministicModel extends DeterministicModel to allow for clients with imperfect knowledge of the request's destiny.
 // An unknown/error response doesn't inform whether the request was persisted or not, so the model
@@ -146,6 +159,9 @@ func compareStates(first, second EtcdState) int {
 }
 
 func (states nonDeterministicState) apply(request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
+	if LinearizationDeadlineTripped.Load() != 0 {
+		return false, nil
+	}
 	var newStates nonDeterministicState
 	switch {
 	case response.Error != "":
@@ -164,6 +180,9 @@ func (states nonDeterministicState) apply(request EtcdRequest, response MaybeEtc
 func (states nonDeterministicState) applyFailedRequest(request EtcdRequest) nonDeterministicState {
 	newStates := make(nonDeterministicState, 0, len(states)*2)
 	for _, s := range states {
+		if LinearizationDeadlineTripped.Load() != 0 {
+			return nil
+		}
 		newStates = append(newStates, s)
 		newState, _ := s.Step(request)
 		if !newState.Equal(s) {
@@ -177,6 +196,9 @@ func (states nonDeterministicState) applyFailedRequest(request EtcdRequest) nonD
 func (states nonDeterministicState) applyPersistedRequest(request EtcdRequest) nonDeterministicState {
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if LinearizationDeadlineTripped.Load() != 0 {
+			return nil
+		}
 		newState, _ := s.Step(request)
 		newStates = append(newStates, newState)
 	}
@@ -187,6 +209,9 @@ func (states nonDeterministicState) applyPersistedRequest(request EtcdRequest) n
 func (states nonDeterministicState) applyPersistedRequestWithRevision(request EtcdRequest, responseRevision int64) nonDeterministicState {
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if LinearizationDeadlineTripped.Load() != 0 {
+			return nil
+		}
 		newState, modelResponse := s.Step(request)
 		if modelResponse.Revision == responseRevision {
 			newStates = append(newStates, newState)
@@ -199,6 +224,9 @@ func (states nonDeterministicState) applyPersistedRequestWithRevision(request Et
 func (states nonDeterministicState) applyRequestWithResponse(request EtcdRequest, response EtcdResponse) nonDeterministicState {
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
+		if LinearizationDeadlineTripped.Load() != 0 {
+			return nil
+		}
 		newState, modelResponse := s.Step(request)
 		if Match(modelResponse, MaybeEtcdResponse{EtcdResponse: response}) {
 			newStates = append(newStates, newState)

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -34,12 +34,34 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
 	start := time.Now()
 
-	model := model.NonDeterministicModel(keys)
-	check, info := porcupine.CheckOperationsVerbose(model, operations, timeout)
+	model.LinearizationDeadlineTripped.Store(0)
+
+	var timer *time.Timer
+	if timeout > 0 {
+		timer = time.AfterFunc(timeout, func() {
+			model.LinearizationDeadlineTripped.Store(1)
+		})
+	}
+
+	m := model.NonDeterministicModel(keys)
+	check, info := porcupine.CheckOperationsVerbose(m, operations, timeout)
+	if timer != nil {
+		timer.Stop()
+	}
+
 	result := LinearizationResult{
 		Info:  info,
-		Model: model,
+		Model: m,
 	}
+
+	if model.LinearizationDeadlineTripped.Load() != 0 {
+		result.Status = Failure
+		result.Message = "timed out"
+		result.Timeout = true
+		lg.Error("Linearization timed out", zap.Duration("duration", time.Since(start)))
+		return result
+	}
+
 	switch check {
 	case porcupine.Ok:
 		result.Status = Success

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -294,6 +294,73 @@ func keyValueRevision(key, value string, rev int64) model.KeyValue {
 	}
 }
 
+func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
+	timeout := time.Second
+	const failedPutCount = 17
+	// Repeat the range read to make the final applyRequestWithResponse step slow.
+	const rangeReadCount = 3072
+
+	history := []porcupine.Operation{}
+	for i := 0; i < failedPutCount; i++ {
+		history = append(history, porcupine.Operation{
+			ClientId: i,
+			Input:    putRequest(fmt.Sprintf("failed%03d", i), "value"),
+			Output:   errorResponse(fmt.Errorf("timeout")),
+			Call:     int64(i),
+			Return:   int64(failedPutCount + i),
+		})
+	}
+
+	rangeOperations := make([]model.EtcdOperation, 0, rangeReadCount)
+	for i := 0; i < rangeReadCount; i++ {
+		rangeOperations = append(rangeOperations, model.EtcdOperation{
+			Type: model.RangeOperation,
+			Range: model.RangeOptions{
+				Start: "failed",
+				End:   "faile~",
+			},
+		})
+	}
+	readRequest := model.EtcdRequest{
+		Type: model.Txn,
+		Txn: &model.TxnRequest{
+			OperationsOnSuccess: rangeOperations,
+		},
+	}
+
+	// Each failed put can be lost or persisted, so the large read-only
+	// transaction reaches applyRequestWithResponse with many possible states in
+	// a single Step call.
+	replay := model.NewReplayFromOperations(history)
+	state, err := replay.StateForRevision(failedPutCount + 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, readResponse := state.Step(readRequest)
+	history = append(history, porcupine.Operation{
+		ClientId: failedPutCount,
+		Input:    readRequest,
+		Output:   readResponse,
+		Call:     int64(2 * failedPutCount),
+		Return:   int64(2*failedPutCount + 1),
+	})
+	keys := model.ModelKeys(history)
+
+	start := time.Now()
+	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, timeout)
+	elapsed := time.Since(start)
+
+	if !result.Timeout {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) timed out = false, message = %q", result.Message)
+	}
+	if result.Message != "timed out" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "timed out")
+	}
+	if elapsed > timeout+250*time.Millisecond {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) does not respect timeout: %v, timeout was %v", elapsed, timeout)
+	}
+}
+
 func BenchmarkValidateLinearizableOperations(b *testing.B) {
 	lg := zap.NewNop()
 	b.Run("SequentialSuccessPuts", func(b *testing.B) {


### PR DESCRIPTION
Before the proper fix https://github.com/etcd-io/etcd/pull/21715 can land, we need a workaround for stabilising the CI.