### PR TITLE
[release-3.5] client/pkg/fileutil: use os.Getuid() to skip TestIsDirWriteable as root

### DIFF
--- a/client/pkg/fileutil/fileutil_test.go
+++ b/client/pkg/fileutil/fileutil_test.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -42,13 +41,7 @@ func TestIsDirWriteable(t *testing.T) {
 	if err = os.Chmod(tmpdir, 0444); err != nil {
 		t.Fatalf("unexpected os.Chmod error: %v", err)
 	}
-	me, err := user.Current()
-	if err != nil {
-		// err can be non-nil when cross compiled
-		// http://stackoverflow.com/questions/20609415/cross-compiling-user-current-not-implemented-on-linux-amd64
-		t.Skipf("failed to get current user: %v", err)
-	}
-	if me.Name == "root" || runtime.GOOS == "windows" {
+	if os.Getuid() == 0 || runtime.GOOS == "windows" {
 		// ideally we should check CAP_DAC_OVERRIDE.
 		// but it does not matter for tests.
 		// Chmod is not supported under windows.


### PR DESCRIPTION
- replace user.Current().Name == "root" with os.Getuid() == 0.
- drop os/user import and user.Current() error path.
- backport of https://github.com/etcd-io/etcd/pull/21788
- address: https://github.com/etcd-io/etcd/issues/21787
