### PR TITLE
pkg/adt: fix Int64Comparable Compare overflow and NewInt64Point endpoint overflow

### DIFF
--- a/pkg/adt/interval_tree.go
+++ b/pkg/adt/interval_tree.go
@@ -902,6 +902,12 @@ func newInt64EmptyInterval() Interval {
 }
 
 func NewInt64Point(a int64) Interval {
+	if a == math.MaxInt64 {
+		// a+1 would overflow. math.MaxInt64 has no representable successor, so
+		// the returned degenerate interval is empty ([a, a)) and matches no
+		// keys, keeping the Begin <= End invariant intact.
+		return Interval{Int64Comparable(a), Int64Comparable(a)}
+	}
 	return Interval{Int64Comparable(a), Int64Comparable(a + 1)}
 }
 
@@ -909,11 +915,10 @@ type Int64Comparable int64
 
 func (v Int64Comparable) Compare(c Comparable) int {
 	vc := c.(Int64Comparable)
-	cmp := v - vc
-	if cmp < 0 {
+	if v < vc {
 		return -1
 	}
-	if cmp > 0 {
+	if v > vc {
 		return 1
 	}
 	return 0

--- a/pkg/adt/interval_tree_test.go
+++ b/pkg/adt/interval_tree_test.go
@@ -541,11 +541,11 @@ func TestInt64ComparableCompareExtremes(t *testing.T) {
 	maxV := Int64Comparable(math.MaxInt64)
 	minV := Int64Comparable(math.MinInt64)
 
-	require.Equal(t, 1, maxV.Compare(minV), "MaxInt64 must compare greater than MinInt64")
-	require.Equal(t, -1, minV.Compare(maxV), "MinInt64 must compare less than MaxInt64")
-	require.Equal(t, 1, maxV.Compare(Int64Comparable(-1)), "MaxInt64 must compare greater than -1")
-	require.Equal(t, -1, Int64Comparable(-1).Compare(maxV), "-1 must compare less than MaxInt64")
-	require.Equal(t, 0, maxV.Compare(maxV), "MaxInt64 must compare equal to itself")
+	require.Equalf(t, 1, maxV.Compare(minV), "MaxInt64 must compare greater than MinInt64")
+	require.Equalf(t, -1, minV.Compare(maxV), "MinInt64 must compare less than MaxInt64")
+	require.Equalf(t, 1, maxV.Compare(Int64Comparable(-1)), "MaxInt64 must compare greater than -1")
+	require.Equalf(t, -1, Int64Comparable(-1).Compare(maxV), "-1 must compare less than MaxInt64")
+	require.Equalf(t, 0, maxV.Compare(maxV), "MaxInt64 must compare equal to itself")
 }
 
 // TestNewInt64PointExtremes ensures point intervals keep the Begin <= End

--- a/pkg/adt/interval_tree_test.go
+++ b/pkg/adt/interval_tree_test.go
@@ -15,6 +15,7 @@
 package adt
 
 import (
+	"math"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -532,4 +533,31 @@ func TestIntervalTreeContains(t *testing.T) {
 		v := ivt.Contains(tt.chkIvl)
 		assert.Equalf(t, v, tt.wContains, "#%d: ivt.Contains got %v, expected %v", i, v, tt.wContains)
 	}
+}
+
+// TestInt64ComparableCompareExtremes ensures the comparator does not overflow
+// when comparing values far apart, e.g. math.MaxInt64 and math.MinInt64.
+func TestInt64ComparableCompareExtremes(t *testing.T) {
+	maxV := Int64Comparable(math.MaxInt64)
+	minV := Int64Comparable(math.MinInt64)
+
+	require.Equal(t, 1, maxV.Compare(minV), "MaxInt64 must compare greater than MinInt64")
+	require.Equal(t, -1, minV.Compare(maxV), "MinInt64 must compare less than MaxInt64")
+	require.Equal(t, 1, maxV.Compare(Int64Comparable(-1)), "MaxInt64 must compare greater than -1")
+	require.Equal(t, -1, Int64Comparable(-1).Compare(maxV), "-1 must compare less than MaxInt64")
+	require.Equal(t, 0, maxV.Compare(maxV), "MaxInt64 must compare equal to itself")
+}
+
+// TestNewInt64PointExtremes ensures point intervals keep the Begin <= End
+// invariant even at the upper bound of int64.
+func TestNewInt64PointExtremes(t *testing.T) {
+	pt := NewInt64Point(math.MaxInt64)
+	require.Equal(t, Int64Comparable(math.MaxInt64), pt.Begin)
+	if pt.Begin.Compare(pt.End) == 1 {
+		t.Fatal("point interval invariant violated: Begin must not be greater than End")
+	}
+
+	normal := NewInt64Point(42)
+	require.Equal(t, Int64Comparable(42), normal.Begin)
+	require.Equal(t, Int64Comparable(43), normal.End)
 }


### PR DESCRIPTION
Fixes #22357

### Description

`Int64Comparable.Compare` implemented trichotomic comparison via subtraction (`cmp := v - vc`). For extreme values the int64 subtraction wraps around: `Int64Comparable(math.MaxInt64).Compare(Int64Comparable(math.MinInt64))` returns -1 instead of 1, and `MaxInt64` vs `-1` also compares as -1. `NewInt64Point(a)` additionally computes `a + 1`, so `NewInt64Point(math.MaxInt64)` produces an interval whose Begin (`MaxInt64`) is greater than its End (`MinInt64`), breaking the tree invariant.

There are no in-tree production callers of the int64 interval constructors today; `pkg/adt` is an exported package though, and downstream consumers of the API may feed arbitrary int64 endpoints.

#### Fixed the bug ...
`Int64Comparable.Compare` now compares `v` and `vc` directly without subtracting, matching the style of the other comparators in the package. `NewInt64Point` special-cases `math.MaxInt64`: since it has no representable successor, it returns a degenerate `[a, a)` interval which is empty and matches no keys, preserving the `Begin <= End` invariant.

Added `TestInt64ComparableCompareExtremes` and `TestNewInt64PointExtremes`; the former reproduces the wrap (fails on the old code with `expected: 1, actual: -1`), the latter locks the point interval invariant at the upper bound. `go test ./pkg/adt` passes.

#### Release note
- `pkg/adt`: fix incorrect comparisons and invalid point intervals for extreme int64 endpoints.