### PR TITLE
fix sending v prefixed semver version to older etcd peer versions that use the coreos/go-semver

### DIFF
--- a/api/version/version.go
+++ b/api/version/version.go
@@ -88,3 +88,14 @@ func LessThan(ver1, ver2 semver.Version) bool {
 func Equal(ver1, ver2 semver.Version) bool {
 	return ver1.Equal(&ver2)
 }
+
+// VersionForPeer returns the version string to use in the X-Server-Version header
+// when communicating with a peer. Peers older than v3.8 use github.com/coreos/go-semver
+// which does not accept a leading "v" prefix and will panic when parsing it.
+// If the peer version is unknown (nil) or less than v3.8, the "v" prefix is stripped.
+func VersionForPeer(peerVer *semver.Version) string {
+	if peerVer == nil || peerVer.LessThan(&V3_8) {
+		return strings.TrimPrefix(Version, "v")
+	}
+	return Version
+}

--- a/client/v3/client.go
+++ b/client/v3/client.go
@@ -504,7 +504,7 @@ func (c *Client) roundRobinQuorumBackoff(waitBetween time.Duration, jitterFracti
 
 // minSupportedVersion returns the minimum version supported, which is the previous minor release.
 func minSupportedVersion() *semver.Version {
-	ver := semver.MustParse(version.Version)
+	ver, _ := semver.NewVersion(version.Version)
 	// consider only major and minor version
 	ver = semver.New(ver.Major(), ver.Minor(), 0, "", "")
 	for i := range version.AllVersions {

--- a/server/etcdserver/api/rafthttp/http.go
+++ b/server/etcdserver/api/rafthttp/http.go
@@ -364,7 +364,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("X-Server-Version", version.Version)
+	w.Header().Set("X-Server-Version", version.VersionForPeer(serverVersion(r.Header)))
 	w.Header().Set("X-Etcd-Cluster-ID", h.cid.String())
 
 	if err := checkClusterCompatibilityFromHeader(h.lg, h.tr.ID, r.Header, h.cid); err != nil {

--- a/server/etcdserver/api/rafthttp/http_test.go
+++ b/server/etcdserver/api/rafthttp/http_test.go
@@ -209,7 +209,7 @@ func TestServeRaftStreamPrefix(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("#%d: failed to attach outgoingConn", i)
 		}
-		if g := rw.Header().Get("X-Server-Version"); g != version.Version {
+		if g := rw.Header().Get("X-Server-Version"); g != version.VersionForPeer(serverVersion(rw.Header())) {
 			t.Errorf("#%d: X-Server-Version = %s, want %s", i, g, version.Version)
 		}
 		if conn.t != tt.wtype {

--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/pkg/v3/pbutil"
 	stats "go.etcd.io/etcd/server/v3/etcdserver/api/v2stats"
@@ -133,7 +134,7 @@ func (p *pipeline) handle() {
 // error on any failure.
 func (p *pipeline) post(data []byte) (err error) {
 	u := p.picker.pick()
-	req := createPostRequest(p.tr.Logger, u, RaftPrefix, bytes.NewBuffer(data), "application/protobuf", p.tr.URLs, p.tr.ID, p.tr.ClusterID)
+	req := createPostRequest(p.tr.Logger, u, RaftPrefix, bytes.NewBuffer(data), "application/protobuf", p.tr.URLs, p.tr.ID, p.tr.ClusterID, version.VersionForPeer(p.tr.getPeerVersion(p.peerID)))
 
 	done := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/etcdserver/api/rafthttp/pipeline_test.go
+++ b/server/etcdserver/api/rafthttp/pipeline_test.go
@@ -148,8 +148,9 @@ func TestPipelinePost(t *testing.T) {
 	if g := req.Header.Get("Content-Type"); g != "application/protobuf" {
 		t.Errorf("content type = %s, want %s", g, "application/protobuf")
 	}
-	if g := req.Header.Get("X-Server-Version"); g != version.Version {
-		t.Errorf("version = %s, want %s", g, version.Version)
+	wantVersion := version.VersionForPeer(tp.getPeerVersion(p.peerID))
+	if g := req.Header.Get("X-Server-Version"); g != wantVersion {
+		t.Errorf("version = %s, want %s", g, wantVersion)
 	}
 	if g := req.Header.Get("X-Min-Cluster-Version"); g != version.MinClusterVersion {
 		t.Errorf("min version = %s, want %s", g, version.MinClusterVersion)

--- a/server/etcdserver/api/rafthttp/snapshot_sender.go
+++ b/server/etcdserver/api/rafthttp/snapshot_sender.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"go.uber.org/zap"
 
+	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/etcd/pkg/v3/httputil"
 	pioutil "go.etcd.io/etcd/pkg/v3/ioutil"
@@ -74,7 +75,7 @@ func (s *snapshotSender) send(merged *snap.Message) {
 	defer body.Close()
 
 	u := s.picker.pick()
-	req := createPostRequest(s.tr.Logger, u, RaftSnapshotPrefix, body, "application/octet-stream", s.tr.URLs, s.from, s.cid)
+	req := createPostRequest(s.tr.Logger, u, RaftSnapshotPrefix, body, "application/octet-stream", s.tr.URLs, s.from, s.cid, version.VersionForPeer(s.tr.getPeerVersion(s.to)))
 
 	snapshotSizeVal := uint64(merged.TotalSize)
 	snapshotSize := humanize.Bytes(snapshotSizeVal)

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -585,7 +585,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("failed to make http request to %v (%w)", u, err)
 	}
 	req.Header.Set("X-Server-From", cr.tr.ID.String())
-	req.Header.Set("X-Server-Version", version.Version)
+	req.Header.Set("X-Server-Version", version.VersionForPeer(cr.tr.getPeerVersion(cr.peerID)))
 	req.Header.Set("X-Min-Cluster-Version", version.MinClusterVersion)
 	req.Header.Set("X-Etcd-Cluster-ID", cr.tr.ClusterID.String())
 	req.Header.Set("X-Raft-To", cr.peerID.String())
@@ -610,6 +610,7 @@ func (cr *streamReader) dial(t streamType) (io.ReadCloser, error) {
 	}
 
 	rv := serverVersion(resp.Header)
+	cr.tr.setPeerVersion(cr.peerID, rv)
 	lv := semver.MustParse(version.Version)
 	if compareMajorMinorVersion(rv, lv) == -1 && !checkStreamSupport(rv, t) {
 		httputil.GracefulClose(resp)

--- a/server/etcdserver/api/rafthttp/transport.go
+++ b/server/etcdserver/api/rafthttp/transport.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/xiang90/probing"
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
@@ -127,8 +128,26 @@ type Transport struct {
 	remotes map[types.ID]*remote // remotes map that helps newly joined member to catch up
 	peers   map[types.ID]Peer    // peers map
 
+	// peerVersions tracks the last known semver of each remote peer, used to
+	// conditionally strip the "v" prefix from X-Server-Version headers for
+	// peers that use github.com/coreos/go-semver (< v3.7) which cannot parse it.
+	peerVersions sync.Map // map[types.ID]*semver.Version
+
 	pipelineProber probing.Prober
 	streamProber   probing.Prober
+}
+
+// getPeerVersion returns the last known version of the given peer, or nil if unknown.
+func (t *Transport) getPeerVersion(id types.ID) *semver.Version {
+	if v, ok := t.peerVersions.Load(id); ok {
+		return v.(*semver.Version)
+	}
+	return nil
+}
+
+// setPeerVersion stores the last known version of the given peer.
+func (t *Transport) setPeerVersion(id types.ID, v *semver.Version) {
+	t.peerVersions.Store(id, v)
 }
 
 func (t *Transport) Start() error {
@@ -340,6 +359,7 @@ func (t *Transport) RemoveAllPeers() {
 
 // the caller of this function must have the peers mutex.
 func (t *Transport) removePeer(id types.ID) {
+	t.peerVersions.Delete(id)
 	// etcd may remove a member again on startup due to WAL files replaying.
 	peer, ok := t.peers[id]
 	if ok {

--- a/server/etcdserver/api/rafthttp/util.go
+++ b/server/etcdserver/api/rafthttp/util.go
@@ -61,7 +61,7 @@ func newStreamRoundTripper(tlsInfo transport.TLSInfo, dialTimeout time.Duration)
 }
 
 // createPostRequest creates a HTTP POST request that sends raft message.
-func createPostRequest(lg *zap.Logger, u url.URL, path string, body io.Reader, ct string, urls types.URLs, from, cid types.ID) *http.Request {
+func createPostRequest(lg *zap.Logger, u url.URL, path string, body io.Reader, ct string, urls types.URLs, from, cid types.ID, serverVer string) *http.Request {
 	uu := u
 	uu.Path = path
 	req, err := http.NewRequest(http.MethodPost, uu.String(), body)
@@ -72,7 +72,7 @@ func createPostRequest(lg *zap.Logger, u url.URL, path string, body io.Reader, c
 	}
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Server-From", from.String())
-	req.Header.Set("X-Server-Version", version.Version)
+	req.Header.Set("X-Server-Version", serverVer)
 	req.Header.Set("X-Min-Cluster-Version", version.MinClusterVersion)
 	req.Header.Set("X-Etcd-Cluster-ID", cid.String())
 	setPeerURLsHeader(req, urls)

--- a/server/etcdserver/api/rafthttp/util_test.go
+++ b/server/etcdserver/api/rafthttp/util_test.go
@@ -109,6 +109,10 @@ func TestServerVersion(t *testing.T) {
 			semver.MustParse("2.1.0"),
 		},
 		{
+			http.Header{"X-Server-Version": []string{"v2.1.0"}},
+			semver.MustParse("v2.1.0"),
+		},
+		{
 			http.Header{"X-Server-Version": []string{"2.1.0-alpha.0+git"}},
 			semver.MustParse("2.1.0-alpha.0+git"),
 		},


### PR DESCRIPTION
In #20915, we are building etcd with Version that is prefixed with v.

Sending, for example, `v2.1.0` in the X-Server-Version header will cause semver parsing errors, so the v needs to be stripped. This code can be removed from 3.9 onwards.