### PR TITLE
server/storage/backend: dedupe intra-batch duplicate keys on the buffer merge path

### DIFF
--- a/server/storage/backend/tx_buffer.go
+++ b/server/storage/backend/tx_buffer.go
@@ -104,9 +104,8 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 			txr.buckets[k] = wb
 			continue
 		}
-		if seq, ok := txw.bucket2seq[k]; ok && !seq && wb.used > 1 {
-			// assume no duplicate keys
-			sort.Sort(wb)
+		if seq, ok := txw.bucket2seq[k]; ok && !seq {
+			wb.dedupe()
 		}
 		rb.merge(wb)
 	}
@@ -213,6 +212,7 @@ func (bb *bucketBuffer) add(k, v []byte) {
 
 // merge merges data from bbsrc into bb.
 func (bb *bucketBuffer) merge(bbsrc *bucketBuffer) {
+	bbsrc.dedupe()
 	for i := 0; i < bbsrc.used; i++ {
 		bb.add(bbsrc.buf[i].key, bbsrc.buf[i].val)
 	}

--- a/server/storage/backend/tx_buffer_test.go
+++ b/server/storage/backend/tx_buffer_test.go
@@ -140,3 +140,24 @@ func TestDedupe(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeNoOverlapKeepsNewestForIntraBatchDuplicate(t *testing.T) {
+	// read buffer already holds a key strictly less than the src keys,
+	// so bucketBuffer.merge takes the no-overlap fast-path (around line 222).
+	rb := &bucketBuffer{buf: make([]kv, 10), used: 0}
+	rb.add([]byte("a"), []byte("1"))
+
+	// write buffer holds the SAME key twice (a key overwritten within one batch):
+	// pre-ordered OLD-before-NEW so the test does not depend on Go's sort behavior.
+	wb := &bucketBuffer{buf: make([]kv, 10), used: 0}
+	wb.add([]byte("k"), []byte("OLD"))
+	wb.add([]byte("k"), []byte("NEW"))
+
+	rb.merge(wb) // 'a' < 'k' -> no-overlap fast-path returns WITHOUT dedupe (the bug)
+
+	// limit=1 single-key read, as read_tx forces for endKey==nil on a non-safeRange bucket
+	keys, vals := rb.Range([]byte("k"), nil, 1)
+	assert.Equal(t, [][]byte{[]byte("k")}, keys)
+	// EXPECT newest; buggy code returns the stale "OLD" (smallest-index match)
+	assert.Equal(t, [][]byte{[]byte("NEW")}, vals)
+}


### PR DESCRIPTION
Fixes #21986

## What

`bucketBuffer.merge` could leave a source-internal duplicate key in the merged buffer, so a key written twice within one batch could read back its OLD value through the read buffer even though the buffer's contract is newest-wins. This makes the merge path dedupe source-internal duplicates the way the direct-assign path already does, so the no-overlap fast-path can no longer leave a stale duplicate behind. It is a fix for a transient in-memory stale read; committed bbolt data was never affected.

## Why

When the read buffer already holds a bucket, `txWriteBuffer.writeback` folds the write buffer in via `merge`. `merge` appends the source entries and then takes a no-overlap fast-path that returns early without calling `dedupe` when the source's smallest key is greater than the destination's largest key. That check only guards the destination/source boundary; it is blind to duplicates internal to the source. `put`/`putInternal`/`add` append unconditionally, so a key put twice in one batch produces `[(k,OLD),(k,NEW)]` in the source, and that duplicate survives the fast-path.

A later single-key read forces `limit=1` (`read_tx.go` `UnsafeRange` for `endKey == nil`), and `bucketBuffer.Range` uses `sort.Search`, which returns the smallest matching index. Because `UnsafeRange` returns as soon as the buffer satisfies the limit, the read returns the stale OLD value and never consults bbolt. This affects non-safeRange buckets (Meta, Lease, Auth, Cluster, Alarm); Meta holds the consistent index and is read with exactly this single-key shape.

The newest-wins behavior is the documented dedupe contract and is pinned by `TestDedupe`. The other `writeback` path already calls `wb.dedupe()`; only the merge path skipped it, behind a `// assume no duplicate keys` comment that the put path does not enforce.

## Test

Added a unit test that drives `merge` directly with a pre-ordered source holding an intra-batch duplicate, so it is deterministic and independent of Go's sort behavior. It takes the no-overlap fast-path and asserts the single-key `Range` returns the newest value. The test fails before the change (returns OLD) and passes after.

I prepared this change with the assistance of generative AI tooling. I reviewed every line, traced the affected code paths, and confirmed the test fails before and passes after the fix.
