### PR TITLE
dependency: bump github.com/anishathalye/porcupine from v1.1.0 to v1.3.0 and adapt the code

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 )
 
 require (
-	github.com/anishathalye/porcupine v1.1.0
+	github.com/anishathalye/porcupine v1.3.0
 	github.com/antithesishq/antithesis-sdk-go v0.7.2
 	github.com/coreos/go-semver v0.3.1
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,7 +1,7 @@
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
-github.com/anishathalye/porcupine v1.1.0 h1:jkMLqDejaWqvhvjxYKyqwQO3d1Jw+/08wHiIw0O4wcU=
-github.com/anishathalye/porcupine v1.1.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
+github.com/anishathalye/porcupine v1.3.0 h1:yo51Niv8Tg0tAAn5XOG2UVvJXUregK4WFuLrBRoowP8=
+github.com/anishathalye/porcupine v1.3.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/antithesishq/antithesis-sdk-go v0.7.2 h1:oEEedg1Xgi8drRjqB0f9tfjhLoInE0IYZfZ6zAhQUbY=
 github.com/antithesishq/antithesis-sdk-go v0.7.2/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/tests/robustness/model/non_deterministic.go
+++ b/tests/robustness/model/non_deterministic.go
@@ -16,25 +16,13 @@ package model
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
-	"sync/atomic"
 
 	"github.com/anishathalye/porcupine"
 )
-
-// LinearizationDeadlineTripped is set when linearization validation exceeds
-// its timeout.
-//
-// Porcupine currently does not propagate its timeout to the model Step
-// callback. A single non-deterministic Step can take seconds or minutes, so
-// CheckOperationsVerbose may not return promptly after its timeout expires.
-// Until etcd depends on a Porcupine version with timeout propagation, validation
-// uses this atomic flag to let Step and its helpers return early.
-//
-// See https://github.com/anishathalye/porcupine/pull/45 and https://github.com/etcd-io/etcd/pull/21715.
-var LinearizationDeadlineTripped atomic.Int32
 
 // NonDeterministicModel extends DeterministicModel to allow for clients with imperfect knowledge of the request's destiny.
 // An unknown/error response doesn't inform whether the request was persisted or not, so the model
