### PR TITLE
Makefile: add more bench-* targets for performance suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 # Benchmark make targets extend scripts/benchmark_test.sh (see #16467).
 # Override defaults with ARGS, e.g.:
 #   make bench-put ARGS='--total=100000 --clients=100'
-#   make bench-range ARGS='foo --total=50000 --consistency=s'
+#   make bench-range ARGS='--total=50000 --consistency=s'
 
 .PHONY: bench-put
 bench-put: build install-benchmark

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,45 @@ else
 	@echo "benchmark tool already installed..."
 endif
 
+# Benchmark make targets extend scripts/benchmark_test.sh (see #16467).
+# Override defaults with ARGS, e.g.:
+#   make bench-put ARGS='--total=100000 --clients=100'
+#   make bench-range ARGS='foo --total=50000 --consistency=s'
+
 .PHONY: bench-put
 bench-put: build install-benchmark
 	@echo "Running benchmark: put $(ARGS)"
 	./scripts/benchmark_test.sh put $(ARGS)
+
+.PHONY: bench-range
+bench-range: build install-benchmark
+	@echo "Running benchmark: range $(ARGS)"
+	./scripts/benchmark_test.sh range foo $(ARGS)
+
+.PHONY: bench-txn-put
+bench-txn-put: build install-benchmark
+	@echo "Running benchmark: txn-put $(ARGS)"
+	./scripts/benchmark_test.sh txn-put $(ARGS)
+
+.PHONY: bench-stm
+bench-stm: build install-benchmark
+	@echo "Running benchmark: stm $(ARGS)"
+	./scripts/benchmark_test.sh stm $(ARGS)
+
+.PHONY: bench-lease-keepalive
+bench-lease-keepalive: build install-benchmark
+	@echo "Running benchmark: lease-keepalive $(ARGS)"
+	./scripts/benchmark_test.sh lease-keepalive $(ARGS)
+
+.PHONY: bench-watch
+bench-watch: build install-benchmark
+	@echo "Running benchmark: watch $(ARGS)"
+	./scripts/benchmark_test.sh watch $(ARGS)
+
+.PHONY: bench-watch-latency
+bench-watch-latency: build install-benchmark
+	@echo "Running benchmark: watch-latency $(ARGS)"
+	./scripts/benchmark_test.sh watch-latency $(ARGS)
 
 PLATFORMS=linux-amd64 linux-386 linux-arm linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64 windows-amd64 windows-arm64
 

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -22,6 +22,37 @@ Alternatively, instead of installing the tool, you can use it by simply running 
   $ go run ./tools/benchmark
 ```
 
+## Running via make (local etcd)
+
+From the repository root, use the `bench-*` make targets. Each target builds etcd,
+installs the benchmark tool if needed, starts a temporary local etcd process, runs
+the named workload with `--report-perfdash`, then tears the server down
+(see `scripts/benchmark_test.sh` and [#16467](https://github.com/etcd-io/etcd/issues/16467)).
+
+```
+  $ make bench-put
+  $ make bench-range
+  $ make bench-txn-put
+  $ make bench-stm
+  $ make bench-lease-keepalive
+  $ make bench-watch
+  $ make bench-watch-latency
+```
+
+Pass extra flags through `ARGS`:
+
+```
+  $ make bench-put ARGS='--total=100000 --clients=100 --conns=10'
+  $ make bench-range ARGS='--total=50000 --consistency=s --limit=100'
+```
+
+`bench-range` uses a default key of `foo`. For custom range bounds, call the
+script directly:
+
+```
+  $ ./scripts/benchmark_test.sh range mykey myend --total=10000
+```
+
 ## Usage
 
 The following command should output the usage per the latest development.

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -27,30 +27,31 @@ Alternatively, instead of installing the tool, you can use it by simply running 
 From the repository root, use the `bench-*` make targets. Each target builds etcd,
 installs the benchmark tool if needed, starts a temporary local etcd process, runs
 the named workload with `--report-perfdash`, then tears the server down
-(see `scripts/benchmark_test.sh` and [#16467](https://github.com/etcd-io/etcd/issues/16467)).
+(see `scripts/benchmark_test.sh` and
+[#16467](https://github.com/etcd-io/etcd/issues/16467)).
 
-```
-  $ make bench-put
-  $ make bench-range
-  $ make bench-txn-put
-  $ make bench-stm
-  $ make bench-lease-keepalive
-  $ make bench-watch
-  $ make bench-watch-latency
+```bash
+make bench-put
+make bench-range
+make bench-txn-put
+make bench-stm
+make bench-lease-keepalive
+make bench-watch
+make bench-watch-latency
 ```
 
 Pass extra flags through `ARGS`:
 
-```
-  $ make bench-put ARGS='--total=100000 --clients=100 --conns=10'
-  $ make bench-range ARGS='--total=50000 --consistency=s --limit=100'
+```bash
+make bench-put ARGS='--total=100000 --clients=100 --conns=10'
+make bench-range ARGS='--total=50000 --consistency=s --limit=100'
 ```
 
 `bench-range` uses a default key of `foo`. For custom range bounds, call the
 script directly:
 
-```
-  $ ./scripts/benchmark_test.sh range mykey myend --total=10000
+```bash
+./scripts/benchmark_test.sh range mykey myend --total=10000
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Extends the existing `make bench-put` / `scripts/benchmark_test.sh` path from #16467
instead of introducing a separate benchmark suite tool.

- Add `make` targets for additional workloads: `bench-range`, `bench-txn-put`,
  `bench-stm`, `bench-lease-keepalive`, `bench-watch`, `bench-watch-latency`
- Keep the same lifecycle as `bench-put`: build etcd, install `benchmark` if needed,
  start a temporary local etcd, run the workload with `--report-perfdash`, tear down
- Improve `scripts/benchmark_test.sh` so it resolves the `benchmark` binary from
  `PATH`, `$(go env GOPATH)/bin`, or `./bin/tools/benchmark`
- Document the new targets in `tools/benchmark/README.md`

This is a follow-up to maintainer feedback that new performance work should expand
the existing benchmarking workflow rather than add another runner.

Fixes: (open/link related issue if any; otherwise reference #16467)

## Test plan

- [ ] `make bench-put ARGS='--total=1000'`
- [ ] `make bench-range ARGS='--total=1000'`
- [ ] `make bench-txn-put ARGS='--total=1000'`
- [ ] `make bench-stm ARGS='--total=1000'`
- [ ] `make bench-lease-keepalive ARGS='--total=1000'`
- [ ] Confirm each run starts/stops local etcd and emits perfdash-compatible output
- [ ] Confirm `benchmark` is found when installed under `$(go env GOPATH)/bin` but not on `PATH`