### PR TITLE
tests/robustness: add k8s-coverage-test make target

### DIFF
--- a/tests/robustness/Makefile
+++ b/tests/robustness/Makefile
@@ -88,6 +88,10 @@ k8s-coverage:
 	@echo "Running k8s coverage script"
 	ETCD_REPO="$(REPOSITORY_ROOT)" "$(REPOSITORY_ROOT)/tests/robustness/coverage/collect_kind_traces.sh"
 
+.PHONY: k8s-coverage-test
+k8s-coverage-test:
+	ETCD_REPO="$(REPOSITORY_ROOT)" "$(REPOSITORY_ROOT)/tests/robustness/coverage/run_coverage_test.sh"
+
 # Failpoints
 
 GOPATH = $(shell go env GOPATH)

--- a/tests/robustness/coverage/run_coverage_test.sh
+++ b/tests/robustness/coverage/run_coverage_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2026 The etcd Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "${ETCD_REPO}"
+
+export ETCD_VERIFY=all
+source ./scripts/test_lib.sh
+
+run_for_module "tests" run_go_tests "./robustness/coverage/..." -timeout=60s -run="^TestInterfaceUse/"


### PR DESCRIPTION
Lets callers run `make k8s-coverage-test` instead of sourcing `scripts/test_lib.sh` and calling its helpers by name, [as the test-infra coverage job does today](https://github.com/kubernetes/test-infra/blob/00c8d96b14b7fb652908dc26d2e221d0b24d43ef/config/jobs/etcd/etcd-periodics-main.yaml#L1146-L1147).

Follow up to https://github.com/kubernetes/test-infra/pull/37176