### PR TITLE
tools/benchmark: measure watch event latency from the put that caused it

### DIFF
--- a/tools/benchmark/cmd/watch.go
+++ b/tools/benchmark/cmd/watch.go
@@ -191,21 +191,24 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 
 	r := newReport("watch-put")
 
+	timeline := newPutTimeline(watchPutTotal)
+
 	wg.Add(len(wk.watches))
 	nrRxed := int32(eventsTotal)
 	for _, w := range wk.watches {
 		go func(wc clientv3.WatchChan) {
 			defer wg.Done()
-			recvWatchChan(wc, r.Results(), &nrRxed)
+			recvWatchChan(wc, r.Results(), &nrRxed, timeline)
 			wk.cancel()
 		}(w)
 	}
 
-	putreqc := make(chan clientv3.Op, len(clients))
+	putreqc := make(chan watchPutReq, len(clients))
 	go func() {
 		defer close(putreqc)
 		for i := 0; i < watchPutTotal; i++ {
-			putreqc <- clientv3.OpPut(wk.watched[i%(len(wk.watched))], "data")
+			key := wk.watched[i%(len(wk.watched))]
+			putreqc <- watchPutReq{seq: i, op: clientv3.OpPut(key, encodePutSeq(i))}
 		}
 	}()
 
@@ -217,11 +220,14 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 	limit := rate.NewLimiter(watchPutLimit, 1)
 	for _, cc := range clients {
 		go func(c *clientv3.Client) {
-			for op := range putreqc {
+			for req := range putreqc {
 				if err := limit.Wait(context.TODO()); err != nil {
 					panic(err)
 				}
-				if _, err := c.Do(context.TODO(), op); err != nil {
+				// Record the issue time before the put is sent: an event can
+				// reach a watcher before Do() returns here.
+				timeline.markIssued(req.seq)
+				if _, err := c.Do(context.TODO(), req.op); err != nil {
 					panic(err)
 				}
 			}
@@ -233,13 +239,87 @@ func benchPutWatches(clients []*clientv3.Client, wk *watchedKeys) {
 	bar.Finish()
 	close(r.Results())
 	fmt.Printf("Watch events received summary:\n%s", <-rc)
+	if n := timeline.unattributed.Load(); n > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %d watch events could not be attributed to a put and are excluded from the summary\n", n)
+	}
 }
 
-func recvWatchChan(wch clientv3.WatchChan, results chan<- report.Result, nrRxed *int32) {
+// watchPutReq pairs a put with its sequence number so the goroutine issuing the
+// put can record when it did so.
+type watchPutReq struct {
+	op  clientv3.Op
+	seq int
+}
+
+// putTimeline records when each put was issued so that a watch event can be
+// timed from the put that caused it, rather than from the moment its
+// WatchResponse had already been received.
+//
+// Times are held as offsets from a single base captured before any put is
+// issued. The base carries a monotonic reading, so base.Add(offset) subtracted
+// from a later time.Now() still uses the monotonic clock.
+type putTimeline struct {
+	base         time.Time
+	issuedAt     []atomic.Int64 // offset from base, 0 means not issued yet
+	unattributed atomic.Int32
+}
+
+func newPutTimeline(puts int) *putTimeline {
+	return &putTimeline{
+		base:     time.Now(),
+		issuedAt: make([]atomic.Int64, puts),
+	}
+}
+
+func (t *putTimeline) markIssued(seq int) {
+	t.issuedAt[seq].Store(int64(time.Since(t.base)))
+}
+
+// issued reports when the put with the given sequence number was issued. It
+// returns false if seq is out of range or the put has not been issued, neither
+// of which is expected for an event this benchmark generated.
+func (t *putTimeline) issued(seq int) (time.Time, bool) {
+	if seq < 0 || seq >= len(t.issuedAt) {
+		return time.Time{}, false
+	}
+	offset := t.issuedAt[seq].Load()
+	if offset <= 0 {
+		return time.Time{}, false
+	}
+	return t.base.Add(time.Duration(offset)), true
+}
+
+// encodePutSeq and decodePutSeq carry a put's sequence number in its value so
+// that a watch event can be matched back to the put that produced it. Matching
+// by position is not possible here: a key may be watched by many watchers and
+// puts are issued concurrently by several clients.
+func encodePutSeq(seq int) string {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(seq))
+	return string(b[:])
+}
+
+func decodePutSeq(value []byte) (int, bool) {
+	if len(value) != 8 {
+		return 0, false
+	}
+	return int(binary.BigEndian.Uint64(value)), true
+}
+
+func recvWatchChan(wch clientv3.WatchChan, results chan<- report.Result, nrRxed *int32, timeline *putTimeline) {
 	for r := range wch {
-		st := time.Now()
-		for range r.Events {
-			results <- report.Result{Start: st, End: time.Now()}
+		for _, ev := range r.Events {
+			now := time.Now()
+			// Time the event from when its put was issued, so the measurement is
+			// end-to-end delivery latency and does not depend on how many events
+			// the server happened to batch into this response.
+			if seq, ok := decodePutSeq(ev.Kv.Value); !ok {
+				timeline.unattributed.Add(1)
+			} else if st, ok := timeline.issued(seq); !ok {
+				timeline.unattributed.Add(1)
+			} else {
+				results <- report.Result{Start: st, End: now}
+			}
 			bar.Increment()
 			if atomic.AddInt32(nrRxed, -1) <= 0 {
 				return

--- a/tools/benchmark/cmd/watch_test.go
+++ b/tools/benchmark/cmd/watch_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPutSeqRoundTrip(t *testing.T) {
+	for _, seq := range []int{0, 1, 42, 1000, 1 << 20} {
+		got, ok := decodePutSeq([]byte(encodePutSeq(seq)))
+		if !ok {
+			t.Fatalf("decodePutSeq(encodePutSeq(%d)) reported failure", seq)
+		}
+		if got != seq {
+			t.Fatalf("decodePutSeq(encodePutSeq(%d)) = %d", seq, got)
+		}
+	}
+}
+
+func TestDecodePutSeqRejectsForeignValues(t *testing.T) {
+	// Values not written by this benchmark must not be decoded into an
+	// arbitrary sequence number and silently skew the report.
+	for _, value := range [][]byte{nil, {}, []byte("data"), []byte("too long to be a sequence")} {
+		if _, ok := decodePutSeq(value); ok {
+			t.Fatalf("decodePutSeq(%q) accepted a value it did not write", value)
+		}
+	}
+}
+
+func TestPutTimelineIssued(t *testing.T) {
+	timeline := newPutTimeline(4)
+
+	if _, ok := timeline.issued(0); ok {
+		t.Fatal("issued() succeeded for a put that was never issued")
+	}
+	for _, seq := range []int{-1, 4, 100} {
+		if _, ok := timeline.issued(seq); ok {
+			t.Fatalf("issued(%d) succeeded for an out-of-range sequence", seq)
+		}
+	}
+
+	before := time.Now()
+	timeline.markIssued(2)
+	after := time.Now()
+
+	st, ok := timeline.issued(2)
+	if !ok {
+		t.Fatal("issued() failed for a put that was issued")
+	}
+	if st.Before(before) || st.After(after) {
+		t.Fatalf("issued() = %v, want within [%v, %v]", st, before, after)
+	}
+
+	// Recording one put must not make the others look issued.
+	if _, ok := timeline.issued(1); ok {
+		t.Fatal("issued(1) succeeded after only put 2 was issued")
+	}
+}
+
+// The event latency must be measured from when the put was issued, not from
+// when its WatchResponse had already been received, so it must not depend on
+// how long the receiver spends handling the batch.
+func TestPutTimelineMeasuresFromPut(t *testing.T) {
+	timeline := newPutTimeline(1)
+	timeline.markIssued(0)
+
+	st, ok := timeline.issued(0)
+	if !ok {
+		t.Fatal("issued() failed for a put that was issued")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if elapsed := time.Since(st); elapsed < 20*time.Millisecond {
+		t.Fatalf("elapsed since put = %v, want >= 20ms", elapsed)
+	}
+}


### PR DESCRIPTION
Resolves #22225

## Problem

The `Watch events received summary` produced by the `watch` benchmark does not measure watch delivery latency. `recvWatchChan()` starts its timer only *after* a `WatchResponse` has already been received, and then reuses that single timestamp for every event in the batch:

```go
for r := range wch {
    st := time.Now()
    for range r.Events {
        results <- report.Result{Start: st, End: time.Now()}
```

So what is being timed is the client's own iteration over the batch plus its send into the report channel. That number is dominated by how many events the server happened to coalesce into one response and by goroutine scheduling, which is why the reporter saw percentiles split into distinct fast and slow groups across otherwise identical runs, with the median moving from 8.6 ms to 0.3 ms purely with the fast/slow trial ratio.

## Fix

Time each event from the put that produced it.

Matching by position is not available here — a key may be watched by many watchers, and puts are issued concurrently by several clients — so each put carries its sequence number in its value, and the goroutine issuing the put records when it did so. Two details that matter:

- The issue time is recorded *before* the put is sent, because an event can reach a watcher before `Do()` returns.
- Times are held as offsets from a single base captured up front. The base carries a monotonic reading, so `base.Add(offset)` subtracted from a later `time.Now()` still uses the monotonic clock rather than the wall clock.

Events carrying a value this benchmark did not write are counted as unattributed and excluded from the summary, rather than decoded into an arbitrary sequence number that would silently skew the report. A warning prints the count if any occur.

## Why fix `watch` rather than reuse `watch-latency`

The issue offered either relabelling the existing measurement or adding a real end-to-end metric. End-to-end latency for a *single* watched key is already covered by the separate `watch-latency` command, but `watch-latency` assumes one key and matches puts to events by position, so it cannot serve the scale-oriented `watch` command (N streams × M watchers over K keys, concurrent putters). Fixing the attribution in `watch` makes it measure what its own help text claims — "the sending performance by changing the value of the watched keys with concurrent put requests" — without duplicating `watch-latency`.

## Testing

Unit tests added in `tools/benchmark/cmd/watch_test.go` covering the sequence round-trip, rejection of values the benchmark did not write, `putTimeline` range/unset handling, and that the measurement is anchored to the put rather than to receive-side work.

Verified against a local single-member cluster (400 puts at 500/s, 200 watchers on the watched key), same workload on both binaries:

| | before | after |
|---|---|---|
| Average | 0.0000 secs | 0.0188 secs |
| Fastest | 0.0000 secs | 0.0048 secs |
| Slowest | 0.0030 secs | 0.0836 secs |

Before, 78,360 of 80,000 samples land in the first 0.3 ms bucket — the old metric reports essentially zero regardless of what the server is doing. After, the distribution is a plausible put-to-delivery spread for that put rate and fan-out.

Out of scope, noted in the issue and not addressed here: waiting for server-side watch establishment before starting the put workload.
