### PR TITLE
etcdserver: protect monitorKVHash s.be read with bemu.RLock (RS-B12-1)

### DIFF
--- a/server/etcdserver/monitor_kvhash_safety_test.go
+++ b/server/etcdserver/monitor_kvhash_safety_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Characterization tests for the monitorKVHash backend-swap data race (RS-B12-1).
+//
+// These tests must pass both BEFORE and AFTER the refactor. Their purpose is to
+// pin down the real production concurrency topology: monitorKVHash runs as an
+// independent goroutine (launched via s.GoAttach(s.monitorKVHash) in Start) and
+// reads s.be unsynchronized, while applySnapshot swaps s.be under
+// s.bemu.Lock(). That combination is a genuine data race + potential
+// use-after-close, not an artificial construction.
+//
+// Expected behavior:
+//   - Under `-race`, TestMonitorKVHashSafety_NoBackendSwapRace fails on the
+//     BASELINE (unfixed) code because the race detector flags the unsynchronized
+//     read of s.be at server.go:2272 against the locked write in the test, and
+//     passes once the read is wrapped in s.bemu.RLock().
+//   - Without `-race`, both baseline and fixed code pass (the detector is the
+//     only discriminator).
+//   - TestMonitorKVHashSafety_DisabledWhenCheckTimeZero is an invariant test:
+//     it passes on both baseline and fixed code.
+package etcdserver
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+
+	"go.etcd.io/etcd/server/v3/config"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
+)
+
+// TestMonitorKVHashSafety_NoBackendSwapRace reproduces the production race
+// between the monitorKVHash goroutine (reading s.be) and a backend swap done
+// under s.bemu.Lock() (as applySnapshot does). On baseline code this fails
+// under -race; after wrapping the read in bemu.RLock it passes.
+func TestMonitorKVHashSafety_NoBackendSwapRace(t *testing.T) {
+	s := &EtcdServer{
+		lgMu:     new(sync.RWMutex),
+		lg:       zaptest.NewLogger(t),
+		memberID: 1, // isLeader() == false (lead defaults to 0): only line 2272 runs, not PeriodicCheck
+		stopping: make(chan struct{}),
+	}
+	s.Cfg = config.ServerConfig{
+		CorruptCheckTime: time.Millisecond,
+	}
+
+	// Initial backend plus a pool of spares to rotate through. Track them all
+	// for cleanup at the end of the test.
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	s.be = be
+	var swapPool []backend.Backend
+	for i := 0; i < 8; i++ {
+		nbe, _ := betesting.NewDefaultTmpBackend(t)
+		swapPool = append(swapPool, nbe)
+	}
+	defer func() {
+		betesting.Close(t, be)
+		for _, b := range swapPool {
+			betesting.Close(t, b)
+		}
+	}()
+
+	go s.monitorKVHash()
+
+	// Swap the backend repeatedly under bemu, giving the 1ms ticker chances to
+	// read s.be concurrently. On baseline code the unsynchronized read at
+	// server.go:2272 races with these writes.
+	for i := 0; i < 50; i++ {
+		nb := swapPool[i%len(swapPool)]
+		s.bemu.Lock()
+		s.be = nb
+		s.bemu.Unlock()
+		time.Sleep(300 * time.Microsecond)
+	}
+
+	close(s.stopping)
+	// Give the monitor goroutine time to observe stopping and exit before we
+	// close the backends in the deferred cleanup.
+	time.Sleep(20 * time.Millisecond)
+}
+
+// TestMonitorKVHashSafety_DisabledWhenCheckTimeZero pins the invariant that
+// monitorKVHash returns immediately when CorruptCheckTime == 0, never entering
+// the ticker loop (server.go:2253). Holds on both baseline and fixed code.
+func TestMonitorKVHashSafety_DisabledWhenCheckTimeZero(t *testing.T) {
+	s := &EtcdServer{
+		lgMu:     new(sync.RWMutex),
+		lg:       zaptest.NewLogger(t),
+		memberID: 1,
+		stopping: make(chan struct{}),
+	}
+	s.Cfg = config.ServerConfig{
+		CorruptCheckTime: 0,
+	}
+	// s.be is intentionally nil: with CorruptCheckTime == 0 it is never read.
+
+	done := make(chan struct{})
+	go func() {
+		s.monitorKVHash()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// returned immediately, as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorKVHash did not return immediately when CorruptCheckTime == 0")
+	}
+}

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -2269,7 +2269,9 @@ func (s *EtcdServer) monitorKVHash() {
 			return
 		case <-checkTicker.C:
 		}
+		s.bemu.RLock()
 		backend.VerifyBackendConsistency(s.be, lg, false, schema.AllBuckets...)
+		s.bemu.RUnlock()
 		if !s.isLeader() {
 			continue
 		}


### PR DESCRIPTION

