### PR TITLE
server/proxy/grpcproxy: invalidate cache after the backend write in P…

### DIFF
--- a/server/proxy/grpcproxy/kv.go
+++ b/server/proxy/grpcproxy/kv.go
@@ -84,6 +84,13 @@ func (p *kvProxy) Put(ctx context.Context, r *pb.PutRequest) (*pb.PutResponse, e
 	cacheKeys.Set(float64(p.cache.Size()))
 
 	resp, err := p.kv.Do(ctx, PutRequestToOp(r))
+	// Invalidate again after the backend write. A concurrent serializable
+	// Range can read the pre-write value and re-cache it in the window
+	// between the first Invalidate and the write committing; without this
+	// second Invalidate that stale entry would persist until the next write
+	// through this proxy.
+	p.cache.Invalidate(r.Key, nil)
+	cacheKeys.Set(float64(p.cache.Size()))
 	return (*pb.PutResponse)(resp.Put()), err
 }
 
@@ -92,6 +99,10 @@ func (p *kvProxy) DeleteRange(ctx context.Context, r *pb.DeleteRangeRequest) (*p
 	cacheKeys.Set(float64(p.cache.Size()))
 
 	resp, err := p.kv.Do(ctx, DelRequestToOp(r))
+	// See Put: invalidate again after the backend write to drop any stale
+	// entry a concurrent serializable Range re-cached during the window.
+	p.cache.Invalidate(r.Key, r.RangeEnd)
+	cacheKeys.Set(float64(p.cache.Size()))
 	return (*pb.DeleteRangeResponse)(resp.Del()), err
 }
 

