### PR TITLE
trace: fix nonblocking read loop in issue #22214

### DIFF
--- a/server/etcdserver/read/metrics.go
+++ b/server/etcdserver/read/metrics.go
@@ -31,9 +31,16 @@ var (
 		Name:      "read_indexes_failed_total",
 		Help:      "The total number of failed read indexes seen.",
 	})
+	droppedReadLoopTraces = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "etcd",
+		Subsystem: "server",
+		Name:      "read_loop_traces_dropped_total",
+		Help:      "The total number of linearizable read loop traces dropped because the log sink could not keep up.",
+	})
 )
 
 func init() {
 	prometheus.MustRegister(slowReadIndex)
 	prometheus.MustRegister(readIndexFailed)
+	prometheus.MustRegister(droppedReadLoopTraces)
 }

--- a/server/etcdserver/read/read.go
+++ b/server/etcdserver/read/read.go
@@ -33,6 +33,9 @@ var (
 	readIndexRetryTime = 500 * time.Millisecond
 )
 
+// slowReadLoopThreshold is the duration above which a read loop iteration gets its trace logged.
+const slowReadLoopThreshold = 100 * time.Millisecond
+
 func NewRead(server server, raft raftInterface) *Read {
 	return &Read{
 		server:   server,
@@ -94,6 +97,15 @@ func (r *Read) LinearizableReadNotify(ctx context.Context) error {
 }
 
 func (r *Read) LinearizableReadLoop() {
+	// Log traces off this goroutine: a slow or stalled log sink would otherwise park the only servicer of read indexes, hanging every linearizable read on the member.
+	traceC := make(chan *traceutil.Trace, 1)
+	defer close(traceC)
+	go func() {
+		for t := range traceC {
+			t.Log()
+		}
+	}()
+
 	for {
 		leaderChangedNotifier := r.server.LeaderChanged()
 		select {
@@ -106,6 +118,7 @@ func (r *Read) LinearizableReadLoop() {
 
 		// as a single loop is can unlock multiple reads, it is not very useful
 		// to propagate the trace from Txn or Range.
+		start := time.Now()
 		_, trace := traceutil.EnsureTrace(context.Background(), r.server.Logger(), "linearizableReadLoop")
 
 		nextnr := newNotifier()
@@ -141,7 +154,14 @@ func (r *Read) LinearizableReadLoop() {
 		nr.notify(nil)
 		trace.Step("applied index is now lower than readState.Index")
 
-		trace.LogAllStepsIfLong(100 * time.Millisecond)
+		if time.Since(start) > slowReadLoopThreshold {
+			select {
+			case traceC <- trace:
+			default:
+				// the log sink is not keeping up; drop the trace rather than stall the next read
+				droppedReadLoopTraces.Inc()
+			}
+		}
 	}
 }
 

--- a/server/etcdserver/read/read_test.go
+++ b/server/etcdserver/read/read_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/errors"
 	"go.etcd.io/raft/v3"
 )
@@ -189,6 +191,77 @@ func TestRequestCurrentIndex_DelayedResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), index)
 }
+
+// TestLinearizableReadLoop_BlockedLogSink verifies that a log sink stuck in write(2) does not stall the read loop,
+// which would hang every subsequent linearizable read. See https://github.com/etcd-io/etcd/issues/22214.
+func TestLinearizableReadLoop_BlockedLogSink(t *testing.T) {
+	s, mockRaft := setupTestRequestCurrentIndex(t)
+	sink := &blockingSyncer{writing: make(chan struct{}, 1), unblock: make(chan struct{})}
+	s.logger = zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(logutil.DefaultZapLoggerConfig.EncoderConfig),
+		zapcore.Lock(zapcore.AddSync(sink)),
+		zap.NewAtomicLevelAt(zap.InfoLevel),
+	))
+	s.appliedIndex = 100
+
+	r := NewRead(s, mockRaft)
+	go r.LinearizableReadLoop()
+	t.Cleanup(func() { close(s.stopping) })
+	defer close(sink.unblock)
+
+	// two rounds: the first is slow enough to log and leaves the sink blocked, the second must still complete
+	for i := 0; i < 2; i++ {
+		readDone := make(chan error, 1)
+		go func() {
+			readDone <- r.LinearizableReadNotify(t.Context())
+		}()
+
+		require.Eventuallyf(t, func() bool {
+			return len(mockRaft.getRequests()) == i+1
+		}, time.Second, 10*time.Millisecond, "Expected %d ReadIndex requests", i+1)
+
+		if i == 0 {
+			// push the loop past slowReadLoopThreshold so that it emits a trace
+			time.Sleep(2 * slowReadLoopThreshold)
+		}
+
+		reqIDBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(reqIDBytes, mockRaft.getRequests()[i])
+		mockRaft.readStateC <- raft.ReadState{Index: 100, RequestCtx: reqIDBytes}
+
+		select {
+		case err := <-readDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("linearizable read %d hung on a blocked log sink", i)
+		}
+
+		if i == 0 {
+			select {
+			case <-sink.writing:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for the read loop trace to reach the log sink")
+			}
+		}
+	}
+}
+
+// blockingSyncer stays inside Write until unblocked, like a write(2) to a saturated disk.
+type blockingSyncer struct {
+	writing chan struct{}
+	unblock chan struct{}
+}
+
+func (b *blockingSyncer) Write(p []byte) (int, error) {
+	select {
+	case b.writing <- struct{}{}:
+	default:
+	}
+	<-b.unblock
+	return len(p), nil
+}
+
+func (b *blockingSyncer) Sync() error { return nil }
 
 func setupTestRequestCurrentIndex(t *testing.T) (*mockServer, *testRaftNode) {
 	s := &mockServer{


### PR DESCRIPTION
Fixes #22214

### Problem

`LinearizableReadLoop` is the only goroutine that services read indexes — every
`Range`/`Txn`/`MemberList` waits on it via `LinearizableReadNotify`. At the end of
each iteration it logged its trace inline:

go trace.LogAllStepsIfLong(100 * time.Millisecond)

zap's lockedWriteSyncer holds a mutex across the write(2) syscall, so when the
log sink is slow or stalled (saturated disk, blocked pipe reader, stuck syslog) the
read loop parks inside that write and every subsequent linearizable read on the
member blocks indefinitely.

The failure is silent: serializable reads bypass the loop and stay instant,
etcd_server_has_leader stays 1, read_indexes_failed_total and health_failures
stay 0. In the reported incident this cost significant diagnosis time — it presents
as a raft/consistency bug, and the reporter went through --cluster-reset, a
snapshot restore, a 3-member expansion and a version bump before reading a goroutine
dump. The 100 ms trace threshold also means the slower the disk gets, the more
certain the loop is to try to log.

### Fix

Emit the trace from a dedicated goroutine over a one-slot channel, and drop the trace
if that goroutine is still stuck in the sink. A slow sink now costs one parked
goroutine and some dropped trace lines instead of the member's entire linearizable
read path.

The threshold is evaluated in the loop rather than inside LogAllStepsIfLong, so
queue time cannot inflate the measured duration and turn a fast iteration into a
logged one. The trace is per-iteration and not touched after handoff. The logger
goroutine's lifetime is tied to the loop's via defer close(traceC), so it exits on
every return path.

Adds etcd_server_read_loop_traces_dropped_total, so "the log sink cannot keep up
with etcd's diagnostics" is visible rather than invisible.