### PR TITLE
Add math/rand[/v2] wrappers in tests/antithesis and replace the rand references with the wrappers

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -531,6 +531,15 @@
 		]
 	},
 	{
+		"project": "go.etcd.io/etcd/tests/v3/pkg/rand",
+		"licenses": [
+			{
+				"type": "Apache License 2.0",
+				"confidence": 0.9988925802879292
+			}
+		]
+	},
+	{
 		"project": "go.etcd.io/etcd/v3",
 		"licenses": [
 			{

--- a/go.work
+++ b/go.work
@@ -15,6 +15,7 @@ use (
 	./pkg
 	./server
 	./tests
+	./tests/antithesis/pkg
 	./tools/mod
 	./tools/rw-heatmaps
 	./tools/testgrid-analysis

--- a/tests/antithesis/Makefile
+++ b/tests/antithesis/Makefile
@@ -26,7 +26,8 @@ antithesis-build-etcd-image:
 		--build-arg GO_IMAGE_TAG=$(shell go work edit -json | jq .Go) \
 		--build-arg REF=$(REF) \
 		--tag etcd-server:latest \
-		$(ANTITHESIS_ROOT)/server/
+		-f ./server/Dockerfile \
+		$(ANTITHESIS_ROOT)
 
 .PHONY: antithesis-build-etcd-image-release-3.4
 antithesis-build-etcd-image-release-3.4: REF=release-3.4

--- a/tests/antithesis/pkg/LICENSE
+++ b/tests/antithesis/pkg/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 The etcd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/antithesis/pkg/go.mod
+++ b/tests/antithesis/pkg/go.mod
@@ -1,0 +1,7 @@
+module go.etcd.io/etcd/tests/v3/pkg
+
+go 1.26
+
+toolchain go1.26.5
+
+require github.com/antithesishq/antithesis-sdk-go v0.7.2

--- a/tests/antithesis/pkg/go.sum
+++ b/tests/antithesis/pkg/go.sum
@@ -1,0 +1,2 @@
+github.com/antithesishq/antithesis-sdk-go v0.7.2 h1:oEEedg1Xgi8drRjqB0f9tfjhLoInE0IYZfZ6zAhQUbY=
+github.com/antithesishq/antithesis-sdk-go v0.7.2/go.mod h1:FQyySiasQQM8735Ddel3MRojmy4dA1IqCeyJ5jmPMbI=

--- a/tests/antithesis/pkg/rand/rand.go
+++ b/tests/antithesis/pkg/rand/rand.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rand is a wrapper of https://antithesis.com/docs/generated/sdk/golang/random/
+// and provides the same functions as math/rand so it can be a drop-in replacement
+//
+// The usages of math/rand currently found in etcd (listing only the first occurrence of each here)
+// to find all, use `for f in $(rg -l 'math/rand"'); do echo $f; grep 'rand\.' $f; done`
+//
+// 1. out = append(out, rand.Int63n(max-min)+min)
+// 2. r := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+// 3. func shuffleEndpoints(r *rand.Rand, eps []string) []string {
+// 4. n := rand.Intn(3) + 3
+// 5. key := fmt.Sprintf("foo%d", rand.Int())
+// 6. membersToChange := rand.Perm(len(clus.Procs))[:numberOfMembersToChange]
+// 7. if _, err := rand.Read(v); err != nil {
+// 8. multiplier := jitter * (rand.Float64()*2 - 1)
+// 9. traceNum := rand.Int31()
+// 10. randID = rand.Uint64()
+// 11. rand.Shuffle(len(perm), func(i, j int) {
+package rand
+
+import (
+	mrand "math/rand"
+
+	antithesis "github.com/antithesishq/antithesis-sdk-go/random"
+)
+
+var (
+	src = antithesis.Source()
+	r   = mrand.New(src)
+)
+
+type Rand = mrand.Rand
+
+func New(_ mrand.Source) *mrand.Rand {
+	return r
+}
+
+func NewSource(_ int64) mrand.Source {
+	return src
+}
+
+func Int63n(n int64) int64 {
+	return r.Int63n(n)
+}
+
+func Uint64() uint64 {
+	return r.Uint64()
+}
+
+func Intn(n int) int {
+	return r.Intn(n)
+}
+
+func Int() int {
+	return r.Int()
+}
+
+func Perm(n int) []int {
+	return r.Perm(n)
+}
+
+func Read(p []byte) (n int, err error) {
+	return r.Read(p)
+}
+
+func Float64() float64 {
+	return r.Float64()
+}
+
+func Int31() int32 {
+	return r.Int31()
+}
+
+func Shuffle(n int, swap func(i, j int)) {
+	r.Shuffle(n, swap)
+}

--- a/tests/antithesis/pkg/rand/v2/randv2.go
+++ b/tests/antithesis/pkg/rand/v2/randv2.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rand is a wrapper of https://antithesis.com/docs/generated/sdk/golang/random/
+// and provides the same functions as math/rand/v2
+//
+// The usages of math/rand/v2 currently found in etcd
+//
+//  1. server/etcdserver/txn/util_bench_test.go
+//     rng := rand.New(rand.NewPCG(1, 2))
+//  2. tests/robustness/validate/operations_test.go
+//     rand.Shuffle(len(historyCopy), func(i, j int)
+//  3. tests/antithesis/test-template/robustness/traffic/main.go
+//     choice := rand.IntN(len(traffics))
+package rand
+
+import (
+	mrandv1 "math/rand"
+	mrandv2 "math/rand/v2"
+
+	antithesis "github.com/antithesishq/antithesis-sdk-go/random"
+)
+
+type sourceV2Func func() uint64
+
+func (f sourceV2Func) Uint64() uint64 {
+	return f()
+}
+
+// antithesis doesn't provide a math/rand/v2 source, so this is
+// needed for making a v1 source a v2.
+var (
+	v1Rand   = mrandv1.New(antithesis.Source())
+	v2Source = sourceV2Func(v1Rand.Uint64)
+	r        = mrandv2.New(v2Source)
+)
+
+func New(_ mrandv2.Source) *mrandv2.Rand {
+	return r
+}
+
+func NewPCG(_, _ int) mrandv2.Source {
+	return v2Source
+}
+
+func IntN(n int) int {
+	return r.IntN(n)
+}
+
+func Shuffle(n int, swap func(i, j int)) {
+	r.Shuffle(n, swap)
+}

--- a/tests/antithesis/server/Dockerfile
+++ b/tests/antithesis/server/Dockerfile
@@ -8,7 +8,15 @@ ARG REF=main
 RUN git clone --depth=1 https://github.com/etcd-io/etcd.git --branch=${REF} /etcd
 RUN go env -w GOTOOLCHAIN="go$(cat .go-version)"
 
-# inject assertions in place of gofail
+# Replacing math/rand with etcd's antithesis-sdk-go/random wrapper
+# See https://antithesis.com/docs/configuration/the_antithesis_environment/?sid=8fce.35&sterm=random&marks=Random#random-devices
+WORKDIR /etcd
+COPY pkg /etcd/tests/antithesis/pkg
+RUN find . -path "./tests/antithesis" -prune -type f -o -name 'go.mod' -type f -execdir go mod edit -replace=math/rand=$(git rev-parse --show-toplevel)/tests/antithesis/pkg/rand \;
+RUN find . -path "./tests/antithesis" -prune -type f -o -name 'go.mod' -type f -execdir go mod edit -replace=math/rand/v2=$(git rev-parse --show-toplevel)/tests/antithesis/pkg/rand/v2 \;
+RUN find . -name 'go.mod' -type f -execdir go mod tidy \;
+
+## inject assertions in place of gofail
 WORKDIR /etcd/server
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN go get github.com/antithesishq/antithesis-sdk-go@v0.7.2
@@ -17,7 +25,7 @@ RUN go mod tidy
 
 # replace verify with antithesis
 WORKDIR /etcd
-COPY inject/* .
+COPY server/inject/* .
 RUN if [ "${REF}" = "main" ]; then git apply *.patch; fi
 WORKDIR /etcd/client/pkg
 RUN go mod tidy


### PR DESCRIPTION
First step for #21720

I'm adding two wrappers of antithesis's random in which they will be drop-in replacements of `math/rand` and `math/rand/v2`.  They need to be merged to main first before I can replace all of the occurrences of `math/rand[/v2' with them as the server dockerfile clones from `main` to build it.  In other words, if these don't exist in main, docker build can replace it but won't be able to build because main doesn't contain them.

Once merged, I will follow up with another commit to introduce the `sed` replacements.  Here is an excerpt of what the code looks like after replaced:

```
diff --git a/pkg/proxy/server.go b/pkg/proxy/server.go
index bc71c3a..6877fcb 100644
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -19,7 +19,7 @@ import (
        "errors"
        "fmt"
        "io"
-       mrand "math/rand"
+       mrand "go.etcd.io/etcd/tests/v3/antithesis/pkg/rand"
        "net"
        "net/http"
        "net/url"
diff --git a/pkg/proxy/server_test.go b/pkg/proxy/server_test.go
index 2a7e622..11e1ba9 100644
--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -20,7 +20,7 @@ import (
        "fmt"
        "io"
        "log"
-       "math/rand"
+       "go.etcd.io/etcd/tests/v3/antithesis/pkg/rand"
        "net"
        "net/http"
        "net/url"
diff --git a/pkg/stringutil/rand.go b/pkg/stringutil/rand.go
index 347ee7c..db940d8 100644
--- a/pkg/stringutil/rand.go
+++ b/pkg/stringutil/rand.go
@@ -15,7 +15,7 @@
 package stringutil

 import (
-       "math/rand"
+       "go.etcd.io/etcd/tests/v3/antithesis/pkg/rand"
 )
```

cc @serathius @henrybear327 @ivanvc 