### PR TITLE
Improve error messages in NewClient to include endpoint information

### DIFF
--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -495,8 +495,7 @@ func newClient(cfg *Config) (*Client, error) {
 	if err != nil {
 		client.cancel()
 		client.resolver.Close()
-		// TODO: Error like `fmt.Errorf(dialing [%s] failed: %v, strings.Join(cfg.Endpoints, ";"), err)` would help with debugging a lot.
-		return nil, err
+		return nil, fmt.Errorf("dialing [%s] failed: %w", strings.Join(cfg.Endpoints, ";"), err)
 	}
 	client.conn = conn
 
@@ -516,8 +515,7 @@ func newClient(cfg *Config) (*Client, error) {
 	if err != nil {
 		client.Close()
 		cancel()
-		// TODO: Consider fmt.Errorf("communicating with [%s] failed: %v", strings.Join(cfg.Endpoints, ";"), err)
-		return nil, err
+		return nil, fmt.Errorf("communicating with [%s] failed: %w", strings.Join(cfg.Endpoints, ";"), err)
 	}
 	cancel()
 


### PR DESCRIPTION
## Summary
Adds endpoint context to error messages when dial or token retrieval fails during client initialization. This improves debuggability for users with multi-endpoint configurations.

Fixes #21709

## Problem
When `NewClient()` fails to dial endpoints or retrieve tokens, the error message provides no information about which endpoints were attempted. Users debugging connection issues must add logging or instrumentation to understand which endpoints were involved in the failure.

## Solution
Wrap error returns with `fmt.Errorf()` including the endpoints list:
- Dial failure: `"dialing [endpoint1;endpoint2] failed: <original error>"`
- Token retrieval: `"communicating with [endpoint1;endpoint2] failed: <original error>"`

## Changes
- Line 498: Dial error now includes endpoints using `strings.Join(cfg.Endpoints, ";")`
- Line 519: Token retrieval error now includes endpoints
- Uses `%w` verb for proper error chain wrapping

## Testing
- Minimal change: only error message formatting
- No behavioral changes
- Existing tests continue to pass
- Error types remain compatible (wrapped with `%w`)

## Impact
**Users benefit from:**
- Clearer diagnostics when multi-endpoint configurations fail
- Reduced troubleshooting time
- Better logs for debugging connection issues

**Risk:** None - error message enhancement only, no functional changes