### PR TITLE
client/v3/leasing: evict all in-range keys in EvictRange

### DIFF
--- a/client/v3/leasing/cache.go
+++ b/client/v3/leasing/cache.go
@@ -187,8 +187,8 @@ func (lc *leaseCache) EvictRange(key, end string) {
 	defer lc.mu.Unlock()
 	for k := range lc.entries {
 		if inRange(k, key, end) {
-			delete(lc.entries, key)
-			lc.revokes[key] = time.Now()
+			delete(lc.entries, k)
+			lc.revokes[k] = time.Now()
 		}
 	}
 }

--- a/client/v3/leasing/cache_evictrange_safety_test.go
+++ b/client/v3/leasing/cache_evictrange_safety_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Safety tests for leaseCache.EvictRange (RS-B03-1).
+//
+// EvictRange must invalidate EVERY cached entry whose key falls in [key, end),
+// because it is called when a range-delete RPC fails and the client can no
+// longer trust any cached value in that range.
+//
+// This is a BUG FIX, not a behavior-preserving refactor: the current code uses
+// the range-start argument `key` instead of the loop variable `k`, so it only
+// ever evicts the single entry equal to the range start. Therefore the
+// "EvictsAll" / "MarksAll" / "ToInfinity" tests below are EXPECTED TO FAIL at
+// baseline (that failure IS the empirical proof of the bug, §阶段 6.5) and to
+// PASS after the two-line fix. The "OutOfRange" / "NoMatch" tests lock
+// invariants that must hold both before and after.
+
+package leasing
+
+import (
+	"testing"
+	"time"
+)
+
+func newEvictTestCache(keys ...string) *leaseCache {
+	lc := &leaseCache{
+		entries: make(map[string]*leaseKey),
+		revokes: make(map[string]time.Time),
+	}
+	for _, k := range keys {
+		lc.entries[k] = &leaseKey{}
+	}
+	return lc
+}
+
+func cachedKeys(lc *leaseCache) map[string]bool {
+	lc.mu.RLock()
+	defer lc.mu.RUnlock()
+	out := make(map[string]bool, len(lc.entries))
+	for k := range lc.entries {
+		out[k] = true
+	}
+	return out
+}
+
+// --- BUG-EXPOSING (FAIL pre-fix, PASS post-fix) ------------------------------
+
+// EvictRange("a","d") covers a,b,c (not d). All three must be removed.
+func TestEvictRangeSafety_EvictsAllInRange(t *testing.T) {
+	lc := newEvictTestCache("a", "b", "c", "d")
+	lc.EvictRange("a", "d")
+
+	got := cachedKeys(lc)
+	for _, k := range []string{"a", "b", "c"} {
+		if got[k] {
+			t.Errorf("key %q still cached after EvictRange[a,d); want evicted", k)
+		}
+	}
+	if !got["d"] {
+		t.Errorf("key %q wrongly evicted; it is outside [a,d)", "d")
+	}
+}
+
+// Every evicted in-range key must be marked in revokes so MayAcquire backs off.
+func TestEvictRangeSafety_MarksAllInRangeRevoked(t *testing.T) {
+	lc := newEvictTestCache("a", "b", "c")
+	lc.EvictRange("a", "d")
+
+	for _, k := range []string{"a", "b", "c"} {
+		if lc.MayAcquire(k) {
+			t.Errorf("MayAcquire(%q) = true after eviction; want false (revoke backoff)", k)
+		}
+	}
+}
+
+// end == "\x00" means "to end of keyspace": every cached key >= start evicts.
+func TestEvictRangeSafety_PrefixToInfinityEvictsAll(t *testing.T) {
+	lc := newEvictTestCache("a", "b", "m", "z")
+	lc.EvictRange("a", "\x00")
+
+	if n := len(cachedKeys(lc)); n != 0 {
+		t.Errorf("EvictRange[a,∞) left %d entries; want 0", n)
+	}
+}
+
+// --- INVARIANTS (PASS pre-fix AND post-fix) ----------------------------------
+
+// Keys outside [key,end) must never be touched.
+func TestEvictRangeSafety_LeavesOutOfRangeUntouched(t *testing.T) {
+	lc := newEvictTestCache("a", "z")
+	lc.EvictRange("a", "d") // only "a" is in range
+
+	got := cachedKeys(lc)
+	if !got["z"] {
+		t.Errorf("out-of-range key %q wrongly evicted", "z")
+	}
+	if lc.MayAcquire("z") == false {
+		t.Errorf("out-of-range key %q wrongly marked revoked", "z")
+	}
+}
+
+// A range matching no cached key must be a no-op.
+func TestEvictRangeSafety_NoMatchIsNoop(t *testing.T) {
+	lc := newEvictTestCache("x", "y")
+	lc.EvictRange("a", "d") // [a,d) matches neither x nor y
+
+	got := cachedKeys(lc)
+	if !got["x"] || !got["y"] {
+		t.Errorf("no-match EvictRange evicted something: %v", got)
+	}
+}


