### PR TITLE
README: fix extra whitespace in image credit line

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [etcdctl][etcdctl] for a simple command line client.
 
 ![etcd reliability is important](logos/etcd-xkcd-2347.png)
 
-<sub>Original image credited to  xkcd.com/2347, alterations by Josh Berkus.</sub>
+<sub>Original image credited to xkcd.com/2347, alterations by Josh Berkus.</sub>
 
 [raft]: https://raft.github.io/
 [k8s]: http://kubernetes.io/


### PR DESCRIPTION
## Summary

Removes the extra space between 'to' and 'xkcd.com/2347' in the README image credit line.

## Changes
- Fixed typo in README.md

## Test Plan
- [x] Verified the fix renders correctly

Fixes #21643