--- a/server/proxy/grpcproxy/kv_invalidate_order_safety_test.go
+++ b/server/proxy/grpcproxy/kv_invalidate_order_safety_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Safety tests for kvProxy cache invalidation ordering (RS-B13-1).
+//
+// kvProxy.Put / DeleteRange invalidate the cache and then write to the
+// backend. A concurrent serializable Range can slip into the window between
+// the invalidate and the backend write committing, read the pre-write value,
+// and re-populate the cache with it — leaving an unbounded stale entry until
+// the next write through this proxy.
+//
+// This is a BUG FIX, not a behavior-preserving refactor. The "StaleReAdd"
+// tests deterministically model the concurrent window by having the fake KV,
+// during the backend Do, perform the cache.Add a racing Range would do (gRPC
+// runs each RPC on its own goroutine, so this interleaving is production-real;
+// the hook just makes it reliable instead of flaky). They are EXPECTED TO FAIL
+// at baseline (proof of the bug) and to PASS once Put/DeleteRange invalidate
+// again after the backend write. The other tests lock invariants that hold
+// both before and after.
+
+package grpcproxy
+
+import (
+	"context"
+	"testing"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/proxy/grpcproxy/cache"
+)
+
+// hookKV stands in for the backend client. onDo runs inside Do — used to
+// simulate a concurrent serializable Range that re-cached the stale value
+// during the write window.
+type hookKV struct {
+	clientv3.KV
+	onDo func(op clientv3.Op)
+}
+
+func (k *hookKV) Do(_ context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+	if k.onDo != nil {
+		k.onDo(op)
+	}
+	return clientv3.OpResponse{}, nil
+}
+
+// serializableRange returns a (req, resp) pair for a serializable Range of key
+// with Revision==0 so cache.Add both stores it and registers it for
+// key-range invalidation.
+func serializableRange(key string) (*pb.RangeRequest, *pb.RangeResponse) {
+	return &pb.RangeRequest{Key: []byte(key), Serializable: true},
+		&pb.RangeResponse{Header: &pb.ResponseHeader{Revision: 1}}
+}
+
+// --- BUG-EXPOSING (FAIL pre-fix, PASS post-fix) ------------------------------
+
+func TestKVProxyInvalidateOrderSafety_PutStaleReAddCleared(t *testing.T) {
+	c := cache.NewCache(cache.DefaultMaxEntries)
+	staleReq, staleResp := serializableRange("k")
+
+	p := &kvProxy{cache: c}
+	p.kv = &hookKV{onDo: func(op clientv3.Op) {
+		if op.IsPut() { // concurrent serializable Range re-adds the pre-write value
+			c.Add(staleReq, staleResp)
+		}
+	}}
+
+	if _, err := p.Put(context.Background(), &pb.PutRequest{Key: []byte("k"), Value: []byte("v1")}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := c.Get(staleReq); err == nil {
+		t.Errorf("serializable Range(k) hit a stale cached value after Put returned; cache must be invalidated after the backend write")
+	}
+}
+
+func TestKVProxyInvalidateOrderSafety_DeleteRangeStaleReAddCleared(t *testing.T) {
+	c := cache.NewCache(cache.DefaultMaxEntries)
+	staleReq, staleResp := serializableRange("k")
+
+	p := &kvProxy{cache: c}
+	p.kv = &hookKV{onDo: func(op clientv3.Op) {
+		if op.IsDelete() {
+			c.Add(staleReq, staleResp)
+		}
+	}}
+
+	if _, err := p.DeleteRange(context.Background(), &pb.DeleteRangeRequest{Key: []byte("k")}); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if _, err := c.Get(staleReq); err == nil {
+		t.Errorf("serializable Range(k) hit a stale cached value after DeleteRange returned; cache must be invalidated after the backend write")
+	}
+}
+
+// --- INVARIANTS (PASS pre-fix AND post-fix) ----------------------------------
+
+// A Put still invalidates a value cached before the write (the no-race path).
+func TestKVProxyInvalidateOrderSafety_PutClearsPreCached(t *testing.T) {
+	c := cache.NewCache(cache.DefaultMaxEntries)
+	req, resp := serializableRange("k")
+	c.Add(req, resp) // pre-cached
+
+	p := &kvProxy{cache: c, kv: &hookKV{}}
+	if _, err := p.Put(context.Background(), &pb.PutRequest{Key: []byte("k"), Value: []byte("v1")}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := c.Get(req); err == nil {
+		t.Errorf("Put did not invalidate the pre-cached value for its own key")
+	}
+}
+
+// A Put must not evict an unrelated key's cache entry.
+func TestKVProxyInvalidateOrderSafety_PutLeavesUnrelatedKey(t *testing.T) {
+	c := cache.NewCache(cache.DefaultMaxEntries)
+	reqA, respA := serializableRange("a")
+	c.Add(reqA, respA)
+
+	p := &kvProxy{cache: c, kv: &hookKV{}}
+	if _, err := p.Put(context.Background(), &pb.PutRequest{Key: []byte("b"), Value: []byte("v1")}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := c.Get(reqA); err != nil {
+		t.Errorf("Put(b) wrongly evicted unrelated cached key a: %v", err)
+	}
+}


### PR DESCRIPTION
## PR-L3 — grpcproxy kvProxy: invalidate cache after backend write, closing the concurrent serializable stale window (RS-B13-1)

- **Status**: ✅ Local complete; 4/4 safety tests pass (normal + `-race`); full grpcproxy package compiles and tests pass; ready to open PR on branch `fix/grpcproxy-cache-invalidate-order`.
- **Corresponding todo entry**: **RS-B13-1** (🟡 P2).
- **Scope of changes** (`server/proxy/grpcproxy/kv.go` only, zero external dependencies):
  - [kv.go Put](server/proxy/grpcproxy/kv.go#L82) / [DeleteRange](server/proxy/grpcproxy/kv.go#L97) — add a second `cache.Invalidate` call **after** `p.kv.Do(...)` returns (keep the pre-write Invalidate, add post-write Invalidate). The `Txn` path already handles cache after write, unchanged.
- **New characterization tests** ([server/proxy/grpcproxy/kv_invalidate_order_safety_test.go](server/proxy/grpcproxy/kv_invalidate_order_safety_test.go)): 4 `TestKVProxyInvalidateOrderSafety_*`
  - Bug-exposing (FAIL at baseline → PASS after fix): PutStaleReAddCleared / DeleteRangeStaleReAddCleared — uses `hookKV` to deterministically inject "concurrent serializable Range re-caches old value during the write window" at the `Do` point, asserting that `cache.Get(k)` must miss after write returns.
  - Invariant (PASS at baseline AND after fix): PutClearsPreCached / PutLeavesUnrelatedKey
- **Invariant assertions**:
  1. After a write operation returns, no stale pre-write value for that key remains in the cache.
  2. A write only affects its own key range; unrelated keys are untouched.
- **Empirical reproduction**: Bug-exposing tests produce clean assertion failures at baseline:
  ```
  PutStaleReAddCleared        FAIL: serializable Range(k) hit a stale cached value after Put returned
  DeleteRangeStaleReAddCleared FAIL: serializable Range(k) hit a stale cached value after DeleteRange returned
  ```
  After fix: all 4 tests pass in normal and `-race` mode.
- **Concurrency fidelity**: The reproducer models gRPC-per-RPC goroutine concurrency — a production reality in grpcproxy, not an artificial construct — via `hookKV` injection at the `Do` point, avoiding flaky true goroutine races. Rated P2 because: opt-in component, serializable reads only, window must be hit; not reachability-limited.
- **Existing tests touched but unchanged** (all PASS): grpcproxy package compiles; cache subpackage has no local tests.
- **Note**: This is an active bug fix, not a behavior-preserving refactor. Bug-exposing tests lock in correct behavior (FAIL at baseline); invariant tests lock in what should not change — never solidifying wrong behavior.

---

## Summary

In `Put` and `DeleteRange`, the cache was invalidated before the backend write (which is correct to clear a pre-existing cached value), but no invalidation happened after the write returned. A concurrent serializable `Range` that re-fills the cache between the pre-write Invalidate and the write completing could re-cache the old value. The fix adds a second `cache.Invalidate` call after `p.kv.Do(...)` returns, ensuring the stale window is closed regardless of timing.