### PR TITLE
tests/robustness/coverage: migrate kubeadm config to v1beta4

### DIFF
--- a/tests/robustness/coverage/kind-with-tracing.yaml
+++ b/tests/robustness/coverage/kind-with-tracing.yaml
@@ -9,6 +9,7 @@ nodes:
         readOnly: true
     kubeadmConfigPatches:
       - |
+        apiVersion: kubeadm.k8s.io/v1beta4
         kind: ClusterConfiguration
         etcd:
           external:
@@ -16,7 +17,8 @@ nodes:
               - http://192.168.32.1:2379
         apiServer:
             extraArgs:
-              tracing-config-file: "/apiserver-shared-conf/tracing.yaml"
+              - name: tracing-config-file
+                value: "/apiserver-shared-conf/tracing.yaml"
             extraVolumes:
               - name: tracing
                 hostPath: "/apiserver-shared-conf"


### PR DESCRIPTION
The `ci-etcd-k8s-coverage-amd64` job builds Kubernetes from `master`, where kubeadm dropped the `v1beta3` config API. Migrate the KIND `ClusterConfiguration` to `kubeadm.k8s.io/v1beta4` so `kubeadm init` no longer rejects it.

- Failing job: [ci-etcd-k8s-coverage-amd64](https://testgrid.k8s.io/sig-etcd-periodics#ci-etcd-k8s-coverage-amd64), [example run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-k8s-coverage-amd64/2061769513220706304) failing on `your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3"`
- v1beta3 removal: [kubernetes/kubernetes#136016](https://github.com/kubernetes/kubernetes/pull/136016)
- Config reference: [kubeadm v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/)
