### PR TITLE
etcdutl: add init command

### DIFF
--- a/CHANGELOG/CHANGELOG-3.8.md
+++ b/CHANGELOG/CHANGELOG-3.8.md
@@ -7,3 +7,7 @@ Previous change logs can be found at [CHANGELOG-3.7](https://github.com/etcd-io/
 ### Dependencies
 
 - Compile binaries using [go 1.26.5](https://github.com/etcd-io/etcd/pull/22062).
+
+### etcdutl
+
+- Add `etcdutl init` command to initialize a member's data directory offline, without a snapshot file or a running server. The command is idempotent: an already initialized data directory is validated against the given configuration instead of being overwritten, so init can run for example as a Kubernetes init container.

--- a/etcdutl/ctl.go
+++ b/etcdutl/ctl.go
@@ -43,6 +43,7 @@ func init() {
 
 	rootCmd.AddCommand(
 		etcdutl.NewDefragCommand(),
+		etcdutl.NewInitCommand(),
 		etcdutl.NewSnapshotCommand(),
 		etcdutl.NewHashKVCommand(),
 		etcdutl.NewVersionCommand(),

--- a/etcdutl/etcdutl/init_command.go
+++ b/etcdutl/etcdutl/init_command.go
@@ -1,0 +1,254 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutl
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.etcd.io/etcd/pkg/v3/cobrautl"
+	"go.etcd.io/etcd/server/v3/config"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/datadir"
+	"go.etcd.io/etcd/server/v3/storage/schema"
+	"go.etcd.io/etcd/server/v3/verify"
+)
+
+var (
+	initCluster      string
+	initClusterToken string
+	initDataDir      string
+	initWALDir       string
+	initPeerURLs     string
+	initName         string
+	initNoVerify     bool
+)
+
+// NewInitCommand returns the cobra command for "init".
+func NewInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init --data-dir {output dir} [options]",
+		Short: "Initializes a new etcd data directory for a member of a new cluster",
+		Long: `Initializes a new etcd data directory, without requiring a snapshot file or a
+running etcd server. The produced data directory contains an empty keyspace and
+the full initial cluster membership, so the member can afterwards be started
+with just --data-dir.
+
+To bootstrap a multi-member cluster, run init once per member with that
+member's --name and --initial-advertise-peer-urls and the same
+--initial-cluster, then place each produced data directory on its member.
+`,
+		Run: initCommandFunc,
+	}
+	cmd.Flags().StringVar(&initDataDir, "data-dir", "", "Path to the output data directory")
+	cmd.Flags().StringVar(&initWALDir, "wal-dir", "", "Path to the WAL directory (use --data-dir if none given)")
+	cmd.Flags().StringVar(&initCluster, "initial-cluster", initialClusterFromName(defaultName), "Initial cluster configuration for init bootstrap")
+	cmd.Flags().StringVar(&initClusterToken, "initial-cluster-token", embed.DefaultInitialClusterToken, "Initial cluster token for the etcd cluster during init bootstrap")
+	cmd.Flags().StringVar(&initPeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster")
+	cmd.Flags().StringVar(&initName, "name", defaultName, "Human-readable name for this member")
+	cmd.Flags().Uint64Var(&initialMmapSize, "initial-memory-map-size", initialMmapSize, "Initial memory map size of the database in bytes. It uses the default value if not defined or defined to 0")
+	cmd.Flags().BoolVar(&initNoVerify, "no-verify", false, "Skip consistency verification of an already initialized data directory")
+
+	cmd.MarkFlagDirname("data-dir")
+	cmd.MarkFlagDirname("wal-dir")
+
+	return cmd
+}
+
+func initCommandFunc(_ *cobra.Command, args []string) {
+	if len(args) != 0 {
+		cobrautl.ExitWithError(cobrautl.ExitBadArgs, errors.New("init doesn't take any positional arguments"))
+	}
+	if err := runInit(initName, initDataDir, initWALDir, initCluster, initClusterToken, initPeerURLs, initialMmapSize, initNoVerify); err != nil {
+		cobrautl.ExitWithError(cobrautl.ExitError, err)
+	}
+}
+
+// defaultDataDir is the data directory used when --data-dir is not given.
+func defaultDataDir(name string) string {
+	return name + ".etcd"
+}
+
+func runInit(name, dataDir, walDir, cluster, clusterToken, peerURLs string, mmapSize uint64, noVerify bool) error {
+	if dataDir == "" {
+		dataDir = defaultDataDir(name)
+	}
+
+	if walDir == "" {
+		walDir = datadir.ToWALDir(dataDir)
+	}
+
+	lg := GetLogger()
+
+	pURLs, err := types.NewURLs(strings.Split(peerURLs, ","))
+	if err != nil {
+		return err
+	}
+	ics, err := types.NewURLsMap(cluster)
+	if err != nil {
+		return err
+	}
+	srv := config.ServerConfig{
+		Logger:              lg,
+		Name:                name,
+		PeerURLs:            pURLs,
+		InitialPeerURLsMap:  ics,
+		InitialClusterToken: clusterToken,
+	}
+	if err = srv.VerifyBootstrap(); err != nil {
+		return err
+	}
+
+	// Make init idempotent: an already initialized data directory is fine as
+	// long as it belongs to a member with the same configuration.
+	if fileutil.Exist(dataDir) && !fileutil.DirEmpty(dataDir) {
+		return validateExistingDataDir(lg, name, dataDir, walDir, ics, clusterToken, noVerify)
+	}
+
+	// Restore requires a snapshot file; synthesize an empty one so the
+	// initialized member starts with an empty keyspace.
+	seedDir, err := os.MkdirTemp("", "etcdutl-init-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(seedDir)
+	seedDB := filepath.Join(seedDir, "db")
+	if err := writeEmptySeedDB(lg, seedDB); err != nil {
+		return err
+	}
+
+	return snapshot.NewV3(lg).Restore(snapshot.RestoreConfig{
+		SnapshotPath:        seedDB,
+		Name:                name,
+		OutputDataDir:       dataDir,
+		OutputWALDir:        walDir,
+		PeerURLs:            strings.Split(peerURLs, ","),
+		InitialCluster:      cluster,
+		InitialClusterToken: clusterToken,
+		// The synthesized db has no trailing sha256, like a db copied
+		// from a data directory.
+		SkipHashCheck:   true,
+		InitialMmapSize: mmapSize,
+	})
+}
+
+// validateExistingDataDir checks that an existing data directory was
+// initialized for the same member and cluster configuration. The expected
+// member ID is derived from the member's peer URLs and the initial cluster
+// token, so a token, peer URL, or membership mismatch surfaces as an unknown
+// member ID.
+func validateExistingDataDir(lg *zap.Logger, name, dataDir, walDir string, ics types.URLsMap, clusterToken string, noVerify bool) error {
+	expectedCluster, err := membership.NewClusterFromURLsMap(lg, clusterToken, ics)
+	if err != nil {
+		return err
+	}
+	expectedMember := expectedCluster.MemberByName(name) //nolint:staticcheck // See https://github.com/dominikh/go-tools/issues/1698
+
+	dbPath := datadir.ToBackendFileName(dataDir)
+	if !fileutil.Exist(dbPath) {
+		return fmt.Errorf("data-dir %q is not empty and has no backend database %q; it is not an etcd data directory", dataDir, dbPath)
+	}
+	if !fileutil.Exist(walDir) || fileutil.DirEmpty(walDir) {
+		return fmt.Errorf("data-dir %q is not empty and has no WAL directory %q; it is not an etcd data directory", dataDir, walDir)
+	}
+
+	be := backend.NewDefaultBackend(lg, dbPath)
+	members, _ := schema.NewMembershipBackend(lg, be).MustReadMembersFromBackend()
+	be.Close()
+
+	found := members[expectedMember.ID]
+	if found == nil {
+		return fmt.Errorf("data-dir %q has no member %q with ID %s; it was initialized with a different --initial-cluster, --initial-cluster-token or --initial-advertise-peer-urls", dataDir, name, expectedMember.ID)
+	}
+	if found.Name != "" && found.Name != name {
+		return fmt.Errorf("data-dir %q member %s has name %q, expected %q; it belongs to a different member", dataDir, expectedMember.ID, found.Name, name)
+	}
+
+	switch {
+	case noVerify:
+		lg.Warn("skipping data consistency verification", zap.String("data-dir", dataDir))
+	case walDir != datadir.ToWALDir(dataDir):
+		// verify.Verify only supports the default layout with the WAL
+		// directory inside the data directory.
+		lg.Warn(
+			"skipping data consistency verification, not supported with a detached --wal-dir",
+			zap.String("data-dir", dataDir),
+			zap.String("wal-dir", walDir),
+		)
+	default:
+		if err := verifyDataDir(lg, dataDir); err != nil {
+			return fmt.Errorf("data-dir %q failed consistency verification: %w", dataDir, err)
+		}
+	}
+
+	lg.Info(
+		"data directory already initialized for this member, skipping",
+		zap.String("data-dir", dataDir),
+		zap.String("name", name),
+		zap.String("member-id", expectedMember.ID.String()),
+	)
+	return nil
+}
+
+// verifyDataDir runs offline consistency verification of a data directory.
+// verify.Verify reports problems as errors but panics on some kinds of
+// corruption; recover those into an error so init fails cleanly.
+func verifyDataDir(lg *zap.Logger, dataDir string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return verify.Verify(verify.Config{
+		Logger:  lg,
+		DataDir: dataDir,
+	})
+}
+
+// writeEmptySeedDB creates an empty backend database with the same buckets a
+// freshly bootstrapped member would create, stamped with this binary's storage
+// version so the started server sees a current-format db rather than falling
+// back to legacy schema-version detection.
+func writeEmptySeedDB(lg *zap.Logger, path string) error {
+	be := backend.NewDefaultBackend(lg, path)
+	defer be.Close()
+
+	tx := be.BatchTx()
+	tx.LockOutsideApply()
+	for _, bucket := range schema.AllBuckets {
+		tx.UnsafeCreateBucket(bucket)
+	}
+
+	binaryVersion := semver.New(version.Version)
+	storageVersion := semver.Version{Major: binaryVersion.Major, Minor: binaryVersion.Minor}
+	schema.UnsafeSetStorageVersion(tx, &storageVersion)
+	tx.Unlock()
+
+	be.ForceCommit()
+	return nil
+}

--- a/etcdutl/etcdutl/init_command_test.go
+++ b/etcdutl/etcdutl/init_command_test.go
@@ -1,0 +1,420 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/api/v3/version"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/datadir"
+	"go.etcd.io/etcd/server/v3/storage/schema"
+	"go.etcd.io/etcd/server/v3/verify"
+)
+
+func TestInit(t *testing.T) {
+	type testCase struct {
+		name            string
+		memberName      string
+		cluster         string
+		clusterToken    string
+		peerURLs        string
+		dataDir         string
+		walDir          string
+		setupFunc       func(t *testing.T, dataDir string)
+		noVerify        bool
+		expectedMembers []string
+		expectError     bool
+		errorRegexp     string
+	}
+
+	testCases := []testCase{
+		{
+			name:            "single member",
+			memberName:      "etcd-0",
+			cluster:         "etcd-0=http://etcd-0:2380",
+			peerURLs:        "http://etcd-0:2380",
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:            "single member with custom cluster token",
+			memberName:      "etcd-0",
+			cluster:         "etcd-0=http://etcd-0:2380",
+			clusterToken:    "custom-token",
+			peerURLs:        "http://etcd-0:2380",
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:            "multi member",
+			memberName:      "etcd-1",
+			cluster:         "etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380",
+			peerURLs:        "http://etcd-1:2380",
+			expectedMembers: []string{"etcd-0", "etcd-1", "etcd-2"},
+			expectError:     false,
+		},
+		{
+			name:            "member with multiple peer urls",
+			memberName:      "etcd-0",
+			cluster:         "etcd-0=http://etcd-0:2380,etcd-0=http://etcd-0:2381",
+			peerURLs:        "http://etcd-0:2380,http://etcd-0:2381",
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:            "custom wal dir",
+			memberName:      "etcd-0",
+			cluster:         "etcd-0=http://etcd-0:2380",
+			peerURLs:        "http://etcd-0:2380",
+			walDir:          "custom-wal",
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:       "existing empty data dir",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, os.MkdirAll(dataDir, 0o700))
+			},
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:        "member name missing from initial cluster",
+			memberName:  "etcd-1",
+			cluster:     "etcd-0=http://etcd-0:2380",
+			peerURLs:    "http://etcd-0:2380",
+			expectError: true,
+			errorRegexp: `couldn't find local name "[^"]+" in the initial cluster configuration`,
+		},
+		{
+			name:        "advertised peer urls not in initial cluster",
+			memberName:  "etcd-0",
+			cluster:     "etcd-0=http://etcd-0:2380",
+			peerURLs:    "http://etcd-0:12380",
+			expectError: true,
+			errorRegexp: `--initial-cluster has [^ ]+ but missing from --initial-advertise-peer-urls=[^ ]+`,
+		},
+		{
+			name:        "invalid peer url",
+			memberName:  "etcd-0",
+			cluster:     "etcd-0=http://etcd-0:2380",
+			peerURLs:    "://bad-url",
+			expectError: true,
+			errorRegexp: `parse "[^"]+": missing protocol scheme`,
+		},
+		{
+			name:       "non-etcd data dir",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, os.MkdirAll(dataDir, 0o700))
+				require.NoError(t, os.WriteFile(filepath.Join(dataDir, "keep"), []byte("data"), 0o600))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" is not empty and has no backend database "[^"]+"; it is not an etcd data directory`,
+		},
+		{
+			name:       "init is idempotent",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:         "reinit with different cluster token",
+			memberName:   "etcd-0",
+			cluster:      "etcd-0=http://etcd-0:2380",
+			clusterToken: "other-token",
+			peerURLs:     "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" has no member "etcd-0" with ID [0-9a-f]+; it was initialized with a different --initial-cluster, --initial-cluster-token or --initial-advertise-peer-urls`,
+		},
+		{
+			name:       "reinit with different peer urls",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:12380",
+			peerURLs:   "http://etcd-0:12380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" has no member "etcd-0" with ID [0-9a-f]+; it was initialized with a different --initial-cluster, --initial-cluster-token or --initial-advertise-peer-urls`,
+		},
+		{
+			name:       "reinit with initial cluster in different order",
+			memberName: "etcd-1",
+			cluster:    "etcd-2=http://etcd-2:2380,etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380",
+			peerURLs:   "http://etcd-1:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-1", dataDir, "",
+					"etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-1:2380", backend.InitialMmapSize, false))
+			},
+			expectedMembers: []string{"etcd-0", "etcd-1", "etcd-2"},
+			expectError:     false,
+		},
+		{
+			name:       "reinit with peer urls in different order",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2381,etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2381,http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380,etcd-0=http://etcd-0:2381", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380,http://etcd-0:2381", backend.InitialMmapSize, false))
+			},
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:       "reinit with custom wal dir",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			walDir:     "custom-wal",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "custom-wal",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectedMembers: []string{"etcd-0"},
+			expectError:     false,
+		},
+		{
+			name:       "reinit missing custom wal dir flag",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "custom-wal",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" is not empty and has no WAL directory "[^"]+"; it is not an etcd data directory`,
+		},
+		{
+			name:       "data dir with backend but no wal",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+				require.NoError(t, os.RemoveAll(datadir.ToWALDir(dataDir)))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" is not empty and has no WAL directory "[^"]+"; it is not an etcd data directory`,
+		},
+		{
+			name:       "data dir with wal but no backend",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+				require.NoError(t, os.RemoveAll(datadir.ToSnapDir(dataDir)))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" is not empty and has no backend database "[^"]+"; it is not an etcd data directory`,
+		},
+		{
+			name:       "reinit as unknown member against existing data dir",
+			memberName: "etcd-99",
+			cluster:    "etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380",
+			peerURLs:   "http://etcd-99:2380",
+			dataDir:    "member.etcd",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectError: true,
+			errorRegexp: `couldn't find local name "etcd-99" in the initial cluster configuration`,
+		},
+		{
+			name:       "reinit with corrupted wal fails verification",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+				corruptWAL(t, dataDir)
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" failed consistency verification`,
+		},
+		{
+			name:       "reinit with corrupted wal passes with no-verify",
+			memberName: "etcd-0",
+			cluster:    "etcd-0=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+				corruptWAL(t, dataDir)
+			},
+			noVerify:    true,
+			expectError: false,
+		},
+		{
+			name:       "reinit with different member name",
+			memberName: "etcd-1",
+			cluster:    "etcd-1=http://etcd-0:2380",
+			peerURLs:   "http://etcd-0:2380",
+			dataDir:    "member.etcd",
+			setupFunc: func(t *testing.T, dataDir string) {
+				require.NoError(t, runInit("etcd-0", dataDir, "",
+					"etcd-0=http://etcd-0:2380", embed.DefaultInitialClusterToken,
+					"http://etcd-0:2380", backend.InitialMmapSize, false))
+			},
+			expectError: true,
+			errorRegexp: `data-dir "[^"]+" member [0-9a-f]+ has name "etcd-0", expected "etcd-1"; it belongs to a different member`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			dataDir := tc.dataDir
+			if dataDir == "" {
+				dataDir = defaultDataDir(tc.memberName)
+			}
+
+			if tc.setupFunc != nil {
+				tc.setupFunc(t, dataDir)
+			}
+
+			clusterToken := tc.clusterToken
+			if clusterToken == "" {
+				clusterToken = embed.DefaultInitialClusterToken
+			}
+
+			err := runInit(tc.memberName, tc.dataDir, tc.walDir, tc.cluster, clusterToken, tc.peerURLs, backend.InitialMmapSize, tc.noVerify)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorRegexp != "" {
+					require.Regexp(t, tc.errorRegexp, err.Error())
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.expectedMembers != nil {
+				assertInitializedDataDir(t, dataDir, tc.walDir, tc.expectedMembers)
+			}
+		})
+	}
+}
+
+// corruptWAL replaces the WAL files of an initialized data directory with
+// garbage, so that offline consistency verification fails while the
+// membership stored in the backend database stays intact.
+func corruptWAL(t *testing.T, dataDir string) {
+	t.Helper()
+	walDir := datadir.ToWALDir(dataDir)
+	entries, err := os.ReadDir(walDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.NoError(t, os.Remove(filepath.Join(walDir, entry.Name())))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(walDir, "0000000000000000-0000000000000000.wal"), []byte("garbage"), 0o600))
+}
+
+// assertInitializedDataDir checks that dataDir contains a backend db with all
+// buckets and the current storage version, membership for all expected
+// members, and a WAL and snapshot that pass offline verification.
+func assertInitializedDataDir(t *testing.T, dataDir, walDir string, memberNames []string) {
+	t.Helper()
+	lg := zap.NewNop()
+
+	if walDir == "" {
+		walDir = datadir.ToWALDir(dataDir)
+	}
+	walFiles, err := filepath.Glob(filepath.Join(walDir, "*.wal"))
+	require.NoError(t, err)
+	require.NotEmpty(t, walFiles)
+
+	dbPath := datadir.ToBackendFileName(dataDir)
+	require.FileExists(t, dbPath)
+
+	db, err := bolt.Open(dbPath, 0o400, &bolt.Options{ReadOnly: true})
+	require.NoError(t, err)
+	expectedVersion := semver.New(version.Version)
+	require.NoError(t, db.View(func(tx *bolt.Tx) error {
+		for _, bucket := range schema.AllBuckets {
+			require.NotNilf(t, tx.Bucket(bucket.Name()), "bucket %q is missing", bucket)
+		}
+		storageVersion := schema.ReadStorageVersionFromSnapshot(tx)
+		require.NotNil(t, storageVersion)
+		require.Equal(t, semver.Version{Major: expectedVersion.Major, Minor: expectedVersion.Minor}, *storageVersion)
+		return nil
+	}))
+	require.NoError(t, db.Close())
+
+	be := backend.NewDefaultBackend(lg, dbPath)
+	members, removed := schema.NewMembershipBackend(lg, be).MustReadMembersFromBackend()
+	be.Close()
+	require.Empty(t, removed)
+	var names []string
+	for _, m := range members {
+		names = append(names, m.Name)
+	}
+	require.ElementsMatch(t, memberNames, names)
+
+	// verify.Verify only supports the default layout with the WAL directory
+	// inside the data directory.
+	if walDir == datadir.ToWALDir(dataDir) {
+		require.NoError(t, verify.Verify(verify.Config{
+			ExactIndex: true,
+			Logger:     lg,
+			DataDir:    dataDir,
+		}))
+	}
+}

