### PR TITLE
client/v3: remove keepAlive entries without subscribers in closeRequireLeader (#22094)

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -383,7 +383,7 @@ func (l *lessor) keepAliveCtxCloser(ctx context.Context, id LeaseID, donec <-cha
 func (l *lessor) closeRequireLeader() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for _, ka := range l.keepAlives {
+	for id, ka := range l.keepAlives {
 		reqIdxs := 0
 		// find all required leader channels, close, mark as nil
 		for i, ctx := range ka.ctxs {
@@ -414,6 +414,9 @@ func (l *lessor) closeRequireLeader() {
 			newIdx++
 		}
 		ka.chs, ka.ctxs = newChs, newCtxs
+		if len(ka.chs) == 0 {
+			delete(l.keepAlives, id)
+		}
 	}
 }
 

--- a/client/v3/lease_internal_test.go
+++ b/client/v3/lease_internal_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCloseRequireLeaderRemovesKeepAliveWithoutSubscribers(t *testing.T) {
+	const leaseID LeaseID = 1
+	responseCh := make(chan *LeaseKeepAliveResponse)
+	l := &lessor{
+		keepAlives: map[LeaseID]*keepAlive{
+			leaseID: {
+				chs:   []chan<- *LeaseKeepAliveResponse{responseCh},
+				ctxs:  []context.Context{WithRequireLeader(t.Context())},
+				donec: make(chan struct{}),
+			},
+		},
+	}
+
+	l.closeRequireLeader()
+
+	if _, ok := l.keepAlives[leaseID]; ok {
+		t.Fatal("keep alive remains registered after its last subscriber is removed")
+	}
+	if _, ok := <-responseCh; ok {
+		t.Fatal("keep alive response channel remains open after leader loss")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes #22094 — when `closeRequireLeader` removes every subscriber for a given lease (all using `WithRequireLeader`), it compacts `ka.chs` and `ka.ctxs` down to length zero, but never deletes the entry from `l.keepAlives`.

### Root cause

`closeRequireLeader` iterates `l.keepAlives` with `for _, ka := range` (discarding the key), so it can never call `delete(l.keepAlives, id)` even when `ka.chs` becomes empty. Compare with `keepAliveCtxCloser` a few lines above, which correctly checks `len(ka.chs) == 0` and deletes the entry.

### Effect

Once `ka.chs` is empty, `ka.deadline` keeps refreshing on every server response (line 529: unconditional), but `ka.nextKeepAlive` never advances because the loop that updates it only runs over `ka.chs` (line 530: `for _, ch := range ka.chs` — zero iterations). `sendKeepAliveLoop` keeps polling `ka.nextKeepAlive.Before(now)` which is stuck in the past, so it keeps sending real `LeaseKeepAliveRequest` for that lease ~every 500ms forever. The server answers, refreshing `deadline`, so `deadlineLoop` never times it out either.

### Changes

1. **`client/v3/lease.go`** — Changed `for _, ka := range` to `for id, ka := range` in `closeRequireLeader`, and added `delete(l.keepAlives, id)` when `len(ka.chs) == 0` after the compacting loop.

2. **`client/v3/lease_internal_test.go`** — Added `TestCloseRequireLeaderRemovesKeepAliveWithoutSubscribers` that verifies the entry is removed and channels are closed.

### Related

- #22081 (the same function, different bug — fixed indexing in the compacting loop)