### PR TITLE
etcdserver: integrate raft async storage writes

### DIFF
--- a/server/etcdserver/bootstrap.go
+++ b/server/etcdserver/bootstrap.go
@@ -41,6 +41,7 @@ import (
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3discovery"
 	"go.etcd.io/etcd/server/v3/etcdserver/cindex"
 	servererrors "go.etcd.io/etcd/server/v3/etcdserver/errors"
+	"go.etcd.io/etcd/server/v3/features"
 	serverstorage "go.etcd.io/etcd/server/v3/storage"
 	"go.etcd.io/etcd/server/v3/storage/backend"
 	"go.etcd.io/etcd/server/v3/storage/schema"
@@ -539,15 +540,16 @@ func bootstrapRaftFromWAL(cfg config.ServerConfig, bwal *bootstrappedWAL) *boots
 
 func raftConfig(cfg config.ServerConfig, id uint64, s *raft.MemoryStorage) *raft.Config {
 	return &raft.Config{
-		ID:              id,
-		ElectionTick:    cfg.ElectionTicks,
-		HeartbeatTick:   1,
-		Storage:         s,
-		MaxSizePerMsg:   maxSizePerMsg,
-		MaxInflightMsgs: maxInflightMsgs,
-		CheckQuorum:     true,
-		PreVote:         cfg.PreVote,
-		Logger:          NewRaftLoggerZap(cfg.Logger.Named("raft")),
+		ID:                 id,
+		ElectionTick:       cfg.ElectionTicks,
+		HeartbeatTick:      1,
+		Storage:            s,
+		MaxSizePerMsg:      maxSizePerMsg,
+		MaxInflightMsgs:    maxInflightMsgs,
+		CheckQuorum:        true,
+		PreVote:            cfg.PreVote,
+		AsyncStorageWrites: cfg.ServerFeatureGate.Enabled(features.RaftAsyncStorageWrites),
+		Logger:             NewRaftLoggerZap(cfg.Logger.Named("raft")),
 	}
 }
 
@@ -563,12 +565,14 @@ func (b *bootstrappedRaft) newRaftNode(ss *snap.Snapshotter, wal *wal.WAL, cl *m
 	raftStatusMu.Unlock()
 	return newRaftNode(
 		raftNodeConfig{
-			lg:          b.lg,
-			isIDRemoved: func(id uint64) bool { return cl.IsIDRemoved(types.ID(id)) },
-			Node:        n,
-			heartbeat:   b.heartbeat,
-			raftStorage: b.storage,
-			storage:     serverstorage.NewStorage(b.lg, wal, ss),
+			lg:                 b.lg,
+			isIDRemoved:        func(id uint64) bool { return cl.IsIDRemoved(types.ID(id)) },
+			Node:               n,
+			localID:            b.config.ID,
+			asyncStorageWrites: b.config.AsyncStorageWrites,
+			heartbeat:          b.heartbeat,
+			raftStorage:        b.storage,
+			storage:            serverstorage.NewStorage(b.lg, wal, ss),
 		},
 	)
 }

--- a/server/etcdserver/bootstrap_test.go
+++ b/server/etcdserver/bootstrap_test.go
@@ -34,16 +34,38 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/pkg/v3/featuregate"
 	"go.etcd.io/etcd/server/v3/config"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"go.etcd.io/etcd/server/v3/features"
 	serverstorage "go.etcd.io/etcd/server/v3/storage"
 	"go.etcd.io/etcd/server/v3/storage/datadir"
 	"go.etcd.io/etcd/server/v3/storage/schema"
 	"go.etcd.io/etcd/server/v3/storage/wal"
 	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 )
