### PR TITLE
ordering: do not automatically resubmit mutable transactions

### DIFF
--- a/client/v3/ordering/doc.go
+++ b/client/v3/ordering/doc.go
@@ -16,6 +16,9 @@
 // to detect ordering violations from stale responses. Users may define a
 // policy on how to handle the ordering violation, but typically the client
 // should connect to another endpoint and reissue the request.
+// The wrapper only reissues read-only transactions. If a transaction that may
+// write has an ordering violation and the policy returns nil, the wrapper returns
+// the original response rather than risk applying the mutation twice.
 //
 // The most common situation where an ordering violation happens is a client
 // reconnects to a partitioned member and issues a serializable read. Since the

--- a/client/v3/ordering/kv.go
+++ b/client/v3/ordering/kv.go
@@ -139,6 +139,8 @@ func (txn *txnOrdering) Commit() (*clientv3.TxnResponse, error) {
 	// middle of the Commit operation.
 	prevRev := txn.getPrevRev()
 	opTxn := clientv3.OpTxn(txn.cmps, txn.thenOps, txn.elseOps)
+	// A retry can select a different branch, so every possible operation must be read-only.
+	canRetry := isReadOnly(opTxn)
 	for {
 		opResp, err := txn.KV.Do(txn.ctx, opTxn)
 		if err != nil {
@@ -153,5 +155,28 @@ func (txn *txnOrdering) Commit() (*clientv3.TxnResponse, error) {
 		if err != nil {
 			return nil, err
 		}
+		if !canRetry {
+			// The successful response may represent an applied mutation, so do not replay it.
+			return txnResp, nil
+		}
 	}
+}
+
+func isReadOnly(op clientv3.Op) bool {
+	if op.IsGet() {
+		return true
+	}
+	if !op.IsTxn() {
+		return false
+	}
+
+	_, thenOps, elseOps := op.Txn()
+	for _, branch := range [][]clientv3.Op{thenOps, elseOps} {
+		for _, nestedOp := range branch {
+			if !isReadOnly(nestedOp) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/client/v3/ordering/kv_test.go
+++ b/client/v3/ordering/kv_test.go
@@ -16,6 +16,7 @@ package ordering
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -30,6 +31,18 @@ type mockKV struct {
 
 func (kv *mockKV) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
 	return kv.response, nil
+}
+
+type mockReplayKV struct {
+	clientv3.KV
+	responses []clientv3.OpResponse
+	calls     int
+}
+
+func (kv *mockReplayKV) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+	resp := kv.responses[kv.calls]
+	kv.calls++
+	return resp, nil
 }
 
 var rangeTests = []struct {
@@ -146,5 +159,134 @@ func TestTxnOrdering(t *testing.T) {
 		if rev := res.Header.Revision; rev < tt.prevRev {
 			t.Errorf("#%d: expected revision %d, got %d", i, tt.prevRev, rev)
 		}
+	}
+}
+
+func TestTxnOrderingDoesNotRetryMutableTxn(t *testing.T) {
+	tests := []struct {
+		name      string
+		succeeded bool
+		thenOps   []clientv3.Op
+		elseOps   []clientv3.Op
+	}{
+		{
+			name:      "write in selected then branch",
+			succeeded: true,
+			thenOps:   []clientv3.Op{clientv3.OpPut("key", "value")},
+		},
+		{
+			name:    "write in selected else branch",
+			elseOps: []clientv3.Op{clientv3.OpDelete("key")},
+		},
+		{
+			name:      "write in nested transaction",
+			succeeded: true,
+			thenOps: []clientv3.Op{clientv3.OpTxn(
+				nil,
+				[]clientv3.Op{clientv3.OpPut("key", "value")},
+				nil,
+			)},
+		},
+		{
+			name:    "write in unselected then branch",
+			thenOps: []clientv3.Op{clientv3.OpPut("key", "value")},
+		},
+		{
+			name:      "write in unselected else branch",
+			succeeded: true,
+			elseOps:   []clientv3.Op{clientv3.OpDelete("key")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			staleResponse := (&clientv3.TxnResponse{
+				Header:    &pb.ResponseHeader{Revision: 9},
+				Succeeded: tt.succeeded,
+			}).OpResponse()
+			freshResponse := (&clientv3.TxnResponse{Header: &pb.ResponseHeader{Revision: 10}}).OpResponse()
+			mKV := &mockReplayKV{
+				KV:        clientv3.NewKVFromKVClient(nil, nil),
+				responses: []clientv3.OpResponse{staleResponse, freshResponse},
+			}
+			violationCalls := 0
+			kv := &kvOrdering{
+				KV: mKV,
+				orderViolationFunc: func(op clientv3.Op, resp clientv3.OpResponse, prevRev int64) error {
+					violationCalls++
+					return nil
+				},
+				prevRev: 10,
+			}
+
+			cmp := clientv3.Compare(clientv3.Version("condition"), "=", 1)
+			_, _ = kv.Txn(t.Context()).If(cmp).Then(tt.thenOps...).Else(tt.elseOps...).Commit()
+			if violationCalls != 1 {
+				t.Fatalf("expected one ordering violation, got %d", violationCalls)
+			}
+			if mKV.calls != 1 {
+				t.Fatalf("expected one transaction execution, got %d", mKV.calls)
+			}
+		})
+	}
+}
+
+func TestTxnOrderingReturnsViolationErrorWithoutRetry(t *testing.T) {
+	staleResponse := (&clientv3.TxnResponse{
+		Header:    &pb.ResponseHeader{Revision: 9},
+		Succeeded: true,
+	}).OpResponse()
+	mKV := &mockReplayKV{
+		KV:        clientv3.NewKVFromKVClient(nil, nil),
+		responses: []clientv3.OpResponse{staleResponse},
+	}
+	wantErr := errors.New("ordering violation")
+	kv := &kvOrdering{
+		KV: mKV,
+		orderViolationFunc: func(op clientv3.Op, resp clientv3.OpResponse, prevRev int64) error {
+			return wantErr
+		},
+		prevRev: 10,
+	}
+
+	_, err := kv.Txn(t.Context()).Then(clientv3.OpPut("key", "value")).Commit()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+	if mKV.calls != 1 {
+		t.Fatalf("expected one transaction execution, got %d", mKV.calls)
+	}
+}
+
+func TestTxnOrderingRetriesReadOnlyTxn(t *testing.T) {
+	staleResponse := (&clientv3.TxnResponse{Header: &pb.ResponseHeader{Revision: 9}}).OpResponse()
+	freshResponse := (&clientv3.TxnResponse{Header: &pb.ResponseHeader{Revision: 10}}).OpResponse()
+	mKV := &mockReplayKV{
+		KV:        clientv3.NewKVFromKVClient(nil, nil),
+		responses: []clientv3.OpResponse{staleResponse, freshResponse},
+	}
+	violationCalls := 0
+	kv := &kvOrdering{
+		KV: mKV,
+		orderViolationFunc: func(op clientv3.Op, resp clientv3.OpResponse, prevRev int64) error {
+			violationCalls++
+			return nil
+		},
+		prevRev: 10,
+	}
+
+	nestedGet := clientv3.OpTxn(nil, []clientv3.Op{clientv3.OpGet("nested")}, nil)
+	resp, err := kv.Txn(t.Context()).Then(clientv3.OpGet("key"), nestedGet).Commit()
+	if err != nil {
+		t.Fatalf("expected response, got error %v", err)
+	}
+	if resp.Header.Revision != 10 {
+		t.Fatalf("expected revision 10, got %d", resp.Header.Revision)
+	}
+	if violationCalls != 1 {
+		t.Fatalf("expected one ordering violation, got %d", violationCalls)
+	}
+	if mKV.calls != 2 {
+		t.Fatalf("expected two transaction executions, got %d", mKV.calls)
 	}
 }


### PR DESCRIPTION
Refs #22086

## What changed

- Classify every possible transaction branch, including nested transactions, before retrying an ordering violation.
- Retry only transactions that are provably read-only.
- Return the original successful response for a potentially mutable transaction when its violation handler returns nil, avoiding a second execution.
- Cover selected and unselected writes, nested transactions, handler errors, and read-only retries.

## Why

`txnOrdering.Commit` currently retries any successful response whose revision is older than the wrapper's previously observed revision when the violation handler returns nil. If either transaction branch can write, the first execution may already have applied a mutation. Replaying the body can duplicate writes or watch events, or choose a different branch after intervening state changes.

Both branches must be read-only before retrying because the transaction comparison may produce a different result on the next endpoint. The violation handler is still called first, and its errors are still returned unchanged.

## Impact

Read-only transaction retry behavior is unchanged. Potentially mutable transactions are reported to the violation handler but are not automatically replayed after a successful response. This does not add or change any exported API.

Backport candidate: `release-3.7` and `release-3.6`.

## Testing

- Confirmed the new regression test fails with the upstream `Commit` implementation.
- `git diff --check`
- `cd client/v3 && go test ./ordering -count=20`
- `cd client/v3 && go test -race ./ordering -count=1`
- `cd client/v3 && go test ./... -count=1`
- `cd client/v3 && go vet ./ordering`
- Targeted `golangci-lint` for `client/v3/ordering`: 0 issues.