@@ -45,8 +33,8 @@ var NonDeterministicModel = func(keys []string) porcupine.Model {
 		Init: func() any {
 			return nonDeterministicState{freshEtcdState(keys)}
 		},
-		Step: func(st any, in any, out any) (bool, any) {
-			return st.(nonDeterministicState).apply(in.(EtcdRequest), out.(MaybeEtcdResponse))
+		StepContext: func(ctx context.Context, st any, in any, out any) (bool, any) {
+			return st.(nonDeterministicState).apply(ctx, in.(EtcdRequest), out.(MaybeEtcdResponse))
 		},
 		Equal: func(st1, st2 any) bool {
 			return st1.(nonDeterministicState).Equal(st2.(nonDeterministicState))
@@ -158,34 +146,46 @@ func compareStates(first, second EtcdState) int {
 	return 0
 }
 
-func (states nonDeterministicState) apply(request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
-	if LinearizationDeadlineTripped.Load() != 0 {
+func (states nonDeterministicState) apply(ctx context.Context, request EtcdRequest, response MaybeEtcdResponse) (bool, nonDeterministicState) {
+	if ctx.Err() != nil {
 		return false, nil
 	}
 	var newStates nonDeterministicState
 	switch {
 	case response.Error != "":
-		newStates = states.applyFailedRequest(request)
+		newStates = states.applyFailedRequest(ctx, request)
 	case response.Persisted && response.PersistedRevision == 0:
-		newStates = states.applyPersistedRequest(request)
+		newStates = states.applyPersistedRequest(ctx, request)
 	case response.Persisted && response.PersistedRevision != 0:
-		newStates = states.applyPersistedRequestWithRevision(request, response.PersistedRevision)
+		newStates = states.applyPersistedRequestWithRevision(ctx, request, response.PersistedRevision)
 	default:
-		newStates = states.applyRequestWithResponse(request, response.EtcdResponse)
+		newStates = states.applyRequestWithResponse(ctx, request, response.EtcdResponse)
+	}
+	if ctx.Err() != nil {
+		return false, nil
 	}
 	return len(newStates) > 0, newStates
 }
 
 // applyFailedRequest returns both the original states and states with applied request. It considers both cases, request was persisted and request was lost.
-func (states nonDeterministicState) applyFailedRequest(request EtcdRequest) nonDeterministicState {
+func (states nonDeterministicState) applyFailedRequest(ctx context.Context, request EtcdRequest) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states)*2)
 	for _, s := range states {
-		if LinearizationDeadlineTripped.Load() != 0 {
+		if ctx.Err() != nil {
 			return nil
 		}
 		newStates = append(newStates, s)
 		newState, _ := s.Step(request)
+		if ctx.Err() != nil {
+			return nil
+		}
 		if !newState.Equal(s) {
+			if ctx.Err() != nil {
+				return nil
+			}
 			newStates = append(newStates, newState)
 		}
 	}
@@ -193,10 +193,13 @@ func (states nonDeterministicState) applyFailedRequest(request EtcdRequest) nonD
 }
 
 // applyPersistedRequest applies request to all possible states.
-func (states nonDeterministicState) applyPersistedRequest(request EtcdRequest) nonDeterministicState {
+func (states nonDeterministicState) applyPersistedRequest(ctx context.Context, request EtcdRequest) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
-		if LinearizationDeadlineTripped.Load() != 0 {
+		if ctx.Err() != nil {
 			return nil
 		}
 		newState, _ := s.Step(request)
@@ -206,10 +209,13 @@ func (states nonDeterministicState) applyPersistedRequest(request EtcdRequest) n
 }
 
 // applyPersistedRequestWithRevision applies request to all possible states, but leaves only states that would return proper revision.
-func (states nonDeterministicState) applyPersistedRequestWithRevision(request EtcdRequest, responseRevision int64) nonDeterministicState {
+func (states nonDeterministicState) applyPersistedRequestWithRevision(ctx context.Context, request EtcdRequest, responseRevision int64) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
-		if LinearizationDeadlineTripped.Load() != 0 {
+		if ctx.Err() != nil {
 			return nil
 		}
 		newState, modelResponse := s.Step(request)
@@ -221,10 +227,13 @@ func (states nonDeterministicState) applyPersistedRequestWithRevision(request Et
 }
 
 // applyRequestWithResponse applies request to all possible states, but leaves only state that would return proper response.
-func (states nonDeterministicState) applyRequestWithResponse(request EtcdRequest, response EtcdResponse) nonDeterministicState {
+func (states nonDeterministicState) applyRequestWithResponse(ctx context.Context, request EtcdRequest, response EtcdResponse) nonDeterministicState {
+	if ctx.Err() != nil {
+		return nil
+	}
 	newStates := make(nonDeterministicState, 0, len(states))
 	for _, s := range states {
-		if LinearizationDeadlineTripped.Load() != 0 {
+		if ctx.Err() != nil {
 			return nil
 		}
 		newState, modelResponse := s.Step(request)

--- a/tests/robustness/model/non_deterministic_test.go
+++ b/tests/robustness/model/non_deterministic_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -330,7 +331,7 @@ func TestModelNonDeterministic(t *testing.T) {
 			model := NonDeterministicModel(keys)
 			state := model.Init()
 			for _, op := range tc.operations {
-				ok, newState := model.Step(state, op.req, op.resp)
+				ok, newState := model.StepContext(context.Background(), state, op.req, op.resp)
 				if ok != !op.expectFailure {
 					t.Logf("state: %v", state)
 					t.Errorf("Unexpected operation result, expect: %v, got: %v, operation: %s", !op.expectFailure, ok, model.DescribeOperation(op.req, op.resp))

--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -35,34 +35,13 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
 	start := time.Now()
 
-	model.LinearizationDeadlineTripped.Store(0)
-
-	var timer *time.Timer
-	if timeout > 0 {
-		// Porcupine timeout is not always enforced (see https://github.com/anishathalye/porcupine/issues/44)
-		// Give it a small grace period before forcing the deadline from inside model execution.
-		timer = time.AfterFunc(timeout*11/10, func() {
-			model.LinearizationDeadlineTripped.Store(1)
-		})
-	}
-
 	m := model.NonDeterministicModel(keys)
 	check, info := porcupine.CheckOperationsVerbose(m, operations, timeout)
-	if timer != nil {
-		timer.Stop()
-	}
 	duration := time.Since(start)
 
 	result := LinearizationResult{
 		Info:  info,
 		Model: m,
-	}
-
-	if model.LinearizationDeadlineTripped.Load() != 0 {
-		result.Status = DeadlineExceeded
-		result.Message = "deadline exceeded"
-		lg.Error("Linearization deadline exceeded", zap.Duration("duration", duration))
-		return result
 	}
 
 	switch check {
@@ -71,6 +50,7 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, keys []string, o
 		lg.Info("Linearization success", zap.Duration("duration", duration))
 	case porcupine.Unknown:
 		result.Status = Timeout
+		result.Message = "timed out"
 		lg.Error("Linearization timed out", zap.Duration("duration", duration))
 	case porcupine.Illegal:
 		result.Status = Failure

--- a/tests/robustness/validate/operations_test.go
+++ b/tests/robustness/validate/operations_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/tests/v3/robustness/model"
 )
 
@@ -295,6 +296,7 @@ func keyValueRevision(key, value string, rev int64) model.KeyValue {
 }
 
 func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
+	testutil.RegisterLeakDetection(t)
 	timeout := time.Second
 	const failedPutCount = 17
 	// Repeat the range read to make the final applyRequestWithResponse step slow.
@@ -350,11 +352,11 @@ func TestValidateLinearizableOperationsTimeoutIsRespected(t *testing.T) {
 	result := validateLinearizableOperationsAndVisualize(zap.NewNop(), keys, history, timeout)
 	elapsed := time.Since(start)
 
-	if result.Status != DeadlineExceeded {
-		t.Fatalf("validateLinearizableOperationsAndVisualize(...) status = %q, want %q", result.Status, DeadlineExceeded)
+	if result.Status != Timeout {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) status = %q, want %q", result.Status, Timeout)
 	}
-	if result.Message != "deadline exceeded" {
-		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "deadline exceeded")
+	if result.Message != "timed out" {
+		t.Fatalf("validateLinearizableOperationsAndVisualize(...) message = %q, want %q", result.Message, "timed out")
 	}
 	if elapsed > timeout+250*time.Millisecond {
 		t.Fatalf("validateLinearizableOperationsAndVisualize(...) does not respect timeout: %v, timeout was %v", elapsed, timeout)

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -41,8 +41,6 @@ var (
 	Success ResultStatus = "Success"
 	Failure ResultStatus = "Failure"
 	Timeout ResultStatus = "Timeout"
-	// DeadlineExceeded is a workaround for Porcupine not always enforcing its timeout. It does not support visualization.
-	DeadlineExceeded ResultStatus = "DeadlineExceeded"
 )
 
 func (r RobustnessResult) Error() error {
@@ -96,6 +94,10 @@ type LinearizationResult struct {
 }
 
 func (r *LinearizationResult) Visualize(lg *zap.Logger, path string) error {
+	if r.Model.Step == nil && r.Model.StepContext == nil {
+		lg.Info("Skipping linearization visualization as model is not initialized")
+		return nil
+	}
 	err := r.Error()
 	if err != nil {
 		lg.Info("Skipping linearization visualization", zap.Error(err))

--- a/tests/robustness/validate/validate_test.go
+++ b/tests/robustness/validate/validate_test.go
@@ -188,19 +188,19 @@ func TestValidateAndReturnVisualize(t *testing.T) {
 	}
 }
 
-func TestLinearizationVisualizeSkipsDeadlineExceeded(t *testing.T) {
+func TestLinearizationVisualizeSkipsTimeout(t *testing.T) {
 	lg := zaptest.NewLogger(t)
 	path := filepath.Join(t.TempDir(), "history.html")
 	result := LinearizationResult{
 		Result: Result{
-			Status:  DeadlineExceeded,
-			Message: "deadline exceeded",
+			Status:  Timeout,
+			Message: "timed out",
 		},
 	}
 
 	require.NoError(t, result.Visualize(lg, path))
 	_, err := os.Stat(path)
-	require.Truef(t, os.IsNotExist(err), "deadline exceeded should not produce visualization")
+	require.Truef(t, os.IsNotExist(err), "timeout should not produce visualization")
 }
 
 func watchEvent(rev int64, isCreate bool, eventType model.OperationType, key, value string) model.WatchEvent {


### PR DESCRIPTION
Leverage the feature from https://github.com/anishathalye/porcupine/issues/44 for robustness test. 

We rollback all changes in https://github.com/etcd-io/etcd/pull/21771, then we adapt the PoC from https://github.com/etcd-io/etcd/pull/21715 to the latest API we have from Porcupine.