### PR TITLE
embed: enforce HTTP body size limit on /v3/ gRPC-gateway endpoints

### DIFF
--- a/server/embed/serve.go
+++ b/server/embed/serve.go
@@ -477,6 +477,21 @@ func (ac *accessController) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	// Enforce HTTP request body size limit for /v3/ gRPC-gateway endpoints to
+	// prevent unauthenticated memory exhaustion via oversized JSON/base64 bodies.
+	// Use 4x MaxRequestBytes to account for base64 and JSON encoding overhead
+	// (base64 expands binary payloads by ~4/3; JSON field names add further
+	// overhead), ensuring legitimate maximum-size requests are not rejected.
+	// WebSocket upgrade requests have no body so this limit is a no-op for them.
+	if strings.HasPrefix(req.URL.Path, "/v3/") && req.Body != nil {
+		maxBodyBytes := int64(ac.s.Cfg.MaxRequestBytes) * 4
+		if req.ContentLength > maxBodyBytes {
+			http.Error(rw, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		req.Body = http.MaxBytesReader(rw, req.Body, maxBodyBytes)
+	}
+
 	ac.mux.ServeHTTP(rw, req)
 }
 


### PR DESCRIPTION
## Problem

Without a request-body size guard on the gRPC-gateway HTTP path, an
unauthenticated attacker can force etcd to allocate GiB-scale memory from a
single 256 MiB HTTP/JSON POST to any `/v3/*` endpoint (e.g. `/v3/kv/range`).
The allocation happens inside JSON decoding, **before** authentication runs
or `--max-request-bytes` is enforced at the gRPC layer. Observed impact:
a 256 MiB JSON request body causes ~1.75 GiB RSS growth, ~7× amplification
(base64 decode + JSON parse + protobuf allocation).

## Fix

In `accessController.ServeHTTP`, wrap `req.Body` with `http.MaxBytesReader`
for all `/v3/` requests before delegating to the mux:

```
maxBodyBytes := int64(ac.s.Cfg.MaxRequestBytes) * 4
```

The 4× factor accounts for:
- Base64 encoding overhead (binary → text is ~4/3×)
- JSON field-name framing (~20–30% additional overhead)

This ensures a legitimate maximum-size payload (up to `MaxRequestBytes`)
encoded as a JSON/base64 body is never rejected, while an oversized
body is either:
- Rejected immediately with 413 if `Content-Length` declares it oversized, or
- Rejected by `MaxBytesReader` mid-read if `Content-Length` is absent.

WebSocket upgrade requests carry no body, so the wrapper is a no-op for them.

## Testing

Manual testing with a `256 MiB` base64 key in a `/v3/kv/range` request:
- **Before**: RSS grows ~1.75 GiB; request eventually returns 429 (rate-limited)
- **After**: 413 returned immediately; RSS stays flat

Fixes #21555