### PR TITLE
tools: add continuous reporting feature to benchmark tool

### DIFF
--- a/tools/benchmark/cmd/live_report.go
+++ b/tools/benchmark/cmd/live_report.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// This file provides shared helpers for periodic live reporting of benchmark
+// metrics, enabled when --report-interval is set to a positive value.
+// Commands that support this feature and must emit a JSON-lines stream of
+// in-progress stats to stdout (keeping the final summary on stderr) use the
+// types and functions in this file.
+
+// intervalTracker accumulates operation latencies for one reporting window.
+// Call snapshot() at the end of each tick to drain the window and get a copy.
+type intervalTracker struct {
+	mu    sync.Mutex
+	lats  []float64
+	start time.Time
+}
+
+func newIntervalTracker() *intervalTracker {
+	return &intervalTracker{start: time.Now()}
+}
+
+// add records the latency of a single completed operation.
+func (t *intervalTracker) add(dur time.Duration) {
+	t.mu.Lock()
+	t.lats = append(t.lats, dur.Seconds())
+	t.mu.Unlock()
+}
+
+// snapshot returns a copy of the latencies accumulated since the last snapshot
+// (or since creation), together with the elapsed duration of that window in
+// seconds, and then resets the window for the next interval.
+func (t *intervalTracker) snapshot() (lats []float64, elapsed float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	lats = append([]float64(nil), t.lats...)
+	elapsed = time.Since(t.start).Seconds()
+	t.lats = nil
+	t.start = time.Now()
+	return lats, elapsed
+}
+
+// summarize computes descriptive statistics for a set of latency samples (in
+// seconds) observed over an elapsed interval (in seconds).
+func summarize(lats []float64, elapsed float64) (ops int, rps, avg, stddev, p50, p90, p99 float64) {
+	ops = len(lats)
+	if ops == 0 || elapsed == 0 {
+		return ops, rps, avg, stddev, p50, p90, p99
+	}
+
+	cp := append([]float64(nil), lats...)
+	sort.Float64s(cp)
+
+	var sum float64
+	for _, v := range cp {
+		sum += v
+	}
+	avg = sum / float64(ops)
+	rps = float64(ops) / elapsed
+
+	var variance float64
+	for _, v := range cp {
+		d := v - avg
+		variance += d * d
+	}
+	stddev = math.Sqrt(variance / float64(ops))
+
+	idx := func(p float64) int {
+		return int(p / 100.0 * float64(len(cp)-1))
+	}
+	p50 = cp[idx(50)]
+	p90 = cp[idx(90)]
+	p99 = cp[idx(99)]
+	return ops, rps, avg, stddev, p50, p90, p99
+}
+
+// singleLiveSnapshot is the JSON record emitted to stdout on each tick by
+// single-metric commands (put, range, txn-put, stm). Latency fields use
+// seconds as the unit, matching the existing report package convention.
+type singleLiveSnapshot struct {
+	ID        uint64  `json:"id"`
+	Timestamp string  `json:"ts"`
+	Elapsed   float64 `json:"elapsed_sec"`
+	Ops       int     `json:"ops"`
+	RPS       float64 `json:"rps"`
+	Avg       float64 `json:"avg_s"`
+	StdDev    float64 `json:"stddev_s"`
+	P50       float64 `json:"p50_s"`
+	P90       float64 `json:"p90_s"`
+	P99       float64 `json:"p99_s"`
+}
+
+// startSingleLiveReporter launches a background goroutine that emits one
+// singleLiveSnapshot JSON line to stdout every intervalSec seconds.
+// Close the returned channel to stop the reporter cleanly.
+func startSingleLiveReporter(intervalSec int, tracker *intervalTracker) chan struct{} {
+	stop := make(chan struct{})
+	var id uint64
+	ticker := time.NewTicker(time.Duration(intervalSec) * time.Second)
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				lats, elapsed := tracker.snapshot()
+				if len(lats) == 0 {
+					continue
+				}
+				ops, rps, avg, stddev, p50, p90, p99 := summarize(lats, elapsed)
+				snap := singleLiveSnapshot{
+					ID:        atomic.AddUint64(&id, 1),
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
+					Elapsed:   elapsed,
+					Ops:       ops,
+					RPS:       rps,
+					Avg:       avg,
+					StdDev:    stddev,
+					P50:       p50,
+					P90:       p90,
+					P99:       p99,
+				}
+				b, err := json.Marshal(snap)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "live report marshal error: %v\n", err)
+					continue
+				}
+				fmt.Fprintln(os.Stdout, string(b))
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return stop
+}

