### PR TITLE
Add config image building to antithesis verify job

### DIFF
--- a/.github/workflows/antithesis-verify.yml
+++ b/.github/workflows/antithesis-verify.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Build etcd-server and etcd-client images
         run: |
+          make -C tests/antithesis antithesis-build-config-image
           make -C tests/antithesis antithesis-build-etcd-image
           make -C tests/antithesis antithesis-build-client-docker-image
 


### PR DESCRIPTION
Add the config image building so that all the scripts in the config Dockerfile gets verified whenever we make changes to it. 

cc @serathius 