### PR TITLE
changelog: add etcdctl RaftTerm fix entry for 3.5, 3.6 and 3.7

### DIFF
--- a/CHANGELOG/CHANGELOG-3.5.md
+++ b/CHANGELOG/CHANGELOG-3.5.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.4](https://github.com/etcd-io/
 
 ## v3.5.34 (TBC)
 
+### etcdctl
+
+- [Fix duplicate `RaftTerm` field in the `endpoint status` output when using `--write-out=fields`](https://github.com/etcd-io/etcd/pull/22219)
+
 ---
 
 ## v3.5.33 (2026-07-23)

--- a/CHANGELOG/CHANGELOG-3.6.md
+++ b/CHANGELOG/CHANGELOG-3.6.md
@@ -6,6 +6,10 @@ Previous change logs can be found at [CHANGELOG-3.5](https://github.com/etcd-io/
 
 ## v3.6.15 (TBC)
 
+### etcdctl
+
+- [Fix duplicate `RaftTerm` field in the `endpoint status` output when using `--write-out=fields`](https://github.com/etcd-io/etcd/pull/22218)
+
 ---
 
 ## v3.6.14 (2026-07-23)

--- a/CHANGELOG/CHANGELOG-3.7.md
+++ b/CHANGELOG/CHANGELOG-3.7.md
@@ -9,6 +9,10 @@ Previous change logs can be found at [CHANGELOG-3.6](https://github.com/etcd-io/
 
 - [Update `MinimalEtcdVersion` to read latest snapshot entry from WAL](https://github.com/etcd-io/etcd/pull/22201)
 
+### etcdctl
+
+- [Fix duplicate `RaftTerm` field in the `endpoint status` output when using `--write-out=fields`](https://github.com/etcd-io/etcd/pull/22208)
+
 ---
 
 ## v3.7.1 (2026-07-23)


### PR DESCRIPTION
Updates the changelog for 3.5, 3.6 and 3.7 to include the fix for the duplicate `RaftTerm` field in `endpoint status --write-out=fields` output.

- 3.7: #22217 
- 3.6: #22218
- 3.5: #22219

Original PR: https://github.com/etcd-io/etcd/pull/22208