### PR TITLE
amend e2e tests to read the built etcd version

### DIFF
--- a/tests/e2e/cluster_downgrade_test.go
+++ b/tests/e2e/cluster_downgrade_test.go
@@ -125,7 +125,7 @@ func testDowngradeUpgrade(t *testing.T, numberOfMembersToDowngrade int, clusterS
 	for i := 0; i < len(epc.Procs); i++ {
 		e2e.ValidateVersion(t, epc.Cfg, epc.Procs[i], version.Versions{
 			Cluster: currentVersionStr,
-			Server:  version.Version,
+			Server:  e2e.ServerVersion(),
 			Storage: currentVersionStr,
 		})
 	}

--- a/tests/e2e/ctl_v3_test.go
+++ b/tests/e2e/ctl_v3_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/pkg/v3/featuregate"
@@ -75,7 +74,7 @@ func TestClusterVersion(t *testing.T) {
 				cfg: *cfg,
 				epc: epc,
 			}
-			cv := version.Cluster(version.Version)
+			cv := e2e.ServerClusterVersion()
 			clusterVersionTest(ctx, `"etcdcluster":"`+cv)
 		})
 	}
@@ -104,7 +103,7 @@ func clusterVersionTest(cx ctlCtx, expected string) {
 
 func ctlV3Version(cx ctlCtx) error {
 	cmdArgs := append(cx.PrefixArgs(), "version")
-	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: version.Version})
+	return e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: e2e.ServerVersion()})
 }
 
 // TestCtlV3DialWithHTTPScheme ensures that client handles Endpoints with HTTPS scheme.

--- a/tests/e2e/etcd_release_upgrade_test.go
+++ b/tests/e2e/etcd_release_upgrade_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/config"
@@ -101,7 +100,7 @@ func TestReleaseUpgrade(t *testing.T) {
 	// TODO: update after release candidate
 	// expect upgraded cluster version
 	// new cluster version needs more time to upgrade
-	ver := version.Cluster(version.Version)
+	ver := e2e.ServerClusterVersion()
 	for i := 0; i < 7; i++ {
 		if err = e2e.CURLGet(epc, e2e.CURLReq{Endpoint: "/version", Expected: expect.ExpectedResponse{Value: `"etcdcluster":"` + ver}}); err != nil {
 			t.Logf("#%d: %v is not ready yet (%v)", i, ver, err)

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/config"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
@@ -65,8 +64,8 @@ func metricsTest(cx ctlCtx) {
 		{"/metrics", "etcd_mvcc_put_total 2"},
 		{"/metrics", "etcd_debugging_mvcc_keys_total 1"},
 		{"/metrics", "etcd_mvcc_delete_total 3"},
-		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
-		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, version.Cluster(version.Version))},
+		{"/metrics", fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, e2e.ServerVersion())},
+		{"/metrics", fmt.Sprintf(`etcd_cluster_version{cluster_version="%s"} 1`, e2e.ServerClusterVersion())},
 		{"/metrics", `grpc_server_handled_total{grpc_code="Canceled",grpc_method="Watch",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"} 6`},
 		{"/health", `{"health":"true","reason":""}`},
 	} {

--- a/tests/e2e/v3_cipher_suite_test.go
+++ b/tests/e2e/v3_cipher_suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -50,10 +49,10 @@ func testCurlV3CipherSuites(t *testing.T, valid bool) {
 func cipherSuiteTestValid(cx ctlCtx) {
 	if err := e2e.CURLGet(cx.epc, e2e.CURLReq{
 		Endpoint: "/metrics",
-		Expected: expect.ExpectedResponse{Value: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version)},
+		Expected: expect.ExpectedResponse{Value: fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, e2e.ServerVersion())},
 		Ciphers:  "ECDHE-RSA-AES128-GCM-SHA256", // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 	}); err != nil {
-		require.ErrorContains(cx.t, err, fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, version.Version))
+		require.ErrorContains(cx.t, err, fmt.Sprintf(`etcd_server_version{server_version="%s"} 1`, e2e.ServerVersion()))
 	}
 }
 

