### PR TITLE
etcdserver: fix typos in code comments

### DIFF
--- a/server/auth/range_perm_cache.go
+++ b/server/auth/range_perm_cache.go
@@ -78,7 +78,7 @@ func checkKeyInterval(
 ) bool {
 	if isOpenEnded(rangeEnd) {
 		rangeEnd = nil
-		// nil rangeEnd will be converetd to []byte{}, the largest element of BytesAffineComparable,
+		// nil rangeEnd will be converted to []byte{}, the largest element of BytesAffineComparable,
 		// in NewBytesAffineInterval().
 	}
 

--- a/server/etcdserver/api/v3compactor/periodic_test.go
+++ b/server/etcdserver/api/v3compactor/periodic_test.go
@@ -33,7 +33,7 @@ func TestPeriodicHourly(t *testing.T) {
 	retentionDuration := time.Duration(retentionHours) * time.Hour
 
 	fc := clockwork.NewFakeClock()
-	// TODO: Do not depand or real time (Recorder.Wait) in unit tests.
+	// TODO: Do not depend on real time (Recorder.Wait) in unit tests.
 	rg := &fakeRevGetter{testutil.NewRecorderStreamWithWaitTimout(0), 0}
 	compactable := &fakeCompactable{testutil.NewRecorderStreamWithWaitTimout(10 * time.Millisecond)}
 	tb := newPeriodic(zaptest.NewLogger(t), fc, retentionDuration, rg, compactable)

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -200,7 +200,7 @@ type Server interface {
 	// Caution:
 	// 1. the returned channel is being closed when the leadership changes.
 	// 2. so the new channel needs to be obtained for each raft term.
-	// 3. user can loose some consecutive channel changes using this API.
+	// 3. user can lose some consecutive channel changes using this API.
 	LeaderChangedNotify() <-chan struct{}
 }
 

--- a/server/etcdserver/version/downgrade.go
+++ b/server/etcdserver/version/downgrade.go
@@ -38,7 +38,7 @@ func isValidDowngrade(verFrom *semver.Version, verTo *semver.Version) bool {
 	return verTo.Equal(*allowedDowngradeVersion(verFrom))
 }
 
-// MustDetectDowngrade will detect local server joining cluster that doesn't support it's version.
+// MustDetectDowngrade will detect local server joining cluster that doesn't support its version.
 func MustDetectDowngrade(lg *zap.Logger, sv, cv *semver.Version) {
 	// only keep major.minor version for comparison against cluster version
 	sv = &semver.Version{Major: sv.Major, Minor: sv.Minor}

--- a/server/storage/schema/schema.go
+++ b/server/storage/schema/schema.go
@@ -80,7 +80,7 @@ func UnsafeMigrate(lg *zap.Logger, tx backend.UnsafeReadWriter, w wal.Version, t
 
 // DetectSchemaVersion returns version of storage schema. Returned value depends on etcd version that created the backend. For
 // * v3.6 and newer will return storage version.
-// * v3.5 will return it's version if it includes all storage fields added in v3.5 (might require a snapshot).
+// * v3.5 will return its version if it includes all storage fields added in v3.5 (might require a snapshot).
 // * v3.4 and older is not supported and will return error.
 func DetectSchemaVersion(lg *zap.Logger, tx backend.ReadTx) (v semver.Version, err error) {
 	tx.RLock()

--- a/server/storage/wal/wal.go
+++ b/server/storage/wal/wal.go
@@ -459,7 +459,7 @@ func openWALFiles(lg *zap.Logger, dirpath string, names []string, nameIndex int,
 // If loaded snap doesn't match with the expected one, it will return
 // all the records and error ErrSnapshotMismatch.
 // TODO: detect not-last-snap error.
-// TODO: maybe loose the checking of match.
+// TODO: maybe lose the checking of match.
 // After ReadAll, the WAL will be ready for appending new records.
 //
 // ReadAll suppresses WAL entries that got overridden (i.e. a newer entry with the same index


### PR DESCRIPTION
## Summary

Fix several typos found in code comments across the etcd server packages.

## Changes

- `depand` → `depend` in `server/etcdserver/api/v3compactor/periodic_test.go`
- `converetd` → `converted` in `server/auth/range_perm_cache.go`
- `loose` → `lose` in `server/storage/wal/wal.go` and `server/etcdserver/server.go`
- `it's` → `its` (possessive) in `server/etcdserver/version/downgrade.go` and `server/storage/schema/schema.go`

## Checklist

- [x] Signed off all commits (DCO)
- [x] PR title follows commit message convention