### PR TITLE
etcdserver: allow defrag on learner members

### DIFF
--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -139,9 +139,11 @@ func isClientCtxErr(ctxErr error, err error) bool {
 	return false
 }
 
-// in v3.4, learner is allowed to serve serializable read and endpoint status
+// in v3.4, learner is allowed to serve local maintenance, serializable read, and endpoint status
 func isRPCSupportedForLearner(req any) bool {
 	switch r := req.(type) {
+	case *pb.DefragmentRequest:
+		return true
 	case *pb.StatusRequest:
 		return true
 	case *pb.RangeRequest:

--- a/server/etcdserver/api/v3rpc/util_test.go
+++ b/server/etcdserver/api/v3rpc/util_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
@@ -46,5 +47,11 @@ func TestGRPCError(t *testing.T) {
 			}
 			t.Errorf("#%d: got %v, expected %v", i, err, tt[i].exp)
 		}
+	}
+}
+
+func TestRPCSupportedForLearnerIncludesDefragment(t *testing.T) {
+	if !isRPCSupportedForLearner(&pb.DefragmentRequest{}) {
+		t.Fatal("expected learners to support maintenance defragment requests")
 	}
 }

--- a/tests/integration/clientv3/maintenance_test.go
+++ b/tests/integration/clientv3/maintenance_test.go
@@ -119,6 +119,29 @@ func (tc hashTestCase) Compact(ctx context.Context, rev int64) error {
 	return err
 }
 
+func TestMaintenanceDefragmentLearner(t *testing.T) {
+	integration.BeforeTest(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 3, DisableStrictReconfigCheck: true})
+	defer clus.Terminate(t)
+
+	clus.AddAndLaunchLearnerMember(t)
+	require.Len(t, clus.Members, 4)
+
+	learner := clus.Members[3]
+	<-learner.ReadyNotify()
+
+	cli, err := integration.NewClient(t, clientv3.Config{
+		Endpoints:   []string{learner.GRPCURL},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	_, err = cli.Defragment(t.Context(), learner.GRPCURL)
+	require.NoError(t, err)
+}
+
 func TestMaintenanceMoveLeader(t *testing.T) {
 	integration.BeforeTest(t)
 


### PR DESCRIPTION
Fixes #21740.

This allows learner members to serve `Maintenance.Defragment` requests. Learners already keep the same bbolt backend as voters, and defrag is a local backend maintenance operation, so the learner RPC gate should not reject it.

The PR also adds:
- a unit test covering the learner RPC allowlist for `DefragmentRequest`
- an integration test that creates a learner, connects a client only to that learner endpoint, and defragments it successfully

Tests:
- `go test ./server/etcdserver/api/v3rpc -run TestRPCSupportedForLearnerIncludesDefragment -count=1` (red first before the allowlist change)
- `go test ./server/etcdserver/api/v3rpc -count=1`
- `go test ./tests/integration/clientv3 -run TestMaintenanceDefragmentLearner -count=1 -v`
- `git diff --check`

AI disclosure:
This PR was written in part with the assistance of generative AI. I reviewed the change and ran the tests above.

Prompt used: inspect etcd issue #21740, read the contribution guidance, add a minimal test-backed fix for learner defrag, verify it, and open a PR.

Rhyme:
etcd keeps the cluster steady and bright,
learners reclaim their storage tonight.
