### PR TITLE
build(deps): add cooldown period to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       codeql:
         patterns:
@@ -14,6 +16,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: direct
 
@@ -21,6 +25,8 @@ updates:
     directory: /tools/mod # Not linked from /go.mod
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: direct
 
@@ -28,26 +34,36 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     target-branch: "release-3.5"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     target-branch: "release-3.6"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     target-branch: "release-3.7"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /tools/container-images/devcontainer
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add a 7-day cooldown period to all Dependabot package-ecosystem entries to reduce supply chain risk.

## Problem
The Dependabot configuration in `.github/dependabot.yml` has 8 package-ecosystem entries, none of which set a cooldown period. Without a cooldown, Dependabot may create PRs for newly published packages within hours. Malicious or unstable packages could be automatically proposed before the community has time to detect issues.

## Fix
Add `cooldown: default-days: 7` to each of the 8 update entries:
- github-actions (weekly)
- gomod (weekly, 2 entries)
- docker (weekly + 3 release branches monthly + devcontainer weekly)

## References
- [GitHub Docs: Dependabot cooldown options](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
- [Semgrep rule: dependabot-missing-cooldown](https://semgrep.dev/r?q=dependabot-missing-cooldown)

Signed-off-by: sunliqiang <sunliqiang@kylinos.cn>