### PR TITLE
benchmark: add compaction benchmark subcommand

### DIFF
--- a/tools/benchmark/cmd/compaction.go
+++ b/tools/benchmark/cmd/compaction.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
+
+	v3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/pkg/v3/report"
+)
+
+// Example (run from the repository root; etcd auto-compaction is disabled by default):
+//
+//     make build
+//     go build -o ./bin/benchmark ./tools/benchmark
+//     PATH="$PWD/bin:$PATH" ./scripts/benchmark_test.sh compaction \
+//       --clients=16 \
+//       --conns=4 \
+//       --rate=1000 \
+//       --total=60000 \
+//       --read-ratio=0.8 \
+//       --compact-interval=10s \
+//       --compact-index-delta=1000
+//
+// Use --enable-compaction=false for a no-compaction baseline.
+// compactionCmd represents the compaction command
+var compactionCmd = &cobra.Command{
+	Use:   "compaction",
+	Short: "Benchmark the impact of compaction on a running read/write workload",
+
+	Run: compactionFunc,
+}
+
+var (
+	compactionKeySize      int
+	compactionValSize      int
+	compactionRate         int
+	compactionTotal        int
+	compactionKeySpaceSize int
+	compactionReadRatio    float64
+	compactionEnabled      bool
+	compactionInterval     time.Duration
+	compactionRevDelta     int64
+)
+
+func init() {
+	RootCmd.AddCommand(compactionCmd)
+	compactionCmd.Flags().IntVar(&compactionKeySize, "key-size", 8, "Key size of request")
+	compactionCmd.Flags().IntVar(&compactionValSize, "val-size", 256, "Value size of put request")
+	compactionCmd.Flags().IntVar(&compactionRate, "rate", 1000, "Maximum requests per second (0 is no limit)")
+	compactionCmd.Flags().IntVar(&compactionTotal, "total", 60000, "Total number of read/write requests")
+	compactionCmd.Flags().IntVar(&compactionKeySpaceSize, "key-space-size", 5000, "Maximum possible keys")
+	compactionCmd.Flags().Float64Var(&compactionReadRatio, "read-ratio", 0.5, "Ratio of RANGE requests in the workload, remainder are PUT requests (0.0 - 1.0)")
+	compactionCmd.Flags().BoolVar(&compactionEnabled, "enable-compaction", true, "Whether to issue compactions during the workload; disable to measure a no-compaction baseline of the same mixed PUT/RANGE load")
+	compactionCmd.Flags().DurationVar(&compactionInterval, "compact-interval", 10*time.Second, `Interval between compactions issued during the workload (do not duplicate this with etcd's 'auto-compaction-retention' flag)`)
+	compactionCmd.Flags().Int64Var(&compactionRevDelta, "compact-index-delta", 1000, "Delta between current revision and compact revision (e.g. current revision 10000, compact at 9000)")
+}
+
+func compactionFunc(_ *cobra.Command, _ []string) {
+	if compactionKeySpaceSize <= 0 {
+		fmt.Fprintf(os.Stderr, "expected positive --key-space-size, got (%v)\n", compactionKeySpaceSize)
+		os.Exit(1)
+	}
+	if compactionReadRatio < 0 || compactionReadRatio > 1 {
+		fmt.Fprintf(os.Stderr, "expected --read-ratio between 0.0 and 1.0, got (%v)\n", compactionReadRatio)
+		os.Exit(1)
+	}
+	if compactionEnabled && compactionInterval <= 0 {
+		fmt.Fprintf(os.Stderr, "expected positive --compact-interval, got (%v)\n", compactionInterval)
+		os.Exit(1)
+	}
+
+	requests := make(chan v3.Op, totalClients)
+	limit := rate.NewLimiter(rate.Limit(compactionRate), 1)
+	clients := mustCreateClients(totalClients, totalConns)
+	k, v := make([]byte, compactionKeySize), string(mustRandBytes(compactionValSize))
+
+	bar = pb.New(compactionTotal)
+	bar.Start()
+
+	putName, rangeName := "put", "range"
+	putLabel, rangeLabel := "PUT", "RANGE"
+	if compactionEnabled {
+		putName, rangeName = "putDuringCompaction", "rangeDuringCompaction"
+		putLabel, rangeLabel = "PUT during compaction", "RANGE during compaction"
+	}
+	putReport := newReport(putName)
+	rangeReport := newReport(rangeName)
+	compactReport := newReport("compaction")
+
+	for i := range clients {
+		wg.Add(1)
+		go func(c *v3.Client) {
+			defer wg.Done()
+			for op := range requests {
+				limit.Wait(context.Background())
+
+				st := time.Now()
+				_, err := c.Do(context.Background(), op)
+				res := report.Result{Err: err, Start: st, End: time.Now()}
+				if op.IsGet() {
+					rangeReport.Results() <- res
+				} else {
+					putReport.Results() <- res
+				}
+				bar.Increment()
+			}
+		}(clients[i])
+	}
+
+	go func() {
+		for i := 0; i < compactionTotal; i++ {
+			binary.PutVarint(k, int64(rand.Intn(compactionKeySpaceSize)))
+			if rand.Float64() < compactionReadRatio {
+				requests <- v3.OpGet(string(k))
+			} else {
+				requests <- v3.OpPut(string(k), v)
+			}
+		}
+		close(requests)
+	}()
+
+	stopCompactor := make(chan struct{})
+	var compactorWg sync.WaitGroup
+	if compactionEnabled {
+		compactorWg.Add(1)
+		go func() {
+			defer compactorWg.Done()
+			ticker := time.NewTicker(compactionInterval)
+			defer ticker.Stop()
+			var lastCompactRev int64
+			for {
+				select {
+				case <-stopCompactor:
+					return
+				case <-ticker.C:
+					lastCompactRev = compactAndMeasure(clients[0], compactReport, lastCompactRev)
+				}
+			}
+		}()
+	}
+
+	putRC := putReport.Run()
+	rangeRC := rangeReport.Run()
+	compactRC := compactReport.Run()
+
+	wg.Wait()
+	close(stopCompactor)
+	compactorWg.Wait()
+
+	close(putReport.Results())
+	close(rangeReport.Results())
+	close(compactReport.Results())
+	bar.Finish()
+
+	fmt.Printf("%s:\n%s\n", putLabel, <-putRC)
+	fmt.Printf("%s:\n%s\n", rangeLabel, <-rangeRC)
+	if compactionEnabled {
+		fmt.Printf("COMPACTION:\n%s\n", <-compactRC)
+	}
+}
+
+func compactAndMeasure(c *v3.Client, r report.Report, lastCompactRev int64) int64 {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	resp, err := c.Get(ctx, "compaction-probe")
+	cancel()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch current revision: %v\n", err)
+		return lastCompactRev
+	}
+	revToCompact := resp.Header.Revision - compactionRevDelta
+	if revToCompact <= lastCompactRev {
+		return lastCompactRev
+	}
+
+	st := time.Now()
+	_, err = c.Compact(context.Background(), revToCompact, v3.WithCompactPhysical())
+	r.Results() <- report.Result{Err: err, Start: st, End: time.Now()}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to compact revision %d: %v\n", revToCompact, err)
+		return lastCompactRev
+	}
+	return revToCompact
+}


