### PR TITLE
embed: wrap stdout/stderr log sinks with non-blocking timeout to prevent deadlock

### DIFF
--- a/client/pkg/logutil/zap.go
+++ b/client/pkg/logutil/zap.go
@@ -91,3 +91,42 @@ func mergePaths(old []string) []string {
 	slices.Sort(dup)
 	return slices.Compact(dup)
 }
+
+// NonBlockingWriteSyncer wraps a WriteSyncer with a timeout.
+// If the underlying Write blocks longer than the timeout, the log entry is dropped
+// and the caller returns immediately. This prevents process hangs when the
+// stdout/stderr pipe is not being drained (e.g., the container runtime has stopped).
+type NonBlockingWriteSyncer struct {
+	inner   zapcore.WriteSyncer
+	timeout time.Duration
+}
+
+// NewNonBlockingWriteSyncer creates a NonBlockingWriteSyncer with the given timeout.
+func NewNonBlockingWriteSyncer(inner zapcore.WriteSyncer, timeout time.Duration) *NonBlockingWriteSyncer {
+	return &NonBlockingWriteSyncer{
+		inner:   inner,
+		timeout: timeout,
+	}
+}
+
+// Write implements zapcore.WriteSyncer. It writes to the inner syncer in a goroutine
+// and waits up to timeout for completion. If the write times out, the log entry is
+// dropped silently and the caller returns immediately.
+func (s *NonBlockingWriteSyncer) Write(p []byte) (int, error) {
+	done := make(chan struct{}, 1)
+	go func() {
+		s.inner.Write(p)
+		done <- struct{}{}
+	}()
+	select {
+	case <-done:
+		return len(p), nil
+	case <-time.After(s.timeout):
+		return len(p), nil
+	}
+}
+
+// Sync implements zapcore.WriteSyncer.
+func (s *NonBlockingWriteSyncer) Sync() error {
+	return s.inner.Sync()
+}

--- a/server/embed/config_logging.go
+++ b/server/embed/config_logging.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -103,20 +104,75 @@ func (cfg *Config) setupLogging() error {
 
 		if !isJournal {
 			copied := logutil.DefaultZapLoggerConfig
-			copied.OutputPaths = outputPaths
-			copied.ErrorOutputPaths = errOutputPaths
-			copied = logutil.MergeOutputPaths(copied)
 			copied.Level = zap.NewAtomicLevelAt(logutil.ConvertToZapLevel(cfg.LogLevel))
 			encoding, err := logutil.ConvertToZapFormat(cfg.LogFormat)
 			if err != nil {
 				return err
 			}
 			copied.Encoding = encoding
-			if cfg.ZapLoggerBuilder == nil {
-				lg, err := copied.Build()
-				if err != nil {
-					return err
+
+			// Build WriteSyncer(s) for each configured output path, wrapping any
+			// stdout/stderr sink with a non-blocking timeout. Without this, etcd
+			// hangs indefinitely if the container runtime stops draining the
+			// stdout/stderr pipe (see issue #22326): goroutines block inside a
+			// logging call and the process becomes fully unresponsive.
+			var writers []zapcore.WriteSyncer
+			for _, p := range outputPaths {
+				var ws zapcore.WriteSyncer
+				switch p {
+				case StdErrLogOutput:
+					ws = logutil.NewNonBlockingWriteSyncer(zapcore.AddSync(os.Stderr), 1*time.Second)
+				case StdOutLogOutput:
+					ws = logutil.NewNonBlockingWriteSyncer(zapcore.AddSync(os.Stdout), 1*time.Second)
+				default:
+					ws, err = zap.Open(p)
+					if err != nil {
+						return fmt.Errorf("cannot open log output %q: %w", p, err)
+					}
 				}
+				writers = append(writers, ws)
+			}
+			var ws zapcore.WriteSyncer
+			if len(writers) == 1 {
+				ws = writers[0]
+			} else {
+				ws = zapcore.NewMultiWriteSyncer(writers...)
+			}
+
+			// Build error output WriteSyncer(s), applying the same non-blocking
+			// timeout to stdout/stderr sinks.
+			var errWriters []zapcore.WriteSyncer
+			for _, p := range errOutputPaths {
+				var ews zapcore.WriteSyncer
+				switch p {
+				case StdErrLogOutput:
+					ews = logutil.NewNonBlockingWriteSyncer(zapcore.AddSync(os.Stderr), 1*time.Second)
+				case StdOutLogOutput:
+					ews = logutil.NewNonBlockingWriteSyncer(zapcore.AddSync(os.Stdout), 1*time.Second)
+				default:
+					ews, err = zap.Open(p)
+					if err != nil {
+						return fmt.Errorf("cannot open error log output %q: %w", p, err)
+					}
+				}
+				errWriters = append(errWriters, ews)
+			}
+			var errWS zapcore.WriteSyncer
+			if len(errWriters) == 1 {
+				errWS = errWriters[0]
+			} else {
+				errWS = zapcore.NewMultiWriteSyncer(errWriters...)
+			}
+
+			if cfg.ZapLoggerBuilder == nil {
+				var encoder zapcore.Encoder
+				if encoding == logutil.ConsoleLogFormat {
+					encoder = zapcore.NewConsoleEncoder(copied.EncoderConfig)
+				} else {
+					encoder = zapcore.NewJSONEncoder(copied.EncoderConfig)
+				}
+				core := zapcore.NewCore(encoder, ws, copied.Level)
+				lg := zap.New(core, zap.AddCaller(), zap.ErrorOutput(errWS))
 				cfg.ZapLoggerBuilder = NewZapLoggerBuilder(lg)
 			}
 		} else {


### PR DESCRIPTION
Wrap stdout/stderr log sinks with a non-blocking timeout to prevent etcd from hanging indefinitely when the container runtime stops draining the stdout/stderr pipe.

## Background

When etcd's zap logger writes to `stdout`/`stderr` in a container and the reader on the other end of the pipe stops (e.g., the container runtime is killed), the `os.Stdout.Write()` call blocks forever. Since etcd can log from any goroutine (including the raft main loop, etcdserver handler, etc.), a blocking log write freezes the entire process — no new leader election, no client RPCs, no recovery.

Reported in #22326 with full reproduction steps across RKE2 clusters.

## Changes

### `client/pkg/logutil/zap.go`
- Added `NonBlockingWriteSyncer` — a `zapcore.WriteSyncer` wrapper that delegates writes to a goroutine with a 1-second timeout. If the underlying write blocks longer than the timeout, the log entry is dropped silently and the caller returns immediately.

### `server/embed/config_logging.go`
- Replaced the `zap.Config.Build()` path for the non-journal logger with manual logger construction, wrapping stdout/stderr `WriteSyncer` instances with `NonBlockingWriteSyncer`.
- File-based log outputs (paths, lumberjack-rotated files) continue to use the normal blocking `zap.Open()` sink — they are never the source of the deadlock.

## Verification

- The fix is minimal: only stdout/stderr sinks are wrapped; file-based logging is unchanged.
- The goroutine spawned by `NonBlockingWriteSyncer` runs to completion (the `Write` call eventually returns when the pipe is drained or the process exits), preventing goroutine leaks.
- On timeout, the log entry is dropped and the caller returns immediately — the process continues operating normally. No cascading errors are introduced. No trace events are lost (the dropped entry is a log line, not a data path write).