### PR TITLE
mvcc: restore Lease field for keys-only Range at latest revision

### DIFF
--- a/server/storage/mvcc/kvstore_txn.go
+++ b/server/storage/mvcc/kvstore_txn.go
@@ -93,6 +93,14 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 		if len(keys) == 0 {
 			return &RangeResult{KVs: nil, Count: 0, Rev: curRev}, nil
 		}
+		// The lessor only tracks the current lease attachment for a key, not its
+		// value at past revisions, so only fill in Lease for reads of the latest
+		// revision. Historical reads (rev < curRev) keep Lease unset, as before.
+		// Note: unlike the other fields here, GetLease reads live lessor state
+		// rather than a revision-pinned snapshot, so a concurrent attach/detach
+		// on the same key can race with this read and return a Lease reflecting
+		// a revision just ahead of ModRevision/CreateRevision/Version.
+		fillLease := tr.s.le != nil && rev == curRev
 		kvs := make([]*mvccpb.KeyValue, len(keys))
 		for i := range len(kvs) {
 			kvs[i] = &mvccpb.KeyValue{
@@ -100,6 +108,11 @@ func (tr *storeTxnCommon) rangeKeys(ctx context.Context, key, end []byte, curRev
 				ModRevision:    modifies[i].Main,
 				CreateRevision: creates[i].Main,
 				Version:        versions[i],
+			}
+			if fillLease {
+				if leaseID := tr.s.le.GetLease(lease.LeaseItem{Key: string(keys[i])}); leaseID != lease.NoLease {
+					kvs[i].Lease = int64(leaseID)
+				}
 			}
 		}
 		return &RangeResult{KVs: kvs, Count: total, Rev: curRev}, nil

--- a/tests/integration/clientv3/kv_test.go
+++ b/tests/integration/clientv3/kv_test.go
@@ -537,6 +537,58 @@ func TestKVGetKeysOnlyWithCountOnly(t *testing.T) {
 	}
 }
 
+// TestKVGetKeysOnlyWithLease ensures that a Range request with KeysOnly set
+// still returns the Lease field for keys attached to a lease.
+// Regression test for https://github.com/etcd-io/etcd/issues/22209.
+func TestKVGetKeysOnlyWithLease(t *testing.T) {
+	integration.BeforeTest(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	kv := clus.RandClient()
+	ctx := t.Context()
+
+	key := "hello"
+	putResp, err := kv.Put(ctx, key, "world")
+	if err != nil {
+		t.Fatalf("couldn't put %q (%v)", key, err)
+	}
+	unleasedRev := putResp.Header.Revision
+
+	lresp, err := kv.Grant(ctx, 100)
+	if err != nil {
+		t.Fatalf("failed to create lease %v", err)
+	}
+	if _, err = kv.Put(ctx, key, "world2", clientv3.WithLease(lresp.ID)); err != nil {
+		t.Fatalf("couldn't put %q (%v)", key, err)
+	}
+
+	resp, err := kv.Get(ctx, key, clientv3.WithKeysOnly())
+	if err != nil {
+		t.Fatalf("couldn't get key (%v)", err)
+	}
+	if len(resp.Kvs) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(resp.Kvs))
+	}
+	if lresp.ID != clientv3.LeaseID(resp.Kvs[0].Lease) {
+		t.Errorf("lease = %d, want %d", resp.Kvs[0].Lease, lresp.ID)
+	}
+
+	// A keys-only range at a historical revision predating the lease attach
+	// must not report the key's current (not-yet-attached) lease.
+	histResp, err := kv.Get(ctx, key, clientv3.WithKeysOnly(), clientv3.WithRev(unleasedRev))
+	if err != nil {
+		t.Fatalf("couldn't get key at historical revision (%v)", err)
+	}
+	if len(histResp.Kvs) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(histResp.Kvs))
+	}
+	if histResp.Kvs[0].Lease != 0 {
+		t.Errorf("historical lease = %d, want 0", histResp.Kvs[0].Lease)
+	}
+}
+
 // TestKVGetRetry ensures get will retry on disconnect.
 func TestKVGetRetry(t *testing.T) {
 	integration.BeforeTest(t)


### PR DESCRIPTION
Motivation:
A RangeRequest with keys_only=true stopped returning the lease field
for leased keys in v3.7 (etcd-io/etcd#22209), even though the field
was populated in v3.6. This is a regression from PR #21791, which
added a fast path (mvcc.RangeOptions.FastKeysOnly) that builds
KeyValue results directly from the in-memory index instead of reading
the full marshaled proto from bbolt. The in-memory index tracks Key,
ModRevision, CreateRevision, and Version, but has no concept of lease
attachment, so the fast path always left Lease unset.

User-visible behavior before this fix: Get(key, WithKeysOnly()) always
returns Lease=0, even for a key attached to a lease. There is no
crash, data loss, or write-path impact; this is purely a missing field
in a read response.

Approach:
In storeTxnCommon.rangeKeys's FastKeysOnly branch, look up each key's
current lease via the store's lessor (Lessor.GetLease), the same
lookup already used by the write path (storeTxnWrite.put) to find a
key's previous lease. This is an O(1) map read under the lessor's own
RLock, so it does not reintroduce the bbolt read that the fast path
was written to avoid.

The lessor only tracks the *current* lease attachment, not per-revision
history, so the lookup is gated to only fire when the query targets the
latest revision (rev == curRev). Historical reads (an explicit past
Revision) keep Lease unset, exactly as before this fix, rather than
risk reporting a lease that doesn't correspond to the requested
revision. A residual, narrow race is called out in a code comment:
a concurrent attach/detach on the same key can still race with the
lease lookup and reflect a revision just ahead of the other returned
fields; a fully race-free fix would require teaching the in-memory
index to track lease history per revision, which is a larger change
out of scope here.

Validation:
- go build ./... (server and tests modules)
- go test ./server/storage/mvcc/...  (full package, no regressions)
- go test ./tests/integration/clientv3/... -run TestKVGetKeysOnlyWithLease -v
  Added TestKVGetKeysOnlyWithLease, which covers both the common case
  (latest-revision keys-only Get returns the correct current lease) and
  the historical-revision edge case (keys-only Get pinned to a revision
  predating the lease attach returns Lease=0, not the current lease).
  Confirmed this test fails against the pre-fix code (reverted the
  kvstore_txn.go change locally and reran) with "lease = 0, want
  <id>", then confirmed it passes with the fix restored.

Fixes #22209

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>