- **Status**: ✅ Local complete (safe-refactor 2026-05-28, all 7 stages passed, independently verified). Ready to open PR on branch `fix/monitorkvhash-bemu-read`.
- **Corresponding todo entry**: **RS-B12-1** (🟢 P3). This PR fixes two coupled problems simultaneously; does not touch RS-B12-2.
- **Background (two coupled problems)**:
  - `(a) Data race on field read`: `monitorKVHash` (independent GoAttach goroutine, [server.go:2272](server/etcdserver/server.go#L2272)) calls `VerifyBackendConsistency(s.be, ...)` reading `s.be` unsynchronized; `applySnapshot` (apply FIFO goroutine, [server.go:1034-1093](server/etcdserver/server.go#L1034)) holds `bemu.Lock()` to swap `s.be = newbe` then `go oldbe.Close()`. Unsynchronized cross-goroutine interface dual-word read triggers `go -race`.
  - `(b) Use-after-swap/close`: After `monitorKVHash` reads `s.be` but before using it, the writer can swap the backend and start `oldbe.Close()`, causing verify to operate on a closing backend → panic "tx closed" in verify mode.
  - Key insight: changing `s.be` → `s.Backend()` only fixes (a), not (b) — `Backend()` releases its RLock at return, not covering the backend's usage span.
- **Scope of changes** (`server/etcdserver/server.go` only, zero external dependencies):
  - [monitorKVHash:2272](server/etcdserver/server.go#L2272) — wrap the entire `VerifyBackendConsistency(s.be, ...)` call with `s.bemu.RLock()` / `RUnlock()` (not replacing with `s.Backend()`), matching the official pattern used by `StorageVersion()` ([server.go:2199-2204](server/etcdserver/server.go#L2199)).
  - Both (a) and (b) are eliminated simultaneously: reads under lock are not torn; RLock held across the entire verify usage span means `applySnapshot`'s `bemu.Lock()` must wait for verify to finish before swapping/closing.
- **Invariant assertions**: While `monitorKVHash` holds `bemu.RLock`, the backend pointed to by `s.be` is neither concurrently replaced nor concurrently closed; verify always operates on a complete, live backend.
- **New characterization tests** ([server/etcdserver/monitor_kvhash_safety_test.go](server/etcdserver/monitor_kvhash_safety_test.go), 2 tests):
  - `TestMonitorKVHashSafety_NoBackendSwapRace` — real production topology: `go s.monitorKVHash()` (memberID=1 makes `isLeader()`=false, only triggers line 2272) vs main goroutine holding `bemu.Lock()` swapping `s.be` 50 times; `-race` detector is the discriminator.
  - `TestMonitorKVHashSafety_DisabledWhenCheckTimeZero` — invariant: `CorruptCheckTime=0` causes `monitorKVHash` to return immediately (line 2253), 2s timeout assertion.
- **Empirical reproduction (stage 6.5, independently verified)**: Temporarily reverting line 2272 to a bare `s.be` read causes `go test -race` to fail deterministically:
  ```
  WARNING: DATA RACE
  Read at ... by goroutine N:
    (*EtcdServer).monitorKVHash()  server/etcdserver/server.go:2272
  Previous write at ... by goroutine M:
    monitor_kvhash_safety_test.go:86  (s.be = nb under bemu.Lock)
  --- FAIL: TestMonitorKVHashSafety_NoBackendSwapRace
  ```
- **Deadlock investigation**: verify takes backend `BatchTx().LockOutsideApply()` (≠ bemu); `applySnapshot` operates on newbe under `bemu.Lock()` without touching oldbe's batchTx; no lock cycle. Confirmed `PeriodicCheck()` (line 2276) path holds no lock conflicting with bemu.
- **Concurrency fidelity**: `monitorKVHash` and `applySnapshot` are two genuinely independent goroutines (`GoAttach` vs schedule FIFO) that exist from etcd startup — concurrency is production-real, not artificially constructed. Rated P3 because `--corrupt-check-time` is off by default + must hit snapshot-swap window + verify gated by `ETCD_VERIFY`; reachability/probability is low, not that concurrency is absent.
- **Expected impact**: Fix eliminates `-race` warnings (including potential CI flake in `tests/e2e/corrupt_test.go` with snapshot overlap) + closes verify-mode use-after-close + aligns with official bemu conventions. Zero-risk one-line change.
- **Existing tests touched but unchanged** (all PASS): all etcdserver package tests PASS.

---

## Summary

`monitorKVHash` reads `s.be` unsynchronized while `applySnapshot` swaps `s.be` under `bemu.Lock()`. This is a genuine data race plus a potential use-after-close: the monitor could read the old backend reference, and before it uses it, the apply goroutine replaces and closes the backend — causing verify to panic on a closed transaction. The fix wraps the `VerifyBackendConsistency(s.be, ...)` call with `s.bemu.RLock()`/`RUnlock()`, ensuring the backend is stable for the duration of the verify call.