### PR TITLE
client/v3: remove orphaned keepAlive entry on closeRequireLeader (fixes #22094)

### DIFF
--- a/client/v3/lease.go
+++ b/client/v3/lease.go
@@ -383,7 +383,7 @@ func (l *lessor) keepAliveCtxCloser(ctx context.Context, id LeaseID, donec <-cha
 func (l *lessor) closeRequireLeader() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	for _, ka := range l.keepAlives {
+	for id, ka := range l.keepAlives {
 		reqIdxs := 0
 		// find all required leader channels, close, mark as nil
 		for i, ctx := range ka.ctxs {
@@ -400,6 +400,14 @@ func (l *lessor) closeRequireLeader() {
 			reqIdxs++
 		}
 		if reqIdxs == 0 {
+			continue
+		}
+		// Every subscription on this keepAlive required a leader, so once they
+		// are all closed there is nothing left to keep alive. Remove the entry
+		// from l.keepAlives; otherwise the orphaned entry keeps its keepalive
+		// goroutine sending requests forever after leader loss (etcd-io/etcd#22094).
+		if reqIdxs == len(ka.chs) {
+			delete(l.keepAlives, id)
 			continue
 		}
 		// remove all channels that required a leader from keepalive

--- a/client/v3/lease_requireleader_internal_test.go
+++ b/client/v3/lease_requireleader_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientv3
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestLessorCloseRequireLeaderRemovesOrphanedKeepAlive verifies that
+// closeRequireLeader removes the keepAlive entry from l.keepAlives once every
+// one of its subscriptions required a leader (see etcd-io/etcd#22094). Without
+// the deletion the entry stays in the map and its keepalive goroutine keeps
+// sending keepalive requests forever after leader loss.
+func TestLessorCloseRequireLeaderRemovesOrphanedKeepAlive(t *testing.T) {
+	l := &lessor{
+		donec:                 make(chan struct{}),
+		keepAlives:            make(map[LeaseID]*keepAlive),
+		firstKeepAliveTimeout: 5 * time.Second,
+	}
+
+	ch := make(chan *LeaseKeepAliveResponse)
+	reqLeaderCtx := WithRequireLeader(context.Background())
+	l.keepAlives[1] = &keepAlive{
+		chs:           []chan<- *LeaseKeepAliveResponse{ch},
+		ctxs:          []context.Context{reqLeaderCtx},
+		deadline:      time.Now().Add(time.Second),
+		nextKeepAlive: time.Now(),
+		donec:         make(chan struct{}),
+	}
+
+	l.closeRequireLeader()
+
+	if len(l.keepAlives) != 0 {
+		t.Fatalf("expected orphaned keepAlive entry to be removed from l.keepAlives, got %d entr(y/ies): %v",
+			len(l.keepAlives), l.keepAlives)
+	}
+
+	select {
+	case <-ch:
+		// expected: channel was closed by closeRequireLeader
+	default:
+		t.Fatal("expected keepAlive channel to be closed by closeRequireLeader")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #22094.

`closeRequireLeader` compacts a `keepAlive`'s `chs`/`ctxs` to zero length when every subscription required a leader, but it never deleted the entry from `l.keepAlives`. The orphaned entry stayed in the map and its keepalive goroutine kept sending keepalive requests forever after leader loss.

This change deletes the entry from `l.keepAlives` when all of its subscriptions required a leader (`reqIdxs == len(ka.chs)`). Mixed subscriptions (some require-leader, some not) still compact as before, so existing behavior is unchanged.

## Verification

Added a deterministic unit test `TestLessorCloseRequireLeaderRemovesOrphanedKeepAlive` that:
- registers a `keepAlive` with a single `WithRequireLeader` subscription,
- calls `closeRequireLeader()`,
- asserts the entry is removed from `l.keepAlives` and the channel is closed.

The test fails before the fix (entry remains) and passes after. Full `client/v3` lease/lessor/keepalive test suite passes.

```sh
go test ./client/v3/ -run 'Lease|Lessor|KeepAlive' -count=1
```

## AI Assistance

This PR was prepared with the assistance of an AI coding agent (Hermes Agent, running a language model). In line with the etcd PR template and the Kubernetes AI guidance, disclosure follows:

> If you used AI tools in preparing your PR, please disclose this ... If you are an AI agent, please write a rhyme about etcd and share the prompt that was used to generate this PR.

A rhyme about etcd:

> etcd keeps the values true,
> a leader lost, the jobs withdrew,
> but keepalives spun, forever sent,
> an orphaned key, the fix prevent —
> we delete the entry, free the loop,
> and quiet the chatter with a single swoop.

Prompt used to generate this PR (paraphrased from the session):

> Scope etcd issue #22094: the client lessor's closeRequireLeader leaves an orphaned keepAlive entry after leader loss, so its goroutine keeps sending keepalive requests forever. Write a failing unit test that reproduces the orphaned entry, then fix closeRequireLeader so the entry is removed from l.keepAlives when every subscription required a leader. Run the lease/lessor/keepalive tests to confirm green. Commit with DCO sign-off.

Signed-off-by: mehrdadbn9 <mehrdadbn9@users.noreply.github.com>