### PR TITLE
robustness: fix mixed-version robustness test failing

### DIFF
--- a/tests/robustness/report/wal.go
+++ b/tests/robustness/report/wal.go
@@ -181,7 +181,7 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 				continue
 			}
 			if !areEntriesEqual(entryWithMostVotes, entry) {
-				diff := cmp.Diff(entryWithMostVotes, entry, protocmp.Transform(), protocmp.IgnoreDefaultScalars(), cmp.Comparer(bytes.Equal))
+				diff := cmp.Diff(transformRaftEntry(entryWithMostVotes), transformRaftEntry(entry), protocmp.Transform(), protocmp.IgnoreDefaultScalars(), cmp.Comparer(bytes.Equal))
 				return nil, fmt.Errorf("mismatching entries on raft index %d, diff: %s", raftIndex, diff)
 			}
 		}
@@ -193,14 +193,77 @@ func mergeMembersEntries(minCommitIndex uint64, memberEntries [][]*raftpb.Entry)
 	return mergedHistory, nil
 }
 
+type decodedRaftEntry struct {
+	Index uint64
+	Term  uint64
+	Type  raftpb.EntryType
+	Data  any
+}
+
+func transformRaftEntry(e *raftpb.Entry) decodedRaftEntry {
+	if e == nil {
+		return decodedRaftEntry{}
+	}
+	res := decodedRaftEntry{
+		Index: e.GetIndex(),
+		Term:  e.GetTerm(),
+		Type:  e.GetType(),
+		Data:  e.GetData(),
+	}
+	switch e.GetType() {
+	case raftpb.EntryNormal:
+		var req pb.InternalRaftRequest
+		if proto.Unmarshal(e.GetData(), &req) == nil {
+			res.Data = &req
+		}
+	case raftpb.EntryConfChange:
+		var cc raftpb.ConfChange
+		if proto.Unmarshal(e.GetData(), &cc) == nil {
+			res.Data = &cc
+		}
+	case raftpb.EntryConfChangeV2:
+		var cc raftpb.ConfChangeV2
+		if proto.Unmarshal(e.GetData(), &cc) == nil {
+			res.Data = &cc
+		}
+	}
+	return res
+}
+
 func areEntriesEqual(e1, e2 *raftpb.Entry) bool {
 	if e1 == nil || e2 == nil {
 		return e1 == e2
 	}
-	return e1.GetIndex() == e2.GetIndex() &&
-		e1.GetTerm() == e2.GetTerm() &&
-		e1.GetType() == e2.GetType() &&
-		bytes.Equal(e1.GetData(), e2.GetData())
+	if e1.GetIndex() != e2.GetIndex() ||
+		e1.GetTerm() != e2.GetTerm() ||
+		e1.GetType() != e2.GetType() {
+		return false
+	}
+	return areDataEqual(e1.GetType(), e1.GetData(), e2.GetData())
+}
+
+func areDataEqual(t raftpb.EntryType, data1, data2 []byte) bool {
+	if bytes.Equal(data1, data2) {
+		return true
+	}
+	switch t {
+	case raftpb.EntryNormal:
+		var req1, req2 pb.InternalRaftRequest
+		if proto.Unmarshal(data1, &req1) == nil && proto.Unmarshal(data2, &req2) == nil {
+			return cmp.Equal(&req1, &req2, protocmp.Transform(), protocmp.IgnoreDefaultScalars())
+		}
+	case raftpb.EntryConfChange:
+		var cc1, cc2 raftpb.ConfChange
+		if proto.Unmarshal(data1, &cc1) == nil && proto.Unmarshal(data2, &cc2) == nil {
+			return cmp.Equal(&cc1, &cc2, protocmp.Transform(), protocmp.IgnoreDefaultScalars())
+		}
+	case raftpb.EntryConfChangeV2:
+		var cc1, cc2 raftpb.ConfChangeV2
+		if proto.Unmarshal(data1, &cc1) == nil && proto.Unmarshal(data2, &cc2) == nil {
+			return cmp.Equal(&cc1, &cc2, protocmp.Transform(), protocmp.IgnoreDefaultScalars())
+		}
+	}
+	return false
 }
 
 func ReadWAL(lg *zap.Logger, dataDir string) (state *raftpb.HardState, ents []*raftpb.Entry, err error) {

--- a/tests/robustness/report/wal_test.go
+++ b/tests/robustness/report/wal_test.go
@@ -771,3 +771,44 @@ func TestParseEntryNormal_IgnoreV2(t *testing.T) {
 		})
 	}
 }
+
+func TestAreEntriesEqual_ProtobufSerializationDifference(t *testing.T) {
+	// e1 has Id field absent (Id: nil)
+	cc1 := &raftpb.ConfChange{
+		Id:      nil,
+		Type:    raftpb.ConfChangeAddNode.Enum(),
+		NodeId:  proto.Uint64(12345),
+		Context: []byte("test"),
+	}
+	data1, err := proto.Marshal(cc1)
+	require.NoError(t, err)
+
+	// e2 has Id field present with default zero (Id: 0)
+	cc2 := &raftpb.ConfChange{
+		Id:      proto.Uint64(0),
+		Type:    raftpb.ConfChangeAddNode.Enum(),
+		NodeId:  proto.Uint64(12345),
+		Context: []byte("test"),
+	}
+	data2, err := proto.Marshal(cc2)
+	require.NoError(t, err)
+
+	e1 := &raftpb.Entry{
+		Index: proto.Uint64(1),
+		Term:  proto.Uint64(1),
+		Type:  raftpb.EntryConfChange.Enum(),
+		Data:  data1,
+	}
+	e2 := &raftpb.Entry{
+		Index: proto.Uint64(1),
+		Term:  proto.Uint64(1),
+		Type:  raftpb.EntryConfChange.Enum(),
+		Data:  data2,
+	}
+
+	// They must not be byte-identical (due to Id field presence)
+	require.NotEqual(t, e1.Data, e2.Data)
+
+	// But they must be semantically equal
+	require.True(t, areEntriesEqual(e1, e2))
+}


### PR DESCRIPTION
In `areEntriesEqual`, the `data` is compared strictly. But due to the protobuf library update, v3.6 write the default value to the data, but v3.7 doesn't, causing the comparison to fail.  

Ref: https://github.com/etcd-io/etcd/issues/21908