### PR TITLE
tests: deflake revision monotonic leader restart test

### DIFF
--- a/tests/integration/revision_test.go
+++ b/tests/integration/revision_test.go
@@ -154,6 +154,7 @@ var connectionErrorMessages = []string{
 	"context deadline exceeded",
 	"etcdserver: request timed out",
 	"error reading from server: EOF",
+	"error reading from server: connection reset by peer",
 	"read: connection reset by peer",
 	"use of closed network connection",
 }


### PR DESCRIPTION
From recent CI failures
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21923/pull-etcd-integration-1-cpu-amd64/2063312304954413056
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21868/pull-etcd-integration-1-cpu-amd64/2063305935136231424
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/21868/pull-etcd-integration-2-cpu-arm64/2063305938500063232

We can see
```
Error Trace:	/home/prow/go/src/github.com/etcd-io/etcd/tests/integration/revision_test.go:119
        	            				/home/prow/go/src/github.com/etcd-io/etcd/tests/integration/revision_test.go:92
        	            				/home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.linux-arm64/src/runtime/asm_arm64.s:1447
        	Error:      	Received unexpected error:
        	            	rpc error: code = Unavailable desc = error reading from server: connection reset by peer
        	Test:       	TestRevisionMonotonicWithLeaderRestarts
```

`error reading from server: connection reset by peer` is the connection error that wasn't ignored, thus, causing the test to fail. 