### PR DESCRIPTION
### What this PR does

Adds a `compaction` subcommand to `tools/benchmark` that measures the impact of MVCC compaction on a live mixed read/write workload.

The command drives a rate-limited PUT/RANGE workload (ratio controlled by `--read-ratio`) while periodically issuing `Compact` requests (`--compact-interval`), keeping `--compact-index-delta` revisions of history each time. Latencies are reported separately for PUT, RANGE, and the compaction operations themselves, so the client-visible cost of compaction can be isolated.

### Motivation

Follow up: https://github.com/etcd-io/etcd/issues/16467 and https://github.com/etcd-io/etcd/pull/21951#issuecomment-5020648775

### Baseline mode: `--enable-compaction=false`

To interpret the numbers you need a control. Passing `--enable-compaction=false` runs the *exact same* rate-limited PUT/RANGE workload but skips the periodic compactions, producing a no-compaction baseline under identical conditions. Comparing the two runs isolates the latency cost attributable to compaction alone, rather than to the mixed workload itself.

### Benchmark results

Environment: single local etcd server (started by `scripts/benchmark_test.sh`), darwin/arm64.
Workload: `--clients=16 --conns=4 --rate=1000 --total=60000 --key-size=8 --val-size=256 --key-space-size=5000 --read-ratio=0.8 --compact-interval=10s --compact-index-delta=1000`

#### Comparison (latencies in ms)