+
+func TestRaftConfigAsyncStorageWritesFeatureGate(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+	fg := features.NewDefaultServerFeatureGate("test", lg)
+	cfg := config.ServerConfig{
+		Logger:            lg,
+		ElectionTicks:     10,
+		ServerFeatureGate: fg,
+	}
+	if got := raftConfig(cfg, 1, raft.NewMemoryStorage()).AsyncStorageWrites; got {
+		t.Fatal("asynchronous storage writes enabled by default")
+	}
+
+	err := fg.(featuregate.MutableFeatureGate).Set("RaftAsyncStorageWrites=true")
+	require.NoError(t, err)
+	if got := raftConfig(cfg, 1, raft.NewMemoryStorage()).AsyncStorageWrites; !got {
+		t.Fatal("asynchronous storage writes disabled when feature gate is enabled")
+	}
+}
 
 func TestBootstrapExistingClusterNoWALMaxLearner(t *testing.T) {
 	tests := []struct {

--- a/server/etcdserver/raft.go
+++ b/server/etcdserver/raft.go
@@ -15,6 +15,7 @@
 package etcdserver
 
 import (
+	"context"
 	"expvar"
 	"fmt"
 	"log"
@@ -39,6 +40,9 @@ const (
 	// Never overflow the rafthttp buffer, which is 4096.
 	// TODO: a better const?
 	maxInflightMsgs = 4096 / 8
+	// Bound the number of append messages accepted ahead of stable storage.
+	// The append worker coalesces compatible messages into a single WAL sync.
+	asyncAppendQueueSize = 64
 )
 
 var (
@@ -63,19 +67,20 @@ func init() {
 	}))
 }
 
-// toApply contains entries, snapshot to be applied. Once
-// an toApply is consumed, the entries will be persisted to
-// raft storage concurrently; the application must read
-// notifyc before assuming the raft messages are stable.
+// toApply contains entries and a snapshot to apply. The application must read
+// notifyc before assuming that the corresponding Raft storage work is complete.
 type toApply struct {
 	entries  []*raftpb.Entry
 	snapshot *raftpb.Snapshot
 	// notifyc synchronizes etcd server applies with the raft node
 	notifyc chan struct{}
-	// raftAdvancedC notifies EtcdServer.apply that
-	// 'raftLog.applied' has advanced by r.Advance
+	// raftAdvancedC notifies EtcdServer.apply that raftLog.applied has advanced
+	// through either r.Advance or a MsgStorageApplyResp.
 	// it should be used only when entries contain raftpb.EntryConfChange
 	raftAdvancedC <-chan struct{}
+	// onApplied is called after the state machine work and its corresponding
+	// Raft storage work have both completed.
+	onApplied func()
 }
 
 type raftNode struct {
@@ -91,6 +96,12 @@ type raftNode struct {
 
 	// a chan to send out apply
 	applyc chan toApply
+	// appendc carries the reliable FIFO stream of MsgStorageAppend work when
+	// asynchronous storage writes are enabled.
+	appendc chan *raftpb.Message
+	// asyncStopc stops asynchronous storage work before Raft storage is closed.
+	asyncStopc       chan struct{}
+	asyncAppendDonec chan struct{}
 
 	// a chan to send out readState
 	readStateC chan raft.ReadState
@@ -110,9 +121,11 @@ type raftNodeConfig struct {
 	// to check if msg receiver is removed from cluster
 	isIDRemoved func(id uint64) bool
 	raft.Node
-	raftStorage *raft.MemoryStorage
-	storage     serverstorage.Storage
-	heartbeat   time.Duration // for logging
+	localID            uint64
+	asyncStorageWrites bool
+	raftStorage        *raft.MemoryStorage
+	storage            serverstorage.Storage
+	heartbeat          time.Duration // for logging
 	// transport specifies the transport to send and receive msgs to members.
 	// Sending messages MUST NOT block. It is okay to drop messages, since
 	// clients should timeout and reissue their messages.
@@ -140,12 +153,15 @@ func newRaftNode(cfg raftNodeConfig) *raftNode {
 		latestTickTs:   time.Now(),
 		// set up contention detectors for raft heartbeat message.
 		// expect to send a heartbeat within 2 heartbeat intervals.
-		td:         contention.NewTimeoutDetector(2 * cfg.heartbeat),
-		readStateC: make(chan raft.ReadState, 1),
-		msgSnapC:   make(chan *raftpb.Message, maxInFlightMsgSnap),
-		applyc:     make(chan toApply),
-		stopped:    make(chan struct{}),
-		done:       make(chan struct{}),
+		td:               contention.NewTimeoutDetector(2 * cfg.heartbeat),
+		readStateC:       make(chan raft.ReadState, 1),
+		msgSnapC:         make(chan *raftpb.Message, maxInFlightMsgSnap),
+		applyc:           make(chan toApply),
+		appendc:          make(chan *raftpb.Message, asyncAppendQueueSize),
+		asyncStopc:       make(chan struct{}),
+		asyncAppendDonec: make(chan struct{}),
+		stopped:          make(chan struct{}),
+		done:             make(chan struct{}),
 	}
 	if r.heartbeat == 0 {
 		r.ticker = &time.Ticker{}
@@ -174,8 +190,17 @@ func (r *raftNode) getLatestTickTs() time.Time {
 func (r *raftNode) start(rh *raftReadyHandler) {
 	internalTimeout := time.Second
 
+	if r.asyncStorageWrites {
+		go r.runAsyncAppend()
+	}
 	go func() {
-		defer r.onStop()
+		defer func() {
+			if r.asyncStorageWrites {
+				close(r.asyncStopc)
+				<-r.asyncAppendDonec
+			}
+			r.onStop()
+		}()
 		islead := false
 
 		for {
@@ -215,6 +240,12 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 						return
 					}
 				}
+				if r.asyncStorageWrites {
+					if !r.processAsyncReady(rd, rh) {
+						return
+					}
+					continue
+				}
 				committedEntries := rd.CommittedEntries
 				notifyc := make(chan struct{}, 1)
 				raftAdvancedC := make(chan struct{}, 1)
@@ -242,49 +273,7 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 					r.transport.Send(r.processMessages(rd.Messages))
 				}
 
-				// Must save the snapshot file and WAL snapshot entry before saving any other entries or hardstate to
-				// ensure that recovery after a snapshot restore is possible.
-				if !raft.IsEmptySnap(raftSnap) {
-					// gofail: var raftBeforeSaveSnap struct{}
-					if err := r.storage.SaveSnap(raftSnap); err != nil {
-						r.lg.Fatal("failed to save Raft snapshot", zap.Error(err))
-					}
-					// gofail: var raftAfterSaveSnap struct{}
-				}
-
-				// gofail: var raftBeforeSave struct{}
-				if err := r.storage.Save(rd.HardState, rd.Entries); err != nil {
-					r.lg.Fatal("failed to save Raft hard state and entries", zap.Error(err))
-				}
-				if !raft.IsEmptyHardState(rd.HardState) {
-					proposalsCommitted.Set(float64(rd.HardState.GetCommit()))
-				}
-				// gofail: var raftAfterSave struct{}
-
-				if !raft.IsEmptySnap(raftSnap) {
-					// Force WAL to fsync its hard state before Release() releases
-					// old data from the WAL. Otherwise could get an error like:
-					// panic: tocommit(107) is out of range [lastIndex(84)]. Was the raft log corrupted, truncated, or lost?
-					// See https://github.com/etcd-io/etcd/issues/10219 for more details.
-					if err := r.storage.Sync(); err != nil {
-						r.lg.Fatal("failed to sync Raft snapshot", zap.Error(err))
-					}
-
-					// etcdserver now claim the snapshot has been persisted onto the disk
-					notifyc <- struct{}{}
-
-					// gofail: var raftBeforeApplySnap struct{}
-					r.raftStorage.ApplySnapshot(raftSnap)
-					r.lg.Info("applied incoming Raft snapshot", zap.Uint64("snapshot-index", raftSnap.Metadata.GetIndex()))
-					// gofail: var raftAfterApplySnap struct{}
-
-					if err := r.storage.Release(raftSnap); err != nil {
-						r.lg.Fatal("failed to release Raft wal", zap.Error(err))
-					}
-					// gofail: var raftAfterWALRelease struct{}
-				}
-
-				r.raftStorage.Append(rd.Entries)
+				r.persistRaftData(rd.HardState, rd.Entries, raftSnap, notifyc)
 
 				confChanged := false
 				for _, ent := range rd.CommittedEntries {
@@ -339,6 +328,294 @@ func (r *raftNode) start(rh *raftReadyHandler) {
 			}
 		}
 	}()
+}
+
+// processAsyncReady dispatches Raft's local storage messages to two reliable
+// FIFO lanes. All other messages are safe to send immediately; messages whose
+// delivery depends on a storage write are carried as responses on the local
+// storage messages instead.
+func (r *raftNode) processAsyncReady(rd raft.Ready, rh *raftReadyHandler) bool {
+	var messages []*raftpb.Message
+	sendMessages := func() {
+		if len(messages) == 0 {
+			return
+		}
+		r.transport.Send(r.processMessages(messages))
+		messages = nil
+	}
+	for _, m := range rd.Messages {
+		switch m.GetTo() {
+		case raft.LocalAppendThread:
+			if m.GetType() != raftpb.MsgStorageAppend {
+				r.lg.Panic("unexpected message to Raft append thread", zap.Stringer("message-type", m.GetType()))
+			}
+			if snap := m.GetSnapshot(); !raft.IsEmptySnap(snap) && rh != nil {
+				updateCommittedIndex(&toApply{snapshot: snap}, rh)
+			}
+			sendMessages()
+			select {
+			case r.appendc <- m:
+			case <-r.stopped:
+				return false
+			}
+		case raft.LocalApplyThread:
+			if m.GetType() != raftpb.MsgStorageApply {
+				r.lg.Panic("unexpected message to Raft apply thread", zap.Stringer("message-type", m.GetType()))
+			}
+			notifyc := make(chan struct{}, 1)
+			notifyc <- struct{}{}
+			raftAdvancedC := make(chan struct{}, 1)
+			responses := m.GetResponses()
+			ap := toApply{
+				entries:       m.GetEntries(),
+				snapshot:      raftpb.EnsureSnapshot(nil),
+				notifyc:       notifyc,
+				raftAdvancedC: raftAdvancedC,
+				onApplied: func() {
+					r.sendStorageResponses(responses)
+					raftAdvancedC <- struct{}{}
+				},
+			}
+			if rh != nil {
+				updateCommittedIndex(&ap, rh)
+			}
+			sendMessages()
+			select {
+			case r.applyc <- ap:
+			case <-r.stopped:
+				return false
+			}
+		default:
+			if raft.IsLocalMsgTarget(m.GetTo()) {
+				r.lg.Panic(
+					"unexpected message to local Raft storage thread",
+					zap.Stringer("message-type", m.GetType()),
+					zap.Uint64("message-to", m.GetTo()),
+				)
+			}
+			messages = append(messages, m)
+		}
+	}
+	sendMessages()
+	return true
+}
+
+func (r *raftNode) runAsyncAppend() {
+	defer close(r.asyncAppendDonec)
+	for {
+		select {
+		case <-r.asyncStopc:
+			return
+		default:
+		}
+		select {
+		case m := <-r.appendc:
+			messages := []*raftpb.Message{m}
+			draining := true
+			for draining && len(messages) < asyncAppendQueueSize {
+				select {
+				case m = <-r.appendc:
+					messages = append(messages, m)
+				default:
+					draining = false
+				}
+			}
+			r.processStorageAppends(messages)
+		case <-r.asyncStopc:
+			return
+		}
+	}
+}
+
+func (r *raftNode) processStorageAppends(messages []*raftpb.Message) {
+	for len(messages) > 0 {
+		if !raft.IsEmptySnap(messages[0].GetSnapshot()) {
+			r.processStorageAppend(messages[0])
+			messages = messages[1:]
+			continue
+		}
+
+		end := 1
+		var entries []*raftpb.Entry
+		entries = append(entries, messages[0].GetEntries()...)
+		for end < len(messages) && raft.IsEmptySnap(messages[end].GetSnapshot()) && canBatchStorageAppend(entries, messages[end].GetEntries()) {
+			entries = append(entries, messages[end].GetEntries()...)
+			end++
+		}
+		r.processStorageAppendBatch(messages[:end], entries)
+		messages = messages[end:]
+	}
+}
+
+func canBatchStorageAppend(entries, next []*raftpb.Entry) bool {
+	return len(entries) == 0 || len(next) == 0 || next[0].GetIndex() == entries[len(entries)-1].GetIndex()+1
+}
+
+func (r *raftNode) processStorageAppendBatch(messages []*raftpb.Message, entries []*raftpb.Entry) {
+	var hardState *raftpb.HardState
+	var responses []*raftpb.Message
+	for _, m := range messages {
+		if m.GetType() != raftpb.MsgStorageAppend {
+			r.lg.Panic("unexpected Raft append work", zap.Stringer("message-type", m.GetType()))
+		}
+		if state := hardStateFromAppendMessage(r.lg, m); state != nil {
+			hardState = state
+		}
+		responses = append(responses, m.GetResponses()...)
+	}
+	// A later HardState supersedes an earlier one, and processStorageAppends
+	// only combines entry ranges that form one contiguous append. Persisting
+	// that final state is therefore equivalent to persisting each message in
+	// order. All responses remain blocked until the combined save is durable.
+	r.persistRaftData(hardState, entries, raftpb.EnsureSnapshot(nil), nil)
+	r.sendStorageResponses(responses)
+}
+
+func (r *raftNode) processStorageAppend(m *raftpb.Message) {
+	if m.GetType() != raftpb.MsgStorageAppend {
+		r.lg.Panic("unexpected Raft append work", zap.Stringer("message-type", m.GetType()))
+	}
+
+	hardState := hardStateFromAppendMessage(r.lg, m)
+
+	var raftSnap *raftpb.Snapshot
+	var applySnap *raftpb.Snapshot
+	if !raft.IsEmptySnap(m.GetSnapshot()) {
+		raftSnap = proto.Clone(m.GetSnapshot()).(*raftpb.Snapshot)
+		applySnap = proto.Clone(m.GetSnapshot()).(*raftpb.Snapshot)
+	} else {
+		raftSnap = raftpb.EnsureSnapshot(nil)
+	}
+
+	var notifyc chan struct{}
+	var snapshotAppliedC chan struct{}
+	if !raft.IsEmptySnap(raftSnap) {
+		notifyc = make(chan struct{}, 1)
+		snapshotAppliedC = make(chan struct{})
+		responses := m.GetResponses()
+		ap := toApply{
+			snapshot:      applySnap,
+			notifyc:       notifyc,
+			raftAdvancedC: make(chan struct{}),
+			onApplied: func() {
+				r.sendStorageResponses(responses)
+				close(snapshotAppliedC)
+			},
+		}
+		select {
+		case r.applyc <- ap:
+		case <-r.asyncStopc:
+			return
+		}
+	}
+
+	r.persistRaftData(hardState, m.GetEntries(), raftSnap, notifyc)
+	if raft.IsEmptySnap(raftSnap) {
+		r.sendStorageResponses(m.GetResponses())
+		return
+	}
+
+	// applySnapshot consumes the first notification sent by persistRaftData.
+	// The second notification allows applyAll to observe that the in-memory
+	// Raft storage update and WAL release are also complete.
+	select {
+	case notifyc <- struct{}{}:
+	case <-r.asyncStopc:
+		return
+	}
+	select {
+	case <-snapshotAppliedC:
+	case <-r.asyncStopc:
+	}
+}
+
+func hardStateFromAppendMessage(lg *zap.Logger, m *raftpb.Message) *raftpb.HardState {
+	if m.Term == nil && m.Vote == nil && m.Commit == nil {
+		return nil
+	}
+	if m.Term == nil || m.Vote == nil || m.Commit == nil {
+		lg.Panic("incomplete hard state on Raft append work")
+	}
+	return &raftpb.HardState{
+		Term:   m.Term,
+		Vote:   m.Vote,
+		Commit: m.Commit,
+	}
+}
+
+// persistRaftData preserves etcd's crash-recovery ordering for both the
+// Ready/Advance and asynchronous storage-write interfaces.
+func (r *raftNode) persistRaftData(
+	hardState *raftpb.HardState,
+	entries []*raftpb.Entry,
+	raftSnap *raftpb.Snapshot,
+	snapshotPersistedC chan<- struct{},
+) {
+	// Must save the snapshot file and WAL snapshot entry before saving any other entries or hardstate to
+	// ensure that recovery after a snapshot restore is possible.
+	if !raft.IsEmptySnap(raftSnap) {
+		// gofail: var raftBeforeSaveSnap struct{}
+		if err := r.storage.SaveSnap(raftSnap); err != nil {
+			r.lg.Fatal("failed to save Raft snapshot", zap.Error(err))
+		}
+		// gofail: var raftAfterSaveSnap struct{}
+	}
+
+	// gofail: var raftBeforeSave struct{}
+	if err := r.storage.Save(hardState, entries); err != nil {
+		r.lg.Fatal("failed to save Raft hard state and entries", zap.Error(err))
+	}
+	if !raft.IsEmptyHardState(hardState) {
+		proposalsCommitted.Set(float64(hardState.GetCommit()))
+	}
+	// gofail: var raftAfterSave struct{}
+
+	if !raft.IsEmptySnap(raftSnap) {
+		// Force WAL to fsync its hard state before Release() releases
+		// old data from the WAL. Otherwise could get an error like:
+		// panic: tocommit(107) is out of range [lastIndex(84)]. Was the raft log corrupted, truncated, or lost?
+		// See https://github.com/etcd-io/etcd/issues/10219 for more details.
+		if err := r.storage.Sync(); err != nil {
+			r.lg.Fatal("failed to sync Raft snapshot", zap.Error(err))
+		}
+
+		// etcdserver now claims the snapshot has been persisted onto the disk.
+		snapshotPersistedC <- struct{}{}
+
+		// gofail: var raftBeforeApplySnap struct{}
+		r.raftStorage.ApplySnapshot(raftSnap)
+		r.lg.Info("applied incoming Raft snapshot", zap.Uint64("snapshot-index", raftSnap.Metadata.GetIndex()))
+		// gofail: var raftAfterApplySnap struct{}
+
+		if err := r.storage.Release(raftSnap); err != nil {
+			r.lg.Fatal("failed to release Raft wal", zap.Error(err))
+		}
+		// gofail: var raftAfterWALRelease struct{}
+	}
+
+	r.raftStorage.Append(entries)
+}
+
+func (r *raftNode) sendStorageResponses(responses []*raftpb.Message) {
+	var messages []*raftpb.Message
+	sendMessages := func() {
+		if len(messages) == 0 {
+			return
+		}
+		r.transport.Send(r.processMessages(messages))
+		messages = nil
+	}
+	for _, m := range responses {
+		if m.GetTo() == r.localID {
+			sendMessages()
+			if err := r.Step(context.Background(), m); err != nil {
+				r.lg.Warn("failed to deliver local Raft storage response", zap.Stringer("message-type", m.GetType()), zap.Error(err))
+			}
+			continue
+		}
+		messages = append(messages, m)
+	}
+	sendMessages()
 }
 
 func updateCommittedIndex(ap *toApply, rh *raftReadyHandler) {

--- a/server/etcdserver/raft_test.go
+++ b/server/etcdserver/raft_test.go
@@ -15,6 +15,7 @@
 package etcdserver
 
 import (
+	"context"
 	"encoding/json"
 	"expvar"
 	"reflect"
@@ -340,5 +341,346 @@ func TestStopRaftNodeMoreThanOnce(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Errorf("*raftNode.stop() is blocked !")
 		}
+	}
+}
+
+func TestAsyncStorageWritesBatchUsesFinalHardState(t *testing.T) {
+	storage := &saveCaptureStorage{Storage: mockstorage.NewStorageRecorder("")}
+	r := newRaftNode(raftNodeConfig{
+		lg:          zaptest.NewLogger(t),
+		Node:        newAsyncReadyNode(),
+		localID:     1,
+		storage:     storage,
+		raftStorage: raft.NewMemoryStorage(),
+		transport:   newNopTransporter(),
+	})
+	first := newStorageAppendMessage(1, 1)
+	first.Term = new(uint64(1))
+	first.Vote = new(uint64(1))
+	first.Commit = new(uint64(1))
+	second := newStorageAppendMessage(2, 2)
+	second.Term = new(uint64(2))
+	second.Vote = new(uint64(2))
+	second.Commit = new(uint64(2))
+
+	r.processStorageAppends([]*raftpb.Message{first, second})
+
+	if storage.saveCount != 1 {
+		t.Fatalf("save count = %d, want 1", storage.saveCount)
+	}
+	if got := storage.hardState.GetTerm(); got != 2 {
+		t.Fatalf("saved hard state term = %d, want 2", got)
+	}
+	if got := storage.hardState.GetVote(); got != 2 {
+		t.Fatalf("saved hard state vote = %d, want 2", got)
+	}
+	if got := storage.hardState.GetCommit(); got != 2 {
+		t.Fatalf("saved hard state commit = %d, want 2", got)
+	}
+	if len(storage.entries) != 2 || storage.entries[0].GetIndex() != 1 || storage.entries[1].GetIndex() != 2 {
+		t.Fatalf("saved entries = %v, want indexes [1 2]", storage.entries)
+	}
+}
+
+func TestAsyncStorageWritesAppendFIFO(t *testing.T) {
+	n := newAsyncReadyNode()
+	saveStartedC := make(chan struct{}, 2)
+	allowSaveC := make(chan struct{})
+	storage := &blockingSaveStorage{
+		Storage:      mockstorage.NewStorageRecorder(""),
+		saveStartedC: saveStartedC,
+		allowSaveC:   allowSaveC,
+	}
+	r := newRaftNode(raftNodeConfig{
+		lg:                 zaptest.NewLogger(t),
+		Node:               n,
+		localID:            1,
+		asyncStorageWrites: true,
+		storage:            storage,
+		raftStorage:        raft.NewMemoryStorage(),
+		transport:          newNopTransporter(),
+	})
+	r.appendc <- newStorageAppendMessage(1, 1)
+	r.appendc <- newStorageAppendMessage(2, 2)
+	r.start(newTestRaftReadyHandler())
+	defer r.stop()
+
+	<-saveStartedC
+	select {
+	case m := <-n.stepc:
+		t.Fatalf("storage response delivered before append was durable: %v", m)
+	default:
+	}
+	allowSaveC <- struct{}{}
+	if got := (<-n.stepc).GetIndex(); got != 1 {
+		t.Fatalf("first response index = %d, want 1", got)
+	}
+	if got := (<-n.stepc).GetIndex(); got != 2 {
+		t.Fatalf("second response index = %d, want 2", got)
+	}
+	select {
+	case <-saveStartedC:
+		t.Fatal("contiguous appends were not coalesced into one storage save")
+	default:
+	}
+
+	lastIndex, err := r.raftStorage.LastIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastIndex != 2 {
+		t.Fatalf("last index = %d, want 2", lastIndex)
+	}
+	select {
+	case <-n.advancec:
+		t.Fatal("Advance called with asynchronous storage writes enabled")
+	default:
+	}
+}
+
+func TestAsyncStorageWritesDoesNotBatchOverwrites(t *testing.T) {
+	n := newAsyncReadyNode()
+	saveStartedC := make(chan struct{}, 2)
+	allowSaveC := make(chan struct{})
+	storage := &blockingSaveStorage{
+		Storage:      mockstorage.NewStorageRecorder(""),
+		saveStartedC: saveStartedC,
+		allowSaveC:   allowSaveC,
+	}
+	r := newRaftNode(raftNodeConfig{
+		lg:                 zaptest.NewLogger(t),
+		Node:               n,
+		localID:            1,
+		asyncStorageWrites: true,
+		storage:            storage,
+		raftStorage:        raft.NewMemoryStorage(),
+		transport:          newNopTransporter(),
+	})
+	r.appendc <- newStorageAppendMessage(1, 1)
+	r.appendc <- newStorageAppendMessage(1, 2)
+	r.start(newTestRaftReadyHandler())
+	defer r.stop()
+
+	<-saveStartedC
+	allowSaveC <- struct{}{}
+	if got := (<-n.stepc).GetLogTerm(); got != 1 {
+		t.Fatalf("first response term = %d, want 1", got)
+	}
+
+	<-saveStartedC
+	select {
+	case m := <-n.stepc:
+		t.Fatalf("overwrite response delivered before its storage save: %v", m)
+	default:
+	}
+	allowSaveC <- struct{}{}
+	if got := (<-n.stepc).GetLogTerm(); got != 2 {
+		t.Fatalf("second response term = %d, want 2", got)
+	}
+
+	term, err := r.raftStorage.Term(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if term != 2 {
+		t.Fatalf("stored term = %d, want 2", term)
+	}
+}
+
+func TestAsyncStorageWritesApplyResponseAfterApplication(t *testing.T) {
+	n := newAsyncReadyNode()
+	r := newRaftNode(raftNodeConfig{
+		lg:                 zaptest.NewLogger(t),
+		Node:               n,
+		localID:            1,
+		asyncStorageWrites: true,
+		storage:            mockstorage.NewStorageRecorder(""),
+		raftStorage:        raft.NewMemoryStorage(),
+		transport:          newNopTransporter(),
+	})
+	r.start(newTestRaftReadyHandler())
+	defer r.stop()
+
+	entry := &raftpb.Entry{Index: new(uint64(1)), Term: new(uint64(1))}
+	response := &raftpb.Message{
+		Type:    raftpb.MsgStorageApplyResp.Enum(),
+		To:      new(uint64(1)),
+		From:    new(uint64(raft.LocalApplyThread)),
+		Entries: []*raftpb.Entry{entry},
+	}
+	n.readyc <- raft.Ready{Messages: []*raftpb.Message{{
+		Type:      raftpb.MsgStorageApply.Enum(),
+		To:        new(uint64(raft.LocalApplyThread)),
+		From:      new(uint64(1)),
+		Entries:   []*raftpb.Entry{entry},
+		Responses: []*raftpb.Message{response},
+	}}}
+
+	ap := <-r.applyc
+	select {
+	case m := <-n.stepc:
+		t.Fatalf("apply response delivered before application completed: %v", m)
+	default:
+	}
+	<-ap.notifyc
+	ap.onApplied()
+
+	if got := <-n.stepc; got.GetType() != raftpb.MsgStorageApplyResp {
+		t.Fatalf("response type = %s, want %s", got.GetType(), raftpb.MsgStorageApplyResp)
+	}
+	select {
+	case <-ap.raftAdvancedC:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Raft apply advancement")
+	}
+}
+
+func TestAsyncStorageWritesSnapshotResponseAfterApplication(t *testing.T) {
+	n := newAsyncReadyNode()
+	storage := mockstorage.NewStorageRecorder("")
+	r := newRaftNode(raftNodeConfig{
+		lg:                 zaptest.NewLogger(t),
+		Node:               n,
+		localID:            1,
+		asyncStorageWrites: true,
+		storage:            storage,
+		raftStorage:        raft.NewMemoryStorage(),
+		transport:          newNopTransporter(),
+	})
+	r.start(newTestRaftReadyHandler())
+	defer r.stop()
+
+	snapshot := raftpb.EnsureSnapshot(nil)
+	snapshot.Metadata.Index = new(uint64(5))
+	snapshot.Metadata.Term = new(uint64(2))
+	snapshot.Metadata.ConfState = &raftpb.ConfState{Voters: []uint64{1}}
+	response := &raftpb.Message{
+		Type:     raftpb.MsgStorageAppendResp.Enum(),
+		To:       new(uint64(1)),
+		From:     new(uint64(raft.LocalAppendThread)),
+		Snapshot: snapshot,
+	}
+	n.readyc <- raft.Ready{Messages: []*raftpb.Message{{
+		Type:      raftpb.MsgStorageAppend.Enum(),
+		To:        new(uint64(raft.LocalAppendThread)),
+		From:      new(uint64(1)),
+		Snapshot:  snapshot,
+		Responses: []*raftpb.Message{response},
+	}}}
+
+	ap := <-r.applyc
+	// The first notification makes the persisted snapshot available to the
+	// state machine restore. The second covers the in-memory Raft update and
+	// WAL release.
+	<-ap.notifyc
+	<-ap.notifyc
+	select {
+	case m := <-n.stepc:
+		t.Fatalf("snapshot response delivered before application completed: %v", m)
+	default:
+	}
+	ap.onApplied()
+
+	if got := <-n.stepc; got.GetType() != raftpb.MsgStorageAppendResp {
+		t.Fatalf("response type = %s, want %s", got.GetType(), raftpb.MsgStorageAppendResp)
+	}
+	storedSnapshot, err := r.raftStorage.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := storedSnapshot.Metadata.GetIndex(); got != 5 {
+		t.Fatalf("snapshot index = %d, want 5", got)
+	}
+	actions, err := storage.Wait(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantActions := []string{"SaveSnap", "Save", "Sync", "Release"}
+	if len(actions) != len(wantActions) {
+		t.Fatalf("storage actions = %v, want %v", actions, wantActions)
+	}
+	for i, want := range wantActions {
+		if actions[i].Name != want {
+			t.Fatalf("storage action %d = %q, want %q", i, actions[i].Name, want)
+		}
+	}
+}
+
+type asyncReadyNode struct {
+	*readyNode
+	stepc    chan *raftpb.Message
+	advancec chan struct{}
+}
+
+func newAsyncReadyNode() *asyncReadyNode {
+	return &asyncReadyNode{
+		readyNode: newNopReadyNode(),
+		stepc:     make(chan *raftpb.Message, 8),
+		advancec:  make(chan struct{}, 1),
+	}
+}
+
+func (n *asyncReadyNode) Step(_ context.Context, m *raftpb.Message) error {
+	n.stepc <- m
+	return nil
+}
+
+func (n *asyncReadyNode) Advance() {
+	n.advancec <- struct{}{}
+}
+
+type blockingSaveStorage struct {
+	serverstorage.Storage
+	saveStartedC chan<- struct{}
+	allowSaveC   <-chan struct{}
+}
+
+func (s *blockingSaveStorage) Save(st *raftpb.HardState, entries []*raftpb.Entry) error {
+	s.saveStartedC <- struct{}{}
+	<-s.allowSaveC
+	return s.Storage.Save(st, entries)
+}
+
+type saveCaptureStorage struct {
+	serverstorage.Storage
+	saveCount int
+	hardState *raftpb.HardState
+	entries   []*raftpb.Entry
+}
+
+func (s *saveCaptureStorage) Save(st *raftpb.HardState, entries []*raftpb.Entry) error {
+	s.saveCount++
+	s.hardState = &raftpb.HardState{
+		Term:   new(st.GetTerm()),
+		Vote:   new(st.GetVote()),
+		Commit: new(st.GetCommit()),
+	}
+	s.entries = append([]*raftpb.Entry(nil), entries...)
+	return s.Storage.Save(st, entries)
+}
+
+func newStorageAppendMessage(index, term uint64) *raftpb.Message {
+	entry := &raftpb.Entry{Index: new(index), Term: new(term)}
+	return &raftpb.Message{
+		Type:    raftpb.MsgStorageAppend.Enum(),
+		To:      new(uint64(raft.LocalAppendThread)),
+		From:    new(uint64(1)),
+		Entries: []*raftpb.Entry{entry},
+		Responses: []*raftpb.Message{{
+			Type:    raftpb.MsgStorageAppendResp.Enum(),
+			To:      new(uint64(1)),
+			From:    new(uint64(raft.LocalAppendThread)),
+			Index:   new(index),
+			LogTerm: new(term),
+		}},
+	}
+}
+
+func newTestRaftReadyHandler() *raftReadyHandler {
+	return &raftReadyHandler{
+		getLead:              func() uint64 { return 0 },
+		updateLead:           func(uint64) {},
+		updateLeadership:     func(bool) {},
+		updateCommittedIndex: func(uint64) {},
 	}
 }

--- a/server/etcdserver/server.go
+++ b/server/etcdserver/server.go
@@ -982,6 +982,10 @@ func (s *EtcdServer) applyAll(ep *etcdProgress, apply *toApply) {
 	// storage, since the raft routine might be slower than toApply routine.
 	<-apply.notifyc
 
+	if apply.onApplied != nil {
+		apply.onApplied()
+	}
+
 	s.snapshotIfNeededAndCompactRaftLog(ep)
 	select {
 	// snapshot requested via send()

--- a/server/features/etcd_features.go
+++ b/server/features/etcd_features.go
@@ -84,6 +84,12 @@ const (
 	// alpha: v3.7
 	// main PR: https://github.com/etcd-io/etcd/pull/20492
 	PriorityRequest featuregate.Feature = "PriorityRequest"
+	// RaftAsyncStorageWrites enables Raft log persistence and state machine application
+	// through Raft's asynchronous storage write message interface.
+	// owner: @mjlshen
+	// issue: https://github.com/etcd-io/etcd/issues/16291
+	// alpha: v3.8
+	RaftAsyncStorageWrites featuregate.Feature = "RaftAsyncStorageWrites"
 )
 
 var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -96,6 +102,7 @@ var DefaultEtcdServerFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	SetMemberLocalAddr:           {Default: false, PreRelease: featuregate.Alpha},
 	FastLeaseKeepAlive:           {Default: true, PreRelease: featuregate.Beta},
 	PriorityRequest:              {Default: false, PreRelease: featuregate.Alpha},
+	RaftAsyncStorageWrites:       {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func NewDefaultServerFeatureGate(name string, lg *zap.Logger) featuregate.FeatureGate {

--- a/tests/antithesis/config/docker-compose-1-node.yml
+++ b/tests/antithesis/config/docker-compose-1-node.yml
@@ -35,6 +35,7 @@ services:
       ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
       ETCD_SNAPSHOT_COUNT: 50
       ETCD_COMPACTION_BATCH_LIMIT: 10
+      ETCD_FEATURE_GATES: "RaftAsyncStorageWrites=true"
       ETCD_VERIFY: "all"
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:

--- a/tests/antithesis/config/docker-compose-3-node.yml
+++ b/tests/antithesis/config/docker-compose-3-node.yml
@@ -37,6 +37,7 @@ services:
       ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
       ETCD_SNAPSHOT_COUNT: 50
       ETCD_COMPACTION_BATCH_LIMIT: 10
+      ETCD_FEATURE_GATES: "RaftAsyncStorageWrites=true"
       ETCD_VERIFY: "all"
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
@@ -64,6 +65,7 @@ services:
       ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
       ETCD_SNAPSHOT_COUNT: 50
       ETCD_COMPACTION_BATCH_LIMIT: 10
+      ETCD_FEATURE_GATES: "RaftAsyncStorageWrites=true"
       ETCD_VERIFY: "all"
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:
@@ -91,6 +93,7 @@ services:
       ETCD_SNAPSHOT_CATCHUP_ENTRIES: 100
       ETCD_SNAPSHOT_COUNT: 50
       ETCD_COMPACTION_BATCH_LIMIT: 10
+      ETCD_FEATURE_GATES: "RaftAsyncStorageWrites=true"
       ETCD_VERIFY: "all"
     user: "${USER_ID:-root}:${GROUP_ID:-root}"
     depends_on:

--- a/tests/e2e/async_storage_writes_test.go
+++ b/tests/e2e/async_storage_writes_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+func TestRaftAsyncStorageWrites(t *testing.T) {
+	e2e.BeforeTest(t)
+
+	ctx := t.Context()
+	clus, err := e2e.NewEtcdProcessCluster(ctx, t,
+		e2e.WithClusterSize(3),
+		e2e.WithSnapshotCount(20),
+		e2e.WithSnapshotCatchUpEntries(5),
+		e2e.WithServerFeatureGate("RaftAsyncStorageWrites", true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clus.Close()) })
+
+	leader := clus.WaitLeader(t)
+	lagging := (leader + 1) % len(clus.Procs)
+	active := (leader + 2) % len(clus.Procs)
+	require.NoError(t, clus.Procs[lagging].Stop())
+
+	client := newClient(t, clus.Procs[active].EndpointsGRPC(), e2e.ClientConfig{})
+	defer client.Close()
+	for i := 0; i < 100; i++ {
+		_, err = client.Put(ctx, fmt.Sprintf("async-key-%03d", i), fmt.Sprintf("value-%03d", i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, clus.Procs[lagging].Restart(ctx))
+	require.Eventually(t, func() bool {
+		healthCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		return clus.Procs[lagging].Etcdctl().Health(healthCtx) == nil
+	}, 30*time.Second, 100*time.Millisecond)
+
+	laggingClient := newClient(t, clus.Procs[lagging].EndpointsGRPC(), e2e.ClientConfig{})
+	defer laggingClient.Close()
+	response, err := laggingClient.Get(ctx, "async-key-099")
+	require.NoError(t, err)
+	require.Len(t, response.Kvs, 1)
+	require.Equal(t, "value-099", string(response.Kvs[0].Value))
+}

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -87,6 +87,20 @@ func TestRobustnessRegression(t *testing.T) {
 	}
 }
 
+func TestRobustnessRaftAsyncStorageWrites(t *testing.T) {
+	testRunner.BeforeTest(t)
+	s := scenarios.RaftAsyncStorageWrites()
+	lg := zaptest.NewLogger(t)
+	s.Cluster.Logger = lg
+	ctx := t.Context()
+	c, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithConfig(&s.Cluster))
+	require.NoError(t, err)
+	defer forcestopCluster(c)
+	t.Run(s.Failpoint.Name(), func(t *testing.T) {
+		testRobustness(ctx, t, lg, s, c)
+	})
+}
+
 func testRobustness(ctx context.Context, t *testing.T, lg *zap.Logger, s scenarios.TestScenario, c *e2e.EtcdProcessCluster) {
 	r, err := report.NewTestReport(lg, testResultsDirectory(t), report.ServerDataPaths(c), &report.TrafficDetail{ExpectUniqueRevision: s.Traffic.ExpectUniqueRevision()})
 	require.NoError(t, err)

--- a/tests/robustness/scenarios/scenarios.go
+++ b/tests/robustness/scenarios/scenarios.go
@@ -85,6 +85,27 @@ type TestScenario struct {
 	Profile   traffic.Profile
 }
 
+func RaftAsyncStorageWrites() TestScenario {
+	return TestScenario{
+		Name:      "RaftAsyncStorageWrites",
+		Failpoint: failpoint.RaftBeforeSavePanic,
+		Traffic:   traffic.EtcdPut,
+		Profile: traffic.Profile{
+			KeyValue:   &traffic.KeyValueHigh,
+			Watch:      &traffic.WatchDefault,
+			Compaction: &traffic.CompactionDefault,
+		},
+		Cluster: *e2e.NewConfig(
+			e2e.WithClusterSize(3),
+			e2e.WithGoFailEnabled(true),
+			e2e.WithIsPeerTLS(true),
+			e2e.WithPeerProxy(true),
+			e2e.WithSnapshotCount(100),
+			e2e.WithServerFeatureGate("RaftAsyncStorageWrites", true),
+		),
+	}
+}
+
 func Exploratory(_ *testing.T) []TestScenario {
 	randomizableOptions := []e2e.EPClusterOption{
 		options.WithClusterOptionGroups(


### PR DESCRIPTION
## What this changes

This implements Raft's asynchronous storage-write message interface into
etcdserver behind a new alpha `RaftAsyncStorageWrites` feature gate, disabled
by default.

When enabled:

- Raft emits `MsgStorageAppend` and `MsgStorageApply` work instead of using
  the synchronous `Ready`/`Advance` storage contract.
- Append work is processed by a reliable, ordered local FIFO worker.
- Compatible contiguous appends are coalesced into one WAL save while
  preserving response order.
- Apply work uses etcd's existing FIFO apply scheduler, and
  `MsgStorageApplyResp` is delivered only after state-machine application.
- Snapshot persistence preserves etcd's existing
  `SaveSnap -> Save -> Sync -> ApplySnapshot -> Release` crash-recovery
  ordering, and the append response waits for state-machine restoration.
- Storage response messages addressed to the local member are stepped back
  into Raft; remote responses continue through the transport.

The feature can be enabled with:

```text
--feature-gates=RaftAsyncStorageWrites=true
```

## Correctness properties

The implementation preserves the two ordering requirements of Raft's async
storage API:

1. Append messages are reliably processed in FIFO order, and their responses
   are not delivered until the corresponding write is durable.
2. Apply messages are reliably processed in FIFO order, and their responses
   are not delivered until the entries have been applied.

Append batching only crosses contiguous entry ranges. A later HardState
supersedes an earlier HardState, so the batch persists the final HardState and
the complete contiguous entry range before releasing any response. Snapshot
work is not coalesced with ordinary appends.

## Validation

The following passed locally on Darwin/arm64 with Go 1.26.5:

```text
go test -race -count=1 ./server/etcdserver ./server/storage/...
make build
make gofail-enable
make build
make gofail-disable
go test ./tests/e2e -run '^TestRaftAsyncStorageWrites$' -count=1 -timeout=90s
```

The new unit coverage checks:

- final HardState and contiguous entries in a combined WAL save;
- append FIFO and durability-before-response;
- overwrite boundaries are not coalesced;
- apply responses wait for state-machine application;
- snapshot response and persistence ordering; and
- `Advance` is not called in async mode.

The e2e test stops a follower, writes through multiple snapshot thresholds,
restarts the lagging member, and verifies recovery of the latest value.

## Preliminary performance

I ran five interleaved repetitions per variant using the same Linux/arm64
image in a three-member Docker Desktop cluster. Every repetition used fresh
Docker volumes, 10,000 warm-up PUTs, then 100,000 measured 1 KiB PUTs with 64
clients and four connections.

Sequence:

```text
off, on, on, off, off, on, on, off, off, on
```

| Metric | Gate off mean | Gate on mean | Change |
| --- | ---: | ---: | ---: |
| Requests/second | 10,022.8 | 12,530.1 | +25.0% |
| Average latency | 6.44 ms | 5.16 ms | -19.9% |
| p50 latency | 4.86 ms | 3.84 ms | -21.0% |
| p90 latency | 11.94 ms | 9.20 ms | -22.9% |
| p99 latency | 27.50 ms | 22.20 ms | -19.3% |
| WAL fsync count | 18,986 | 14,460 | -23.8% |
| Backend commit count | 301.0 | 247.6 | -17.7% |
| Server process CPU | 20.02 s | 20.01 s | -0.06% |

The equivalent applied-proposal counts and unchanged CPU, together with fewer
WAL fsyncs and backend commits, support increased batching as the source of
the improvement.

I believe that a longer benchmark (suggestions welcome!) on a dedicated
Linux host with direct local disks would be nice to have - or any other guidance 
around taking a benchmark.