### PR TITLE
etcd.conf.yml.sample: drop v2 proxy settings removed in v3.6

### DIFF
--- a/etcd.conf.yml.sample
+++ b/etcd.conf.yml.sample
@@ -73,24 +73,6 @@ strict-reconfig-check: false
 # Enable runtime profiling data via HTTP server
 enable-pprof: true
 
-# Valid values include 'on', 'readonly', 'off'
-proxy: 'off'
-
-# Time (in milliseconds) an endpoint will be held in a failed state.
-proxy-failure-wait: 5000
-
-# Time (in milliseconds) of the endpoints refresh interval.
-proxy-refresh-interval: 30000
-
-# Time (in milliseconds) for a dial to timeout.
-proxy-dial-timeout: 1000
-
-# Time (in milliseconds) for a write to timeout.
-proxy-write-timeout: 5000
-
-# Time (in milliseconds) for a read to timeout.
-proxy-read-timeout: 0
-
 client-transport-security:
   # Path to the client server TLS cert file.
   cert-file:


### PR DESCRIPTION
`etcd.conf.yml.sample` still ships six settings that no longer exist:

```yaml
# Valid values include 'on', 'readonly', 'off'
proxy: 'off'

# Time (in milliseconds) an endpoint will be held in a failed state.
proxy-failure-wait: 5000

# Time (in milliseconds) of the endpoints refresh interval.
proxy-refresh-interval: 30000

# Time (in milliseconds) for a dial to timeout.
proxy-dial-timeout: 1000

# Time (in milliseconds) for a write to timeout.
proxy-write-timeout: 5000

# Time (in milliseconds) for a read to timeout.
proxy-read-timeout: 0
```

All six flags were removed in v3.6. From `CHANGELOG/CHANGELOG-3.6.md`, under **Flags Removed**:

> - `--proxy`
> - `--proxy-failure-wait`
> - `--proxy-refresh-interval`
> - `--proxy-dial-timeout`
> - `--proxy-write-timeout`
> - `--proxy-read-timeout`

Checks on `main`:

- none of the six is registered in `server/embed/config.go` or `server/etcdmain/config.go`
- none appears in `server/etcdmain/help.go`, so they are absent from `etcd --help`
- `--discovery-fallback` still mentions them in passing ("Note that v2 proxy is removed"), which confirms the removal rather than contradicting it

Because `Config.parse` uses a non-strict `yaml.Unmarshal`, these keys do not cause a startup error — they are silently ignored. A user who copies the sample therefore ends up believing that proxy mode is configured while nothing happens.

This PR removes the six settings from the sample. No other keys are touched, and no code changes.