### PR TITLE
Replace math/rand with Antithesis's SDK for the test client

### DIFF
--- a/tests/antithesis/test-template/Dockerfile
+++ b/tests/antithesis/test-template/Dockerfile
@@ -5,6 +5,13 @@ FROM golang:$GO_IMAGE_TAG AS build
 WORKDIR /build
 COPY . .
 
+# Replacing math/rand with etcd's antithesis-sdk-go/random wrapper
+# See https://antithesis.com/docs/configuration/the_antithesis_environment/?sid=8fce.35&sterm=random&marks=Random#random-devices
+WORKDIR /build
+RUN find . -path "./tests/antithesis" -prune -type f -o -name 'go.mod' -type f -execdir go mod edit -replace=math/rand=$(git rev-parse --show-toplevel)/tests/antithesis/pkg/rand \;
+RUN find . -path "./tests/antithesis" -prune -type f -o -name 'go.mod' -type f -execdir go mod edit -replace=math/rand/v2=$(git rev-parse --show-toplevel)/tests/antithesis/pkg/rand/v2 \;
+RUN find . -name 'go.mod' -type f -execdir go mod tidy \;
+
 WORKDIR /build/tests
 RUN go build -o /opt/antithesis/entrypoint/entrypoint -race ./antithesis/test-template/entrypoint/main.go
 RUN go build -o /opt/antithesis/test/v1/robustness/singleton_driver_traffic -race ./antithesis/test-template/robustness/traffic/main.go


### PR DESCRIPTION
Ref: https://github.com/etcd-io/etcd/issues/21720#issuecomment-5121947423

This is to add the math/rand replacement for the client part.  Test building the client image in my local successfully.  Here is from the built image, showing that `math/rand[*]` has been replaced in `tests/go.mod`.

```
	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
	gopkg.in/yaml.v3 v3.0.1 // indirect
	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
	sigs.k8s.io/yaml v1.6.0 // indirect
)

replace math/rand => /build/tests/antithesis/pkg/rand

replace math/rand/v2 => /build/tests/antithesis/pkg/rand/v2
```

cc @serathius 