### PR TITLE
etcdctl: support custom check perf config

### DIFF
--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -1603,11 +1603,21 @@ The test checks for the following conditions:
 
 Hence, a workload model may work while another one might fail.
 
+The preset workload can be customized by setting `--clients`, `--limit`, or
+`--duration`. These flags override the selected `--load` preset values when
+provided.
+
 RPC: CheckPerf
 
 #### Options
 
 - load -- the performance check's workload model. Accepted workloads: s(small), m(medium), l(large), xl(xLarge)
+
+- clients -- override the number of clients for the performance check workload.
+
+- limit -- override the expected throughput limit for the performance check workload.
+
+- duration -- override the duration of the performance check workload in seconds.
 
 - prefix -- the prefix for writing the performance check's keys.
 

--- a/etcdctl/ctlv3/command/check.go
+++ b/etcdctl/ctlv3/command/check.go
@@ -38,6 +38,9 @@ import (
 var (
 	checkPerfLoad        string
 	checkPerfPrefix      string
+	checkPerfLimit       int
+	checkPerfClients     int
+	checkPerfDuration    int
 	checkDatascaleLoad   string
 	checkDatascalePrefix string
 	autoCompact          bool
@@ -127,8 +130,10 @@ func NewCheckPerfCommand() *cobra.Command {
 		Run:   newCheckPerfCommand,
 	}
 
-	// TODO: support customized configuration
 	cmd.Flags().StringVar(&checkPerfLoad, "load", "s", "The performance check's workload model. Accepted workloads: s(small), m(medium), l(large), xl(xLarge). Different workload models use different configurations in terms of number of clients and expected throughput.")
+	cmd.Flags().IntVar(&checkPerfClients, "clients", 0, "Override the number of clients for the performance check workload.")
+	cmd.Flags().IntVar(&checkPerfLimit, "limit", 0, "Override the expected throughput limit for the performance check workload.")
+	cmd.Flags().IntVar(&checkPerfDuration, "duration", 0, "Override the duration of the performance check workload in seconds.")
 	cmd.Flags().StringVar(&checkPerfPrefix, "prefix", "/etcdctl-check-perf/", "The prefix for writing the performance check's keys.")
 	cmd.Flags().BoolVar(&autoCompact, "auto-compact", false, "Compact storage with last revision after test is finished.")
 	cmd.Flags().BoolVar(&autoDefrag, "auto-defrag", false, "Defragment storage after test is finished.")
@@ -139,8 +144,7 @@ func NewCheckPerfCommand() *cobra.Command {
 	return cmd
 }
 
-// newCheckPerfCommand executes the "check perf" command.
-func newCheckPerfCommand(cmd *cobra.Command, args []string) {
+func checkPerfConfigFromCmd(cmd *cobra.Command) (checkPerfCfg, int, error) {
 	checkPerfAlias := map[string]string{
 		"s": "s", "small": "s",
 		"m": "m", "medium": "m",
@@ -150,9 +154,38 @@ func newCheckPerfCommand(cmd *cobra.Command, args []string) {
 
 	model, ok := checkPerfAlias[checkPerfLoad]
 	if !ok {
-		cobrautl.ExitWithError(cobrautl.ExitBadFeature, fmt.Errorf("unknown load option %v", checkPerfLoad))
+		return checkPerfCfg{}, cobrautl.ExitBadFeature, fmt.Errorf("unknown load option %v", checkPerfLoad)
 	}
 	cfg := checkPerfCfgMap[model]
+
+	if cmd.Flags().Changed("clients") {
+		if checkPerfClients <= 0 {
+			return checkPerfCfg{}, cobrautl.ExitInvalidInput, fmt.Errorf("clients must be greater than 0")
+		}
+		cfg.clients = checkPerfClients
+	}
+	if cmd.Flags().Changed("limit") {
+		if checkPerfLimit <= 0 {
+			return checkPerfCfg{}, cobrautl.ExitInvalidInput, fmt.Errorf("limit must be greater than 0")
+		}
+		cfg.limit = checkPerfLimit
+	}
+	if cmd.Flags().Changed("duration") {
+		if checkPerfDuration <= 0 {
+			return checkPerfCfg{}, cobrautl.ExitInvalidInput, fmt.Errorf("duration must be greater than 0")
+		}
+		cfg.duration = checkPerfDuration
+	}
+
+	return cfg, cobrautl.ExitSuccess, nil
+}
+
+// newCheckPerfCommand executes the "check perf" command.
+func newCheckPerfCommand(cmd *cobra.Command, args []string) {
+	cfg, exitCode, err := checkPerfConfigFromCmd(cmd)
+	if err != nil {
+		cobrautl.ExitWithError(exitCode, err)
+	}
 
 	requests := make(chan v3.Op, cfg.clients)
 	limit := rate.NewLimiter(rate.Limit(cfg.limit), 1)
@@ -231,7 +264,7 @@ func newCheckPerfCommand(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	ok = true
+	ok := true
 	if len(s.ErrorDist) != 0 {
 		fmt.Println("FAIL: too many errors")
 		for k, v := range s.ErrorDist {

--- a/etcdctl/ctlv3/command/check_test.go
+++ b/etcdctl/ctlv3/command/check_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/pkg/v3/cobrautl"
+)
+
+func TestCheckPerfConfigFromCmd(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want checkPerfCfg
+	}{
+		{
+			name: "uses selected preset when overrides are omitted",
+			args: []string{"--load", "m"},
+			want: checkPerfCfg{
+				limit:    1000,
+				clients:  200,
+				duration: 60,
+			},
+		},
+		{
+			name: "overrides selected preset with custom values",
+			args: []string{"--load", "m", "--clients", "7", "--limit", "42", "--duration", "5"},
+			want: checkPerfCfg{
+				limit:    42,
+				clients:  7,
+				duration: 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCheckPerfCommand()
+			require.NoError(t, cmd.Flags().Parse(tt.args))
+
+			got, code, err := checkPerfConfigFromCmd(cmd)
+
+			require.NoError(t, err)
+			require.Equal(t, cobrautl.ExitSuccess, code)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckPerfConfigFromCmdRejectsInvalidOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "clients must be positive",
+			args:    []string{"--clients", "0"},
+			wantErr: "clients must be greater than 0",
+		},
+		{
+			name:    "limit must be positive",
+			args:    []string{"--limit", "-1"},
+			wantErr: "limit must be greater than 0",
+		},
+		{
+			name:    "duration must be positive",
+			args:    []string{"--duration", "0"},
+			wantErr: "duration must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCheckPerfCommand()
+			require.NoError(t, cmd.Flags().Parse(tt.args))
+
+			_, code, err := checkPerfConfigFromCmd(cmd)
+
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(t, cobrautl.ExitInvalidInput, code)
+		})
+	}
+}
+
+func TestCheckPerfConfigFromCmdRejectsUnknownLoad(t *testing.T) {
+	cmd := NewCheckPerfCommand()
+	require.NoError(t, cmd.Flags().Parse([]string{"--load", "tiny"}))
+
+	_, code, err := checkPerfConfigFromCmd(cmd)
+
+	require.ErrorContains(t, err, "unknown load option tiny")
+	require.Equal(t, cobrautl.ExitBadFeature, code)
+}


### PR DESCRIPTION
Fixes #21724

This adds custom workload overrides for `etcdctl check perf`:

- `--clients` overrides the selected preset client count.
- `--limit` overrides the selected preset throughput limit.
- `--duration` overrides the selected preset duration.
- Custom override values must be greater than zero.

The existing `--load` presets remain the default behavior when overrides are omitted.

Tests:

- `GOMODCACHE=/private/tmp/etcd-21724-gomodcache GOCACHE=/private/tmp/etcd-21724-gocache go test -count=1 ./etcdctl/...`
- `GOMODCACHE=/private/tmp/etcd-21724-gomodcache GOCACHE=/private/tmp/etcd-21724-gocache go run ./etcdctl check perf --help`
- `git diff --check`

Special notes for your reviewer:

- AI disclosure: Prepared with AI assistance. I reviewed the diff and verified the behavior locally before submitting.
- Prompt used: "Implement etcdctl check perf custom workload flags for issue #21724, following contribution guidelines, tests first, and cleanup."
- Rhyme: etcd keeps state precise and bright; custom perf loads now tune the write.
