### PR TITLE
mvcc: remove compacted watchers from the unsynced group when capped

### DIFF
--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -544,6 +544,59 @@ func TestWatchNoEventLossOnCompact(t *testing.T) {
 	}
 }
 
+func TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped(t *testing.T) {
+	oldMaxWatchersPerSync := maxWatchersPerSync
+	defer func() { maxWatchersPerSync = oldMaxWatchersPerSync }()
+
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := newWatchableStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})
+	defer cleanup(s, b)
+
+	testKey, testValue := []byte("foo"), []byte("bar")
+	maxRev := 10
+	compactRev := int64(5)
+	for i := 0; i < maxRev; i++ {
+		s.Put(testKey, testValue, lease.NoLease)
+	}
+	_, err := s.Compact(traceutil.TODO(), compactRev)
+	require.NoError(t, err)
+
+	w := s.NewWatchStream()
+	defer w.Close()
+
+	// Register more watchers than a single sync round may select, so that
+	// choose() takes its capped branch. All of them start below compactRev.
+	const watcherCount = 2
+	maxWatchersPerSync = watcherCount
+	for id := WatchID(0); id < watcherCount; id++ {
+		_, err = w.Watch(t.Context(), id, testKey, nil, 1)
+		require.NoError(t, err)
+	}
+	require.Equal(t, watcherCount, s.unsynced.size())
+
+	s.syncWatchers()
+
+	compacted := make(map[WatchID]int)
+	for i := 0; i < watcherCount; i++ {
+		resp := <-w.Chan()
+		require.Equal(t, compactRev, resp.CompactRevision)
+		compacted[resp.WatchID]++
+	}
+	require.Lenf(t, compacted, watcherCount, "each watcher should be sent exactly one compaction response")
+
+	// A watcher that was told its start revision is compacted must not be
+	// left behind in the unsynced group.
+	require.Equalf(t, 0, s.unsynced.size(), "compacted watchers should be removed from the unsynced group")
+
+	// And it must not be sent the same compaction response again.
+	s.syncWatchers()
+	select {
+	case resp := <-w.Chan():
+		t.Fatalf("unexpected duplicate response for watcher %d: %+v", resp.WatchID, resp)
+	default:
+	}
+}
+
 func TestWatchFutureRev(t *testing.T) {
 	b, _ := betesting.NewDefaultTmpBackend(t)
 	s := New(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{})

--- a/server/storage/mvcc/watcher_group.go
+++ b/server/storage/mvcc/watcher_group.go
@@ -228,14 +228,26 @@ func (wg *watcherGroup) choose(maxWatchers int, curRev, compactRev int64) (*watc
 		return wg, wg.chooseAll(curRev, compactRev)
 	}
 	ret := newWatcherGroup()
+	selected := make([]*watcher, 0, maxWatchers)
 	for w := range wg.watchers {
 		if maxWatchers <= 0 {
 			break
 		}
 		maxWatchers--
 		ret.add(w)
+		selected = append(selected, w)
 	}
-	return &ret, ret.chooseAll(curRev, compactRev)
+	minRev := ret.chooseAll(curRev, compactRev)
+	// chooseAll retires watchers whose minimum revision was compacted away,
+	// but here it only sees the temporary group. Retire them from wg as well.
+	// Otherwise they stay in the unsynced group forever and are sent a
+	// duplicate compaction response on every resync.
+	for _, w := range selected {
+		if _, ok := ret.watchers[w]; !ok {
+			wg.delete(w)
+		}
+	}
+	return &ret, minRev
 }
 
 func (wg *watcherGroup) chooseAll(curRev, compactRev int64) int64 {


### PR DESCRIPTION
Fixes #22294

### What

Track the watchers moved into the temporary group in `watcherGroup.choose`, and after
`chooseAll` runs, delete from the source group any watcher that `chooseAll` retired.

```go
	ret := newWatcherGroup()
	selected := make([]*watcher, 0, maxWatchers)
	for w := range wg.watchers {
		if maxWatchers <= 0 {
			break
		}
		maxWatchers--
		ret.add(w)
		selected = append(selected, w)
	}
	minRev := ret.chooseAll(curRev, compactRev)
	// chooseAll retires watchers whose minimum revision was compacted away,
	// but here it only sees the temporary group. Retire them from wg as well.
	// Otherwise they stay in the unsynced group forever and are sent a
	// duplicate compaction response on every resync.
	for _, w := range selected {
		if _, ok := ret.watchers[w]; !ok {
			wg.delete(w)
		}
	}
	return &ret, minRev
```

The uncapped branch is unchanged, since there `wg` and the group `chooseAll` operates on are the
same object.

### Why this shape

`chooseAll` also leaves a watcher in place on purpose when the send fails because the channel is
full, so that the next resync retries. Comparing membership after the call, rather than
duplicating the compaction predicate, keeps that retry behaviour intact without restating
`chooseAll`'s logic in the caller.

### Test

`TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped` registers `watcherCount` watchers all
starting below the compaction revision, sets `maxWatchersPerSync` to exactly `watcherCount` so
`choose` takes the capped branch, runs one `syncWatchers`, and asserts three things: each watcher
got exactly one compaction response, the unsynced group is empty afterwards, and a second
`syncWatchers` produces no further responses.

It uses `newWatchableStore` rather than `New` so the background resync loop does not run
concurrently with the assertions.

### Test evidence

Run on Linux, `golang:1.26` container, in a copy of the tree.

Without the fix, with the test present:

```
    watchable_store_test.go:589:
        	Error Trace:	/t/server/storage/mvcc/watchable_store_test.go:589
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 2
        	Test:       	TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped
        	Messages:   	compacted watchers should be removed from the unsynced group
--- FAIL: TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped (0.01s)
FAIL
FAIL	go.etcd.io/etcd/server/v3/storage/mvcc	0.020s
```

Both watchers received their compaction response and both were still in the unsynced group.

With the fix:

```
=== RUN   TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped
--- PASS: TestWatchCompactedWatcherRemovedFromUnsyncedWhenCapped (0.03s)
PASS
ok  	go.etcd.io/etcd/server/v3/storage/mvcc	0.043s
```

Whole package, with and without the race detector:

```
--- mvcc (plain) ---
ok  	go.etcd.io/etcd/server/v3/storage/mvcc	12.311s
--- mvcc (race) ---
ok  	go.etcd.io/etcd/server/v3/storage/mvcc	16.427s
```

Full `server` module unit suite, `go test -count=1 -timeout 30m ./...`: no failures.

Lint:

```
### LINT ###
0 issues.
'lint' PASSED and completed at Sat Aug 15 14:35:24 UTC 2026
SUCCESS
```

### Checklist

- [x] Test fails without the fix and passes with it, both states shown above
- [x] `make verify-lint` clean
- [x] Full `server` module unit tests pass
- [x] DCO sign-off on the commit
- [x] Issue filed and referenced (#22294)
- [x] Rebased on current `main`
- [ ] Backport consideration: `choose` is byte-identical on `release-3.7` and `release-3.6`
      (`server/storage/mvcc/watcher_group.go`) and on `release-3.5` (`server/mvcc/watcher_group.go`),
      verified against the GitHub contents API. Worth asking whether cherry-picks are wanted.

---

This PR was written in part with the assistance of generative AI. Every change was reviewed, built and tested before submitting, and no AI co-author or `assisted-by` trailers are used, per https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance
