### PR TITLE
Add support for limit and withTotalCount to FastKeysOnly Range

### DIFF
--- a/server/storage/mvcc/index.go
+++ b/server/storage/mvcc/index.go
@@ -23,7 +23,7 @@ import (
 
 type index interface {
 	Get(key []byte, atRev int64) (rev, created Revision, ver int64, err error)
-	Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64)
+	Range(key, end []byte, atRev int64, limit int, withTotalCount bool) (keys [][]byte, modifies, creates []Revision, versions []int64, totalCount int)
 	Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int)
 	CountRevisions(key, end []byte, atRev int64) int
 	Put(key []byte, rev Revision)
@@ -160,27 +160,34 @@ func (ti *treeIndex) CountRevisions(key, end []byte, atRev int64) int {
 	return total
 }
 
-func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64) {
+func (ti *treeIndex) Range(key, end []byte, atRev int64, limit int, withTotalCount bool) (keys [][]byte, modifies, creates []Revision, versions []int64, totalCount int) {
 	ti.RLock()
 	defer ti.RUnlock()
 
 	if end == nil {
 		modified, created, version, err := ti.unsafeGet(key, atRev)
 		if err != nil {
-			return nil, nil, nil, nil
+			return nil, nil, nil, nil, 0
 		}
-		return [][]byte{key}, []Revision{modified}, []Revision{created}, []int64{version}
+		return [][]byte{key}, []Revision{modified}, []Revision{created}, []int64{version}, 1
 	}
 	ti.unsafeVisit(key, end, func(ki *keyIndex) bool {
+		reachedLimit := limit > 0 && len(keys) >= limit
+		if reachedLimit && !withTotalCount {
+			return false
+		}
 		if modified, created, version, err := ki.get(ti.lg, atRev); err == nil {
-			modifies = append(modifies, modified)
-			keys = append(keys, ki.key)
-			creates = append(creates, created)
-			versions = append(versions, version)
+			if !reachedLimit {
+				modifies = append(modifies, modified)
+				keys = append(keys, ki.key)
+				creates = append(creates, created)
+				versions = append(versions, version)
+			}
+			totalCount++
 		}
 		return true
 	})
-	return keys, modifies, creates, versions
+	return keys, modifies, creates, versions, totalCount
 }
 
 func (ti *treeIndex) Tombstone(key []byte, rev Revision) error {

--- a/server/storage/mvcc/index_test.go
+++ b/server/storage/mvcc/index_test.go
@@ -75,6 +75,8 @@ func TestIndexRange(t *testing.T) {
 	tests := []struct {
 		name                 string
 		rangeStart, rangeEnd []byte
+		rangeLimit           int
+		withTotalCount       bool
 		expectKeys           [][]byte
 		expectRevisions      []Revision
 		expectTotalCount     int
@@ -86,6 +88,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       nil,
 			expectRevisions:  nil,
 			expectTotalCount: 0,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "single key that found",
@@ -94,6 +98,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys[:1],
 			expectRevisions:  allRevs[:1],
 			expectTotalCount: 1,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "range keys, return first member",
@@ -102,6 +108,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys[:1],
 			expectRevisions:  allRevs[:1],
 			expectTotalCount: 1,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "range keys, return first two members",
@@ -110,6 +118,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys[:2],
 			expectRevisions:  allRevs[:2],
 			expectTotalCount: 2,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "range keys, return all members",
@@ -118,6 +128,108 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys,
 			expectRevisions:  allRevs,
 			expectTotalCount: 3,
+			rangeLimit:       0,
+			withTotalCount:   false,
+		},
+		{
+			name:             "range keys limiting to one result without total count, return the first member",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("fop"),
+			expectKeys:       allKeys[:1],
+			expectRevisions:  allRevs[:1],
+			expectTotalCount: 1,
+			rangeLimit:       1,
+			withTotalCount:   false,
+		},
+		{
+			name:             "range keys with limit equal the index size without total count, return all members",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("fop"),
+			expectKeys:       allKeys,
+			expectRevisions:  allRevs,
+			expectTotalCount: 3,
+			rangeLimit:       3,
+			withTotalCount:   false,
+		},
+		{
+			name:             "range keys with over limit, without total count, return all members",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("fop"),
+			expectKeys:       allKeys,
+			expectRevisions:  allRevs,
+			expectTotalCount: 3,
+			rangeLimit:       4,
+			withTotalCount:   false,
+		},
+		{
+			name:             "range keys limiting to one result with total count, return the first member and all total count",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("fop"),
+			expectKeys:       allKeys[:1],
+			expectRevisions:  allRevs[:1],
+			expectTotalCount: 3,
+			rangeLimit:       1,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range keys with limit on non-existent keys, return nothing",
+			rangeStart:       []byte("fo"),
+			rangeEnd:         []byte("foo"),
+			expectKeys:       nil,
+			expectRevisions:  nil,
+			expectTotalCount: 0,
+			rangeLimit:       3,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range keys with more limit than the one key found, returning the key",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("foo1"),
+			expectKeys:       allKeys[:1],
+			expectRevisions:  allRevs[:1],
+			expectTotalCount: 1,
+			rangeLimit:       3,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range of 1 keys with 1 limit and total count, returning 1 key with 1 count",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("foo1"),
+			expectKeys:       allKeys[:1],
+			expectRevisions:  allRevs[:1],
+			expectTotalCount: 1,
+			rangeLimit:       1,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range of 3 keys with 1 limit and total count, returning 1 key with 3 count",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("foo3"),
+			expectKeys:       allKeys[:1],
+			expectRevisions:  allRevs[:1],
+			expectTotalCount: 3,
+			rangeLimit:       1,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range of 2 keys not starting from the beginning with 1 limit and total count, returning 1 key with 2 count",
+			rangeStart:       []byte("foo1"),
+			rangeEnd:         []byte("foo3"),
+			expectKeys:       allKeys[1:2],
+			expectRevisions:  allRevs[1:2],
+			expectTotalCount: 2,
+			rangeLimit:       1,
+			withTotalCount:   true,
+		},
+		{
+			name:             "range of all keys with equal-sized limit and total count, returning all keys with the same count",
+			rangeStart:       []byte("foo"),
+			rangeEnd:         []byte("fop"),
+			expectKeys:       allKeys,
+			expectRevisions:  allRevs,
+			expectTotalCount: 3,
+			rangeLimit:       3,
+			withTotalCount:   true,
 		},
 		{
 			name:             "range keys, return last two members",
@@ -126,6 +238,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys[1:],
 			expectRevisions:  allRevs[1:],
 			expectTotalCount: 2,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "range keys, return last member",
@@ -134,6 +248,8 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       allKeys[2:],
 			expectRevisions:  allRevs[2:],
 			expectTotalCount: 1,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 		{
 			name:             "range keys, return nothing",
@@ -142,16 +258,21 @@ func TestIndexRange(t *testing.T) {
 			expectKeys:       nil,
 			expectRevisions:  nil,
 			expectTotalCount: 0,
+			rangeLimit:       0,
+			withTotalCount:   false,
 		},
 	}
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keys, revs, _, _ := ti.Range(tt.rangeStart, tt.rangeEnd, atRev)
+			keys, revs, _, _, total := ti.Range(tt.rangeStart, tt.rangeEnd, atRev, tt.rangeLimit, tt.withTotalCount)
 			if !reflect.DeepEqual(keys, tt.expectKeys) {
 				t.Errorf("#%d: keys = %+v, want %+v", i, keys, tt.expectKeys)
 			}
 			if !reflect.DeepEqual(revs, tt.expectRevisions) {
 				t.Errorf("#%d: revs = %+v, want %+v", i, revs, tt.expectRevisions)
+			}
+			if total != tt.expectTotalCount {
+				t.Errorf("#%d: total = %+d, want %+d", i, total, tt.expectTotalCount)
 			}
 		})
 	}

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -201,11 +201,11 @@ func TestStoreRange(t *testing.T) {
 		r    rangeResp
 	}{
 		{
-			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 1}}, []int64{1}},
+			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 1}}, []int64{1}, 1},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 		{
-			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{{Main: 2}, {Main: 3}}, []Revision{{Main: 2}, {Main: 3}}, []int64{1, 1}},
+			indexRangeResp{[][]byte{[]byte("foo"), []byte("foo1")}, []Revision{{Main: 2}, {Main: 3}}, []Revision{{Main: 2}, {Main: 3}}, []int64{1, 1}, 2},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 		},
 	}
