### PR TITLE
robustness: Fix defaulting for proto comparison when merging WAL history

### DIFF
--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -23,8 +23,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
@@ -145,7 +147,7 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 				if entry2.GetIndex() != raftIndex {
 					continue
 				}
-				if proto.Equal(entry1, entry2) {
+				if cmp.Equal(entry1, entry2, protocmp.Transform(), protocmp.IgnoreDefaultScalars()) {
 					votes[i]++
 					votes[j]++
 				}
@@ -177,11 +179,11 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 				}
 				continue
 			}
-			if !proto.Equal(entryWithMostVotes, entry) {
-				return nil, fmt.Errorf("mismatching entries on raft index %d, mostVotes: %+v, other: %+v", raftIndex, entryWithMostVotes, entry)
+			if !cmp.Equal(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars()) {
+				return nil, fmt.Errorf("mismatching entries on raft index %d, diff: %s", raftIndex, cmp.Diff(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars()))
 			}
 		}
-		mergedHistory = append(mergedHistory, entryWithMostVotes)
+		mergedHistory = append(mergedHistory, proto.Clone(entryWithMostVotes).(*raftpb.Entry))
 	}
 	if len(mergedHistory) == 0 {
 		return nil, errors.New("no WAL entries matched")


### PR DESCRIPTION
Fixes recent failures in robustness test https://testgrid.k8s.io/sig-etcd-robustness#ci-etcd-robustness-main-amd64 after merging https://github.com/etcd-io/etcd/pull/21778

## Cause
Following the standard Protobuf migration in PR #21778, enum and scalar fields on generated types (like raftpb.Entry) became Go pointers (e.g., *EntryType) to track field presence. When unmarshaling WAL logs:

One member parses Type as nil (implicitly defaulting to EntryNormal).
Another explicitly parses it as a pointer to 0 (EntryNormal).
Strict message comparison via proto.Equal treats a present-but-default pointer (*Type == 0) as unequal to an absent pointer (Type == nil), causing history merging to fail.

```
    validate_test.go:49: mismatching entries on raft index 1685, diff:   (*raftpb.Entry)(Inverse(protocmp.Transform, protocmp.Message{
                ... // 2 identical entries
                "Index": uint64(1685),
                "Term":  uint64(2),
        -       "Type":  s"EntryNormal",
          }))
```

## Fix
Transitioned comparisons in mergeMembersEntries to use cmp.Equal with protocmp.Transform() and protocmp.IgnoreDefaultScalars(). This instructs the comparator to treat unset fields and fields explicitly set to their zero/default value as equivalent, ignoring structural pointer-presence mismatches.

/cc @henrybear327 @fuweid @ahrtr 