### PR TITLE
scripts/container_scan.sh: add container image CVE scanning

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2026 The etcd Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Container image CVE scan
+
+on:
+  push:
+    branches: [main, release-3.4, release-3.5, release-3.6]
+    paths:
+      - Dockerfile
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+  schedule:
+    - cron: '20 14 * * 5'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scan:
+    name: Scan container base image for OS-level CVEs
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Scan base image with Trivy
+        run: |
+          ./scripts/container_scan.sh sarif trivy-results.sarif
+
+      - name: Upload Trivy results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -16,14 +16,6 @@
 name: Container image CVE scan
 
 on:
-  push:
-    branches: [main, release-3.4, release-3.5, release-3.6]
-    paths:
-      - Dockerfile
-  pull_request:
-    branches: [main]
-    paths:
-      - Dockerfile
   schedule:
     - cron: '20 14 * * 5'
   workflow_dispatch:
@@ -32,7 +24,7 @@ permissions: read-all
 
 jobs:
   scan:
-    name: Scan container base image for OS-level CVEs
+    name: Scan released container image for CVEs
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -40,8 +32,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
-      - name: Scan base image with Trivy
+      - name: Scan released image with Trivy
         run: |
           ./scripts/container_scan.sh sarif trivy-results.sarif
 

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -29,6 +29,10 @@ jobs:
     permissions:
       security-events: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ["release-3.4", "release-3.5", "release-3.6", "release-3.7", "main"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,10 +41,10 @@ jobs:
 
       - name: Scan released image with Trivy
         run: |
-          ./scripts/container_scan.sh sarif trivy-results.sarif
+          ./scripts/container_scan.sh origin/${{ matrix.branch }} sarif "trivy-results-${{ matrix.branch }}.sarif"
 
       - name: Upload Trivy results to GitHub Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
-          sarif_file: trivy-results.sarif
+          sarif_file: "trivy-results-${{ matrix.branch }}.sarif"

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ fix-yamllint:
 run-govulncheck:
 	PASSES="govuln" ./scripts/test.sh
 
+.PHONY: verify-container-scan
+verify-container-scan:
+	./scripts/container_scan.sh
+
 # Tools
 
 .PHONY: install-golangci-lint

--- a/scripts/container_scan.sh
+++ b/scripts/container_scan.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2026 The etcd Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ETCD_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BASE_IMAGE=$(sed -n 's/^FROM --platform=linux\/${ARCH} //p' "${ETCD_ROOT_DIR}/Dockerfile")
+if [ -z "${BASE_IMAGE}" ]; then
+  echo "error: Could not extract base image reference from Dockerfile" >&2
+  exit 1
+fi
+
+if ! command -v trivy &>/dev/null; then
+  echo "Installing trivy..." >&2
+  go install github.com/aquasecurity/trivy/cmd/trivy@v0.70.0
+  TRIVY="$(go env GOPATH)/bin/trivy"
+else
+  TRIVY=trivy
+fi
+
+FORMAT=${1:-table}
+OUTPUT=${2:-}
+
+ARGS=(--severity CRITICAL,HIGH --exit-code 1 --format "${FORMAT}")
+if [ -n "${OUTPUT}" ]; then
+  ARGS+=(--output "${OUTPUT}")
+fi
+
+exec "${TRIVY}" image "${ARGS[@]}" "${BASE_IMAGE}"

--- a/scripts/container_scan.sh
+++ b/scripts/container_scan.sh
@@ -17,9 +17,13 @@ set -euo pipefail
 
 ETCD_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-LATEST_TAG=$(git -C "${ETCD_ROOT_DIR}" describe --tags --abbrev=0 --match 'v*')
+BRANCH=${1:-HEAD}
+FORMAT=${2:-table}
+OUTPUT=${3:-}
+
+LATEST_TAG=$(git -C "${ETCD_ROOT_DIR}" describe --tags --abbrev=0 --match 'v*' "${BRANCH}")
 if [ -z "${LATEST_TAG}" ]; then
-  echo "error: Could not extract latest tag" >&2
+  echo "error: Could not extract latest tag for ${BRANCH}" >&2
   exit 1
 fi
 IMAGE="quay.io/coreos/etcd:${LATEST_TAG}"
@@ -32,8 +36,6 @@ else
   TRIVY=trivy
 fi
 
-FORMAT=${1:-table}
-OUTPUT=${2:-}
 
 ARGS=(--severity CRITICAL,HIGH --exit-code 1 --format "${FORMAT}")
 if [ -n "${OUTPUT}" ]; then

--- a/scripts/container_scan.sh
+++ b/scripts/container_scan.sh
@@ -17,11 +17,12 @@ set -euo pipefail
 
 ETCD_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-BASE_IMAGE=$(sed -n 's/^FROM --platform=linux\/${ARCH} //p' "${ETCD_ROOT_DIR}/Dockerfile")
-if [ -z "${BASE_IMAGE}" ]; then
-  echo "error: Could not extract base image reference from Dockerfile" >&2
+LATEST_TAG=$(git -C "${ETCD_ROOT_DIR}" describe --tags --abbrev=0 --match 'v*')
+if [ -z "${LATEST_TAG}" ]; then
+  echo "error: Could not extract latest tag" >&2
   exit 1
 fi
+IMAGE="quay.io/coreos/etcd:${LATEST_TAG}"
 
 if ! command -v trivy &>/dev/null; then
   echo "Installing trivy..." >&2
@@ -39,4 +40,4 @@ if [ -n "${OUTPUT}" ]; then
   ARGS+=(--output "${OUTPUT}")
 fi
 
-exec "${TRIVY}" image "${ARGS[@]}" "${BASE_IMAGE}"
+exec "${TRIVY}" image "${ARGS[@]}" "${IMAGE}"


### PR DESCRIPTION
Add a script, Makefile target, and CI workflow to scan the container base image with Trivy for OS-level CVEs. etcd is built with CGO_ENABLED=0 and the existing govulncheck+CodeQL pipeline only covers Go vulnerabilities, so OS-level CVEs in the distroless base image were not detected. 

Closes #21252
Related to #19363