### PR TITLE
membership: don't panic in IsLocalMemberLearner when local member is absent

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -788,11 +788,17 @@ func (c *RaftCluster) IsLocalMemberLearner() bool {
 	defer c.Unlock()
 	localMember, ok := c.members[c.localID]
 	if !ok {
-		c.lg.Panic(
-			"failed to find local ID in cluster members",
+		// The local member can be absent from the members map when it has
+		// been removed concurrently, e.g. an in-flight RPC racing with the
+		// apply of a ConfChangeRemoveNode that removes the local member.
+		// Report it as a non-learner instead of panicking, so that the
+		// removed member can shut down cleanly.
+		c.lg.Debug(
+			"failed to find local ID in cluster members; the member may have been removed",
 			zap.String("cluster-id", c.cid.String()),
 			zap.String("local-member-id", c.localID.String()),
 		)
+		return false
 	}
 	return localMember.IsLearner
 }

--- a/server/etcdserver/api/membership/cluster_test.go
+++ b/server/etcdserver/api/membership/cluster_test.go
@@ -548,6 +548,45 @@ func TestClusterAddMemberAsLearner(t *testing.T) {
 	})
 }
 
+func TestIsLocalMemberLearner(t *testing.T) {
+	tests := []struct {
+		name      string
+		members   []*Member
+		localID   types.ID
+		isLearner bool
+	}{
+		{
+			name:      "local member is a learner",
+			members:   []*Member{newTestMemberAsLearner(1, nil, "node1", nil)},
+			localID:   1,
+			isLearner: true,
+		},
+		{
+			name:      "local member is a voting member",
+			members:   []*Member{newTestMember(1, nil, "node1", nil)},
+			localID:   1,
+			isLearner: false,
+		},
+		{
+			// The local member can be absent from the members map when it
+			// has been removed concurrently, e.g. an in-flight RPC racing
+			// with the apply of a ConfChangeRemoveNode. It must be reported
+			// as a non-learner without panicking.
+			name:      "local member removed from the cluster",
+			members:   []*Member{newTestMember(2, nil, "node2", nil)},
+			localID:   1,
+			isLearner: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCluster(t, tt.members)
+			c.localID = tt.localID
+			assert.Equal(t, tt.isLearner, c.IsLocalMemberLearner())
+		})
+	}
+}
+
 func TestClusterMembers(t *testing.T) {
 	cls := newTestCluster(t, []*Member{
 		{ID: 1},


### PR DESCRIPTION
### What this PR does / why

`RaftCluster.IsLocalMemberLearner()` calls `lg.Panic` when the local member ID is absent from the members map. When a member is removed via `ConfChangeRemoveNode`, the raft apply goroutine deletes the local member from `c.members` before the gRPC server drains in-flight requests, so any concurrent request that reaches `IsLocalMemberLearner()` in that window crashes the process (exit code 2) instead of letting the removed member shut down cleanly.

Three request paths reach this function through `EtcdServer.IsLearner()`:

- `Maintenance/Status` (`server/etcdserver/api/v3rpc/maintenance.go`)
- the learner unary/stream interceptors (`server/etcdserver/api/v3rpc/interceptor.go`) — these check `IsMemberExist()` first, but the check and the `IsLearner()` call are not atomic, so the removal can land in between
- the HTTP health handler (`server/etcdserver/api/etcdhttp/health.go`)

An absent local member is an expected transient during member removal, not a programming error. This change logs the condition at debug level and reports the member as a non-learner (a removed member is not a learner), covering all three paths at the leaf.

This follows the review feedback given on the previous attempt #21967 (use debug rather than warn level, and add a regression test), which was closed without being merged.

### Testing

- New regression test `TestIsLocalMemberLearner` in `server/etcdserver/api/membership/cluster_test.go` covering the learner, voter, and absent-local-member cases. The last case panics without this fix.
- `go test ./etcdserver/api/membership/...` passes.
- `golangci-lint run` (v2.12.2, the version pinned in `tools/mod`) on the membership package reports 0 issues.
- Verified with the reproducer attached to #21966 against a build of this branch: the `failed to find local ID in cluster members` panic no longer occurs in any run (it reproduced on the first attempt with an unpatched build of current `main`).

### Note on a separate crash surfaced during verification

While verifying with the reproducer, a second, independent crash in the same shutdown window surfaced once the `IsLocalMemberLearner` panic was removed: `Maintenance/Status` can reach `EtcdServer.StorageVersion()` after the backend has been closed, causing a nil pointer dereference in `bbolt.(*Tx).Bucket` via `schema.DetectSchemaVersion` → `backend.(*baseReadTx).UnsafeRange`. That is a pre-existing bug unrelated to this change (on current `main` it is masked in this path because `IsLocalMemberLearner` panics earlier in the same handler). It will be filed as a separate issue so it can be tracked and fixed independently.

Fixes #21966

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
