### PR TITLE
keys-only Range optimization

### DIFF
--- a/server/etcdserver/txn/range.go
+++ b/server/etcdserver/txn/range.go
@@ -64,6 +64,7 @@ func executeRange(ctx context.Context, lg *zap.Logger, txnRead mvcc.TxnRead, r *
 		Limit:          limit,
 		Rev:            r.Revision,
 		CountOnly:      r.CountOnly,
+		FastKeysOnly:   r.KeysOnly && r.SortTarget != pb.RangeRequest_VALUE,
 		WithTotalCount: withTotalCount,
 	}
 

--- a/server/storage/mvcc/index.go
+++ b/server/storage/mvcc/index.go
@@ -23,7 +23,7 @@ import (
 
 type index interface {
 	Get(key []byte, atRev int64) (rev, created Revision, ver int64, err error)
-	Range(key, end []byte, atRev int64) ([][]byte, []Revision)
+	Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64)
 	Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int)
 	CountRevisions(key, end []byte, atRev int64) int
 	Put(key []byte, rev Revision)
@@ -160,25 +160,27 @@ func (ti *treeIndex) CountRevisions(key, end []byte, atRev int64) int {
 	return total
 }
 
-func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, revs []Revision) {
+func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64) {
 	ti.RLock()
 	defer ti.RUnlock()
 
 	if end == nil {
-		rev, _, _, err := ti.unsafeGet(key, atRev)
+		modified, created, version, err := ti.unsafeGet(key, atRev)
 		if err != nil {
-			return nil, nil
+			return nil, nil, nil, nil
 		}
-		return [][]byte{key}, []Revision{rev}
+		return [][]byte{key}, []Revision{modified}, []Revision{created}, []int64{version}
 	}
 	ti.unsafeVisit(key, end, func(ki *keyIndex) bool {
-		if rev, _, _, err := ki.get(ti.lg, atRev); err == nil {
-			revs = append(revs, rev)
+		if modified, created, version, err := ki.get(ti.lg, atRev); err == nil {
+			modifies = append(modifies, modified)
 			keys = append(keys, ki.key)
+			creates = append(creates, created)
+			versions = append(versions, version)
 		}
 		return true
 	})
-	return keys, revs
+	return keys, modifies, creates, versions
 }
 
 func (ti *treeIndex) Tombstone(key []byte, rev Revision) error {

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -111,7 +111,7 @@ func TestIndexRange(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		keys, revs := ti.Range(tt.key, tt.end, atRev)
+		keys, revs, _, _ := ti.Range(tt.key, tt.end, atRev)
 		if !reflect.DeepEqual(keys, tt.wkeys) {
 			t.Errorf("#%d: keys = %+v, want %+v", i, keys, tt.wkeys)
 		}

--- a/server/storage/mvcc/kv.go
+++ b/server/storage/mvcc/kv.go
@@ -27,6 +27,7 @@ type RangeOptions struct {
 	Limit          int64
 	Rev            int64
 	CountOnly      bool
+	FastKeysOnly   bool
 	WithTotalCount bool
 }
 

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -201,11 +201,11 @@ func TestStoreRange(t *testing.T) {
 		r    rangeResp
 	}{
 		{
-			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}},
+			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 1}}, []int64{1}},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 		{
-			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{{Main: 2}, {Main: 3}}},
+			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{{Main: 2}, {Main: 3}}, []Revision{{Main: 2}, {Main: 3}}, []int64{1, 1}},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 	}
@@ -280,7 +280,7 @@ func TestStoreDeleteRange(t *testing.T) {
 	}{
 		{
 			Revision{Main: 2},
-			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}},
+			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 2}}, []int64{1}},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 
 			newTestBucketKeyBytes(newBucketKey(3, 0, true)),
@@ -1014,8 +1014,10 @@ type indexGetResp struct {
 }
 
 type indexRangeResp struct {
-	keys [][]byte
-	revs []Revision
+	keys     [][]byte
+	revs     []Revision
+	creates  []Revision
+	versions []int64
 }
 
 type indexRangeEventsResp struct {
@@ -1031,7 +1033,7 @@ type fakeIndex struct {
 }
 
 func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int) {
-	_, rev := i.Range(key, end, atRev)
+	_, rev, _, _ := i.Range(key, end, atRev)
 	if len(rev) >= limit {
 		rev = rev[:limit]
 	}
@@ -1039,7 +1041,7 @@ func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotal
 }
 
 func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
-	_, rev := i.Range(key, end, atRev)
+	_, rev, _, _ := i.Range(key, end, atRev)
 	return len(rev)
 }
 