--- a/tools/benchmark/cmd/put.go
+++ b/tools/benchmark/cmd/put.go
@@ -21,7 +21,9 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -45,8 +47,9 @@ var (
 	keySize int
 	valSize int
 
-	putTotal int
-	putRate  int
+	putTotal          int
+	putRate           int
+	putReportInterval int
 
 	keySpaceSize int
 	seqKeys      bool
@@ -71,11 +74,17 @@ func init() {
 	putCmd.Flags().DurationVar(&compactInterval, "compact-interval", 0, `Interval to compact database (do not duplicate this with etcd's 'auto-compaction-retention' flag) (e.g. --compact-interval=5m compacts every 5-minute)`)
 	putCmd.Flags().Int64Var(&compactIndexDelta, "compact-index-delta", 1000, "Delta between current revision and compact revision (e.g. current revision 10000, compact at 9000)")
 	putCmd.Flags().BoolVar(&checkHashkv, "check-hashkv", false, "'true' to check hashkv")
+	putCmd.Flags().IntVar(&putReportInterval, "report-interval", -1, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 func putFunc(cmd *cobra.Command, _ []string) {
 	if keySpaceSize <= 0 {
 		fmt.Fprintf(os.Stderr, "expected positive --key-space-size, got (%v)", keySpaceSize)
+		os.Exit(1)
+	}
+
+	if putReportInterval < -1 || putReportInterval == 0 {
+		fmt.Fprintf(os.Stderr, "--report-interval must be >=1 or -1 to disable\n")
 		os.Exit(1)
 	}
 
@@ -88,7 +97,33 @@ func putFunc(cmd *cobra.Command, _ []string) {
 	k, v := make([]byte, keySize), string(mustRandBytes(valSize))
 
 	bar = pb.New(putTotal)
+	// when live reporting is active, use stderr for the progress bar
+	// to keep stdout as a clean stream for JSON metrics
+	if putReportInterval > 0 {
+		bar.SetWriter(os.Stderr)
+	}
 	bar.Start()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	tracker := newIntervalTracker()
+	var stopLive chan struct{}
+	if putReportInterval > 0 {
+		stopLive = startSingleLiveReporter(putReportInterval, tracker)
+	}
 
 	r := newReport(cmd.Name())
 	for i := range clients {
@@ -96,26 +131,38 @@ func putFunc(cmd *cobra.Command, _ []string) {
 		go func(c *v3.Client) {
 			defer wg.Done()
 			for op := range requests {
-				limit.Wait(context.Background())
-
+				if err := limit.Wait(ctx); err != nil {
+					return
+				}
 				st := time.Now()
-				_, err := c.Do(context.Background(), op)
+				_, err := c.Do(ctx, op)
+				dur := time.Since(st)
 				r.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+				tracker.add(dur)
 				bar.Increment()
 			}
 		}(clients[i])
 	}
 
 	go func() {
+		defer close(requests)
 		for i := 0; i < putTotal; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			if seqKeys {
 				binary.PutVarint(k, int64(i%keySpaceSize))
 			} else {
 				binary.PutVarint(k, int64(rand.Intn(keySpaceSize)))
 			}
-			requests <- v3.OpPut(prefix+string(k), v)
+			select {
+			case requests <- v3.OpPut(prefix+string(k), v):
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(requests)
 	}()
 
 	if compactInterval > 0 {
@@ -131,7 +178,17 @@ func putFunc(cmd *cobra.Command, _ []string) {
 	wg.Wait()
 	close(r.Results())
 	bar.Finish()
-	fmt.Println(<-rc)
+	if stopLive != nil {
+		close(stopLive)
+	}
+
+	// When live reporting is active, keep stdout as a clean JSON-lines stream
+	// by redirecting the final summary to stderr.
+	summaryOut := os.Stdout
+	if putReportInterval > 0 {
+		summaryOut = os.Stderr
+	}
+	fmt.Fprintln(summaryOut, <-rc)
 
 	if checkHashkv {
 		hashKV(cmd, clients)

--- a/tools/benchmark/cmd/range.go
+++ b/tools/benchmark/cmd/range.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -44,15 +46,16 @@ var rangeCmd = &cobra.Command{
 }
 
 var (
-	rangeRate        int
-	rangeTotal       int
-	rangeConsistency string
-	rangeLimit       int64
-	rangeCountOnly   bool
-	rangeKeysOnly    bool
-	rangeStream      bool
-	rangePaginate    bool
-	rangePrefix      bool
+	rangeRate           int
+	rangeTotal          int
+	rangeConsistency    string
+	rangeLimit          int64
+	rangeCountOnly      bool
+	rangeKeysOnly       bool
+	rangeStream         bool
+	rangePaginate       bool
+	rangePrefix         bool
+	rangeReportInterval int
 )
 
 func init() {
@@ -66,6 +69,7 @@ func init() {
 	rangeCmd.Flags().BoolVar(&rangeStream, "stream", false, "Use RangeStream instead of unary Range")
 	rangeCmd.Flags().BoolVar(&rangePaginate, "paginate", false, "Use paginated unary range with 10k-key pages")
 	rangeCmd.Flags().BoolVar(&rangePrefix, "prefix", false, "Range over all keys with the given key as prefix")
+	rangeCmd.Flags().IntVar(&rangeReportInterval, "report-interval", -1, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 func rangeFunc(cmd *cobra.Command, args []string) {
@@ -93,10 +97,22 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if rangeReportInterval < -1 || rangeReportInterval == 0 {
+		fmt.Fprintf(os.Stderr, "--report-interval must be >=1 or -1 to disable\n")
+		os.Exit(1)
+	}
+
+	// When live reporting is enabled, status messages go to stderr so stdout
+	// remains a clean JSON-lines stream.
+	messageOut := os.Stdout
+	if rangeReportInterval > 0 {
+		messageOut = os.Stderr
+	}
+
 	if rangeConsistency == "l" {
-		fmt.Println("bench with linearizable range")
+		fmt.Fprintln(messageOut, "bench with linearizable range")
 	} else if rangeConsistency == "s" {
-		fmt.Println("bench with serializable range")
+		fmt.Fprintln(messageOut, "bench with serializable range")
 	} else {
 		fmt.Fprintln(os.Stderr, cmd.Usage())
 		os.Exit(1)
@@ -111,7 +127,33 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 	clients := mustCreateClients(totalClients, totalConns)
 
 	bar = pb.New(rangeTotal)
+	// when live reporting is active, use stderr for the progress bar
+	// to keep stdout as a clean stream for JSON metrics
+	if rangeReportInterval > 0 {
+		bar.SetWriter(os.Stderr)
+	}
 	bar.Start()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	tracker := newIntervalTracker()
+	var stopLive chan struct{}
+	if rangeReportInterval > 0 {
+		stopLive = startSingleLiveReporter(rangeReportInterval, tracker)
+	}
 
 	var baseOpts []v3.OpOption
 	if rangeLimit > 0 {
@@ -149,39 +191,62 @@ func rangeFunc(cmd *cobra.Command, args []string) {
 		go func(c *v3.Client) {
 			defer wg.Done()
 			for range requests {
-				limit.Wait(context.Background())
+				if err := limit.Wait(ctx); err != nil {
+					return
+				}
 				st := time.Now()
 				var err error
 				switch {
 				case rangeStream:
 					var stream v3.GetStreamChan
-					stream, err = c.GetStream(context.Background(), key, baseOpts...)
+					stream, err = c.GetStream(ctx, key, baseOpts...)
 					if err == nil {
 						_, err = v3.GetStreamToGetResponse(stream)
 					}
 				case rangePaginate:
 					err = paginatedRange(c, key, k8sWatchCachePageSize, baseOpts)
 				default:
-					_, err = c.Get(context.Background(), key, baseOpts...)
+					_, err = c.Get(ctx, key, baseOpts...)
 				}
+				dur := time.Since(st)
 				r.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+				tracker.add(dur)
 				bar.Increment()
 			}
 		}(clients[i])
 	}
 
 	go func() {
+		defer close(requests)
 		for i := 0; i < rangeTotal; i++ {
-			requests <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			select {
+			case requests <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(requests)
 	}()
 
 	rc := r.Run()
 	wg.Wait()
 	close(r.Results())
 	bar.Finish()
-	fmt.Printf("%s", <-rc)
+	if stopLive != nil {
+		close(stopLive)
+	}
+
+	summaryOut := os.Stdout
+	// direct final summary to stderr if report interval is enabled,
+	// to separate it from live JSON snapshots in stdout
+	if rangeReportInterval > 0 {
+		summaryOut = os.Stderr
+	}
+	fmt.Fprintf(summaryOut, "%s", <-rc)
 }
 
 func paginatedRange(c *v3.Client, key string, pageSize int64, baseOpts []v3.OpOption) error {

--- a/tools/benchmark/cmd/stm.go
+++ b/tools/benchmark/cmd/stm.go
@@ -21,6 +21,8 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -47,13 +49,14 @@ var (
 	stmIsolation string
 	stmIso       v3sync.Isolation
 
-	stmTotal        int
-	stmKeysPerTxn   int
-	stmKeyCount     int
-	stmValSize      int
-	stmWritePercent int
-	stmLocker       string
-	stmRate         int
+	stmTotal          int
+	stmKeysPerTxn     int
+	stmKeyCount       int
+	stmValSize        int
+	stmWritePercent   int
+	stmLocker         string
+	stmRate           int
+	stmReportInterval int
 )
 
 func init() {
@@ -67,6 +70,7 @@ func init() {
 	stmCmd.Flags().StringVar(&stmLocker, "stm-locker", "stm", "Wrap STM transaction with a custom locking mechanism (stm, lock-client, lock-rpc)")
 	stmCmd.Flags().IntVar(&stmValSize, "val-size", 8, "Value size of each STM put request")
 	stmCmd.Flags().IntVar(&stmRate, "rate", 0, "Maximum STM transactions per second (0 is no limit)")
+	stmCmd.Flags().IntVar(&stmReportInterval, "report-interval", -1, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 func stmFunc(cmd *cobra.Command, _ []string) {
@@ -82,6 +86,11 @@ func stmFunc(cmd *cobra.Command, _ []string) {
 
 	if stmKeysPerTxn < 0 || stmKeysPerTxn > stmKeyCount {
 		fmt.Fprintf(os.Stderr, "expected --keys-per-txn between 0 and %v, got (%v)", stmKeyCount, stmKeysPerTxn)
+		os.Exit(1)
+	}
+
+	if stmReportInterval < -1 || stmReportInterval == 0 {
+		fmt.Fprintf(os.Stderr, "--report-interval must be >=1 or -1 to disable\n")
 		os.Exit(1)
 	}
 
@@ -108,16 +117,48 @@ func stmFunc(cmd *cobra.Command, _ []string) {
 	clients := mustCreateClients(totalClients, totalConns)
 
 	bar = pb.New(stmTotal)
+	// when live reporting is active, use stderr for the progress bar
+	// to keep stdout as a clean stream for JSON metrics
+	if stmReportInterval > 0 {
+		bar.SetWriter(os.Stderr)
+	}
 	bar.Start()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	tracker := newIntervalTracker()
+	var stopLive chan struct{}
+	if stmReportInterval > 0 {
+		stopLive = startSingleLiveReporter(stmReportInterval, tracker)
+	}
 
 	r := newReport(cmd.Name())
 	for i := range clients {
 		wg.Add(1)
-		go doSTM(clients[i], requests, r.Results())
+		go doSTM(ctx, clients[i], requests, r.Results(), tracker)
 	}
 
 	go func() {
+		defer close(requests)
 		for i := 0; i < stmTotal; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			kset := make(map[string]struct{})
 			for len(kset) != stmKeysPerTxn {
 				k := make([]byte, 16)
@@ -139,19 +180,32 @@ func stmFunc(cmd *cobra.Command, _ []string) {
 				return nil
 			}
 
-			requests <- applyf
+			select {
+			case requests <- applyf:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(requests)
 	}()
 
 	rc := r.Run()
 	wg.Wait()
 	close(r.Results())
 	bar.Finish()
-	fmt.Printf("%s", <-rc)
+	if stopLive != nil {
+		close(stopLive)
+	}
+
+	summaryOut := os.Stdout
+	// direct final summary to stderr if report interval is enabled,
+	// to separate it from live JSON snapshots in stdout
+	if stmReportInterval > 0 {
+		summaryOut = os.Stderr
+	}
+	fmt.Fprintf(summaryOut, "%s", <-rc)
 }
 
-func doSTM(client *v3.Client, requests <-chan stmApply, results chan<- report.Result) {
+func doSTM(_ context.Context, client *v3.Client, requests <-chan stmApply, results chan<- report.Result, tracker *intervalTracker) {
 	defer wg.Done()
 
 	lock, unlock := func() error { return nil }, func() error { return nil }
@@ -201,7 +255,11 @@ func doSTM(client *v3.Client, requests <-chan stmApply, results chan<- report.Re
 		if lerr := unlock(); lerr != nil {
 			panic(lerr)
 		}
+		dur := time.Since(st)
 		results <- report.Result{Err: err, Start: st, End: time.Now()}
+		if tracker != nil {
+			tracker.add(dur)
+		}
 		bar.Increment()
 	}
 }

--- a/tools/benchmark/cmd/txn_mixed.go
+++ b/tools/benchmark/cmd/txn_mixed.go
@@ -17,10 +17,14 @@ package cmd
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
 	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -45,6 +49,7 @@ var (
 	mixedTxnReadWriteRatio float64
 	mixedTxnRangeLimit     int64
 	mixedTxnEndKey         string
+	mixedTxnReportInterval int
 
 	writeOpsTotal uint64
 	readOpsTotal  uint64
@@ -62,11 +67,40 @@ func init() {
 	mixedTxnCmd.Flags().IntVar(&keySpaceSize, "key-space-size", 1, "Maximum possible keys")
 	mixedTxnCmd.Flags().StringVar(&rangeConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
 	mixedTxnCmd.Flags().Float64Var(&mixedTxnReadWriteRatio, "rw-ratio", 1, "Read/write ops ratio")
+	mixedTxnCmd.Flags().IntVar(&mixedTxnReportInterval, "report-interval", 10, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 type request struct {
 	isWrite bool
 	op      v3.Op
+}
+
+// liveSnapshot is the JSON record emitted to stdout on each tick by txn-mixed.
+// It carries separate read and write statistics for the reporting interval.
+type liveSnapshot struct {
+	ID         uint64  `json:"id"`
+	Timestamp  string  `json:"ts"`
+	ElapsedSec float64 `json:"elapsed_sec"`
+
+	Read struct {
+		Ops    int     `json:"ops"`
+		RPS    float64 `json:"rps"`
+		Avg    float64 `json:"avg"`
+		StdDev float64 `json:"stddev"`
+		P50    float64 `json:"p50"`
+		P90    float64 `json:"p90"`
+		P99    float64 `json:"p99"`
+	} `json:"read"`
+
+	Write struct {
+		Ops    int     `json:"ops"`
+		RPS    float64 `json:"rps"`
+		Avg    float64 `json:"avg"`
+		StdDev float64 `json:"stddev"`
+		P50    float64 `json:"p50"`
+		P90    float64 `json:"p90"`
+		P99    float64 `json:"p99"`
+	} `json:"write"`
 }
 
 func mixedTxnFunc(cmd *cobra.Command, _ []string) {
@@ -75,10 +109,20 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	if mixedTxnReportInterval < -1 || mixedTxnReportInterval == 0 {
+		fmt.Fprintf(os.Stderr, "--report-interval must be >=1. Or -1 to disable.\n")
+		os.Exit(1)
+	}
+
+	messageOut := os.Stdout
+	if mixedTxnReportInterval > 0 {
+		messageOut = os.Stderr
+	}
+
 	if rangeConsistency == "l" {
-		fmt.Println("bench with linearizable range")
+		fmt.Fprintln(messageOut, "bench with linearizable range")
 	} else if rangeConsistency == "s" {
-		fmt.Println("bench with serializable range")
+		fmt.Fprintln(messageOut, "bench with serializable range")
 	} else {
 		fmt.Fprintln(os.Stderr, cmd.Usage())
 		os.Exit(1)
@@ -93,22 +137,125 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 	k, v := make([]byte, keySize), string(mustRandBytes(valSize))
 
 	bar = pb.New(mixedTxnTotal)
+	// when live reporting is active, use stderr for the progress bar
+	// to keep stdout as a clean stream for JSON metrics
+	if mixedTxnReportInterval > 0 {
+		bar.SetWriter(os.Stderr)
+	}
 	bar.Start()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 
 	reportRead := newReport(cmd.Name() + "-read")
 	reportWrite := newReport(cmd.Name() + "-write")
+
+	readTracker := newIntervalTracker()
+	writeTracker := newIntervalTracker()
+
+	var snapshotID uint64
+	var stopLive chan struct{}
+
+	if mixedTxnReportInterval > 0 {
+		stopLive = make(chan struct{})
+		ticker := time.NewTicker(time.Duration(mixedTxnReportInterval) * time.Second)
+
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					readLats, readElapsed := readTracker.snapshot()
+					writeLats, writeElapsed := writeTracker.snapshot()
+
+					if len(readLats)+len(writeLats) == 0 {
+						continue
+					}
+
+					// Use the longer of the two elapsed windows so RPS values
+					// for both operation types share a consistent denominator.
+					elapsed := readElapsed
+					if writeElapsed > elapsed {
+						elapsed = writeElapsed
+					}
+
+					rc, rrps, ravg, rstddev, rp50, rp90, rp99 :=
+						summarize(readLats, elapsed)
+					wc, wrps, wavg, wstddev, wp50, wp90, wp99 :=
+						summarize(writeLats, elapsed)
+
+					snap := liveSnapshot{
+						ID:         atomic.AddUint64(&snapshotID, 1),
+						Timestamp:  time.Now().UTC().Format(time.RFC3339),
+						ElapsedSec: elapsed,
+					}
+
+					snap.Read.Ops = rc
+					snap.Read.RPS = rrps
+					snap.Read.Avg = ravg
+					snap.Read.StdDev = rstddev
+					snap.Read.P50 = rp50
+					snap.Read.P90 = rp90
+					snap.Read.P99 = rp99
+
+					snap.Write.Ops = wc
+					snap.Write.RPS = wrps
+					snap.Write.Avg = wavg
+					snap.Write.StdDev = wstddev
+					snap.Write.P50 = wp50
+					snap.Write.P90 = wp90
+					snap.Write.P99 = wp99
+
+					b, err := json.Marshal(snap)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "marshal error: %v\n", err)
+						continue
+					}
+					// write intermediate JSON snapshot to stdout, when report interval is enabled
+					fmt.Fprintln(os.Stdout, string(b))
+				case <-stopLive:
+					return
+				}
+			}
+		}()
+	}
+
 	for i := range clients {
 		wg.Add(1)
 		go func(c *v3.Client) {
 			defer wg.Done()
 			for req := range requests {
-				limit.Wait(context.Background())
+				if err := limit.Wait(ctx); err != nil {
+					return
+				}
 				st := time.Now()
 				_, err := c.Txn(context.TODO()).Then(req.op).Commit()
+				end := time.Now()
+
+				res := report.Result{
+					Err:   err,
+					Start: st,
+					End:   end,
+				}
+
 				if req.isWrite {
-					reportWrite.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+					reportWrite.Results() <- res
+					writeTracker.add(end.Sub(st))
 				} else {
-					reportRead.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+					reportRead.Results() <- res
+					readTracker.add(end.Sub(st))
 				}
 				bar.Increment()
 			}
@@ -116,7 +263,13 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 	}
 
 	go func() {
+		defer close(requests)
 		for i := 0; i < mixedTxnTotal; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			var req request
 			if rand.Float64() < mixedTxnReadWriteRatio/(1+mixedTxnReadWriteRatio) {
 				opts := []v3.OpOption{v3.WithRange(mixedTxnEndKey)}
@@ -126,16 +279,19 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 				opts = append(opts, v3.WithPrefix(), v3.WithLimit(mixedTxnRangeLimit))
 				req.op = v3.OpGet("", opts...)
 				req.isWrite = false
-				readOpsTotal++
+				atomic.AddUint64(&readOpsTotal, 1)
 			} else {
 				binary.PutVarint(k, int64(i%keySpaceSize))
 				req.op = v3.OpPut(string(k), v)
 				req.isWrite = true
-				writeOpsTotal++
+				atomic.AddUint64(&writeOpsTotal, 1)
 			}
-			requests <- req
+			select {
+			case requests <- req:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(requests)
 	}()
 
 	rcRead := reportRead.Run()
@@ -144,8 +300,18 @@ func mixedTxnFunc(cmd *cobra.Command, _ []string) {
 	close(reportRead.Results())
 	close(reportWrite.Results())
 	bar.Finish()
-	fmt.Printf("Total Read Ops: %d\nDetails:", readOpsTotal)
-	fmt.Println(<-rcRead)
-	fmt.Printf("Total Write Ops: %d\nDetails:", writeOpsTotal)
-	fmt.Println(<-rcWrite)
+	if stopLive != nil {
+		close(stopLive)
+	}
+
+	// direct final summary to stderr if report interval is enabled,
+	// to separate it from live JSON snapshots in stdout
+	summaryOut := os.Stdout
+	if mixedTxnReportInterval > 0 {
+		summaryOut = os.Stderr
+	}
+	fmt.Fprintf(summaryOut, "Total Read Ops: %d\nDetails:", atomic.LoadUint64(&readOpsTotal))
+	fmt.Fprintln(summaryOut, <-rcRead)
+	fmt.Fprintf(summaryOut, "Total Write Ops: %d\nDetails:", atomic.LoadUint64(&writeOpsTotal))
+	fmt.Fprintln(summaryOut, <-rcWrite)
 }

--- a/tools/benchmark/cmd/txn_mixed.go
+++ b/tools/benchmark/cmd/txn_mixed.go
@@ -67,7 +67,7 @@ func init() {
 	mixedTxnCmd.Flags().IntVar(&keySpaceSize, "key-space-size", 1, "Maximum possible keys")
 	mixedTxnCmd.Flags().StringVar(&rangeConsistency, "consistency", "l", "Linearizable(l) or Serializable(s)")
 	mixedTxnCmd.Flags().Float64Var(&mixedTxnReadWriteRatio, "rw-ratio", 1, "Read/write ops ratio")
-	mixedTxnCmd.Flags().IntVar(&mixedTxnReportInterval, "report-interval", 10, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
+	mixedTxnCmd.Flags().IntVar(&mixedTxnReportInterval, "report-interval", -1, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 type request struct {

--- a/tools/benchmark/cmd/txn_put.go
+++ b/tools/benchmark/cmd/txn_put.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -39,9 +41,10 @@ var txnPutCmd = &cobra.Command{
 }
 
 var (
-	txnPutTotal     int
-	txnPutRate      int
-	txnPutOpsPerTxn int
+	txnPutTotal          int
+	txnPutRate           int
+	txnPutOpsPerTxn      int
+	txnPutReportInterval int
 )
 
 func init() {
@@ -53,6 +56,7 @@ func init() {
 
 	txnPutCmd.Flags().IntVar(&txnPutTotal, "total", 10000, "Total number of txn requests")
 	txnPutCmd.Flags().IntVar(&keySpaceSize, "key-space-size", 1, "Maximum possible keys")
+	txnPutCmd.Flags().IntVar(&txnPutReportInterval, "report-interval", -1, "Print live JSON metrics every N seconds (min=1, -1 to disable)")
 }
 
 func txnPutFunc(cmd *cobra.Command, _ []string) {
@@ -67,6 +71,11 @@ func txnPutFunc(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
+	if txnPutReportInterval < -1 || txnPutReportInterval == 0 {
+		fmt.Fprintf(os.Stderr, "--report-interval must be >=1 or -1 to disable\n")
+		os.Exit(1)
+	}
+
 	requests := make(chan []v3.Op, totalClients)
 	if txnPutRate == 0 {
 		txnPutRate = math.MaxInt32
@@ -76,7 +85,33 @@ func txnPutFunc(cmd *cobra.Command, _ []string) {
 	k, v := make([]byte, keySize), string(mustRandBytes(valSize))
 
 	bar = pb.New(txnPutTotal)
+	// when live reporting is active, use stderr for the progress bar
+	// to keep stdout as a clean stream for JSON metrics
+	if txnPutReportInterval > 0 {
+		bar.SetWriter(os.Stderr)
+	}
 	bar.Start()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	tracker := newIntervalTracker()
+	var stopLive chan struct{}
+	if txnPutReportInterval > 0 {
+		stopLive = startSingleLiveReporter(txnPutReportInterval, tracker)
+	}
 
 	r := newReport(cmd.Name())
 	for i := range clients {
@@ -84,30 +119,53 @@ func txnPutFunc(cmd *cobra.Command, _ []string) {
 		go func(c *v3.Client) {
 			defer wg.Done()
 			for ops := range requests {
-				limit.Wait(context.Background())
+				if err := limit.Wait(ctx); err != nil {
+					return
+				}
 				st := time.Now()
 				_, err := c.Txn(context.TODO()).Then(ops...).Commit()
+				dur := time.Since(st)
 				r.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+				tracker.add(dur)
 				bar.Increment()
 			}
 		}(clients[i])
 	}
 
 	go func() {
+		defer close(requests)
 		for i := 0; i < txnPutTotal; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			ops := make([]v3.Op, txnPutOpsPerTxn)
 			for j := 0; j < txnPutOpsPerTxn; j++ {
 				binary.PutVarint(k, int64(((i*txnPutOpsPerTxn)+j)%keySpaceSize))
 				ops[j] = v3.OpPut(string(k), v)
 			}
-			requests <- ops
+			select {
+			case requests <- ops:
+			case <-ctx.Done():
+				return
+			}
 		}
-		close(requests)
 	}()
 
 	rc := r.Run()
 	wg.Wait()
 	close(r.Results())
 	bar.Finish()
-	fmt.Println(<-rc)
+	if stopLive != nil {
+		close(stopLive)
+	}
+
+	summaryOut := os.Stdout
+	// direct final summary to stderr if report interval is enabled,
+	// to separate it from live JSON snapshots in stdout
+	if txnPutReportInterval > 0 {
+		summaryOut = os.Stderr
+	}
+	fmt.Fprintln(summaryOut, <-rc)
 }


### PR DESCRIPTION
Report results at regular intervals if required, for e.g while executing long-running benchmarks.

Also, terminate gracefully upon SIGINT/SIGTERM after printing report of the run until this point.

Addresses #21828 
