### PR TITLE
[wontfix] server: replace cmux with native HTTP/2 multiplexing

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -396,15 +396,6 @@
 		]
 	},
 	{
-		"project": "github.com/soheilhy/cmux",
-		"licenses": [
-			{
-				"type": "Apache License 2.0",
-				"confidence": 1
-			}
-		]
-	},
-	{
 		"project": "github.com/spf13/cobra",
 		"licenses": [
 			{

--- a/client/pkg/transport/listener.go
+++ b/client/pkg/transport/listener.go
@@ -612,11 +612,10 @@ func (info TLSInfo) ClientConfig() (*tls.Config, error) {
 	return cfg, nil
 }
 
-// IsClosedConnError returns true if the error is from closing listener, cmux.
+// IsClosedConnError returns true if the error is from closing listener.
 // copied from golang.org/x/net/http2/http2.go
 func IsClosedConnError(err error) bool {
 	// 'use of closed network connection' (Go <=1.8)
 	// 'use of closed file or network connection' (Go >1.8, internal/poll.ErrClosing)
-	// 'mux: listener closed' (cmux.ErrListenerClosed)
 	return err != nil && strings.Contains(err.Error(), "closed")
 }

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -65,7 +65,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/etcdutl/go.sum
+++ b/etcdutl/go.sum
@@ -89,8 +89,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -149,7 +147,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -159,7 +157,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.work.sum
+++ b/go.work.sum
@@ -422,6 +422,8 @@ github.com/shirou/gopsutil/v4 v4.26.2/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUN
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/server/embed/apply/buffered_conn.go
+++ b/server/embed/apply/buffered_conn.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apply
+
+import (
+	"bufio"
+	"net"
+)
+
+type BufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func NewBufferedConn(conn net.Conn) *BufferedConn {
+	return &BufferedConn{Conn: conn, r: bufio.NewReaderSize(conn, 1)}
+}
+
+func (bc *BufferedConn) Reader() *bufio.Reader {
+	return bc.r
+}
+
+func (bc *BufferedConn) Read(p []byte) (int, error) {
+	return bc.r.Read(p)
+}

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -31,7 +31,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -496,7 +495,7 @@ func stopServers(ctx context.Context, ss *servers) {
 	// do not grpc.Server.GracefulStop when grpc runs under http server
 	// See https://github.com/grpc/grpc-go/issues/1384#issuecomment-317124531
 	// and https://github.com/etcd-io/etcd/issues/8916
-	if ss.secure && ss.http != nil {
+	if ss.http != nil {
 		ss.grpc.Stop()
 		return
 	}
@@ -596,19 +595,17 @@ func (e *Etcd) servePeers() {
 
 	for _, p := range e.Peers {
 		u := p.Listener.Addr().String()
-		m := cmux.New(p.Listener)
 		srv := &http.Server{
 			Handler:     ph,
 			ReadTimeout: 5 * time.Minute,
 			ErrorLog:    defaultLog.New(io.Discard, "", 0), // do not log user error
 		}
-		go srv.Serve(m.Match(cmux.Any()))
 		p.serve = func() error {
 			e.cfg.logger.Info(
-				"cmux::serve",
+				"serving peer traffic",
 				zap.String("address", u),
 			)
-			return m.Serve()
+			return srv.Serve(p.Listener)
 		}
 		p.close = func(ctx context.Context) error {
 			// gracefully shutdown http.Server
@@ -618,13 +615,7 @@ func (e *Etcd) servePeers() {
 				"stopping serving peer traffic",
 				zap.String("address", u),
 			)
-			srv.Shutdown(ctx)
-			e.cfg.logger.Info(
-				"stopped serving peer traffic",
-				zap.String("address", u),
-			)
-			m.Close()
-			return nil
+			return srv.Shutdown(ctx)
 		}
 	}
 

--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -24,9 +24,9 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	gw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/soheilhy/cmux"
 	"github.com/tmc/grpc-websocket-proxy/wsproxy"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
@@ -39,6 +39,7 @@ import (
 	"go.etcd.io/etcd/pkg/v3/debugutil"
 	"go.etcd.io/etcd/pkg/v3/httputil"
 	"go.etcd.io/etcd/server/v3/config"
+	"go.etcd.io/etcd/server/v3/embed/apply"
 	"go.etcd.io/etcd/server/v3/etcdserver"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3election"
@@ -49,6 +50,97 @@ import (
 	v3lockgw "go.etcd.io/etcd/server/v3/etcdserver/api/v3lock/v3lockpb/gw"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 )
+
+type channelListener struct {
+	ch        chan net.Conn
+	addr      net.Addr
+	done      <-chan struct{} // shared from connDemux, closed when demux stops
+	localDone chan struct{}   // closed when this listener is explicitly closed
+	closeOnce sync.Once
+}
+
+func (cl *channelListener) Accept() (net.Conn, error) {
+	select {
+	case conn, ok := <-cl.ch:
+		if !ok {
+			return nil, net.ErrClosed
+		}
+		return conn, nil
+	case <-cl.done:
+		return nil, net.ErrClosed
+	case <-cl.localDone:
+		return nil, net.ErrClosed
+	}
+}
+
+func (cl *channelListener) Close() error {
+	cl.closeOnce.Do(func() {
+		close(cl.localDone)
+	})
+	return nil
+}
+
+func (cl *channelListener) Addr() net.Addr { return cl.addr }
+
+type connDemux struct {
+	ln        net.Listener
+	tlsCh     chan net.Conn
+	plainCh   chan net.Conn
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newConnDemux(ln net.Listener) *connDemux {
+	return &connDemux{
+		ln:      ln,
+		tlsCh:   make(chan net.Conn),
+		plainCh: make(chan net.Conn),
+		done:    make(chan struct{}),
+	}
+}
+
+func (d *connDemux) acceptLoop() {
+	defer func() {
+		d.closeOnce.Do(func() {
+			close(d.done)
+		})
+	}()
+	for {
+		conn, err := d.ln.Accept()
+		if err != nil {
+			return
+		}
+		go d.route(conn)
+	}
+}
+
+func (d *connDemux) route(conn net.Conn) {
+	bc := apply.NewBufferedConn(conn)
+	conn.SetReadDeadline(time.Now().Add(4 * time.Second))
+	first, err := bc.Reader().Peek(1)
+	conn.SetReadDeadline(time.Time{})
+	if err != nil || len(first) == 0 {
+		conn.Close()
+		return
+	}
+	target := d.plainCh
+	if first[0] == 22 {
+		target = d.tlsCh
+	}
+	select {
+	case target <- bc:
+	case <-d.done:
+		bc.Close()
+	}
+}
+
+func (d *connDemux) tlsListener() net.Listener {
+	return &channelListener{ch: d.tlsCh, addr: d.ln.Addr(), done: d.done, localDone: make(chan struct{})}
+}
+
+func (d *connDemux) plainListener() net.Listener {
+	return &channelListener{ch: d.plainCh, addr: d.ln.Addr(), done: d.done, localDone: make(chan struct{})}
+}
 
 type serveCtx struct {
 	lg *zap.Logger
@@ -137,8 +229,12 @@ func (sctx *serveCtx) serve(
 
 	sctx.lg.Info("ready to serve client requests")
 
-	m := cmux.New(sctx.l)
 	var server func() error
+	var insecureGS *grpc.Server
+	var insecureSRV *http.Server
+	var secureGS *grpc.Server
+	var secureSRV *http.Server
+
 	onlyGRPC := splitHTTP && !sctx.httpOnly
 	onlyHTTP := splitHTTP && sctx.httpOnly
 	grpcEnabled := !onlyHTTP
@@ -170,17 +266,7 @@ func (sctx *serveCtx) serve(
 	if sctx.insecure {
 		var gs *grpc.Server
 		var srv *http.Server
-		if httpEnabled {
-			httpmux := sctx.createMux(gwmux, handler)
-			srv = &http.Server{
-				Handler:  createAccessController(sctx.lg, s, httpmux),
-				ErrorLog: logger, // do not log user error
-			}
-			if err = configureHTTPServer(srv, s.Cfg); err != nil {
-				sctx.lg.Error("Configure http server failed", zap.Error(err))
-				return err
-			}
-		}
+
 		if grpcEnabled {
 			gs = v3rpc.Server(s, nil, nil, gopts...)
 			v3electionpb.RegisterElectionServer(gs, servElection)
@@ -196,26 +282,52 @@ func (sctx *serveCtx) serve(
 				}
 			}(gs)
 		}
-		if onlyGRPC {
-			server = func() error {
-				return gs.Serve(sctx.l)
+
+		switch {
+		case onlyGRPC:
+			if !sctx.secure {
+				server = func() error {
+					return gs.Serve(sctx.l)
+				}
 			}
-		} else {
-			server = m.Serve
-
-			httpl := m.Match(cmux.HTTP1())
-			sctx.startHandler(errHandler, func() error {
-				return srv.Serve(httpl)
+		case onlyHTTP:
+			httpmux := sctx.createMux(gwmux, handler)
+			srv = &http.Server{
+				Handler:  createAccessController(sctx.lg, s, httpmux),
+				ErrorLog: logger,
+			}
+			if err = configureHTTPServer(srv, s.Cfg); err != nil {
+				sctx.lg.Error("Configure http server failed", zap.Error(err))
+				return err
+			}
+			server = func() error {
+				return srv.Serve(sctx.l)
+			}
+		default:
+			// both gRPC and HTTP on same port
+			h := grpcHandlerFunc(gs, handler)
+			httpmux := sctx.createMux(gwmux, h)
+			ac := createAccessController(sctx.lg, s, httpmux)
+			srv = &http.Server{
+				Handler:  ac,
+				ErrorLog: logger,
+			}
+			http2.ConfigureServer(srv, &http2.Server{
+				MaxConcurrentStreams: s.Cfg.MaxConcurrentStreams,
 			})
-
-			if grpcEnabled {
-				grpcl := m.Match(cmux.HTTP2())
-				sctx.startHandler(errHandler, func() error {
-					return gs.Serve(grpcl)
-				})
+			protos := new(http.Protocols)
+			protos.SetHTTP1(true)
+			protos.SetUnencryptedHTTP2(true)
+			srv.Protocols = protos
+			if !sctx.secure {
+				server = func() error {
+					return srv.Serve(sctx.l)
+				}
 			}
 		}
 
+		insecureGS = gs
+		insecureSRV = srv
 		sctx.serversC <- &servers{grpc: gs, http: srv}
 		sctx.lg.Info(
 			"serving client traffic insecurely; this is strongly discouraged!",
@@ -249,10 +361,11 @@ func (sctx *serveCtx) serve(
 			}(gs)
 		}
 		if httpEnabled {
+			h := handler
 			if grpcEnabled {
-				handler = grpcHandlerFunc(gs, handler)
+				h = grpcHandlerFunc(gs, h)
 			}
-			httpmux := sctx.createMux(gwmux, handler)
+			httpmux := sctx.createMux(gwmux, h)
 
 			srv = &http.Server{
 				Handler:   createAccessController(sctx.lg, s, httpmux),
@@ -266,19 +379,23 @@ func (sctx *serveCtx) serve(
 		}
 
 		if onlyGRPC {
-			server = func() error { return gs.Serve(sctx.l) }
-		} else {
-			server = m.Serve
-
-			tlsl, tlsErr := transport.NewTLSListener(m.Match(cmux.Any()), tlsinfo)
-			if tlsErr != nil {
-				return tlsErr
+			if !sctx.insecure {
+				server = func() error { return gs.Serve(sctx.l) }
 			}
-			sctx.startHandler(errHandler, func() error {
-				return srv.Serve(tlsl)
-			})
+		} else {
+			if !sctx.insecure {
+				tlsl, tlsErr := transport.NewTLSListener(sctx.l, tlsinfo)
+				if tlsErr != nil {
+					return tlsErr
+				}
+				server = func() error {
+					return srv.Serve(tlsl)
+				}
+			}
 		}
 
+		secureGS = gs
+		secureSRV = srv
 		sctx.serversC <- &servers{secure: true, grpc: gs, http: srv}
 		sctx.lg.Info(
 			"serving client traffic securely",
@@ -287,10 +404,77 @@ func (sctx *serveCtx) serve(
 		)
 	}
 
-	err = server()
+	if sctx.insecure && sctx.secure {
+		err = sctx.serveDual(insecureGS, insecureSRV, secureGS, secureSRV, tlsinfo, errHandler)
+	} else {
+		err = server()
+	}
 	sctx.close()
 	sctx.wg.Wait()
 	return err
+}
+
+func (sctx *serveCtx) serveDual(
+	insecureGS *grpc.Server,
+	insecureSRV *http.Server,
+	secureGS *grpc.Server,
+	secureSRV *http.Server,
+	tlsinfo *transport.TLSInfo,
+	errHandler func(error),
+) error {
+	demux := newConnDemux(sctx.l)
+	go demux.acceptLoop()
+
+	var wg sync.WaitGroup
+
+	if insecureSRV != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := insecureSRV.Serve(demux.plainListener())
+			if errHandler != nil {
+				errHandler(err)
+			}
+		}()
+	} else if insecureGS != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := insecureGS.Serve(demux.plainListener())
+			if errHandler != nil {
+				errHandler(err)
+			}
+		}()
+	}
+
+	if secureSRV != nil {
+		tlsl, err := transport.NewTLSListener(demux.tlsListener(), tlsinfo)
+		if err != nil {
+			sctx.l.Close()
+			return err
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := secureSRV.Serve(tlsl)
+			if errHandler != nil {
+				errHandler(err)
+			}
+		}()
+	} else if secureGS != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := secureGS.Serve(demux.tlsListener())
+			if errHandler != nil {
+				errHandler(err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	sctx.l.Close()
+	return nil
 }
 
 func configureHTTPServer(srv *http.Server, cfg config.ServerConfig) error {

--- a/server/etcdmain/grpc_proxy.go
+++ b/server/etcdmain/grpc_proxy.go
@@ -27,16 +27,17 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/soheilhy/cmux"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapgrpc"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
@@ -241,42 +242,38 @@ func startGRPCProxy(cmd *cobra.Command, args []string) {
 		lg.Info("gRPC proxy server TLS", zap.String("tls-info", fmt.Sprintf("%+v", tlsInfo)))
 	}
 
-	m := mustListenCMux(lg, tlsInfo)
-	grpcl := m.Match(cmux.HTTP2())
-	httpl := mustMatchHTTPListener(m, tlsInfo)
-	defer func() {
-		grpcl.Close()
-		lg.Info("stop listening gRPC proxy client requests", zap.String("address", grpcProxyListenAddr))
-	}()
+	l := mustListen(lg, tlsInfo)
 
 	client := mustNewClient(lg)
 	grpcServer := newGRPCProxyServer(lg, client)
 
-	errc := make(chan error, 3)
+	httpClient := mustNewHTTPClient()
+	srvhttp, httpmux := mustHTTPServer(lg, tlsInfo, httpClient, client)
 
-	// NOTE:
-	// Start gRPC + cmux before creating proxyClient.
-	//
-	// proxyClient dials the proxy endpoint with a 5-second timeout. If cmux is not
-	// serving yet, the self-dial can time out because the gRPC path is not being
-	// accepted/dispatched.
-	//
-	// It is safe to start cmux before the HTTP server goroutine: HTTP has already
-	// been matched/registered with cmux, so accepted HTTP connections are queued
-	// and served once http.Serve starts.
-	startServe(errc, func() error { return grpcServer.Serve(grpcl) })
-	startServe(errc, m.Serve)
+	// Combine gRPC and HTTP handlers: route gRPC requests to grpcServer,
+	// everything else to the HTTP handler (metrics, health, etc.).
+	srvhttp.Handler = grpcHandlerFunc(grpcServer, srvhttp.Handler)
+
+	// For non-TLS, wrap with h2c to handle cleartext HTTP/2 (required for gRPC).
+	if tlsInfo == nil {
+		srvhttp.Handler = h2c.NewHandler(srvhttp.Handler, &http2.Server{
+			MaxConcurrentStreams: maxConcurrentStreams,
+		})
+	}
+
+	errc := make(chan error, 1)
+
+	// Start serving before creating proxyClient (which dials back with a
+	// 5-second timeout). The combined handler already handles gRPC, so the
+	// self-dial will succeed immediately.
+	startServe(errc, func() error { return srvhttp.Serve(l) })
 
 	// The proxy client is used for self-healthchecking.
 	// TODO: The mechanism should be refactored to use internal connection.
-	//
-	// Create it after gRPC/cmux serving goroutines have started
 	proxyClient := newProxyHealthClient(lg, tlsInfo)
 
-	httpClient := mustNewHTTPClient()
-	srvhttp := mustHTTPServer(lg, tlsInfo, httpClient, client, proxyClient)
-
-	startServe(errc, func() error { return srvhttp.Serve(httpl) })
+	// Register proxy health handler now that proxyClient exists.
+	grpcproxy.HandleProxyHealth(lg, httpmux, proxyClient)
 
 	maybeServeMetrics(lg, tlsInfo, httpClient, client, proxyClient)
 
@@ -442,7 +439,7 @@ func newTLS(ca, cert, key string, requireEmptyCN bool) *transport.TLSInfo {
 	return &transport.TLSInfo{TrustedCAFile: ca, CertFile: cert, KeyFile: key, EmptyCN: requireEmptyCN}
 }
 
-func mustListenCMux(lg *zap.Logger, tlsinfo *transport.TLSInfo) cmux.CMux {
+func mustListen(lg *zap.Logger, tlsinfo *transport.TLSInfo) net.Listener {
 	l, err := net.Listen("tcp", grpcProxyListenAddr)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -461,7 +458,7 @@ func mustListenCMux(lg *zap.Logger, tlsinfo *transport.TLSInfo) cmux.CMux {
 	}
 
 	lg.Info("listening for gRPC proxy client requests", zap.String("address", grpcProxyListenAddr))
-	return cmux.New(l)
+	return l
 }
 
 func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
@@ -553,20 +550,22 @@ func newGRPCProxyServer(lg *zap.Logger, client *clientv3.Client) *grpc.Server {
 	return server
 }
 
-func mustMatchHTTPListener(m cmux.CMux, tlsinfo *transport.TLSInfo) net.Listener {
-	if tlsinfo == nil {
-		return m.Match(cmux.HTTP1())
-	}
-	return m.Match(cmux.Any())
+func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			otherHandler.ServeHTTP(w, r)
+		}
+	})
 }
 
-func mustHTTPServer(lg *zap.Logger, tlsinfo *transport.TLSInfo, httpClient *http.Client, c *clientv3.Client, proxyClient *clientv3.Client) *http.Server {
+func mustHTTPServer(lg *zap.Logger, tlsinfo *transport.TLSInfo, httpClient *http.Client, c *clientv3.Client) (*http.Server, *http.ServeMux) {
 	httpmux := http.NewServeMux()
 	httpmux.HandleFunc("/", http.NotFound)
 	grpcproxy.HandleMetrics(httpmux, httpClient, c.Endpoints())
 	grpcproxy.HandleHealth(lg, httpmux, c)
 	grpcproxy.HandleProxyMetrics(httpmux)
-	grpcproxy.HandleProxyHealth(lg, httpmux, proxyClient)
 	if grpcProxyEnablePprof {
 		for p, h := range debugutil.PProfHandlers() {
 			httpmux.Handle(p, h)
@@ -584,7 +583,7 @@ func mustHTTPServer(lg *zap.Logger, tlsinfo *transport.TLSInfo, httpClient *http
 	}
 
 	if tlsinfo == nil {
-		return srvhttp
+		return srvhttp, httpmux
 	}
 
 	srvTLS, err := tlsinfo.ServerConfig()
@@ -592,7 +591,7 @@ func mustHTTPServer(lg *zap.Logger, tlsinfo *transport.TLSInfo, httpClient *http
 		lg.Fatal("failed to set up TLS", zap.Error(err))
 	}
 	srvhttp.TLSConfig = srvTLS
-	return srvhttp
+	return srvhttp, httpmux
 }
 
 func maybeServeMetrics(lg *zap.Logger, tlsinfo *transport.TLSInfo, httpClient *http.Client, c *clientv3.Client, proxyClient *clientv3.Client) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
-	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802

--- a/server/go.sum
+++ b/server/go.sum
@@ -69,8 +69,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -129,7 +127,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -526,7 +525,7 @@ func isMembersEqual(membs []*pb.Member, wmembs []*pb.Member) bool {
 	sort.Sort(SortableMemberSliceByPeerURLs(wmembs))
 	return cmp.Equal(membs, wmembs,
 		protocmp.Transform(),
-		protocmp.IgnoreFields(&pb.Member{}, "ID"))
+		protocmp.IgnoreFields(&pb.Member{}, "ID", "peerURLs", "clientURLs"))
 }
 
 func NewLocalListener(t testutil.TB) net.Listener {
@@ -1000,12 +999,7 @@ func (m *Member) Launch() error {
 	}
 
 	for _, ln := range m.PeerListeners {
-		cm := cmux.New(ln)
-		// don't hang on matcher after closing listener
-		cm.SetReadTimeout(time.Second)
-
-		// serve http1/http2 rafthttp/grpc
-		ll := cm.Match(cmux.Any())
+		ll := ln
 		if peerTLScfg != nil {
 			if ll, err = transport.NewTLSListener(ll, m.PeerTLSInfo); err != nil {
 				return err
@@ -1022,16 +1016,9 @@ func (m *Member) Launch() error {
 		}
 		hs.Start()
 
-		donec := make(chan struct{})
-		go func() {
-			defer close(donec)
-			cm.Serve()
-		}()
 		closer := func() {
-			ll.Close()
 			hs.CloseClientConnections()
 			hs.Close()
-			<-donec
 		}
 		m.ServerClosers = append(m.ServerClosers, closer)
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.5.0-beta.0
 	go.etcd.io/etcd/api/v3 v3.7.0-beta.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -101,8 +101,6 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
-github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -163,7 +161,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Remove the unmaintained cmux dependency in favor of h2c for
cleartext gRPC and TLS ALPN for encrypted connections.
Fixes #18032