### PR TITLE
mvcc: avoid a non-positive interval when resetting the watch resync ticker

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -239,12 +239,7 @@ func (s *watchableStore) syncWatchersLoop() {
 		}
 		syncDuration := time.Since(st)
 
-		delayTicker.Reset(watchResyncPeriod)
-		// more work pending?
-		if unsyncedWatchers != 0 && lastUnsyncedWatchers > unsyncedWatchers {
-			// be fair to other store operations by yielding time taken
-			delayTicker.Reset(syncDuration)
-		}
+		delayTicker.Reset(resyncDelay(syncDuration, lastUnsyncedWatchers, unsyncedWatchers))
 
 		select {
 		case <-delayTicker.C:
@@ -252,6 +247,22 @@ func (s *watchableStore) syncWatchersLoop() {
 			return
 		}
 	}
+}
+
+// resyncDelay returns how long syncWatchersLoop waits before calling
+// syncWatchers again. When the last pass made progress but watchers are still
+// unsynced, it yields the time that pass took so that store operations are not
+// starved. Otherwise it falls back to watchResyncPeriod.
+//
+// The returned duration is always positive. time.Ticker.Reset panics on a
+// non-positive interval, and syncDuration can be zero on platforms whose
+// monotonic clock resolution is coarser than a sync pass takes.
+func resyncDelay(syncDuration time.Duration, lastUnsyncedWatchers, unsyncedWatchers int) time.Duration {
+	// more work pending?
+	if unsyncedWatchers != 0 && lastUnsyncedWatchers > unsyncedWatchers && syncDuration > 0 {
+		return syncDuration
+	}
+	return watchResyncPeriod
 }
 
 // syncVictimsLoop tries to write precomputed watcher responses to

--- a/server/storage/mvcc/watchable_store_test.go
+++ b/server/storage/mvcc/watchable_store_test.go
@@ -987,3 +987,59 @@ func TestStressWatchCancelClose(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestResyncDelay verifies that the delay syncWatchersLoop feeds to
+// time.Ticker.Reset is always positive. A zero syncDuration is reachable on
+// platforms whose monotonic clock resolution is coarser than a sync pass
+// takes, and Ticker.Reset panics on a non-positive interval.
+func TestResyncDelay(t *testing.T) {
+	tests := []struct {
+		name                 string
+		syncDuration         time.Duration
+		lastUnsyncedWatchers int
+		unsyncedWatchers     int
+		want                 time.Duration
+	}{
+		{
+			name:                 "no progress falls back to resync period",
+			syncDuration:         5 * time.Millisecond,
+			lastUnsyncedWatchers: 3,
+			unsyncedWatchers:     3,
+			want:                 watchResyncPeriod,
+		},
+		{
+			name:                 "all watchers synced falls back to resync period",
+			syncDuration:         5 * time.Millisecond,
+			lastUnsyncedWatchers: 3,
+			unsyncedWatchers:     0,
+			want:                 watchResyncPeriod,
+		},
+		{
+			name:                 "progress with work pending yields time taken",
+			syncDuration:         5 * time.Millisecond,
+			lastUnsyncedWatchers: 3,
+			unsyncedWatchers:     1,
+			want:                 5 * time.Millisecond,
+		},
+		{
+			name:                 "progress with unmeasurable sync duration falls back to resync period",
+			syncDuration:         0,
+			lastUnsyncedWatchers: 3,
+			unsyncedWatchers:     1,
+			want:                 watchResyncPeriod,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resyncDelay(tt.syncDuration, tt.lastUnsyncedWatchers, tt.unsyncedWatchers)
+			require.Equal(t, tt.want, got)
+			require.Positivef(t, got, "delay must be positive, time.Ticker.Reset panics otherwise")
+
+			// Reset really does panic on a non-positive interval, so exercise it.
+			ticker := time.NewTicker(watchResyncPeriod)
+			defer ticker.Stop()
+			require.NotPanics(t, func() { ticker.Reset(got) })
+		})
+	}
+}


### PR DESCRIPTION
Fixes #22296

### What

Extract the delay computation from `syncWatchersLoop` into a small helper and make it fall back
to `watchResyncPeriod` when the measured duration is not positive.

```go
// resyncDelay returns how long syncWatchersLoop waits before calling
// syncWatchers again. When the last pass made progress but watchers are still
// unsynced, it yields the time that pass took so that store operations are not
// starved. Otherwise it falls back to watchResyncPeriod.
//
// The returned duration is always positive. time.Ticker.Reset panics on a
// non-positive interval, and syncDuration can be zero on platforms whose
// monotonic clock resolution is coarser than a sync pass takes.
func resyncDelay(syncDuration time.Duration, lastUnsyncedWatchers, unsyncedWatchers int) time.Duration {
	// more work pending?
	if unsyncedWatchers != 0 && lastUnsyncedWatchers > unsyncedWatchers && syncDuration > 0 {
		return syncDuration
	}
	return watchResyncPeriod
}
```

