### PR TITLE
snap: keep snapshot db files until they have been applied

### DIFF
--- a/server/etcdserver/api/snap/db.go
+++ b/server/etcdserver/api/snap/db.go
@@ -54,6 +54,7 @@ func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 	fn := s.dbFilePath(id)
 	if fileutil.Exist(fn) {
 		os.Remove(f.Name())
+		s.markPendingDB(id)
 		return n, nil
 	}
 	err = os.Rename(f.Name(), fn)
@@ -61,6 +62,7 @@ func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 		os.Remove(f.Name())
 		return n, err
 	}
+	s.markPendingDB(id)
 
 	s.lg.Info(
 		"saved database snapshot to disk",
@@ -71,6 +73,34 @@ func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 
 	snapDBSaveSec.Observe(time.Since(start).Seconds())
 	return n, nil
+}
+
+// markPendingDB records that the snapshot database file with the given id has
+// been saved but not applied yet, protecting it from ReleaseSnapDBs.
+func (s *Snapshotter) markPendingDB(id uint64) {
+	s.pendingDBsMu.Lock()
+	defer s.pendingDBsMu.Unlock()
+	s.pendingDBs[id] = struct{}{}
+}
+
+// isPendingDB reports whether the snapshot database file with the given id is
+// still waiting to be applied.
+func (s *Snapshotter) isPendingDB(id uint64) bool {
+	s.pendingDBsMu.Lock()
+	defer s.pendingDBsMu.Unlock()
+	_, ok := s.pendingDBs[id]
+	return ok
+}
+
+// ReleaseDBSnapshot removes the pending-apply protection from the snapshot
+// database file with the given id. It must be called once the file has been
+// consumed by the apply path, so that ReleaseSnapDBs can clean up any file
+// that is left behind (for example when the same snapshot db is received
+// again).
+func (s *Snapshotter) ReleaseDBSnapshot(id uint64) {
+	s.pendingDBsMu.Lock()
+	defer s.pendingDBsMu.Unlock()
+	delete(s.pendingDBs, id)
 }
 
 // DBFilePath returns the file path for the snapshot of the database with

