### PR TITLE
server/v2auth: reject empty permission patterns

### DIFF
--- a/server/etcdserver/api/v2auth/auth.go
+++ b/server/etcdserver/api/v2auth/auth.go
@@ -602,6 +602,9 @@ func (rw RWPermission) HasRecursiveAccess(key string, write bool) bool {
 }
 
 func simpleMatch(pattern string, key string) (match bool, err error) {
+	if pattern == "" {
+		return false, nil
+	}
 	if pattern[len(pattern)-1] == '*' {
 		return strings.HasPrefix(key, pattern[:len(pattern)-1]), nil
 	}
@@ -609,6 +612,9 @@ func simpleMatch(pattern string, key string) (match bool, err error) {
 }
 
 func prefixMatch(pattern string, key string) (match bool, err error) {
+	if pattern == "" {
+		return false, nil
+	}
 	if pattern[len(pattern)-1] != '*' {
 		return false, nil
 	}

--- a/server/etcdserver/api/v2auth/auth_test.go
+++ b/server/etcdserver/api/v2auth/auth_test.go
@@ -676,3 +676,34 @@ func TestSimpleMatch(t *testing.T) {
 		t.Fatal("role has unexpected access")
 	}
 }
+
+func TestEmptyPatternDoesNotPanic(t *testing.T) {
+	// A role whose permission list contains an empty-string pattern can be
+	// stored through the v2 role API. Matching an empty pattern must be
+	// rejected gracefully instead of panicking with index out of range.
+	role := Role{Role: "foo", Permissions: Permissions{KV: RWPermission{Read: []string{""}, Write: []string{""}}}}
+
+	if role.HasKeyAccess("/foodir/foo/bar", false) {
+		t.Fatal("role with empty read pattern should not grant access")
+	}
+	if role.HasKeyAccess("/foodir/foo/bar", true) {
+		t.Fatal("role with empty write pattern should not grant access")
+	}
+	if role.HasRecursiveAccess("/foodir/foo/bar", false) {
+		t.Fatal("role with empty read pattern should not grant recursive access")
+	}
+	if role.HasRecursiveAccess("/foodir/foo/bar", true) {
+		t.Fatal("role with empty write pattern should not grant recursive access")
+	}
+
+	if match, _ := simpleMatch("", "/foodir/foo/bar"); match {
+		t.Fatal("simpleMatch with empty pattern should not match")
+	}
+	if match, _ := prefixMatch("", "/foodir/foo/bar"); match {
+		t.Fatal("prefixMatch with empty pattern should not match")
+	}
+
+	if match, _ := simpleMatch("*", "/foodir/foo/bar"); !match {
+		t.Fatal("simpleMatch with '*' pattern should match")
+	}
+}


### PR DESCRIPTION
`simpleMatch` and `prefixMatch` in the v2 auth package dereference `pattern[len(pattern)-1]` without checking whether the pattern is empty. An empty-string permission pattern can be stored through the v2 role API (no validation when the role is created or updated), and the next time a user whose role carries that pattern accesses a key, matching panics with `runtime error: index out of range [-1]`. The panic is recovered by net/http which then closes the connection, so the request is dropped without a response.

## Fix

Treat an empty pattern as non-matching in both `simpleMatch` and `prefixMatch` so that roles containing an empty pattern are denied access gracefully instead of crashing the request handler.

## Test

Added `TestEmptyPatternDoesNotPanic` covering `HasKeyAccess`, `HasRecursiveAccess`, `simpleMatch` and `prefixMatch` with an empty pattern, plus a sanity check that the `*` wildcard still matches.