The loop body becomes a single `delayTicker.Reset(resyncDelay(...))`, replacing the previous
reset-then-maybe-reset-again pair.

### Behaviour change

Only for the case that currently panics. Whenever `syncDuration > 0`, the returned delay is
identical to today. When it measures as zero, the loop waits `watchResyncPeriod` instead of
crashing.

I considered clamping to a small non-zero minimum instead, so that a very fast pass still loops
promptly rather than waiting the full 100ms. I did not do that because it introduces a new tuning
constant, and a pass that completes in under the clock resolution had almost nothing to do. Happy
to switch if reviewers prefer it.

### Test

`TestResyncDelay` is a table test over the four combinations that matter, including the
zero-duration case. Each case asserts the expected delay, asserts it is positive, and calls
`time.Ticker.Reset` with the value so that the actual panic condition is exercised rather than
only approximated.

### Test evidence

Run on Linux, `golang:1.26` container. The test is platform independent, so it reproduces the
bug on Linux too even though the panic itself only fires on Windows.

Without the fix (guard removed, helper and test present):

```
=== RUN   TestResyncDelay
=== RUN   TestResyncDelay/progress_with_unmeasurable_sync_duration_falls_back_to_resync_period
    watchable_store_test.go:1036:
        	Error:      	Not equal:
        	            	expected: 100ms
        	            	actual  : 0s
        	Test:       	TestResyncDelay/progress_with_unmeasurable_sync_duration_falls_back_to_resync_period
--- FAIL: TestResyncDelay (0.00s)
    --- PASS: TestResyncDelay/no_progress_falls_back_to_resync_period (0.00s)
    --- PASS: TestResyncDelay/all_watchers_synced_falls_back_to_resync_period (0.00s)
    --- PASS: TestResyncDelay/progress_with_work_pending_yields_time_taken (0.00s)
    --- FAIL: TestResyncDelay/progress_with_unmeasurable_sync_duration_falls_back_to_resync_period (0.00s)
FAIL
FAIL	go.etcd.io/etcd/server/v3/storage/mvcc	0.014s
```

With the fix:

```
=== RUN   TestResyncDelay
--- PASS: TestResyncDelay (0.00s)
    --- PASS: TestResyncDelay/no_progress_falls_back_to_resync_period (0.00s)
    --- PASS: TestResyncDelay/all_watchers_synced_falls_back_to_resync_period (0.00s)
    --- PASS: TestResyncDelay/progress_with_work_pending_yields_time_taken (0.00s)
    --- PASS: TestResyncDelay/progress_with_unmeasurable_sync_duration_falls_back_to_resync_period (0.00s)
PASS
ok  	go.etcd.io/etcd/server/v3/storage/mvcc	0.012s
```

Original panic, on Windows 11 native, before and after the fix, 5 runs each of
`go test -count=1 -run "TestWatch" ./storage/mvcc/`:

```
before:  run 1: PANIC   run 2: PANIC   run 3: PANIC   run 4: PANIC   run 5: PANIC
after:   run 1: no panic  run 2: no panic  run 3: no panic  run 4: no panic  run 5: no panic
```

Full `server` module unit suite on Linux: no failures.

Lint:

```
### LINT: fix-watch-resync-ticker-panic ###
0 issues.
'lint' PASSED and completed at Sat Aug 15 14:31:31 UTC 2026
SUCCESS
```

### Not fixed here

While reproducing this I hit two other Windows-only failures in the same package. Both look
unrelated and are left alone:

- `TestStoreRev` fails in cleanup with `TempDir RemoveAll cleanup: unlinkat ...: The process
  cannot access the file because it is being used by another process`, which is bbolt's mmap
  holding a handle open.
- `TestWatchVictims` times out. There is already an open PR, #22269, "mvcc: deflake
  TestWatchVictims with synctime".

### Checklist

- [x] Test fails without the fix and passes with it, both states shown above
- [x] `make verify-lint` clean
- [x] Full `server` module unit tests pass on Linux
- [x] Original panic no longer reproduces on Windows
- [x] DCO sign-off on the commit
- [x] Issue filed and referenced (#22296)
- [x] Rebased on current `main`

### A note on the test, so a reviewer is not misled

`TestResyncDelay` covers `resyncDelay` directly. It cannot be run against
unpatched `main` to show it failing, because the function it tests is the one
this change introduces: reverting `watchable_store.go` alone leaves the test
unable to compile. What is demonstrable without the patch is the mechanism, and
both halves of it were measured on this machine (Windows 11, go1.26.6):

```
time.Since(time.Now()) == 0 in 199999 of 200000 samples
Ticker.Reset(0) panics: non-positive interval for Ticker.Reset
```

So `syncDuration` is zero on this platform essentially whenever a sync pass is
shorter than the clock's resolution, and a zero interval is exactly what
`Ticker.Reset` refuses. The guard is `syncDuration > 0`.

---

This PR was written in part with the assistance of generative AI. Every change was reviewed, built and tested before submitting, and no AI co-author or `assisted-by` trailers are used, per https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance
