### PR TITLE
tests/robustness: fix go vet copylocks failures in wal_test

### DIFF
--- a/tests/robustness/report/wal_test.go
+++ b/tests/robustness/report/wal_test.go
@@ -618,7 +618,10 @@ func TestWriteReadWAL(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range tcs {
+	// Iterate by index: the test cases embed raftpb.HardState, which contains
+	// a mutex since the raft v3.7 protobuf regeneration and must not be copied.
+	for i := range tcs {
+		tc := &tcs[i]
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			lg := zaptest.NewLogger(t)
@@ -647,7 +650,7 @@ func TestWriteReadWAL(t *testing.T) {
 					require.NoError(t, err)
 				}
 				if !proto.Equal(&tc.walReadAll.wantState, state) {
-					t.Errorf("wantState mismatch\n got  %+v\n want %+v", state, tc.walReadAll.wantState)
+					t.Errorf("wantState mismatch\n got  %+v\n want %+v", state, &tc.walReadAll.wantState)
 				}
 				if diff := cmp.Diff(tc.walReadAll.wantEntries, entries, cmpopts.IgnoreUnexported(raftpb.Entry{}, raftpb.HardState{})); diff != "" {
 					t.Errorf("wantEntries mismatch (-want +got):\n%s", diff)
@@ -661,7 +664,7 @@ func TestWriteReadWAL(t *testing.T) {
 					require.NoError(t, err)
 				}
 				if !proto.Equal(&tc.readAllEntries.wantState, state) {
-					t.Errorf("wantState mismatch\n got  %+v\n want %+v", state, tc.readAllEntries.wantState)
+					t.Errorf("wantState mismatch\n got  %+v\n want %+v", state, &tc.readAllEntries.wantState)
 				}
 				if diff := cmp.Diff(tc.readAllEntries.wantEntries, entries, cmpopts.IgnoreUnexported(raftpb.Entry{}, raftpb.HardState{})); diff != "" {
 					t.Errorf("wantEntries mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
go vet currently fails in the tests module:

```
$ cd tests && go vet ./robustness/report/...
robustness/report/wal_test.go:621:9: range var tc copies lock: ... contains sync.Mutex
robustness/report/wal_test.go:650:66: call of t.Errorf copies lock value: ...
robustness/report/wal_test.go:664:66: call of t.Errorf copies lock value: ...
```

These are latent copylocks introduced by the raft v3.7 bump: raftpb.HardState now embeds protoimpl.MessageState, which contains a sync.Mutex. CI stays green because the vet gate does not cover this path, but local go vet ./... in the tests module fails.

The fix iterates the test cases by index and passes the HardState by pointer in the two t.Errorf calls. No behavior change; the only visible difference is an & prefix in the two failure-message formats.

Verified with: cd tests && go vet ./robustness/report/... (clean) and go test ./robustness/report/ (pass).

Per the AI guidance referenced in the PR template: AI tooling was used in preparing this change. I have reviewed it and can explain every line.
