### PR TITLE
etcdctl: fix lease ID parsing and error reporting in txn comparison

### DIFF
--- a/etcdctl/ctlv3/command/txn_command.go
+++ b/etcdctl/ctlv3/command/txn_command.go
@@ -221,13 +221,15 @@ func ParseCompare(line string) (*clientv3.Cmp, error) {
 	case "val", "value":
 		cmp = clientv3.Compare(clientv3.Value(key), op, val)
 	case "lease":
-		cmp = clientv3.Compare(clientv3.LeaseValue(key), op, val)
+		if v, err = strconv.ParseInt(val, 16, 64); err == nil {
+			cmp = clientv3.Compare(clientv3.LeaseValue(key), op, v)
+		}
 	default:
 		return nil, fmt.Errorf("malformed comparison: %s (unknown target %s)", line, target)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("invalid txn compare request: %s", line)
+		return nil, fmt.Errorf("invalid txn compare request: %s (%w)", line, err)
 	}
 
 	return &cmp, nil

--- a/etcdctl/ctlv3/command/txn_command_test.go
+++ b/etcdctl/ctlv3/command/txn_command_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+func TestParseCompareLease(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		expected    *pb.Compare
+		expectedErr string
+	}{
+		{
+			name: "zero lease ID parsing",
+			line: `lease("foo") > "0"`,
+			expected: &pb.Compare{
+				Key:         []byte("foo"),
+				Target:      pb.Compare_LEASE,
+				Result:      pb.Compare_GREATER,
+				TargetUnion: &pb.Compare_Lease{Lease: 0},
+			},
+		},
+		{
+			name: "valid hex lease id",
+			line: `lease("foo") = "2d8257079fa1bc0c"`,
+			expected: &pb.Compare{
+				Key:         []byte("foo"),
+				Target:      pb.Compare_LEASE,
+				Result:      pb.Compare_EQUAL,
+				TargetUnion: &pb.Compare_Lease{Lease: 0x2d8257079fa1bc0c},
+			},
+		},
+		{
+			name:        "overflows int64",
+			line:        `lease("foo") > "ffffffffffffffff"`,
+			expectedErr: "value out of range",
+		},
+		{
+			name:        "non-hex character",
+			line:        `lease("foo") > "g"`,
+			expectedErr: "invalid syntax",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmp, err := ParseCompare(tt.line)
+
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(t, proto.Equal(tt.expected, cmp.GetCompare()))
+		})
+	}
+}


### PR DESCRIPTION
Solves #20773 

So, when a user runs a lease comparison in a txn command like below
```
λ ./bin/etcdctl txn <<<'lease("foo1") > "0"

get foo1

get foo2
'
```
it panics
```
panic: bad value

goroutine 1 [running]:
go.etcd.io/etcd/client/v3.mustInt64(...)
        go.etcd.io/etcd/client/v3/compare.go:176
go.etcd.io/etcd/client/v3.mustInt64orLeaseID(...)
        go.etcd.io/etcd/client/v3/compare.go:185
go.etcd.io/etcd/client/v3.Compare({0x804235e6380}, {0xd5f670?, 0x4?}, {0xb6f9e0, 0x80423907a40})
...
```
because the value "0" is passed as a string. All other target values are also received as strings, but they are converted to the appropriate type before being passed to `clientv3.Compare`. The lease target was missing this conversion, so the raw string was passed to `clientv3.Compare` instead of an int64.


https://github.com/etcd-io/etcd/blob/22d55b52acba4d981da3d139b6bc8912c7cadd18/etcdctl/ctlv3/command/txn_command.go#L208-L227

This causes the panic, see line 175 and 178, since `mustInt64orLeaseID` only accepts int, int64, or LeaseID

https://github.com/etcd-io/etcd/blob/22d55b52acba4d981da3d139b6bc8912c7cadd18/client/v3/compare.go#L168-L185

---

The fix parses the value to a base-16 integer before passing it to `clientv3.Compare`.  The parse errors are now wrapped with underlying reason so users get meaningful messages like below in CLI and is easy to assert specific failure causes in tests. 
```
λ ./bin/etcdctl txn <<< 'lease("foo1") > "g"'
Error: invalid txn compare request: lease("foo1") > "g" (strconv.ParseInt: parsing "g": invalid syntax)
```

