### PR TITLE
server: fix infinite loop on snapshot write failure and session leak on expiry

### DIFF
--- a/server/etcdserver/api/v3rpc/maintenance.go
+++ b/server/etcdserver/api/v3rpc/maintenance.go
@@ -144,11 +144,15 @@ func (ms *maintenanceServer) Snapshot(sr *pb.SnapshotRequest, srv pb.Maintenance
 	defer pr.Close()
 
 	go func() {
-		snap.WriteTo(pw)
+		if _, err := snap.WriteTo(pw); err != nil {
+			ms.lg.Warn("failed to send snapshot", zap.Error(err))
+			pw.CloseWithError(err)
+		} else {
+			pw.Close()
+		}
 		if err := snap.Close(); err != nil {
 			ms.lg.Warn("failed to close snapshot", zap.Error(err))
 		}
-		pw.Close()
 	}()
 
 	// record SHA digest of snapshot data

--- a/server/proxy/grpcproxy/register.go
+++ b/server/proxy/grpcproxy/register.go
@@ -53,6 +53,7 @@ func Register(lg *zap.Logger, c *clientv3.Client, prefix string, addr string, tt
 			case <-ss.Done():
 				lg.Warn("session expired; possible network partition or server restart")
 				lg.Warn("creating a new session to rejoin")
+				ss.Close()
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary

This PR fixes two bugs that can cause server hangs and resource leaks:

### 1. Infinite loop on snapshot write failure (maintenance.go)

When `snap.WriteTo(pw)` fails during a client-initiated snapshot transfer (e.g., disk I/O error, node shutdown), the error was silently discarded and `pw.Close()` was called instead of `pw.CloseWithError(err)`. This caused the pipe reader to receive `io.EOF` (indicating success) instead of the actual error. The reading loop treated `io.EOF` as success, `sent` never increased, but `total-sent > 0` remained true, resulting in an **infinite loop** that hangs the gRPC handler goroutine.

**Fix:** Capture the error from `snap.WriteTo(pw)` and propagate it via `pw.CloseWithError(err)` so the reader loop exits with the proper error.

### 2. Session resource leak on expiry (register.go)

When a concurrency session expires (`ss.Done()` fires), the gRPC proxy registration loop created a new session but never called `ss.Close()` on the old session. Each expired session leaked goroutines (lease keepalive, etc.), causing unbounded goroutine and memory growth under sustained network instability.

**Fix:** Add `ss.Close()` before creating the new session in the expiry path, matching the existing pattern in the context cancellation path.

## Related Issues

## Testing

Both fixes follow established patterns in the codebase:
- `pw.CloseWithError(err)` is used in `server/etcdserver/snapshot_merge.go:76`
- `ss.Close()` is called in the `c.Ctx().Done()` path on the same function

## Checklist

- [x] DCO sign-off included
- [x] Code follows the project's coding style
- [x] Changes are minimal and focused
- [x] No unrelated changes included