### PR TITLE
leasing cache range scan in LockWriteOps races with concurrent writes

### DIFF
--- a/client/v3/leasing/cache.go
+++ b/client/v3/leasing/cache.go
@@ -93,14 +93,7 @@ func (lc *leaseCache) LockWriteOps(ops []v3.Op) (ret []chan<- struct{}) {
 				ret = append(ret, wc)
 			}
 		} else {
-			for k := range lc.entries {
-				if !inRange(k, key, end) {
-					continue
-				}
-				if wc, _ := lc.Lock(k); wc != nil {
-					ret = append(ret, wc)
-				}
-			}
+			ret = append(ret, lc.LockRange(key, end)...)
 		}
 	}
 	return ret

--- a/client/v3/leasing/cache_lock_write_ops_test.go
+++ b/client/v3/leasing/cache_lock_write_ops_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leasing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	v3pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3 "go.etcd.io/etcd/client/v3"
+)
+
+// TestLeaseCacheLockWriteOpsRangeConcurrency exercises the range branch of
+// LockWriteOps concurrently with Add and Evict to surface data races on
+// lc.entries.
+func TestLeaseCacheLockWriteOpsRangeConcurrency(t *testing.T) {
+	lc := &leaseCache{
+		entries: make(map[string]*leaseKey),
+		revokes: make(map[string]time.Time),
+	}
+
+	for i := 0; i < 8; i++ {
+		key := fmt.Sprintf("k/%d", i)
+		lc.Add(key, getResponseForKey(key, int64(i+2)), v3.OpGet(key))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			wcs := lc.LockWriteOps([]v3.Op{
+				v3.OpDelete("k/", v3.WithRange("k0")),
+			})
+			closeAll(wcs)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; ctx.Err() == nil; i++ {
+			key := fmt.Sprintf("k/%d", i%16)
+			lc.Add(key, getResponseForKey(key, int64(i+2)), v3.OpGet(key))
+			if i%2 == 0 {
+				lc.Evict(key)
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func getResponseForKey(key string, rev int64) *v3.GetResponse {
+	return &v3.GetResponse{
+		Header: &v3pb.ResponseHeader{Revision: rev},
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:            []byte(key),
+				Value:          []byte("value"),
+				CreateRevision: rev,
+				ModRevision:    rev,
+				Version:        1,
+			},
+		},
+		Count: 1,
+	}
+}


### PR DESCRIPTION
Was reading through the leasing client while chasing down a different issue and noticed `LockWriteOps` has a hand-rolled range loop that doesn't hold `lc.mu`, even though the single-key path right above it goes through `lc.Lock` which does.

Running a quick concurrent test with `-race` confirms it:

```
WARNING: DATA RACE
Read at ... by goroutine ...:
  go.etcd.io/etcd/client/v3/leasing.(*leaseCache).LockWriteOps()
      client/v3/leasing/cache.go:96

Previous write at ... by goroutine ...:
  go.etcd.io/etcd/client/v3/leasing.(*leaseCache).Add()
      client/v3/leasing/cache.go:133
```

Two goroutines, one doing range deletes via `LockWriteOps`, the other doing `Add`/`Evict`, and the unsynchronized `for k := range lc.entries` at line 96 races with the `lc.entries[key] = lk` write at line 133. Outside the race detector this can also kill the process with `fatal error: concurrent map iteration and map write`.

The fix is small. `LockRange(begin, end)` already does exactly the same scan while holding `lc.mu` — it iterates entries, replaces `waitc` for keys in range, returns them. It's what `deleteRange` in `kv.go` uses for the same key/end pair pattern. So just defer to it instead of duplicating the loop without the lock.

This is the bug reported in #22084 — I reproduced it with the test from that issue, then wrote a slightly tighter version that runs in ~200ms as a unit test (no need to spin up an integration cluster). Test is included, and `go test -race ./leasing` passes locally.

Not 100% sure if there's a reason the original loop avoided `LockRange` (maybe to skip the lock when nothing's in range?), but I don't see one — `LockRange` returns early naturally when entries is empty, and the semantic is identical.
