### PR TITLE
clientv3/concurrency: preserve leadership state on failed Resign

### DIFF
--- a/client/v3/concurrency/election.go
+++ b/client/v3/concurrency/election.go
@@ -136,12 +136,13 @@ func (e *Election) Resign(ctx context.Context) (err error) {
 	client := e.session.Client()
 	cmp := v3.Compare(v3.CreateRevision(e.leaderKey), "=", e.leaderRev)
 	resp, err := client.Txn(ctx).If(cmp).Then(v3.OpDelete(e.leaderKey)).Commit()
-	if err == nil {
-		e.hdr = resp.Header
+	if err != nil {
+		return err
 	}
+	e.hdr = resp.Header
 	e.leaderKey = ""
 	e.leaderSession = nil
-	return err
+	return nil
 }
 
 // Leader returns the leader value for the current election.

--- a/tests/integration/clientv3/concurrency/election_resign_test.go
+++ b/tests/integration/clientv3/concurrency/election_resign_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package concurrency_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.etcd.io/etcd/tests/v3/framework/integration"
+)
+
+func TestElectionResignCanRetryAfterError(t *testing.T) {
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	session, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer session.Close()
+
+	election := concurrency.NewElection(session, "/resign-retry")
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	require.NoError(t, election.Campaign(ctx, "candidate"))
+	leaderKey := election.Key()
+
+	canceledCtx, cancelResign := context.WithCancel(t.Context())
+	cancelResign()
+	require.ErrorIs(t, election.Resign(canceledCtx), context.Canceled)
+	require.Equal(t, leaderKey, election.Key())
+	resp, err := cli.Get(ctx, leaderKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+
+	require.NoError(t, election.Resign(ctx))
+	resp, err = cli.Get(ctx, leaderKey)
+	require.NoError(t, err)
+	require.Empty(t, resp.Kvs)
+}


### PR DESCRIPTION
Refs #22123.

## What changed

- Preserve an election's local leadership state when `Resign` returns a transaction error.
- Add an integration regression proving that a failed resignation can be retried successfully.

## Why

`Election.Resign` previously cleared `leaderKey` and `leaderSession` even when the delete transaction returned an error. If the request never reached etcd, the server-side leader key remained while the client forgot how to remove it.

The existing create-revision comparison makes a retry safe: it cannot delete a newer incarnation of the same key. A successful transaction response still retires the local state, including when the comparison does not match.

## Impact

Callers can retry `Resign` after an RPC error. Successful resignation behavior and the exported API are unchanged.

This is complementary to #21165 and distinct from #19598 and #21128. Those changes concern `Campaign` cleanup or waiting-session expiration rather than errors returned by `Resign` itself.

Backport candidate: `release-3.7` and `release-3.6`.

## Testing

- Confirmed the regression fails on upstream `main` because the failed call clears `Election.Key()`.
- `cd tests && go test ./integration/clientv3/concurrency -run '^TestElectionResignCanRetryAfterError$' -count=20`
- `cd tests && go test ./integration/clientv3/concurrency -count=1`
- `cd tests && go test -race ./integration/clientv3/concurrency -run '^TestElectionResignCanRetryAfterError$' -count=1`
- `cd client/v3 && go test ./concurrency -count=1`
- `cd client/v3 && go vet ./concurrency`
- `make verify-lint`
- `git diff --check`

The aggregate `make verify` cannot complete faithfully on this Darwin/arm64 host: the local BOM generator excludes the amd64-only Antithesis SDK and therefore differs from the checked-in Linux BOM. All non-BOM verify targets were run separately.

