### PR TITLE
etcdserver: don't read storage version from a closed backend

### DIFF
--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -956,7 +956,12 @@ func (s *EtcdServer) Cleanup() {
 		s.authStore.Close()
 	}
 	if s.be != nil {
+		// Hold the bemu lock so that in-flight readers of the backend
+		// (e.g. StorageVersion) finish before it is closed, and readers
+		// arriving afterwards observe s.stopping as closed.
+		s.bemu.Lock()
 		s.be.Close()
+		s.bemu.Unlock()
 	}
 	if s.compactor != nil {
 		s.compactor.Stop()
@@ -2189,6 +2194,16 @@ func (s *EtcdServer) StorageVersion() *semver.Version {
 	// `applySnapshot` sets a new backend instance, so we need to acquire the bemu lock.
 	s.bemu.RLock()
 	defer s.bemu.RUnlock()
+
+	// Cleanup closes the backend while holding the bemu lock after s.stopping
+	// has been closed, so checking s.stopping under the lock guarantees the
+	// backend is not read after it has been closed. Reading from a closed
+	// backend would panic.
+	select {
+	case <-s.stopping:
+		return nil
+	default:
+	}
 
 	v, err := schema.DetectSchemaVersion(s.lg, s.be.ReadTx())
 	if err != nil {

--- a/server/etcdserver/server_test.go
+++ b/server/etcdserver/server_test.go
@@ -1248,6 +1248,57 @@ func TestStopNotify(t *testing.T) {
 	}
 }
 
+// TestStorageVersionDuringStop ensures that StorageVersion (e.g. reached via a
+// concurrent Maintenance Status RPC) does not panic when it races with server
+// shutdown closing the backend.
+func TestStorageVersionDuringStop(t *testing.T) {
+	newStoppingServer := func(t *testing.T) *EtcdServer {
+		be, _ := betesting.NewDefaultTmpBackend(t)
+		return &EtcdServer{
+			lgMu:     new(sync.RWMutex),
+			lg:       zaptest.NewLogger(t),
+			be:       be,
+			stopping: make(chan struct{}, 1),
+		}
+	}
+
+	t.Run("AfterCleanup", func(t *testing.T) {
+		s := newStoppingServer(t)
+		// Mirror the shutdown sequence in the run goroutine's defer:
+		// stopping is closed first, then Cleanup closes the backend.
+		close(s.stopping)
+		s.Cleanup()
+
+		assert.NotPanics(t, func() {
+			assert.Nil(t, s.StorageVersion())
+		})
+	})
+
+	t.Run("ConcurrentWithCleanup", func(t *testing.T) {
+		s := newStoppingServer(t)
+
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("StorageVersion panicked: %v", r)
+					}
+				}()
+				for range 100 {
+					s.StorageVersion()
+				}
+			}()
+		}
+
+		close(s.stopping)
+		s.Cleanup()
+		wg.Wait()
+	})
+}
+
 func TestGetOtherPeerURLs(t *testing.T) {
 	lg := zaptest.NewLogger(t)
 	tests := []struct {


### PR DESCRIPTION
Fixes #22189

### What this PR does

Fixes a SIGSEGV when a `Maintenance/Status` gRPC call races with server shutdown (e.g. the member being removed from the cluster).

The run goroutine's shutdown defer closes `s.stopping` and then calls `Cleanup()`, which closes the backend without synchronizing with in-flight readers. A concurrent `Status` handler that reaches `EtcdServer.StorageVersion()` in that window calls `schema.DetectSchemaVersion()` on the closed backend, whose shared read transaction has already been reset to `nil` by the final `CommitAndStop`, and `backend.(*baseReadTx).UnsafeRange()` dereferences the nil `*bolt.Tx`:

```
SIGSEGV in bbolt.(*Tx).Bucket
  <- backend.(*baseReadTx).UnsafeRange   (server/storage/backend/read_tx.go:103)
  <- schema.UnsafeReadStorageVersion
  <- schema.DetectSchemaVersion
  <- EtcdServer.StorageVersion           (server/etcdserver/server.go:2193)
  <- serverVersionAdapter.GetStorageVersion
  <- maintenanceServer.Status
```

### How it is fixed

Two small changes in `server/etcdserver/server.go`:

1. `Cleanup()` now closes the backend while holding `s.bemu` (the mutex `StorageVersion` already takes for reading, because `applySnapshot` can swap the backend instance).
2. `StorageVersion()` checks `s.stopping` after acquiring `s.bemu.RLock()` and returns nil when the server is stopping.

Since `s.stopping` is closed strictly before `Cleanup()` runs, the lock gives the needed happens-before edge: a reader that does not observe `stopping` as closed cannot have its backend closed while it holds the read lock, and a reader that acquires the lock after the close observes `stopping` as closed and returns nil. The `Status` handler already handles a nil storage version by omitting the field, and the internal caller (`monitorStorageVersion`) exits on `s.stopping` before `Cleanup()` runs, so no behavior changes outside the shutdown window.

### Relationship to #21966 / #22188

This crash was discovered while verifying the fix for #21966: on current `main` it is masked in the `Status` path because the same handler panics earlier in `RaftCluster.IsLocalMemberLearner`. With #22188 applied, the #21966 reproducer immediately surfaces this second, independent crash. This change is standalone and does not depend on #22188.

### Testing

- New regression test `TestStorageVersionDuringStop` (fails with the SIGSEGV stack above before the fix; the concurrent subtest also deadlocks before the fix because the panic escapes `UnsafeRange` with `txMu` held):
  - `go test ./etcdserver/ -run TestStorageVersionDuringStop -v -race` — PASS
- `go test ./etcdserver/ -count=1` — ok
- End-to-end with the #21966 reproducer against a build including #22188: before this fix, SIGSEGV on the first run; after, 3/3 clean exits with code 0 (~300k Status calls per run).

---

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