--- a/tests/e2e/v3_curl_maintenance_test.go
+++ b/tests/e2e/v3_curl_maintenance_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
@@ -56,7 +55,7 @@ func testCurlV3MaintenanceStatus(cx ctlCtx) {
 		}
 	}
 
-	require.Equal(cx.t, version.Version, resp["version"])
+	require.Equal(cx.t, e2e.ServerVersion(), resp["version"])
 }
 
 func TestCurlV3MaintenanceDefragment(t *testing.T) {

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -503,26 +504,61 @@ func parseFailpointsBody(body io.Reader) (map[string]string, error) {
 }
 
 var GetVersionFromBinary = func(binaryPath string) (*semver.Version, error) {
+	versionString, err := GetFullVersionFromBinary(binaryPath)
+	if err != nil {
+		return nil, err
+	}
+	version, err := semver.NewVersion(versionString)
+	if err != nil {
+		return nil, err
+	}
+	return semver.New(version.Major(), version.Minor(), version.Patch(), "", ""), nil
+}
+
+// GetFullVersionFromBinary returns the version string reported by the binary
+// verbatim, including any pre-release and build metadata. Unlike
+// GetVersionFromBinary it preserves values injected at build time through the
+// `-X .../api/v3/version.Version` ldflag.
+func GetFullVersionFromBinary(binaryPath string) (string, error) {
 	if !fileutil.Exist(binaryPath) {
-		return nil, fmt.Errorf("binary path does not exist: %s", binaryPath)
+		return "", fmt.Errorf("binary path does not exist: %s", binaryPath)
 	}
 	lines, err := RunUtilCompletion([]string{binaryPath, "--version"}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not find binary version from %s, err: %w", binaryPath, err)
+		return "", fmt.Errorf("could not find binary version from %s, err: %w", binaryPath, err)
 	}
 
 	for _, line := range lines {
 		if strings.HasPrefix(line, "etcd Version:") {
-			versionString := strings.TrimSpace(strings.SplitAfter(line, ":")[1])
-			version, err := semver.NewVersion(versionString)
-			if err != nil {
-				return nil, err
-			}
-			return semver.New(version.Major(), version.Minor(), version.Patch(), "", ""), nil
+			return strings.TrimSpace(strings.SplitAfter(line, ":")[1]), nil
 		}
 	}
 
-	return nil, fmt.Errorf("could not find version in binary output of %s, lines outputted were %v", binaryPath, lines)
+	return "", fmt.Errorf("could not find version in binary output of %s, lines outputted were %v", binaryPath, lines)
+}
+
+// serverVersion is resolved lazily because BinPath is only populated once
+// InitFlags has run.
+var serverVersion = sync.OnceValue(func() string {
+	v, err := GetFullVersionFromBinary(BinPath.Etcd)
+	if err != nil {
+		return version.Version
+	}
+	return v
+})
+
+// ServerVersion returns the version string reported by the etcd binary under
+// test. It differs from version.Version compiled into the test binary whenever
+// etcd is built with a custom version symbol, so e2e assertions about versions
+// reported by the server must use this instead.
+func ServerVersion() string {
+	return serverVersion()
+}
+
+// ServerClusterVersion returns the major.minor cluster version of the etcd
+// binary under test.
+func ServerClusterVersion() string {
+	return version.Cluster(ServerVersion())
 }
 
 // setGetVersionFromBinary changes the GetVersionFromBinary function to a mock in testing.


### PR DESCRIPTION
In #20915, there is a bug in the test where the e2e framework doesn't read the etcd version from the built binary; instead, it uses hardcoded values in the test, and it fails if etcd is built with a custom version.

Now we run etcd --version before starting the test process.