### PR TITLE
Patch MustVerifyIfEnabled with Unreachable in Antithesis

### DIFF
--- a/tests/antithesis/server/Dockerfile
+++ b/tests/antithesis/server/Dockerfile
@@ -16,10 +16,12 @@ RUN for file in $(grep -rl '// gofail'); do sed -i 's|\/\/ gofail.*var \([[:alnu
 RUN go mod tidy
 
 # replace verify with antithesis
-WORKDIR /etcd/client/pkg/verify
-COPY inject/verify.patch verify.patch
-RUN if [ "${REF}" = "main" ]; then git apply verify.patch; fi
+WORKDIR /etcd
+COPY inject/* .
+RUN if [ "${REF}" = "main" ]; then git apply *.patch; fi
 WORKDIR /etcd/client/pkg
+RUN go mod tidy
+WORKDIR /etcd/server
 RUN go mod tidy
 WORKDIR /etcd
 

--- a/tests/antithesis/server/inject/mustverifyifenabled.patch
+++ b/tests/antithesis/server/inject/mustverifyifenabled.patch
@@ -1,0 +1,29 @@
+diff --git a/server/verify/verify.go b/server/verify/verify.go
+index 1eb68b2b0..ed9648b4a 100644
+--- a/server/verify/verify.go
++++ b/server/verify/verify.go
+@@ -27,6 +27,8 @@ import (
+ 	wal2 "go.etcd.io/etcd/server/v3/storage/wal"
+ 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+ 	"go.etcd.io/raft/v3/raftpb"
++
++	"github.com/antithesishq/antithesis-sdk-go/assert"
+ )
+ 
+ const envVerifyValueStorageWAL verify.VerificationType = "storage_wal"
+@@ -102,9 +104,12 @@ func VerifyIfEnabled(cfg Config) error {
+ // See Verify for more information.
+ func MustVerifyIfEnabled(cfg Config) {
+ 	if err := VerifyIfEnabled(cfg); err != nil {
+-		cfg.Logger.Fatal("Verification failed",
+-			zap.String("data-dir", cfg.DataDir),
+-			zap.Error(err))
++		assert.Unreachable("Verification failed",
++			map[string]any{
++				"data-dir": cfg.DataDir,
++				"error":    err,
++			},
++		)
+ 	}
+ }
+ 


### PR DESCRIPTION
Fix #21775 

From the extracted container's rootfs, I could see that the content was patched as intended:
```
    /tmp/extracted/serverunpacked/rootfs/etcd  on   main !21 ?2  git --no-pager diff server/verify                                                                   ✔    at 23:18:02 
diff --git a/server/verif   /ty/verify.go b/server/verify/verify.go
index 1eb68b2..ed9648b 100644
--- a/server/verify/verify.go
+++ b/server/verify/verify.go
@@ -27,6 +27,8 @@ import (
 	wal2 "go.etcd.io/etcd/server/v3/storage/wal"
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
 	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 )

 const envVerifyValueStorageWAL verify.VerificationType = "storage_wal"
@@ -102,9 +104,12 @@ func VerifyIfEnabled(cfg Config) error {
 // See Verify for more information.
 func MustVerifyIfEnabled(cfg Config) {
 	if err := VerifyIfEnabled(cfg); err != nil {
-		cfg.Logger.Fatal("Verification failed",
-			zap.String("data-dir", cfg.DataDir),
-			zap.Error(err))
+		assert.Unreachable("Verification failed",
+			map[string]any{
+				"data-dir": cfg.DataDir,
+				"error":    err,
+			},
+		)
 	}
 }
```

cc @serathius @marcus-hodgson-antithesis 
