### PR TITLE
resolver: eliminate double cc.UpdateState in EtcdManualResolver.Build

### DIFF
--- a/client/v3/internal/resolver/resolver.go
+++ b/client/v3/internal/resolver/resolver.go
@@ -45,12 +45,21 @@ func (r *EtcdManualResolver) Build(target resolver.Target, cc resolver.ClientCon
 	if r.serviceConfig.Err != nil {
 		return nil, r.serviceConfig.Err
 	}
+	// Pre-seed the manual resolver's initial state with the complete resolver
+	// state (endpoints + service config) so that manual.Resolver.Build() emits
+	// a single cc.UpdateState call instead of two.
+	//
+	// Previously Build() called r.Resolver.Build() first, which sent the state
+	// that was stored by a prior SetEndpoints/updateState call (endpoints only,
+	// service config nil), and then called r.updateState() to send a second
+	// update with the service config.  The two rapid cc.UpdateState calls caused
+	// gRPC to switch load-balancing policies mid-connection, killing in-flight
+	// SubConns and producing spurious "operation was canceled" warnings.
+	r.Resolver.InitialState(r.buildResolverState())
 	res, err := r.Resolver.Build(target, cc, opts)
 	if err != nil {
 		return nil, err
 	}
-	// Populates endpoints stored in r into ClientConn (cc).
-	r.updateState()
 	return res, nil
 }
 
@@ -61,18 +70,23 @@ func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
 
 func (r EtcdManualResolver) updateState() {
 	if getCC(r) != nil {
-		eps := make([]resolver.Endpoint, len(r.endpoints))
-		for i, ep := range r.endpoints {
-			addr, serverName := endpoint.Interpret(ep)
-			eps[i] = resolver.Endpoint{Addresses: []resolver.Address{
-				{Addr: addr, ServerName: serverName},
-			}}
-		}
-		state := resolver.State{
-			Endpoints:     eps,
-			ServiceConfig: r.serviceConfig,
-		}
-		r.UpdateState(state)
+		r.UpdateState(r.buildResolverState())
+	}
+}
+
+// buildResolverState constructs the complete resolver.State from the current
+// endpoints and service config.
+func (r EtcdManualResolver) buildResolverState() resolver.State {
+	eps := make([]resolver.Endpoint, len(r.endpoints))
+	for i, ep := range r.endpoints {
+		addr, serverName := endpoint.Interpret(ep)
+		eps[i] = resolver.Endpoint{Addresses: []resolver.Address{
+			{Addr: addr, ServerName: serverName},
+		}}
+	}
+	return resolver.State{
+		Endpoints:     eps,
+		ServiceConfig: r.serviceConfig,
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes `EtcdManualResolver.Build()` sending two `cc.UpdateState` calls in rapid succession on every new gRPC connection, causing gRPC to switch load-balancing policies mid-connection, kill in-flight `SubConn`s, and log spurious `"operation was canceled"` warnings.

## Root cause

`Build()` previously executed this sequence:

```go
r.serviceConfig = cc.ParseServiceConfig(`{"loadBalancingPolicy": "round_robin"}`)
res, err := r.Resolver.Build(target, cc, opts)  // Update #1: endpoints, nil service config
r.updateState()                                   // Update #2: endpoints + round_robin
```

When `SetEndpoints` is called before `Build()` (the normal path), it stores the state via `r.Resolver.UpdateState({endpoints, serviceConfig: nil})`. Then `manual.Resolver.Build()` sends this stored state as Update #1 (no service config), followed immediately by `r.updateState()` sending the complete state as Update #2.

The two updates cause gRPC to see a policy change (`""` → `round_robin`) and tear down the existing `SubConn`, producing:
```
[core] [Channel #N SubChannel #M] grpc: addrConn.createTransport failed to connect: 
  connection error: transport: Error while dialing: dial tcp ...: operation was canceled
```

## Fix

Before calling `r.Resolver.Build()`, inject the complete resolver state (endpoints + service config) via `r.Resolver.InitialState()`. `manual.Resolver.Build()` then emits a single `cc.UpdateState` with the full state.

Also extracts `buildResolverState()` as a shared helper used by both `Build()` (via `InitialState`) and `updateState()` (via `UpdateState` after build), removing the duplicated state-construction logic.

## Testing

Existing integration tests cover `SetEndpoints` and connection behaviour. The elimination of the double update can be observed by adding a `UpdateStateCallback` to the manual resolver in tests — the double callback is gone with this change.

Fixes #21660