### PR TITLE
server: commit compaction deletes after unlocking batch tx

### DIFF
--- a/server/storage/backend/batch_tx.go
+++ b/server/storage/backend/batch_tx.go
@@ -54,6 +54,7 @@ type BatchTx interface {
 	CommitAndStop()
 	LockInsideApply()
 	LockOutsideApply()
+	UnsafeDeleteForCompaction(bucket Bucket, key []byte)
 	UnsafeReadWriter
 }
 
@@ -224,6 +225,10 @@ func (t *batchTx) UnsafeDelete(bucketType Bucket, key []byte) {
 		)
 	}
 	t.pending++
+}
+
+func (t *batchTx) UnsafeDeleteForCompaction(bucketType Bucket, key []byte) {
+	t.UnsafeDelete(bucketType, key)
 }
 
 // UnsafeForEach must be called holding the lock on the tx.
@@ -398,6 +403,10 @@ func (t *batchTxBuffered) UnsafeSeqPut(bucket Bucket, key []byte, value []byte) 
 func (t *batchTxBuffered) UnsafeDelete(bucketType Bucket, key []byte) {
 	t.batchTx.UnsafeDelete(bucketType, key)
 	t.pendingDeleteOperations++
+}
+
+func (t *batchTxBuffered) UnsafeDeleteForCompaction(bucketType Bucket, key []byte) {
+	t.batchTx.UnsafeDeleteForCompaction(bucketType, key)
 }
 
 func (t *batchTxBuffered) UnsafeDeleteBucket(bucket Bucket) {

--- a/server/storage/backend/compaction_delete_benchmark_test.go
+++ b/server/storage/backend/compaction_delete_benchmark_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend_test
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/schema"
+)
+
+func BenchmarkCompactionDeleteApplyWait(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		compaction bool
+	}{
+		{name: "DeleteCommitOnUnlock"},
+		{name: "CompactionDeleteCommitAfterUnlock", compaction: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			be, keys := newCompactionBenchmarkBackend(b)
+			defer be.Close()
+			tx := be.BatchTx()
+
+			b.StopTimer()
+			for i := range b.N {
+				tx.Lock()
+				if tc.compaction {
+					tx.UnsafeDeleteForCompaction(schema.Test, keys[i])
+				} else {
+					tx.UnsafeDelete(schema.Test, keys[i])
+				}
+
+				started := make(chan struct{})
+				done := make(chan struct{})
+				go func() {
+					close(started)
+					tx.Lock()
+					tx.Unlock()
+					close(done)
+				}()
+				<-started
+				// A real apply waiter can spend milliseconds behind a compaction
+				// batch. Ensure the waiter is queued before compaction unlocks.
+				time.Sleep(2 * time.Millisecond)
+
+				b.StartTimer()
+				tx.Unlock()
+				<-done
+				b.StopTimer()
+
+				if tc.compaction {
+					be.ForceCommit()
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCompactionDeleteBatch(b *testing.B) {
+	for _, tc := range []struct {
+		name       string
+		compaction bool
+	}{
+		{name: "DeleteCommitOnUnlock"},
+		{name: "CompactionDeleteCommitAfterUnlock", compaction: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			be, keys := newCompactionBenchmarkBackend(b)
+			defer be.Close()
+			tx := be.BatchTx()
+
+			for i := range b.N {
+				tx.Lock()
+				if tc.compaction {
+					tx.UnsafeDeleteForCompaction(schema.Test, keys[i])
+				} else {
+					tx.UnsafeDelete(schema.Test, keys[i])
+				}
+				tx.Unlock()
+				if tc.compaction {
+					be.ForceCommit()
+				}
+			}
+		})
+	}
+}
+
+func newCompactionBenchmarkBackend(b *testing.B) (backend.Backend, [][]byte) {
+	cfg := backend.DefaultBackendConfig(zap.NewNop())
+	cfg.Path = filepath.Join(b.TempDir(), "database")
+	cfg.BatchInterval = time.Hour
+	cfg.BatchLimit = 10000
+	be := backend.New(cfg)
+	tx := be.BatchTx()
+	tx.Lock()
+	tx.UnsafeCreateBucket(schema.Test)
+	keys := make([][]byte, b.N)
+	for i := range b.N {
+		keys[i] = make([]byte, 8)
+		binary.BigEndian.PutUint64(keys[i], uint64(i))
+		tx.UnsafePut(schema.Test, keys[i], []byte("value"))
+	}
+	tx.Unlock()
+	be.ForceCommit()
+	return be, keys
+}

--- a/server/storage/mvcc/kvstore_compaction.go
+++ b/server/storage/mvcc/kvstore_compaction.go
@@ -54,17 +54,24 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 		for i := range keys {
 			rev = BytesToRev(keys[i])
 			if _, ok := keep[rev]; !ok {
-				tx.UnsafeDelete(schema.Key, keys[i])
+				tx.UnsafeDeleteForCompaction(schema.Key, keys[i])
 				keyCompactions++
 			}
 			h.WriteKeyValue(keys[i], values[i])
 		}
 
-		if len(keys) < batchNum {
+		finished := len(keys) < batchNum
+		if finished {
 			// gofail: var compactBeforeSetFinishedCompact struct{}
 			UnsafeSetFinishedCompact(tx, compactMainRev)
-			tx.Unlock()
-			dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
+		}
+		tx.Unlock()
+
+		s.b.ForceCommit()
+		// gofail: var compactAfterCommitBatch struct{}
+		dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
+
+		if finished {
 			// gofail: var compactAfterSetFinishedCompact struct{}
 			hash := h.Hash()
 			size, sizeInUse := s.b.Size(), s.b.SizeInUse()
@@ -82,14 +89,8 @@ func (s *store) scheduleCompaction(compactMainRev, prevCompactRev int64) (KeyVal
 			return hash, nil
 		}
 
-		tx.Unlock()
 		// update last
 		last = RevToBytes(Revision{Main: rev.Main, Sub: rev.Sub + 1}, last)
-		// Immediately commit the compaction deletes instead of letting them accumulate in the write buffer
-		// gofail: var compactBeforeCommitBatch struct{}
-		s.b.ForceCommit()
-		// gofail: var compactAfterCommitBatch struct{}
-		dbCompactionPauseMs.Observe(float64(time.Since(start) / time.Millisecond))
 
 		select {
 		case <-time.After(s.cfg.CompactionSleepInterval):


### PR DESCRIPTION
This PR reduces lock contention during compaction deletes.

Previously, compaction synchronously committed bbolt while holding the batch-tx lock after deleting old revisions. Any apply operation queued behind it had to wait for the fsync to complete.

The change releases the batch-tx lock before committing, so queued apply operations can proceed without being blocked by compaction’s fsync.

Normal client deletes are unchanged and retain their existing immediate-commit semantics.