### PR TITLE
grpcproxy: fix adding watchers to stopped watchBroadcast. Fixes #21813

### DIFF
--- a/server/proxy/grpcproxy/watch_broadcast.go
+++ b/server/proxy/grpcproxy/watch_broadcast.go
@@ -39,10 +39,12 @@ type watchBroadcast struct {
 	receivers map[*watcher]struct{}
 	// responses counts the number of responses
 	responses int
-	lg        *zap.Logger
+	// stopped indicates the underlying etcd watch has been disconnected.
+	stopped bool
+	lg      *zap.Logger
 }
 
-func newWatchBroadcast(lg *zap.Logger, wp *watchProxy, w *watcher, update func(*watchBroadcast)) *watchBroadcast {
+func newWatchBroadcast(lg *zap.Logger, wp *watchProxy, w *watcher, update func(*watchBroadcast), reattach func(*watchBroadcast)) *watchBroadcast {
 	cctx, cancel := context.WithCancel(wp.ctx)
 	wb := &watchBroadcast{
 		cancel:    cancel,
@@ -53,6 +55,7 @@ func newWatchBroadcast(lg *zap.Logger, wp *watchProxy, w *watcher, update func(*
 	}
 	wb.add(w)
 	go func() {
+		defer reattach(wb)
 		defer close(wb.donec)
 
 		opts := []clientv3.OpOption{
@@ -72,6 +75,10 @@ func newWatchBroadcast(lg *zap.Logger, wp *watchProxy, w *watcher, update func(*
 			wb.bcast(wr)
 			update(wb)
 		}
+
+		wb.mu.Lock()
+		wb.stopped = true
+		wb.mu.Unlock()
 	}()
 	return wb
 }
@@ -97,6 +104,9 @@ func (wb *watchBroadcast) bcast(wr clientv3.WatchResponse) {
 func (wb *watchBroadcast) add(w *watcher) bool {
 	wb.mu.Lock()
 	defer wb.mu.Unlock()
+	if wb.stopped {
+		return false
+	}
 	if wb.nextrev > w.nextrev || (wb.nextrev == 0 && w.nextrev != 0) {
 		// wb is too far ahead, w will miss events
 		// or wb is being established with a current watcher

--- a/server/proxy/grpcproxy/watch_broadcasts.go
+++ b/server/proxy/grpcproxy/watch_broadcasts.go
@@ -55,6 +55,10 @@ func (wbs *watchBroadcasts) coalesce(wb *watchBroadcast) {
 		return
 	}
 	wbs.mu.Lock()
+	if _, ok := wbs.bcasts[wb]; !ok {
+		wbs.mu.Unlock()
+		return
+	}
 	for wbswb := range wbs.bcasts {
 		if wbswb == wb {
 			continue
@@ -64,7 +68,8 @@ func (wbs *watchBroadcasts) coalesce(wb *watchBroadcast) {
 		// 1. check if wbswb is behind wb so it won't skip any events in wb
 		// 2. ensure wbswb started; nextrev == 0 may mean wbswb is waiting
 		// for a current watcher and expects a create event from the server.
-		if wb.nextrev >= wbswb.nextrev && wbswb.responses > 0 {
+		// 3. do not migrate to a stopped wbswb to avoid losing events.
+		if wb.nextrev >= wbswb.nextrev && wbswb.responses > 0 && !wbswb.stopped {
 			for w := range wb.receivers {
 				wbswb.receivers[w] = struct{}{}
 				wbs.watchers[w] = wbswb
@@ -93,9 +98,58 @@ func (wbs *watchBroadcasts) add(w *watcher) {
 		}
 	}
 	// no fit; create a bcast
-	wb := newWatchBroadcast(wbs.wp.lg, wbs.wp, w, wbs.update)
+	wb := newWatchBroadcast(wbs.wp.lg, wbs.wp, w, wbs.update, wbs.reattach)
 	wbs.watchers[w] = wb
 	wbs.bcasts[wb] = struct{}{}
+}
+
+func (wbs *watchBroadcasts) reattach(wb *watchBroadcast) {
+	wbs.mu.Lock()
+	defer wbs.mu.Unlock()
+	if _, ok := wbs.bcasts[wb]; !ok {
+		return
+	}
+
+	// collect orphaned watchers that need to be reassigned
+	wb.mu.Lock()
+	orphans := make([]*watcher, 0, len(wb.receivers))
+	for w := range wb.receivers {
+		orphans = append(orphans, w)
+	}
+	wb.receivers = nil
+	wb.mu.Unlock()
+
+	delete(wbs.bcasts, wb)
+	wb.cancel()
+
+	// reassign each orphaned watcher to an existing or new broadcast.
+	var newWb *watchBroadcast
+	for _, w := range orphans {
+		placed := false
+		for existingWb := range wbs.bcasts {
+			existingWb.mu.Lock()
+			if !existingWb.stopped && existingWb.responses > 0 && w.nextrev >= existingWb.nextrev {
+				existingWb.receivers[w] = struct{}{}
+				wbs.watchers[w] = existingWb
+				placed = true
+			}
+			existingWb.mu.Unlock()
+			if placed {
+				break
+			}
+		}
+		if !placed {
+			if newWb == nil {
+				newWb = newWatchBroadcast(wbs.wp.lg, wbs.wp, w, wbs.update, wbs.reattach)
+				wbs.bcasts[newWb] = struct{}{}
+			} else {
+				newWb.mu.Lock()
+				newWb.receivers[w] = struct{}{}
+				newWb.mu.Unlock()
+			}
+			wbs.watchers[w] = newWb
+		}
+	}
 }
 
 // delete removes a watcher and returns the number of remaining watchers.


### PR DESCRIPTION
## Problem

When a `watchBroadcast`'s underlying etcd watch connection breaks, the watch goroutine exits (`for wr := range wch` completes), but the `watchBroadcast` remains in `watchBroadcasts.bcasts` with no indication that it is dead.

This causes:
1. `add()` places new watchers into the dead broadcast — they never receive events.
2. `coalesce()` migrates watchers into the dead broadcast — they stop receiving events.
3. Existing watchers on the dead broadcast become orphaned with no recovery path.

## Fix

1. **Add `stopped` flag**: Mark the broadcast as stopped when its goroutine exits.
2. **Guard `add()`**: Return false if `wb.stopped`, preventing new watchers from joining a dead broadcast.
3. **Guard `coalesce()`**: Add `!wbswb.stopped` check to prevent migrating watchers to a dead broadcast.
4. **Add `reattach()` mechanism**: When a broadcast dies, collect its orphaned watchers and reassign them to a healthy existing broadcast (directly manipulating the receivers map to avoid re-sending Created events) or create a new broadcast.
5. **Ordering fix**: Call `reattach()` after `close(donec)` to avoid deadlock where `stop()` holds `wbs.mu` and waits on `donec` while `reattach()` needs `wbs.mu`.
6. **Defensive checks**: `coalesce()` and `reattach()` check if wb still exists in `bcasts` before proceeding.

## Testing

- Verified compilation passes.
- Manual testing with simulated backend disconnection confirms watchers are properly reassigned.

Fixes #XXXXX

Signed-off-by: Your Name <your-email@example.com>