### PR TITLE
[WIP] membership: exempt SHA-1 ID derivation from FIPS 140-only enforcement

### DIFF
--- a/server/etcdserver/api/membership/cluster.go
+++ b/server/etcdserver/api/membership/cluster.go
@@ -16,6 +16,7 @@ package membership
 
 import (
 	"context"
+	"crypto/fips140"
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/json"
@@ -234,7 +235,14 @@ func (c *RaftCluster) genID() {
 	for i, id := range mIDs {
 		binary.BigEndian.PutUint64(b[8*i:], uint64(id))
 	}
-	hash := sha1.Sum(b)
+	// SHA-1 here is used only to derive a numeric cluster ID from the set of
+	// member IDs, not for any cryptographic (auth/integrity/confidentiality)
+	// purpose, so it is exempt from FIPS 140-only enforcement. Swapping the
+	// hash would also change cluster IDs for existing deployments.
+	var hash [20]byte
+	fips140.WithoutEnforcement(func() {
+		hash = sha1.Sum(b)
+	})
 	c.cid = types.ID(binary.BigEndian.Uint64(hash[:8]))
 }
 

--- a/server/etcdserver/api/membership/member.go
+++ b/server/etcdserver/api/membership/member.go
@@ -15,6 +15,7 @@
 package membership
 
 import (
+	"crypto/fips140"
 	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
@@ -71,7 +72,15 @@ func computeMemberID(peerURLs types.URLs, clusterName string, now *time.Time) ty
 		b = append(b, []byte(fmt.Sprintf("%d", now.Unix()))...)
 	}
 
-	hash := sha1.Sum(b)
+	// SHA-1 here is used only to derive a numeric member ID from the peer
+	// URLs/cluster name/timestamp, not for any cryptographic (auth/integrity/
+	// confidentiality) purpose, so it is exempt from FIPS 140-only
+	// enforcement. Swapping the hash would also change member IDs for
+	// existing deployments.
+	var hash [20]byte
+	fips140.WithoutEnforcement(func() {
+		hash = sha1.Sum(b)
+	})
 	return types.ID(binary.BigEndian.Uint64(hash[:8]))
 }
 


### PR DESCRIPTION
Fixes
## Problem

etcd panics on startup under `GODEBUG=fips140=only` because Go's native
FIPS 140-3 mode refuses to execute SHA-1, which `computeMemberID` and
`RaftCluster.genID` use to derive numeric member/cluster IDs from peer
URLs, cluster name, and timestamp (see stack trace in ).

## Why not just swap the algorithm

A one-line swap to SHA-256 would compile and fix the panic, but it
changes every member/cluster ID. These IDs are persisted in the WAL, in
snapshots, and exchanged during peer handshakes. A node built with the
new hash could not rejoin or recover a cluster bootstrapped with the
old hash — backward-incompatible for every existing deployment.

## Fix

This SHA-1 usage has no cryptographic purpose (no auth, integrity, or
confidentiality property depends on it — it's just a deterministic
digest used to produce a numeric ID). `crypto/fips140.WithoutEnforcement`
(available from Go 1.24+, used by etcd already via `go 1.26` in go.mod)
exists exactly for this: it disables strict FIPS 140-3 enforcement only
while executing the wrapped callback, so the binary can still run under
`GODEBUG=fips140=only` overall.

Wrapped both `sha1.Sum` call sites (`member.go`, `cluster.go`) in
`fips140.WithoutEnforcement`, with an inline comment on each explaining
why it's exempt and why the algorithm itself can't be swapped.

## Testing

- `go test ./server/etcdserver/api/membership/...` passes.
- Built `etcd`/`etcdctl` with `GOFIPS140=v1.0.0` and ran a single-member
  cluster under `GODEBUG=fips140=only`: starts, elects itself leader
  (exercises `computeMemberID`/`genID`), serves `put`/`get` — no panic.