### PR TITLE
robutsness: don't visualize history if there is any failure during linearization

### DIFF
--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -62,11 +62,7 @@ func validateReports(lg *zap.Logger, serversDataPath map[string]string, reports 
 	validateConfig := validate.Config{ExpectRevisionUnique: tf.ExpectUniqueRevision}
 	result := validate.ValidateAndReturnVisualize(lg, validateConfig, reports, persistedRequests, 5*time.Minute)
 	assertResult(result.Assumptions, "Validation assumptions fulfilled")
-	if result.Linearization.Timeout {
-		assert.Unreachable("Linearization timeout", nil)
-	} else {
-		assertResult(result.Linearization.Result, "Linearization validation passes")
-	}
+	assertResult(result.Linearization.Result, "Linearization validation passes")
 	assertResult(result.Watch, "Watch validation passes")
 	assertResult(result.Serializable, "Serializable validation passes")
 	lg.Info("Completed robustness validation")
@@ -77,8 +73,7 @@ func assertResult(result validate.Result, name string) {
 	switch result.Status {
 	case validate.Success, validate.Failure:
 		assert.Always(result.Status == validate.Success, name, map[string]any{"msg": result.Message})
-	case validate.Unknown:
 	default:
-		assert.Unreachable(name, map[string]any{"msg": result.Message})
+		assert.Unreachable(name, map[string]any{"error": result.Error().Error()})
 	}
 }

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -113,10 +113,11 @@ func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenari
 		t.Error(err)
 	}
 	result := validate.ValidateAndReturnVisualize(lg, validateConfig, clientReports, persistedRequests, 5*time.Minute)
-	r.SetVisualizer(result.Linearization.Visualize)
 	err = result.Error()
 	if err != nil {
 		t.Error(err)
+	} else {
+		r.SetVisualizer(result.Linearization.Visualize)
 	}
 	panicked = false
 }

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -16,6 +16,7 @@ package validate
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/anishathalye/porcupine"
@@ -38,7 +39,9 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 
 	var timer *time.Timer
 	if timeout > 0 {
-		timer = time.AfterFunc(timeout, func() {
+		// Porcupine timeout is not always enforced (see https://github.com/anishathalye/porcupine/issues/44)
+		// Give it a small grace period before forcing the deadline from inside model execution.
+		timer = time.AfterFunc(timeout*11/10, func() {
 			model.LinearizationDeadlineTripped.Store(1)
 		})
 	}
@@ -48,6 +51,7 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 	if timer != nil {
 		timer.Stop()
 	}
+	duration := time.Since(start)
 
 	result := LinearizationResult{
 		Info:  info,
@@ -55,29 +59,26 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 	}
 
 	if model.LinearizationDeadlineTripped.Load() != 0 {
-		result.Status = Failure
-		result.Message = "timed out"
-		result.Timeout = true
-		lg.Error("Linearization timed out", zap.Duration("duration", time.Since(start)))
+		result.Status = DeadlineExceeded
+		result.Message = "deadline exceeded"
+		lg.Error("Linearization deadline exceeded", zap.Duration("duration", duration))
 		return result
 	}
 
 	switch check {
 	case porcupine.Ok:
 		result.Status = Success
-		lg.Info("Linearization success", zap.Duration("duration", time.Since(start)))
+		lg.Info("Linearization success", zap.Duration("duration", duration))
 	case porcupine.Unknown:
-		result.Status = Failure
-		result.Message = "timed out"
-		result.Timeout = true
-		lg.Error("Linearization timed out", zap.Duration("duration", time.Since(start)))
+		result.Status = Timeout
+		lg.Error("Linearization timed out", zap.Duration("duration", duration))
 	case porcupine.Illegal:
 		result.Status = Failure
 		result.Message = "illegal"
-		lg.Error("Linearization illegal", zap.Duration("duration", time.Since(start)))
+		lg.Error("Linearization illegal", zap.Duration("duration", duration))
 	default:
 		result.Status = Failure
-		result.Message = "unknown"
+		result.Message = fmt.Sprintf("unknown results from porcupine: %s", check)
 	}
 	return result
 }

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -350,11 +350,11 @@ func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
 	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, timeout)
 	elapsed := time.Since(start)
 
