### PR TITLE
etcdutl: handle malformed revision key during snapshot restore

### DIFF
--- a/etcdutl/snapshot/v3_snapshot.go
+++ b/etcdutl/snapshot/v3_snapshot.go
@@ -421,8 +421,11 @@ func (s *v3Manager) unsafeMarkRevisionCompacted(tx backend.UnsafeWriter, latest 
 
 func (s *v3Manager) unsafeGetLatestRevision(tx backend.UnsafeReader) (mvcc.Revision, error) {
 	var latest mvcc.Revision
-	err := tx.UnsafeForEach(schema.Key, func(k, _ []byte) (err error) {
-		rev := mvcc.BytesToRev(k)
+	err := tx.UnsafeForEach(schema.Key, func(k, _ []byte) error {
+		rev, err := bytesToRev(k)
+		if err != nil {
+			return fmt.Errorf("cannot parse revision key: %q err: %w", k, err)
+		}
 
 		if rev.GreaterThan(latest) {
 			latest = rev

--- a/etcdutl/snapshot/v3_snapshot_test.go
+++ b/etcdutl/snapshot/v3_snapshot_test.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver"
+	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 	"go.etcd.io/etcd/server/v3/storage/schema"
 )
@@ -257,4 +258,27 @@ func createDB(t *testing.T, generateContent func(*etcdserver.EtcdServer)) string
 	generateContent(etcd.Server)
 
 	return filepath.Join(cfg.Dir, "member", "snap", "db")
+}
+
+// TestUnsafeGetLatestRevisionMalformedKey verifies that a snapshot whose key
+// bucket holds a revision key of unexpected length is reported as a parse
+// error rather than panicking the restore.
+func TestUnsafeGetLatestRevisionMalformedKey(t *testing.T) {
+	be := backend.NewDefaultBackend(zap.NewNop(), filepath.Join(t.TempDir(), "db"))
+	defer be.Close()
+
+	tx := be.BatchTx()
+	tx.LockOutsideApply()
+	tx.UnsafeCreateBucket(schema.Key)
+	tx.UnsafePut(schema.Key, []byte("short"), []byte{})
+	tx.Unlock()
+	be.ForceCommit()
+
+	s := &v3Manager{lg: zap.NewNop()}
+	rtx := be.ReadTx()
+	rtx.RLock()
+	defer rtx.RUnlock()
+
+	_, err := s.unsafeGetLatestRevision(rtx)
+	require.Error(t, err)
 }


### PR DESCRIPTION
unsafeGetLatestRevision walks the key bucket of the snapshot being restored and feeds each key straight into mvcc.BytesToRev, which panics on a key whose length, separator byte, or revision is unexpected. Restoring a corrupted or crafted snapshot with --mark-compacted --bump-revision then dies with an unrecovered panic. The Status path already runs the same call through the bytesToRev helper that turns that panic into an error; the restore path just never adopted it. Routing through the same helper so a bad key surfaces as a parse error.