### PR TITLE
tests: return early when NewSession fails in double barrier tests

### DIFF
--- a/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
+++ b/tests/integration/clientv3/experimental/recipes/v3_double_barrier_test.go
@@ -37,9 +37,7 @@ func TestDoubleBarrier(t *testing.T) {
 
 	waiters := 10
 	session, err := concurrency.NewSession(clus.RandClient())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer session.Orphan()
 
 	b := recipe.NewDoubleBarrier(session, "test-barrier", waiters)
@@ -50,6 +48,7 @@ func TestDoubleBarrier(t *testing.T) {
 			session, err := concurrency.NewSession(clus.RandClient())
 			if err != nil {
 				t.Error(err)
+				return
 			}
 			defer session.Orphan()
 
@@ -109,9 +108,7 @@ func TestDoubleBarrierTooManyClients(t *testing.T) {
 
 	waiters := 10
 	session, err := concurrency.NewSession(clus.RandClient())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer session.Orphan()
 
 	b := recipe.NewDoubleBarrier(session, "test-barrier", waiters)
@@ -129,6 +126,8 @@ func TestDoubleBarrierTooManyClients(t *testing.T) {
 			gsession, gerr := concurrency.NewSession(clus.RandClient())
 			if gerr != nil {
 				t.Error(gerr)
+				wgEntered.Done()
+				return
 			}
 			defer gsession.Orphan()
 
@@ -174,14 +173,10 @@ func TestDoubleBarrierFailover(t *testing.T) {
 	defer close(donec)
 
 	s0, err := concurrency.NewSession(clus.Client(0))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer s0.Orphan()
 	s1, err := concurrency.NewSession(clus.Client(0))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	defer s1.Orphan()
 
 	// sacrificial barrier holder; lease will be revoked


### PR DESCRIPTION
## Problem

`TestDoubleBarrier` (and its variants) can crash the test binary with a nil-pointer `SIGSEGV` instead of failing gracefully, as reported in #22010:

```
[signal SIGSEGV: segmentation violation]
(*Session).Orphan(...)   client/v3/concurrency/session.go:103
panic(...)
(*Session).Client(...)   client/v3/concurrency/session.go:83
(*DoubleBarrier).Enter    client/v3/experimental/recipes/double_barrier.go:47
```

## Root cause

When `concurrency.NewSession(...)` returns an error, the tests log it with `t.Error(err)` but do **not** `return`, so execution continues with a nil `Session`. That nil session then flows into `DoubleBarrier.Enter()` → `Session.Client()` (and the deferred `Session.Orphan()` during panic unwind), dereferencing a nil receiver.

This only surfaces when `NewSession` fails transiently (e.g. a hiccup on the CI runner), which is why it appears as a flake.

## Fix

Guard every session-creation site so a failed session is never used:
- `require.NoError(t, err)` on the main test goroutines.
- `t.Error(err)` + `return` in the child goroutines (releasing the `WaitGroup` in `TestDoubleBarrierTooManyClients` so an early return can't strand `wgEntered.Wait()`).

## Verification

- Reproduced the identical SIGSEGV locally by forcing `NewSession` to fail (via an already-cancelled context) in the child goroutine.
- With the fix, the nil-session path is unreachable; `go vet` is clean and the `TestDoubleBarrier*` tests pass.

Fixes #22010