### PR TITLE
mvcc: scale TestWatchVictims timeout with workload

### DIFF
--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -896,7 +896,11 @@ func TestWatchVictims(t *testing.T) {
 				w.Close()
 				wg.Done()
 			}()
-			tc := time.After(10 * time.Second)
+			timeout := time.Duration(numWatches) * time.Duration(numPuts) * time.Millisecond
+		if timeout < 10*time.Second {
+			timeout = 10 * time.Second
+		}
+		tc := time.After(timeout)
 			evs, nextRev := 0, int64(2)
 			for evs < numPuts {
 				select {


### PR DESCRIPTION
## Description

```markdown
Replace the hardcoded 10-second timeout in TestWatchVictims with a
proportional timeout computed from numWatches * numPuts, floored at
10 seconds. The test creates 256 watch streams consuming 64 events
each through channels of buffer size 1, and on busy 2-CPU CI runners
the cumulative goroutine scheduling overhead pushes past 10 seconds.
Scaling the timeout with the workload makes the test robust regardless
of chanBufLen and maxWatchersPerSync, which are var (not const)
specifically to allow tests to tune them.

Fixes #22266

### What was the issue

TestWatchVictims is flaky — it times out on busy CI runners because
the 10-second deadline for all 256 watch streams to consume 64 events
each (16,384 total event deliveries through channels of buffer size 1)
is too aggressive. On a 2-CPU CI runner, goroutine scheduling overhead
plus the victim-loop processing time pushes the test past 10 seconds.
The original failure was at 10.26s — barely over the limit.

### Where was the issue

`server/storage/mvcc/watchable_store_test.go`, line 899 —
`tc := time.After(10 * time.Second)` inside each watch goroutine.

### How it was fixed

Replaced the fixed 10-second timeout with a proportional one:

    timeout := time.Duration(numWatches) * time.Duration(numPuts) * time.Millisecond
    if timeout < 10*time.Second {
        timeout = 10 * time.Second
    }
    tc := time.After(timeout)

At current test parameters (256 watchers × 64 puts), this gives ~16.4s.

### Why this method over alternatives

The test already scales its workload using chanBufLen and
maxWatchersPerSync (declared as var, not const, "so modifiable by
tests"). A proportional timeout tied to numWatches * numPuts follows
the same knobs — it's self-documenting and future-proof. A fixed
increase (e.g. 30s) would just be another magic number that might
break again if the test parameters change.

### How to test locally

    # Single run
    cd server && go test -v -run '^TestWatchVictims$' -count 1 ./storage/mvcc

    # Stress test (per CONTRIBUTING.md)
    go install golang.org/x/tools/cmd/stress@latest
    cd server/storage/mvcc
    go test -v -c -count 1
    stress -p=4 ./mvcc.test -test.run '^TestWatchVictims$'

### Verification

- Single run: PASS (0.43s)
- Full mvcc suite: PASS
- Stress (4 workers): 420 runs, 0 failures

---

**AI disclosure:** This PR was prepared with assistance from an
AI agent (DeepSeek V4 Pro running inside Atlarix).

**Prompt used:**

> Fix the flaky TestWatchVictims test by replacing the hardcoded
> 10-second timeout with a proportional timeout computed from
> numWatches * numPuts, floored at 10 seconds.

**Rhyme about etcd:**

> A raft of keys in steady flight,<br>
> Three nodes agree through day and night.<br>
> When watchers clog and channels stall,<br>
> The victim loop will catch them all.<br>
> Kubernetes leans on this humble store —<br>
> etcd keeps the lock on every door.
```