### PR TITLE
rafthttp: bound msgappv2 entry count and size before allocating

### DIFF
--- a/server/etcdserver/api/rafthttp/msgappv2_codec.go
+++ b/server/etcdserver/api/rafthttp/msgappv2_codec.go
@@ -203,12 +203,18 @@ func (dec *msgAppV2Decoder) decode() (*raftpb.Message, error) {
 			return nil, err
 		}
 		l := binary.BigEndian.Uint64(dec.uint64buf)
+		if l > readBytesLimit {
+			return nil, ErrExceedSizeLimit
+		}
 		m.Entries = make([]*raftpb.Entry, int(l))
 		for i := 0; i < int(l); i++ {
 			if _, err := io.ReadFull(dec.r, dec.uint64buf); err != nil {
 				return nil, err
 			}
 			size := binary.BigEndian.Uint64(dec.uint64buf)
+			if size > readBytesLimit {
+				return nil, ErrExceedSizeLimit
+			}
 			var buf []byte
 			if size < msgAppV2BufSize {
 				buf = dec.buf[:size]
@@ -235,6 +241,9 @@ func (dec *msgAppV2Decoder) decode() (*raftpb.Message, error) {
 		var size uint64
 		if err := binary.Read(dec.r, binary.BigEndian, &size); err != nil {
 			return nil, err
+		}
+		if size > readBytesLimit {
+			return nil, ErrExceedSizeLimit
 		}
 		buf := make([]byte, int(size))
 		if _, err := io.ReadFull(dec.r, buf); err != nil {

--- a/server/etcdserver/api/rafthttp/msgappv2_codec_test.go
+++ b/server/etcdserver/api/rafthttp/msgappv2_codec_test.go
@@ -16,6 +16,7 @@ package rafthttp
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -123,4 +124,39 @@ func TestMsgAppV2(t *testing.T) {
 			t.Errorf("#%d: message = %+v, want %+v", i, m, tt)
 		}
 	}
+}
+
+// TestMsgAppV2DecodeOversize ensures a peer cannot make the decoder allocate
+// (or panic via uint64->int narrowing) by claiming an oversized entry count or
+// entry/message length, matching the limit enforced by the message stream.
+func TestMsgAppV2DecodeOversize(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "entry count",
+			data: appendUint64([]byte{msgTypeAppEntries}, ^uint64(0)),
+		},
+		{
+			name: "entry size",
+			data: appendUint64(appendUint64([]byte{msgTypeAppEntries}, 1), readBytesLimit+1),
+		},
+		{
+			name: "message size",
+			data: appendUint64([]byte{msgTypeApp}, readBytesLimit+1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dec := newMsgAppV2Decoder(bytes.NewReader(tt.data), types.ID(2), types.ID(1))
+			if _, err := dec.decode(); err != ErrExceedSizeLimit {
+				t.Fatalf("error = %v, want %v", err, ErrExceedSizeLimit)
+			}
+		})
+	}
+}
+
+func appendUint64(b []byte, v uint64) []byte {
+	return binary.BigEndian.AppendUint64(b, v)
 }

--- a/tests/e2e/raft_msgappv2_oversize_test.go
+++ b/tests/e2e/raft_msgappv2_oversize_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// msgTypeAppEntries is the leading byte of an AppEntries frame on the
+// msgappv2 stream (see server/etcdserver/api/rafthttp/msgappv2_codec.go).
+const msgTypeAppEntries = 1
+
+// TestRaftMsgAppV2OversizeFrame verifies that a peer feeding the msgappv2 stream
+// a crafted frame cannot crash the receiving member. A learner is added whose
+// peer URL points at a server that, when the member dials its msgapp stream,
+// replies with an AppEntries frame claiming the maximum possible entry count.
+// Before the entry count and length fields were bounded, that count narrowed to
+// a negative slice length and panicked makeslice in the stream reader goroutine,
+// taking the member process down. With the bound the member resets the stream
+// and keeps serving, so the Put below succeeds.
+func TestRaftMsgAppV2OversizeFrame(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	frame := binary.BigEndian.AppendUint64([]byte{msgTypeAppEntries}, ^uint64(0))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/raft/stream/msgapp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Server-Version", version.Version)
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		w.Write(frame)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"etcdserver":"` + version.Version + `","etcdcluster":"` + version.MinClusterVersion + `"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Server-Version", version.Version)
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	})
+	peer := httptest.NewServer(mux)
+	defer peer.Close()
+
+	ctx := context.Background()
+	clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithClusterSize(1))
+	require.NoError(t, err)
+	defer clus.Close()
+
+	ctl := clus.Etcdctl()
+	_, err = ctl.MemberAddAsLearner(ctx, "malicious", []string{peer.URL})
+	require.NoError(t, err)
+
+	// Give the member time to dial the learner's msgapp stream and decode the
+	// crafted frame. Before the fix this panicked in the reader goroutine and
+	// crashed the member within a second or so of the add.
+	time.Sleep(3 * time.Second)
+
+	require.True(t, clus.Procs[0].IsRunning(), "member crashed after receiving oversized msgappv2 frame")
+	_, err = ctl.Put(ctx, "k", "v", config.PutOptions{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The msgappv2 stream decoder reads the entry count and each entry/message length straight off the peer connection as uint64 and hands them to make() after narrowing to int, without any cap. An AppEntries header claiming 0xffffffffffffffff entries narrows to a negative length and panics in makeslice; large length fields force an arbitrary allocation. The message stream decoder in msg_codec.go already caps these at readBytesLimit and returns ErrExceedSizeLimit, so the msgapp path was the odd one out. Cap the three sites the same way.