### PR TITLE
fix(proxy): add dial timeout and prevent double-close in TCP proxy

### DIFF
--- a/server/proxy/tcpproxy/userspace.go
+++ b/server/proxy/tcpproxy/userspace.go
@@ -166,8 +166,8 @@ func (tp *TCPProxy) serve(in net.Conn) {
 		if remote == nil {
 			break
 		}
-		// TODO: add timeout
-		out, err = net.Dial("tcp", remote.addr)
+		// Use a timeout to prevent hanging on unreachable endpoints
+		out, err = net.DialTimeout("tcp", remote.addr, 5*time.Second)
 		if err == nil {
 			break
 		}
@@ -182,15 +182,20 @@ func (tp *TCPProxy) serve(in net.Conn) {
 		return
 	}
 
+	// Use sync.Once to prevent double-close of connections
+	var inOnce, outOnce sync.Once
+	closeIn := func() { inOnce.Do(func() { in.Close() }) }
+	closeOut := func() { outOnce.Do(func() { out.Close() }) }
+
 	go func() {
 		io.Copy(in, out)
-		in.Close()
-		out.Close()
+		closeIn()
+		closeOut()
 	}()
 
 	io.Copy(out, in)
-	out.Close()
-	in.Close()
+	closeOut()
+	closeIn()
 }
 
 func (tp *TCPProxy) runMonitor() {


### PR DESCRIPTION
## Summary
- Replace `net.Dial` with `net.DialTimeout(5s)` to prevent hanging on unreachable endpoints
- Use `sync.Once` to prevent double-close of connections when both `io.Copy` goroutines finish

## Motivation
The TCP proxy had two issues:
1. `net.Dial` without timeout could block indefinitely if an endpoint was unreachable but not refusing connections (firewall dropping packets). This was acknowledged with a TODO comment.
2. Both directions of the bidirectional copy could race to close the same connections, causing unnecessary error logs and potential issues with non-idempotent connection implementations (e.g., TLS).

## Changes
| File | Change |
|------|--------|
| `server/proxy/tcpproxy/userspace.go:170` | `net.Dial` → `net.DialTimeout("tcp", remote.addr, 5*time.Second)` |
| `server/proxy/tcpproxy/userspace.go:185-193` | Use `sync.Once` for connection cleanup |

## Testing
- [x] Existing tests pass
- [x] No behavioral change for successful connections

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>