### PR TITLE
client/pkg/fileutil: use os.Getuid() to skip TestIsDirWriteable as root

### DIFF
--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -35,13 +34,7 @@ func TestIsDirWriteable(t *testing.T) {
 	tmpdir := t.TempDir()
 	require.NoErrorf(t, IsDirWriteable(tmpdir), "unexpected IsDirWriteable error")
 	require.NoErrorf(t, os.Chmod(tmpdir, 0o444), "unexpected os.Chmod error")
-	me, err := user.Current()
-	if err != nil {
-		// err can be non-nil when cross compiled
-		// http://stackoverflow.com/questions/20609415/cross-compiling-user-current-not-implemented-on-linux-amd64
-		t.Skipf("failed to get current user: %v", err)
-	}
-	if me.Name == "root" || runtime.GOOS == "windows" {
+	if os.Getuid() == 0 || runtime.GOOS == "windows" {
 		// ideally we should check CAP_DAC_OVERRIDE.
 		// but it does not matter for tests.
 		// Chmod is not supported under windows.


### PR DESCRIPTION
- replace user.Current().Name == "root" with os.Getuid() == 0.
- drop os/user import and user.Current() error path.
- Address: https://github.com/etcd-io/etcd/issues/21787