### PR TITLE
fix robustness check failed due to nil pointer

### DIFF
--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -73,7 +73,7 @@ func assertResult(result validate.Result, name string) {
 	switch result.Status {
 	case validate.Success, validate.Failure:
 		assert.Always(result.Status == validate.Success, name, map[string]any{"msg": result.Message})
-	case validate.Unknown:
+	case validate.Skipped:
 		// Validation intentionally skipped (e.g. an earlier stage already
 		// failed, or required data wasn't available) — expected, not a bug.
 	default:

--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -73,11 +73,10 @@ func assertResult(result validate.Result, name string) {
 	switch result.Status {
 	case validate.Success, validate.Failure:
 		assert.Always(result.Status == validate.Success, name, map[string]any{"msg": result.Message})
+	case validate.Unknown:
+		// Validation intentionally skipped (e.g. an earlier stage already
+		// failed, or required data wasn't available) — expected, not a bug.
 	default:
-		details := map[string]any{"status": result.Status, "msg": result.Message}
-		if err := result.Error(); err != nil {
-			details["error"] = err.Error()
-		}
-		assert.Unreachable(name, details)
+		assert.Unreachable(name, map[string]any{"error": result.Error().Error()})
 	}
 }

--- a/tests/antithesis/test-template/robustness/finally/main.go
+++ b/tests/antithesis/test-template/robustness/finally/main.go
@@ -74,6 +74,10 @@ func assertResult(result validate.Result, name string) {
 	case validate.Success, validate.Failure:
 		assert.Always(result.Status == validate.Success, name, map[string]any{"msg": result.Message})
 	default:
-		assert.Unreachable(name, map[string]any{"error": result.Error().Error()})
+		details := map[string]any{"status": result.Status, "msg": result.Message}
+		if err := result.Error(); err != nil {
+			details["error"] = err.Error()
+		}
+		assert.Unreachable(name, details)
 	}
 }

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -73,7 +73,7 @@ func ResultFromError(err error) Result {
 
 func (r Result) Error() error {
 	switch r.Status {
-	case Success:
+	case Success, Unknown:
 		return nil
 	default:
 		return errors.New(r.String())

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -41,6 +41,7 @@ var (
 	Success ResultStatus = "Success"
 	Failure ResultStatus = "Failure"
 	Timeout ResultStatus = "Timeout"
+	Skipped ResultStatus = "Skipped"
 )
 
 func (r RobustnessResult) Error() error {

--- a/tests/robustness/validate/result.go
+++ b/tests/robustness/validate/result.go
@@ -73,7 +73,7 @@ func ResultFromError(err error) Result {
 
 func (r Result) Error() error {
 	switch r.Status {
-	case Success, Unknown:
+	case Success:
 		return nil
 	default:
 		return errors.New(r.String())

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -32,6 +32,8 @@ var ErrNotEmptyDatabase = errors.New("non empty database at start, required by m
 func ValidateAndReturnVisualize(lg *zap.Logger, cfg Config, reports []report.ClientReport, persistedRequests []model.EtcdRequest, timeout time.Duration) (result RobustnessResult) {
 	result.Assumptions = ResultFromError(checkValidationAssumptions(reports))
 	if result.Assumptions.Error() != nil {
+		result.Watch = Result{Status: Skipped, Message: "Assumtion Failed"}
+		result.Serializable = Result{Status: Skipped, Message: "Assumtion Failed"}
 		return result
 	}
 	linearizableOperations, serializableOperations, operationsForVisualization := prepareAndCategorizeOperations(reports)
@@ -47,10 +49,14 @@ func ValidateAndReturnVisualize(lg *zap.Logger, cfg Config, reports []report.Cli
 	// Skip other validations if model is not linearizable, as they are expected to fail too and obfuscate the logs.
 	if result.Linearization.Error() != nil {
 		lg.Info("Skipping other validations as linearization failed")
+		result.Watch = Result{Status: Skipped, Message: "linearization failed"}
+		result.Serializable = Result{Status: Skipped, Message: "linearization failed"}
 		return result
 	}
 	if len(persistedRequests) == 0 {
 		lg.Info("Skipping other validations as persisted requests were empty")
+		result.Watch = Result{Status: Skipped, Message: "no persisted requests"}
+		result.Serializable = Result{Status: Skipped, Message: "no persisted requests"}
 		return result
 	}
 	replay := model.NewReplay(persistedRequests)


### PR DESCRIPTION
Fix panic in assertResult caused by Result.Error() treating Unknown status as success

Fixes #22027

What was happening

The Antithesis robustness harness panicked with a nil pointer dereference:
```go
panic: runtime error: invalid memory address or nil pointer dereference
main.assertResult(...)
	tests/antithesis/test-template/robustness/finally/main.go:77
Root cause
```
In tests/v3/robustness/validate/result.go, Result.Error() groups Unknown (the zero value of ResultStatus) together with Success:

```go
func (r Result) Error() error {
	switch r.Status {
	case Success, Unknown:
		return nil
	default:
		return errors.New(r.String())
	}
}
```

Meanwhile, assertResult in finally/main.go only special-cases Success/Failure and falls into its default branch for anything else (including Unknown), where it unconditionally calls result.Error().Error():
```go
default:
	assert.Unreachable(name, map[string]any{"error": result.Error().Error()})
```
Because Result.Error() returns nil for Unknown, this call dereferences a nil error and panics.

This is more than a crash: Unknown means a validation stage's status was never actually set (e.g. it exited early or never ran), and treating that the same as Success means such a case would otherwise be silently reported as a passing validation.

Fix

Only Success should short-circuit Error() to nil. Failure, Timeout, and Unknown should all produce a real error:
```go
func (r Result) Error() error {
	switch r.Status {
	case Success:
		return nil
	default:
		return errors.New(r.String())
	}
}
```


