### PR TITLE
robustness: follow up change for #21806

### DIFF
--- a/tests/antithesis/test-template/robustness/traffic/main.go
+++ b/tests/antithesis/test-template/robustness/traffic/main.go
@@ -76,7 +76,10 @@ func main() {
 	choice := rand.IntN(len(traffics))
 	tf := traffics[choice]
 	lg.Info("Traffic", zap.String("Type", trafficNames[choice]))
-	r := report.NewTestReport(lg, reportPath, etcdetcdDataPaths, &report.TrafficDetail{ExpectUniqueRevision: tf.ExpectUniqueRevision()})
+	r, err := report.NewTestReport(lg, reportPath, etcdetcdDataPaths, &report.TrafficDetail{ExpectUniqueRevision: tf.ExpectUniqueRevision()})
+	if err != nil {
+		lg.Fatal("Failed to create test report", zap.Error(err))
+	}
 	defer func() {
 		if err = r.SaveEtcdData(); err != nil {
 			lg.Error("Failed to save traffic generation report", zap.Error(err))

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -88,20 +88,21 @@ func TestRobustnessRegression(t *testing.T) {
 }
 
 func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenarios.TestScenario, c *e2e.EtcdProcessCluster) {
-	r := report.NewTestReport(lg, testResultsDirectory(t), report.ServerDataPaths(c), &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()})
+	r, err := report.NewTestReport(lg, testResultsDirectory(t), report.ServerDataPaths(c), &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()})
+	require.NoError(t, err)
 	// t.Failed() returns false during panicking. We need to forcibly
 	// save data on panicking.
 	// Refer to: https://github.com/golang/go/issues/49929
 	panicked := true
 	defer func() {
-		err := r.Finalize(t.Failed(), panicked)
+		err = r.Finalize(t.Failed(), panicked)
 		if err != nil {
 			t.Error(err)
 		}
 	}()
 	clientReports := runScenario(ctx, t, s, lg, c)
 	r.SetClientReports(clientReports)
-	err := r.SaveEtcdData()
+	err = r.SaveEtcdData()
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/robustness/report/report.go
+++ b/tests/robustness/report/report.go
@@ -36,16 +36,16 @@ type TestReport struct {
 	dataSaved       bool
 }
 
-func NewTestReport(lg *zap.Logger, reportPath string, serverDataPaths map[string]string, traffic *TrafficDetail) *TestReport {
+func NewTestReport(lg *zap.Logger, reportPath string, serverDataPaths map[string]string, traffic *TrafficDetail) (*TestReport, error) {
 	if reportPath == "" {
-		panic("reportPath is not set")
+		return nil, fmt.Errorf("reportPath is not set")
 	}
 	return &TestReport{
 		logger:          lg,
 		reportPath:      reportPath,
 		serverDataPaths: serverDataPaths,
 		traffic:         traffic,
-	}
+	}, nil
 }
 
 func (r *TestReport) SetClientReports(reports []ClientReport) {


### PR DESCRIPTION
Address https://github.com/etcd-io/etcd/pull/21806#discussion_r3295325461

The main idea is to not `panic` but return an error.