### PR TITLE
mvcc: add watch failpoints for robustness testing

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -283,6 +283,7 @@ func (s *watchableStore) syncVictimsLoop() {
 
 // moveVictims tries to update watches with already pending event data
 func (s *watchableStore) moveVictims() (moved int) {
+	// gofail: var beforeMoveVictims struct{}
 	s.mu.Lock()
 	victims := s.victims
 	s.victims = nil
@@ -344,6 +345,7 @@ func (s *watchableStore) moveVictims() (moved int) {
 //  3. use minimum revision to get all key-value pairs and send those events to watchers
 //  4. remove synced watchers in set from unsynced group and move to synced group
 func (s *watchableStore) syncWatchers() int {
+	// gofail: var beforeSyncWatchers struct{}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -513,6 +515,7 @@ func (s *watchableStore) progressAll(watchers map[WatchID]*watcher) bool {
 }
 
 func (s *watchableStore) progressIfSync(watchers map[WatchID]*watcher, responseWatchID WatchID) bool {
+	// gofail: var beforeProgressIfSync struct{}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/tests/robustness/failpoint/failpoint.go
+++ b/tests/robustness/failpoint/failpoint.go
@@ -53,6 +53,9 @@ var allFailpoints = []Failpoint{
 	RaftAfterSaveSleep,
 	ApplyBeforeOpenSnapshot,
 	SleepBeforeSendWatchResponse,
+	SleepBeforeSyncWatchers,
+	SleepBeforeMoveVictims,
+	SleepBeforeProgressIfSync,
 }
 
 func PickRandom(clus *e2e.EtcdProcessCluster, profile traffic.Profile) (Failpoint, error) {

--- a/tests/robustness/failpoint/gofail.go
+++ b/tests/robustness/failpoint/gofail.go
@@ -62,6 +62,9 @@ var (
 	RaftBeforeSaveSleep                       Failpoint = gofailSleepAndDeactivate{"raftBeforeSave", time.Second}
 	RaftAfterSaveSleep                        Failpoint = gofailSleepAndDeactivate{"raftAfterSave", time.Second}
 	SleepBeforeSendWatchResponse              Failpoint = gofailSleepAndDeactivate{"beforeSendWatchResponse", time.Second}
+	SleepBeforeSyncWatchers                   Failpoint = gofailSleepAndDeactivate{"beforeSyncWatchers", time.Second}
+	SleepBeforeMoveVictims                    Failpoint = gofailSleepAndDeactivate{"beforeMoveVictims", time.Second}
+	SleepBeforeProgressIfSync                 Failpoint = gofailSleepAndDeactivate{"beforeProgressIfSync", time.Second}
 )
 
 type goPanicFailpoint struct {


### PR DESCRIPTION
This adds three gofail failpoints to the etcd server watch code so the robustness tests can inject slowness into the paths listed in issue #18681: watcher synchronization, victim resynchronization, and progress notification. All three sit in server/storage/mvcc/watchable_store.go, right before each function takes the store lock, so an injected sleep delays the operation without holding the lock during the sleep.

- beforeSyncWatchers in syncWatchers, the batch that catches up unsynced watchers from the backend. Slowness here simulates watchers on old revisions staying behind under load.
- beforeMoveVictims in moveVictims, which retries delivery to watchers whose channels blocked. Slowness here extends the backpressure window while the system is already struggling.
- beforeProgressIfSync in progressIfSync, which both the periodic progress notify ticker and manual progress requests flow through. Slowness here stresses clients that depend on progress guarantees, like the case in #20221

Each failpoint is registered as a gofailSleepAndDeactivate for the exploratory scenarios, following the same pattern as beforeSendWatchResponse from #17680. No build changes are needed since gofail-enable already instruments server/storage/mvcc.

Validation:
- Built with make gofail-enable and make build, confirmed all three failpoints appear on the GOFAIL_HTTP endpoint.
- Manually activated beforeSyncWatchers=sleep(1000) on a live member, verified watch delivery stays correct and the endpoint stays healthy.
- Ran TestRobustnessExploratory/KubernetesLowTraffic with the new failpoints in the pool, which passes.

Fixes #18681