### PR TITLE
server/etcdserver/txn: defer txnWrite.End() to release batchTx lock on panic

### DIFF
--- a/server/etcdserver/txn/txn.go
+++ b/server/etcdserver/txn/txn.go
@@ -68,8 +68,12 @@ func Txn(ctx context.Context, lg *zap.Logger, rt *pb.TxnRequest, txnModeWriteWit
 	} else {
 		txnWrite = mvcc.NewReadOnlyTxnWrite(txnRead)
 	}
+	// Use defer to ensure txnWrite.End() is called even if txn() panics (e.g.
+	// when a write operation fails and lg.Panic is called). Without defer, a
+	// panic would leave the batchTx lock permanently held, causing a deadlock
+	// when the panic is recovered and the server attempts a subsequent write.
+	defer txnWrite.End()
 	txnResp, err = txn(ctx, lg, txnWrite, rt, isWrite, txnPath, skipRangeExecution)
-	txnWrite.End()
 
 	trace.AddField(
 		traceutil.Field{Key: "number_of_response", Value: len(txnResp.Responses)},


### PR DESCRIPTION
## Problem

In `server/etcdserver/txn/txn.go`, the `Txn` function opens a write
transaction via `kv.Write(trace)`, which acquires the backend `batchTx`
lock. The lock is normally released by `txnWrite.End()` after the inner
`txn()` call returns.

However, when a write operation fails inside `txn()`, the code calls
`lg.Panic(...)` (see the `isWrite` error branch). This panic unwinds the
stack before the explicit `txnWrite.End()` on the line below is reached,
leaving the `batchTx` lock permanently held.

If the panic is recovered upstream (for example in tests or middleware),
any subsequent attempt to acquire the `batchTx` lock will deadlock. This
is the root cause of the flake reported in `TestWriteTxnPanicWithoutApply`
(#21939), where the test recovers the panic via `assert.Panicsf` and the
cleanup path then tries to take the same lock.

## Fix

Replace the explicit `txnWrite.End()` call with a deferred call registered
immediately after `txnWrite` is assigned. Using `defer` guarantees the lock
is released exactly once regardless of whether the function returns normally
or unwinds due to a panic.

```go
// Before
txnWrite = kv.Write(trace)
...
txnResp, err = txn(ctx, lg, txnWrite, rt, isWrite, txnPath, skipRangeExecution)
txnWrite.End()   // <-- never reached on panic

// After
txnWrite = kv.Write(trace)
defer txnWrite.End()  // <-- always executes, even on panic
...
txnResp, err = txn(ctx, lg, txnWrite, rt, isWrite, txnPath, skipRangeExecution)
```

The same deferred call also covers the read-only path
(`mvcc.NewReadOnlyTxnWrite`) since `txnWrite` is assigned before the
defer is registered in both branches.

Fixes #21939