--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -54,6 +55,16 @@ var (
 type Snapshotter struct {
 	lg  *zap.Logger
 	dir string
+
+	// pendingDBsMu protects pendingDBs.
+	pendingDBsMu sync.Mutex
+	// pendingDBs tracks the indices of snapshot database files that were
+	// saved on receipt but have not been applied yet. ReleaseSnapDBs must
+	// not delete these files: a newer snapshot can arrive before an older
+	// one has been applied, and deleting the older file while its apply is
+	// pending makes the apply panic with "failed to open snapshot backend".
+	// See https://github.com/etcd-io/etcd/issues/18055.
+	pendingDBs map[uint64]struct{}
 }
 
 func New(lg *zap.Logger, dir string) *Snapshotter {
@@ -61,8 +72,9 @@ func New(lg *zap.Logger, dir string) *Snapshotter {
 		lg = zap.NewNop()
 	}
 	return &Snapshotter{
-		lg:  lg,
-		dir: dir,
+		lg:         lg,
+		dir:        dir,
+		pendingDBs: make(map[uint64]struct{}),
 	}
 }
 
@@ -273,6 +285,10 @@ func (s *Snapshotter) ReleaseSnapDBs(snap *raftpb.Snapshot) error {
 				continue
 			}
 			if index < snap.Metadata.GetIndex() {
+				if s.isPendingDB(index) {
+					s.lg.Info("skipping deletion of .snap.db file pending apply", zap.String("path", filename))
+					continue
+				}
 				s.lg.Info("found orphaned .snap.db file; deleting", zap.String("path", filename))
 				if rmErr := os.Remove(filepath.Join(s.dir, filename)); rmErr != nil && !os.IsNotExist(rmErr) {
 					s.lg.Error("failed to remove orphaned .snap.db file", zap.String("path", filename), zap.String("error", rmErr.Error()))

--- a/server/etcdserver/api/snap/snapshotter_test.go
+++ b/server/etcdserver/api/snap/snapshotter_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap/zaptest"
@@ -305,5 +306,49 @@ func TestReleaseSnapDBs(t *testing.T) {
 		if !fileutil.Exist(filename) {
 			t.Errorf("expected %s (index: %d) to be retained, but it no longer exists", filename, index)
 		}
+	}
+}
+
+// TestReleaseSnapDBsRetainsSnapshotPendingApply reproduces the scenario from
+// https://github.com/etcd-io/etcd/issues/18055. A follower saves the database
+// file for snapshot A on receipt (rafthttp -> SaveDBFrom) and the snapshot
+// waits in the apply queue. Before A is applied, a newer snapshot B arrives
+// and the raft loop releases all older database files (ReleaseSnapDBs),
+// deleting A's file while its apply is still pending. When the apply loop
+// finally opens A's file (OpenSnapshotBackend -> DBFilePath), the file is
+// gone and etcdserver panics with "failed to open snapshot backend".
+func TestReleaseSnapDBsRetainsSnapshotPendingApply(t *testing.T) {
+	dir := t.TempDir()
+	ss := New(zaptest.NewLogger(t), dir)
+
+	const (
+		indexA uint64 = 100
+		indexB uint64 = 200
+	)
+
+	// Snapshot A is received and its database file saved.
+	if _, err := ss.SaveDBFrom(strings.NewReader("A"), indexA); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot B arrives before A has been applied; the raft loop releases
+	// older snapshot database files.
+	if err := ss.ReleaseSnapDBs(&raftpb.Snapshot{Metadata: &raftpb.SnapshotMetadata{Index: new(uint64(indexB))}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The apply loop now looks up snapshot A's database file to apply it.
+	if _, err := ss.DBFilePath(indexA); err != nil {
+		t.Errorf("DBFilePath(%d) = %v, want success: a saved snapshot db must not be released before it has been applied", indexA, err)
+	}
+
+	// Once the apply path has consumed the file, the protection is dropped
+	// and any leftover file becomes eligible for cleanup again.
+	ss.ReleaseDBSnapshot(indexA)
+	if err := ss.ReleaseSnapDBs(&raftpb.Snapshot{Metadata: &raftpb.SnapshotMetadata{Index: new(uint64(indexB))}}); err != nil {
+		t.Fatal(err)
+	}
+	if fileutil.Exist(filepath.Join(dir, fmt.Sprintf("%016x.snap.db", indexA))) {
+		t.Errorf("expected snapshot db for index %d to be deleted after its apply completed", indexA)
 	}
 }

--- a/server/storage/backend.go
+++ b/server/storage/backend.go
@@ -64,6 +64,9 @@ func OpenSnapshotBackend(cfg config.ServerConfig, ss *snap.Snapshotter, snapshot
 	if err := os.Rename(snapPath, cfg.BackendPath()); err != nil {
 		return nil, fmt.Errorf("failed to rename database snapshot file (%w)", err)
 	}
+	// The snapshot db file has been consumed by the rename above; drop its
+	// pending-apply protection so ReleaseSnapDBs can clean up any leftover.
+	ss.ReleaseDBSnapshot(snapshot.Metadata.GetIndex())
 	return OpenBackend(cfg, hooks), nil
 }
 


### PR DESCRIPTION
When a follower receives two snapshots in a short period, the raft loop persisting the newer one releases all older snapshot database files, while the apply loop may still be waiting to apply an older snapshot. Its .snap.db file gets deleted while the apply is pending, and when applySnapshot opens it through OpenSnapshotBackend the server panics with "failed to open snapshot backend". This has been hit in robustness testing CI and reproduced by Antithesis on default configuration.

The Snapshotter now tracks snapshot database files that are pending apply: SaveDBFrom marks the index on save, ReleaseSnapDBs skips marked files, and OpenSnapshotBackend drops the mark once the rename consumes the file. The tracking is in memory only, so stale files from a previous run are still cleaned up at boot, same as before.

Added a test reproducing the sequence: save the db file for snapshot A, run ReleaseSnapDBs for a newer snapshot B, then look up A's file as the apply path does. It fails on main with "snap: snapshot file doesn't exist", the exact error behind the panic, and passes with the change. The test also verifies the file becomes eligible for cleanup again once the apply completes.

Fixes #18055