### PR TITLE
server: bound hashKVHandler request body size

### DIFF
--- a/server/etcdserver/corrupt.go
+++ b/server/etcdserver/corrupt.go
@@ -510,6 +510,11 @@ func (s *EtcdServer) getPeerHashKVs(rev int64) []*peerHashKVResp {
 
 const PeerHashKVPath = "/members/hashkv"
 
+// maxHashKVHTTPRequestSize bounds how much of a request body ServeHTTP will
+// read. A legitimate HashKVRequest is a few bytes; this mirrors the same
+// bound already applied to the sibling lease HTTP handler.
+const maxHashKVHTTPRequestSize = 64 * 1024
+
 type hashKVHandler struct {
 	lg     *zap.Logger
 	server *EtcdServer
@@ -535,8 +540,13 @@ func (h *hashKVHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	b, err := io.ReadAll(r.Body)
+	b, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHashKVHTTPRequestSize))
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "error reading body", http.StatusBadRequest)
 		return
 	}

--- a/server/etcdserver/corrupt_test.go
+++ b/server/etcdserver/corrupt_test.go
@@ -578,3 +578,40 @@ func TestHashKVHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestHashKVHandlerRejectsOversizedBody(t *testing.T) {
+	localClusterID := 111196
+
+	etcdSrv := &EtcdServer{}
+	etcdSrv.cluster = newTestCluster(t)
+	etcdSrv.cluster.SetID(types.ID(localClusterID), types.ID(localClusterID))
+	be, _ := betesting.NewDefaultTmpBackend(t)
+	defer betesting.Close(t, be)
+	etcdSrv.kv = mvcc.New(zap.NewNop(), be, &lease.FakeLessor{}, mvcc.StoreConfig{})
+	defer func() {
+		assert.NoError(t, etcdSrv.kv.Close())
+	}()
+	ph := &hashKVHandler{
+		lg:     zap.NewNop(),
+		server: etcdSrv,
+	}
+	srv := httptest.NewServer(ph)
+	defer srv.Close()
+
+	// A legitimate HashKVRequest is a few bytes; pad it well past
+	// maxHashKVHTTPRequestSize with an unknown field so it still unmarshals
+	// if the size limit were not enforced.
+	padding := strings.Repeat("a", maxHashKVHTTPRequestSize*2)
+	oversizedBody := []byte(`{"revision":1,"padding":"` + padding + `"}`)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+PeerHashKVPath, bytes.NewReader(oversizedBody))
+	require.NoErrorf(t, err, "failed to create request: %v", err)
+	req.Header.Set("X-Etcd-Cluster-ID", strconv.FormatUint(uint64(localClusterID), 16))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoErrorf(t, err, "failed to get http response: %v", err)
+	defer resp.Body.Close()
+
+	require.Equalf(t, http.StatusRequestEntityTooLarge, resp.StatusCode,
+		"oversized hashKV request body should be rejected, got status %d", resp.StatusCode)
+}


### PR DESCRIPTION
This was originally reported privately to security@etcd.io on 2026-07-29 as a possible DoS (unbounded `io.ReadAll` on the peer-only `/members/hashkv` handler). Per etcd's own `THREAT_MODEL.md` (merged 2026-05-18, extended 2026-07-31), panics or unbounded allocations reachable only from an authenticated peer are explicitly classified as robustness defects, not vulnerabilities, so re-filing this as a normal PR rather than continuing to wait on the private channel.

`hashKVHandler.ServeHTTP` reads the request body via a bare `io.ReadAll(r.Body)` with no size limit. A legitimate `HashKVRequest` is a few bytes. This mirrors the same `http.MaxBytesReader` bound already applied to the sibling lease HTTP handler (`server/lease/leasehttp/http.go`).

Added `TestHashKVHandlerRejectsOversizedBody`, verified fail-before/pass-after: fails against the unmodified handler (oversized body accepted), passes with the fix. Existing `TestHashKVHandler` cases unaffected. `go build`, `go vet`, and `gofmt` all clean.

AI disclosure: this fix and the PR description were prepared with AI coding-agent assistance (Claude Code), independently verified against current source (build, tests, gofmt/vet all re-run locally) before opening.