### PR TITLE
server: add defer cancel for context lifecycle safety and close response body on error

### DIFF
--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -137,6 +137,7 @@ func (p *pipeline) post(data []byte) (err error) {
 
 	done := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	req = req.WithContext(ctx)
 	go func() {
 		select {

--- a/server/etcdserver/api/rafthttp/snapshot_sender.go
+++ b/server/etcdserver/api/rafthttp/snapshot_sender.go
@@ -159,7 +159,10 @@ func (s *snapshotSender) post(req *http.Request) (err error) {
 	go func() {
 		resp, err := s.tr.pipelineRt.RoundTrip(req)
 		if err != nil {
-			result <- responseAndError{resp, nil, err}
+			if resp != nil {
+				resp.Body.Close()
+			}
+			result <- responseAndError{nil, nil, err}
 			return
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes two safety issues in the raft HTTP transport layer:

### 1. Missing defer cancel in pipeline.post (pipeline.go)

The `context.WithCancel` in `pipeline.post` had no `defer cancel()` safety net. If `RoundTrip` panics (rare but possible with buggy transport implementations), `cancel()` is never called, leaking the context and its associated resources. Since `pipeline.post` is called for every Raft message sent to a peer — millions of times in a cluster's lifetime — this is a real concern.

**Fix:** Add `defer cancel()` immediately after context creation, as a safety net that ensures cleanup regardless of how the function exits.

### 2. Nil response body on RoundTrip error (snapshot_sender.go)

When `RoundTrip` returns an error, `resp` may be nil (standard Go HTTP behavior per `net/http.RoundTripper` documentation). The nil `resp` was sent into the `responseAndError` struct, creating a latent nil dereference risk if future code changes access `r.resp` before checking `r.err`. Additionally, per Go docs, when `RoundTrip` returns a non-nil response with a non-nil error (redirect failures), the response body is already closed — but this code made no attempt to close it.

**Fix:** Close the response body defensively when `RoundTrip` returns an error, and send `nil` as the response to make the invariant explicit.

## Related Issues

## Testing

Both fixes follow established Go patterns:
- `defer cancel()` is the standard pattern for context cleanup
- `resp.Body.Close()` on error is the standard pattern per `net/http` documentation

## Checklist

- [x] DCO sign-off included
- [x] Code follows the project's coding style
- [x] Changes are minimal and focused
- [x] No unrelated changes included