@@ -1049,10 +1051,10 @@ func (i *fakeIndex) Get(key []byte, atRev int64) (rev, created Revision, ver int
 	return r.rev, r.created, r.ver, r.err
 }
 
-func (i *fakeIndex) Range(key, end []byte, atRev int64) ([][]byte, []Revision) {
+func (i *fakeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64) {
 	i.Recorder.Record(testutil.Action{Name: "range", Params: []any{key, end, atRev}})
 	r := <-i.indexRangeRespc
-	return r.keys, r.revs
+	return r.keys, r.revs, r.creates, r.versions
 }
 
 func (i *fakeIndex) Put(key []byte, rev Revision) {

--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -86,18 +86,35 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 		tr.trace.Step("count revisions from in-memory index tree")
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
+
+	if ro.FastKeysOnly {
+		keys, modifies, creates, versions := tr.s.kvindex.Range(key, end, rev)
+		tr.trace.Step("keys only range from in-memory index tree")
+		if len(keys) == 0 {
+			return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
+		}
+		cappedKeysCount := sliceCapWithLimit(int(ro.Limit), keys)
+		kvs := make([]*mvccpb.KeyValue, cappedKeysCount)
+		for i := range len(kvs) {
+			kvs[i] = &mvccpb.KeyValue{
+				Key:            keys[i],
+				ModRevision:    modifies[i].Main,
+				CreateRevision: creates[i].Main,
+				Version:        versions[i],
+			}
+		}
+		return &RangeResult{KVs: kvs, Count: len(keys), Rev: curRev}, nil
+	}
+
 	revpairs, total := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit), ro.WithTotalCount)
 	tr.trace.Step("range keys from in-memory index tree")
 	if len(revpairs) == 0 {
 		return &RangeResult{KVs: nil, Count: total, Rev: curRev}, nil
 	}
 
-	limit := int(ro.Limit)
-	if limit <= 0 || limit > len(revpairs) {
-		limit = len(revpairs)
-	}
+	cappedEntriesCount := sliceCapWithLimit(int(ro.Limit), revpairs)
 
-	kvs := make([]*mvccpb.KeyValue, limit)
+	kvs := make([]*mvccpb.KeyValue, cappedEntriesCount)
 	revBytes := NewRevBytes()
 	for i, revpair := range revpairs[:len(kvs)] {
 		select {
@@ -105,6 +122,7 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 			return nil, fmt.Errorf("rangeKeys: context cancelled: %w", ctx.Err())
 		default:
 		}
+
 		revBytes = RevToBytes(revpair, revBytes)
 		_, vs := tr.tx.UnsafeRange(schema.Key, revBytes, nil, 0)
 		if len(vs) != 1 {
@@ -132,6 +150,13 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 	}
 	tr.trace.Step("range keys from bolt db")
 	return &RangeResult{KVs: kvs, Count: total, Rev: curRev}, nil
+}
+
+func sliceCapWithLimit[S any](limit int, s []S) int {
+	if limit <= 0 || limit > len(s) {
+		return len(s)
+	}
+	return limit
 }
 
 func (tr *storeTxnRead) End() {
@@ -271,7 +296,7 @@ func (tw *storeTxnWrite) deleteRange(key, end []byte) int64 {
 	if len(tw.changes) > 0 {
 		rrev++
 	}
-	keys, _ := tw.s.kvindex.Range(key, end, rrev)
+	keys, _, _, _ := tw.s.kvindex.Range(key, end, rrev)
 	if len(keys) == 0 {
 		return 0
 	}


### PR DESCRIPTION
A draft for #20386.

Technically, `Range` with `--keys-only` can avoid retrieving data from bbolt and instead return the keys from the in memory index b-tree.  However, to support sorting and filtering by modified/created revisions or versions options, we can't return just the keys.  Even though we still need to retrieve all the data when `--sort-by=value` is specified, luckily the rest of the metadata required by the sorting and filtering are available in the index b-tree.  

This PR does the following:
  - Add  `keysOnly` to mvcc.RangeOption, which is set when `--keys-only` is specified but not `--sort-by=value`.
  - Make `treeIndex.Range` return the list of created revisions and versions in addition to keys and modified revisions.
  - Make `storeTxnCommon.rangeKeys` use the newly added option to call the newly adjusted `treeIndex.Range` to create the `RangeResult.kvs` with `CreateRevision` and `Version`.

[Filtering and sorting](https://github.com/etcd-io/etcd/blob/58f45a9ff1c083130830eb02b0cc7d9783609095/server/etcdserver/txn/range.go#L75) would work the same way, with the data and metadata they need to do their jobs.