### PR TITLE
lint: enable unexported-return revive rule in pkg module

### DIFF
--- a/pkg/flags/uint32.go
+++ b/pkg/flags/uint32.go
@@ -22,7 +22,7 @@ import (
 type uint32Value uint32
 
 // NewUint32Value creates an uint32 instance with the provided value.
-func NewUint32Value(v uint32) *uint32Value {
+func NewUint32Value(v uint32) flag.Value {
 	val := new(uint32Value)
 	*val = uint32Value(v)
 	return val

--- a/pkg/wait/wait_time.go
+++ b/pkg/wait/wait_time.go
@@ -35,7 +35,7 @@ type timeList struct {
 	m                   map[uint64]chan struct{}
 }
 
-func NewTimeList() *timeList {
+func NewTimeList() WaitTime {
 	return &timeList{m: make(map[uint64]chan struct{})}
 }
 

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -84,7 +84,6 @@ linters:
         - name: exported
           disabled: true
         - name: unexported-return
-          disabled: true
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
lint: enable unexported-return revive rule in pkg module

Enable the unexported-return revive rule by removing `disabled: true`
from tools/.golangci.yaml and fix the two violations found in pkg/:

- pkg/flags/uint32.go: NewUint32Value now returns flag.Value interface
  instead of unexported *uint32Value
- pkg/wait/wait_time.go: NewTimeList now returns WaitTime interface
  instead of unexported *timeList

Closes #18370