### PR TITLE
v3rpc: map lease.ErrNotPrimary to codes.Unavailable instead of codes.Unknown

### DIFF
--- a/api/v3rpc/rpctypes/error.go
+++ b/api/v3rpc/rpctypes/error.go
@@ -36,6 +36,7 @@ var (
 	ErrGRPCLeaseNotFound    = status.Error(codes.NotFound, "etcdserver: requested lease not found")
 	ErrGRPCLeaseExist       = status.Error(codes.FailedPrecondition, "etcdserver: lease already exists")
 	ErrGRPCLeaseTTLTooLarge = status.Error(codes.OutOfRange, "etcdserver: too large lease TTL")
+	ErrGRPCNotPrimary       = status.Error(codes.Unavailable, "etcdserver: not a primary lessor")
 
 	ErrGRPCWatchCanceled = status.Error(codes.Canceled, "etcdserver: watch canceled")
 
@@ -113,6 +114,7 @@ var (
 		ErrorDesc(ErrGRPCLeaseNotFound):    ErrGRPCLeaseNotFound,
 		ErrorDesc(ErrGRPCLeaseExist):       ErrGRPCLeaseExist,
 		ErrorDesc(ErrGRPCLeaseTTLTooLarge): ErrGRPCLeaseTTLTooLarge,
+		ErrorDesc(ErrGRPCNotPrimary):       ErrGRPCNotPrimary,
 
 		ErrorDesc(ErrGRPCMemberExist):            ErrGRPCMemberExist,
 		ErrorDesc(ErrGRPCPeerURLExist):           ErrGRPCPeerURLExist,
@@ -181,6 +183,7 @@ var (
 	ErrLeaseNotFound    = Error(ErrGRPCLeaseNotFound)
 	ErrLeaseExist       = Error(ErrGRPCLeaseExist)
 	ErrLeaseTTLTooLarge = Error(ErrGRPCLeaseTTLTooLarge)
+	ErrNotPrimary       = Error(ErrGRPCNotPrimary)
 
 	ErrMemberExist            = Error(ErrGRPCMemberExist)
 	ErrPeerURLExist           = Error(ErrGRPCPeerURLExist)

--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -71,6 +71,7 @@ var toGRPCErrorMap = map[error]error{
 	lease.ErrLeaseNotFound:    rpctypes.ErrGRPCLeaseNotFound,
 	lease.ErrLeaseExists:      rpctypes.ErrGRPCLeaseExist,
 	lease.ErrLeaseTTLTooLarge: rpctypes.ErrGRPCLeaseTTLTooLarge,
+	lease.ErrNotPrimary:       rpctypes.ErrGRPCNotPrimary,
 
 	auth.ErrRootUserNotExist:     rpctypes.ErrGRPCRootUserNotExist,
 	auth.ErrRootRoleNotExist:     rpctypes.ErrGRPCRootRoleNotExist,


### PR DESCRIPTION
#### Which issue(s) does the PR fix:

Fixes #21671

#### Release notes for end users (**ALL** commits must be considered).
*Reviewers should verify clarity and quality.*

```release-notes
[BUG] v3rpc: lease keepalive now returns codes.Unavailable (not codes.Unknown) when the server is not the primary lessor, allowing clients to retry on another member.
```

## Summary

`lease.ErrNotPrimary` was missing from `toGRPCErrorMap` in
`server/etcdserver/api/v3rpc/util.go`.  When `LeaseRenew` returned this
error (e.g. after a leader switch causes `ensureLeadership()` to fail),
`togRPCError` fell through to the catch-all `status.Error(codes.Unknown, …)`,
surfacing as gRPC code **2 (Unknown)** with the message
`"not a primary lessor"` — giving clients no signal that retrying on a
different member would succeed.

### Root cause

`togRPCError` uses a direct map lookup (`toGRPCErrorMap[err]`), so every
sentinel error that should map to a specific gRPC code must be listed
explicitly. `lease.ErrNotPrimary` was never added.

### Fix

1. **`api/v3rpc/rpctypes/error.go`** — add `ErrGRPCNotPrimary = codes.Unavailable`
   alongside the other lease errors, register it in `errStringToError` and the
   client-side `ErrNotPrimary` var.
2. **`server/etcdserver/api/v3rpc/util.go`** — map `lease.ErrNotPrimary → rpctypes.ErrGRPCNotPrimary`.

`codes.Unavailable` is consistent with `ErrGRPCNoLeader` and
`ErrGRPCLeaderChanged` and is the correct code for "this member can't serve
the request right now, try another one".