-	if !result.Timeout {
-		t.Fatalf("validateLinearizableOperationsAndVisualize(...) timed out = false, message = %q", result.Message)
+	if result.Status != DeadlineExceeded {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) status = %q, want %q", result.Status, DeadlineExceeded)
 	}
-	if result.Message != "timed out" {
-		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "timed out")
+	if result.Message != "deadline exceeded" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "deadline exceeded")
 	}
 	if elapsed > timeout+250*time.Millisecond {
 		t.Fatalf("validateLinearizableOperationsAndVisualize(...) does not respect timeout: %v, timeout was %v", elapsed, timeout)

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -40,6 +40,9 @@ var (
 	Unknown ResultStatus
 	Success ResultStatus = "Success"
 	Failure ResultStatus = "Failure"
+	Timeout ResultStatus = "Timeout"
+	// DeadlineExceeded is a workaround for Porcupine not always enforcing its timeout. It does not support visualization.
+	DeadlineExceeded ResultStatus = "DeadlineExceeded"
 )
 
 func (r RobustnessResult) Error() error {
@@ -71,25 +74,36 @@ func ResultFromError(err error) Result {
 }
 
 func (r Result) Error() error {
-	if r.Status == Failure {
-		if r.Message != "" {
-			return errors.New(r.Message)
-		}
-		return errors.New("failure")
+	switch r.Status {
+	case Success, Unknown:
+		return nil
+	default:
+		return errors.New(r.String())
 	}
-	return nil
+}
+
+func (r Result) String() string {
+	if r.Message != "" {
+		return fmt.Sprintf("%s: %s", r.Status, r.Message)
+	}
+	return string(r.Status)
 }
 
 type LinearizationResult struct {
 	Info  porcupine.LinearizationInfo
 	Model porcupine.Model
 	Result
-	Timeout bool
 }
 
 func (r *LinearizationResult) Visualize(lg *zap.Logger, path string) error {
+	err := r.Error()
+	if err != nil {
+		lg.Info("Skipping linearization visualization", zap.Error(err))
+		return nil
+	}
+
 	lg.Info("Saving visualization", zap.String("path", path))
-	err := porcupine.VisualizePath(r.Model, r.Info, path)
+	err = porcupine.VisualizePath(r.Model, r.Info, path)
 	if err != nil {
 		return fmt.Errorf("failed to visualize, err: %w", err)
 	}

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -169,7 +169,7 @@ func TestValidateAndReturnVisualize(t *testing.T) {
 				},
 			},
 			persistedRequests: []model.EtcdRequest{putRequest("key", "value")},
-			expectError:       "watch: broke Reliable",
+			expectError:       "watch: Failure: broke Reliable",
 		},
 	}
 	for _, tc := range tcs {
@@ -186,6 +186,21 @@ func TestValidateAndReturnVisualize(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestLinearizationVisualizeSkipsDeadlineExceeded(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	path := filepath.Join(t.TempDir(), "history.html")
+	result := LinearizationResult{
+		Result: Result{
+			Status:  DeadlineExceeded,
+			Message: "deadline exceeded",
+		},
+	}
+
+	require.NoError(t, result.Visualize(lg, path))
+	_, err := os.Stat(path)
+	require.Truef(t, os.IsNotExist(err), "deadline exceeded should not produce visualization")
 }
 
 func watchEvent(rev int64, isCreate bool, eventType model.OperationType, key, value string) model.WatchEvent {


### PR DESCRIPTION
In a recent robustness CI run [ci-etcd-robustness-main-arm64/2060645815625453568](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-arm64/2060645815625453568), the test suite encounters a panic:
```
panic: valid partial linearization returned non-ok result from model step [recovered, repanicked]
```

The cause stems from the fix for the Porcupine timeout handling issue implemented in [#21771](https://github.com/etcd-io/etcd/pull/21771) - we introduced an atomic flag (`LinearizationDeadlineTripped`) that forces the model's `Step` function to return `false` once a timeout is reached, essentially attempting to abandon the linearization execution since we cannot forcefully stop it. 

The side effect is that state exploration continues on the Porcupine side for a short while, which will likely causes it to enter a broken internal state.

This PR propose that we should not attempt to visualize the results when we know a timeout or failure has occurred, as there is no value in visualizing a broken search state. Also, with [#21807](https://github.com/etcd-io/etcd/pull/21807) which is now merged, we can always download and visualize the failed report locally if needed.