### PR TITLE
auth: add etcd_debugging_auth_simple_tokens metric

### DIFF
--- a/CHANGELOG/CHANGELOG-3.8.md
+++ b/CHANGELOG/CHANGELOG-3.8.md
@@ -17,3 +17,4 @@ Previous change logs can be found at [CHANGELOG-3.7](https://github.com/etcd-io/
 See [List of metrics](https://etcd.io/docs/latest/metrics/) for all metrics per release.
 
 - Expose the full set of Go `runtime/metrics` on `/metrics` when `--metrics extensive` is set.
+- Add `etcd_debugging_auth_simple_tokens`; log a warning whenever the in-memory simple token count reaches a multiple of 10000.

--- a/server/auth/metrics.go
+++ b/server/auth/metrics.go
@@ -37,8 +37,18 @@ var (
 	// overridden by auth store initialization
 	reportCurrentAuthRevMu sync.RWMutex
 	reportCurrentAuthRev   = func() float64 { return 0 }
+
+	simpleTokenGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "etcd_debugging",
+			Subsystem: "auth",
+			Name:      "simple_tokens",
+			Help:      "The current number of simple tokens stored in memory.",
+		},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(currentAuthRevision)
+	prometheus.MustRegister(simpleTokenGauge)
 }

--- a/server/auth/simple_token.go
+++ b/server/auth/simple_token.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	letters                  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	defaultSimpleTokenLength = 16
+	letters                       = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	defaultSimpleTokenLength      = 16
+	simpleTokenCountWarnThreshold = 10000
 )
 
 // var for testing purposes
@@ -50,6 +51,7 @@ type simpleTokenTTLKeeper struct {
 	deleteTokenFunc func(string)
 	mu              *sync.Mutex
 	simpleTokenTTL  time.Duration
+	lg              *zap.Logger
 }
 
 func (tm *simpleTokenTTLKeeper) stop() {
@@ -62,6 +64,17 @@ func (tm *simpleTokenTTLKeeper) stop() {
 
 func (tm *simpleTokenTTLKeeper) addSimpleToken(token string) {
 	tm.tokens[token] = time.Now().Add(tm.simpleTokenTTL)
+	n := len(tm.tokens)
+	simpleTokenGauge.Set(float64(n))
+	// Log every simpleTokenCountWarnThreshold tokens so operators without
+	// metrics can see unbounded growth without flooding the log.
+	if n > 0 && n%simpleTokenCountWarnThreshold == 0 && tm.lg != nil {
+		tm.lg.Warn(
+			"high number of simple tokens stored in memory",
+			zap.Int("simple-token-count", n),
+			zap.Duration("auth-token-ttl", tm.simpleTokenTTL),
+		)
+	}
 }
 
 func (tm *simpleTokenTTLKeeper) resetSimpleToken(token string) {
@@ -72,6 +85,7 @@ func (tm *simpleTokenTTLKeeper) resetSimpleToken(token string) {
 
 func (tm *simpleTokenTTLKeeper) deleteSimpleToken(token string) {
 	delete(tm.tokens, token)
+	simpleTokenGauge.Set(float64(len(tm.tokens)))
 }
 
 func (tm *simpleTokenTTLKeeper) run() {
@@ -91,6 +105,7 @@ func (tm *simpleTokenTTLKeeper) run() {
 					delete(tm.tokens, t)
 				}
 			}
+			simpleTokenGauge.Set(float64(len(tm.tokens)))
 			tm.mu.Unlock()
 		case <-tm.stopc:
 			return
@@ -184,6 +199,7 @@ func (t *tokenSimple) enable() {
 		deleteTokenFunc: delf,
 		mu:              &t.simpleTokensMu,
 		simpleTokenTTL:  t.simpleTokenTTL,
+		lg:              t.lg,
 	}
 	go t.simpleTokenKeeper.run()
 }
@@ -197,6 +213,7 @@ func (t *tokenSimple) disable() {
 	if tk != nil {
 		tk.stop()
 	}
+	simpleTokenGauge.Set(0)
 }
 
 func (t *tokenSimple) info(ctx context.Context, token string, revision uint64) (*AuthInfo, bool) {

--- a/tests/e2e/metrics_test.go
+++ b/tests/e2e/metrics_test.go
@@ -138,6 +138,7 @@ func TestNoMetricsMissing(t *testing.T) {
 		basicMetrics = []string{
 			"etcd_cluster_version",
 			"etcd_debugging_auth_revision",
+			"etcd_debugging_auth_simple_tokens",
 			"etcd_debugging_disk_backend_commit_rebalance_duration_seconds",
 			"etcd_debugging_disk_backend_commit_spill_duration_seconds",
 			"etcd_debugging_disk_backend_commit_write_duration_seconds",


### PR DESCRIPTION
Fixes #22337

We ran into an etcd outage caused by too many simple tokens in memory.

`--auth-token-ttl` was set to 315360000 (10 years), so tokens never expired. Clients also called Authenticate on every LeaseKeepAlive/Watch stream instead of reusing the token. The in-memory map just kept growing.

simpleTokenTTLKeeper.run walks that map under a lock every second. Authenticate apply needs the same lock, so once the map is huge, normal requests stall.

In our case:
- cpu pprof (60s): ~99% in simpleTokenTTLKeeper.run
- heap: ~2.5GB in addSimpleToken / assignSimpleTokenToUser
- top: etcd at 101% CPU, 2.3GB RSS
- logs full of "apply request took too long" on authenticate, and "invalid auth token" from retries

I'll attach the pprof / top / log screenshots below.
<img width="1115" height="1115" alt="cpu60s采样" src="https://github.com/user-attachments/assets/30f65189-f6b9-49cc-bb6b-58c975510a33" />
<img width="1624" height="2387" alt="heap" src="https://github.com/user-attachments/assets/258514a6-61c6-4a2c-b315-504050d1729c" />

<img width="1084" height="401" alt="etcd日志" src="https://github.com/user-attachments/assets/e3896111-3255-49dc-9135-759bb81647b7" />

<img width="2232" height="141" alt="af52d4c8caad0028f18c793b83173793" src="https://github.com/user-attachments/assets/774f8425-20bf-44f6-a4bb-d3fee99b7b22" />
<img width="1124" height="583" alt="top命令图" src="https://github.com/user-attachments/assets/d621b0c8-a325-4cbe-bda5-13deb104633a" />

This doesn't try to make simple tokens production-ready (JWT or mTLS is still the right setup). It just makes the growth visible:

- metric `etcd_debugging_auth_simple_tokens`
- warn every 10000 tokens so you can see it in logs if you aren't scraping metrics

Default TTL (300s) and token type are unchanged. clientv3 getToken() is also unchanged.

Tested with `go test ./server/auth/`. The new metric is in TestNoMetricsMissing.