### PR TITLE
[release-3.4] etcdserver: fix cannot promote with auth from follower

### DIFF
--- a/etcdserver/api/etcdhttp/peer.go
+++ b/etcdserver/api/etcdhttp/peer.go
@@ -25,8 +25,10 @@ import (
 	"go.etcd.io/etcd/etcdserver/api"
 	"go.etcd.io/etcd/etcdserver/api/membership"
 	"go.etcd.io/etcd/etcdserver/api/rafthttp"
+	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/lease/leasehttp"
 	"go.etcd.io/etcd/pkg/types"
+	"google.golang.org/grpc/metadata"
 
 	"go.uber.org/zap"
 )
@@ -132,7 +134,13 @@ func (h *peerMemberPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	resp, err := h.server.PromoteMember(r.Context(), id)
+	ctx := r.Context()
+	if token := r.Header.Get("Authorization"); token != "" {
+		md := metadata.New(map[string]string{rpctypes.TokenFieldNameGRPC: token})
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+
+	resp, err := h.server.PromoteMember(ctx, id)
 	if err != nil {
 		switch err {
 		case membership.ErrIDNotFound:

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/etcdserver/api/membership"
+	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/pkg/types"
 	"go.etcd.io/etcd/version"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/coreos/go-semver/semver"
 	"go.uber.org/zap"
@@ -381,6 +383,17 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	if err != nil {
 		return nil, err
 	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		ts, ok := md[rpctypes.TokenFieldNameGRPC]
+		if !ok {
+			ts, ok = md[rpctypes.TokenFieldNameSwagger]
+		}
+		if ok && len(ts) > 0 {
+			req.Header.Set("Authorization", ts[0])
+		}
+	}
+
 	req = req.WithContext(ctx)
 	resp, err := cc.Do(req)
 	if err != nil {

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -20,7 +20,10 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/etcdserver"
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 )
 
@@ -61,8 +64,17 @@ func TestCtlV3MemberAddClientAutoTLS(t *testing.T) {
 }
 func TestCtlV3MemberAddPeerTLS(t *testing.T)    { testCtl(t, memberAddTest, withCfg(configPeerTLS)) }
 func TestCtlV3MemberAddForLearner(t *testing.T) { testCtl(t, memberAddForLearnerTest) }
-func TestCtlV3MemberUpdate(t *testing.T)        { testCtl(t, memberUpdateTest) }
-func TestCtlV3MemberUpdateNoTLS(t *testing.T)   { testCtl(t, memberUpdateTest, withCfg(configNoTLS)) }
+
+func TestCtlV3MemberPromoteWithAuthFromLeader(t *testing.T) {
+	testCtl(t, memberPromoteWithAuth(false), withQuorum(), withTestTimeout(30*time.Second))
+}
+
+func TestCtlV3MemberPromoteWithAuthFromFollower(t *testing.T) {
+	testCtl(t, memberPromoteWithAuth(true), withQuorum(), withTestTimeout(30*time.Second))
+}
+
+func TestCtlV3MemberUpdate(t *testing.T)      { testCtl(t, memberUpdateTest) }
+func TestCtlV3MemberUpdateNoTLS(t *testing.T) { testCtl(t, memberUpdateTest, withCfg(configNoTLS)) }
 func TestCtlV3MemberUpdateClientTLS(t *testing.T) {
 	testCtl(t, memberUpdateTest, withCfg(configClientTLS))
 }
@@ -140,6 +152,78 @@ func ctlV3MemberAdd(cx ctlCtx, peerURL string, isLearner bool) error {
 		cmdArgs = append(cmdArgs, "--learner")
 	}
 	return spawnWithExpect(cmdArgs, " added to cluster ")
+}
+
+func memberPromoteWithAuth(fromFollower bool) func(cx ctlCtx) {
+	return func(cx ctlCtx) {
+		leaderIdx := cx.epc.WaitLeader(cx.t)
+		followerIdx := (leaderIdx + 1) % len(cx.epc.procs)
+
+		learnerClusterCfg := *cx.epc.cfg
+		learnerClusterCfg.clusterSize = len(cx.epc.procs) + 1
+		learnerCfg := learnerClusterCfg.etcdServerProcessConfigs()[len(cx.epc.procs)]
+		learnerCfg.args = patchArgs(learnerCfg.args, "initial-cluster-state", "existing")
+
+		var addErr error
+		for {
+			addErr = ctlV3MemberAdd(cx, learnerCfg.purl.String(), true)
+			if addErr != nil {
+				if strings.Contains(addErr.Error(), "etcdserver: unhealthy cluster") {
+					time.Sleep(1 * time.Second)
+					continue
+				}
+			}
+			break
+		}
+		require.NoError(cx.t, addErr)
+
+		mr, err := getMemberList(cx)
+		require.NoError(cx.t, err)
+
+		var learnerID uint64
+		for _, m := range mr.Members {
+			if m.IsLearner {
+				learnerID = m.ID
+				break
+			}
+		}
+		require.NotZero(cx.t, learnerID)
+
+		learnerProc, err := newEtcdProcess(learnerCfg)
+		require.NoError(cx.t, err)
+		cx.epc.procs = append(cx.epc.procs, learnerProc)
+		require.NoError(cx.t, learnerProc.Start())
+
+		require.NoError(cx.t, authEnable(cx))
+		cx.user = "root"
+		cx.pass = "root"
+
+		endpoint := cx.epc.procs[leaderIdx].EndpointsV3()
+		if fromFollower {
+			endpoint = cx.epc.procs[followerIdx].EndpointsV3()
+		}
+
+		expectedErr := etcdserver.ErrLearnerNotReady.Error()
+		timeout := time.After(5 * time.Second)
+		var promoteErr error
+		for {
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-timeout:
+				cx.t.Fatalf("failed all attempts to promote learner member, last error: %v", promoteErr)
+			}
+
+			cmdArgs := append(cx.prefixArgs(endpoint), "member", "promote", fmt.Sprintf("%x", learnerID))
+			promoteErr = spawnWithExpect(cmdArgs, "promoted in cluster")
+			if promoteErr == nil {
+				break
+			}
+			if !strings.Contains(promoteErr.Error(), expectedErr) {
+				break
+			}
+		}
+		require.NoError(cx.t, promoteErr)
+	}
 }
 
 func memberUpdateTest(cx ctlCtx) {


### PR DESCRIPTION
Fixes/backports: #20757

This is a manual backport of the fix to `release-3.4`. The server-side changes are the same as the `release-3.5` backport. The tests are different because some of the required test helpers from that branch are not available in `release-3.4`.

The learner promote retry in the test is based on the existing `TestMemberPromote` test in `release-3.4`: https://github.com/etcd-io/etcd/blob/release-3.4/clientv3/integration/cluster_test.go#L219-L293

AI usage: I used AI to review my code and help with PR wording. I reviewed the changes myself and tested the code with the make commands.