### PR TITLE
auth: match (key, range_end) pair when updating role permission

### DIFF
--- a/server/auth/store.go
+++ b/server/auth/store.go
@@ -826,9 +826,20 @@ func (as *authStore) RoleGrantPermission(r *pb.AuthRoleGrantPermissionRequest) (
 		return bytes.Compare(role.KeyPermission[i].Key, r.Perm.Key) >= 0
 	})
 
-	if idx < len(role.KeyPermission) && bytes.Equal(role.KeyPermission[idx].Key, r.Perm.Key) && bytes.Equal(role.KeyPermission[idx].RangeEnd, r.Perm.RangeEnd) {
+	// KeyPermission is sorted by Key only, so a role may hold several
+	// permissions sharing Key but differing in RangeEnd. Scan all of them
+	// for the exact (Key, RangeEnd) pair instead of only the first match.
+	existing := -1
+	for i := idx; i < len(role.KeyPermission) && bytes.Equal(role.KeyPermission[i].Key, r.Perm.Key); i++ {
+		if bytes.Equal(role.KeyPermission[i].RangeEnd, r.Perm.RangeEnd) {
+			existing = i
+			break
+		}
+	}
+
+	if existing >= 0 {
 		// update existing permission
-		role.KeyPermission[idx].PermType = r.Perm.PermType
+		role.KeyPermission[existing].PermType = r.Perm.PermType
 	} else {
 		// append new permission to the role
 		newPerm := &authpb.Permission{

--- a/server/auth/store_test.go
+++ b/server/auth/store_test.go
@@ -509,6 +509,38 @@ func TestRoleGrantPermission(t *testing.T) {
 	assert.Equal(t, perm, r.Perm[0])
 }
 
+func TestRoleGrantPermissionSameKeyDifferentRangeEnd(t *testing.T) {
+	as, tearDown := setupAuthStore(t)
+	defer tearDown(t)
+
+	_, err := as.RoleAdd(&pb.AuthRoleAddRequest{Name: "role-test-1"})
+	require.NoError(t, err)
+
+	grant := func(rangeEnd []byte, pt authpb.Permission_Type) {
+		t.Helper()
+		_, err := as.RoleGrantPermission(&pb.AuthRoleGrantPermissionRequest{
+			Name: "role-test-1",
+			Perm: &authpb.Permission{PermType: pt, Key: []byte("foo"), RangeEnd: rangeEnd},
+		})
+		require.NoError(t, err)
+	}
+
+	grant([]byte("fop"), authpb.Permission_WRITE)
+	grant([]byte("foq"), authpb.Permission_WRITE)
+	// updating an existing permission must not append a duplicate when the
+	// role already holds another permission with the same Key.
+	grant([]byte("foq"), authpb.Permission_READ)
+
+	r, err := as.RoleGet(&pb.AuthRoleGetRequest{Role: "role-test-1"})
+	require.NoError(t, err)
+	require.Len(t, r.Perm, 2)
+	for _, p := range r.Perm {
+		if string(p.RangeEnd) == "foq" {
+			assert.Equal(t, authpb.Permission_READ, p.PermType)
+		}
+	}
+}
+
 func TestRoleGrantInvalidPermission(t *testing.T) {
 	as, tearDown := setupAuthStore(t)
 	defer tearDown(t)


### PR DESCRIPTION
RoleGrantPermission in server/auth/store.go:825 binary-searches KeyPermission by Key alone, so updating a permission whose Key matches an earlier entry with a different RangeEnd appends a duplicate instead of updating it and leaves the old PermType in place (a downgrade silently has no effect). Scan the contiguous same-Key entries for the exact (Key, RangeEnd) pair before deciding to append.