### PR TITLE
storage/mvcc: bound the syncWatchers scan to watchBatchMaxRevs

### DIFF
--- a/server/storage/mvcc/watchable_store.go
+++ b/server/storage/mvcc/watchable_store.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -362,8 +363,31 @@ func (s *watchableStore) syncWatchers() int {
 	curRev := s.store.currentRev
 	compactionRev := s.store.compactMainRev
 
-	wg, minRev := s.unsynced.choose(maxWatchersPerSync, curRev, compactionRev)
-	evs := rangeEvents(s.store.lg, s.store.b, minRev, curRev+1, wg)
+	wg, _ := s.unsynced.choose(maxWatchersPerSync, curRev, compactionRev)
+
+	// Scan at most watchBatchMaxRevs revisions per pass, the same bound already applied to how
+	// many revisions are sent per pass, so unsent revisions aren't scanned. Watchers are grouped
+	// into cohorts and each cohort gets its own scan.
+	for _, c := range cohortsByRevision(wg, compactionRev) {
+		maxScanRev := curRev + 1
+		if c.minRev <= curRev && curRev-c.minRev > int64(watchBatchMaxRevs) {
+			maxScanRev = c.minRev + int64(watchBatchMaxRevs) + 1
+		}
+		s.syncWatcherCohort(c.wg, c.minRev, maxScanRev, curRev, compactionRev)
+	}
+
+	vsz := 0
+	for _, v := range s.victims {
+		vsz += len(v)
+	}
+	slowWatcherGauge.Set(float64(s.unsynced.size() + vsz))
+
+	return s.unsynced.size()
+}
+
+func (s *watchableStore) syncWatcherCohort(wg *watcherGroup, minRev, maxScanRev, curRev, compactionRev int64) {
+	reachedCurRev := maxScanRev == curRev+1
+	evs := rangeEvents(s.store.lg, s.store.b, minRev, maxScanRev, wg)
 
 	victims := make(watcherBatch)
 	wb := newWatcherBatch(wg, evs)
@@ -373,13 +397,15 @@ func (s *watchableStore) syncWatchers() int {
 			// Next retry of syncWatchers would try to resend the compacted watch response to w.ch
 			continue
 		}
-		w.minRev = max(curRev+1, w.minRev)
+		w.minRev = max(maxScanRev, w.minRev)
 
 		eb, ok := wb[w]
 		if !ok {
-			// bring un-notified watcher to synced
-			s.synced.add(w)
-			s.unsynced.delete(w)
+			if reachedCurRev {
+				// bring un-notified watcher to synced
+				s.synced.add(w)
+				s.unsynced.delete(w)
+			}
 			continue
 		}
 
@@ -396,7 +422,7 @@ func (s *watchableStore) syncWatchers() int {
 		if w.victim {
 			victims[w] = eb
 		} else {
-			if eb.moreRev != 0 {
+			if eb.moreRev != 0 || !reachedCurRev {
 				// stay unsynced; more to read
 				continue
 			}
@@ -405,14 +431,39 @@ func (s *watchableStore) syncWatchers() int {
 		s.unsynced.delete(w)
 	}
 	s.addVictim(victims)
+}
 
-	vsz := 0
-	for _, v := range s.victims {
-		vsz += len(v)
+// revCohort is a group of unsynced watchers whose minRevs fall within one
+// watchBatchMaxRevs-wide window starting at minRev.
+type revCohort struct {
+	minRev int64
+	wg     *watcherGroup
+}
+
+// cohortsByRevision groups wg's watchers into windows of at most watchBatchMaxRevs revisions,
+// sorted by minRev so each window covers a contiguous run of watchers.
+func cohortsByRevision(wg *watcherGroup, compactionRev int64) []revCohort {
+	sorted := make([]*watcher, 0, len(wg.watchers))
+	for w := range wg.watchers {
+		// Skip compacted watchers since they cannot be recovered.
+		if w.minRev < compactionRev {
+			continue
+		}
+		sorted = append(sorted, w)
 	}
-	slowWatcherGauge.Set(float64(s.unsynced.size() + vsz))
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].minRev < sorted[j].minRev })
 
-	return s.unsynced.size()
+	var cohorts []revCohort
+	for _, w := range sorted {
+		if n := len(cohorts); n > 0 && w.minRev-cohorts[n-1].minRev <= int64(watchBatchMaxRevs) {
+			cohorts[n-1].wg.add(w)
+			continue
+		}
+		g := newWatcherGroup()
+		g.add(w)
+		cohorts = append(cohorts, revCohort{minRev: w.minRev, wg: &g})
+	}
+	return cohorts
 }
 
 // rangeEvents returns events in range [minRev, maxRev).

--- a/server/storage/mvcc/watchable_store_bench_test.go
+++ b/server/storage/mvcc/watchable_store_bench_test.go
@@ -15,6 +15,7 @@
 package mvcc
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -196,5 +197,43 @@ func BenchmarkWatchableStoreSyncedCancel(b *testing.B) {
 		if err := w.Cancel(watchIDs[idx]); err != nil {
 			b.Error(err)
 		}
+	}
+}
+
+// BenchmarkWatchableStoreSyncWatchersDeepBacklog measures one syncWatchers pass for a watcher far
+// behind the current revision. The per-pass cost is what the watchable-store lock is held for, and
+// what the apply path waits on.
+func BenchmarkWatchableStoreSyncWatchersDeepBacklog(b *testing.B) {
+	for _, backlog := range []int{10000, 100000} {
+		b.Run(fmt.Sprintf("backlog=%d", backlog), func(b *testing.B) {
+			be, _ := betesting.NewDefaultTmpBackend(b)
+			s := &watchableStore{
+				store:    NewStore(zaptest.NewLogger(b), be, &lease.FakeLessor{}, StoreConfig{}),
+				unsynced: newWatcherGroup(),
+				synced:   newWatcherGroup(),
+				stopc:    make(chan struct{}),
+			}
+			defer cleanup(s, be)
+
+			for i := 0; i < backlog; i++ {
+				s.Put([]byte(fmt.Sprintf("k%d", i%10)), []byte("v"), lease.NoLease)
+			}
+			ws := s.NewWatchStream()
+			defer ws.Close()
+			if _, err := ws.Watch(b.Context(), 0, []byte("k0"), []byte("l"), 1); err != nil {
+				b.Fatal(err)
+			}
+			w := ws.(*watchStream).watchers[0]
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				w.minRev = 1 // same starting depth every iteration
+				s.syncWatchers()
+				for len(ws.Chan()) > 0 {
+					<-ws.Chan()
+				}
+			}
+		})
 	}
 }

