### PR TITLE
fix(rafthttp): properly cancel context and close response body in snapshot sender

### DIFF
--- a/server/etcdserver/api/rafthttp/snapshot_sender.go
+++ b/server/etcdserver/api/rafthttp/snapshot_sender.go
@@ -168,11 +168,14 @@ func (s *snapshotSender) post(req *http.Request) (err error) {
 		// successfully receives the request body.
 		time.AfterFunc(snapResponseReadTimeout, func() { httputil.GracefulClose(resp) })
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		result <- responseAndError{resp, body, err}
 	}()
 
 	select {
 	case <-s.stopc:
+		// Cancel the context to abort any in-flight RoundTrip
+		cancel()
 		return errStopped
 	case r := <-result:
 		if r.err != nil {


### PR DESCRIPTION
## Summary
- Explicitly cancel context when `stopc` fires to abort in-flight `RoundTrip`
- Close response body after `io.ReadAll` to prevent resource leaks
- Ensure goroutine cleanup on cancellation

## Motivation
When the snapshot sender is stopped (via `stopc`), the goroutine performing the HTTP request continues running. The context cancellation was deferred, but not explicitly called on the stop path. Additionally, the response body was not closed after reading, which could leak connections.

## Changes
| File | Change |
|------|--------|
| `server/etcdserver/api/rafthttp/snapshot_sender.go:170` | Add `resp.Body.Close()` after `io.ReadAll` |
| `server/etcdserver/api/rafthttp/snapshot_sender.go:175-176` | Explicitly call `cancel()` when `stopc` fires |

## Testing
- [x] Existing tests pass
- [x] No behavioral change for successful snapshot sends

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>