### PR TITLE
docs: remove Build etcd image section from bump_etcd_version_k8s.md

### DIFF
--- a/Documentation/contributor-guide/bump_etcd_version_k8s.md
+++ b/Documentation/contributor-guide/bump_etcd_version_k8s.md
@@ -53,48 +53,7 @@ You can refer to the guide [vendor update guide](https://github.com/kubernetes/c
 
 ### Build etcd image
 
-> **Deprecated**: Since Kubernetes now uses the officially released etcd image, building the etcd image via `cluster/images/etcd` is no longer necessary.
-> This section is kept for historical reference and will be removed when `cluster/images/etcd` is removed from the Kubernetes repository.
-> Refer to the [Publish etcd image](#publish-etcd-image) section below for the current workflow.
->
-> Reference: [etcd image build PR](https://github.com/kubernetes/kubernetes/pull/131105) [etcd image bump PR](https://github.com/kubernetes/kubernetes/pull/131126)
-
-1. In `build/dependencies.yaml`, update the `version` of `etcd-image` to the new version. Update `golang: etcd release version` if necessary.
-
-    ```yaml
-    - name: "etcd-image"
-      # version: 3.5.17
-      version: 3.5.21
-      refPaths:
-      - path: cluster/images/etcd/Makefile
-        match: BUNDLED_ETCD_VERSIONS\?|
-    ---
-    - name: "golang: etcd release version"
-      # version: 1.22.9
-      version: 1.23.7 # https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md
-    ```
-
-2. In `cluster/images/etcd/Makefile`, include the new version in `BUNDLED_ETCD_VERSIONS` and update the `LATEST_ETCD_VERSION` as well (the image tag will be generated from the `LATEST_ETCD_VERSION`). Update `GOLANG_VERSION` according to the version used to compile that release version (`"golang: etcd release version"` in step 1).
-
-    ```Makefile
-    # BUNDLED_ETCD_VERSIONS?=3.4.18 3.5.17
-    BUNDLED_ETCD_VERSIONS?=3.4.18 3.5.21
-
-    # LATEST_ETCD_VERSION?=3.5.17
-    LATEST_ETCD_VERSION?=3.5.21
-
-    # GOLANG_VERSION := 1.22.9
-    GOLANG_VERSION := 1.23.7
-    ```
-
-3. In `cluster/images/etcd/migrate/options.go`, include the new version in the `supportedEtcdVersions` slice.
-
-    ```go
-    var (
-    // supportedEtcdVersions = []string{"3.4.18", "3.5.17"}
-    supportedEtcdVersions = []string{"3.4.18", "3.5.21"}
-    )
-    ```
+Kubernetes now uses the officially released etcd image, so there is no need to build additional etcd images anymore.
 
 ### Publish etcd image
 


### PR DESCRIPTION
Remove the deprecated Build etcd image section since cluster/images/etcd has been removed from Kubernetes.
Follow-up to #21800.