--- a/etcdutl/etcdutl/snapshot_command.go
+++ b/etcdutl/etcdutl/snapshot_command.go
@@ -22,6 +22,7 @@ import (
 
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
 	"go.etcd.io/etcd/pkg/v3/cobrautl"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
 )
@@ -75,7 +76,7 @@ func NewSnapshotRestoreCommand() *cobra.Command {
 	cmd.Flags().StringVar(&restoreDataDir, "data-dir", "", "Path to the output data directory")
 	cmd.Flags().StringVar(&restoreWALDir, "wal-dir", "", "Path to the WAL directory (use --data-dir if none given)")
 	cmd.Flags().StringVar(&restoreCluster, "initial-cluster", initialClusterFromName(defaultName), "Initial cluster configuration for restore bootstrap")
-	cmd.Flags().StringVar(&restoreClusterToken, "initial-cluster-token", "etcd-cluster", "Initial cluster token for the etcd cluster during restore bootstrap")
+	cmd.Flags().StringVar(&restoreClusterToken, "initial-cluster-token", embed.DefaultInitialClusterToken, "Initial cluster token for the etcd cluster during restore bootstrap")
 	cmd.Flags().StringVar(&restorePeerURLs, "initial-advertise-peer-urls", defaultInitialAdvertisePeerURLs, "List of this member's peer URLs to advertise to the rest of the cluster")
 	cmd.Flags().StringVar(&restoreName, "name", defaultName, "Human-readable name for this member")
 	cmd.Flags().BoolVar(&skipHashCheck, "skip-hash-check", false, "Ignore snapshot integrity hash value (required if copied from data directory)")

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -127,6 +127,7 @@ var (
 
 	DefaultInitialAdvertisePeerURLs = "http://localhost:2380"
 	DefaultAdvertiseClientURLs      = "http://localhost:2379"
+	DefaultInitialClusterToken      = "etcd-cluster"
 
 	defaultHostname   string
 	defaultHostStatus error
@@ -540,7 +541,7 @@ func NewConfig() *Config {
 		AdvertiseClientUrls: []url.URL{*acurl},
 
 		ClusterState:        ClusterStateFlagNew,
-		InitialClusterToken: "etcd-cluster",
+		InitialClusterToken: DefaultInitialClusterToken,
 
 		StrictReconfigCheck: DefaultStrictReconfigCheck,
 		Metrics:             "basic",

--- a/tests/e2e/utl_init_test.go
+++ b/tests/e2e/utl_init_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/pkg/v3/expect"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestEtcdutlInit(t *testing.T) {
+	tcs := []struct {
+		name        string
+		clusterSize int
+	}{
+		{name: "SingleMember", clusterSize: 1},
+		{name: "MultiMember", clusterSize: 3},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			e2e.BeforeTest(t)
+			ctx := t.Context()
+
+			epc, err := e2e.InitEtcdProcessCluster(t, e2e.NewConfig(
+				e2e.WithClusterSize(tc.clusterSize),
+				e2e.WithKeepDataDir(true),
+			))
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, epc.Close())
+			}()
+
+			t.Log("etcdutl init all members")
+			for _, proc := range epc.Procs {
+				require.NoError(t, e2e.SpawnWithExpect(
+					initArgs(proc, proc.Config().InitialToken), expect.ExpectedResponse{Value: "added member"}))
+			}
+
+			t.Log("Dropping bootstrap flags, members start from the initialized data dirs alone")
+			for _, proc := range epc.Procs {
+				var minimal []string
+				for _, arg := range proc.Config().Args {
+					if strings.HasPrefix(arg, "--initial-cluster") ||
+						strings.HasPrefix(arg, "--initial-advertise-peer-urls") {
+						continue
+					}
+					minimal = append(minimal, arg)
+				}
+				proc.Config().Args = minimal
+			}
+			require.NoError(t, epc.Start(ctx))
+
+			dialTimeout := 10 * time.Second
+			prefixArgs := []string{
+				e2e.BinPath.Etcdctl,
+				"--endpoints", strings.Join(epc.EndpointsGRPC(), ","),
+				"--dial-timeout", dialTimeout.String(),
+			}
+
+			t.Log("Writing and reading a key")
+			require.NoError(t, e2e.SpawnWithExpect(
+				append(prefixArgs, "put", "foo", "bar"), expect.ExpectedResponse{Value: "OK"}))
+			require.NoError(t, e2e.SpawnWithExpect(
+				append(prefixArgs, "get", "foo"), expect.ExpectedResponse{Value: "bar"}))
+
+			t.Log("Checking all members are voting members")
+			memberListArgs := append(prefixArgs, "member", "list")
+			lines := make([]expect.ExpectedResponse, tc.clusterSize)
+			for i := range lines {
+				lines[i] = expect.ExpectedResponse{Value: "started"}
+			}
+			_, err = e2e.SpawnWithExpectLines(ctx, memberListArgs, nil, lines...)
+			require.NoError(t, err)
+
+			t.Log("Stopping the members")
+			require.NoError(t, epc.Stop())
+
+			t.Log("etcdutl init again is idempotent")
+			for _, proc := range epc.Procs {
+				require.NoError(t, e2e.SpawnWithExpect(
+					initArgs(proc, proc.Config().InitialToken), expect.ExpectedResponse{Value: "already initialized"}))
+			}
+
+			t.Log("etcdutl init with a different cluster token fails")
+			for _, proc := range epc.Procs {
+				err := e2e.SpawnWithExpect(
+					initArgs(proc, "different-token"), expect.ExpectedResponse{Value: "initialized with a different"})
+				require.ErrorContains(t, err, "initialized with a different")
+			}
+
+			t.Log("Restarting the members, data must survive")
+			require.NoError(t, epc.Restart(ctx))
+			require.NoError(t, e2e.SpawnWithExpect(
+				append(prefixArgs, "get", "foo"), expect.ExpectedResponse{Value: "bar"}))
+
+			t.Log("Killing the members uncleanly")
+			require.NoError(t, e2e.SpawnWithExpect(
+				append(prefixArgs, "put", "foo2", "bar2"), expect.ExpectedResponse{Value: "OK"}))
+			for _, proc := range epc.Procs {
+				require.NoError(t, proc.Kill())
+				require.NoError(t, proc.Wait(ctx))
+			}
+
+			t.Log("etcdutl init after unclean shutdown is idempotent")
+			for _, proc := range epc.Procs {
+				require.NoError(t, e2e.SpawnWithExpect(
+					initArgs(proc, proc.Config().InitialToken), expect.ExpectedResponse{Value: "already initialized"}))
+			}
+
+			t.Log("Restarting the members after unclean shutdown, data must survive")
+			require.NoError(t, epc.Restart(ctx))
+			require.NoError(t, e2e.SpawnWithExpect(
+				append(prefixArgs, "get", "foo2"), expect.ExpectedResponse{Value: "bar2"}))
+		})
+	}
+}
+
+// initArgs builds the etcdutl init invocation for a member from the
+// configuration the e2e framework generated for its process.
+func initArgs(proc e2e.EtcdProcess, clusterToken string) []string {
+	cfg := proc.Config()
+	return []string{
+		e2e.BinPath.Etcdutl, "init",
+		"--name", cfg.Name,
+		"--data-dir", cfg.DataDirPath,
+		"--initial-cluster", cfg.InitialCluster,
+		"--initial-cluster-token", clusterToken,
+		"--initial-advertise-peer-urls", cfg.PeerURL.String(),
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/etcd-io/etcd/issues/22090

Add an `etcdutl init` command that initializes a member's data directory offline — no snapshot file, no running server:

```bash
etcdutl init \
  --name etcd-0 \
  --data-dir /var/lib/etcd \
  --initial-cluster etcd-0=http://etcd-0:2380,etcd-1=http://etcd-1:2380,etcd-2=http://etcd-2:2380 \
  --initial-cluster-token my-cluster \
  --initial-advertise-peer-urls http://etcd-0:2380
```

Run once per member with the shared `--initial-cluster`, the produced data directories contain the full cluster membership, so members afterwards start with just `--name` and `--data-dir` — no `--initial-*` bootstrap flags on the server invocation. See the issue for the full motivation (Kubernetes StatefulSet init containers) and example manifest.

## Implementation

- `init` synthesizes an empty backend database (all `schema.AllBuckets`, stamped with the binary's storage version) and reuses the existing `etcdutl snapshot restore` machinery (`snapshot.Restore` with `SkipHashCheck`) to write the WAL and membership. The `etcdutl/snapshot` package is unchanged.
- **Idempotent:** if the data directory already exists, `init` validates it instead of failing — the expected member ID (derived from peer URLs + cluster token) must exist in the stored membership with the expected name, and the directory must pass `verify.Verify` offline consistency checks. Mismatches (different token, peer URLs, or member name) fail with specific errors; a naked default run produces the same member identity as a default `etcd` first boot.
- `--no-verify` skips the WAL consistency scan (which reads the full WAL and can be slow on large data directories); identity checks always run.
- The only server-module change is cosmetic: `embed.DefaultInitialClusterToken` is exported and used by `embed.NewConfig()` and both `etcdutl` commands, replacing three copies of the `"etcd-cluster"` literal. No behavior change; happy to drop the export and keep a package-local constant in `etcdutl` if preferred.

## Testing

- Unit (`etcdutl/etcdutl/init_command_test.go`): 23 table-driven cases — create paths (single/multi member, multiple peer URLs per member, custom `--wal-dir`), idempotent reinit (including reordered `--initial-cluster`/peer URLs), identity mismatches (token, peer URLs, member name, unknown member against an existing directory), partial and corrupted data directories, and `--no-verify`.
- e2e (`tests/e2e/utl_init_test.go`): 1- and 3-member clusters — init all members with the real binaries, start the servers without `--initial-*` flags, write/read data, verify idempotent reinit after both clean and unclean (SIGKILL) shutdown, verify a different cluster token is rejected, and confirm data survives restarts.

## Notes

- CHANGELOG-3.8 entry included.
- This PR was written in part with the assistance of generative AI (Claude Code), following the AI-assistance guidance linked from the PR template. All changes were reviewed, tested, and are understood by the author.
