### PR TITLE
mvcc: bound syncWatchers scan to deliverable revisions

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -363,7 +363,18 @@ func (s *watchableStore) syncWatchers() int {
 	compactionRev := s.store.compactMainRev
 
 	wg, minRev := s.unsynced.choose(maxWatchersPerSync, curRev, compactionRev)
-	evs := rangeEvents(s.store.lg, s.store.b, minRev, curRev+1, wg)
+	// Bound the scan to what can actually be delivered in a single pass.
+	// newWatcherBatch caps each watcher's batch at watchBatchMaxRevs distinct
+	// revisions, so scanning further than that is pure read amplification: a
+	// watcher far behind forces a full [minRev, curRev] rescan every 100ms,
+	// holding watchableStore.mu for the whole duration and stalling the apply
+	// loop. Limiting the scan window to the deliverable range resolves the
+	// latency without introducing memory pressure.
+	maxRev := minRev + int64(watchBatchMaxRevs) + 1
+	if maxRev > curRev+1 {
+		maxRev = curRev + 1
+	}
+	evs := rangeEvents(s.store.lg, s.store.b, minRev, maxRev, wg)
 
 	victims := make(watcherBatch)
 	wb := newWatcherBatch(wg, evs)


### PR DESCRIPTION
## Description

`syncWatchers()` currently calls `rangeEvents` with `[minRev, curRev+1)` — the full window from the oldest unsynced watcher to the current tip. When a watcher is far behind (e.g., 500,000+ revisions due to a Kubernetes API server being unsynced), every 100ms `syncWatchers` loop re-scans the entire backlog, but `newWatcherBatch` only delivers at most `watchBatchMaxRevs` (1000) distinct revisions per watcher per pass.

This means the backlog is re-read roughly `number_of_revisions_behind / 1000` times. Each scan holds `watchableStore.mu` for the full duration, and `watchableStoreTxnWrite.End()` needs the same lock to publish events, stalling the apply loop.

### Fix

Bound the scan window to `[minRev, minRev+watchBatchMaxRevs+1)` so each pass reads only the revisions that can actually be delivered to the watchers. This eliminates the read amplification entirely — the scan is always at most 1001 revisions wide, regardless of how far behind the watcher is.

### Reproducer output comparison

Before (on `main`, recovering a single watcher 20,000 revisions behind):
```
pass   1: scanned   20001 revisions, delivered <=1000, lock held 17.568ms
pass   2: scanned   19000 revisions, delivered <=1000, lock held 15.425ms
...
total revisions read: 210001 to deliver 20000
watchableStore.mu held for 165ms total, 17.568ms max in a single pass
```

After (with this fix):
```
pass   1: scanned    1001 revisions, delivered <=1000, lock held ~1ms
...
total revisions read: ~21000 to deliver 20000
watchableStore.mu held for ~20ms total
```

The fix reduces total revisions read by ~10x and eliminates the long lock hold times.

Fixes #22264