### PR TITLE
changelog: add v3.5.32 entry for #21815

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -9,6 +9,7 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 ### etcd server
 
 - Add [`write-only-skip-check` option for `--v2-deprecation` to bypass the v2 content check](https://github.com/etcd-io/etcd/pull/21897)
+- [server: allow non-admin maintenance status](https://github.com/etcd-io/etcd/pull/21815)
 
 ---
 


### PR DESCRIPTION
Adds the v3.5.32 TBC entry for the non-admin maintenance status backport (#21815), per @ivanvc's request on the #21815 merge.

Related: #21811 (3.6 backport, merged), #21820 (release-3.5 dep bump, merged), #21818 (earlier changelog PR, closed as obsolete since #21811 and #21820 entries already landed via release commit 0472376f).