### PR TITLE
server/storage/backend: dedupe intra-batch duplicate keys in writeback before merge

### DIFF
--- a/server/storage/backend/tx_buffer.go
+++ b/server/storage/backend/tx_buffer.go
@@ -104,9 +104,8 @@ func (txw *txWriteBuffer) writeback(txr *txReadBuffer) {
 			txr.buckets[k] = wb
 			continue
 		}
-		if seq, ok := txw.bucket2seq[k]; ok && !seq && wb.used > 1 {
-			// assume no duplicate keys
-			sort.Sort(wb)
+		if seq, ok := txw.bucket2seq[k]; ok && !seq {
+			wb.dedupe()
 		}
 		rb.merge(wb)
 	}

--- a/server/storage/backend/tx_buffer_test.go
+++ b/server/storage/backend/tx_buffer_test.go
@@ -21,6 +21,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testBucket struct {
+	id   BucketID
+	name []byte
+}
+
+func (b testBucket) ID() BucketID            { return b.id }
+func (b testBucket) Name() []byte            { return b.name }
+func (b testBucket) String() string          { return string(b.name) }
+func (b testBucket) IsSafeRangeBucket() bool { return false }
+
 func Test_bucketBuffer_CopyUsed_After_Add(t *testing.T) {
 	bb := &bucketBuffer{buf: make([]kv, 10), used: 0}
 	for i := 0; i < 20; i++ {
@@ -89,6 +99,32 @@ func Test_bucketBuffer_CopyUsed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWritebackDedupesIntraBatchDuplicateForNonSeqBucket(t *testing.T) {
+	bucket := testBucket{id: 1, name: []byte("test")}
+	txw := &txWriteBuffer{
+		txBuffer:   txBuffer{buckets: make(map[BucketID]*bucketBuffer)},
+		bucket2seq: make(map[BucketID]bool),
+	}
+	txw.put(bucket, []byte("k"), []byte("OLD"))
+	txw.put(bucket, []byte("k"), []byte("NEW"))
+
+	rb := &bucketBuffer{buf: make([]kv, 10), used: 0}
+	rb.add([]byte("a"), []byte("1"))
+	txr := &txReadBuffer{
+		txBuffer: txBuffer{
+			buckets: map[BucketID]*bucketBuffer{
+				bucket.ID(): rb,
+			},
+		},
+	}
+
+	txw.writeback(txr)
+
+	keys, vals := txr.Range(bucket, []byte("k"), nil, 1)
+	assert.Equal(t, [][]byte{[]byte("k")}, keys)
+	assert.Equal(t, [][]byte{[]byte("NEW")}, vals)
 }
 
 func TestDedupe(t *testing.T) {


### PR DESCRIPTION
When the read buffer already holds a bucket, `txWriteBuffer.writeback` folds the write buffer in via `bucketBuffer.merge`. The non-sequential path was sorting and assuming no duplicate keys, but `put`/`putInternal`/`add` append unconditionally, so a key overwritten twice in one batch (e.g. `[(k,OLD),(k,NEW)]`) survived the merge. A subsequent single-key read with `endKey == nil` forces `limit=1`, and `bucketBuffer.Range`/`sort.Search` returns the smallest-index match, returning the stale `OLD` value from the in-memory buffer.

This change makes the non-sequential branch in `writeback` call `wb.dedupe()` before `rb.merge(wb)`, mirroring the sibling delete branch and honoring the newest-wins contract that `TestDedupe` pins. `bucketBuffer.merge` itself is intentionally left unchanged: its only caller (`writeback`) now guarantees the source is duplicate-free for non-seq buckets, and adding dedupe inside merge would double-dedupe non-seq buckets while needlessly sorting the hot sequential `Key`/revision bucket on every merge.

Resolves #21986

Changes:
- `server/storage/backend/tx_buffer.go`: in `txWriteBuffer.writeback`, replace the non-sequential `sort.Sort(wb)` (gated on `wb.used > 1`) with `wb.dedupe()` for the read-buffer-already-has-bucket branch.
- `server/storage/backend/tx_buffer_test.go`: add `TestWritebackDedupesIntraBatchDuplicateForNonSeqBucket`, a regression test that exercises the bug through the real `writeback` path on a non-sequential bucket. It puts the same key twice in one batch, primes the read buffer with a smaller key so the no-overlap merge fast-path fires, calls `txw.writeback(txr)`, and asserts that the subsequent `txr.Range(bucket, key, nil, 1)` returns `NEW`. The test fails on the previous `sort.Sort` logic and passes after the fix.

This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.