### PR TITLE
clientv3/naming: reject range delete options in DeleteEndpoint

### DIFF
--- a/client/v3/naming/endpoints/endpoints_impl.go
+++ b/client/v3/naming/endpoints/endpoints_impl.go
@@ -74,7 +74,11 @@ func (m *endpointManager) Update(ctx context.Context, updates []*UpdateWithOpts)
 			}
 			ops = append(ops, clientv3.OpPut(update.Key, string(v), update.Opts...))
 		case Delete:
-			ops = append(ops, clientv3.OpDelete(update.Key, update.Opts...))
+			delOp := clientv3.OpDelete(update.Key, update.Opts...)
+			if len(delOp.RangeBytes()) > 0 {
+				return status.Errorf(codes.InvalidArgument, "endpoints: range delete is not supported in endpoint manager")
+			}
+			ops = append(ops, delOp)
 		default:
 			return status.Error(codes.InvalidArgument, "endpoints: bad update op")
 		}

--- a/tests/integration/clientv3/naming/endpoints_test.go
+++ b/tests/integration/clientv3/naming/endpoints_test.go
@@ -183,3 +183,41 @@ func TestEndpointManagerCRUD(t *testing.T) {
 	require.Lenf(t, eps, 1, "unexpected the number of endpoints: %d", len(eps))
 	require.Truef(t, reflect.DeepEqual(eps[k3], e3), "unexpected endpoints: %s", k3)
 }
+
+func TestEndpointManagerDeleteEndpointRejectsRangeOptions(t *testing.T) {
+	integration.BeforeTest(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	c := clus.RandClient()
+	em, err := endpoints.NewManager(c, "foo")
+	require.NoError(t, err)
+
+	emOther, err := endpoints.NewManager(c, "foo_other")
+	require.NoError(t, err)
+
+	err = em.AddEndpoint(t.Context(), "foo/a", endpoints.Endpoint{Addr: "127.0.0.1:2000"})
+	require.NoError(t, err)
+	err = em.AddEndpoint(t.Context(), "foo/b", endpoints.Endpoint{Addr: "127.0.0.1:2001"})
+	require.NoError(t, err)
+	err = emOther.AddEndpoint(t.Context(), "foo_other/a", endpoints.Endpoint{Addr: "127.0.0.1:2002"})
+	require.NoError(t, err)
+
+	// Range delete options must be rejected
+	for _, opt := range []etcd.OpOption{
+		etcd.WithFromKey(),
+		etcd.WithPrefix(),
+		etcd.WithRange("foo/z"),
+	} {
+		err = em.DeleteEndpoint(t.Context(), "foo/a", opt)
+		require.Error(t, err, "expected range delete option to be rejected")
+	}
+
+	// Verify that none of the endpoints were deleted
+	for _, key := range []string{"foo/a", "foo/b", "foo_other/a"} {
+		resp, err := c.Get(t.Context(), key)
+		require.NoError(t, err)
+		require.Lenf(t, resp.Kvs, 1, "expected %q to remain after rejected delete, got %d keys", key, len(resp.Kvs))
+	}
+}


### PR DESCRIPTION


### What this PR does / why we need it:
`client/v3/naming/endpoints.Manager.DeleteEndpoint` is documented to delete a single endpoint for a given target. Previously, `endpointManager.Update` forwarded all delete options directly into `clientv3.OpDelete` without checking if range options (such as `WithFromKey`, `WithPrefix`, or `WithRange`) were specified.

When range options were passed, `DeleteEndpoint` would execute a multi-key range delete that deleted other endpoints under the same target and even endpoints belonging to other targets.

This PR checks whether the constructed `OpDelete` specifies a range end (`len(delOp.RangeBytes()) > 0`) and returns an `InvalidArgument` error before submitting the transaction.

### Which issue(s) this PR fixes:
Fixes #22085

### Testing done:
- Added `TestEndpointManagerDeleteEndpointRejectsRangeOptions` in `tests/integration/clientv3/naming/endpoints_test.go`.
- Ran naming integration test suite: `go test -v -count=1 ./integration/clientv3/naming/...`
- Ran static checks: `go vet`, `gofmt`.