| Metric | PUT baseline | PUT w/ compaction | Δ | RANGE baseline | RANGE w/ compaction | Δ |
|---|---|---|---|---|---|---|
| Average | 6.4 | 7.3 | +14% | 3.2 | 4.0 | +25% |
| p50 | 5.2 | 5.8 | +12% | 1.9 | 2.6 | +37% |
| p90 | 10.7 | 13.3 | +24% | 7.7 | 9.8 | +27% |
| p99 | 20.2 | 25.8 | +28% | 17.1 | 21.5 | +26% |
| p99.9 | 31.3 | 42.0 | +34% | 27.7 | 36.0 | +30% |
| Stddev | 3.6 | 4.7 | +31% | 3.8 | 4.8 | +26% |

The 6 compaction operations (one per 10s interval over ~62s) took 55–265 ms each (avg 189 ms, ~1.9% of wall time). The overhead is concentrated in the tail — p99.9 rises ~30–34% — which matches the expected signature of periodic stalls, while the slowest single request is essentially unchanged (~51 ms in both runs), i.e. no pathological multi-hundred-ms stalls leak into the client path at this load.

<details>
<summary>Full output: with compaction (<code>--enable-compaction=true</code>)</summary>

```
PUT during compaction:

Summary:
  Total:        61.9575 secs.
  Slowest:      0.0507 secs.
  Fastest:      0.0023 secs.
  Average:      0.0073 secs.
  Stddev:       0.0047 secs.
  Requests/sec: 192.3092

Latency distribution:
  10% in 0.0039 secs.
  25% in 0.0046 secs.
  50% in 0.0058 secs.
  75% in 0.0078 secs.
  90% in 0.0133 secs.
  95% in 0.0170 secs.
  99% in 0.0258 secs.
  99.9% in 0.0420 secs.

RANGE during compaction:

Summary:
  Total:        61.9575 secs.
  Slowest:      0.0493 secs.
  Fastest:      0.0001 secs.
  Average:      0.0040 secs.
  Stddev:       0.0048 secs.
  Requests/sec: 776.0969

Latency distribution:
  10% in 0.0003 secs.
  25% in 0.0005 secs.
  50% in 0.0026 secs.
  75% in 0.0056 secs.
  90% in 0.0098 secs.
  95% in 0.0141 secs.
  99% in 0.0215 secs.
  99.9% in 0.0360 secs.

COMPACTION:

Summary:
  Total:        61.9576 secs.
  Slowest:      0.2650 secs.
  Fastest:      0.0553 secs.
  Average:      0.1895 secs.
  Stddev:       0.0740 secs.
  Requests/sec: 0.0968

Latency distribution:
  10% in 0.1318 secs.
  25% in 0.2105 secs.
  50% in 0.2169 secs.
  75% in 0.2650 secs.
```
</details>

<details>
<summary>Full output: no-compaction baseline (<code>--enable-compaction=false</code>)</summary>

```
PUT:

Summary:
  Total:        60.9291 secs.
  Slowest:      0.0517 secs.
  Fastest:      0.0025 secs.
  Average:      0.0064 secs.
  Stddev:       0.0036 secs.
  Requests/sec: 196.9831

Latency distribution:
  10% in 0.0037 secs.
  25% in 0.0042 secs.
  50% in 0.0052 secs.
  75% in 0.0069 secs.
  90% in 0.0107 secs.
  95% in 0.0141 secs.
  99% in 0.0202 secs.
  99.9% in 0.0313 secs.

RANGE:

Summary:
  Total:        60.9291 secs.
  Slowest:      0.0509 secs.
  Fastest:      0.0001 secs.
  Average:      0.0032 secs.
  Stddev:       0.0038 secs.
  Requests/sec: 787.7681

Latency distribution:
  10% in 0.0003 secs.
  25% in 0.0005 secs.
  50% in 0.0019 secs.
  75% in 0.0046 secs.
  90% in 0.0077 secs.
  95% in 0.0111 secs.
  99% in 0.0171 secs.
  99.9% in 0.0277 secs.
```
</details>

### Usage

```sh
# with compaction
./scripts/benchmark_test.sh compaction --clients=16 --conns=4 --rate=1000 --total=60000 \
  --key-size=8 --val-size=256 --key-space-size=5000 --read-ratio=0.8 \
  --enable-compaction=true --compact-interval=10s --compact-index-delta=1000

# no-compaction baseline, same workload
./scripts/benchmark_test.sh compaction ... --enable-compaction=false
```


