### PR TITLE
concurrency: retain leader state in Resign when the delete transaction fails

### DIFF
--- a/client/v3/concurrency/election.go
+++ b/client/v3/concurrency/election.go
@@ -136,12 +136,17 @@ func (e *Election) Resign(ctx context.Context) (err error) {
 	client := e.session.Client()
 	cmp := v3.Compare(v3.CreateRevision(e.leaderKey), "=", e.leaderRev)
 	resp, err := client.Txn(ctx).If(cmp).Then(v3.OpDelete(e.leaderKey)).Commit()
-	if err == nil {
-		e.hdr = resp.Header
+	if err != nil {
+		// The transaction may not have reached etcd at all (e.g. a
+		// canceled context), so the leader key might still exist there.
+		// Keep the local state so a subsequent Resign can retry the
+		// delete instead of silently becoming a no-op.
+		return err
 	}
+	e.hdr = resp.Header
 	e.leaderKey = ""
 	e.leaderSession = nil
-	return err
+	return nil
 }
 
 // Leader returns the leader value for the current election.

--- a/tests/integration/clientv3/concurrency/election_test.go
+++ b/tests/integration/clientv3/concurrency/election_test.go
@@ -103,3 +103,49 @@ func TestResumeElection(t *testing.T) {
 		t.Errorf("expected new leader to be 'candidate1' got %q", string(kv.Value))
 	}
 }
+
+// TestElectionResignCanRetryAfterError reproduces
+// https://github.com/etcd-io/etcd/issues/22123: if Resign's delete
+// transaction fails (e.g. because its context is canceled before the
+// request reaches etcd), Resign must not forget its local leadership
+// state. Otherwise a later Resign call becomes a silent no-op and can
+// never remove the still-existing leader key.
+func TestElectionResignCanRetryAfterError(t *testing.T) {
+	const prefix = "/resign-retry/"
+
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	s, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer s.Close()
+
+	e := concurrency.NewElection(s, prefix)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+	defer cancel()
+
+	require.NoError(t, e.Campaign(ctx, "candidate1"))
+	leaderKey := e.Key()
+	require.NotEmpty(t, leaderKey)
+
+	canceledCtx, cancelNow := context.WithCancel(ctx)
+	cancelNow()
+	err = e.Resign(canceledCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The failed Resign must retain enough state to retry: the leader
+	// key must still be there, both locally and in etcd.
+	require.Equal(t, leaderKey, e.Key())
+	resp, err := cli.Get(ctx, leaderKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1, "leader key should still exist in etcd after the failed Resign")
+
+	// A retried Resign with a valid context should now actually succeed.
+	require.NoError(t, e.Resign(ctx))
+	require.Empty(t, e.Key())
+	resp, err = cli.Get(ctx, leaderKey)
+	require.NoError(t, err)
+	require.Empty(t, resp.Kvs, "leader key should be gone after the successful retry")
+}


### PR DESCRIPTION
`concurrency.Election.Resign` clears `leaderKey` and `leaderSession` even when its delete transaction returns an error. If the request never reaches etcd (e.g. because the context is already canceled), the leader key remains on the server, but `Election` forgets it locally — a later `Resign` then returns `nil` without retrying the delete, since `leaderSession == nil` short-circuits it.

**Fix:** only clear the local state after a successful transaction response. The delete is already guarded by a `CreateRevision` comparison, so retrying is safe even if the first response was ambiguous — a stale election cannot delete a newer incarnation of the same key.

**Testing:** added `TestElectionResignCanRetryAfterError`, which cancels the context before calling `Resign`, then verifies the leader key is still present both locally (`Election.Key()`) and in etcd, and that a subsequent `Resign` with a valid context successfully removes it. Verified this locally: reverted the fix and confirmed the test fails exactly as described in the issue (`Election.Key()` empty after the failed `Resign`); restored the fix and confirmed it passes. Full `concurrency` integration and unit test packages still pass.

Fixes #22123

Assisted-by: Claude Sonnet 5 — I found this issue, investigated the root cause, wrote the fix and the regression test, and verified the reproduction/fix cycle before submitting.

Signed-off-by: zanarelli <zanarelli.dev@gmail.com>