### PR TITLE
switch to an updated semver library

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
-	github.com/coreos/go-semver v0.3.1
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/stretchr/testify v1.11.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,7 +1,7 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/api/version/version.go
+++ b/api/version/version.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 var (
@@ -35,17 +35,17 @@ var (
 
 // Get all constant versions defined in a centralized place.
 var (
-	V3_0 = semver.Version{Major: 3, Minor: 0}
-	V3_1 = semver.Version{Major: 3, Minor: 1}
-	V3_2 = semver.Version{Major: 3, Minor: 2}
-	V3_3 = semver.Version{Major: 3, Minor: 3}
-	V3_4 = semver.Version{Major: 3, Minor: 4}
-	V3_5 = semver.Version{Major: 3, Minor: 5}
-	V3_6 = semver.Version{Major: 3, Minor: 6}
-	V3_7 = semver.Version{Major: 3, Minor: 7}
-	V3_8 = semver.Version{Major: 3, Minor: 8}
-	V3_9 = semver.Version{Major: 3, Minor: 9}
-	V4_0 = semver.Version{Major: 4, Minor: 0}
+	V3_0 = *semver.New(3, 0, 0, "", "")
+	V3_1 = *semver.New(3, 1, 0, "", "")
+	V3_2 = *semver.New(3, 2, 0, "", "")
+	V3_3 = *semver.New(3, 3, 0, "", "")
+	V3_4 = *semver.New(3, 4, 0, "", "")
+	V3_5 = *semver.New(3, 5, 0, "", "")
+	V3_6 = *semver.New(3, 6, 0, "", "")
+	V3_7 = *semver.New(3, 7, 0, "", "")
+	V3_8 = *semver.New(3, 8, 0, "", "")
+	V3_9 = *semver.New(3, 9, 0, "", "")
+	V4_0 = *semver.New(4, 0, 0, "", "")
 
 	// AllVersions keeps all the versions in ascending order.
 	AllVersions = []semver.Version{V3_0, V3_1, V3_2, V3_3, V3_4, V3_5, V3_6, V3_7, V3_8, V4_0}
@@ -54,7 +54,7 @@ var (
 func init() {
 	ver, err := semver.NewVersion(Version)
 	if err == nil {
-		APIVersion = fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
+		APIVersion = fmt.Sprintf("%d.%d", ver.Major(), ver.Minor())
 	}
 }
 
@@ -67,6 +67,9 @@ type Versions struct {
 
 // Cluster only keeps the major.minor.
 func Cluster(v string) string {
+	if ver, err := semver.NewVersion(v); err == nil {
+		return fmt.Sprintf("%d.%d", ver.Major(), ver.Minor())
+	}
 	vs := strings.Split(v, ".")
 	if len(vs) <= 2 {
 		return v
@@ -75,13 +78,13 @@ func Cluster(v string) string {
 }
 
 func Compare(ver1, ver2 semver.Version) int {
-	return ver1.Compare(ver2)
+	return ver1.Compare(&ver2)
 }
 
 func LessThan(ver1, ver2 semver.Version) bool {
-	return ver1.LessThan(ver2)
+	return ver1.LessThan(&ver2)
 }
 
 func Equal(ver1, ver2 semver.Version) bool {
-	return ver1.Equal(ver2)
+	return ver1.Equal(&ver2)
 }

--- a/api/version/version_test.go
+++ b/api/version/version_test.go
@@ -17,7 +17,7 @@ package version
 import (
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -1,5 +1,14 @@
 [
 	{
+		"project": "github.com/Masterminds/semver/v3",
+		"licenses": [
+			{
+				"type": "MIT License",
+				"confidence": 0.9891304347826086
+			}
+		]
+	},
+	{
 		"project": "github.com/VividCortex/ewma",
 		"licenses": [
 			{
@@ -85,15 +94,6 @@
 		"licenses": [
 			{
 				"type": "MIT License",
-				"confidence": 1
-			}
-		]
-	},
-	{
-		"project": "github.com/coreos/go-semver/semver",
-		"licenses": [
-			{
-				"type": "Apache License 2.0",
 				"confidence": 1
 			}
 		]

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/cache/go.sum
+++ b/cache/go.sum
@@ -1,9 +1,9 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -504,11 +504,11 @@ func (c *Client) roundRobinQuorumBackoff(waitBetween time.Duration, jitterFracti
 
 // minSupportedVersion returns the minimum version supported, which is the previous minor release.
 func minSupportedVersion() *semver.Version {
-	ver := semver.Must(semver.NewVersion(version.Version))
+	ver := semver.MustParse(version.Version)
 	// consider only major and minor version
-	ver = &semver.Version{Major: ver.Major, Minor: ver.Minor}
+	ver = semver.New(ver.Major(), ver.Minor(), 0, "", "")
 	for i := range version.AllVersions {
-		if version.AllVersions[i].Equal(*ver) {
+		if version.AllVersions[i].Equal(ver) {
 			if i == 0 {
 				return ver
 			}
@@ -545,7 +545,7 @@ func (c *Client) checkVersion() (err error) {
 				return
 			}
 
-			if vs.LessThan(*minSupportedVersion()) {
+			if vs.LessThan(minSupportedVersion()) {
 				rerr = ErrOldCluster
 			}
 			errc <- rerr

--- a/client/v3/client_test.go
+++ b/client/v3/client_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -401,7 +401,7 @@ func TestMinSupportedVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			version.Version = tt.currentVersion.String()
-			require.True(t, minSupportedVersion().Equal(tt.minSupportedVersion))
+			require.True(t, minSupportedVersion().Equal(&tt.minSupportedVersion))
 		})
 	}
 }

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
-	github.com/coreos/go-semver v0.3.1
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0

--- a/client/v3/go.sum
+++ b/client/v3/go.sum
@@ -1,9 +1,9 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -23,11 +23,11 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.19.0 // indirect

--- a/etcdctl/go.sum
+++ b/etcdctl/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -12,8 +14,6 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
@@ -87,7 +87,7 @@ func (o *migrateOptions) Config() (*migrateConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse target version: %w", err)
 	}
-	if c.targetVersion.LessThan(version.V3_5) {
+	if c.targetVersion.LessThan(&version.V3_5) {
 		return nil, fmt.Errorf(`target version %q not supported. Minimal "3.5"`, storageVersionToString(c.targetVersion))
 	}
 
@@ -160,7 +160,7 @@ func migrateForce(lg *zap.Logger, tx backend.BatchTx, target *semver.Version) {
 	tx.LockOutsideApply()
 	defer tx.Unlock()
 	// Storage version is only supported since v3.6
-	if target.LessThan(version.V3_6) {
+	if target.LessThan(&version.V3_6) {
 		schema.UnsafeClearStorageVersion(tx)
 		lg.Warn("forcefully cleared storage version")
 	} else {
@@ -170,5 +170,5 @@ func migrateForce(lg *zap.Logger, tx backend.BatchTx, target *semver.Version) {
 }
 
 func storageVersionToString(ver *semver.Version) string {
-	return fmt.Sprintf("%d.%d", ver.Major, ver.Minor)
+	return fmt.Sprintf("%d.%d", ver.Major(), ver.Minor())
 }

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -13,7 +13,7 @@ replace (
 )
 
 require (
-	github.com/coreos/go-semver v0.3.1
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/spf13/cobra v1.10.2

--- a/etcdutl/go.sum
+++ b/etcdutl/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -10,8 +12,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ replace (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/bgentry/speakeasy v0.2.0
 	github.com/cheggaaa/pb/v3 v3.1.7
-	github.com/coreos/go-semver v0.3.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -16,8 +18,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.work.sum
+++ b/go.work.sum
@@ -232,6 +232,8 @@ github.com/cloudflare/redoctober v0.0.0-20211013234631-6a74ccc611f6/go.mod h1:Ik
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe h1:QQ3GSy+MqSHxm/d8nCtnAiZdYFd45cYZPs8vOOIYKfk=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cristalhq/acmd v0.12.0 h1:RdlKnxjN+txbQosg8p/TRNZ+J1Rdne43MVQZ1zDhGWk=
 github.com/cristalhq/acmd v0.12.0/go.mod h1:LG5oa43pE/BbxtfMoImHCQN++0Su7dzipdgBjMCBVDQ=

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,7 +157,7 @@ main() {
     local source_version
     source_version=$(grep -E "\s+Version\s*=" api/version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
     if [[ "${source_version}" != "${VERSION}" ]]; then
-      source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
+      source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2 | sed 's/^v//')
       if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
         log_error "Wrong etcd minor version in api/version/version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
         exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -503,7 +503,7 @@ function release_pass {
   rm -f ./bin/etcd-last-release
 
   # Work out the previous release based on the version reported by etcd binary
-  binary_version=$(./bin/etcd --version | grep --only-matching --perl-regexp '(?<=etcd Version: )\d+\.\d+')
+  binary_version=$(./bin/etcd --version | grep --only-matching --perl-regexp '(?<=etcd Version: )v?\d+\.\d+\.\d+' | sed 's/^v//')
   binary_major=$(echo "${binary_version}" | cut -d '.' -f 1)
   binary_minor=$(echo "${binary_version}" | cut -d '.' -f 2)
   previous_minor=$((binary_minor - 1))

--- a/server/etcdserver/adapters.go
+++ b/server/etcdserver/adapters.go
@@ -17,7 +17,7 @@ package etcdserver
 import (
 	"context"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/membershippb"

--- a/server/etcdserver/api/capability.go
+++ b/server/etcdserver/api/capability.go
@@ -17,7 +17,7 @@ package api
 import (
 	"sync"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"

--- a/server/etcdserver/api/cluster.go
+++ b/server/etcdserver/api/cluster.go
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"

--- a/server/etcdserver/api/etcdhttp/peer_test.go
+++ b/server/etcdserver/api/etcdhttp/peer_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap/zaptest"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
@@ -267,7 +267,7 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 
 	c.buildMembershipMetric()
 
-	sv := semver.Must(semver.NewVersion(version.Version))
+	sv := semver.MustParse(version.Version)
 	if c.downgradeInfo != nil && c.downgradeInfo.Enabled {
 		c.lg.Info(
 			"cluster is downgrading to target version",
@@ -583,7 +583,7 @@ func (c *RaftCluster) Version() *semver.Version {
 	if c.version == nil {
 		return nil
 	}
-	return semver.Must(semver.NewVersion(c.version.String()))
+	return semver.MustParse(c.version.String())
 }
 
 func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *semver.Version), shouldApplyV3 ShouldApplyV3) {
@@ -607,7 +607,7 @@ func (c *RaftCluster) SetVersion(ver *semver.Version, onSet func(*zap.Logger, *s
 	}
 	oldVer := c.version
 	c.version = ver
-	sv := semver.Must(semver.NewVersion(version.Version))
+	sv := semver.MustParse(version.Version)
 	serverversion.MustDetectDowngrade(c.lg, sv, c.version)
 
 	if shouldApplyV3 {

--- a/server/etcdserver/api/membership/membership_test.go
+++ b/server/etcdserver/api/membership/membership_test.go
@@ -17,7 +17,7 @@ package membership
 import (
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 

--- a/server/etcdserver/api/membership/store.go
+++ b/server/etcdserver/api/membership/store.go
@@ -17,7 +17,7 @@ package membership
 import (
 	"path"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"

--- a/server/etcdserver/api/membership/storev2.go
+++ b/server/etcdserver/api/membership/storev2.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"

--- a/server/etcdserver/api/membership/storev2_test.go
+++ b/server/etcdserver/api/membership/storev2_test.go
@@ -17,7 +17,7 @@ package membership
 import (
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -33,7 +33,7 @@ func TestIsMetaStoreOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")
 
-	mustSaveClusterVersionToStore(lg, s, semver.New("3.5.17"))
+	mustSaveClusterVersionToStore(lg, s, semver.MustParse("3.5.17"))
 	metaOnly, err = IsMetaStoreOnly(s)
 	require.NoError(t, err)
 	assert.Truef(t, metaOnly, "Just created v2store should be meta-only")

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
@@ -610,7 +610,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 	}
 
 	rv := serverVersion(resp.Header)
-	lv := semver.Must(semver.NewVersion(version.Version))
+	lv := semver.MustParse(version.Version)
 	if compareMajorMinorVersion(rv, lv) == -1 && !checkStreamSupport(rv, t) {
 		httputil.GracefulClose(resp)
 		cr.picker.unreachable(u)
@@ -709,7 +709,7 @@ func (cr *streamReader) resume() {
 // checkStreamSupport checks whether the stream type is supported in the
 // given version.
 func checkStreamSupport(v *semver.Version, t streamType) bool {
-	nv := &semver.Version{Major: v.Major, Minor: v.Minor}
+	nv := semver.New(v.Major(), v.Minor(), 0, "", "")
 	for _, s := range supportedStream[nv.String()] {
 		if s == t {
 			return true

--- a/server/etcdserver/api/rafthttp/stream_test.go
+++ b/server/etcdserver/api/rafthttp/stream_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
@@ -355,19 +355,19 @@ func TestCheckStreamSupport(t *testing.T) {
 	}{
 		// support
 		{
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0"),
 			streamTypeMsgAppV2,
 			true,
 		},
 		// ignore patch
 		{
-			semver.Must(semver.NewVersion("2.1.9")),
+			semver.MustParse("2.1.9"),
 			streamTypeMsgAppV2,
 			true,
 		},
 		// ignore prerelease
 		{
-			semver.Must(semver.NewVersion("2.1.0-alpha")),
+			semver.MustParse("2.1.0-alpha"),
 			streamTypeMsgAppV2,
 			true,
 		},

--- a/server/etcdserver/api/rafthttp/util.go
+++ b/server/etcdserver/api/rafthttp/util.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -132,12 +132,12 @@ func reportCriticalError(err error, errc chan<- error) {
 // their major and minor version. The result will be 0 if a==b, -1 if a < b,
 // and 1 if a > b.
 func compareMajorMinorVersion(a, b *semver.Version) int {
-	na := &semver.Version{Major: a.Major, Minor: a.Minor}
-	nb := &semver.Version{Major: b.Major, Minor: b.Minor}
+	na := semver.New(a.Major(), a.Minor(), 0, "", "")
+	nb := semver.New(b.Major(), b.Minor(), 0, "", "")
 	switch {
-	case na.LessThan(*nb):
+	case na.LessThan(nb):
 		return -1
-	case nb.LessThan(*na):
+	case nb.LessThan(na):
 		return 1
 	default:
 		return 0
@@ -151,7 +151,7 @@ func serverVersion(h http.Header) *semver.Version {
 	if verStr == "" {
 		verStr = "2.0.0"
 	}
-	return semver.Must(semver.NewVersion(verStr))
+	return semver.MustParse(verStr)
 }
 
 // serverVersion returns the min cluster version from the given header.
@@ -161,7 +161,7 @@ func minClusterVersion(h http.Header) *semver.Version {
 	if verStr == "" {
 		verStr = "2.0.0"
 	}
-	return semver.Must(semver.NewVersion(verStr))
+	return semver.MustParse(verStr)
 }
 
 // checkVersionCompatibility checks whether the given version is compatible
@@ -171,8 +171,8 @@ func checkVersionCompatibility(name string, server, minCluster *semver.Version) 
 	localMinCluster *semver.Version,
 	err error,
 ) {
-	localServer = semver.Must(semver.NewVersion(version.Version))
-	localMinCluster = semver.Must(semver.NewVersion(version.MinClusterVersion))
+	localServer = semver.MustParse(version.Version)
+	localMinCluster = semver.MustParse(version.MinClusterVersion)
 	if compareMajorMinorVersion(server, localMinCluster) == -1 {
 		return localServer, localMinCluster, fmt.Errorf("remote version is too low: remote[%s]=%s, local=%s", name, server, localServer)
 	}

--- a/server/etcdserver/api/rafthttp/util_test.go
+++ b/server/etcdserver/api/rafthttp/util_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"google.golang.org/protobuf/proto"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -58,32 +58,32 @@ func TestCompareMajorMinorVersion(t *testing.T) {
 	}{
 		// equal to
 		{
-			semver.Must(semver.NewVersion("2.1.0")),
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0"),
+			semver.MustParse("2.1.0"),
 			0,
 		},
 		// smaller than
 		{
-			semver.Must(semver.NewVersion("2.0.0")),
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.0.0"),
+			semver.MustParse("2.1.0"),
 			-1,
 		},
 		// bigger than
 		{
-			semver.Must(semver.NewVersion("2.2.0")),
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.2.0"),
+			semver.MustParse("2.1.0"),
 			1,
 		},
 		// ignore patch
 		{
-			semver.Must(semver.NewVersion("2.1.1")),
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.1"),
+			semver.MustParse("2.1.0"),
 			0,
 		},
 		// ignore prerelease
 		{
-			semver.Must(semver.NewVersion("2.1.0-alpha.0")),
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0-alpha.0"),
+			semver.MustParse("2.1.0"),
 			0,
 		},
 	}
@@ -102,15 +102,15 @@ func TestServerVersion(t *testing.T) {
 		// backward compatibility with etcd 2.0
 		{
 			http.Header{},
-			semver.Must(semver.NewVersion("2.0.0")),
+			semver.MustParse("2.0.0"),
 		},
 		{
 			http.Header{"X-Server-Version": []string{"2.1.0"}},
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0"),
 		},
 		{
 			http.Header{"X-Server-Version": []string{"2.1.0-alpha.0+git"}},
-			semver.Must(semver.NewVersion("2.1.0-alpha.0+git")),
+			semver.MustParse("2.1.0-alpha.0+git"),
 		},
 	}
 	for i, tt := range tests {
@@ -129,15 +129,15 @@ func TestMinClusterVersion(t *testing.T) {
 		// backward compatibility with etcd 2.0
 		{
 			http.Header{},
-			semver.Must(semver.NewVersion("2.0.0")),
+			semver.MustParse("2.0.0"),
 		},
 		{
 			http.Header{"X-Min-Cluster-Version": []string{"2.1.0"}},
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0"),
 		},
 		{
 			http.Header{"X-Min-Cluster-Version": []string{"2.1.0-alpha.0+git"}},
-			semver.Must(semver.NewVersion("2.1.0-alpha.0+git")),
+			semver.MustParse("2.1.0-alpha.0+git"),
 		},
 	}
 	for i, tt := range tests {
@@ -149,8 +149,8 @@ func TestMinClusterVersion(t *testing.T) {
 }
 
 func TestCheckVersionCompatibility(t *testing.T) {
-	ls := semver.Must(semver.NewVersion(version.Version))
-	lmc := semver.Must(semver.NewVersion(version.MinClusterVersion))
+	ls := semver.MustParse(version.Version)
+	lmc := semver.MustParse(version.MinClusterVersion)
 	tests := []struct {
 		server     *semver.Version
 		minCluster *semver.Version
@@ -165,25 +165,25 @@ func TestCheckVersionCompatibility(t *testing.T) {
 		// one version lower
 		{
 			lmc,
-			&semver.Version{},
+			semver.New(0, 0, 0, "", ""),
 			true,
 		},
 		// one version higher
 		{
-			&semver.Version{Major: ls.Major + 1},
+			semver.New(ls.Major()+1, 0, 0, "", ""),
 			ls,
 			true,
 		},
 		// too low version
 		{
-			&semver.Version{Major: lmc.Major - 1},
-			&semver.Version{},
+			semver.New(lmc.Major()-1, 0, 0, "", ""),
+			semver.New(0, 0, 0, "", ""),
 			false,
 		},
 		// too high version
 		{
-			&semver.Version{Major: ls.Major + 1, Minor: 1},
-			&semver.Version{Major: ls.Major + 1},
+			semver.New(ls.Major()+1, 1, 0, "", ""),
+			semver.New(ls.Major()+1, 0, 0, "", ""),
 			false,
 		},
 	}

--- a/server/etcdserver/apply/backend.go
+++ b/server/etcdserver/apply/backend.go
@@ -17,7 +17,7 @@ package apply
 import (
 	"context"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -269,10 +269,10 @@ func (a *applierV3backend) RoleList(r *pb.AuthRoleListRequest) (*pb.AuthRoleList
 
 func (a *applierV3backend) ClusterVersionSet(r *membershippb.ClusterVersionSetRequest, shouldApplyV3 membership.ShouldApplyV3) {
 	prevVersion := a.options.Cluster.Version()
-	newVersion := semver.Must(semver.NewVersion(r.Ver))
+	newVersion := semver.MustParse(r.Ver)
 	a.options.Cluster.SetVersion(newVersion, api.UpdateCapability, shouldApplyV3)
 	// Force snapshot after cluster version downgrade.
-	if prevVersion != nil && newVersion.LessThan(*prevVersion) {
+	if prevVersion != nil && newVersion.LessThan(prevVersion) {
 		lg := a.options.Logger
 		if lg != nil {
 			lg.Info("Cluster version downgrade detected, forcing snapshot",

--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/dustin/go-humanize"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -483,7 +483,7 @@ func (c *bootstrappedCluster) Finalize(cfg config.ServerConfig, s *bootstrappedS
 }
 
 func (c *bootstrappedCluster) databaseFileMissing(s *bootstrappedStorage) bool {
-	v3Cluster := c.cl.Version() != nil && !c.cl.Version().LessThan(semver.Version{Major: 3})
+	v3Cluster := c.cl.Version() != nil && !c.cl.Version().LessThan(semver.New(3, 0, 0, "", ""))
 	return v3Cluster && !s.backend.beExist
 }
 

--- a/server/etcdserver/cluster_util.go
+++ b/server/etcdserver/cluster_util.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 
@@ -172,14 +172,14 @@ func getMembersVersions(lg *zap.Logger, cl *membership.RaftCluster, local types.
 // if the downgrade enabled status is true, the version window is [oneMinorHigher, oneMinorHigher]
 // if the downgrade is not enabled, the version window is [MinClusterVersion, localVersion]
 func allowedVersionRange(downgradeEnabled bool) (minV *semver.Version, maxV *semver.Version) {
-	minV = semver.Must(semver.NewVersion(version.MinClusterVersion))
-	maxV = semver.Must(semver.NewVersion(version.Version))
-	maxV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
+	minV = semver.MustParse(version.MinClusterVersion)
+	maxV = semver.MustParse(version.Version)
+	maxV = semver.New(maxV.Major(), maxV.Minor(), 0, "", "")
 
 	if downgradeEnabled {
 		// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
-		maxV.Minor = maxV.Minor + 1
-		minV = &semver.Version{Major: maxV.Major, Minor: maxV.Minor}
+		maxV = semver.New(maxV.Major(), maxV.Minor()+1, 0, "", "")
+		minV = semver.New(maxV.Major(), maxV.Minor(), 0, "", "")
 	}
 	return minV, maxV
 }
@@ -216,7 +216,7 @@ func isCompatibleWithVers(lg *zap.Logger, vers map[string]*version.Versions, loc
 			)
 			continue
 		}
-		if clusterv.LessThan(*minV) {
+		if clusterv.LessThan(minV) {
 			lg.Warn(
 				"cluster version of remote member is not compatible; too low",
 				zap.String("remote-member-id", id),
@@ -225,7 +225,7 @@ func isCompatibleWithVers(lg *zap.Logger, vers map[string]*version.Versions, loc
 			)
 			return false
 		}
-		if maxV.LessThan(*clusterv) {
+		if maxV.LessThan(clusterv) {
 			lg.Warn(
 				"cluster version of remote member is not compatible; too high",
 				zap.String("remote-member-id", id),
@@ -436,14 +436,14 @@ func getDowngradeEnabled(lg *zap.Logger, m *membership.Member, rt http.RoundTrip
 func convertToClusterVersion(v string) (*semver.Version, error) {
 	ver, err := semver.NewVersion(v)
 	if err != nil {
-		// allow input version format Major.Minor
+		// allow input version format Major.Minor()
 		ver, err = semver.NewVersion(v + ".0")
 		if err != nil {
 			return nil, errors.ErrWrongDowngradeVersionFormat
 		}
 	}
 	// cluster version only keeps major.minor, remove patch version
-	ver = &semver.Version{Major: ver.Major, Minor: ver.Minor}
+	ver = semver.New(ver.Major(), ver.Minor(), 0, "", "")
 	return ver, nil
 }
 

--- a/server/etcdserver/cluster_util_test.go
+++ b/server/etcdserver/cluster_util_test.go
@@ -17,7 +17,7 @@ package etcdserver
 import (
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap/zaptest"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -39,7 +39,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 				"c": {Server: "2.1.0", Cluster: "2.1.0"},
 			},
 			0xa,
-			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.0.0")),
+			semver.MustParse("2.0.0"), semver.MustParse("2.0.0"),
 			false,
 		},
 		{
@@ -49,7 +49,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 				"c": {Server: "2.1.0", Cluster: "2.1.0"},
 			},
 			0xa,
-			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.0.0"), semver.MustParse("2.1.0"),
 			true,
 		},
 		// too high
@@ -60,7 +60,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 				"c": {Server: "2.0.0", Cluster: "2.0.0"},
 			},
 			0xa,
-			semver.Must(semver.NewVersion("2.1.0")), semver.Must(semver.NewVersion("2.2.0")),
+			semver.MustParse("2.1.0"), semver.MustParse("2.2.0"),
 			false,
 		},
 		// cannot get b's version, expect ok
@@ -71,7 +71,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 				"c": {Server: "2.1.0", Cluster: "2.1.0"},
 			},
 			0xa,
-			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.0.0"), semver.MustParse("2.1.0"),
 			true,
 		},
 		// cannot get b and c's version, expect not ok
@@ -82,7 +82,7 @@ func TestIsCompatibleWithVers(t *testing.T) {
 				"c": nil,
 			},
 			0xa,
-			semver.Must(semver.NewVersion("2.0.0")), semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.0.0"), semver.MustParse("2.1.0"),
 			false,
 		},
 	}
@@ -103,13 +103,13 @@ func TestConvertToClusterVersion(t *testing.T) {
 		hasError    bool
 	}{
 		{
-			"Succeeded: Major.Minor.Patch",
+			"Succeeded: Major.Minor().Patch()",
 			"3.4.2",
 			"3.4.0",
 			false,
 		},
 		{
-			"Succeeded: Major.Minor",
+			"Succeeded: Major.Minor()",
 			"3.4",
 			"3.4.0",
 			false,
@@ -139,9 +139,9 @@ func TestConvertToClusterVersion(t *testing.T) {
 }
 
 func TestDecideAllowedVersionRange(t *testing.T) {
-	minClusterV := semver.Must(semver.NewVersion(version.MinClusterVersion))
-	localV := semver.Must(semver.NewVersion(version.Version))
-	localV = &semver.Version{Major: localV.Major, Minor: localV.Minor}
+	minClusterV := semver.MustParse(version.MinClusterVersion)
+	localV := semver.MustParse(version.Version)
+	localV = semver.New(localV.Major(), localV.Minor(), 0, "", "")
 
 	tests := []struct {
 		name             string
@@ -152,8 +152,8 @@ func TestDecideAllowedVersionRange(t *testing.T) {
 		{
 			"When cluster enables downgrade",
 			true,
-			&semver.Version{Major: localV.Major, Minor: localV.Minor + 1},
-			&semver.Version{Major: localV.Major, Minor: localV.Minor + 1},
+			semver.New(localV.Major(), localV.Minor()+1, 0, "", ""),
+			semver.New(localV.Major(), localV.Minor()+1, 0, "", ""),
 		},
 		{
 			"When cluster disables downgrade",
@@ -166,11 +166,11 @@ func TestDecideAllowedVersionRange(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			minV, maxV := allowedVersionRange(tt.downgradeEnabled)
-			if !minV.Equal(*tt.expectedMinV) {
+			if !minV.Equal(tt.expectedMinV) {
 				t.Errorf("Expected minV is %v; Got %v", tt.expectedMinV.String(), minV.String())
 			}
 
-			if !maxV.Equal(*tt.expectedMaxV) {
+			if !maxV.Equal(tt.expectedMaxV) {
 				t.Errorf("Expected maxV is %v; Got %v", tt.expectedMaxV.String(), maxV.String())
 			}
 		})

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -27,7 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"

--- a/server/etcdserver/version/downgrade.go
+++ b/server/etcdserver/version/downgrade.go
@@ -15,7 +15,7 @@
 package version
 
 import (
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -30,22 +30,22 @@ type DowngradeInfo struct {
 }
 
 func (d *DowngradeInfo) GetTargetVersion() *semver.Version {
-	return semver.Must(semver.NewVersion(d.TargetVersion))
+	return semver.MustParse(d.TargetVersion)
 }
 
 // isValidDowngrade verifies whether the cluster can be downgraded from verFrom to verTo
 func isValidDowngrade(verFrom *semver.Version, verTo *semver.Version) bool {
-	return verTo.Equal(*allowedDowngradeVersion(verFrom))
+	return verTo.Equal(allowedDowngradeVersion(verFrom))
 }
 
 // MustDetectDowngrade will detect local server joining cluster that doesn't support it's version.
 func MustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) {
 	// only keep major.minor version for comparison against cluster version
-	sv = &semver.Version{Major: sv.Major, Minor: sv.Minor}
+	sv = semver.New(sv.Major(), sv.Minor(), 0, "", "")
 
 	// if the cluster disables downgrade, check local version against determined cluster version.
 	// the validation passes when local version is not less than cluster version
-	if cv != nil && sv.LessThan(*cv) {
+	if cv != nil && sv.LessThan(cv) {
 		lg.Panic(
 			"invalid downgrade; server version is lower than determined cluster version",
 			zap.String("current-server-version", sv.String()),
@@ -56,7 +56,7 @@ func MustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) {
 
 func allowedDowngradeVersion(ver *semver.Version) *semver.Version {
 	// Todo: handle the case that downgrading from higher major version(e.g. downgrade from v4.0 to v3.x)
-	return &semver.Version{Major: ver.Major, Minor: ver.Minor - 1}
+	return semver.New(ver.Major(), ver.Minor()-1, 0, "", "")
 }
 
 // IsValidClusterVersionChange checks the two scenario when version is valid to change:
@@ -66,10 +66,10 @@ func allowedDowngradeVersion(ver *semver.Version) *semver.Version {
 // is set to MinVersion(3.0), when all members are at higher version, cluster version
 // is lower than minimal server version, cluster version should change
 func IsValidClusterVersionChange(verFrom *semver.Version, verTo *semver.Version) bool {
-	verFrom = &semver.Version{Major: verFrom.Major, Minor: verFrom.Minor}
-	verTo = &semver.Version{Major: verTo.Major, Minor: verTo.Minor}
+	verFrom = semver.New(verFrom.Major(), verFrom.Minor(), 0, "", "")
+	verTo = semver.New(verTo.Major(), verTo.Minor(), 0, "", "")
 
-	if isValidDowngrade(verFrom, verTo) || (verFrom.Major == verTo.Major && verFrom.LessThan(*verTo)) {
+	if isValidDowngrade(verFrom, verTo) || (verFrom.Major() == verTo.Major() && verFrom.LessThan(verTo)) {
 		return true
 	}
 	return false

--- a/server/etcdserver/version/downgrade_test.go
+++ b/server/etcdserver/version/downgrade_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -27,10 +27,10 @@ import (
 )
 
 func TestMustDetectDowngrade(t *testing.T) {
-	lv := semver.Must(semver.NewVersion(version.Version))
-	lv = &semver.Version{Major: lv.Major, Minor: lv.Minor}
-	oneMinorHigher := &semver.Version{Major: lv.Major, Minor: lv.Minor + 1}
-	oneMinorLower := &semver.Version{Major: lv.Major, Minor: lv.Minor - 1}
+	lv := semver.MustParse(version.Version)
+	lv = semver.New(lv.Major(), lv.Minor(), 0, "", "")
+	oneMinorHigher := semver.New(lv.Major(), lv.Minor()+1, 0, "", "")
+	oneMinorLower := semver.New(lv.Major(), lv.Minor()-1, 0, "", "")
 
 	tests := []struct {
 		name           string
@@ -67,7 +67,7 @@ func TestMustDetectDowngrade(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lg := zaptest.NewLogger(t)
-			sv := semver.Must(semver.NewVersion(version.Version))
+			sv := semver.MustParse(version.Version)
 			err := tryMustDetectDowngrade(lg, sv, tt.clusterVersion)
 
 			if tt.success != (err == nil) {
@@ -112,7 +112,7 @@ func TestIsValidDowngrade(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := isValidDowngrade(
-				semver.Must(semver.NewVersion(tt.verFrom)), semver.Must(semver.NewVersion(tt.verTo)))
+				semver.MustParse(tt.verFrom), semver.MustParse(tt.verTo))
 			if res != tt.result {
 				t.Errorf("Expected downgrade valid is %v; Got %v", tt.result, res)
 			}
@@ -179,8 +179,8 @@ func TestIsVersionChangable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			verFrom := semver.Must(semver.NewVersion(tt.verFrom))
-			verTo := semver.Must(semver.NewVersion(tt.verTo))
+			verFrom := semver.MustParse(tt.verFrom)
+			verTo := semver.MustParse(tt.verTo)
 			ret := IsValidClusterVersionChange(verFrom, verTo)
 			assert.Equal(t, tt.expectedResult, ret)
 		})

--- a/server/etcdserver/version/monitor.go
+++ b/server/etcdserver/version/monitor.go
@@ -17,8 +17,9 @@ package version
 import (
 	"context"
 	"errors"
+	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -55,7 +56,7 @@ func NewMonitor(lg *zap.Logger, storage Server) *Monitor {
 func (m *Monitor) UpdateClusterVersionIfNeeded() error {
 	newClusterVersion, err := m.decideClusterVersion()
 	if newClusterVersion != nil {
-		newClusterVersion = &semver.Version{Major: newClusterVersion.Major, Minor: newClusterVersion.Minor}
+		newClusterVersion = semver.New(newClusterVersion.Major(), newClusterVersion.Minor(), 0, "", "")
 		m.s.UpdateClusterVersion(newClusterVersion.String())
 	}
 	return err
@@ -71,14 +72,14 @@ func (m *Monitor) decideClusterVersion() (*semver.Version, error) {
 		if minimalServerVersion != nil {
 			return minimalServerVersion, nil
 		}
-		return semver.New(version.MinClusterVersion), nil
+		return semver.MustParse(version.MinClusterVersion), nil
 	}
 	if minimalServerVersion == nil {
 		return nil, nil
 	}
 	downgrade := m.s.GetDowngradeInfo()
 	if downgrade != nil && downgrade.Enabled {
-		if downgrade.GetTargetVersion().Equal(*clusterVersion) {
+		if downgrade.GetTargetVersion().Equal(clusterVersion) {
 			return nil, nil
 		}
 		if !isValidDowngrade(clusterVersion, downgrade.GetTargetVersion()) {
@@ -97,7 +98,7 @@ func (m *Monitor) decideClusterVersion() (*semver.Version, error) {
 		}
 		return downgrade.GetTargetVersion(), nil
 	}
-	if clusterVersion.LessThan(*minimalServerVersion) && IsValidClusterVersionChange(clusterVersion, minimalServerVersion) {
+	if clusterVersion.LessThan(minimalServerVersion) && IsValidClusterVersionChange(clusterVersion, minimalServerVersion) {
 		return minimalServerVersion, nil
 	}
 	return nil, nil
@@ -111,11 +112,11 @@ func (m *Monitor) UpdateStorageVersionIfNeeded() {
 	}
 	sv := m.s.GetStorageVersion()
 
-	if sv == nil || sv.Major != cv.Major || sv.Minor != cv.Minor {
+	if sv == nil || sv.Major() != cv.Major() || sv.Minor() != cv.Minor() {
 		if sv != nil {
 			m.lg.Info("cluster version differs from storage version.", zap.String("cluster-version", cv.String()), zap.String("storage-version", sv.String()))
 		}
-		err := m.s.UpdateStorageVersion(semver.Version{Major: cv.Major, Minor: cv.Minor})
+		err := m.s.UpdateStorageVersion(*semver.New(cv.Major(), cv.Minor(), 0, "", ""))
 		if err != nil {
 			m.lg.Error("failed to update storage version", zap.String("cluster-version", cv.String()), zap.Error(err))
 			return
@@ -138,7 +139,7 @@ func (m *Monitor) CancelDowngradeIfNeeded() {
 	}
 
 	targetVersion := d.TargetVersion
-	v := semver.Must(semver.NewVersion(targetVersion))
+	v := semver.MustParse(targetVersion)
 	if m.versionsMatchTarget(v) {
 		m.lg.Info("the cluster has been downgraded", zap.String("cluster-version", targetVersion))
 		err := m.s.DowngradeCancel(context.Background())
@@ -155,13 +156,13 @@ func (m *Monitor) CancelDowngradeIfNeeded() {
 func (m *Monitor) membersMinimalServerVersion() *semver.Version {
 	vers := m.s.GetMembersVersions()
 	var minV *semver.Version
-	lv := semver.Must(semver.NewVersion(version.Version))
+	lv := semver.MustParse(version.Version)
 
 	for mid, ver := range vers {
 		if ver == nil {
 			return nil
 		}
-		v, err := semver.NewVersion(ver.Server)
+		v, err := parseServerVersion(ver.Server)
 		if err != nil {
 			m.lg.Warn(
 				"failed to parse server version of remote member",
@@ -171,7 +172,7 @@ func (m *Monitor) membersMinimalServerVersion() *semver.Version {
 			)
 			return nil
 		}
-		if lv.LessThan(*v) {
+		if lv.LessThan(v) {
 			m.lg.Warn(
 				"leader found higher-versioned member",
 				zap.String("local-member-version", lv.String()),
@@ -181,7 +182,7 @@ func (m *Monitor) membersMinimalServerVersion() *semver.Version {
 		}
 		if minV == nil {
 			minV = v
-		} else if v.LessThan(*minV) {
+		} else if v.LessThan(minV) {
 			minV = v
 		}
 	}
@@ -192,12 +193,12 @@ func (m *Monitor) membersMinimalServerVersion() *semver.Version {
 // It can be used to decide the whether the cluster finishes downgrading to target version.
 func (m *Monitor) versionsMatchTarget(targetVersion *semver.Version) bool {
 	vers := m.s.GetMembersVersions()
-	targetVersion = &semver.Version{Major: targetVersion.Major, Minor: targetVersion.Minor}
+	targetVersion = semver.New(targetVersion.Major(), targetVersion.Minor(), 0, "", "")
 	for mid, ver := range vers {
 		if ver == nil {
 			return false
 		}
-		v, err := semver.NewVersion(ver.Server)
+		v, err := parseServerVersion(ver.Server)
 		if err != nil {
 			m.lg.Warn(
 				"failed to parse server version of remote member",
@@ -207,8 +208,8 @@ func (m *Monitor) versionsMatchTarget(targetVersion *semver.Version) bool {
 			)
 			return false
 		}
-		v = &semver.Version{Major: v.Major, Minor: v.Minor}
-		if !targetVersion.Equal(*v) {
+		v = semver.New(v.Major(), v.Minor(), 0, "", "")
+		if !targetVersion.Equal(v) {
 			m.lg.Warn("remotes server has mismatching etcd version",
 				zap.String("remote-member-id", mid),
 				zap.String("current-server-version", v.String()),
@@ -218,4 +219,8 @@ func (m *Monitor) versionsMatchTarget(targetVersion *semver.Version) bool {
 		}
 	}
 	return true
+}
+
+func parseServerVersion(serverVersion string) (*semver.Version, error) {
+	return semver.StrictNewVersion(strings.TrimPrefix(serverVersion, "v"))
 }

--- a/server/etcdserver/version/monitor_test.go
+++ b/server/etcdserver/version/monitor_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 
@@ -34,7 +34,7 @@ func TestMemberMinimalVersion(t *testing.T) {
 	}{
 		{
 			map[string]*version.Versions{"a": {Server: "2.0.0"}},
-			semver.Must(semver.NewVersion("2.0.0")),
+			semver.MustParse("2.0.0"),
 		},
 		// unknown
 		{
@@ -43,11 +43,11 @@ func TestMemberMinimalVersion(t *testing.T) {
 		},
 		{
 			map[string]*version.Versions{"a": {Server: "2.0.0"}, "b": {Server: "2.1.0"}, "c": {Server: "2.1.0"}},
-			semver.Must(semver.NewVersion("2.0.0")),
+			semver.MustParse("2.0.0"),
 		},
 		{
 			map[string]*version.Versions{"a": {Server: "2.1.0"}, "b": {Server: "2.1.0"}, "c": {Server: "2.1.0"}},
-			semver.Must(semver.NewVersion("2.1.0")),
+			semver.MustParse("2.1.0"),
 		},
 		{
 			map[string]*version.Versions{"a": nil, "b": {Server: "2.1.0"}, "c": {Server: "2.1.0"}},
@@ -124,7 +124,7 @@ func TestVersionMatchTarget(t *testing.T) {
 	}{
 		{
 			"When downgrade finished",
-			&semver.Version{Major: 3, Minor: 4},
+			semver.New(3, 4, 0, "", ""),
 			map[string]*version.Versions{
 				"mem1": {Server: "3.4.1", Cluster: "3.4.0"},
 				"mem2": {Server: "3.4.2-pre", Cluster: "3.4.0"},
@@ -133,8 +133,18 @@ func TestVersionMatchTarget(t *testing.T) {
 			true,
 		},
 		{
+			"When downgrade finished with v-prefixed peer versions",
+			semver.New(3, 4, 0, "", ""),
+			map[string]*version.Versions{
+				"mem1": {Server: "v3.4.1", Cluster: "3.4.0"},
+				"mem2": {Server: "v3.4.2-pre", Cluster: "3.4.0"},
+				"mem3": {Server: "v3.4.2", Cluster: "3.4.0"},
+			},
+			true,
+		},
+		{
 			"When cannot parse peer version",
-			&semver.Version{Major: 3, Minor: 4},
+			semver.New(3, 4, 0, "", ""),
 			map[string]*version.Versions{
 				"mem1": {Server: "3.4", Cluster: "3.4.0"},
 				"mem2": {Server: "3.4.2-pre", Cluster: "3.4.0"},
@@ -144,7 +154,7 @@ func TestVersionMatchTarget(t *testing.T) {
 		},
 		{
 			"When downgrade not finished",
-			&semver.Version{Major: 3, Minor: 4},
+			semver.New(3, 4, 0, "", ""),
 			map[string]*version.Versions{
 				"mem1": {Server: "3.4.1", Cluster: "3.4.0"},
 				"mem2": {Server: "3.4.2-pre", Cluster: "3.4.0"},
@@ -415,7 +425,7 @@ type storageMock struct {
 var _ Server = (*storageMock)(nil)
 
 func (s *storageMock) UpdateClusterVersion(version string) {
-	s.clusterVersion = semver.New(version)
+	s.clusterVersion = semver.MustParse(version)
 }
 
 func (s *storageMock) LinearizableReadNotify(ctx context.Context) error {

--- a/server/etcdserver/version/version.go
+++ b/server/etcdserver/version/version.go
@@ -17,7 +17,7 @@ package version
 import (
 	"context"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 )
 
@@ -45,7 +45,7 @@ func (m *Manager) DowngradeValidate(ctx context.Context, targetVersion *semver.V
 	}
 	cv := m.s.GetClusterVersion()
 	allowedTargetVersion := allowedDowngradeVersion(cv)
-	if !targetVersion.Equal(*allowedTargetVersion) {
+	if !targetVersion.Equal(allowedTargetVersion) {
 		return ErrInvalidDowngradeTargetVersion
 	}
 

--- a/server/etcdserver/version/version_test.go
+++ b/server/etcdserver/version/version_test.go
@@ -20,7 +20,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -127,7 +127,7 @@ func newCluster(lg *zap.Logger, memberCount int, ver semver.Version) *clusterMoc
 		clusterVersion: ver,
 		members:        make([]*memberMock, 0, memberCount),
 	}
-	majorMinVer := semver.Version{Major: ver.Major, Minor: ver.Minor}
+	majorMinVer := *semver.New(ver.Major(), ver.Minor(), 0, "", "")
 	for i := 0; i < memberCount; i++ {
 		m := &memberMock{
 			isRunning:      true,
@@ -210,7 +210,7 @@ type memberMock struct {
 var _ Server = (*memberMock)(nil)
 
 func (m *memberMock) UpdateClusterVersion(version string) {
-	m.cluster.clusterVersion = *semver.New(version)
+	m.cluster.clusterVersion = *semver.MustParse(version)
 }
 
 func (m *memberMock) LinearizableReadNotify(ctx context.Context) error {

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.5
 
 require (
-	github.com/coreos/go-semver v0.3.1
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -6,8 +8,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"

--- a/server/lease/lessor_test.go
+++ b/server/lease/lessor_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -697,11 +697,11 @@ func NewTestBackend(t *testing.T) (string, backend.Backend) {
 }
 
 func clusterLatest() cluster {
-	return fakeCluster{semver.New(version.Cluster(version.Version) + ".0")}
+	return fakeCluster{semver.MustParse(version.Cluster(version.Version) + ".0")}
 }
 
 func clusterV3_5() cluster {
-	return fakeCluster{semver.New("3.5.0")}
+	return fakeCluster{semver.MustParse("3.5.0")}
 }
 
 func clusterNil() cluster {

--- a/server/mock/mockstorage/storage_recorder.go
+++ b/server/mock/mockstorage/storage_recorder.go
@@ -15,7 +15,7 @@
 package mockstorage
 
 import (
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/raft/v3"

--- a/server/storage/schema/membership.go
+++ b/server/storage/schema/membership.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -202,7 +202,7 @@ func (s *membershipBackend) ClusterVersionFromBackend() *semver.Version {
 			zap.Int("number-of-key", len(keys)),
 		)
 	}
-	return semver.Must(semver.NewVersion(string(vals[0])))
+	return semver.MustParse(string(vals[0]))
 }
 
 // DowngradeInfoFromBackend reads downgrade info from backend.

--- a/server/storage/schema/migration.go
+++ b/server/storage/schema/migration.go
@@ -17,7 +17,7 @@ package schema
 import (
 	"fmt"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -29,15 +29,15 @@ type migrationPlan []migrationStep
 func newPlan(lg *zap.Logger, current semver.Version, target semver.Version) (plan migrationPlan, err error) {
 	current = trimToMinor(current)
 	target = trimToMinor(target)
-	if current.Major != target.Major {
+	if current.Major() != target.Major() {
 		lg.Error("Changing major storage version is not supported",
 			zap.String("storage-version", current.String()),
 			zap.String("target-storage-version", target.String()),
 		)
 		return plan, fmt.Errorf("changing major storage version is not supported")
 	}
-	for !current.Equal(target) {
-		isUpgrade := current.Minor < target.Minor
+	for !current.Equal(&target) {
+		isUpgrade := current.Minor() < target.Minor()
 
 		changes, err := schemaChangesForVersion(current, isUpgrade)
 		if err != nil {
@@ -83,9 +83,9 @@ func newMigrationStep(v semver.Version, isUpgrade bool, changes []schemaChange) 
 		}
 	}
 	if isUpgrade {
-		step.target = semver.Version{Major: v.Major, Minor: v.Minor + 1}
+		step.target = *semver.New(v.Major(), v.Minor()+1, 0, "", "")
 	} else {
-		step.target = semver.Version{Major: v.Major, Minor: v.Minor - 1}
+		step.target = *semver.New(v.Major(), v.Minor()-1, 0, "", "")
 	}
 	return step
 }
@@ -97,12 +97,12 @@ func (s migrationStep) unsafeExecute(lg *zap.Logger, tx backend.UnsafeReadWriter
 		return err
 	}
 	// Storage version is available since v3.6, downgrading target v3.5 should clean this field.
-	if !s.target.LessThan(version.V3_6) {
+	if !s.target.LessThan(&version.V3_6) {
 		UnsafeSetStorageVersion(tx, &s.target)
 	}
 	return nil
 }
 
 func trimToMinor(ver semver.Version) semver.Version {
-	return semver.Version{Major: ver.Major, Minor: ver.Minor}
+	return *semver.New(ver.Major(), ver.Minor(), 0, "", "")
 }

--- a/server/storage/schema/migration_test.go
+++ b/server/storage/schema/migration_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -105,31 +105,31 @@ func TestMigrationStepExecute(t *testing.T) {
 	}{
 		{
 			name:           "Upgrade execute changes in order and updates version",
-			currentVersion: semver.Version{Major: 99, Minor: 0},
+			currentVersion: *semver.New(99, 0, 0, "", ""),
 			isUpgrade:      true,
 			changes: []schemaChange{
 				recorder.changeMock("A"),
 				recorder.changeMock("B"),
 			},
 
-			expectVersion:         &semver.Version{Major: 99, Minor: 1},
+			expectVersion:         semver.New(99, 1, 0, "", ""),
 			expectRecordedActions: []string{"upgrade A", "upgrade B"},
 		},
 		{
 			name:           "Downgrade execute changes in reversed order and downgrades version",
-			currentVersion: semver.Version{Major: 99, Minor: 1},
+			currentVersion: *semver.New(99, 1, 0, "", ""),
 			isUpgrade:      false,
 			changes: []schemaChange{
 				recorder.changeMock("A"),
 				recorder.changeMock("B"),
 			},
 
-			expectVersion:         &semver.Version{Major: 99, Minor: 0},
+			expectVersion:         semver.New(99, 0, 0, "", ""),
 			expectRecordedActions: []string{"downgrade B", "downgrade A"},
 		},
 		{
 			name:           "Failure during upgrade should revert previous changes in reversed order and not change version",
-			currentVersion: semver.Version{Major: 99, Minor: 0},
+			currentVersion: *semver.New(99, 0, 0, "", ""),
 			isUpgrade:      true,
 			changes: []schemaChange{
 				recorder.changeMock("A"),
@@ -139,13 +139,13 @@ func TestMigrationStepExecute(t *testing.T) {
 				recorder.changeMock("E"),
 			},
 
-			expectVersion:         &semver.Version{Major: 99, Minor: 0},
+			expectVersion:         semver.New(99, 0, 0, "", ""),
 			expectRecordedActions: []string{"upgrade A", "upgrade B", "upgrade error C", "revert upgrade B", "revert upgrade A"},
 			expectError:           errorC,
 		},
 		{
 			name:           "Failure during downgrade should revert previous changes in reversed order and not change version",
-			currentVersion: semver.Version{Major: 99, Minor: 0},
+			currentVersion: *semver.New(99, 0, 0, "", ""),
 			isUpgrade:      false,
 			changes: []schemaChange{
 				recorder.changeMock("A"),
@@ -155,13 +155,13 @@ func TestMigrationStepExecute(t *testing.T) {
 				recorder.changeMock("E"),
 			},
 
-			expectVersion:         &semver.Version{Major: 99, Minor: 0},
+			expectVersion:         semver.New(99, 0, 0, "", ""),
 			expectRecordedActions: []string{"downgrade E", "downgrade D", "downgrade error C", "revert downgrade D", "revert downgrade E"},
 			expectError:           errorC,
 		},
 		{
 			name:           "Downgrade below to below v3.6 doesn't leave storage version as it was not supported then",
-			currentVersion: semver.Version{Major: 3, Minor: 6},
+			currentVersion: *semver.New(3, 6, 0, "", ""),
 			changes:        schemaChanges[version.V3_6],
 			isUpgrade:      false,
 			expectVersion:  nil,

--- a/server/storage/schema/schema.go
+++ b/server/storage/schema/schema.go
@@ -17,7 +17,7 @@ package schema
 import (
 	"fmt"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -44,8 +44,8 @@ func unsafeValidate(lg *zap.Logger, tx backend.UnsafeReader) error {
 }
 
 func localBinaryVersion() semver.Version {
-	v := semver.New(version.Version)
-	return semver.Version{Major: v.Major, Minor: v.Minor}
+	v := semver.MustParse(version.Version)
+	return *semver.New(v.Major(), v.Minor(), 0, "", "")
 }
 
 // Migrate updates storage schema to provided target version.
@@ -66,9 +66,9 @@ func UnsafeMigrate(lg *zap.Logger, tx backend.UnsafeReadWriter, w wal.Version, t
 	if err != nil {
 		return fmt.Errorf("cannot create migration plan: %w", err)
 	}
-	if target.LessThan(current) {
+	if target.LessThan(&current) {
 		minVersion := w.MinimalEtcdVersion()
-		if minVersion != nil && target.LessThan(*minVersion) {
+		if minVersion != nil && target.LessThan(minVersion) {
 			// Occasionally we may see this error during downgrade test due to ClusterVersionSet,
 			// which is harmless. Please read https://github.com/etcd-io/etcd/pull/13405#discussion_r1890378185.
 			return fmt.Errorf("cannot downgrade storage, WAL contains newer entries, as the target version (%s) is lower than the version (%s) detected from WAL logs",
@@ -111,7 +111,7 @@ func schemaChangesForVersion(v semver.Version, isUpgrade bool) ([]schemaChange, 
 	// changes should be taken from higher version
 	higherV := v
 	if isUpgrade {
-		higherV = semver.Version{Major: v.Major, Minor: v.Minor + 1}
+		higherV = *semver.New(v.Major(), v.Minor()+1, 0, "", "")
 	}
 
 	actions, found := schemaChanges[higherV]

--- a/server/storage/schema/schema_test.go
+++ b/server/storage/schema/schema_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/server/storage/schema/version.go
+++ b/server/storage/schema/version.go
@@ -15,7 +15,7 @@
 package schema
 
 import (
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"go.etcd.io/bbolt"
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -57,7 +57,7 @@ func ReadStorageVersionFromSnapshot(tx *bbolt.Tx) *semver.Version {
 // UnsafeSetStorageVersion updates etcd storage version in backend.
 // Populated since v3.6
 func UnsafeSetStorageVersion(tx backend.UnsafeWriter, v *semver.Version) {
-	sv := semver.Version{Major: v.Major, Minor: v.Minor}
+	sv := *semver.New(v.Major(), v.Minor(), 0, "", "")
 	tx.UnsafePut(Meta, MetaStorageVersionName, []byte(sv.String()))
 }
 

--- a/server/storage/schema/version_test.go
+++ b/server/storage/schema/version_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -63,7 +63,7 @@ func TestVersion(t *testing.T) {
 			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(Meta)
-			UnsafeSetStorageVersion(tx, semver.New(tc.version))
+			UnsafeSetStorageVersion(tx, semver.MustParse(tc.version))
 			tx.Unlock()
 			be.ForceCommit()
 			be.Close()
@@ -107,7 +107,7 @@ func TestVersionSnapshot(t *testing.T) {
 			require.NotNilf(t, tx, "batch tx is nil")
 			tx.Lock()
 			tx.UnsafeCreateBucket(Meta)
-			UnsafeSetStorageVersion(tx, semver.New(tc.version))
+			UnsafeSetStorageVersion(tx, semver.MustParse(tc.version))
 			tx.Unlock()
 			be.ForceCommit()
 			be.Close()

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -17,7 +17,7 @@ package storage
 import (
 	"sync"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"

--- a/server/storage/wal/version.go
+++ b/server/storage/wal/version.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/golang/protobuf/proto" //nolint:staticcheck // TODO: remove for a supported version
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -244,7 +244,7 @@ func visitDescriptor(md protoreflect.Descriptor, visitor Visitor) error {
 }
 
 func maxVersion(a *semver.Version, b *semver.Version) *semver.Version {
-	if a != nil && (b == nil || b.LessThan(*a)) {
+	if a != nil && (b == nil || b.LessThan(a)) {
 		return a
 	}
 	return b

--- a/server/storage/wal/version_test.go
+++ b/server/storage/wal/version_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"

--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -102,17 +102,20 @@ func testDowngradeUpgrade(t *testing.T, numberOfMembersToDowngrade int, clusterS
 	currentVersion, err := e2e.GetVersionFromBinary(currentEtcdBinary)
 	require.NoError(t, err)
 	// wipe any pre-release suffix like -alpha.0 we see commonly in builds
-	currentVersion.PreRelease = ""
+	currentVersionWithoutPrerelease, err := currentVersion.SetPrerelease("")
+	require.NoError(t, err)
+	currentVersion = &currentVersionWithoutPrerelease
 
 	lastVersion, err := e2e.GetVersionFromBinary(lastReleaseBinary)
 	require.NoError(t, err)
 
-	require.Equalf(t, lastVersion.Minor, currentVersion.Minor-1, "unexpected minor version difference")
+	require.Equalf(t, lastVersion.Minor(), currentVersion.Minor()-1, "unexpected minor version difference")
 	currentVersionStr := currentVersion.String()
 	lastVersionStr := lastVersion.String()
 
-	lastClusterVersion := semver.New(lastVersionStr)
-	lastClusterVersion.Patch = 0
+	lastClusterVersion, err := semver.StrictNewVersion(lastVersionStr)
+	require.NoError(t, err)
+	lastClusterVersion = semver.New(lastClusterVersion.Major(), lastClusterVersion.Minor(), 0, "", "")
 
 	e2e.BeforeTest(t)
 

--- a/tests/e2e/utl_migrate_test.go
+++ b/tests/e2e/utl_migrate_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -60,7 +60,7 @@ func TestEtctlutlMigrate(t *testing.T) {
 			name:                 "Invalid target version",
 			targetVersion:        "3.a",
 			clusterSize:          1,
-			expectLogsSubString:  `Error: failed to parse target version: strconv.ParseInt: parsing "a": invalid syntax`,
+			expectLogsSubString:  `Error: failed to parse target version: invalid semantic version`,
 			expectStorageVersion: &version.V3_8,
 		},
 		{
@@ -119,7 +119,7 @@ func TestEtctlutlMigrate(t *testing.T) {
 			clusterSize:          1,
 			force:                true,
 			expectLogsSubString:  "forcefully set storage version\t" + `{"storage-version": "3.9"}`,
-			expectStorageVersion: &semver.Version{Major: 3, Minor: 9},
+			expectStorageVersion: &version.V3_9,
 		},
 		{
 			name:                 "Migrate v3.8 to v3.8 is no-op",

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -707,7 +707,7 @@ func (epc *EtcdProcessCluster) MinServerVersion() (*semver.Version, error) {
 			return nil, fmt.Errorf("failed to get version from member %s binary: %w", member.Config().Name, err)
 		}
 
-		if minVersion == nil || ver.LessThan(*minVersion) {
+		if minVersion == nil || ver.LessThan(minVersion) {
 			minVersion = ver
 		}
 	}

--- a/tests/framework/e2e/cluster_test.go
+++ b/tests/framework/e2e/cluster_test.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEtcdServerProcessConfig(t *testing.T) {
-	v3_7_0 := semver.Version{Major: 3, Minor: 7, Patch: 0}
-	v3_8_0 := semver.Version{Major: 3, Minor: 8, Patch: 0}
+	v3_7_0 := *semver.New(3, 7, 0, "", "")
+	v3_8_0 := *semver.New(3, 8, 0, "", "")
 	tcs := []struct {
 		name                 string
 		config               *EtcdProcessClusterConfig

--- a/tests/framework/e2e/config.go
+++ b/tests/framework/e2e/config.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -108,7 +108,7 @@ var experimentalFlags = map[string]struct{}{
 // need to convert flags accordingly based on the binary version.
 func convertFlag(name, value string, ver *semver.Version) string {
 	// For versions >= 3.6, use the normal (non-experimental) flag.
-	if ver == nil || !ver.LessThan(version.V3_6) {
+	if ver == nil || !ver.LessThan(&version.V3_6) {
 		return fmt.Sprintf("--%s=%s", name, value)
 	}
 

--- a/tests/framework/e2e/downgrade.go
+++ b/tests/framework/e2e/downgrade.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -139,7 +139,7 @@ func DowngradeUpgradeMembersByID(t *testing.T, lg *zap.Logger, clus *EtcdProcess
 	if lg == nil {
 		lg = clus.lg
 	}
-	isDowngrade := targetVersion.LessThan(*currentVersion)
+	isDowngrade := targetVersion.LessThan(currentVersion)
 	opString := "upgrading"
 	newExecPath := BinPath.Etcd
 	if isDowngrade {
@@ -242,16 +242,16 @@ func ValidateVersion(t *testing.T, cfg *EtcdProcessClusterConfig, member EtcdPro
 
 // OffsetMinor returns the version with offset from the original minor, with the same major.
 func OffsetMinor(v *semver.Version, offset int) *semver.Version {
-	var minor int64
+	var minor uint64
 	if offset >= 0 {
-		minor = v.Minor + int64(offset)
+		minor = v.Minor() + uint64(offset)
 	} else {
-		diff := int64(-offset)
-		if diff < v.Minor {
-			minor = v.Minor - diff
+		diff := uint64(-offset)
+		if diff < v.Minor() {
+			minor = v.Minor() - diff
 		}
 	}
-	return &semver.Version{Major: v.Major, Minor: minor}
+	return semver.New(v.Major(), minor, 0, "", "")
 }
 
 func majorMinorVersionsEqual(v1, v2 string) (bool, error) {
@@ -263,7 +263,7 @@ func majorMinorVersionsEqual(v1, v2 string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return ver1.Major == ver2.Major && ver1.Minor == ver2.Minor, nil
+	return ver1.Major() == ver2.Major() && ver1.Minor() == ver2.Minor(), nil
 }
 
 func compareMemberVersion(expect version.Versions, target version.Versions) error {

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	"go.etcd.io/etcd/api/v3/version"
@@ -518,11 +518,7 @@ var GetVersionFromBinary = func(binaryPath string) (*semver.Version, error) {
 			if err != nil {
 				return nil, err
 			}
-			return &semver.Version{
-				Major: version.Major,
-				Minor: version.Minor,
-				Patch: version.Patch,
-			}, nil
+			return semver.New(version.Major(), version.Minor(), version.Patch(), "", ""), nil
 		}
 	}
 
@@ -544,8 +540,8 @@ func CouldSetSnapshotCatchupEntries(execPath string) bool {
 		return false
 	}
 	// snapshot-catchup-entries flag was backported in https://github.com/etcd-io/etcd/pull/17808
-	v3_5_14 := semver.Version{Major: 3, Minor: 5, Patch: 14}
-	return v.Compare(v3_5_14) >= 0
+	v3_5_14 := *semver.New(3, 5, 14, "", "")
+	return v.Compare(&v3_5_14) >= 0
 }
 
 func IsSnapshotCatchupEntriesFlagAvailable(execPath string) bool {
@@ -553,5 +549,5 @@ func IsSnapshotCatchupEntriesFlagAvailable(execPath string) bool {
 	if err != nil {
 		return false
 	}
-	return !v.LessThan(version.V3_6)
+	return !v.LessThan(&version.V3_6)
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,9 +16,9 @@ replace (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/anishathalye/porcupine v1.3.0
 	github.com/antithesishq/antithesis-sdk-go v0.7.2
-	github.com/coreos/go-semver v0.3.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/anishathalye/porcupine v1.3.0 h1:yo51Niv8Tg0tAAn5XOG2UVvJXUregK4WFuLrBRoowP8=
@@ -20,8 +22,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
-github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
-github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tests/integration/utl_wal_version_test.go
+++ b/tests/integration/utl_wal_version_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -80,7 +80,7 @@ func TestEtcdVersionFromWAL(t *testing.T) {
 
 	walVersion, err := wal.ReadWALVersion(w)
 	require.NoError(t, err)
-	assert.Equal(t, &semver.Version{Major: 3, Minor: 5}, walVersion.MinimalEtcdVersion())
+	assert.Equal(t, semver.New(3, 5, 0, "", ""), walVersion.MinimalEtcdVersion())
 }
 
 func waitForClusterVersionReady(srv *embed.Etcd) error {

--- a/tests/robustness/failpoint/cluster.go
+++ b/tests/robustness/failpoint/cluster.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -196,9 +196,9 @@ func (f memberDowngrade) Available(config e2e.EtcdProcessClusterConfig, member e
 	if err != nil {
 		panic("Failed checking etcd version binary")
 	}
-	v3_6 := semver.Version{Major: 3, Minor: 6}
+	v3_6 := *semver.New(3, 6, 0, "", "")
 	// only current version cluster can be downgraded.
-	return v.Compare(v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
+	return v.Compare(&v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
 }
 
 type memberDowngradeUpgrade struct{}
@@ -263,9 +263,9 @@ func (f memberDowngradeUpgrade) Available(config e2e.EtcdProcessClusterConfig, m
 	if err != nil {
 		panic("Failed checking etcd version binary")
 	}
-	v3_6 := semver.Version{Major: 3, Minor: 6}
+	v3_6 := *semver.New(3, 6, 0, "", "")
 	// only current version cluster can be downgraded.
-	return v.Compare(v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
+	return v.Compare(&v3_6) >= 0 && (config.Version == e2e.CurrentVersion && member.Config().ExecPath == e2e.BinPath.Etcd)
 }
 
 func (f memberDowngradeUpgrade) Timeout() time.Duration {

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -322,7 +322,7 @@ func Regression(t *testing.T) []TestScenario {
 			e2e.WithSnapshotCatchUpEntries(10),
 		),
 	})
-	if v.Compare(version.V3_5) >= 0 {
+	if v.Compare(&version.V3_5) >= 0 {
 		opts := []e2e.EPClusterOption{
 			e2e.WithSnapshotCount(100),
 			e2e.WithPeerProxy(true),

--- a/tools/proto-annotations/cmd/etcd_version.go
+++ b/tools/proto-annotations/cmd/etcd_version.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/coreos/go-semver/semver"
+	"github.com/Masterminds/semver/v3"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
@@ -104,16 +104,16 @@ func (a etcdVersionAnnotation) Validate() (errs []error) {
 	if a.version == nil {
 		return nil
 	}
-	if a.version.Major == 0 {
+	if a.version.Major() == 0 {
 		errs = append(errs, fmt.Errorf("%s: etcd_version major version should not be zero", a.fullName))
 	}
-	if a.version.Patch != 0 {
+	if a.version.Patch() != 0 {
 		errs = append(errs, fmt.Errorf("%s: etcd_version patch version should be zero", a.fullName))
 	}
-	if a.version.PreRelease != "" {
+	if a.version.Prerelease() != "" {
 		errs = append(errs, fmt.Errorf("%s: etcd_version should not be prerelease", a.fullName))
 	}
-	if a.version.Metadata != "" {
+	if a.version.Metadata() != "" {
 		errs = append(errs, fmt.Errorf("%s: etcd_version should not have metadata", a.fullName))
 	}
 	return errs
@@ -124,6 +124,6 @@ func (a etcdVersionAnnotation) PrintLine(out io.Writer) error {
 		_, err := fmt.Fprintf(out, "%s: \"\"\n", a.fullName)
 		return err
 	}
-	_, err := fmt.Fprintf(out, "%s: \"%d.%d\"\n", a.fullName, a.version.Major, a.version.Minor)
+	_, err := fmt.Fprintf(out, "%s: \"%d.%d\"\n", a.fullName, a.version.Major(), a.version.Minor())
 	return err
 }


### PR DESCRIPTION
In #20915, we are fetching the version from git which appears as v3.7.0 instead of 3.7.0, and it's breaking the semver resolution.


```
through raft","local-member-id":"ca50e9357181d758","local-member-attributes":"{Name:TestConnectionMultiplexingServerTLS-test-0 ClientURLs:[https://localhost:20000]}","cluster-id":"34f27e83b3bc2ff","publish-timeout":"7s"}
        	            	panic: strconv.ParseInt: parsing "v3": invalid syntax
        	            	
        	            	goroutine 175 [running]:
        	            	github.com/coreos/go-semver/semver.Must(...)
        	            		github.com/coreos/go-semver@v0.3.1/semver/semver.go:65
        	            	go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).membersMinimalServerVersion(0xc7d4fc4)
        	            		go.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:158 +0x67c
        	            	go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).decideClusterVersion(0xc7d4fc4)
        	            		go.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:69 +0x4f
        	            	go.etcd.io/etcd/server/v3/etcdserver/version.(*Monitor).UpdateClusterVersionIfNeeded(0xc7d4fc4)
        	            		go.etcd.io/etcd/server/v3/etcdserver/version/monitor.go:56 +0x25
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).monitorClusterVersions(0xc4df008)
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:2228 +0x193
        	            	go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach.func1()
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:2428 +0x52
        	            	created by go.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).GoAttach in goroutine 1
        	            		go.etcd.io/etcd/server/v3/etcdserver/server.go:2426 +0xe7
        	Test:       	TestConnectionMultiplexing/ServerTLS
    --- FAIL: TestConnectionMultiplexing/ServerTLS (0.58s)
```

`github.com/coreos/go-semver` hasn't had a new release in years, so I'm switching it to `github.com/Masterminds/semver/v3`, which is a newer library and supports semver strings prefixed with v.