### PR DESCRIPTION
## PR-L1 — leasing cache `EvictRange`: wrong variable used in range eviction (RS-B03-1)

- **Status**: ✅ Local complete; 5/5 safety tests pass (normal + `-race`); full package regression passes; ready to open PR.
- **Corresponding todo entry**: **RS-B03-1** (🟡 P2). This PR does not touch RS-B03-2 or RS-B13-1 — each is independent.
- **Scope of changes** (`client/v3/leasing/` only, zero external dependencies):
  - [client/v3/leasing/cache.go:194-195](client/v3/leasing/cache.go#L194) — `EvictRange` loop body: `delete(lc.entries, key)` → `delete(lc.entries, k)` and `lc.revokes[key]` → `lc.revokes[k]` (loop variable `k` is used for matching, but the parameter `key` was incorrectly used for eviction — a copy-paste bug).
- **New characterization tests** ([client/v3/leasing/cache_evictrange_safety_test.go](client/v3/leasing/cache_evictrange_safety_test.go)): 5 `TestEvictRangeSafety_*`
  - Bug-exposing (FAIL at baseline → PASS after fix): EvictsAllInRange / MarksAllInRangeRevoked / PrefixToInfinityEvictsAll
  - Invariant (PASS at baseline AND after fix): LeavesOutOfRangeUntouched / NoMatchIsNoOp
- **Invariant assertions**:
  1. `EvictRange[a,d)` must evict all in-range cache entries a/b/c (not just the start point a)
  2. Every evicted in-range key enters `revokes` → `MayAcquire` backoff takes effect
  3. `end=="\x00"` (to end of keyspace) evicts all cached entries ≥ start
  4. Out-of-range keys (e.g. z) are neither evicted nor marked revoke
  5. No matching range = no-op
- **Empirical reproduction**: Bug-exposing tests produce clean assertion failures at baseline:
  ```
  TestEvictRangeSafety_EvictsAllInRange   FAIL: key "b"/"c" still cached after EvictRange[a,d)
  TestEvictRangeSafety_MarksAllInRangeRevoked  FAIL: MayAcquire("b")/("c") = true after eviction
  TestEvictRangeSafety_PrefixToInfinityEvictsAll  FAIL: EvictRange[a,∞) left 3 entries; want 0
  ```
  After fix: all 5 tests pass in normal and `-race` mode; full `go test ./client/v3/leasing/` clean.
- **Existing tests touched but unchanged** (all PASS): all leasing package local tests PASS.
- **Note**: This is an active bug fix, not a behavior-preserving refactor. Bug-exposing tests lock in correct behavior (FAIL at baseline); invariant tests lock in what should not change — never solidifying wrong behavior.

---

## Summary

A copy-paste bug in `EvictRange` causes range evictions to delete only the start key of the range, leaving all intermediate and trailing keys stale in the cache. The fix replaces the parameter `key` with the loop variable `k` in both `delete` calls.