### PR TITLE
Comparing value in TXN on non-existing key always returns failure.

### DIFF
--- a/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+++ b/Documentation/dev-guide/apispec/swagger/rpc.swagger.json
@@ -2070,7 +2070,7 @@
         "value": {
           "type": "string",
           "format": "byte",
-          "description": "value is the value of the given key, in bytes."
+          "description": "value is the value of the given key, in bytes. A value comparison against a\nkey that does not exist, or against a range that contains no keys, always\nevaluates to false, regardless of the comparison operator."
         },
         "lease": {
           "type": "string",

--- a/api/etcdserverpb/rpc.pb.go
+++ b/api/etcdserverpb/rpc.pb.go
@@ -1414,7 +1414,9 @@ type Compare_ModRevision struct {
 }
 
 type Compare_Value struct {
-	// value is the value of the given key, in bytes.
+	// value is the value of the given key, in bytes. A value comparison against a
+	// key that does not exist, or against a range that contains no keys, always
+	// evaluates to false, regardless of the comparison operator.
 	Value []byte `protobuf:"bytes,7,opt,name=value,proto3,oneof"`
 }
 

--- a/api/etcdserverpb/rpc.proto
+++ b/api/etcdserverpb/rpc.proto
@@ -632,7 +632,9 @@ message Compare {
     int64 create_revision = 5;
     // mod_revision is the last modified revision of the given key.
     int64 mod_revision = 6;
-    // value is the value of the given key, in bytes.
+    // value is the value of the given key, in bytes. A value comparison against a
+    // key that does not exist, or against a range that contains no keys, always
+    // evaluates to false, regardless of the comparison operator.
     bytes value = 7;
     // lease is the lease id of the given key.
     int64 lease = 8 [(versionpb.etcd_version_field)="3.3"];


### PR DESCRIPTION
Refs: etcd-io/etcd#19678

## What changed

- Clarify that a value comparison against a missing key, or a range containing no keys, evaluates to false regardless of the comparison operator.
- Regenerate the Go protobuf and Swagger artifacts from `rpc.proto`.

This updates the canonical API documentation source. Publishing the generated API reference to the website remains follow-up work, so this PR references rather than closes the issue.

## Validation

- `./scripts/genproto.sh`
- `make verify-proto-annotations`
- `go test ./api/etcdserverpb`
- `go test ./server/etcdserver/txn`
- `jq empty Documentation/dev-guide/apispec/swagger/rpc.swagger.json`
- `gofmt -d api/etcdserverpb/rpc.pb.go`
- `git diff --check upstream/main...HEAD`
