### PR TITLE
[release-3.6] Add `write-only-skip-check` option for `--v2-deprecation` to bypass the v2 content check

### DIFF
--- a/server/config/v2_deprecation.go
+++ b/server/config/v2_deprecation.go
@@ -36,6 +36,11 @@ const (
 	//revive:disable-next-line:var-naming
 	V2_DEPR_1_WRITE_ONLY = V2Depr1WriteOnly
 
+	// V2Depr1WriteOnlySkipCheck is like V2Depr1WriteOnly, but bypasses the v2 content check.
+	// Use only for 3.5 -> 3.6 upgrades with existing v2 data.
+	// WARNING: Users should read the 3.5 -> 3.6 upgrade guide and use this option at their own risk.
+	V2Depr1WriteOnlySkipCheck = V2DeprecationEnum("write-only-skip-check")
+
 	// V2Depr1WriteOnlyDrop means v2store is WIPED if found !!!
 	// Will be default in 3.7.
 	V2Depr1WriteOnlyDrop = V2DeprecationEnum("write-only-drop-data")
@@ -73,7 +78,7 @@ func (e V2DeprecationEnum) level() int {
 	switch e {
 	case V2Depr0NotYet:
 		return 0
-	case V2Depr1WriteOnly:
+	case V2Depr1WriteOnly, V2Depr1WriteOnlySkipCheck:
 		return 1
 	case V2Depr1WriteOnlyDrop:
 		return 2

--- a/server/etcdmain/config.go
+++ b/server/etcdmain/config.go
@@ -116,6 +116,7 @@ func newConfig() *config {
 		),
 		v2deprecation: flags.NewSelectiveStringsValue(
 			string(cconfig.V2Depr1WriteOnly),
+			string(cconfig.V2Depr1WriteOnlySkipCheck),
 			string(cconfig.V2Depr1WriteOnlyDrop),
 			string(cconfig.V2Depr2Gone)),
 	}
@@ -245,8 +246,11 @@ func (cfg *config) parse(arguments []string) error {
 		cfg.ec.DistributedTracingSamplingRatePerMillion = cfg.ec.ExperimentalDistributedTracingSamplingRatePerMillion
 	}
 
-	// `V2Deprecation` (--v2-deprecation) is deprecated and scheduled for removal in v3.8. The default value is enforced, ignoring user input.
-	cfg.ec.V2Deprecation = cconfig.V2DeprDefault
+	// `V2Deprecation` (--v2-deprecation) is deprecated and scheduled for removal in v3.8.
+	// It can only be V2DeprDefault or V2Depr1WriteOnlySkipCheck, ignore other user input.
+	if cfg.ec.V2Deprecation != cconfig.V2Depr1WriteOnlySkipCheck {
+		cfg.ec.V2Deprecation = cconfig.V2DeprDefault
+	}
 
 	cfg.ec.WarningUnaryRequestDuration, perr = cfg.parseWarningUnaryRequestDuration()
 	if perr != nil {

--- a/server/etcdmain/help.go
+++ b/server/etcdmain/help.go
@@ -173,6 +173,7 @@ Clustering:
     Supported values:
       'not-yet'                // Issues a warning if v2store have meaningful content (default in v3.5)
       'write-only'             // Custom v2 state is not allowed (default in v3.6)
+      'write-only-skip-check'  // Custom v2 state is not allowed similar to 'write-only', but bypass the v2 content check. WARNING: Users should read the 3.5 -> 3.6 upgrade guide and use this option at their own risk.
       'write-only-drop-data'   // Custom v2 state will get DELETED ! (planned default in v3.7)
       'gone'                   // v2store is not maintained any longer. (planned to cleanup anything related to v2store in v3.8)
 

--- a/server/storage/util.go
+++ b/server/storage/util.go
@@ -39,6 +39,10 @@ func AssertNoV2StoreContent(lg *zap.Logger, st v2store.Store, deprecationStage c
 	if metaOnly {
 		return nil
 	}
+	if deprecationStage == config.V2Depr1WriteOnlySkipCheck {
+		lg.Warn("WARNING: --v2-deprecation=write-only-skip-check is enabled; v2 content detected, but validation check is being bypassed")
+		return nil
+	}
 	if deprecationStage.IsAtLeast(config.V2Depr1WriteOnly) {
 		return fmt.Errorf("detected disallowed custom content in v2store for stage --v2-deprecation=%s", deprecationStage)
 	}


### PR DESCRIPTION
Takes over #21250 

I saw #21848 PR to my understanding it was closed due to it targeting the main and `AssertNoV2StoreContent` has already been removed

I have backported it to 3.6 with the changes from #21250 

While reproducing locally with no snapshot I saw these errors for WAL check due to 3.6 replaying v2 WAL entries and panics.
```
{"level":"panic","ts":"2026-05-29T10:03:47.719549-0400","caller":"schedule/schedule.go:202","msg":"execute job failed","job":"server_applyAll","panic":"detected disallowed v2 WAL for stage --v2-deprecation=write-only","stacktrace":"go.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob.func1\n\tgo.etcd.io/etcd/pkg/v3@v3.6.11/schedule/schedule.go:202\nruntime.gopanic\n\truntime/panic.go:783\ngo.uber.org/zap/zapcore.CheckWriteAction.OnWrite\n\tgo.uber.org/zap@v1.27.0/zapcore/entry.go:196\ngo.uber.org/zap/zapcore.(*CheckedEntry).Write\n\tgo.uber.org/zap@v1.27.0/zapcore/entry.go:262\ngo.uber.org/zap.(*Logger).Panic\n\tgo.uber.org/zap@v1.27.0/logger.go:285\ngo.etcd.io/etcd/server/v3/etcdserver.v2ToV3Request\n\tgo.etcd.io/etcd/server/v3/etcdserver/apply_v2.go:31\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntryNormal\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:1983\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).apply\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:1924\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyEntries\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:1210\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).applyAll\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:985\ngo.etcd.io/etcd/server/v3/etcdserver.(*EtcdServer).run.func6\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:855\ngo.etcd.io/etcd/pkg/v3/schedule.job.Do\n\tgo.etcd.io/etcd/pkg/v3@v3.6.11/schedule/schedule.go:41\ngo.etcd.io/etcd/pkg/v3/schedule.(*fifo).executeJob\n\tgo.etcd.io/etcd/pkg/v3@v3.6.11/schedule/schedule.go:206\ngo.etcd.io/etcd/pkg/v3/schedule.(*fifo).run\n\tgo.etcd.io/etcd/pkg/v3@v3.6.11/schedule/schedule.go:187"}
panic: detected disallowed v2 WAL for stage --v2-deprecation=write-only [recovered]
        panic: execute job failed
```
I did not include any changes for this as it is beyond the scope of original PR but open to a discussion to implement it. 