### PR TITLE
etcdserver: document auth-token expiry caveat in v3election/v3lock

### DIFF
--- a/server/etcdserver/api/v3election/doc.go
+++ b/server/etcdserver/api/v3election/doc.go
@@ -13,4 +13,14 @@
 // limitations under the License.
 
 // Package v3election provides a v3 election service from an etcdserver.
+//
+// Caution: the gRPC Election service is not recommended for general use.
+// Campaign blocks on the server for as long as the caller is not elected
+// leader, reusing the auth token from the original request for internal
+// calls made while it waits. If that token expires before the call
+// returns, Campaign fails with an auth error even though the caller never
+// did anything wrong (see
+// https://github.com/etcd-io/etcd/issues/17623). Prefer the
+// client/v3/concurrency package directly where a client SDK is available;
+// this service mainly exists for clients without a native SDK equivalent.
 package v3election

--- a/server/etcdserver/api/v3lock/doc.go
+++ b/server/etcdserver/api/v3lock/doc.go
@@ -13,4 +13,14 @@
 // limitations under the License.
 
 // Package v3lock provides a v3 locking service from an etcdserver.
+//
+// Caution: the gRPC Lock service is not recommended for general use. Lock
+// blocks on the server for as long as the caller is waiting to acquire the
+// lock, reusing the auth token from the original request for internal
+// calls made while it waits. If that token expires before the call
+// returns, Lock fails with an auth error even though the caller never did
+// anything wrong (see https://github.com/etcd-io/etcd/issues/17623).
+// Prefer the client/v3/concurrency package directly where a client SDK is
+// available; this service mainly exists for clients without a native SDK
+// equivalent.
 package v3lock


### PR DESCRIPTION
## Summary

The gRPC `Election.Campaign` (`server/etcdserver/api/v3election`) and `Lock.Lock` (`server/etcdserver/api/v3lock`) services both create an in-process client session scoped to the incoming request's context and then block server-side until the call resolves (election won, or lock acquired). Internal calls made while blocked reuse the auth token from that original context. If the token expires before the call returns, the call fails with an auth error even though the caller did nothing wrong.

This was raised in #17623 and the related #17502, where a maintainer proposed documenting the limitation and recommending `client/v3/concurrency` directly for Go users, since the gRPC service is mainly useful for clients without a native SDK equivalent.

This PR documents that limitation in the package doc comments for both `v3election` and `v3lock`.

## Scope

This is intentionally documentation only:
- Not touching the `.proto` files. Regenerating `.pb.go` from proto comments needs `protoc v3.20.3` per CONTRIBUTING.md, and this environment only has `protoc 25.1` available, so regenerating here would risk unrelated diffs across generated files. Happy to follow up with the `.proto` comments if a maintainer can verify with the pinned toolchain.
- Not attempting a code-level fix (for example, refreshing the auth token for long-blocked internal calls). That's a larger design change flagged as the harder alternative in the issue discussion, out of scope here.

Updates #17623

## Test plan

- `go build ./server/etcdserver/api/v3election/... ./server/etcdserver/api/v3lock/...`
- `go vet ./server/etcdserver/api/v3election/... ./server/etcdserver/api/v3lock/...`
- `go test ./server/etcdserver/api/v3election/... ./server/etcdserver/api/v3lock/...`
- `gofmt -l` on both changed files (clean)