### PR TITLE
etcdserver: fix grammatical errors in code comments

### DIFF
--- a/server/embed/config_tracing.go
+++ b/server/embed/config_tracing.go
@@ -131,7 +131,7 @@ func determineSampler(samplingRate int) tracesdk.Sampler {
 
 // As Tracing service Instance ID must be unique, it should
 // never use the empty default string value, it's set if
-// if it's a non empty string.
+// it's a non-empty string.
 func determineResourceWithIDKey(serviceInstanceID string) *resource.Resource {
 	if serviceInstanceID != "" {
 		return resource.NewSchemaless(

--- a/server/etcdserver/api/v3rpc/watch.go
+++ b/server/etcdserver/api/v3rpc/watch.go
@@ -208,7 +208,7 @@ func (ws *watchServer) Watch(stream pb.Watch_WatchServer) (err error) {
 		}
 	}()
 
-	// TODO: There's a race here. When a stream  is closed (e.g. due to a cancellation),
+	// TODO: There's a race here. When a stream is closed (e.g. due to a cancellation),
 	// the underlying error (e.g. a gRPC stream error) may be returned and handled
 	// through errc if the recv goroutine finishes before the send goroutine.
 	// When the recv goroutine wins, the stream error is retained. When recv loses

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -195,7 +195,7 @@ type Server interface {
 	Alarms() []*pb.AlarmMember
 
 	// LeaderChangedNotify returns a channel for application level code to be notified
-	// when etcd leader changes, this function is intend to be used only in application
+	// when etcd leader changes, this function is intended to be used only in application
 	// which embed etcd.
 	// Caution:
 	// 1. the returned channel is being closed when the leadership changes.

--- a/server/lease/lessor.go
+++ b/server/lease/lessor.go
@@ -257,8 +257,8 @@ func newLessor(lg *zap.Logger, b backend.Backend, cluster cluster, cfg LessorCon
 // smaller term and will not be committed.
 //
 // TODO: raft follower do not forward lease management proposals. There might be a
-// very small window (within second normally which depends on go scheduling) that
-// a raft follow is the primary between the raft leader demotion and lessor demotion.
+// very small window (within a second normally, which depends on Go scheduling) that
+// a raft follower is the primary between the raft leader demotion and lessor demotion.
 // Usually this should not be a problem. Lease should not be that sensitive to timing.
 func (le *lessor) isPrimary() bool {
 	return le.demotec != nil


### PR DESCRIPTION
## Summary

Fix several grammatical errors found in code comments across the etcd server packages.

## Changes

- `is intend to` → `is intended to` in `server/etcdserver/server.go`
- Remove duplicate space in `server/etcdserver/api/v3rpc/watch.go`
- `non empty` → `non-empty` in `server/embed/config_tracing.go`
- `within second` → `within a second` and `follow` → `follower` in `server/lease/lessor.go`
- Remove duplicate `if` in `server/embed/config_tracing.go`

## Checklist

- [x] Signed off all commits (DCO)
- [x] PR title follows commit message convention