### PR TITLE
grpcproxy: drop re-established Created in watch broadcast

### DIFF
--- a/server/proxy/grpcproxy/watch_broadcast.go
+++ b/server/proxy/grpcproxy/watch_broadcast.go
@@ -83,7 +83,19 @@ func (wb *watchBroadcast) bcast(wr clientv3.WatchResponse) {
 	if wb.responses > 0 || wb.nextrev == 0 {
 		wb.nextrev = wr.Header.Revision + 1
 	}
+	firstResponse := wb.responses == 0
 	wb.responses++
+	// A plain Created response after the broadcast's first response means the
+	// underlying etcd watcher was re-established (e.g. after an etcd restart or
+	// a transient disconnect). The client already received its Created when the
+	// broadcast was first set up; forwarding a second one corrupts clientv3's
+	// positional Created<->substream matching and can deliver this broadcast's
+	// events to a different watcher (cross-prefix delivery). Drop it. A Created
+	// that also carries a cancel (e.g. compaction) is not a plain re-create and
+	// still flows through so the client re-watches.
+	if !firstResponse && wr.Created && !wr.Canceled && wr.Err() == nil {
+		return
+	}
 	for r := range wb.receivers {
 		r.send(wr)
 	}

--- a/server/proxy/grpcproxy/watch_broadcast_test.go
+++ b/server/proxy/grpcproxy/watch_broadcast_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestWatchBroadcastSuppressReestablishCreated verifies that a broadcast
+// forwards only its first Created response to receivers. A second plain Created,
+// which the underlying etcd watcher emits when it is re-established after a
+// restart or transient disconnect, must be dropped: forwarding it would corrupt
+// clientv3's positional Created<->substream matching and deliver this
+// broadcast's events to a different watcher (cross-prefix delivery). Events that
+// follow the dropped Created must still be delivered.
+func TestWatchBroadcastSuppressReestablishCreated(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	wps := &watchProxyStream{
+		watchCh: make(chan *pb.WatchResponse, 8),
+		lg:      lg,
+	}
+	w := &watcher{id: 1, wps: wps}
+	wb := &watchBroadcast{
+		receivers: map[*watcher]struct{}{w: {}},
+		lg:        lg,
+	}
+
+	// First response: the initial Created emitted when the broadcast is set up.
+	wb.bcast(clientv3.WatchResponse{Header: &pb.ResponseHeader{Revision: 5}, Created: true})
+	// A normal event flows through.
+	wb.bcast(clientv3.WatchResponse{
+		Header: &pb.ResponseHeader{Revision: 6},
+		Events: []*clientv3.Event{{Kv: &mvccpb.KeyValue{Key: []byte("k"), ModRevision: 6}}},
+	})
+	// Second plain Created: the backend watcher was re-established. Must be dropped.
+	wb.bcast(clientv3.WatchResponse{Header: &pb.ResponseHeader{Revision: 7}, Created: true})
+	// A further event after re-establishment still flows through.
+	wb.bcast(clientv3.WatchResponse{
+		Header: &pb.ResponseHeader{Revision: 8},
+		Events: []*clientv3.Event{{Kv: &mvccpb.KeyValue{Key: []byte("k"), ModRevision: 8}}},
+	})
+
+	var got []*pb.WatchResponse
+	for {
+		select {
+		case resp := <-wps.watchCh:
+			got = append(got, resp)
+			continue
+		default:
+		}
+		break
+	}
+
+	require.Len(t, got, 3, "expected one Created plus two events, re-establishment Created dropped")
+
+	createdCount := 0
+	eventCount := 0
+	for _, resp := range got {
+		if resp.Created {
+			createdCount++
+			require.Empty(t, resp.Events, "Created response should carry no events")
+		} else {
+			eventCount++
+		}
+	}
+	require.Equal(t, 1, createdCount, "exactly one Created should reach the client")
+	require.Equal(t, 2, eventCount, "both events should reach the client")
+}


### PR DESCRIPTION
## Problem

When the underlying etcd watcher of a `watchBroadcast` is re-established - for example after an etcd restart or a transient proxy↔etcd disconnect - it emits a fresh `Created` response. The broadcast forwarded that second `Created` to its client receivers, which had already received their `Created` when the broadcast
was first set up.

`clientv3` matches `Created` responses to its resuming substreams **positionally** (`run()` binds an incoming `Created` to the head of the `resuming` queue, `addSubstream(pbresp, resuming[0])`). An unexpected extra
`Created` shifts the `WatchId`↔substream bindings, so one broadcast's events can be delivered to a watcher on a different key range - cross-prefix delivery. It surfaces under a re-watch storm, e.g. right after an etcd restart, when many broadcasts re-establish while clients are resuming.

We hit this in production at our company: after an etcd restart, watchers behind the grpcproxy started receiving events for key ranges they had not subscribed to.

This is likely a contributing cause behind reports such as #9988 and #18231 (events delayed/missed or delivered incorrectly through the grpc-proxy).

## Fix

Forward only the broadcast's first `Created`; drop a plain `Created` that arrives afterwards. A `Created` that also carries a cancel (e.g. compaction) is not a plain re-create and still flows through so the client rewatches. The broadcast's
first `Created` - which carries the real store revision that current-revision watches depend on - is left untouched, so the watch revision guarantee is preserved.

## Test

Adds a unit test (`watch_broadcast_test.go`) asserting that a second plain `Created` is dropped while the first `Created` and the surrounding events are still delivered.