### PR TITLE
mvcc: keep the live value of a key re-created in the compacted revision

### DIFF
--- a/CHANGELOG/CHANGELOG-3.8.md
+++ b/CHANGELOG/CHANGELOG-3.8.md
@@ -12,6 +12,7 @@ Previous change logs can be found at [CHANGELOG-3.7](https://github.com/etcd-io/
   - [Remove flag `--max-snapshots` and `--v2-deprecation`](https://github.com/etcd-io/etcd/pull/22306)
   - [Cleanup the legacy v2 snapshot files on bootstrap](https://github.com/etcd-io/etcd/pull/22336)
   - [Cleanup the legacy v2 snapshot source code and cleanup orphaned defragmentation files on bootstrap](https://github.com/etcd-io/etcd/pull/22341)
+- Fix [compaction deleting the live value of a key that was deleted and re-created in the compacted revision](https://github.com/etcd-io/etcd/pull/22377), which caused a `range failed to find revision pair` fatal and an empty keyspace after the restart.
 
 ### Dependencies
 

--- a/server/storage/mvcc/key_index.go
+++ b/server/storage/mvcc/key_index.go
@@ -269,7 +269,16 @@ func (ki *keyIndex) doCompact(atRev int64, available map[Revision]struct{}) (gen
 	genIdx, g := 0, &ki.generations[0]
 	// find first generation includes atRev or created after atRev
 	for genIdx < len(ki.generations)-1 {
-		if tomb := g.revs[len(g.revs)-1].Main; tomb >= atRev {
+		tomb := g.revs[len(g.revs)-1].Main
+		if tomb > atRev {
+			break
+		}
+		// A tombstone at exactly atRev is kept, so this generation is the one
+		// to compact into -- unless the key was re-created within the same main
+		// revision, in which case the higher sub revision supersedes the
+		// tombstone and the key is alive at the end of atRev. Its live revision
+		// lives in the next generation and must survive the compaction.
+		if tomb == atRev && !ki.generations[genIdx+1].isRecreatedAt(atRev) {
 			break
 		}
 		genIdx++
@@ -350,6 +359,12 @@ type generation struct {
 }
 
 func (g *generation) isEmpty() bool { return g == nil || len(g.revs) == 0 }
+
+// isRecreatedAt reports whether this generation was created by a put in main
+// revision rev, i.e. the key was deleted and re-created within that revision.
+func (g *generation) isRecreatedAt(rev int64) bool {
+	return !g.isEmpty() && g.revs[0].Main == rev
+}
 
 // walk walks through the revisions in the generation in descending order.
 // It passes the revision to the given function.

--- a/server/storage/mvcc/key_index_test.go
+++ b/server/storage/mvcc/key_index_test.go
@@ -608,6 +608,129 @@ func TestKeyIndexCompactAndKeep(t *testing.T) {
 	}
 }
 
+// TestKeyIndexCompactAndKeepOnRecreatedRev covers keys that are deleted and
+// re-created within a single main revision (a DeleteRange followed by a Put in
+// one transaction) and are then compacted at exactly that revision. The later
+// sub revision supersedes the tombstone, so the key is alive at the end of the
+// revision and its live revision must survive the compaction.
+func TestKeyIndexCompactAndKeepOnRecreatedRev(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   func(lg *zap.Logger) *keyIndex
+		compact int64
+
+		wki      *keyIndex
+		wcompact map[Revision]struct{}
+		wkeep    map[Revision]struct{}
+	}{
+		{
+			name: "deleted and re-created in the compacted revision",
+			build: func(lg *zap.Logger) *keyIndex {
+				ki := &keyIndex{key: []byte("foo")}
+				ki.put(lg, 3, 89)
+				require.NoError(t, ki.tombstone(lg, 4, 0))
+				ki.put(lg, 4, 145)
+				return ki
+			},
+			compact: 4,
+			wki: &keyIndex{
+				key:      []byte("foo"),
+				modified: Revision{Main: 4, Sub: 145},
+				generations: []generation{
+					{created: Revision{Main: 4, Sub: 145}, ver: 1, revs: []Revision{{Main: 4, Sub: 145}}},
+				},
+			},
+			wcompact: map[Revision]struct{}{{Main: 4, Sub: 145}: {}},
+			wkeep:    map[Revision]struct{}{{Main: 4, Sub: 145}: {}},
+		},
+		{
+			name: "deleted, re-created and deleted again in the compacted revision",
+			build: func(lg *zap.Logger) *keyIndex {
+				ki := &keyIndex{key: []byte("foo")}
+				ki.put(lg, 1, 0)
+				require.NoError(t, ki.tombstone(lg, 2, 0))
+				ki.put(lg, 2, 1)
+				require.NoError(t, ki.tombstone(lg, 2, 2))
+				return ki
+			},
+			compact: 2,
+			wki: &keyIndex{
+				key:      []byte("foo"),
+				modified: Revision{Main: 2, Sub: 2},
+				generations: []generation{
+					{created: Revision{Main: 2, Sub: 1}, ver: 2, revs: []Revision{{Main: 2, Sub: 2}}},
+					{},
+				},
+			},
+			// the last tombstone of the revision is kept, the superseded one is not
+			wcompact: map[Revision]struct{}{{Main: 2, Sub: 2}: {}},
+			wkeep:    map[Revision]struct{}{},
+		},
+		{
+			// regression guard for #18274
+			name: "tombstone at the compacted revision is kept",
+			build: func(lg *zap.Logger) *keyIndex {
+				ki := &keyIndex{key: []byte("foo")}
+				ki.put(lg, 2, 0)
+				ki.put(lg, 3, 0)
+				require.NoError(t, ki.tombstone(lg, 4, 0))
+				return ki
+			},
+			compact: 4,
+			wki: &keyIndex{
+				key:      []byte("foo"),
+				modified: Revision{Main: 4},
+				generations: []generation{
+					{created: Revision{Main: 2}, ver: 3, revs: []Revision{{Main: 4}}},
+					{},
+				},
+			},
+			wcompact: map[Revision]struct{}{{Main: 4}: {}},
+			wkeep:    map[Revision]struct{}{},
+		},
+		{
+			name: "re-created in a later revision keeps the tombstone",
+			build: func(lg *zap.Logger) *keyIndex {
+				ki := &keyIndex{key: []byte("foo")}
+				ki.put(lg, 1, 0)
+				require.NoError(t, ki.tombstone(lg, 2, 0))
+				ki.put(lg, 3, 0)
+				return ki
+			},
+			compact: 2,
+			wki: &keyIndex{
+				key:      []byte("foo"),
+				modified: Revision{Main: 3},
+				generations: []generation{
+					{created: Revision{Main: 1}, ver: 2, revs: []Revision{{Main: 2}}},
+					{created: Revision{Main: 3}, ver: 1, revs: []Revision{{Main: 3}}},
+				},
+			},
+			wcompact: map[Revision]struct{}{{Main: 2}: {}},
+			wkeep:    map[Revision]struct{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := zaptest.NewLogger(t)
+
+			ki := tt.build(lg)
+			kiClone := cloneKeyIndex(ki)
+			keep := make(map[Revision]struct{})
+			ki.keep(tt.compact, keep)
+			require.Equalf(t, kiClone, ki, "keep must not modify the keyIndex for %q", tt.name)
+			require.Equal(t, tt.wkeep, keep)
+
+			ki = tt.build(lg)
+			am := make(map[Revision]struct{})
+			ki.compact(lg, tt.compact, am)
+			require.Equal(t, tt.wcompact, am)
+			require.Equal(t, tt.wki, ki)
+		})
+	}
+}
+
 func cloneKeyIndex(ki *keyIndex) *keyIndex {
 	generations := make([]generation, len(ki.generations))
 	for i, gen := range ki.generations {

--- a/server/storage/mvcc/kvstore_test.go
+++ b/server/storage/mvcc/kvstore_test.go
@@ -30,7 +30,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -369,6 +371,59 @@ func TestStoreCompact(t *testing.T) {
 	if g := fi.Action(); !reflect.DeepEqual(g, wact) {
 		t.Errorf("index action = %+v, want %+v", g, wact)
 	}
+}
+
+// TestStoreCompactRecreatedKeyInSameRevision writes a key, then deletes and
+// re-creates it in a single transaction, and compacts at that revision. The
+// live value must survive the compaction: before the fix its backend row was
+// deleted while the index kept pointing at it, so the next range over the key
+// hit the "range failed to find revision pair" fatal, and a restart rebuilt an
+// empty keyspace from the backend.
+func TestStoreCompactRecreatedKeyInSameRevision(t *testing.T) {
+	// turn the fatal in rangeKeys into a recoverable panic
+	lg := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WithFatalHook(zapcore.WriteThenPanic)))
+	b, _ := betesting.NewDefaultTmpBackend(t)
+	s := NewStore(lg, b, &lease.FakeLessor{}, StoreConfig{})
+	defer func() {
+		s.Close()
+		b.Close()
+	}()
+
+	s.Put([]byte("foo"), []byte("bar"), lease.NoLease)
+	s.Put([]byte("foo2"), []byte("bar2"), lease.NoLease)
+
+	// one transaction rewriting the whole keyspace: every key gets a tombstone
+	// and its re-creation in the same main revision, at different sub revisions
+	tw := s.Write(traceutil.TODO())
+	tw.DeleteRange([]byte("foo"), []byte("fop"))
+	tw.Put([]byte("foo"), []byte("bar-new"), lease.NoLease)
+	tw.Put([]byte("foo2"), []byte("bar2-new"), lease.NoLease)
+	tw.End()
+
+	rev := s.Rev()
+	ch, err := s.Compact(traceutil.TODO(), rev)
+	require.NoError(t, err)
+	<-ch
+
+	assertRange := func(t *testing.T, s KV) {
+		t.Helper()
+		tr := s.Read(ConcurrentReadTxMode, traceutil.TODO())
+		defer tr.End()
+		r, err := tr.Range(t.Context(), []byte("foo"), []byte("fop"), RangeOptions{})
+		require.NoError(t, err)
+		require.Len(t, r.KVs, 2)
+		require.Equal(t, []byte("bar-new"), r.KVs[0].Value)
+		require.Equal(t, []byte("bar2-new"), r.KVs[1].Value)
+	}
+
+	assertRange(t, s)
+
+	// the backend must still be able to rebuild the index, i.e. a restart does
+	// not come back with an empty keyspace
+	s.Close()
+	s = NewStore(lg, b, &lease.FakeLessor{}, StoreConfig{})
+	require.Equal(t, rev, s.Rev())
+	assertRange(t, s)
 }
 
 func TestStoreRestore(t *testing.T) {

--- a/tests/e2e/reproduce_22376_test.go
+++ b/tests/e2e/reproduce_22376_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+)
+
+// TestReproduce22376 reproduces the issue: https://github.com/etcd-io/etcd/issues/22376
+//
+// A key that is deleted and re-created within a single main revision must keep
+// its value when the store is compacted at exactly that revision. Before the
+// fix the live value was deleted from the backend while the index still
+// referenced it, so the next range hit the "range failed to find revision pair"
+// fatal and the restarted member served an empty keyspace.
+func TestReproduce22376(t *testing.T) {
+	e2e.BeforeTest(t)
+	// bound the context: if the member dies on the fatal below, the client
+	// would otherwise retry until the test binary times out
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	clus, err := e2e.NewEtcdProcessCluster(ctx, t, e2e.WithClusterSize(1))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clus.Stop()) })
+
+	cli := newClient(t, clus.EndpointsGRPC(), e2e.ClientConfig{})
+
+	keys := []string{"cfg/a", "cfg/b", "cfg/c"}
+	for _, k := range keys {
+		_, err = cli.Put(ctx, k, "v1")
+		require.NoError(t, err)
+	}
+
+	// Rewrite the whole keyspace in one transaction, so that every key gets a
+	// tombstone and its re-creation in the same main revision.
+	ops := []clientv3.Op{clientv3.OpDelete("\x00", clientv3.WithFromKey())}
+	for _, k := range keys {
+		ops = append(ops, clientv3.OpPut(k, "v2"))
+	}
+	txnResp, err := cli.Txn(ctx).Then(ops...).Commit()
+	require.NoError(t, err)
+
+	_, err = cli.Compact(ctx, txnResp.Header.Revision, clientv3.WithCompactPhysical())
+	require.NoError(t, err)
+
+	assertKeys := func(t *testing.T) {
+		t.Helper()
+		resp, gerr := cli.Get(ctx, "cfg/", clientv3.WithPrefix())
+		require.NoError(t, gerr)
+		require.Len(t, resp.Kvs, len(keys))
+		for _, kv := range resp.Kvs {
+			require.Equal(t, []byte("v2"), kv.Value)
+		}
+	}
+
+	assertKeys(t)
+
+	// the backend must still hold enough to rebuild the index on restart
+	require.NoError(t, clus.Procs[0].Restart(ctx))
+	assertKeys(t)
+}


### PR DESCRIPTION
This was done by Claude.

Fixes #22376.

A key deleted and re-created within a single main revision loses its value when the store is compacted at exactly that revision. The next range over the key hits the `range failed to find revision pair` fatal at `mvcc/kvstore_txn.go:128`, the process exits, and the restarted member rebuilds an empty index from a backend that no longer holds the rows — serving an empty keyspace while reporting itself healthy.

This is a regression from #18274, which changed the generation-selection condition in `keyIndex.doCompact` from `tomb > atRev` to `tomb >= atRev`. Verified by building the unit reproducer at `bbdc94181^` (passes) and `bbdc94181` (fails).

### The defect

For a key that existed before the rewrite, one transaction that deletes and re-creates it produces:

```
gen0: [ ..., 4.0 put, 7.2 tombstone ]   <- the DeleteRange
gen1: [ 7.5 put ]                        <- the Put, same main revision
```

`doCompact(7)` breaks on `gen0` because its tombstone's main revision equals `atRev`, so `gen1` is never walked and `7.5` never reaches `available`. `scheduleCompaction` then deletes that row from the backend, while `compact()` leaves `gen1` in the index still referencing it.

### The fix

Advance past a generation whose tombstone sits on `atRev` only when the next generation was created in the *same* main revision — i.e. the key was re-created and the tombstone is superseded. `keyIndex.since()` already encodes this rule, hiding superseded revisions of a main revision from watchers, so the key is alive at the end of `atRev` and its put must survive.

A tombstone that is the key's last word at `atRev` is still kept, so #18274's behaviour is unchanged.

### Compaction hash values do not change

`keyIndex.keep()` feeds `newKVHasher` and is required to stay consistent across versions. I enumerated every put/tombstone sequence of length 4 over a small main/sub revision space and compared `keep()` and `compact()`'s `available` for every `atRev`, against both the pre-#18274 algorithm and current `main` (5285 cases):

| comparison | `keep()` diffs | `compact()` available diffs |
| --- | ---: | ---: |
| fixed vs pre-#18274 (≤ 3.5.15 / ≤ 3.4.33) | **0** | 624 |
| fixed vs current `main` | 126 | 131 |

- **`keep()` is byte-identical to pre-#18274 in every case**, so `HashByRev` is restored to exactly the value older versions produce. The 126 differences against current `main` are precisely the affected shape, where `main` has already deleted live data.
- The 624 `compact()` differences against pre-#18274 are #18274's own intentional change (keeping the tombstone at the compaction revision), already compensated for in `hash.go`; this PR does not add to them.
- Every revision whose membership in `available` changes has `Main == atRev` (asserted in the same sweep). The compaction hasher only gates membership for revisions with `Main <= prevCompactRev < compactMainRev`, so it never consults the entries that changed.

Empirically, compaction hashes over workloads that do not contain the affected shape — including #18274's own tombstone-at-compaction-revision shape and repeated delete/re-create across revisions — are bit-identical before and after this change (22 (workload, revision) pairs compared).

There are 5 shapes in the sweep where the result differs from *both* prior versions, all the same one: delete, re-create and delete again inside one revision. There the fix keeps the revision's **final** tombstone; current `main` keeps a superseded earlier one and pre-#18274 kept neither. That is what #18274 intended, and it is not a data-loss case.

### Tests

- `TestKeyIndexCompactAndKeepOnRecreatedRev` — the generation selection, asserting `compact()` and `keep()` separately, with the #18274 tombstone case as an explicit regression guard.
- `TestStoreCompactRecreatedKeyInSameRevision` — store level over a real backend: `DeleteRange` + `Put` in one write txn, compact at that revision, range the keys, then re-open the store over the same backend to prove the index still rebuilds.
- `TestReproduce22376` — e2e, via the public client API.

All three fail on `main` and pass with the fix. `make verify-lint`, `go test -race ./storage/...`, `tests/common` (integration), and the integration compaction/corruption/hash/watch suites are green.

### Backports

The regressing commit is on every supported branch (`release-3.5` from v3.5.16, `release-3.6`, `release-3.7`; `release-3.4` is EOL). I confirmed the defect reproduces on `origin/release-3.4` and `origin/release-3.5` with an equivalent unit reproducer. Happy to open backport PRs for 3.5, 3.6 and 3.7 with their CHANGELOG entries once this is reviewed.

### Note on reachability

`checkIntervals` in `server/etcdserver/api/v3rpc/key.go` is meant to reject a txn that deletes and puts the same key, but it builds the delete's interval as `[key, range_end)`. For `range_end == "\x00"` — `clientv3.WithFromKey()`, the idiomatic "delete to the end of the keyspace" — that interval is empty and intersects nothing, so the overlapping puts are accepted. Details and a measured table of which forms are caught are in #22376. Whether to tighten that check is a separate question; the mvcc layer needs to be correct either way, since the apply path does not validate and the same entry applies unchecked on followers and on WAL replay.

<!-- Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow. -->
