### PR TITLE
[release-3.5] server: allow non-admin maintenance status

### DIFF
--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -342,7 +342,7 @@ func (ams *authMaintenanceServer) Alarm(ctx context.Context, ar *pb.AlarmRequest
 }
 
 func (ams *authMaintenanceServer) Status(ctx context.Context, ar *pb.StatusRequest) (*pb.StatusResponse, error) {
-	if err := ams.isAuthenticated(ctx); err != nil {
+	if err := ams.requireAuthInfo(ctx); err != nil {
 		return nil, togRPCError(err)
 	}
 	return ams.maintenanceServer.Status(ctx, ar)

--- a/tests/integration/v3_auth_test.go
+++ b/tests/integration/v3_auth_test.go
@@ -914,8 +914,11 @@ func TestV3AuthMemberListAndStatus(t *testing.T) {
 	_, err = testUserCli.MemberList(ctx)
 	require.NoError(t, err)
 
+	_, err = anonCli.Status(ctx, clus.Client(0).Endpoints()[0])
+	require.ErrorContains(t, err, "etcdserver: user name is empty")
+
 	_, err = testUserCli.Status(ctx, clus.Client(0).Endpoints()[0])
-	require.ErrorContains(t, err, PermissionDenied)
+	require.NoError(t, err)
 
 	_, err = rootCli.MemberList(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
Manual backport of #21666 to release-3.5.

The `tests/common/maintenance_auth_test.go` from main does not exist on release-3.5, so the test coverage is folded into the existing `TestV3AuthMemberListAndStatus` in `tests/integration/v3_auth_test.go` — same pattern as #21550 used for the MemberList carve-out (`cdbfd651cd`).

Source change is the helper-name swap appropriate for this branch: `isAuthenticated` → `requireAuthInfo` on `Status`. Behavior matches the main-branch fix.

`TestV3AuthMemberListAndStatus` passes locally on release-3.5 + diff:

```
cd tests && go test -count=1 -run TestV3AuthMemberListAndStatus -timeout 180s -v ./integration
--- PASS: TestV3AuthMemberListAndStatus (0.24s)
ok  	go.etcd.io/etcd/tests/v3/integration	0.637s
```

Follow-up to #21811 (3.6 backport). Tracks #21663.