### PR TITLE
concurrency: stale Mutex.Unlock retry can delete a newer same-session lock

### DIFF
--- a/client/v3/concurrency/mutex.go
+++ b/client/v3/concurrency/mutex.go
@@ -141,7 +141,7 @@ func (m *Mutex) Unlock(ctx context.Context) error {
 	}
 
 	client := m.s.Client()
-	if _, err := client.Delete(ctx, m.myKey); err != nil {
+	if _, err := client.Txn(ctx).If(m.IsOwner()).Then(v3.OpDelete(m.myKey)).Commit(); err != nil {
 		return err
 	}
 	m.myKey = "\x00"

--- a/tests/integration/clientv3/concurrency/mutex_test.go
+++ b/tests/integration/clientv3/concurrency/mutex_test.go
@@ -15,11 +15,17 @@
 package concurrency_test
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
@@ -87,4 +93,73 @@ func TestMutexUnlock(t *testing.T) {
 	if !errors.Is(err, concurrency.ErrLockReleased) {
 		t.Fatal(err)
 	}
+}
+
+func TestMutexStaleUnlockDoesNotDeleteSameSessionRelock(t *testing.T) {
+	var loseFirstDeleteReply atomic.Bool
+	loseFirstDeleteReply.Store(true)
+	loseDeleteReply := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		deletesKey := method == pb.KV_DeleteRange_FullMethodName
+		if txn, ok := req.(*pb.TxnRequest); ok {
+			for _, op := range txn.Success {
+				deletesKey = deletesKey || op.GetRequestDeleteRange() != nil
+			}
+		}
+		if err == nil && deletesKey && loseFirstDeleteReply.CompareAndSwap(true, false) {
+			return status.Error(codes.DeadlineExceeded, "simulated lost delete response")
+		}
+		return err
+	}
+
+	cli, err := integration.NewClient(t, clientv3.Config{
+		Endpoints: exampleEndpoints(),
+		// Keep one total attempt so the injected post-commit error is returned instead of retried.
+		MaxUnaryRetries: 1,
+		DialOptions: []grpc.DialOption{
+			grpc.WithChainUnaryInterceptor(loseDeleteReply),
+		},
+	})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	session, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer session.Close()
+
+	ctx := t.Context()
+	oldMutex := concurrency.NewMutex(session, "/my-lock/")
+	require.NoError(t, oldMutex.Lock(ctx))
+	oldKey := oldMutex.Key()
+	oldGet, err := cli.Get(ctx, oldKey)
+	require.NoError(t, err)
+	require.Len(t, oldGet.Kvs, 1)
+	oldRevision := oldGet.Kvs[0].CreateRevision
+
+	require.Error(t, oldMutex.Unlock(ctx))
+	afterLostReply, err := cli.Get(ctx, oldKey)
+	require.NoError(t, err)
+	require.Empty(t, afterLostReply.Kvs)
+
+	currentMutex := concurrency.NewMutex(session, "/my-lock/")
+	require.NoError(t, currentMutex.Lock(ctx))
+	require.Equal(t, oldKey, currentMutex.Key())
+	currentGet, err := cli.Get(ctx, currentMutex.Key())
+	require.NoError(t, err)
+	require.Len(t, currentGet.Kvs, 1)
+	require.Greater(t, currentGet.Kvs[0].CreateRevision, oldRevision)
+
+	require.NoError(t, oldMutex.Unlock(ctx))
+	afterStaleUnlock, err := cli.Get(ctx, currentMutex.Key())
+	require.NoError(t, err)
+	require.Len(t, afterStaleUnlock.Kvs, 1)
+	require.Equal(t, currentGet.Kvs[0].CreateRevision, afterStaleUnlock.Kvs[0].CreateRevision)
+	require.NoError(t, currentMutex.Unlock(ctx))
 }


### PR DESCRIPTION
Fixes #22082

## Problem

If an `Unlock` delete commits but its response is lost, the old `Mutex`
retains its key and create revision. A later lock using the same session and
prefix reuses the key at a newer create revision. Retrying the stale `Unlock`
currently deletes that newer lock.

## Root cause

`Mutex.Unlock` deletes by key name only, without verifying that the key is
still the incarnation acquired by that `Mutex`.

## Change

Fence the delete in one transaction with `Mutex.IsOwner()`, which compares the
key's current create revision with the revision recorded at acquisition. A
stale comparison performs no delete; after a successful RPC, the old local
mutex handle is retired as before.

The regression test adapts the reproducer from #22082. It simulates a committed
delete whose response is replaced by `DeadlineExceeded`, reacquires the
identical key with the same session, and verifies that retrying the old unlock
preserves the newer create revision.

## Verification

The new test failed before the production change because the newer key was
deleted. It passes after the change.

- `go test ./integration/clientv3/concurrency -run '^TestMutexStaleUnlockDoesNotDeleteSameSessionRelock$' -count=10`
- `go test -race ./integration/clientv3/concurrency -run '^TestMutexStaleUnlockDoesNotDeleteSameSessionRelock$' -count=1`
- `go test ./integration/clientv3/concurrency -count=1`
- `go test ./concurrency -count=1`
- `go vet ./concurrency`
- `make verify-lint`
- `make verify-mod-tidy`
- `git diff --check`

The aggregate `make verify` reached `verify-bom` but cannot complete faithfully
on this Darwin/arm64 host: the local BOM generator excludes the amd64-only
Antithesis SDK and therefore differs from the checked-in Linux BOM. Prow's
supported Linux/amd64 checks remain authoritative.

## Compatibility

This changes one `DeleteRange` RPC into one transactional compare-and-delete
RPC. There is no public API, documentation, or main-branch changelog change.
Maintainers can decide whether the fix should be backported.

