### PR TITLE
robustness: optimize WAL entry comparison in history merging

### DIFF
--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -15,6 +15,7 @@
 package report
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -147,7 +148,7 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 				if entry2.GetIndex() != raftIndex {
 					continue
 				}
-				if cmp.Equal(entry1, entry2, protocmp.Transform(), protocmp.IgnoreDefaultScalars()) {
+				if areEntriesEqual(entry1, entry2) {
 					votes[i]++
 					votes[j]++
 				}
@@ -179,8 +180,9 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 				}
 				continue
 			}
-			if !cmp.Equal(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars()) {
-				return nil, fmt.Errorf("mismatching entries on raft index %d, diff: %s", raftIndex, cmp.Diff(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars()))
+			if !areEntriesEqual(entryWithMostVotes, entry) {
+				diff := cmp.Diff(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars(), cmp.Comparer(bytes.Equal))
+				return nil, fmt.Errorf("mismatching entries on raft index %d, diff: %s", raftIndex, diff)
 			}
 		}
 		mergedHistory = append(mergedHistory, proto.Clone(entryWithMostVotes).(*raftpb.Entry))
@@ -189,6 +191,16 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 		return nil, errors.New("no WAL entries matched")
 	}
 	return mergedHistory, nil
+}
+
+func areEntriesEqual(e1, e2 *raftpb.Entry) bool {
+	if e1 == nil || e2 == nil {
+		return e1 == e2
+	}
+	return e1.GetIndex() == e2.GetIndex() &&
+		e1.GetTerm() == e2.GetTerm() &&
+		e1.GetType() == e2.GetType() &&
+		bytes.Equal(e1.GetData(), e2.GetData())
 }
 
 func ReadWAL(lg *zap.Logger, dataDir string) (state *raftpb.HardState, ents []*raftpb.Entry, err error) {

--- a/tests/robustness/report/wal_test.go
+++ b/tests/robustness/report/wal_test.go
@@ -16,6 +16,7 @@
 package report
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -667,5 +668,81 @@ func TestWriteReadWAL(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestAreEntriesEqualVerifyAllFields(t *testing.T) {
+	base := &raftpb.Entry{
+		Index: new(uint64(1)),
+		Term:  new(uint64(1)),
+		Type:  raftpb.EntryNormal.Enum(),
+		Data:  []byte("data"),
+	}
+
+	val := reflect.ValueOf(base).Elem()
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		t.Run(field.Name, func(t *testing.T) {
+			modified := proto.Clone(base).(*raftpb.Entry)
+			modVal := reflect.ValueOf(modified).Elem()
+
+			f := modVal.Field(i)
+			switch f.Kind() {
+			case reflect.Pointer:
+				if f.Type().Elem().Kind() == reflect.Uint64 {
+					v := uint64(999)
+					f.Set(reflect.ValueOf(&v))
+				} else if f.Type().Elem().Kind() == reflect.Int32 {
+					v := int32(999)
+					f.Set(reflect.ValueOf(&v).Convert(f.Type()))
+				}
+			case reflect.Slice:
+				if f.Type().Elem().Kind() == reflect.Uint8 {
+					f.SetBytes([]byte("different-data-payload"))
+				}
+			default:
+				t.Fatalf("Unhandled field type for reflection: %s", f.Type())
+			}
+
+			if areEntriesEqual(base, modified) {
+				t.Errorf("areEntriesEqual returned true after mutating field %q! This means changes to %q are not being compared.", field.Name, field.Name)
+			}
+		})
+	}
+}
+
+func BenchmarkMergeMemberEntries(b *testing.B) {
+	const numEntries = 1000
+	memberEntries := make([][]*raftpb.Entry, 3)
+	for i := 0; i < 3; i++ {
+		memberEntries[i] = make([]*raftpb.Entry, numEntries)
+		for j := 0; j < numEntries; j++ {
+			var entryType *raftpb.EntryType
+			if i == 0 {
+				entryType = nil
+			} else {
+				entryType = raftpb.EntryNormal.Enum()
+			}
+			memberEntries[i][j] = &raftpb.Entry{
+				Index: new(uint64(j + 1)),
+				Term:  new(uint64(1)),
+				Type:  entryType,
+				Data:  []byte("some realistic data payload for entry"),
+			}
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := mergeMembersEntries(0, memberEntries)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Noticed 10 minute increase in robustness tests execution after recent changes.

<img width="991" height="267" alt="image" src="https://github.com/user-attachments/assets/ac078c8a-8f79-4b27-916f-cb346271edb1" />


This PR replaces slow reflection-based 'cmp.Equal' and 'protocmp.Transform()' comparisons in 'mergeMembersEntries' with a custom, direct 'areEntriesEqual' helper. This helper leverages generated protobuf getters to compare fields directly, bypassing reflection while correctly supporting default-value comparisons. A simplified reflection mutation safeguard is also added to prevent the helper from drifting.

```
benchstat comparison:
goos: linux
goarch: amd64
pkg: go.etcd.io/etcd/tests/v3/robustness/report
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                      │ current_results.txt │          new_results.txt          │
                      │       sec/op        │   sec/op     vs base              │
MergeMemberEntries-24        615867.3µ ± 3%   390.1µ ± 0%  -99.94% (p=0.002 n=6)

                      │ current_results.txt │           new_results.txt         │
                      │        B/op         │     B/op      vs base             │
MergeMemberEntries-24        56801.2Ki ± 0%   173.3Ki ± 0%  -99.69% (p=0.002 n=6)

                      │ current_results.txt │          new_results.txt          │
                      │      allocs/op      │  allocs/op   vs base              │
MergeMemberEntries-24         818.258k ± 0%   4.008k ± 0%  -99.51% (p=0.002 n=6)
```

/cc @fuweid @henrybear327 