### PR TITLE
tests: complete snapshot auth tests in common framework

### DIFF
--- a/tests/common/maintenance_auth_test.go
+++ b/tests/common/maintenance_auth_test.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -145,9 +146,10 @@ func TestSnapshotWithUserAuth(t *testing.T) {
 	testSnapshotWithAuth(t, false, true, WithAuth("user0", "user0Pass"))
 }
 
-func testSnapshotWithAuth(t *testing.T, _expectConnectionError, _expectOperationError bool, _opts ...config.ClientOption) {
-	// TODO(ahrtr): finish this after we added interface methods `Snapshot` into `Client`
-	t.Skip()
+func testSnapshotWithAuth(t *testing.T, expectConnectionError, expectOperationError bool, opts ...config.ClientOption) {
+	testMaintenanceOperationWithAuth(t, expectConnectionError, expectOperationError, func(ctx context.Context, cc intf.Client) error {
+		return cc.Snapshot(ctx, filepath.Join(t.TempDir(), "snapshot.db"))
+	}, opts...)
 }
 
 /*

--- a/tests/framework/e2e/etcdctl.go
+++ b/tests/framework/e2e/etcdctl.go
@@ -92,6 +92,14 @@ func WithDialTimeout(tio time.Duration) config.ClientOption {
 	}
 }
 
+func (ctl *EtcdctlV3) Snapshot(ctx context.Context, outFile string) error {
+	// etcdctl requires the snapshot to be requested from exactly one node.
+	singleEndpointCtl := *ctl
+	singleEndpointCtl.endpoints = []string{ctl.endpoints[0]}
+	_, err := SpawnWithExpectLines(ctx, singleEndpointCtl.cmdArgs("snapshot", "save", outFile), nil, expect.ExpectedResponse{Value: "Snapshot saved at"})
+	return err
+}
+
 func (ctl *EtcdctlV3) DowngradeEnable(ctx context.Context, version string) error {
 	_, err := SpawnWithExpectLines(ctx, ctl.cmdArgs("downgrade", "enable", version), nil, expect.ExpectedResponse{Value: "Downgrade enable success"})
 	return err

--- a/tests/framework/integration/integration.go
+++ b/tests/framework/integration/integration.go
@@ -17,6 +17,8 @@ package integration
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -331,6 +333,21 @@ func (c integrationClient) Defragment(ctx context.Context, o config.DefragOption
 		}
 	}
 	return nil
+}
+
+func (c integrationClient) Snapshot(ctx context.Context, outFile string) error {
+	rc, err := c.Client.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	f, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, rc)
+	return err
 }
 
 func (c integrationClient) TimeToLive(ctx context.Context, id clientv3.LeaseID, o config.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error) {

--- a/tests/framework/interfaces/interface.go
+++ b/tests/framework/interfaces/interface.go
@@ -51,6 +51,7 @@ type Client interface {
 	HashKV(context context.Context, rev int64) ([]*clientv3.HashKVResponse, error)
 	Health(context context.Context) error
 	Defragment(context context.Context, opts config.DefragOption) error
+	Snapshot(context context.Context, outFile string) error
 	AlarmList(context context.Context) (*clientv3.AlarmResponse, error)
 	AlarmDisarm(context context.Context, alarmMember *clientv3.AlarmMember) (*clientv3.AlarmResponse, error)
 	Grant(context context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error)


### PR DESCRIPTION
Completes the four skipped `testSnapshotWithAuth` tests in `tests/common/maintenance_auth_test.go`, resolving the in-code `TODO(ahrtr): finish this after we added interface methods Snapshot into Client`.

**What changed**

- Adds `Snapshot(ctx, outFile string) error` to the framework `Client` interface.
- e2e implementation runs `etcdctl snapshot save`, pinned to a single endpoint because etcdctl rejects snapshot requests against multiple endpoints.
- Integration implementation streams `clientv3.Maintenance.Snapshot` to the output file.
- Un-skips the four auth tests through the existing `testMaintenanceOperationWithAuth` harness.

The auth expectations exercised here (no-auth and non-root fail, root succeeds) are enforced server-side by `authMaintenanceServer.Snapshot` → `isPermitted` (AuthAdmin) in `server/etcdserver/api/v3rpc/maintenance.go`.

**Testing**

All four tests pass in both modes, and the first e2e run caught (and this PR fixes) the multi-endpoint issue above:

```
go test -tags integration ./common -run 'TestSnapshotWith'   # 4/4, repeated 3x
go test -tags e2e ./common -run 'TestSnapshotWith'           # 4/4
```

Note: #22262 (move-leader migration) touches the same auth test file in adjacent hunks; whichever lands second gets a trivial rebase.
