### PR TITLE
CI: Measure TestGrid Flakiness workflow fails due to DNS resolution error for testgrid-data.k8s.io

### DIFF
--- a/.github/workflows/measure-testgrid-flakiness.yaml
+++ b/.github/workflows/measure-testgrid-flakiness.yaml
@@ -5,7 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # run every day at midnight
 
-permissions: read-all
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   measure-testgrid-flakiness:

--- a/tools/testgrid-analysis/cmd/data.go
+++ b/tools/testgrid-analysis/cmd/data.go
@@ -27,6 +27,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+const testGridAPIBaseURL = "https://testgrid-api.prow.k8s.io"
+
 var (
 	validTestStatuses      = []statuspb.TestStatus{statuspb.TestStatus_PASS, statuspb.TestStatus_FAIL, statuspb.TestStatus_FLAKY}
 	failureTestStatuses    = []statuspb.TestStatus{statuspb.TestStatus_FAIL, statuspb.TestStatus_FLAKY}
@@ -47,8 +49,8 @@ type TestResultSummary struct {
 
 func fetchTestResultSummaries(dashboard, tab string) []*TestResultSummary {
 	// Fetch test data
-	rowsURL := fmt.Sprintf("http://testgrid-data.k8s.io/api/v1/dashboards/%s/tabs/%s/rows", dashboard, tab)
-	headersURL := fmt.Sprintf("http://testgrid-data.k8s.io/api/v1/dashboards/%s/tabs/%s/headers", dashboard, tab)
+	rowsURL := fmt.Sprintf("%s/api/v1/dashboards/%s/tabs/%s/rows", testGridAPIBaseURL, dashboard, tab)
+	headersURL := fmt.Sprintf("%s/api/v1/dashboards/%s/tabs/%s/headers", testGridAPIBaseURL, dashboard, tab)
 
 	var testData apipb.ListRowsResponse
 	var headerData apipb.ListHeadersResponse


### PR DESCRIPTION
Fixes #21912

## What changed

- Switch TestGrid row and header requests from the retired `http://testgrid-data.k8s.io` host to the official `https://testgrid-api.prow.k8s.io` API.
- Replace `permissions: read-all` with the least-privilege permissions the scheduled job needs: `contents: read` and `issues: write`.

## Why

The scheduled Measure TestGrid Flakiness workflow fails before analysis because `testgrid-data.k8s.io` no longer resolves. Repairing the endpoint alone is not enough: the periodic commands use `--create-issue`, while the existing read-only token cannot create the intended flake issues.

## Impact

The nightly analysis can fetch results for its four configured TestGrid tabs and create missing `type/flake` issues. The workflow receives no repository permissions beyond reading contents and managing issues.

## Testing

- `go test ./...` from `tools/testgrid-analysis`
- `make verify-yamllint`
- `PATH="/opt/homebrew/bin:$PATH" make verify-lint`
- Live, non-writing smoke tests for all configured tabs:

  ```console
  go run . flaky --dashboard=sig-etcd-periodics --tab=ci-etcd-e2e-amd64 --max-days=14 --min-runs=1000000
  go run . flaky --dashboard=sig-etcd-periodics --tab=ci-etcd-unit-test-amd64 --max-days=14 --min-runs=1000000
  go run . flaky --dashboard=sig-etcd-presubmits --tab=pull-etcd-e2e-amd64 --min-runs=1000000
  go run . flaky --dashboard=sig-etcd-presubmits --tab=pull-etcd-unit-test --min-runs=1000000
  ```

The live checks deliberately omitted `--create-issue`, so validation did not write to GitHub.

