### PR TITLE
Make the etcd client creation non-blocking

### DIFF
--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -9,6 +9,10 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 
 ## v3.7.0-rc.1 (TBC)
 
+### Package `clientv3`
+
+- [Make the etcd client creation non-blocking](https://github.com/etcd-io/etcd/pull/21832): etcd no longer honors the deprecated `grpc.WithBlock` dial option. To preserve the previous blocking behavior when needed, follow the guidance in grpc-go's [anti-patterns documentation](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#especially-bad-using-deprecated-dialoptions).
+
 ### etcd server
 
 - Fix [websocket authentication with bearer-prefixed auth tokens](https://github.com/etcd-io/etcd/pull/21929).

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/codes"
 	grpccredentials "google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
@@ -326,52 +325,7 @@ func (c *Client) dial(creds grpccredentials.TransportCredentials, dopts ...grpc.
 	opts = append(opts, c.cfg.DialOptions...)
 
 	target := fmt.Sprintf("%s://%p/%s", resolver.Schema, c, authority(c.endpoints[0]))
-	conn, err := grpc.NewClient(target, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if dialTimeout := c.cfg.DialTimeout; dialTimeout > 0 {
-		dctx, cancel := context.WithTimeout(c.ctx, dialTimeout)
-		defer cancel()
-
-		if err := waitForConnection(dctx, conn); err != nil {
-			conn.Close()
-			return nil, err
-		}
-	}
-	return conn, nil
-}
-
-func waitForConnection(ctx context.Context, conn *grpc.ClientConn) error {
-	cli := healthpb.NewHealthClient(conn)
-
-	// Use WaitForReady to wait until the connection is ready. The health check
-	// may return Unimplemented if the server does not expose the health endpoint,
-	// or FailedPrecondition if the leader has not yet applied the configuration
-	// change that enables it. In both cases, we can still treat the connection as
-	// healthy enough to proceed.
-	//
-	// Use withMax to disable retrying on Unimplemented, so that we can
-	// return the original error immediately.
-	_, err := cli.Check(ctx, &healthpb.HealthCheckRequest{}, grpc.WaitForReady(true), withMax(0))
-	if err == nil {
-		return nil
-	}
-	if cerr := ctx.Err(); cerr != nil {
-		if serr, ok := status.FromError(err); ok && serr.Message() != "" {
-			return fmt.Errorf("etcdclient: failed to connect to the etcd server: %s: %w", serr.Message(), cerr)
-		}
-		return fmt.Errorf("etcdclient: failed to connect to the etcd server: %w", cerr)
-	}
-
-	serr, ok := status.FromError(err)
-	if ok {
-		switch serr.Code() {
-		case codes.Unimplemented, codes.FailedPrecondition:
-			return nil
-		}
-	}
-	return fmt.Errorf("etcdclient: failed to dial by invoking health endpoint: %w", err)
+	return grpc.NewClient(target, opts...)
 }
 
 func authority(endpoint string) string {

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -139,54 +139,6 @@ func TestDialCancel(t *testing.T) {
 	}
 }
 
-func TestDialTimeout(t *testing.T) {
-	testutil.RegisterLeakDetection(t)
-
-	wantError := context.DeadlineExceeded
-
-	testCfgs := []Config{
-		{
-			Endpoints:   []string{"http://254.0.0.1:12345"},
-			DialTimeout: 2 * time.Second,
-		},
-		{
-			Endpoints:   []string{"http://254.0.0.1:12345"},
-			DialTimeout: time.Second,
-			Username:    "abc",
-			Password:    "def",
-		},
-	}
-
-	for i, cfg := range testCfgs {
-		donec := make(chan error, 1)
-		go func(cfg Config, i int) {
-			// without timeout, dial continues forever on ipv4 black hole
-			c, err := NewClient(t, cfg)
-			if c != nil || err == nil {
-				t.Errorf("#%d: new client should fail", i)
-			}
-			donec <- err
-		}(cfg, i)
-
-		time.Sleep(10 * time.Millisecond)
-
-		select {
-		case err := <-donec:
-			t.Errorf("#%d: dial didn't wait (%v)", i, err)
-		default:
-		}
-
-		select {
-		case <-time.After(5 * time.Second):
-			t.Errorf("#%d: failed to timeout dial on time", i)
-		case err := <-donec:
-			if !errors.Is(err, wantError) {
-				t.Errorf("#%d: unexpected error '%v', want '%v'", i, err, wantError)
-			}
-		}
-	}
-}
-
 func TestDialNoTimeout(t *testing.T) {
 	cfg := Config{Endpoints: []string{"127.0.0.1:12345"}}
 	c, err := NewClient(t, cfg)

--- a/tests/integration/clientv3/connectivity/dial_test.go
+++ b/tests/integration/clientv3/connectivity/dial_test.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-// TestDialTLSExpired tests client with expired certs fails to dial.
+// TestDialTLSExpired tests client with expired certs fails the read request.
 func TestDialTLSExpired(t *testing.T) {
 	integration.BeforeTest(t)
 	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1, PeerTLS: &testTLSInfo, ClientTLS: &testTLSInfo})
@@ -56,15 +56,23 @@ func TestDialTLSExpired(t *testing.T) {
 	tls, err := testTLSInfoExpired.ClientConfig()
 	require.NoError(t, err)
 	// expect remote errors "tls: bad certificate"
-	_, err = integration.NewClient(t, clientv3.Config{
+	c, err := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 3 * time.Second,
 		TLS:         tls,
 	})
-	require.Truef(t, clientv3test.IsClientTimeout(err), "expected dial timeout error")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, c.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	_, rerr := c.Get(ctx, "foo")
+	cancel()
+	require.Truef(t, clientv3test.IsClientTimeout(rerr), "expected get timeout error")
 }
 
-// TestDialTLSNoConfig ensures the client fails to dial / times out
+// TestDialTLSNoConfig ensures the client fails to range / times out
 // when TLS endpoints (https, unixs) are given but no tls config.
 func TestDialTLSNoConfig(t *testing.T) {
 	integration.BeforeTest(t)
@@ -75,12 +83,15 @@ func TestDialTLSNoConfig(t *testing.T) {
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: time.Second,
 	})
+	require.NoError(t, err)
 	defer func() {
-		if c != nil {
-			c.Close()
-		}
+		require.NoError(t, c.Close())
 	}()
-	require.Truef(t, clientv3test.IsClientTimeout(err), "expected dial timeout error")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	_, rerr := c.Get(ctx, "foo")
+	cancel()
+	require.Truef(t, clientv3test.IsClientTimeout(rerr), "expected get timeout error")
 }
 
 // TestDialSetEndpointsBeforeFail ensures SetEndpoints can replace unavailable

--- a/tests/integration/v3_grpc_test.go
+++ b/tests/integration/v3_grpc_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -1952,9 +1953,13 @@ func TestTLSGRPCRejectSecureClient(t *testing.T) {
 	clus.Members[0].ClientTLSInfo = &integration.TestTLSInfo
 	clus.Members[0].GRPCURL = strings.Replace(clus.Members[0].GRPCURL, "http://", "https://", 1)
 	client, err := integration.NewClientV3(clus.Members[0])
-	if client != nil || err == nil {
-		client.Close()
-		t.Fatalf("expected no client")
+	require.NoError(t, err)
+	defer client.Close()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	_, err = client.Status(ctx, client.Endpoints()[0])
+	cancel()
+	if err == nil {
+		t.Fatalf("expected error")
 	} else if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("unexpected error (%v)", err)
 	}
@@ -2083,11 +2088,15 @@ func testTLSReload(
 	})
 	defer clus.Terminate(t)
 
-	// 3. concurrent client dialing while certs become expired
+	// 3. concurrent client creation while certs become expired
 	errc := make(chan error, 1)
+	donec := make(chan struct{})
+	var tlsInvalid *tls.Config
 	go func() {
+		defer close(donec)
 		for {
-			cc, err := tlsInfo.ClientConfig()
+			var err error
+			tlsInvalid, err = tlsInfo.ClientConfig()
 			if err != nil {
 				// errors in 'go/src/crypto/tls/tls.go'
 				// tls: private key does not match public key
@@ -2100,44 +2109,67 @@ func testTLSReload(
 			cli, cerr := integration.NewClient(t, clientv3.Config{
 				Endpoints:   []string{clus.Members[0].GRPCURL},
 				DialTimeout: time.Second,
-				TLS:         cc,
+				TLS:         tlsInvalid,
 			})
 			if cerr != nil {
 				errc <- cerr
-				return
 			}
 			cli.Close()
+			return
 		}
 	}()
 
 	// 4. replace certs with expired ones
 	replaceFunc()
 
-	// 5. expect dial time-out when loading expired certs
 	select {
 	case gerr := <-errc:
-		if !errors.Is(gerr, context.DeadlineExceeded) {
-			t.Fatalf("expected %v, got %v", context.DeadlineExceeded, gerr)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("failed to receive dial timeout error")
+		t.Fatalf("expected no error, got %v", gerr)
+	case <-time.After(2 * time.Second):
 	}
+	<-donec
+
+	readTest := func(tlsCfg *tls.Config, expectedErr error) {
+		cli, cerr := integration.NewClient(t, clientv3.Config{
+			Endpoints:   []string{clus.Members[0].GRPCURL},
+			DialTimeout: time.Second,
+			TLS:         tlsCfg,
+		})
+		require.NoError(t, cerr)
+		defer func() {
+			require.NoError(t, cli.Close())
+		}()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		_, rerr := cli.Get(ctx, "foo")
+		cancel()
+		if expectedErr != nil {
+			require.ErrorIs(t, rerr, expectedErr)
+		} else {
+			require.NoError(t, rerr)
+		}
+	}
+
+	// 5. expect read request timed out when loading expired certs
+	readTest(tlsInvalid, context.DeadlineExceeded)
 
 	// 6. replace expired certs back with valid ones
 	revertFunc()
 
-	// 7. new requests should trigger listener to reload valid certs
-	tls, terr := tlsInfo.ClientConfig()
+	tlsValid, terr := tlsInfo.ClientConfig()
 	require.NoError(t, terr)
 	cl, cerr := integration.NewClient(t, clientv3.Config{
 		Endpoints:   []string{clus.Members[0].GRPCURL},
 		DialTimeout: 5 * time.Second,
-		TLS:         tls,
+		TLS:         tlsValid,
 	})
 	if cerr != nil {
 		t.Fatalf("expected no error, got %v", cerr)
 	}
-	cl.Close()
+	require.NoError(t, cl.Close())
+
+	// 7. new requests should trigger listener to reload valid certs
+	readTest(tlsValid, nil)
 }
 
 func TestGRPCRequireLeader(t *testing.T) {

--- a/tests/integration/v3_tls_test.go
+++ b/tests/integration/v3_tls_test.go
@@ -32,7 +32,7 @@ func TestTLSClientCipherSuitesValid(t *testing.T)    { testTLSCipherSuites(t, tr
 func TestTLSClientCipherSuitesMismatch(t *testing.T) { testTLSCipherSuites(t, false) }
 
 // testTLSCipherSuites ensures mismatching client-side cipher suite
-// fail TLS handshake with the server.
+// fail the range request to the server.
 func testTLSCipherSuites(t *testing.T, valid bool) {
 	integration.BeforeTest(t)
 
@@ -67,14 +67,20 @@ func testTLSCipherSuites(t *testing.T, valid bool) {
 		DialTimeout: time.Second,
 		TLS:         cc,
 	})
-	if cli != nil {
-		cli.Close()
-	}
-	if !valid && !errors.Is(cerr, context.DeadlineExceeded) {
-		t.Fatalf("expected %v with TLS handshake failure, got %v", context.DeadlineExceeded, cerr)
-	}
-	if valid && cerr != nil {
-		t.Fatalf("expected TLS handshake success, got %v", cerr)
+	require.NoError(t, cerr)
+	defer func() {
+		require.NoError(t, cli.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	_, rerr := cli.Get(ctx, "foo")
+	cancel()
+	if valid {
+		require.NoError(t, rerr)
+	} else {
+		if !errors.Is(rerr, context.DeadlineExceeded) {
+			t.Fatalf("expected %v with TLS handshake failure, got %v", context.DeadlineExceeded, rerr)
+		}
 	}
 }
 


### PR DESCRIPTION
Resolve https://github.com/etcd-io/etcd/issues/21830

This PR makes the etcd client creation non-blocking. It aligns with grpc-go's best practice.