### PR TITLE
rafthttp: tolerate malformed peer version headers

### DIFF
--- a/server/etcdserver/api/rafthttp/util.go
+++ b/server/etcdserver/api/rafthttp/util.go
@@ -151,7 +151,16 @@ func serverVersion(h http.Header) *semver.Version {
 	if verStr == "" {
 		verStr = "2.0.0"
 	}
-	return semver.Must(semver.NewVersion(verStr))
+	v, err := semver.NewVersion(verStr)
+	if err != nil {
+		// The header is peer-supplied, so a malformed value must not panic
+		// the request goroutine via semver.Must. Fall back to the 2.0
+		// default so the request is rejected by the normal version
+		// compatibility check, matching how cluster_util.go tolerates an
+		// unparsable remote version.
+		return semver.Must(semver.NewVersion("2.0.0"))
+	}
+	return v
 }
 
 // serverVersion returns the min cluster version from the given header.
@@ -161,7 +170,16 @@ func minClusterVersion(h http.Header) *semver.Version {
 	if verStr == "" {
 		verStr = "2.0.0"
 	}
-	return semver.Must(semver.NewVersion(verStr))
+	v, err := semver.NewVersion(verStr)
+	if err != nil {
+		// The header is peer-supplied, so a malformed value must not panic
+		// the request goroutine via semver.Must. Fall back to the 2.0
+		// default so the request is rejected by the normal version
+		// compatibility check, matching how cluster_util.go tolerates an
+		// unparsable remote version.
+		return semver.Must(semver.NewVersion("2.0.0"))
+	}
+	return v
 }
 
 // checkVersionCompatibility checks whether the given version is compatible

--- a/server/etcdserver/api/rafthttp/util_test.go
+++ b/server/etcdserver/api/rafthttp/util_test.go
@@ -112,6 +112,12 @@ func TestServerVersion(t *testing.T) {
 			http.Header{"X-Server-Version": []string{"2.1.0-alpha.0+git"}},
 			semver.Must(semver.NewVersion("2.1.0-alpha.0+git")),
 		},
+		// a malformed peer-supplied value falls back to the 2.0 default
+		// instead of panicking
+		{
+			http.Header{"X-Server-Version": []string{"not-a-version"}},
+			semver.Must(semver.NewVersion("2.0.0")),
+		},
 	}
 	for i, tt := range tests {
 		v := serverVersion(tt.h)
@@ -138,6 +144,12 @@ func TestMinClusterVersion(t *testing.T) {
 		{
 			http.Header{"X-Min-Cluster-Version": []string{"2.1.0-alpha.0+git"}},
 			semver.Must(semver.NewVersion("2.1.0-alpha.0+git")),
+		},
+		// a malformed peer-supplied value falls back to the 2.0 default
+		// instead of panicking
+		{
+			http.Header{"X-Min-Cluster-Version": []string{"not-a-version"}},
+			semver.Must(semver.NewVersion("2.0.0")),
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
serverVersion and minClusterVersion in server/etcdserver/api/rafthttp/util.go call semver.Must on the X-Server-Version and X-Min-Cluster-Version headers, so a peer that supplies a non-semver value panics the request goroutine. The same parse error is already handled gracefully in etcdserver/cluster_util.go isCompatibleWithVers. Fall back to the existing 2.0.0 default when parsing fails so the peer fails the normal version-compatibility check instead.