### PR TITLE
clientv3: remove keepalive entries without subscribers

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -383,7 +383,7 @@ func (l *lessor) keepAliveCtxCloser(ctx context.Context, id LeaseID, donec <-cha
 func (l *lessor) closeRequireLeader() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for _, ka := range l.keepAlives {
+	for id, ka := range l.keepAlives {
 		reqIdxs := 0
 		// find all required leader channels, close, mark as nil
 		for i, ctx := range ka.ctxs {
@@ -414,6 +414,9 @@ func (l *lessor) closeRequireLeader() {
 			newIdx++
 		}
 		ka.chs, ka.ctxs = newChs, newCtxs
+		if len(ka.chs) == 0 {
+			delete(l.keepAlives, id)
+		}
 	}
 }
 

--- a/client/v3/lease_internal_test.go
+++ b/client/v3/lease_internal_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCloseRequireLeaderRemovesKeepAliveWithoutSubscribers(t *testing.T) {
+	const leaseID LeaseID = 1
+	responseCh := make(chan *LeaseKeepAliveResponse)
+	l := &lessor{
+		keepAlives: map[LeaseID]*keepAlive{
+			leaseID: {
+				chs:   []chan<- *LeaseKeepAliveResponse{responseCh},
+				ctxs:  []context.Context{WithRequireLeader(t.Context())},
+				donec: make(chan struct{}),
+			},
+		},
+	}
+
+	l.closeRequireLeader()
+
+	if _, ok := l.keepAlives[leaseID]; ok {
+		t.Fatal("keep alive remains registered after its last subscriber is removed")
+	}
+	if _, ok := <-responseCh; ok {
+		t.Fatal("keep alive response channel remains open after leader loss")
+	}
+}


### PR DESCRIPTION
Fixes #22094.

## Problem

When leader loss removes every `WithRequireLeader` subscriber for a lease, `closeRequireLeader` compacts the subscriber slices to zero length but leaves the `keepAlive` registered in `lessor.keepAlives`.

The orphan remains active. `sendKeepAliveLoop` continues scanning it, successful responses refresh its deadline, and `nextKeepAlive` cannot advance because `recvKeepAlive` updates it inside the now-empty response-channel loop. The client can therefore keep renewing a lease that has no local listener.

PR #4574 introduced multiplexed keepalive subscribers and deletes the map entry when context cancellation removes the last listener. PR #7630 later added the leader-loss path but omitted the equivalent cleanup after compaction.

## Change

- Iterate `lessor.keepAlives` with the lease ID in `closeRequireLeader`.
- Delete an entry when removing require-leader subscribers leaves it with no response channels.
- Add a package-level regression test covering the final-subscriber case.

The deletion remains under the existing mutex and does not affect entries that retain any subscriber.

## Verification

```text
go test ./client/v3 -run '^TestCloseRequireLeaderRemovesKeepAliveWithoutSubscribers$' -count=1
ok      go.etcd.io/etcd/client/v3    0.018s
```

The same test failed before the implementation change with `keep alive remains registered after its last subscriber is removed`.