### PR TITLE
add grpc gateway client metric

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -830,6 +831,10 @@ func (e *Etcd) grpcGatewayDial(splitHTTP bool) (grpcDial func(ctx context.Contex
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
+	opts = append(opts,
+		grpc.WithUnaryInterceptor(grpcprom.UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(grpcprom.StreamClientInterceptor),
+	)
 
 	return func(_ context.Context) (*grpc.ClientConn, error) {
 		conn, err := grpc.NewClient(addr, opts...)


### PR DESCRIPTION
There is no any metric for grpc gateway。
This PR adds grpc client metric for grpc gateway
Or we can set grpc gateway feature false from true default

