### PR TITLE
Add support for KeysOnly into robustness tests

### DIFF
--- a/tests/robustness/client/client.go
+++ b/tests/robustness/client/client.go
@@ -90,10 +90,10 @@ func (c *RecordingClient) Do(ctx context.Context, op clientv3.Op) (clientv3.OpRe
 
 func (c *RecordingClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	op := clientv3.OpGet(key, opts...)
-	return c.Range(ctx, key, string(op.RangeBytes()), op.Rev(), op.Limit())
+	return c.Range(ctx, key, string(op.RangeBytes()), op.Rev(), op.Limit(), op.IsKeysOnly())
 }
 
-func (c *RecordingClient) Range(ctx context.Context, start, end string, revision, limit int64) (*clientv3.GetResponse, error) {
+func (c *RecordingClient) Range(ctx context.Context, start, end string, revision, limit int64, keyOnly bool) (*clientv3.GetResponse, error) {
 	ops := []clientv3.OpOption{}
 	if end != "" {
 		ops = append(ops, clientv3.WithRange(end))
@@ -103,17 +103,20 @@ func (c *RecordingClient) Range(ctx context.Context, start, end string, revision
 	}
 	if limit != 0 {
 		ops = append(ops, clientv3.WithLimit(limit))
+	}
+	if keyOnly {
+		ops = append(ops, clientv3.WithKeysOnly())
 	}
 	c.kvMux.Lock()
 	defer c.kvMux.Unlock()
 	callTime := time.Since(c.baseTime)
 	resp, err := c.client.Get(ctx, start, ops...)
 	returnTime := time.Since(c.baseTime)
-	c.kvOperations.AppendRange(start, end, revision, limit, callTime, returnTime, resp, err)
+	c.kvOperations.AppendRange(start, end, revision, limit, keyOnly, callTime, returnTime, resp, err)
 	return resp, err
 }
 
-func (c *RecordingClient) RangeStream(ctx context.Context, start, end string, revision, limit int64) (*clientv3.GetResponse, error) {
+func (c *RecordingClient) RangeStream(ctx context.Context, start, end string, revision, limit int64, keyOnly bool) (*clientv3.GetResponse, error) {
 	ops := []clientv3.OpOption{}
 	if end != "" {
 		ops = append(ops, clientv3.WithRange(end))
@@ -123,6 +126,9 @@ func (c *RecordingClient) RangeStream(ctx context.Context, start, end string, re
 	}
 	if limit != 0 {
 		ops = append(ops, clientv3.WithLimit(limit))
+	}
+	if keyOnly {
+		ops = append(ops, clientv3.WithKeysOnly())
 	}
 	c.kvMux.Lock()
 	defer c.kvMux.Unlock()
@@ -133,7 +139,7 @@ func (c *RecordingClient) RangeStream(ctx context.Context, start, end string, re
 		resp, err = clientv3.GetStreamToGetResponse(stream)
 	}
 	returnTime := time.Since(c.baseTime)
-	c.kvOperations.AppendRange(start, end, revision, limit, callTime, returnTime, resp, err)
+	c.kvOperations.AppendRange(start, end, revision, limit, keyOnly, callTime, returnTime, resp, err)
 	return resp, err
 }
 

--- a/tests/robustness/model/describe.go
+++ b/tests/robustness/model/describe.go
@@ -219,6 +219,9 @@ func describeRangeRequest(opts RangeOptions, revision int64) string {
 	if opts.Limit != 0 {
 		kwargs = append(kwargs, fmt.Sprintf("limit=%d", opts.Limit))
 	}
+	if opts.KeysOnly {
+		kwargs = append(kwargs, "keysOnly")
+	}
 	kwargsString := strings.Join(kwargs, ", ")
 	if kwargsString != "" {
 		kwargsString = ", " + kwargsString
@@ -252,7 +255,11 @@ func describeRangeResponse(request RangeOptions, response RangeResponse) string 
 	if request.End != "" {
 		kvs := make([]string, len(response.KVs))
 		for i, kv := range response.KVs {
-			kvs[i] = describeValueOrHash(kv.Value)
+			if request.KeysOnly {
+				kvs[i] = kv.Key
+			} else {
+				kvs[i] = fmt.Sprintf("%s:%s", kv.Key, describeValueOrHash(kv.Value))
+			}
 		}
 		return fmt.Sprintf("[%s], count: %d", strings.Join(kvs, ","), response.Count)
 	}
@@ -272,7 +279,7 @@ func DescribeOperationMetadata(response MaybeEtcdResponse) string {
 
 func describeValueOrHash(value ValueOrHash) string {
 	if value.Hash != 0 {
-		return fmt.Sprintf("hash: %d", value.Hash)
+		return fmt.Sprintf("<hash:%d>", value.Hash)
 	}
 	if value.Value == "" {
 		return "nil"

--- a/tests/robustness/model/describe_test.go
+++ b/tests/robustness/model/describe_test.go
@@ -43,7 +43,7 @@ func TestModelDescribe(t *testing.T) {
 		{
 			req:            getRequest("key2b"),
 			resp:           getResponse("key2b", "01234567890123456789", 2, 2),
-			expectDescribe: `get("key2b") -> hash: 2945867837, rev: 2`,
+			expectDescribe: `get("key2b") -> <hash:2945867837>, rev: 2`,
 		},
 		{
 			req:            putRequest("key3", "3"),
@@ -58,7 +58,7 @@ func TestModelDescribe(t *testing.T) {
 		{
 			req:            putRequest("key3c", "01234567890123456789"),
 			resp:           putResponse(3),
-			expectDescribe: `put("key3c", hash: 2945867837) -> ok, rev: 3`,
+			expectDescribe: `put("key3c", <hash:2945867837>) -> ok, rev: 3`,
 		},
 		{
 			req:            putRequest("key4", "4"),
@@ -137,13 +137,13 @@ func TestModelDescribe(t *testing.T) {
 		},
 		{
 			req:            listRequest("key12", 0),
-			resp:           rangeResponse([]*mvccpb.KeyValue{{Value: []byte("12")}}, 2, 12),
-			expectDescribe: `list("key12") -> ["12"], count: 2, rev: 12`,
+			resp:           rangeResponse([]*mvccpb.KeyValue{{Key: []byte("key12"), Value: []byte("12")}}, 2, 12),
+			expectDescribe: `list("key12") -> [key12:"12"], count: 2, rev: 12`,
 		},
 		{
 			req:            listRequest("key13", 0),
-			resp:           rangeResponse([]*mvccpb.KeyValue{{Value: []byte("01234567890123456789")}}, 1, 13),
-			expectDescribe: `list("key13") -> [hash: 2945867837], count: 1, rev: 13`,
+			resp:           rangeResponse([]*mvccpb.KeyValue{{Key: []byte("key13"), Value: []byte("01234567890123456789")}}, 1, 13),
+			expectDescribe: `list("key13") -> [key13:<hash:2945867837>], count: 1, rev: 13`,
 		},
 		{
 			req:            listRequest("key14", 14),

--- a/tests/robustness/model/deterministic.go
+++ b/tests/robustness/model/deterministic.go
@@ -296,7 +296,11 @@ func (s EtcdState) getRange(options RangeOptions) RangeResponse {
 			}
 			k := s.Keys[i]
 			if k >= options.Start && k < options.End {
-				response.KVs = append(response.KVs, KeyValue{Key: k, ValueRevision: *v})
+				kv := KeyValue{Key: k, ValueRevision: *v}
+				if options.KeysOnly {
+					kv.ValueRevision.Value = ValueOrHash{}
+				}
+				response.KVs = append(response.KVs, kv)
 				count++
 			}
 		}

--- a/tests/robustness/model/history.go
+++ b/tests/robustness/model/history.go
@@ -58,8 +58,8 @@ func NewAppendableHistory(ids identity.Provider) *AppendableHistory {
 	}
 }
 
-func (h *AppendableHistory) AppendRange(startKey, endKey string, revision, limit int64, start, end time.Duration, resp *clientv3.GetResponse, err error) {
-	request := staleRangeRequest(startKey, endKey, limit, revision)
+func (h *AppendableHistory) AppendRange(startKey, endKey string, revision, limit int64, keysOnly bool, start, end time.Duration, resp *clientv3.GetResponse, err error) {
+	request := staleRangeRequest(startKey, endKey, limit, revision, keysOnly)
 	if err != nil {
 		h.appendFailed(request, start, end, err)
 		return
@@ -343,11 +343,11 @@ func getRequest(key string) EtcdRequest {
 }
 
 func staleGetRequest(key string, revision int64) EtcdRequest {
-	return staleRangeRequest(key, "", 0, revision)
+	return staleRangeRequest(key, "", 0, revision, false)
 }
 
 func rangeRequest(start, end string, limit int64) EtcdRequest {
-	return staleRangeRequest(start, end, limit, 0)
+	return staleRangeRequest(start, end, limit, 0, false)
 }
 
 func listRequest(key string, limit int64) EtcdRequest {
@@ -355,11 +355,11 @@ func listRequest(key string, limit int64) EtcdRequest {
 }
 
 func staleListRequest(key string, limit, revision int64) EtcdRequest {
-	return staleRangeRequest(key, clientv3.GetPrefixRangeEnd(key), limit, revision)
+	return staleRangeRequest(key, clientv3.GetPrefixRangeEnd(key), limit, revision, false)
 }
 
-func staleRangeRequest(start, end string, limit, revision int64) EtcdRequest {
-	return EtcdRequest{Type: Range, Range: &RangeRequest{RangeOptions: RangeOptions{Start: start, End: end, Limit: limit}, Revision: revision}}
+func staleRangeRequest(start, end string, limit, revision int64, keysOnly bool) EtcdRequest {
+	return EtcdRequest{Type: Range, Range: &RangeRequest{RangeOptions: RangeOptions{Start: start, End: end, Limit: limit, KeysOnly: keysOnly}, Revision: revision}}
 }
 
 func emptyGetResponse(revision int64) MaybeEtcdResponse {

--- a/tests/robustness/model/types.go
+++ b/tests/robustness/model/types.go
@@ -71,9 +71,10 @@ type RangeRequest struct {
 }
 
 type RangeOptions struct {
-	Start string
-	End   string
-	Limit int64
+	Start    string
+	End      string
+	Limit    int64
+	KeysOnly bool
 }
 
 type PutOptions struct {

--- a/tests/robustness/report/client_test.go
+++ b/tests/robustness/report/client_test.go
@@ -38,7 +38,7 @@ func TestPersistLoadClientReports(t *testing.T) {
 	start := time.Since(baseTime)
 	time.Sleep(time.Nanosecond)
 	stop := time.Since(baseTime)
-	h.AppendRange("key", "", 0, 0, start, stop, &clientv3.GetResponse{Header: &etcdserverpb.ResponseHeader{Revision: 2}, Count: 2, Kvs: []*mvccpb.KeyValue{{
+	h.AppendRange("key", "", 0, 0, false, start, stop, &clientv3.GetResponse{Header: &etcdserverpb.ResponseHeader{Revision: 2}, Count: 2, Kvs: []*mvccpb.KeyValue{{
 		Key:         []byte("key"),
 		ModRevision: 2,
 		Value:       []byte("value"),

--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -323,9 +323,10 @@ func toEtcdOperation(op *pb.RequestOp) (operation model.EtcdOperation) {
 		operation = model.EtcdOperation{
 			Type: model.RangeOperation,
 			Range: model.RangeOptions{
-				Start: string(rangeOp.Key),
-				End:   string(rangeOp.RangeEnd),
-				Limit: rangeOp.Limit,
+				Start:    string(rangeOp.Key),
+				End:      string(rangeOp.RangeEnd),
+				Limit:    rangeOp.Limit,
+				KeysOnly: rangeOp.GetKeysOnly(),
 			},
 		}
 	case op.GetRequestPut() != nil:

--- a/tests/robustness/traffic/etcd.go
+++ b/tests/robustness/traffic/etcd.go
@@ -37,8 +37,10 @@ var (
 		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
-			{Choice: List, Weight: 8},
-			{Choice: ListStream, Weight: 7},
+			{Choice: List, Weight: 4},
+			{Choice: ListKeyOnly, Weight: 4},
+			{Choice: ListStream, Weight: 4},
+			{Choice: ListStreamKeyOnly, Weight: 3},
 			{Choice: StaleGet, Weight: 10},
 			{Choice: StaleList, Weight: 5},
 			{Choice: StaleListStream, Weight: 5},
@@ -56,8 +58,10 @@ var (
 		// Please keep the sum of weights equal 100.
 		requests: []random.ChoiceWeight[etcdRequestType]{
 			{Choice: Get, Weight: 15},
-			{Choice: List, Weight: 8},
-			{Choice: ListStream, Weight: 7},
+			{Choice: List, Weight: 4},
+			{Choice: ListKeyOnly, Weight: 4},
+			{Choice: ListStream, Weight: 4},
+			{Choice: ListStreamKeyOnly, Weight: 3},
 			{Choice: StaleGet, Weight: 10},
 			{Choice: StaleList, Weight: 5},
 			{Choice: StaleListStream, Weight: 5},
@@ -89,19 +93,21 @@ func (t etcdTraffic) ExpectUniqueRevision() bool {
 type etcdRequestType string
 
 const (
-	Get             etcdRequestType = "get"
-	StaleGet        etcdRequestType = "staleGet"
-	List            etcdRequestType = "list"
-	StaleList       etcdRequestType = "staleList"
-	ListStream      etcdRequestType = "listStream"
-	StaleListStream etcdRequestType = "staleListStream"
-	Put             etcdRequestType = "put"
-	Delete          etcdRequestType = "delete"
-	MultiOpTxn      etcdRequestType = "multiOpTxn"
-	PutWithLease    etcdRequestType = "putWithLease"
-	LeaseRevoke     etcdRequestType = "leaseRevoke"
-	CompareAndSet   etcdRequestType = "compareAndSet"
-	Defragment      etcdRequestType = "defragment"
+	Get               etcdRequestType = "get"
+	StaleGet          etcdRequestType = "staleGet"
+	List              etcdRequestType = "list"
+	ListKeyOnly       etcdRequestType = "listKeyOnly"
+	StaleList         etcdRequestType = "staleList"
+	ListStream        etcdRequestType = "listStream"
+	ListStreamKeyOnly etcdRequestType = "listStreamKeyOnly"
+	StaleListStream   etcdRequestType = "staleListStream"
+	Put               etcdRequestType = "put"
+	Delete            etcdRequestType = "delete"
+	MultiOpTxn        etcdRequestType = "multiOpTxn"
+	PutWithLease      etcdRequestType = "putWithLease"
+	LeaseRevoke       etcdRequestType = "leaseRevoke"
+	CompareAndSet     etcdRequestType = "compareAndSet"
+	Defragment        etcdRequestType = "defragment"
 )
 
 func (t etcdTraffic) Name() string {
@@ -228,27 +234,41 @@ func (c etcdTrafficClient) Request(ctx context.Context, request etcdRequestType,
 		}
 	case List:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit)
+		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit, false)
+		if resp != nil {
+			c.keyStore.SyncKeys(resp)
+			rev = resp.Header.Revision
+		}
+	case ListKeyOnly:
+		var resp *clientv3.GetResponse
+		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit, true)
 		if resp != nil {
 			c.keyStore.SyncKeys(resp)
 			rev = resp.Header.Revision
 		}
 	case StaleList:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit)
+		resp, err = c.client.Range(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit, false)
 		if resp != nil {
 			rev = resp.Header.Revision
 		}
 	case ListStream:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit)
+		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit, false)
+		if resp != nil {
+			c.keyStore.SyncKeys(resp)
+			rev = resp.Header.Revision
+		}
+	case ListStreamKeyOnly:
+		var resp *clientv3.GetResponse
+		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), 0, limit, true)
 		if resp != nil {
 			c.keyStore.SyncKeys(resp)
 			rev = resp.Header.Revision
 		}
 	case StaleListStream:
 		var resp *clientv3.GetResponse
-		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit)
+		resp, err = c.client.RangeStream(opCtx, c.keyStore.GetPrefix(), clientv3.GetPrefixRangeEnd(c.keyStore.GetPrefix()), lastRev, limit, false)
 		if resp != nil {
 			rev = resp.Header.Revision
 		}

--- a/tests/robustness/validate/patch_history_test.go
+++ b/tests/robustness/validate/patch_history_test.go
@@ -44,7 +44,7 @@ func TestPatchHistory(t *testing.T) {
 		{
 			name: "successful range remains",
 			historyFunc: func(h *model.AppendableHistory) {
-				h.AppendRange("key", "", 0, 0, 100, 200, &clientv3.GetResponse{}, nil)
+				h.AppendRange("key", "", 0, 0, false, 100, 200, &clientv3.GetResponse{}, nil)
 			},
 			expectedRemainingOperations: []porcupine.Operation{
 				{Return: 200, Output: rangeResponse(0)},


### PR DESCRIPTION
For https://github.com/etcd-io/etcd/pull/21791