### PR TITLE
fix(alerts): align etcdHighNumberOfFailedProposals description with rate window

### DIFF
--- a/contrib/mixin/alerts/alerts.libsonnet
+++ b/contrib/mixin/alerts/alerts.libsonnet
@@ -141,7 +141,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'etcd cluster "{{ $labels.%s }}": {{ $value }} proposal failures within the last 30 minutes on etcd instance {{ $labels.instance }}.' % $._config.clusterLabel,
+              description: 'etcd cluster "{{ $labels.%s }}": {{ $value }} proposal failures within the last 15 minutes on etcd instance {{ $labels.instance }}.' % $._config.clusterLabel,
               summary: 'etcd cluster has high number of proposal failures.',
             },
           },


### PR DESCRIPTION
## What

The `etcdHighNumberOfFailedProposals` alert description said proposal failures occurred within the last **30 minutes**, but:

- `expr` uses `rate(...[15m])`
- `for` is `15m`

So the description matched neither the PromQL window that produces `{{ $value }}` nor the pending duration.

## Fix

Update the description only: `30 minutes` → `15 minutes` (same pattern as `etcdHighNumberOfLeaderChanges`, which already says “last 15 minutes” for its 15m window).

No changes to expression, `for`, severity, or summary.

## Why

Misleading for operators reading the alert in consoles / Alertmanager. OpenShift inherits this mixin via cluster-etcd-operator.

Tracked for OpenShift as [OCPBUGS-105285](https://redhat.atlassian.net/browse/OCPBUGS-105285).

## Test plan

- [x] Diff is description-only
- [x] `rate(...[15m])` and `for: 15m` unchanged