### PR TITLE
leasing: Delete with WithFromKey removes leasing protocol keys

### DIFF
--- a/client/v3/leasing/doc.go
+++ b/client/v3/leasing/doc.go
@@ -24,6 +24,9 @@
 //	    // handle error
 //	}
 //
+// The supplied prefix reserves a key range for leasing protocol state. Delete
+// operations that intersect this range fail with a gRPC InvalidArgument status.
+//
 // A range request for a key "abc" tries to acquire a leasing key so it can cache the range's
 // key locally. On the server, the leasing key is stored to "leasing-prefix/abc":
 //

--- a/client/v3/leasing/kv.go
+++ b/client/v3/leasing/kv.go
@@ -377,7 +377,35 @@ func (lkv *leasingKV) deleteRange(ctx context.Context, op v3.Op) (*v3.DeleteResp
 	return nil, ctx.Err()
 }
 
+func (lkv *leasingKV) deleteIntersectsLeasingPrefix(op v3.Op) bool {
+	key, end := string(op.KeyBytes()), string(op.RangeBytes())
+	prefixEnd := v3.GetPrefixRangeEnd(lkv.pfx)
+	if end == "" {
+		return inRange(key, lkv.pfx, prefixEnd)
+	}
+	return inRange(key, lkv.pfx, prefixEnd) || inRange(lkv.pfx, key, end)
+}
+
+func (lkv *leasingKV) validateDelete(op v3.Op) error {
+	if op.IsDelete() && lkv.deleteIntersectsLeasingPrefix(op) {
+		return status.Errorf(codes.InvalidArgument, "leasing: delete range intersects leasing prefix %q", lkv.pfx)
+	}
+	return nil
+}
+
+func (lkv *leasingKV) validateDeleteOps(ops []v3.Op) error {
+	for _, op := range gatherOps(ops) {
+		if err := lkv.validateDelete(op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (lkv *leasingKV) delete(ctx context.Context, op v3.Op) (dr *v3.DeleteResponse, err error) {
+	if err := lkv.validateDelete(op); err != nil {
+		return nil, err
+	}
 	if err := lkv.waitSession(ctx); err != nil {
 		return nil, err
 	}

--- a/client/v3/leasing/txn.go
+++ b/client/v3/leasing/txn.go
@@ -50,6 +50,12 @@ func (txn *txnLeasing) Else(ops ...v3.Op) v3.Txn {
 }
 
 func (txn *txnLeasing) Commit() (*v3.TxnResponse, error) {
+	if err := txn.lkv.validateDeleteOps(txn.opst); err != nil {
+		return nil, err
+	}
+	if err := txn.lkv.validateDeleteOps(txn.opse); err != nil {
+		return nil, err
+	}
 	if resp, err := txn.eval(); resp != nil || err != nil {
 		return resp, err
 	}

--- a/client/v3/leasing/util_test.go
+++ b/client/v3/leasing/util_test.go
@@ -153,6 +153,67 @@ func TestCopyKeyValue(t *testing.T) {
 	})
 }
 
+func TestDeleteIntersectsLeasingPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		op   v3.Op
+		want bool
+	}{
+		{
+			name: "single key before prefix",
+			op:   v3.OpDelete("a"),
+		},
+		{
+			name: "single key in prefix",
+			op:   v3.OpDelete("pfx/a"),
+			want: true,
+		},
+		{
+			name: "range ending at prefix",
+			op:   v3.OpDelete("a", v3.WithRange("pfx/")),
+		},
+		{
+			name: "range overlapping prefix",
+			op:   v3.OpDelete("a", v3.WithRange("pfx0")),
+			want: true,
+		},
+		{
+			name: "range starting in prefix",
+			op:   v3.OpDelete("pfx/a", v3.WithRange("z")),
+			want: true,
+		},
+		{
+			name: "range starting after prefix",
+			op:   v3.OpDelete("pfx0", v3.WithRange("z")),
+		},
+		{
+			name: "from key before prefix",
+			op:   v3.OpDelete("b", v3.WithFromKey()),
+			want: true,
+		},
+		{
+			name: "from key after prefix",
+			op:   v3.OpDelete("pfx0", v3.WithFromKey()),
+		},
+		{
+			name: "matching prefix",
+			op:   v3.OpDelete("pfx/", v3.WithPrefix()),
+			want: true,
+		},
+		{
+			name: "non-matching prefix",
+			op:   v3.OpDelete("user/", v3.WithPrefix()),
+		},
+	}
+
+	lkv := &leasingKV{pfx: "pfx/"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, lkv.deleteIntersectsLeasingPrefix(tt.op))
+		})
+	}
+}
+
 func countProtobufFields(v any) int {
 	t := reflect.TypeOf(v)
 	if t.Kind() == reflect.Pointer {

--- a/tests/integration/clientv3/lease/leasing_test.go
+++ b/tests/integration/clientv3/lease/leasing_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -439,6 +441,56 @@ func TestLeasingDeleteNonOwner(t *testing.T) {
 	resp, err := lkv1.Get(t.Context(), "k")
 	require.NoError(t, err)
 	require.Emptyf(t, resp.Kvs, `expected "k" to be deleted, got response %+v`, resp)
+}
+
+func TestLeasingDeleteProtectsProtocolKeys(t *testing.T) {
+	integration.BeforeTest(t)
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	lkv, closeLKV, err := leasing.NewKV(clus.Client(0), "pfx/")
+	require.NoError(t, err)
+	defer closeLKV()
+
+	for _, key := range []string{"a", "b"} {
+		_, err = lkv.Put(t.Context(), key, key)
+		require.NoError(t, err)
+		_, err = lkv.Get(t.Context(), key)
+		require.NoError(t, err)
+	}
+
+	deleteFromB := clientv3.OpDelete("b", clientv3.WithFromKey())
+	deleteCalls := map[string]func() error{
+		"Delete": func() error {
+			_, callErr := lkv.Delete(t.Context(), "b", clientv3.WithFromKey())
+			return callErr
+		},
+		"Do": func() error {
+			_, callErr := lkv.Do(t.Context(), deleteFromB)
+			return callErr
+		},
+		"Txn": func() error {
+			_, callErr := lkv.Txn(t.Context()).Then(deleteFromB).Commit()
+			return callErr
+		},
+		"nested Txn": func() error {
+			nestedTxn := clientv3.OpTxn(nil, []clientv3.Op{deleteFromB}, nil)
+			_, callErr := lkv.Txn(t.Context()).Then(nestedTxn).Commit()
+			return callErr
+		},
+	}
+	for name, call := range deleteCalls {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, codes.InvalidArgument, status.Code(call()))
+		})
+	}
+
+	userKeys, err := clus.Client(0).Get(t.Context(), "a", clientv3.WithRange("c"))
+	require.NoError(t, err)
+	require.Len(t, userKeys.Kvs, 2)
+	protocolKeys, err := clus.Client(0).Get(t.Context(), "pfx/", clientv3.WithPrefix())
+	require.NoError(t, err)
+	require.Len(t, protocolKeys.Kvs, 2)
 }
 
 func TestLeasingOverwriteResponse(t *testing.T) {


### PR DESCRIPTION
Fixes #22083

## What changed

- Reject leasing `Delete` operations whose key range intersects the configured leasing protocol prefix.
- Apply the same validation to direct operations, transactions, and recursively nested transactions before any cache or server mutation.
- Document the reserved-prefix behavior and add boundary-focused unit and integration coverage.

## Why

`WithFromKey` encodes an open-ended range with `"\x00"`. The leasing wrapper previously forwarded that user range unchanged, allowing it to delete protocol keys stored under the configured prefix.

This draft chooses the issue's conservative rejection option instead of splitting the range. A transaction is rejected when an intersecting delete appears in either branch, so maintainers can confirm that policy before the PR is marked ready.

## Impact

Intersecting deletes now fail with gRPC `InvalidArgument` before mutation. Non-overlapping deletes and internal protocol cleanup are unchanged.

## Testing

- `go test ./client/v3/leasing -count=1`
- `cd tests && go test ./integration/clientv3/lease -run '^TestLeasingDeleteProtectsProtocolKeys$' -count=1`
- `cd tests && go test ./integration/clientv3/lease -count=1`
- `PATH="/opt/homebrew/bin:$PATH" make verify-lint`

All passed locally.

