### PR TITLE
Add range --count-only and --keys-only mutual exclusivity check

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -97,6 +97,8 @@ var (
 	ErrGRPCCanceled         = status.Error(codes.Canceled, "etcdserver: request canceled")
 	ErrGRPCDeadlineExceeded = status.Error(codes.DeadlineExceeded, "etcdserver: context deadline exceeded")
 
+	ErrGRPCRangeKeysAndCountOptions = status.Error(codes.InvalidArgument, "etcdserver: both KeysOnly and CountOnly cannot be true at the same time")
+
 	errStringToError = map[string]error{
 		ErrorDesc(ErrGRPCEmptyKey):      ErrGRPCEmptyKey,
 		ErrorDesc(ErrGRPCKeyNotFound):   ErrGRPCKeyNotFound,
@@ -162,6 +164,8 @@ var (
 		ErrorDesc(ErrGRPCInvalidDowngradeTargetVersion): ErrGRPCInvalidDowngradeTargetVersion,
 		ErrorDesc(ErrGRPCDowngradeInProcess):            ErrGRPCDowngradeInProcess,
 		ErrorDesc(ErrGRPCNoInflightDowngrade):           ErrGRPCNoInflightDowngrade,
+
+		ErrorDesc(ErrGRPCRangeKeysAndCountOptions): ErrGRPCRangeKeysAndCountOptions,
 	}
 )
 
@@ -234,6 +238,8 @@ var (
 	ErrInvalidDowngradeTargetVersion = Error(ErrGRPCInvalidDowngradeTargetVersion)
 	ErrDowngradeInProcess            = Error(ErrGRPCDowngradeInProcess)
 	ErrNoInflightDowngrade           = Error(ErrGRPCNoInflightDowngrade)
+
+	ErrRangeKeysAndCountOptions = Error(ErrGRPCRangeKeysAndCountOptions)
 )
 
 // EtcdError defines gRPC server errors.

--- a/server/etcdserver/api/v3rpc/key.go
+++ b/server/etcdserver/api/v3rpc/key.go
@@ -155,6 +155,10 @@ func checkRangeRequest(r *pb.RangeRequest) error {
 		return rpctypes.ErrGRPCEmptyKey
 	}
 
+	if r.KeysOnly && r.CountOnly {
+		return rpctypes.ErrGRPCRangeKeysAndCountOptions
+	}
+
 	if _, ok := pb.RangeRequest_SortOrder_name[int32(r.SortOrder)]; !ok {
 		return rpctypes.ErrGRPCInvalidSortOption
 	}

--- a/server/etcdserver/api/v3rpc/key_test.go
+++ b/server/etcdserver/api/v3rpc/key_test.go
@@ -25,11 +25,15 @@ func TestCheckRangeRequest(t *testing.T) {
 	rangeReqs := []struct {
 		sortOrder     pb.RangeRequest_SortOrder
 		sortTarget    pb.RangeRequest_SortTarget
+		countOnly     bool
+		keysOnly      bool
 		expectedError error
 	}{
 		{
 			sortOrder:     pb.RangeRequest_ASCEND,
 			sortTarget:    pb.RangeRequest_CREATE,
+			countOnly:     false,
+			keysOnly:      false,
 			expectedError: nil,
 		},
 		{
@@ -42,6 +46,27 @@ func TestCheckRangeRequest(t *testing.T) {
 			sortTarget:    pb.RangeRequest_MOD,
 			expectedError: rpctypes.ErrGRPCInvalidSortOption,
 		},
+		{
+			sortOrder:     pb.RangeRequest_ASCEND,
+			sortTarget:    pb.RangeRequest_CREATE,
+			countOnly:     true,
+			keysOnly:      false,
+			expectedError: nil,
+		},
+		{
+			sortOrder:     pb.RangeRequest_ASCEND,
+			sortTarget:    pb.RangeRequest_CREATE,
+			countOnly:     false,
+			keysOnly:      true,
+			expectedError: nil,
+		},
+		{
+			sortOrder:     pb.RangeRequest_ASCEND,
+			sortTarget:    pb.RangeRequest_CREATE,
+			countOnly:     true,
+			keysOnly:      true,
+			expectedError: rpctypes.ErrGRPCRangeKeysAndCountOptions,
+		},
 	}
 
 	for _, req := range rangeReqs {
@@ -49,6 +74,8 @@ func TestCheckRangeRequest(t *testing.T) {
 			Key:        []byte{1, 2, 3},
 			SortOrder:  req.sortOrder,
 			SortTarget: req.sortTarget,
+			CountOnly:  req.countOnly,
+			KeysOnly:   req.keysOnly,
 		}
 
 		actualRet := checkRangeRequest(&rangeReq)


### PR DESCRIPTION
Adding the mutual exclusivity check for Range on the server side.

Addressing the comment https://github.com/etcd-io/etcd/pull/21791#discussion_r3292474414.