### PR TITLE
v3rpc: allow Defragment RPC on learner members

### DIFF
--- a/server/etcdserver/api/v3rpc/util.go
+++ b/server/etcdserver/api/v3rpc/util.go
@@ -139,10 +139,15 @@ func isClientCtxErr(ctxErr error, err error) bool {
 	return false
 }
 
-// in v3.4, learner is allowed to serve serializable read and endpoint status
+// in v3.4, learner is allowed to serve serializable read and endpoint status.
+// Defragmentation is also permitted because it is a purely local maintenance
+// operation that reclaims disk space in the BoltDB file without any Raft
+// consensus involvement, making it safe to run on learner members.
 func isRPCSupportedForLearner(req any) bool {
 	switch r := req.(type) {
 	case *pb.StatusRequest:
+		return true
+	case *pb.DefragmentRequest:
 		return true
 	case *pb.RangeRequest:
 		return r.Serializable

--- a/server/etcdserver/api/v3rpc/util_test.go
+++ b/server/etcdserver/api/v3rpc/util_test.go
@@ -22,9 +22,31 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/server/v3/storage/mvcc"
 )
+
+func TestIsRPCSupportedForLearner(t *testing.T) {
+	tt := []struct {
+		req  any
+		want bool
+	}{
+		{req: &pb.StatusRequest{}, want: true},
+		{req: &pb.DefragmentRequest{}, want: true},
+		{req: &pb.RangeRequest{Serializable: true}, want: true},
+		{req: &pb.RangeRequest{Serializable: false}, want: false},
+		{req: &pb.PutRequest{}, want: false},
+		{req: &pb.DeleteRangeRequest{}, want: false},
+		{req: &pb.AlarmRequest{}, want: false},
+	}
+	for i, tc := range tt {
+		got := isRPCSupportedForLearner(tc.req)
+		if got != tc.want {
+			t.Errorf("#%d: isRPCSupportedForLearner(%T) = %v, want %v", i, tc.req, got, tc.want)
+		}
+	}
+}
 
 func TestGRPCError(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
## Problem

Learner members cannot be defragmented. Running `etcdctl defrag` skips
learner endpoints, and targeting the learner directly fails with:

```
rpc error: code = Unavailable desc = etcdserver: rpc not supported for learner
```

Over time, a learner's BoltDB file grows unbounded while voting members
can reclaim space via defragmentation. There is no supported workaround.

## Root cause

`isRPCSupportedForLearner()` in `server/etcdserver/api/v3rpc/util.go`
only permits `StatusRequest` and serializable `RangeRequest` for learner
members. `DefragmentRequest` falls through to the `default: return false`
case, causing the unary interceptor to reject it before the handler runs.

## Fix

Add `*pb.DefragmentRequest` to the set of RPCs permitted for learner members.

Defragmentation is a purely local, read-write maintenance operation on the
BoltDB file (`bbolt` compact + copy). It:
- does **not** propose any entry to the Raft log
- does **not** modify any replicated state
- does **not** require leader contact or quorum
- is already permitted on followers without restriction

Allowing it on learners is therefore safe and consistent with how it works
on voting members.

Fixes #21740