--- a/server/storage/mvcc/watchable_store_syncwatchers_test.go
+++ b/server/storage/mvcc/watchable_store_syncwatchers_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mvcc
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"go.etcd.io/etcd/server/v3/lease"
+	betesting "go.etcd.io/etcd/server/v3/storage/backend/testing"
+)
+
+// newSyncWatchersStore builds a watchableStore with empty watcher groups, so a test controls
+// unsynced membership and drives syncWatchers by hand rather than racing the background loop.
+func newSyncWatchersStore(t *testing.T) *watchableStore {
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := &watchableStore{
+		store:    NewStore(zaptest.NewLogger(t), b, &lease.FakeLessor{}, StoreConfig{}),
+		unsynced: newWatcherGroup(),
+		synced:   newWatcherGroup(),
+		// Close() closes stopc and waits on wg; no loops are started, so wg is already done.
+		stopc: make(chan struct{}),
+	}
+	t.Cleanup(func() { cleanup(s, b) })
+	return s
+}
+
+// putRevisions writes n revisions over keyCount keys, so the revision window grows while the key
+// count stays constant.
+func putRevisions(s *watchableStore, keyCount, n int) {
+	for i := 0; i < n; i++ {
+		s.Put([]byte(fmt.Sprintf("k%d", i%keyCount)), []byte("v"), lease.NoLease)
+	}
+}
+
+func drainModRevs(ws *watchStream) []int64 {
+	var out []int64
+	for {
+		select {
+		case wr := <-ws.ch:
+			for _, e := range wr.Events {
+				out = append(out, e.Kv.ModRevision)
+			}
+		default:
+			return out
+		}
+	}
+}
+
+// A watcher behind by more than watchBatchMaxRevs is caught up over several passes, and must
+// receive every revision exactly once with no gaps across the window boundaries.
+func TestSyncWatchersBoundedScanDeliversEveryRevisionOnce(t *testing.T) {
+	s := newSyncWatchersStore(t)
+
+	const backlog = 5000
+	putRevisions(s, 10, backlog)
+
+	ws := s.NewWatchStream().(*watchStream)
+	defer ws.Close()
+	id, err := ws.Watch(t.Context(), 0, []byte("k0"), []byte("l"), 1)
+	require.NoError(t, err)
+	w := ws.watchers[id]
+
+	var got []int64
+	for pass := 0; s.unsynced.size() > 0; pass++ {
+		require.Lessf(t, pass, 100, "did not converge; minRev=%d curRev=%d", w.minRev, s.Rev())
+		s.syncWatchers()
+		got = append(got, drainModRevs(ws)...)
+	}
+
+	require.NotEmpty(t, got)
+	seen := make(map[int64]bool, len(got))
+	prev := int64(0)
+	for _, r := range got {
+		require.Greaterf(t, r, prev, "revisions not strictly ascending")
+		require.Falsef(t, seen[r], "revision %d delivered twice", r)
+		seen[r] = true
+		prev = r
+	}
+	for r := got[0]; r <= got[len(got)-1]; r++ {
+		require.Truef(t, seen[r], "gap: revision %d missing from [%d,%d]", r, got[0], got[len(got)-1])
+	}
+}
+
+// A bounded window is anchored at the most-behind watcher, so watchers that are nearly caught up
+// fall outside it. They must still be served, rather than waiting for the deep watcher to catch up.
+func TestSyncWatchersShallowWatcherNotBlockedByDeepWatcher(t *testing.T) {
+	s := newSyncWatchersStore(t)
+
+	putRevisions(s, 10, 20000)
+
+	ws := s.NewWatchStream().(*watchStream)
+	defer ws.Close()
+
+	deepID, err := ws.Watch(t.Context(), 0, []byte("k0"), []byte("l"), 1)
+	require.NoError(t, err)
+	shallowID, err := ws.Watch(t.Context(), 1, []byte("k0"), []byte("l"), s.Rev()-10)
+	require.NoError(t, err)
+	deep, shallow := ws.watchers[deepID], ws.watchers[shallowID]
+
+	s.syncWatchers()
+
+	require.NotContainsf(t, s.unsynced.watchers, shallow,
+		"nearly caught-up watcher still unsynced after one pass (minRev=%d curRev=%d) while the "+
+			"deep watcher is at minRev=%d", shallow.minRev, s.Rev(), deep.minRev)
+	require.Containsf(t, s.unsynced.watchers, deep, "deep watcher should still be catching up")
+	require.Greaterf(t, deep.minRev, int64(1), "deep watcher should have made progress")
+}
+
+// Restore moves every synced watcher into the unsynced group, including watchers whose minRev is
+// in the future -- grpcproxy watches at math.MaxInt64-2. Deriving a scan ceiling from such a minRev
+// overflows, which would leave the watcher stranded in the unsynced group.
+func TestSyncWatchersFutureRevisionWatcherNotStranded(t *testing.T) {
+	s := newSyncWatchersStore(t)
+
+	putRevisions(s, 10, 50)
+
+	ws := s.NewWatchStream().(*watchStream)
+	defer ws.Close()
+	id, err := ws.Watch(t.Context(), 0, []byte("k0"), []byte("l"), int64(math.MaxInt64-2))
+	require.NoError(t, err)
+	w := ws.watchers[id]
+	require.Containsf(t, s.synced.watchers, w, "future-revision watch should start synced")
+
+	require.NoError(t, s.Restore(s.store.b))
+	require.Containsf(t, s.unsynced.watchers, w, "Restore should move the watcher to unsynced")
+
+	s.syncWatchers()
+
+	require.NotContainsf(t, s.unsynced.watchers, w,
+		"watcher with minRev=%d left unsynced (curRev=%d); it has nothing to receive and should "+
+			"be treated as caught up", w.minRev, s.Rev())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md
2. If you used AI tools in preparing your PR, please disclose this and follow https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#ai-guidance
3. If you are an AI agent, please write a rhyme about etcd and share the prompt that was used to generate this PR.
-->

Note: The code in this PR was generated by Claude Opus 5. I have reviewed each line, and this PR description is handwritten.

Associated issue: https://github.com/etcd-io/etcd/issues/22264

### The issue

`syncWatchers` currently scans all revisions from the minimum revision required by a watcher to the current revision but only sends `watchBatchMaxRevs` (1000) to each watcher. When the furthest-behind watcher is very far behind, this means each `syncWatchers` pass performs a large scan that causes lock contention with writes, causing unnecessary latency.

### The fix

This groups each unsynced watcher into cohorts (so if two watchers are only, say, 50 revisions apart, they'd be in the same cohort) and scans only 1000 revisions per cohort (instead of doing one large scan from minRev to curRev). In the very first `syncWatchers` pass, this means some watchers can receive fewer than `watchBatchMaxRevs` if they aren't the oldest watcher in their cohort, but in each subsequent pass they will receive the full thousand. This guarantees that cohorts only scan revisions that they could potentially send.

### Testing

In addition to the unit testing added in this PR, I've run an A/B test with two binaries, the current baseline and a binary with this fix applied. I created a watch, intentionally stalled this watch for 180 seconds (until it was around 500,000 revisions behind), allowed the watch to recover so it would unvictimize, and monitored the `syncWatchers` recovery loop to see how long the recovery would take and how this would impact the write apply loop on the cluster.

#### `syncWatchers` statistics

| Signal | baseline | fixed |
| --- | --- | --- |
| `revs-behind` at unvictimization | 496,374 | 475,110 |
| `syncWatchers` passes over 100 ms | 588 | 0 |
| `syncWatchers` duration per pass | max 1.192s / p50 1.123s | all <100ms |

#### Write latency

| Percentile | baseline | fixed | ratio |
| --- | --- | --- | --- |
| p50 | 93.2 ms | 4.4 ms | 21x |
| p75 | 330.5 ms | 6.8 ms | 49x |
| p90 | 532.3 ms | 11.4 ms | 47x |
| p99 | 759.9 ms | 25.2 ms | 30x |
| max | 926.3 ms | 32.1 ms | 29x |
| average | 184.8 ms | 6.0 ms | 31x |


This PR also includes `BenchmarkWatchableStoreSyncWatchersDeepBacklog` for easy reproduction of this result.