### PR TITLE
pkg: fix unexported-return revive linter warnings

### DIFF
--- a/pkg/flags/uint32.go
+++ b/pkg/flags/uint32.go
@@ -19,27 +19,27 @@ import (
 	"strconv"
 )
 
-type uint32Value uint32
+type Uint32Value uint32
 
 // NewUint32Value creates an uint32 instance with the provided value.
-func NewUint32Value(v uint32) *uint32Value {
-	val := new(uint32Value)
-	*val = uint32Value(v)
+func NewUint32Value(v uint32) *Uint32Value {
+	val := new(Uint32Value)
+	*val = Uint32Value(v)
 	return val
 }
 
 // Set parses a command line uint32 value.
 // Implements "flag.Value" interface.
-func (i *uint32Value) Set(s string) error {
+func (i *Uint32Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 32)
-	*i = uint32Value(v)
+	*i = Uint32Value(v)
 	return err
 }
 
-func (i *uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 // Uint32FromFlag return the uint32 value of a flag with the given name
 func Uint32FromFlag(fs *flag.FlagSet, name string) uint32 {
-	val := *fs.Lookup(name).Value.(*uint32Value)
+	val := *fs.Lookup(name).Value.(*Uint32Value)
 	return uint32(val)
 }

--- a/pkg/flags/uint32_test.go
+++ b/pkg/flags/uint32_test.go
@@ -52,7 +52,7 @@ func TestUint32Value(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var val uint32Value
+			var val Uint32Value
 			err := val.Set(tc.s)
 
 			if tc.expectError {

--- a/pkg/wait/wait_time.go
+++ b/pkg/wait/wait_time.go
@@ -35,7 +35,7 @@ type timeList struct {
 	m                   map[uint64]chan struct{}
 }
 
-func NewTimeList() *timeList {
+func NewTimeList() WaitTime {
 	return &timeList{m: make(map[uint64]chan struct{})}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR addresses the `unexported-return` linter warnings in the `pkg/` module as part of the codebase effort to enable the `unexported-return` revive linter rule. 

This addresses a subtask of **#18370**.

### What changes were made?
1. **`pkg/flags/uint32.go`**: Exported the type `uint32Value` as `Uint32Value` so that the constructor `NewUint32Value` returns an exported type.
2. **`pkg/flags/uint32_test.go`**: Updated the corresponding test references to `Uint32Value`.
3. **`pkg/wait/wait_time.go`**: Updated the constructor `NewTimeList()` to return the exported `WaitTime` interface instead of the unexported type pointer `*timeList`.

All unit tests pass and `golangci-lint` runs clean for the `pkg/` module.