### PR TITLE
tests: migrate move leader test to common test framework

### DIFF
--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -50,7 +50,7 @@ func TestDefragmentWithUserAuth(t *testing.T) {
 }
 
 func testDefragmentWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
-	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, nil, func(ctx context.Context, cc intf.Client) error {
 		return cc.Defragment(ctx, config.DefragOption{Timeout: 10 * time.Second})
 	}, opts...)
 }
@@ -80,7 +80,7 @@ func testDowngradeWithAuth(t *testing.T, expectConnectionError, expectOperationE
 	// downgrade validate only accepts a target of exactly one minor version below the current one
 	targetVersion := semver.New(currentVersion.Major(), currentVersion.Minor()-1, 0, "", "")
 
-	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, nil, func(ctx context.Context, cc intf.Client) error {
 		_, err := cc.Downgrade(ctx, clientv3.DowngradeValidate, targetVersion.String())
 		return err
 	}, opts...)
@@ -106,7 +106,7 @@ func TestHashKVWithUserAuth(t *testing.T) {
 }
 
 func testHashKVWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
-	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, nil, func(ctx context.Context, cc intf.Client) error {
 		_, err := cc.HashKV(ctx, 0)
 		return err
 	}, opts...)
@@ -131,9 +131,24 @@ func TestMoveLeaderWithUserAuth(t *testing.T) {
 	testMoveLeaderWithAuth(t, false, true, WithAuth("user0", "user0Pass"))
 }
 
