### PR TITLE
tests/integration: poll instead of sleeping in TestV3WatchCancellation

### DIFF
--- a/tests/integration/clientv3/watch/v3_watch_test.go
+++ b/tests/integration/clientv3/watch/v3_watch_test.go
@@ -1365,23 +1365,23 @@ func TestV3WatchCancellation(t *testing.T) {
 		wcancel()
 	}
 
-	// Wait a little for cancellations to take hold
-	time.Sleep(3 * time.Second)
-
-	minWatches, err := clus.Members[0].Metric("etcd_debugging_mvcc_watcher_total")
-	require.NoError(t, err)
-
-	var expected string
+	expected := "1"
 	if integration.ThroughProxy {
 		// grpc proxy has additional 2 watches open
 		expected = "3"
-	} else {
-		expected = "1"
 	}
 
-	if minWatches != expected {
-		t.Fatalf("expected %s watch, got %s", expected, minWatches)
-	}
+	// Cancelled watchers are cleaned up asynchronously, so poll the metric until
+	// it settles rather than waiting a fixed amount of time. A fixed wait is both
+	// slower than necessary and flaky: on a loaded runner the cleanup can take
+	// longer than the wait and spuriously fail the test.
+	var minWatches string
+	var lastErr error
+	require.Eventuallyf(t, func() bool {
+		minWatches, lastErr = clus.Members[0].Metric("etcd_debugging_mvcc_watcher_total")
+		return lastErr == nil && minWatches == expected
+	}, 10*time.Second, 10*time.Millisecond,
+		"expected %s watch, got %s (last err: %v)", expected, minWatches, lastErr)
 }
 
 // TestV3WatchCloseCancelRace ensures that watch close doesn't decrement the watcher total too far.


### PR DESCRIPTION
`TestV3WatchCancellation` opens and cancels 1000 watchers, then checks that `etcd_debugging_mvcc_watcher_total` has settled back to the single persistent watch. It did this by sleeping a fixed **3s** before reading the metric once:

```go
// Wait a little for cancellations to take hold
time.Sleep(3 * time.Second)
minWatches, err := clus.Members[0].Metric("etcd_debugging_mvcc_watcher_total")
```

Watcher cleanup is asynchronous, so a fixed sleep is the wrong tool in both directions:

- **Flaky** — on a loaded CI runner the cleanup can take longer than 3s, and the test fails spuriously with `expected 1 watch, got …` even though nothing is actually broken.
- **Slow** — when cleanup finishes quickly (the common case, a few ms), the test still burns the full 3s.

This polls the metric with `require.Eventuallyf` until it settles (10s ceiling, 10ms interval) instead. Same final assertion, no fixed-window race.

### Verification

Ran the integration test locally (single-member in-process cluster):
- before: `--- PASS: TestV3WatchCancellation (3.84s)` / package `4.738s`
- after: package `2.139s`

`gofmt` and `go vet ./tests/integration/clientv3/watch/` clean. Test-only change; no production code touched.