### PR TITLE
docs: clarify bug report isolation guidance

### DIFF
--- a/Documentation/contributor-guide/reporting_bugs.md
+++ b/Documentation/contributor-guide/reporting_bugs.md
@@ -8,7 +8,7 @@ To make the bug report accurate and easy to understand, please try to create bug
 
 - Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please include the steps that might lead to the problem. If possible, please attach the affected etcd data dir and stack trace to the bug report.
 
-- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on etcd is out of scope, but we are happy to provide guidance in the right direction or help with using etcd itself.
+- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. Too many dependencies can significantly slow down debugging and resolution. Debugging external systems that rely on etcd is out of scope, but we are happy to provide guidance in the right direction or help with using etcd itself.
 
 - Unique. Do not duplicate existing bug reports.
 


### PR DESCRIPTION
Documentation now explains why reducing dependencies helps debugging.

Assisted-by: OpenAI GPT-5