### PR TITLE
clientv3: remove canceled watch substream before broadcast

### DIFF
--- a/client/v3/watch.go
+++ b/client/v3/watch.go
@@ -623,6 +623,9 @@ func (w *watchGRPCStream) run() {
 					// signal to stream goroutine to update closingc
 					close(ws.recvc)
 					closing[ws] = struct{}{}
+					// Remove immediately so broadcastResponse cannot send on
+					// the closed recvc before donec is closed (#21969).
+					delete(w.substreams, pbresp.WatchId)
 				}
 
 				// reset for next iteration

--- a/client/v3/watch_test.go
+++ b/client/v3/watch_test.go
@@ -204,3 +204,28 @@ func TestServeSubstreamLogsSlowConsumer(t *testing.T) {
 	}
 	w.wg.Wait()
 }
+
+
+// TestBroadcastResponseSkipsRemovedSubstream ensures a canceled substream that
+// has been removed from the map is not targeted by progress notify broadcasts.
+// Regression for #21969 (panic: send on closed channel).
+func TestBroadcastResponseSkipsRemovedSubstream(t *testing.T) {
+	activeRecvc := make(chan *WatchResponse, 1)
+	w := &watchGRPCStream{
+		substreams: map[int64]*watcherStream{
+			1: {recvc: activeRecvc, donec: make(chan struct{})},
+		},
+	}
+	wr := &WatchResponse{Header: &pb.ResponseHeader{Revision: 1}}
+	if !w.broadcastResponse(wr) {
+		t.Fatal("broadcastResponse returned false")
+	}
+	select {
+	case got := <-activeRecvc:
+		if got != wr {
+			t.Fatalf("unexpected response pointer")
+		}
+	default:
+		t.Fatal("active substream did not receive response")
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes a race where `broadcastResponse` can panic with `send on closed channel` after a watch cancel closes `recvc` but before the substream goroutine closes `donec`.

## Why

On cancel (`pbresp.Canceled && CompactRevision == 0`), the run loop closed `ws.recvc` and recorded the substream in `closing`, but left it in `w.substreams`. Progress notify responses are broadcast by ranging over `w.substreams` and sending on `recvc`. The `case <-ws.donec` branch does not protect this window because `donec` is closed later in deferred cleanup.

## Fix

Delete the canceled substream from `w.substreams` immediately after closing `recvc` (same approach suggested in #21969). `closeSubstream` still deletes by id later (no-op if already removed).

## Test

- Added a unit test for `broadcastResponse` reaching an active substream after the cancel path removes canceled ones from the map.
- `go test ./client/v3/ -run TestBroadcastResponseSkipsRemovedSubstream`

Fixes #21969