### PR TITLE
e2e: relax TestEtcdHealthyWithTinySnapshotCatchupEntries conditions

### DIFF
--- a/tests/e2e/etcd_config_test.go
+++ b/tests/e2e/etcd_config_test.go
@@ -597,13 +597,13 @@ func TestSnapshotCatchupEntriesFlag(t *testing.T) {
 	}
 }
 
-// TestEtcdHealthyWithTinySnapshotCatchupEntries ensures multi-node etcd cluster remains healthy with 1 snapshot catch up entry
+// TestEtcdHealthyWithTinySnapshotCatchupEntries ensures multi-node etcd cluster remains healthy with 10 snapshot catch up entry
 func TestEtcdHealthyWithTinySnapshotCatchupEntries(t *testing.T) {
 	e2e.BeforeTest(t)
 	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t,
 		e2e.WithClusterSize(3),
-		e2e.WithSnapshotCount(1),
-		e2e.WithSnapshotCatchUpEntries(1),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
 	)
 	require.NoErrorf(t, err, "could not start etcd process cluster (%v)", err)
 	t.Cleanup(func() {


### PR DESCRIPTION
This specific test flakes a lot recently, and during the offline discussion, it was pointed out that the scenario used in this test is far from how Kubernetes is setting this value. 

This PR relaxed this e2e test.

Ref: 
- Tracking issue https://github.com/etcd-io/etcd/issues/21852
- Original PR https://github.com/etcd-io/etcd/pull/15033