### PR TITLE
etcdserver: add TestWriteTxnPanicWithoutApply_deadlock to detect goroutine leak when write txn panics

### DIFF
--- a/server/etcdserver/txn/txn_test.go
+++ b/server/etcdserver/txn/txn_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"go.etcd.io/etcd/client/pkg/v3/testutil"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
@@ -441,6 +442,45 @@ func TestWriteTxnPanicWithoutApply(t *testing.T) {
 	// we verify the following properties below:
 	// 1. server panics after a write txn aply fails (invariant: server should never try to move on from a failed write)
 	// 2. no writes from the txn are applied to the backend (invariant: failed write should have no side-effect on DB state besides panic)
+	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}, false) }, "Expected panic in Txn with writes")
+	dbHashAfter, err := computeFileHash(bePath)
+	require.NoErrorf(t, err, "failed to compute DB file hash after txn")
+	require.Equalf(t, dbHashBefore, dbHashAfter, "mismatch in DB hash before and after failed write txn")
+}
+
+// Copy of TestWriteTxnPanicWithoutApply, but with goleak to verify that all background goroutines have exited.
+func TestWriteTxnPanicWithoutApply_deadlock(t *testing.T) {
+	testutil.RegisterLeakDetection(t)
+	b, bePath := betesting.NewDefaultTmpBackend(t)
+	s := mvcc.NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, mvcc.StoreConfig{})
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	txn := &pb.TxnRequest{
+		Success: []*pb.RequestOp{
+			{
+				Request: &pb.RequestOp_RequestPut{
+					RequestPut: &pb.PutRequest{
+						Key:   []byte("foo"),
+						Value: []byte("bar"),
+					},
+				},
+			},
+			{
+				Request: &pb.RequestOp_RequestRange{
+					RequestRange: &pb.RangeRequest{
+						Key: []byte("foo"),
+					},
+				},
+			},
+		},
+	}
+
+	dbHashBefore, err := computeFileHash(bePath)
+	require.NoErrorf(t, err, "failed to compute DB file hash before txn")
+
 	assert.Panicsf(t, func() { Txn(ctx, zaptest.NewLogger(t), txn, false, s, &lease.FakeLessor{}, false) }, "Expected panic in Txn with writes")
 	dbHashAfter, err := computeFileHash(bePath)
 	require.NoErrorf(t, err, "failed to compute DB file hash after txn")


### PR DESCRIPTION
This change adds a regression test to detect a goroutine deadlock/leak in the write transaction panic path. See issue https://github.com/etcd-io/etcd/issues/21939 for the context.

In `TestWriteTxnPanicWithoutApply`, a background goroutine can get stuck when a write txn panics before being properly finalized.

To make this issue reproducible and prevent future regressions, I added a new test `TestWriteTxnPanicWithoutApply_deadlock`, which is identical to `TestWriteTxnPanicWithoutApply` except that it uses `goleak.VerifyNone` to detect leaked goroutines.

This ensures that any failure to properly exit background goroutines will be caught by CI.

**Output from goleak when running `go test -run TestWriteTxnPanicWithoutApply_deadlock `:** 

```
--- FAIL: TestWriteTxnPanicWithoutApply_deadlock (0.48s)
    logger.go:146: 2026-06-11T11:26:48.215+0800 INFO    bbolt   Opening db file (/tmp/TestWriteTxnPanicWithoutApply_deadlock3091311943/001/etcd_backend_test1594815258/database) with mode -rw------- and with options: {Timeout: 0s, NoGrowSync: false, NoFreelistSync: true, PreLoadFreelist: false, FreelistType: , ReadOnly: false, MmapFlags: 8000, InitialMmapSize: 10737418240, PageSize: 0, MaxSize: 0, NoSync: false, OpenFile: 0x0, Mlock: false, Logger: 0x354193f32818, NoStatistics: false}
    logger.go:146: 2026-06-11T11:26:48.220+0800 INFO    bbolt   Opening bbolt db (/tmp/TestWriteTxnPanicWithoutApply_deadlock3091311943/001/etcd_backend_test1594815258/database) successfully
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Starting a new transaction [writable: true]
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Starting a new transaction [writable: true] successfully
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Starting a new transaction [writable: false]
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Starting a new transaction [writable: false] successfully
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Creating bucket if not exist "key"
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Creating bucket if not exist "key" successfully
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Creating bucket if not exist "meta"
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Creating bucket if not exist "meta" successfully
    logger.go:146: 2026-06-11T11:26:48.220+0800 DEBUG   bbolt   Committing transaction 2
    logger.go:146: 2026-06-11T11:26:48.224+0800 DEBUG   bbolt   Committing transaction 2 successfully
    logger.go:146: 2026-06-11T11:26:48.224+0800 DEBUG   bbolt   Starting a new transaction [writable: true]
    logger.go:146: 2026-06-11T11:26:48.224+0800 DEBUG   bbolt   Starting a new transaction [writable: true] successfully
    logger.go:146: 2026-06-11T11:26:48.224+0800 DEBUG   bbolt   Starting a new transaction [writable: false]
    logger.go:146: 2026-06-11T11:26:48.224+0800 DEBUG   bbolt   Starting a new transaction [writable: false] successfully
    logger.go:146: 2026-06-11T11:26:48.226+0800 INFO    kvstore restored        {"current-rev": 1}
    logger.go:146: 2026-06-11T11:26:48.238+0800 DEBUG   bbolt   Putting key "\x00\x00\x00\x00\x00\x00\x00\x02_\x00\x00\x00\x00\x00\x00\x00\x00"
    logger.go:146: 2026-06-11T11:26:48.238+0800 DEBUG   bbolt   Putting key "\x00\x00\x00\x00\x00\x00\x00\x02_\x00\x00\x00\x00\x00\x00\x00\x00" successfully
    logger.go:146: 2026-06-11T11:26:48.238+0800 PANIC   unexpected error during txn with writes {"error": "applyTxn: failed Range: rangeKeys: context cancelled: context canceled"}
    txn_test.go:488: found unexpected goroutines:
        [Goroutine 76 in state sync.Mutex.Lock, with internal/sync.runtime_SemacquireMutex on top of the stack:
        internal/sync.runtime_SemacquireMutex(0x354194280978?, 0x5c?, 0x354193fcf788?)
                /home/zhengshi357/go1.26.4/src/runtime/sema.go:95 +0x25
        internal/sync.(*Mutex).lockSlow(0x3541941c57c0)
                /home/zhengshi357/go1.26.4/src/internal/sync/mutex.go:149 +0x15d
        internal/sync.(*Mutex).Lock(...)
                /home/zhengshi357/go1.26.4/src/internal/sync/mutex.go:70
        sync.(*Mutex).Lock(...)
                /home/zhengshi357/go1.26.4/src/sync/mutex.go:46
        go.etcd.io/etcd/server/v3/storage/backend.(*batchTx).safePending(0x354193fcf778?)
                /home/zhengshi357/CCT-projects/etcd/server/storage/backend/batch_tx.go:256 +0x4b
        go.etcd.io/etcd/server/v3/storage/backend.(*backend).run(0x354194041e00)
                /home/zhengshi357/CCT-projects/etcd/server/storage/backend/backend.go:452 +0x10d
        created by go.etcd.io/etcd/server/v3/storage/backend.newBackend in goroutine 75
                /home/zhengshi357/CCT-projects/etcd/server/storage/backend/backend.go:255 +0x699
        ]
FAIL
exit status 1
FAIL    go.etcd.io/etcd/server/v3/etcdserver/txn        0.488s
```