### PR TITLE
clientv3: suppress noisy warn/error logs on expected shutdown cancellation

### DIFF
--- a/client/v3/retry_interceptor.go
+++ b/client/v3/retry_interceptor.go
@@ -65,6 +65,14 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 			if lastErr == nil {
 				return nil
 			}
+			if isContextError(lastErr) {
+				if ctx.Err() != nil {
+					// Expected context cancellation (e.g., client.Close()); avoid noisy warn log.
+					return lastErr
+				}
+				// its the callCtx deadline or cancellation, in which case try again.
+				continue
+			}
 			c.GetLogger().Warn(
 				"retrying of unary invoker failed",
 				zap.String("target", cc.Target()),
@@ -73,14 +81,6 @@ func (c *Client) unaryClientInterceptor(optFuncs ...retryOption) grpc.UnaryClien
 				zap.Uint("attempt", attempt),
 				zap.Error(lastErr),
 			)
-			if isContextError(lastErr) {
-				if ctx.Err() != nil {
-					// its the context deadline or cancellation.
-					return lastErr
-				}
-				// its the callCtx deadline or cancellation, in which case try again.
-				continue
-			}
 			if c.shouldRefreshToken(lastErr, callOpts) {
 				gtErr := c.refreshToken(ctx)
 				if gtErr != nil {
@@ -117,7 +117,12 @@ func (c *Client) streamClientInterceptor(optFuncs ...retryOption) grpc.StreamCli
 		// (see https://github.com/etcd-io/etcd/issues/11954 for more).
 		err := c.getToken(ctx)
 		if err != nil {
-			c.GetLogger().Error("clientv3/retry_interceptor: getToken failed", zap.Error(err))
+			if isContextError(err) {
+				// Context cancelled (e.g., client.Close()); log at debug to avoid noisy error during expected shutdown.
+				c.GetLogger().Debug("clientv3/retry_interceptor: getToken failed", zap.Error(err))
+			} else {
+				c.GetLogger().Error("clientv3/retry_interceptor: getToken failed", zap.Error(err))
+			}
 			return nil, err
 		}
 		grpcOpts, retryOpts := filterCallOptions(opts)


### PR DESCRIPTION
## Problem

When `client.Close()` is called with auth enabled and active watch
streams, `clientv3` emits confusing log messages during normal
application shutdown:

```
warn  retrying of unary invoker failed ... method=/etcdserverpb.Auth/Authenticate ... error="rpc error: code = Canceled desc = context canceled"
error clientv3/retry_interceptor: getToken failed error="context canceled"
```

These are caused by two separate issues in `retry_interceptor.go`:

1. **`streamClientInterceptor`**: `getToken` is called at stream
   creation time. When `client.Close()` cancels the client context,
   `getToken` returns `context.Canceled` which is unconditionally logged
   at `Error` level.

2. **`unaryClientInterceptor`**: the `Warn` log for a failed retry
   attempt is emitted *before* the check that detects context
   cancellation, so every auth token refresh attempt during shutdown
   produces a spurious warn.

## Fix

- `unaryClientInterceptor`: move the `isContextError` / `ctx.Err()`
  check to run *before* the `Warn` log. When the outer context is
  already done the interceptor returns immediately without logging.

- `streamClientInterceptor`: downgrade the `getToken` failure log from
  `Error` to `Debug` when the error is a context cancellation
  (i.e., an expected shutdown signal).

No functional behaviour is changed; only the log level of expected
cancellation events is adjusted.

Fixes #21643