-func testMoveLeaderWithAuth(t *testing.T, _expectConnectionError, _expectOperationError bool, _opts ...config.ClientOption) {
-	// TODO(ahrtr): finish this after we added interface methods `MoveLeader` into `Client`
-	t.Skip()
+func testMoveLeaderWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
+	// The transferee must be resolved before auth is enabled so the assertions
+	// below only exercise the MoveLeader call itself.
+	var transfereeID uint64
+	prepare := func(ctx context.Context, cc intf.Client) {
+		statuses, err := cc.Status(ctx)
+		require.NoError(t, err)
+		for _, status := range statuses {
+			if status.Header.GetMemberId() != status.Leader {
+				transfereeID = status.Header.GetMemberId()
+				break
+			}
+		}
+		require.NotZero(t, transfereeID)
+	}
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, prepare, func(ctx context.Context, cc intf.Client) error {
+		return cc.MoveLeader(ctx, transfereeID)
+	}, opts...)
 }
 
 /*
@@ -156,7 +171,7 @@ func TestSnapshotWithUserAuth(t *testing.T) {
 }
 
 func testSnapshotWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
-	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, nil, func(ctx context.Context, cc intf.Client) error {
 		return cc.Snapshot(ctx, filepath.Join(t.TempDir(), "snapshot.db"))
 	}, opts...)
 }
@@ -181,7 +196,7 @@ func TestStatusWithUserAuth(t *testing.T) {
 }
 
 func testStatusWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
-	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, nil, func(ctx context.Context, cc intf.Client) error {
 		_, err := cc.Status(ctx)
 		return err
 	}, opts...)
@@ -212,7 +227,7 @@ func setupAuthForMaintenanceTest(c intf.Client) error {
 	return setupAuth(c, roles, users)
 }
 
-func testMaintenanceOperationWithAuth(t *testing.T, expectConnectError, expectOperationError bool, f func(context.Context, intf.Client) error, opts ...config.ClientOption) {
+func testMaintenanceOperationWithAuth(t *testing.T, expectConnectError, expectOperationError bool, prepare func(context.Context, intf.Client), f func(context.Context, intf.Client) error, opts ...config.ClientOption) {
 	testRunner.BeforeTest(t)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -221,6 +236,9 @@ func testMaintenanceOperationWithAuth(t *testing.T, expectConnectError, expectOp
 	defer clus.Close()
 
 	cc := testutils.MustClient(clus.Client())
+	if prepare != nil {
+		prepare(ctx, cc)
+	}
 	err := setupAuthForMaintenanceTest(cc)
 	require.NoError(t, err)
 

--- a/tests/common/move_leader_test.go
+++ b/tests/common/move_leader_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.etcd.io/etcd/tests/v3/framework/config"
+	intf "go.etcd.io/etcd/tests/v3/framework/interfaces"
+	"go.etcd.io/etcd/tests/v3/framework/testutils"
+)
+
+func TestMoveLeader(t *testing.T) {
+	testRunner.BeforeTest(t)
+	for _, tc := range clusterTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.config.ClusterSize < 2 {
+				t.Skip("Skipping test for single-member cluster")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
+			defer clus.Close()
+			cc := testutils.MustClient(clus.Client())
+
+			testutils.ExecuteUntil(ctx, t, func() {
+				leaderID, transfereeID := leaderAndTransferee(ctx, t, cc)
+				require.NotZero(t, leaderID)
+				require.NotZero(t, transfereeID)
+
+				require.NoError(t, cc.MoveLeader(ctx, transfereeID))
+
+				// The transfer is complete when MoveLeader returns, but followers
+				// may briefly report the old leader until they observe the new term.
+				require.Eventually(t, func() bool {
+					statuses, err := cc.Status(ctx)
+					if err != nil {
+						return false
+					}
+					for _, status := range statuses {
+						if status.Leader != transfereeID {
+							return false
+						}
+					}
+					return true
+				}, 15*time.Second, 100*time.Millisecond, "leadership was not transferred to the transferee")
+			})
+		})
+	}
+}
+
+func TestMoveLeaderToNonexistentMember(t *testing.T) {
+	testRunner.BeforeTest(t)
+	for _, tc := range clusterTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.config.ClusterSize < 2 {
+				t.Skip("Skipping test for single-member cluster")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+
+			clus := testRunner.NewCluster(ctx, t, config.WithClusterConfig(tc.config))
+			defer clus.Close()
+			cc := testutils.MustClient(clus.Client())
+
+			testutils.ExecuteUntil(ctx, t, func() {
+				statuses, err := cc.Status(ctx)
+				require.NoError(t, err)
+				memberIDs := make(map[uint64]struct{}, len(statuses))
+				for _, status := range statuses {
+					memberIDs[status.Header.GetMemberId()] = struct{}{}
+				}
+				transfereeID := uint64(1)
+				for {
+					if _, ok := memberIDs[transfereeID]; !ok {
+						break
+					}
+					transfereeID++
+				}
+
+				require.Error(t, cc.MoveLeader(ctx, transfereeID))
+			})
+		})
+	}
+}
+
+// leaderAndTransferee returns the leader's member ID and the ID of one
+// follower from the cluster's current statuses.
+func leaderAndTransferee(ctx context.Context, t *testing.T, cc intf.Client) (leaderID, transfereeID uint64) {
+	statuses, err := cc.Status(ctx)
+	require.NoError(t, err)
+	for _, status := range statuses {
+		if status.Header.GetMemberId() == status.Leader {
+			leaderID = status.Leader
+		} else {
+			transfereeID = status.Header.GetMemberId()
+		}
+	}
+	return leaderID, transfereeID
+}

--- a/tests/e2e/ctl_v3_move_leader_test.go
+++ b/tests/e2e/ctl_v3_move_leader_test.go
@@ -16,80 +16,44 @@ package e2e
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"go.etcd.io/etcd/client/pkg/v3/transport"
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/pkg/v3/expect"
 	"go.etcd.io/etcd/tests/v3/framework/e2e"
 )
 
-func TestCtlV3MoveLeaderScenarios(t *testing.T) {
-	securityParent := map[string]struct {
-		cfg e2e.EtcdProcessClusterConfig
-	}{
-		"Secure":   {cfg: *e2e.NewConfigTLS()},
-		"Insecure": {cfg: *e2e.NewConfigNoTLS()},
-	}
+// TestCtlV3MoveLeaderEnvVars ensures `etcdctl move-leader` works when
+// ETCDCTL_ENDPOINTS is set alongside the --endpoints flag, guarding against
+// a regression of the conflicting-environment-variable failure fixed by
+// 3fc16608f. The behavioral move-leader coverage lives in
+// tests/common/move_leader_test.go.
+func TestCtlV3MoveLeaderEnvVars(t *testing.T) {
+	e2e.BeforeTest(t)
 
-	tests := map[string]struct {
-		env map[string]string
-	}{
-		"happy path": {env: map[string]string{}},
-		"with env":   {env: map[string]string{"ETCDCTL_ENDPOINTS": "something-else-is-set"}},
-	}
-
-	for testName, tc := range securityParent {
-		for subTestName, tx := range tests {
-			t.Run(testName+" "+subTestName, func(t *testing.T) {
-				testCtlV3MoveLeader(t, tc.cfg, tx.env)
-			})
-		}
-	}
-}
-
-func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars map[string]string) {
-	epc := setupEtcdctlTest(t, &cfg, true)
+	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(e2e.NewConfigNoTLS()))
+	require.NoError(t, err)
 	defer func() {
-		if errC := epc.Close(); errC != nil {
-			t.Fatalf("error closing etcd processes (%v)", errC)
-		}
+		require.NoError(t, epc.Close())
 	}()
 
-	var tcfg *tls.Config
-	if cfg.Client.ConnectionType == e2e.ClientTLS {
-		tinfo := transport.TLSInfo{
-			CertFile:      e2e.CertPath,
-			KeyFile:       e2e.PrivateKeyPath,
-			TrustedCAFile: e2e.CaPath,
-		}
-		var err error
-		tcfg, err = tinfo.ClientConfig()
-		require.NoError(t, err)
-	}
-
 	var leadIdx int
-	var leaderID uint64
-	var transferee uint64
+	var leaderID, transferee uint64
 	for i, ep := range epc.EndpointsGRPC() {
 		cli, err := clientv3.New(clientv3.Config{
 			Endpoints:   []string{ep},
 			DialTimeout: 3 * time.Second,
-			TLS:         tcfg,
 		})
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		resp, err := cli.Status(ctx, ep)
-		if err != nil {
-			t.Fatalf("failed to get status from endpoint %s: %v", ep, err)
-		}
 		cancel()
+		require.NoError(t, err)
 		cli.Close()
 
 		if resp.Header.GetMemberId() == resp.Leader {
@@ -105,49 +69,10 @@ func testCtlV3MoveLeader(t *testing.T, cfg e2e.EtcdProcessClusterConfig, envVars
 		cfg:         *e2e.NewConfigNoTLS(),
 		dialTimeout: 7 * time.Second,
 		epc:         epc,
-		envMap:      envVars,
+		envMap:      map[string]string{"ETCDCTL_ENDPOINTS": "something-else-is-set"},
 	}
-
-	tests := []struct {
-		eps       []string
-		expect    string
-		expectErr bool
-	}{
-		{ // request to non-leader
-			[]string{cx.epc.EndpointsGRPC()[(leadIdx+1)%3]},
-			"no leader endpoint given at ",
-			true,
-		},
-		{ // request to leader
-			[]string{cx.epc.EndpointsGRPC()[leadIdx]},
-			fmt.Sprintf("Leadership transferred from %s to %s", types.ID(leaderID), types.ID(transferee)),
-			false,
-		},
-		{ // request to all endpoints
-			cx.epc.EndpointsGRPC(),
-			"Leadership transferred",
-			false,
-		},
-	}
-	for i, tc := range tests {
-		prefix := cx.prefixArgs(tc.eps)
-		cmdArgs := append(prefix, "move-leader", types.ID(transferee).String())
-		err := e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{Value: tc.expect})
-		if tc.expectErr {
-			require.ErrorContains(t, err, tc.expect)
-		} else {
-			require.NoErrorf(t, err, "#%d: %v", i, err)
-		}
-	}
-}
-
-func setupEtcdctlTest(t *testing.T, cfg *e2e.EtcdProcessClusterConfig, quorum bool) *e2e.EtcdProcessCluster {
-	if !quorum {
-		cfg = e2e.ConfigStandalone(*cfg)
-	}
-	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(cfg))
-	if err != nil {
-		t.Fatalf("could not start etcd process cluster (%v)", err)
-	}
-	return epc
+	cmdArgs := append(cx.prefixArgs([]string{epc.EndpointsGRPC()[leadIdx]}), "move-leader", types.ID(transferee).String())
+	require.NoError(t, e2e.SpawnWithExpectWithEnv(cmdArgs, cx.envMap, expect.ExpectedResponse{
+		Value: fmt.Sprintf("Leadership transferred from %s to %s", types.ID(leaderID), types.ID(transferee)),
+	}))
 }

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -352,6 +353,34 @@ func (c integrationClient) Snapshot(ctx context.Context, outFile string) error {
 
 func (c integrationClient) Downgrade(ctx context.Context, action clientv3.DowngradeAction, version string) (*clientv3.DowngradeResponse, error) {
 	return c.Client.Downgrade(ctx, action, version)
+}
+
+func (c integrationClient) MoveLeader(ctx context.Context, transfereeID uint64) error {
+	// MoveLeader requests must be served by the leader, so find the leader's
+	// endpoint first, the same way etcdctl resolves it.
+	var leaderEp string
+	for _, ep := range c.Endpoints() {
+		status, err := c.Client.Status(ctx, ep)
+		if err != nil {
+			return err
+		}
+		if status.Header.GetMemberId() == status.Leader {
+			leaderEp = ep
+			break
+		}
+	}
+	if leaderEp == "" {
+		return fmt.Errorf("no leader endpoint found in %v", c.Endpoints())
+	}
+	// The embedded clientv3.Client sends maintenance RPCs to whichever endpoint
+	// the balancer picked, so dial the leader endpoint explicitly instead.
+	conn, err := c.Dial(leaderEp)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = pb.NewMaintenanceClient(conn).MoveLeader(ctx, &pb.MoveLeaderRequest{TargetID: transfereeID})
+	return err
 }
 
 func (c integrationClient) TimeToLive(ctx context.Context, id clientv3.LeaseID, o config.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error) {

--- a/tests/framework/interfaces/interface.go
+++ b/tests/framework/interfaces/interface.go
@@ -53,6 +53,7 @@ type Client interface {
 	Defragment(context context.Context, opts config.DefragOption) error
 	Snapshot(context context.Context, outFile string) error
 	Downgrade(ctx context.Context, action clientv3.DowngradeAction, version string) (*clientv3.DowngradeResponse, error)
+	MoveLeader(context context.Context, transfereeID uint64) error
 	AlarmList(context context.Context) (*clientv3.AlarmResponse, error)
 	AlarmDisarm(context context.Context, alarmMember *clientv3.AlarmMember) (*clientv3.AlarmResponse, error)
 	Grant(context context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error)


### PR DESCRIPTION
Part of #13637

Migrates the `move-leader` e2e test to the common test framework so it runs in both e2e and integration modes.

**What changed**

- Adds `MoveLeader(ctx, transfereeID uint64) error` to the framework `Client` interface. The e2e side was already implemented by `EtcdctlV3.MoveLeader`; the integration side resolves the leader endpoint via per-endpoint `Status` and dials it explicitly (mirroring how `etcdctl move-leader` resolves the leader), since the embedded `clientv3.Client` would send the RPC to a balancer-picked endpoint and fail on non-leaders.
- Adds `tests/common/move_leader_test.go`: `TestMoveLeader` (leadership actually transfers, verified across all members) and `TestMoveLeaderToNonexistentMember`, both iterating `clusterTestCases()` like the sibling migrations and skipping single-member configs.
- Completes the four skipped `testMoveLeaderWithAuth` stubs in `tests/common/maintenance_auth_test.go`, resolving the in-code `TODO(ahrtr)`; the shared `testMaintenanceOperationWithAuth` helper gains an optional `prepare` hook so the transferee can be resolved before auth is enabled, instead of duplicating the helper.
- Slims `tests/e2e/ctl_v3_move_leader_test.go` down to `TestCtlV3MoveLeaderEnvVars`, which is kept in e2e deliberately: it guards the `ETCDCTL_ENDPOINTS`-shadowing regression fixed by 3fc16608f (this was the only test covering that case) and asserts the exact "Leadership transferred from X to Y" CLI output.

**Deliberately dropped as etcdctl-specific** (following prior migrations that removed whole ctl_v3 e2e files, e.g. 56231c57e, 1f7163f55): the client-side "no leader endpoint given at" assertion — server-side non-leader rejection remains covered by `TestMoveLeaderError` in `tests/integration/v3_leadership_test.go` — and the TLS×env test matrix, which `clusterTestCases()` now covers more systematically.

**Testing**

All new/changed tests pass locally in both modes, and the integration variants passed 8 consecutive runs as a flake check:

```
go test -tags integration ./common -run 'TestMoveLeader'   # incl. 4 auth tests, TLS variants
go test -tags e2e ./common -run 'TestMoveLeader'
go test -tags e2e ./e2e -run 'TestCtlV3MoveLeaderEnvVars'
```
