### PR TITLE
Add `write-only-skip-check` option for `--v2-deprecation` to bypass the v2 content check

### DIFF
--- a/server/config/v2_deprecation.go
+++ b/server/config/v2_deprecation.go
@@ -26,6 +26,11 @@ const (
 	// The V2 files are maintained for v3.5 rollback.
 	V2Depr1WriteOnly = V2DeprecationEnum("write-only")
 
+	// V2Depr1WriteOnlySkipCheck is like V2Depr1WriteOnly, but bypasses the v2 content check.
+	// Use only for 3.5 -> 3.6 upgrades with existing v2 data.
+	// WARNING: Users should read the 3.5 -> 3.6 upgrade guide and use this option at their own risk
+	V2Depr1WriteOnlySkipCheck = V2DeprecationEnum("write-only-skip-check")
+
 	// V2Depr1WriteOnlyDrop means v2store is WIPED if found !!!
 	// Will be default in 3.7.
 	V2Depr1WriteOnlyDrop = V2DeprecationEnum("write-only-drop-data")
@@ -48,7 +53,7 @@ func (e V2DeprecationEnum) level() int {
 	switch e {
 	case V2Depr0NotYet:
 		return 0
-	case V2Depr1WriteOnly:
+	case V2Depr1WriteOnly, V2Depr1WriteOnlySkipCheck:
 		return 1
 	case V2Depr1WriteOnlyDrop:
 		return 2

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -99,6 +99,7 @@ func newConfig() *config {
 		),
 		v2deprecation: flags.NewSelectiveStringsValue(
 			string(cconfig.V2Depr1WriteOnly),
+			string(cconfig.V2Depr1WriteOnlySkipCheck),
 			string(cconfig.V2Depr1WriteOnlyDrop),
 			string(cconfig.V2Depr2Gone)),
 	}

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -176,6 +176,7 @@ Clustering:
     Supported values:
       'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)
       'write-only'             // Custom v2 state is not allowed (default in v3.6)
+      'write-only-skip-check'  // Custom v2 state is not allowed similar to 'write-only', but bypass the v2 content check.
       'write-only-drop-data'   // Custom v2 state will get DELETED ! (planned default in v3.7)
       'gone'                   // v2store is not maintained any longer. (planned to cleanup anything related to v2store in v3.8)
 


### PR DESCRIPTION
take over https://github.com/etcd-io/etcd/pull/21250. Note that `AssertNoV2StoreContent` has gone in 3.7 (main). 

This PR needs to be backported to 3.6. 

cc @fuweid @ivanvc @serathius 