### PR TITLE
tests: migrate member list serializable test to common test framework

### DIFF
--- a/tests/common/member_test.go
+++ b/tests/common/member_test.go
@@ -230,6 +230,59 @@ func TestMemberRemove(t *testing.T) {
 	}
 }
 
+func TestMemberListSerializable(t *testing.T) {
+	testRunner.BeforeTest(t)
+	tcs := []struct {
+		name         string
+		serializable bool
+		timeout      time.Duration
+
+		expectedError string
+	}{
+		{
+			name:         "Serializable",
+			serializable: true,
+		},
+		{
+			name:          "Linearizable",
+			timeout:       time.Second,
+			expectedError: "context deadline exceeded",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterSize(1))
+			defer clus.Close()
+			cc := testutils.MustClient(clus.Client())
+
+			testutils.ExecuteUntil(ctx, t, func() {
+				resp, err := cc.MemberList(ctx, false)
+				require.NoError(t, err)
+				require.Len(t, resp.Members, 1)
+
+				_, err = cc.MemberAdd(ctx, "newmember", []string{"http://localhost:123"})
+				require.NoError(t, err)
+
+				callCtx := ctx
+				if tc.timeout != 0 {
+					var cancelCall context.CancelFunc
+					callCtx, cancelCall = context.WithTimeout(ctx, tc.timeout)
+					defer cancelCall()
+				}
+				resp, err = cc.MemberList(callCtx, tc.serializable)
+				if tc.expectedError != "" {
+					require.ErrorContains(t, err, tc.expectedError)
+					return
+				}
+				require.NoError(t, err)
+				require.Len(t, resp.Members, 2)
+			})
+		})
+	}
+}
+
 // memberToRemove chooses a member to remove.
 // If clusterSize == 1, return the only member.
 // Otherwise, return a member that client has not connected to.

--- a/tests/e2e/ctl_v3_member_test.go
+++ b/tests/e2e/ctl_v3_member_test.go
@@ -37,12 +37,6 @@ import (
 
 func TestCtlV3MemberList(t *testing.T)        { testCtl(t, memberListTest) }
 func TestCtlV3MemberListWithHex(t *testing.T) { testCtl(t, memberListWithHexTest) }
-func TestCtlV3MemberListSerializable(t *testing.T) {
-	cfg := e2e.NewConfig(
-		e2e.WithClusterSize(1),
-	)
-	testCtl(t, memberListSerializableTest, withCfg(*cfg))
-}
 
 func TestCtlV3MemberAdd(t *testing.T)          { testCtl(t, memberAddTest) }
 func TestCtlV3MemberAddAsLearner(t *testing.T) { testCtl(t, memberAddAsLearnerTest) }
@@ -163,20 +157,6 @@ func memberListTest(cx ctlCtx) {
 	if err := ctlV3MemberList(cx); err != nil {
 		cx.t.Fatalf("memberListTest ctlV3MemberList error (%v)", err)
 	}
-}
-
-func memberListSerializableTest(cx ctlCtx) {
-	resp, err := getMemberList(cx, false)
-	require.NoError(cx.t, err)
-	require.Len(cx.t, resp.Members, 1)
-
-	peerURL := fmt.Sprintf("http://localhost:%d", e2e.EtcdProcessBasePort+11)
-	err = ctlV3MemberAdd(cx, peerURL, false)
-	require.NoError(cx.t, err)
-
-	resp, err = getMemberList(cx, true)
-	require.NoError(cx.t, err)
-	require.Len(cx.t, resp.Members, 2)
 }
 
 func ctlV3MemberList(cx ctlCtx) error {


### PR DESCRIPTION
Move `TestCtlV3MemberListSerializable` from `tests/e2e` into `tests/common`, so that one test covers both the e2e and the integration mode.

The new test also adds a linearizable subtest. It shows what the option changes: after the single member cluster loses quorum, the serializable member list is still served from the local member, while the linearizable one blocks until the context deadline.

The helper `getMemberList` stays in `tests/e2e/ctl_v3_member_test.go`, because other tests still use it.

Part of #13637
