### PR TITLE
[release-3.5] server/auth: avoid logging for JWT token for a case of failed parsing

### DIFF
--- a/server/auth/jwt.go
+++ b/server/auth/jwt.go
@@ -62,7 +62,6 @@ func (t *tokenJWT) info(ctx context.Context, token string, rev uint64) (*AuthInf
 	if err != nil {
 		t.lg.Warn(
 			"failed to parse a JWT token",
-			zap.String("token", token),
 			zap.Error(err),
 		)
 		return nil, false
@@ -70,7 +69,7 @@ func (t *tokenJWT) info(ctx context.Context, token string, rev uint64) (*AuthInf
 
 	claims, ok := parsed.Claims.(jwt.MapClaims)
 	if !parsed.Valid || !ok {
-		t.lg.Warn("invalid JWT token", zap.String("token", token))
+		t.lg.Warn("failed to obtain claims from a JWT token")
 		return nil, false
 	}
 


### PR DESCRIPTION
- cherry picked from commit 2e74e4d636654b2879bf7fd32a9e14e9c621d725