### PR TITLE
Fix handling V2 entry in robustness tests after changes to proto

### DIFF
--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -237,7 +237,7 @@ func parseEntryNormal(ent *raftpb.Entry) (*model.EtcdRequest, error) {
 		// v3.7 protobuf can no longer parse. As a result, robustness fails when
 		// parsing those WAL entries. We intentionally ignore this error here.
 		// See https://github.com/etcd-io/etcd/pull/21263#discussion_r2776042340
-		if strings.Contains(err.Error(), "proto: wrong wireType") {
+		if errors.Is(err, proto.Error) {
 			return nil, nil
 		}
 		return nil, err

--- a/tests/robustness/report/wal_test.go
+++ b/tests/robustness/report/wal_test.go
@@ -746,3 +746,28 @@ func BenchmarkMergeMemberEntries(b *testing.B) {
 		}
 	}
 }
+
+func TestParseEntryNormal_IgnoreV2(t *testing.T) {
+	tcs := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "invalid wire format (proto: cannot parse invalid wire-format data)",
+			// 0x1a is field number 3 (RangeRequest), wire type 2 (length-delimited).
+			// Followed by length 5 and bytes that do not form a valid RangeRequest message.
+			data: []byte{0x1a, 0x05, 'a', 'b', 'c', 'd', 'e'},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ent := &raftpb.Entry{
+				Data: tc.data,
+			}
+			req, err := parseEntryNormal(ent)
+			require.NoError(t, err)
+			require.Nil(t, req)
+		})
+	}
+}


### PR DESCRIPTION
/cc @henrybear327 

Fixes https://testgrid.k8s.io/sig-etcd-robustness#ci-etcd-robustness-release36-amd64