### PR TITLE
membership: replace Panic with Warn in IsLocalMemberLearner when member absent

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -788,11 +788,15 @@ func (c *RaftCluster) IsLocalMemberLearner() bool {
 	defer c.Unlock()
 	localMember, ok := c.members[c.localID]
 	if !ok {
-		c.lg.Panic(
-			"failed to find local ID in cluster members",
+		// The local member may have been concurrently removed (e.g. during
+		// ConfChangeRemoveNode). Treat it as a non-learner rather than
+		// panicking, which would turn a clean removal into a crash.
+		c.lg.Warn(
+			"local member ID not found in cluster members during learner check; member may have been removed",
 			zap.String("cluster-id", c.cid.String()),
 			zap.String("local-member-id", c.localID.String()),
 		)
+		return false
 	}
 	return localMember.IsLearner
 }

--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -791,7 +791,7 @@ func (c *RaftCluster) IsLocalMemberLearner() bool {
 		// The local member may have been concurrently removed (e.g. during
 		// ConfChangeRemoveNode). Treat it as a non-learner rather than
 		// panicking, which would turn a clean removal into a crash.
-		c.lg.Warn(
+		c.lg.Debug(
 			"local member ID not found in cluster members during learner check; member may have been removed",
 			zap.String("cluster-id", c.cid.String()),
 			zap.String("local-member-id", c.localID.String()),

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -548,6 +548,31 @@ func TestClusterAddMemberAsLearner(t *testing.T) {
 	})
 }
 
+func TestIsLocalMemberLearner(t *testing.T) {
+	// localID present, member is a learner
+	c := newTestCluster(t, nil)
+	c.localID = types.ID(1)
+	c.AddMember(newTestMemberAsLearner(1, []string{}, "node1", []string{"http://node1"}), true)
+	if !c.IsLocalMemberLearner() {
+		t.Error("expected local member to be learner")
+	}
+
+	// localID present, member is a voter
+	c2 := newTestCluster(t, nil)
+	c2.localID = types.ID(2)
+	c2.AddMember(newTestMember(2, []string{}, "node2", []string{"http://node2"}), true)
+	if c2.IsLocalMemberLearner() {
+		t.Error("expected local voter member to not be learner")
+	}
+
+	// localID absent (concurrent removal window): must return false without panicking
+	c3 := newTestCluster(t, nil)
+	c3.localID = types.ID(99)
+	if c3.IsLocalMemberLearner() {
+		t.Error("expected absent local member to report non-learner")
+	}
+}
+
 func TestClusterMembers(t *testing.T) {
 	cls := newTestCluster(t, []*Member{
 		{ID: 1},


### PR DESCRIPTION
## Root cause

`RaftCluster.IsLocalMemberLearner()` calls `c.lg.Panic(...)` when the local
member ID is absent from `c.members`. During a `ConfChangeRemoveNode`, the
apply goroutine deletes `localID` from `c.members` before the gRPC server is
closed. Any in-flight `Maintenance/Status` RPC that calls `IsLocalMemberLearner`
during this narrow window panics with exit code 2 instead of shutting down
cleanly.

## Fix

The missing-member case is an expected race between member removal and RPC
drain, not a programming error. Replacing `Panic` with `Warn` + `return false`
lets concurrent handlers finish without crashing the server. Returning `false`
(non-learner) is a safe sentinel: callers use this value to decide whether to
allow certain operations on learners; treating a just-removed member as a
non-learner has no harmful side-effects during shutdown.

## Testing

- The issue includes a standalone reproducer that triggers the panic reliably.
- Existing membership unit tests continue to pass (`go test ./server/etcdserver/api/membership/...`).

Fixes #21966