@@ -280,7 +280,7 @@ func TestStoreDeleteRange(t *testing.T) {
 	}{
 		{
 			Revision{Main: 2},
-			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 2}}, []int64{1}},
+			indexRangeResp{[][]byte{[]byte("foo")}, []Revision{{Main: 2}}, []Revision{{Main: 2}}, []int64{1}, 1},
 			rangeResp{[][]byte{key}, [][]byte{kvb}},
 
 			newTestBucketKeyBytes(newBucketKey(3, 0, true)),
@@ -1018,6 +1018,7 @@ type indexRangeResp struct {
 	revs     []Revision
 	creates  []Revision
 	versions []int64
+	total    int
 }
 
 type indexRangeEventsResp struct {
@@ -1033,7 +1034,7 @@ type fakeIndex struct {
 }
 
 func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotalCount bool) ([]Revision, int) {
-	_, rev, _, _ := i.Range(key, end, atRev)
+	_, rev, _, _, _ := i.Range(key, end, atRev, limit, withTotalCount)
 	if len(rev) >= limit {
 		rev = rev[:limit]
 	}
@@ -1041,7 +1042,7 @@ func (i *fakeIndex) Revisions(key, end []byte, atRev int64, limit int, withTotal
 }
 
 func (i *fakeIndex) CountRevisions(key, end []byte, atRev int64) int {
-	_, rev, _, _ := i.Range(key, end, atRev)
+	_, rev, _, _, _ := i.Range(key, end, atRev, 0, true)
 	return len(rev)
 }
 
@@ -1051,10 +1052,10 @@ func (i *fakeIndex) Get(key []byte, atRev int64) (rev, created Revision, ver int
 	return r.rev, r.created, r.ver, r.err
 }
 
-func (i *fakeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, modifies, creates []Revision, versions []int64) {
+func (i *fakeIndex) Range(key, end []byte, atRev int64, limit int, withTotalCount bool) (keys [][]byte, modifies, creates []Revision, versions []int64, total int) {
 	i.Recorder.Record(testutil.Action{Name: "range", Params: []any{key, end, atRev}})
 	r := <-i.indexRangeRespc
-	return r.keys, r.revs, r.creates, r.versions
+	return r.keys, r.revs, r.creates, r.versions, r.total
 }
 
 func (i *fakeIndex) Put(key []byte, rev Revision) {

--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -88,13 +88,12 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 	}
 
 	if ro.FastKeysOnly {
-		keys, modifies, creates, versions := tr.s.kvindex.Range(key, end, rev)
+		keys, modifies, creates, versions, total := tr.s.kvindex.Range(key, end, rev, int(ro.Limit), ro.WithTotalCount)
 		tr.trace.Step("keys only range from in-memory index tree")
 		if len(keys) == 0 {
 			return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
 		}
-		cappedKeysCount := sliceCapWithLimit(int(ro.Limit), keys)
-		kvs := make([]*mvccpb.KeyValue, cappedKeysCount)
+		kvs := make([]*mvccpb.KeyValue, len(keys))
 		for i := range len(kvs) {
 			kvs[i] = &mvccpb.KeyValue{
 				Key:            keys[i],
@@ -103,7 +102,7 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 				Version:        versions[i],
 			}
 		}
-		return &RangeResult{KVs: kvs, Count: len(keys), Rev: curRev}, nil
+		return &RangeResult{KVs: kvs, Count: total, Rev: curRev}, nil
 	}
 
 	revpairs, total := tr.s.kvindex.Revisions(key, end, rev, int(ro.Limit), ro.WithTotalCount)
@@ -296,7 +295,7 @@ func (tw *storeTxnWrite) deleteRange(key, end []byte) int64 {
 	if len(tw.changes) > 0 {
 		rrev++
 	}
-	keys, _, _, _ := tw.s.kvindex.Range(key, end, rrev)
+	keys, _, _, _, _ := tw.s.kvindex.Range(key, end, rrev, 0, false)
 	if len(keys) == 0 {
 		return 0
 	}


### PR DESCRIPTION
For #20386 and addressing the [comment](https://github.com/etcd-io/etcd/pull/21791#discussion_r3314006880)
