### PR TITLE
robustness: fix downgrade test failure

### DIFF
--- a/tests/robustness/Makefile
+++ b/tests/robustness/Makefile
@@ -13,8 +13,12 @@ test-robustness-reports:
 TOPLEVEL_MAKE := $(MAKE) --directory=$(REPOSITORY_ROOT)
 
 .PHONY: test-robustness-main
-test-robustness-main: /tmp/etcd-main-failpoints/bin /tmp/etcd-release-3.6-failpoints/bin
-	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-main-failpoints/bin --bin-last-release=/tmp/etcd-release-3.6-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
+test-robustness-main: /tmp/etcd-main-failpoints/bin /tmp/etcd-release-3.7-failpoints/bin
+	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-main-failpoints/bin --bin-last-release=/tmp/etcd-release-3.7-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
+
+.PHONY: test-robustness-release-3.7
+test-robustness-release-3.7: /tmp/etcd-release-3.7-failpoints/bin /tmp/etcd-release-3.6-failpoints/bin
+	GO_TEST_FLAGS="$${GO_TEST_FLAGS} --bin-dir=/tmp/etcd-release-3.7-failpoints/bin --bin-last-release=/tmp/etcd-release-3.6-failpoints/bin/etcd" $(TOPLEVEL_MAKE) test-robustness
 
 .PHONY: test-robustness-release-3.6
 test-robustness-release-3.6: /tmp/etcd-release-3.6-failpoints/bin /tmp/etcd-release-3.5-failpoints/bin
@@ -141,6 +145,14 @@ $(GOPATH)/bin/gofail: $(REPOSITORY_ROOT)/tools/mod/go.mod $(REPOSITORY_ROOT)/too
 	  git remote add origin https://github.com/etcd-io/etcd.git; \
 	  git fetch --depth 1 origin bc47e7711664ec5557c5ae528d0d02175ea6e166; \
 	  git checkout FETCH_HEAD; \
+	  $(MAKE) gofail-enable; \
+	  $(MAKE) build;
+
+/tmp/etcd-release-3.7-failpoints/bin: $(GOPATH)/bin/gofail
+	rm -rf /tmp/etcd-release-3.7-failpoints/
+	mkdir -p /tmp/etcd-release-3.7-failpoints/
+	cd /tmp/etcd-release-3.7-failpoints/; \
+	  git clone --depth 1 --branch release-3.7 https://github.com/etcd-io/etcd.git .; \
 	  $(MAKE) gofail-enable; \
 	  $(MAKE) build;
 


### PR DESCRIPTION
From several recent robustness test runs
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-amd64/2062980951805267968
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-etcd-robustness-main-arm64/2063182783718625280

We can see 
```
Error Trace:	/home/prow/go/src/github.com/etcd-io/etcd/tests/framework/e2e/downgrade.go:41
        	            				/home/prow/go/src/github.com/etcd-io/etcd/tests/framework/testutils/execute.go:38
        	            				/home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.linux-amd64/src/runtime/asm_amd64.s:1771
        	Error:      	Received unexpected error:
        	            	[/tmp/etcd-main-failpoints/bin/etcdctl --endpoints=http://localhost:20000 downgrade enable 3.6.12] match not found.  Set EXPECT_DEBUG for more info Errs: [unexpected exit code [1] after running [/tmp/etcd-main-failpoints/bin/etcdctl --endpoints=http://localhost:20000 downgrade enable 3.6.12]], last lines:
        	            	{"level":"warn","ts":"2026-06-05T19:37:39.619956Z","logger":"etcd-client","caller":"v3/retry_interceptor.go:68","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0x36ab70732e00/localhost:20000","peer":"Peer{Addr: '127.0.0.1:20000', LocalAddr: '127.0.0.1:55318', AuthInfo: 'insecure'}","method":"/etcdserverpb.Maintenance/Downgrade","attempt":0,"error":"rpc error: code = InvalidArgument desc = etcdserver: invalid downgrade target version"}
        	            	Error: etcdserver: invalid downgrade target version
        	            	 (expected "Downgrade enable success", got []). Try EXPECT_DEBUG=TRUE
        	Test:       	TestRobustnessExploratory/KubernetesLowTraffic/ClusterOfSize1/MemberDowngradeUpgrade
```

The root cause is in the setup mechanism of the robustness test, where we assign the current and previous versions in the Makefile target. 

When we bump from 3.6 to 3.7, we also need to add a new entry.