### PR TITLE
rafthttp: add byte-based backpressure to stream replication

### DIFF
--- a/server/etcdserver/api/rafthttp/peer.go
+++ b/server/etcdserver/api/rafthttp/peer.go
@@ -17,10 +17,12 @@ package rafthttp
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
+	"google.golang.org/protobuf/proto"
 
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
@@ -243,9 +245,44 @@ func (p *peer) send(m *raftpb.Message) {
 	}
 
 	writec, name := p.pick(m)
+
+	var pendingBytes *int64
+	if name == streamAppV2 {
+		pendingBytes = &p.msgAppV2Writer.pendingBytes
+	} else if name == streamMsg {
+		pendingBytes = &p.writer.pendingBytes
+	}
+
+	if pendingBytes != nil {
+		msgSize := int64(proto.Size(m))
+		if atomic.LoadInt64(pendingBytes)+msgSize > maxPendingBytes {
+			p.r.ReportUnreachable(m.GetTo())
+			if isMsgSnap(m) {
+				p.r.ReportSnapshot(m.GetTo(), raft.SnapshotFailure)
+			}
+			if p.lg != nil {
+				p.lg.Warn(
+					"dropped internal Raft message since sending buffer is full (byte limit exceeded)",
+					zap.String("message-type", m.GetType().String()),
+					zap.String("local-member-id", p.localID.String()),
+					zap.String("from", types.ID(m.GetFrom()).String()),
+					zap.String("remote-peer-id", p.id.String()),
+					zap.String("remote-peer-name", name),
+					zap.Bool("remote-peer-active", p.status.isActive()),
+				)
+			}
+			sentFailures.WithLabelValues(types.ID(m.GetTo()).String()).Inc()
+			return
+		}
+		atomic.AddInt64(pendingBytes, msgSize)
+	}
+
 	select {
 	case writec <- m:
 	default:
+		if pendingBytes != nil {
+			atomic.AddInt64(pendingBytes, -int64(proto.Size(m)))
+		}
 		p.r.ReportUnreachable(m.GetTo())
 		if isMsgSnap(m) {
 			p.r.ReportSnapshot(m.GetTo(), raft.SnapshotFailure)

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -43,6 +44,8 @@ const (
 	streamTypeMsgAppV2 streamType = "msgappv2"
 
 	streamBufSize = 4096
+
+	maxPendingBytes = 50 * 1024 * 1024 // 50MB
 )
 
 var (
@@ -134,6 +137,8 @@ type streamWriter struct {
 	connc chan *outgoingConn
 	stopc chan struct{}
 	done  chan struct{}
+
+	pendingBytes int64
 }
 
 // startStreamWriter creates a streamWrite and starts a long running go-routine that accepts
@@ -206,6 +211,7 @@ func (cw *streamWriter) run() {
 			heartbeatc, msgc = nil, nil
 
 		case m := <-msgc:
+			atomic.AddInt64(&cw.pendingBytes, int64(-proto.Size(m)))
 			err := enc.encode(m)
 			if err == nil {
 				unflushed += proto.Size(m)


### PR DESCRIPTION
Previously, the outbound stream replication queue (msgc) was only bounded by a hardcoded message count (4096). During a network partition, a blocked network socket could cause the leader to queue up to 4096 large MsgApp messages (up to 1.5MB each), quietly consuming ~6GB of memory and causing an OOM crash. This introduces a 50MB byte-size limit (maxPendingBytes) to the streamWriter. If the pending byte threshold is exceeded, the leader drops the message and reports the peer as unreachable, gracefully degrading instead of crashing.