### PR TITLE
Fix typos in comments and two error messages

### DIFF
--- a/cache/demux.go
+++ b/cache/demux.go
@@ -30,7 +30,7 @@ type demux struct {
 	activeWatchers  map[*watcher]int64
 	laggingWatchers map[*watcher]int64
 	resyncInterval  time.Duration
-	// Range of revisions maintained for demux operations, inclusive. Broader than history as event revision is not contious.
+	// Range of revisions maintained for demux operations, inclusive. Broader than history as event revision is not continuous.
 	// maxRev tracks highest seen revision; minRev sets watcher compaction threshold (updated to evictedRev+1 on history overflow)
 	minRev, maxRev int64
 	// History stores events within [minRev, maxRev].

--- a/client/v3/internal/endpoint/endpoint.go
+++ b/client/v3/internal/endpoint/endpoint.go
@@ -25,7 +25,7 @@ import (
 type CredsRequirement int
 
 const (
-	// CredsRequire - Credentials/certificate required for thi type of connection.
+	// CredsRequire - Credentials/certificate required for this type of connection.
 	CredsRequire CredsRequirement = iota
 	// CredsDrop - Credentials/certificate not needed and should get ignored.
 	CredsDrop

--- a/etcdutl/etcdutl/migrate_command.go
+++ b/etcdutl/etcdutl/migrate_command.go
@@ -106,7 +106,7 @@ func (c *migrateConfig) finalize() error {
 	walPath := datadir.ToWALDir(c.dataDir)
 	walSnap, err := getLatestWALSnap(c.lg, c.dataDir)
 	if err != nil {
-		return fmt.Errorf("failed to get the lastest snapshot: %w", err)
+		return fmt.Errorf("failed to get the latest snapshot: %w", err)
 	}
 	w, err := wal.OpenForRead(c.lg, walPath, walSnap)
 	if err != nil {

--- a/server/embed/config.go
+++ b/server/embed/config.go
@@ -171,7 +171,7 @@ type Config struct {
 	// SnapshotCount is the number of committed transactions that trigger a snapshot.
 	SnapshotCount uint64 `json:"snapshot-count"`
 
-	// SnapshotCatchUpEntries is the number of entires for a slow follower
+	// SnapshotCatchUpEntries is the number of entries for a slow follower
 	// to catch-up after compacting the raft storage entries.
 	// We expect the follower has a millisecond level latency with the leader.
 	// The max throughput is around 10K. Keep a 5K entries is enough for helping

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -391,7 +391,7 @@ func (e *Etcd) Config() Config {
 
 // Close gracefully shuts down all servers/listeners.
 // Client requests will be terminated with request timeout.
-// After timeout, enforce remaning requests be closed immediately.
+// After timeout, enforce remaining requests be closed immediately.
 //
 // The rough workflow to shut down etcd:
 //  1. close the `stopc` channel, so that all error handlers (child

--- a/server/etcdserver/api/rafthttp/pipeline.go
+++ b/server/etcdserver/api/rafthttp/pipeline.go
@@ -52,7 +52,7 @@ type pipeline struct {
 	status *peerStatus
 	raft   Raft
 	errorc chan error
-	// deprecate when we depercate v2 API
+	// deprecate when we deprecate v2 API
 	followerStats *stats.FollowerStats
 
 	msgc chan *raftpb.Message

--- a/server/storage/schema/actions.go
+++ b/server/storage/schema/actions.go
@@ -81,7 +81,7 @@ func (as ActionList) unsafeExecute(lg *zap.Logger, tx backend.UnsafeReadWriter) 
 	return nil
 }
 
-// unsafeExecuteInReversedOrder executes actions in revered order. Will panic on
+// unsafeExecuteInReversedOrder executes actions in reversed order. Will panic on
 // action error. Should be used when reverting.
 func (as ActionList) unsafeExecuteInReversedOrder(lg *zap.Logger, tx backend.UnsafeReadWriter) {
 	for j := len(as) - 1; j >= 0; j-- {

--- a/tools/proto-annotations/cmd/root.go
+++ b/tools/proto-annotations/cmd/root.go
@@ -70,7 +70,7 @@ func runProtoAnnotation(annotation string) error {
 		for _, err := range errs {
 			fmt.Fprintln(os.Stderr, err)
 		}
-		return fmt.Errorf("failed reading anotation")
+		return fmt.Errorf("failed reading annotation")
 	}
 	return nil
 }


### PR DESCRIPTION
Typo fixes found with codespell. No functional changes; no identifiers renamed.

Comments:
- `thi type` -> `this type` (client/v3/internal/endpoint)
- `entires` -> `entries` (server/embed/config.go)
- `remaning` -> `remaining` (server/embed/etcd.go)
- `depercate` -> `deprecate` (server/etcdserver/api/rafthttp/pipeline.go)
- `revered order` -> `reversed order` (server/storage/schema/actions.go)
- `contious` -> `continuous` (cache/demux.go)

Error messages:
- `failed to get the lastest snapshot` -> `latest` (etcdutl)
- `failed reading anotation` -> `annotation` (tools/proto-annotations)