### PR TITLE
[release-3.6] server: allow non-admin maintenance status

### DIFF
--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -364,7 +364,7 @@ func (ams *authMaintenanceServer) Alarm(ctx context.Context, ar *pb.AlarmRequest
 }
 
 func (ams *authMaintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (*pb.StatusResponse, error) {
-	if err := ams.isPermitted(ctx); err != nil {
+	if err := ams.requireAuthInfo(ctx); err != nil {
 		return nil, togRPCError(err)
 	}
 

--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -166,7 +166,7 @@ func TestStatusWithRootAuth(t *testing.T) {
 }
 
 func TestStatusWithUserAuth(t *testing.T) {
-	testStatusWithAuth(t, false, true, WithAuth("user0", "user0Pass"))
+	testStatusWithAuth(t, false, false, WithAuth("user0", "user0Pass"))
 }
 
 func testStatusWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {


### PR DESCRIPTION
Manual backport of #21666 to release-3.6.

Verbatim cherry-pick. The `requireAuthInfo` helper exists on release-3.6 via the same `*AuthAdmin` embed, no adaptation needed.

`TestStatusWithUserAuth` and `TestStatusWithRootAuth` pass locally:

```
go test -tags=integration -run "TestStatusWithUserAuth|TestStatusWithRootAuth" ./common/...
ok  	go.etcd.io/etcd/tests/v3/common	4.366s
```

Tracks #21663.