### PR TITLE
client/v3: remove cancelled substream from w.substreams before closing recvc

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -623,6 +623,11 @@ func (w *watchGRPCStream) run() {
 					// signal to stream goroutine to update closingc
 					close(ws.recvc)
 					closing[ws] = struct{}{}
+					// Remove from substreams immediately so broadcastResponse does not
+					// attempt to send on the now-closed recvc channel, which would panic.
+					// closeSubstream will still be called when closingc is drained; the
+					// redundant delete there is a safe no-op.
+					delete(w.substreams, pbresp.WatchId)
 				}
 
 				// reset for next iteration

--- a/client/v3/watch_test.go
+++ b/client/v3/watch_test.go
@@ -204,3 +204,53 @@ func TestServeSubstreamLogsSlowConsumer(t *testing.T) {
 	}
 	w.wg.Wait()
 }
+
+// TestBroadcastResponseNoPanicOnCancelledSubstream is a regression test for
+// https://github.com/etcd-io/etcd/issues/21969.
+//
+// When a cancel response is received in run(), ws.recvc is closed and the
+// substream is removed from w.substreams.  If a progress-notify response
+// arrives before closeSubstream drains closingc, broadcastResponse iterates
+// w.substreams and would previously panic with "send on closed channel"
+// because the cancelled substream was still present.  The fix removes the
+// substream from w.substreams eagerly at cancel time so broadcastResponse
+// never encounters a closed recvc.
+func TestBroadcastResponseNoPanicOnCancelledSubstream(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ws := &watcherStream{
+		initReq: watchRequest{ctx: ctx},
+		outc:    make(chan WatchResponse, 1),
+		recvc:   make(chan *WatchResponse, 1),
+		donec:   make(chan struct{}),
+		id:      1,
+	}
+
+	w := &watchGRPCStream{
+		ctx:        t.Context(),
+		substreams: map[int64]*watcherStream{1: ws},
+		closingc:   make(chan *watcherStream, 1),
+		lg:         zap.NewNop(),
+	}
+
+	// Reproduce the fixed cancel-response path: close ws.recvc and immediately
+	// remove the substream from w.substreams so that broadcastResponse cannot
+	// send on the closed channel.
+	close(ws.recvc)
+	delete(w.substreams, ws.id)
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		w.broadcastResponse(&WatchResponse{Header: &pb.ResponseHeader{Revision: 1}})
+	}()
+
+	if panicked {
+		t.Fatal("broadcastResponse panicked after substream was removed from w.substreams")
+	}
+}

--- a/client/v3/watch_test.go
+++ b/client/v3/watch_test.go
@@ -216,41 +216,63 @@ func TestServeSubstreamLogsSlowConsumer(t *testing.T) {
 // substream from w.substreams eagerly at cancel time so broadcastResponse
 // never encounters a closed recvc.
 func TestBroadcastResponseNoPanicOnCancelledSubstream(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	ws := &watcherStream{
-		initReq: watchRequest{ctx: ctx},
-		outc:    make(chan WatchResponse, 1),
-		recvc:   make(chan *WatchResponse, 1),
-		donec:   make(chan struct{}),
-		id:      1,
+	newStream := func(t *testing.T) (*watcherStream, *watchGRPCStream) {
+		t.Helper()
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		ws := &watcherStream{
+			initReq: watchRequest{ctx: ctx},
+			outc:    make(chan WatchResponse, 1),
+			recvc:   make(chan *WatchResponse, 1),
+			donec:   make(chan struct{}),
+			id:      1,
+		}
+		w := &watchGRPCStream{
+			ctx:        t.Context(),
+			substreams: map[int64]*watcherStream{1: ws},
+			closingc:   make(chan *watcherStream, 1),
+			lg:         zap.NewNop(),
+		}
+		return ws, w
 	}
 
-	w := &watchGRPCStream{
-		ctx:        t.Context(),
-		substreams: map[int64]*watcherStream{1: ws},
-		closingc:   make(chan *watcherStream, 1),
-		lg:         zap.NewNop(),
-	}
+	// Verify that sending on a closed recvc still present in substreams causes
+	// a panic — this is the pre-fix bug state that the fix must prevent.
+	t.Run("panics when closed recvc is still in substreams", func(t *testing.T) {
+		ws, w := newStream(t)
+		close(ws.recvc)
+		// Do NOT remove ws from substreams: simulate the bug.
 
-	// Reproduce the fixed cancel-response path: close ws.recvc and immediately
-	// remove the substream from w.substreams so that broadcastResponse cannot
-	// send on the closed channel.
-	close(ws.recvc)
-	delete(w.substreams, ws.id)
-
-	panicked := false
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				panicked = true
-			}
+		var recovered any
+		func() {
+			defer func() { recovered = recover() }()
+			w.broadcastResponse(&WatchResponse{Header: &pb.ResponseHeader{Revision: 1}})
 		}()
-		w.broadcastResponse(&WatchResponse{Header: &pb.ResponseHeader{Revision: 1}})
-	}()
+		if recovered == nil {
+			t.Fatal("expected panic when closed recvc is still in substreams — test setup may be wrong")
+		}
+	})
 
-	if panicked {
-		t.Fatal("broadcastResponse panicked after substream was removed from w.substreams")
-	}
+	// Verify that removing the substream from w.substreams before broadcasting
+	// (what run() now does eagerly at cancel time) prevents the panic.
+	t.Run("no panic after substream removed from substreams", func(t *testing.T) {
+		ws, w := newStream(t)
+		close(ws.recvc)
+		// Mimic the fix: run() now deletes the substream from w.substreams
+		// immediately after close(ws.recvc), before any broadcastResponse call.
+		delete(w.substreams, ws.id)
+
+		panicked := false
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked = true
+				}
+			}()
+			w.broadcastResponse(&WatchResponse{Header: &pb.ResponseHeader{Revision: 1}})
+		}()
+		if panicked {
+			t.Fatal("broadcastResponse panicked after substream was removed from w.substreams")
+		}
+	})
 }


### PR DESCRIPTION
## Root cause

When a watch cancel response arrives in `run()`, `ws.recvc` is closed and
the substream is added to the `closing` map — but it is **not** removed from
`w.substreams`.

If a progress-notify response (`WatchId == InvalidWatchID`) is received
before `closingc` is drained, `broadcastResponse` iterates every entry in
`w.substreams` and executes:

```go
case ws.recvc <- wr:
```

Sending on an already-closed channel panics with `"send on closed channel"`.

## Fix

Delete the cancelled substream from `w.substreams` immediately after
`close(ws.recvc)`, closing the race window.  `closeSubstream` still calls
`delete(w.substreams, ws.id)` when `closingc` is drained; the redundant
delete is a safe no-op on a map.

## Test

Added `TestBroadcastResponseNoPanicOnCancelledSubstream` which reproduces
the race window (close `ws.recvc`, remove from `w.substreams`, then call
`broadcastResponse`) and asserts no panic occurs.

Fixes #21969