### PR TITLE
etcdctl: add --from-key to watch command

### DIFF
--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -39,6 +39,7 @@ var (
 var (
 	watchRev         int64
 	watchPrefix      bool
+	watchFromKey     bool
 	watchInteractive bool
 	watchPrevKey     bool
 	progressNotify   bool
@@ -55,6 +56,7 @@ func NewWatchCommand() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&watchInteractive, "interactive", "i", false, "Interactive mode")
 	cmd.Flags().BoolVar(&watchPrefix, "prefix", false, "Watch on a prefix if prefix is set")
+	cmd.Flags().BoolVar(&watchFromKey, "from-key", false, "Watch keys that are greater than or equal to the given key using byte compare")
 	cmd.Flags().Int64Var(&watchRev, "rev", 0, "Revision to start watching")
 	cmd.Flags().BoolVar(&watchPrevKey, "prev-kv", false, "get the previous key-value pair before the event happens")
 	cmd.Flags().BoolVar(&progressNotify, "progress-notify", false, "get periodic watch progress notification from server")
@@ -149,10 +151,19 @@ func getWatchChan(c *clientv3.Client, args []string) (clientv3.WatchChan, error)
 		if watchPrefix {
 			return nil, fmt.Errorf("`range_end` and `--prefix` are mutually exclusive")
 		}
+		if watchFromKey {
+			return nil, fmt.Errorf("`range_end` and `--from-key` are mutually exclusive")
+		}
 		opts = append(opts, clientv3.WithRange(args[1]))
+	}
+	if watchPrefix && watchFromKey {
+		return nil, fmt.Errorf("`--prefix` and `--from-key` are mutually exclusive")
 	}
 	if watchPrefix {
 		opts = append(opts, clientv3.WithPrefix())
+	}
+	if watchFromKey {
+		opts = append(opts, clientv3.WithFromKey())
 	}
 	if watchPrevKey {
 		opts = append(opts, clientv3.WithPrevKV())
@@ -217,7 +228,7 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 	if interactive {
 		if watchArgs[0] != "watch" {
 			// "watch" not found
-			watchPrefix, watchRev, watchPrevKey = false, 0, false
+			watchPrefix, watchFromKey, watchRev, watchPrevKey = false, false, 0, false
 			return nil, nil, errBadArgsInteractiveWatch
 		}
 		watchArgs = watchArgs[1:]
@@ -272,20 +283,20 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 		}
 		if execExist && execIdx == len(watchArgs)-1 {
 			// "watch foo bar --" should error
-			watchPrefix, watchRev, watchPrevKey = false, 0, false
+			watchPrefix, watchFromKey, watchRev, watchPrevKey = false, false, 0, false
 			return nil, nil, errBadArgsNumSeparator
 		}
 
 		flagset := NewWatchCommand().Flags()
 		if perr := flagset.Parse(watchArgs); perr != nil {
-			watchPrefix, watchRev, watchPrevKey = false, 0, false
+			watchPrefix, watchFromKey, watchRev, watchPrevKey = false, false, 0, false
 			return nil, nil, perr
 		}
 		pArgs := flagset.Args()
 
 		// "watch" with no argument should error
 		if !execExist && envKey == "" && len(pArgs) < 1 {
-			watchPrefix, watchRev, watchPrevKey = false, 0, false
+			watchPrefix, watchFromKey, watchRev, watchPrevKey = false, false, 0, false
 			return nil, nil, errBadArgsNum
 		}
 		// check conflicting arguments
@@ -293,7 +304,7 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 		if !execExist && len(pArgs) > 0 && envKey != "" {
 			// "ETCDCTL_WATCH_KEY=foo watch foo" should error
 			// (watchArgs==["foo"])
-			watchPrefix, watchRev, watchPrevKey = false, 0, false
+			watchPrefix, watchFromKey, watchRev, watchPrevKey = false, false, 0, false
 			return nil, nil, errBadArgsNumConflictEnv
 		}
 	}
@@ -323,6 +334,10 @@ func parseWatchArgs(osArgs, commandArgs []string, envKey, envRange string, inter
 		watchArgs = flagset.Args()
 
 		watchPrefix, err = flagset.GetBool("prefix")
+		if err != nil {
+			return nil, nil, err
+		}
+		watchFromKey, err = flagset.GetBool("from-key")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tests/e2e/ctl_v3_watch_test.go
+++ b/tests/e2e/ctl_v3_watch_test.go
@@ -175,6 +175,12 @@ func watchTest(cx ctlCtx) {
 			args:   []string{"--rev", "1", "--prefix"},
 			wkv:    []kvExec{{key: "key1", val: "val1"}, {key: "key2", val: "val2"}, {key: "key3", val: "val3"}},
 		},
+		{ // watch keys from a given key onward (>=), with env
+			puts:   []kv{{"key1", "val1"}, {"key2", "val2"}, {"key3", "val3"}},
+			envKey: "key1",
+			args:   []string{"--rev", "1", "--from-key"},
+			wkv:    []kvExec{{key: "key1", val: "val1"}, {key: "key2", val: "val2"}, {key: "key3", val: "val3"}},
+		},
 		{ // watch 3 keys by range, with env
 			puts:     []kv{{"key1", "val1"}, {"key3", "val3"}, {"key2", "val2"}},
 			envKey:   "key",


### PR DESCRIPTION
Fixes #22381 

## Problem

`etcdctl get` and `etcdctl del` both support `--from-key` (watch/get/delete all keys that
are byte-wise >= the given key), but `etcdctl watch` doesn't -- it can only watch an exact
key or a `--prefix`.

## Change

- Added a `--from-key` flag to the `watch` command, mirroring the exact pattern already
  used by `get`/`del` (`etcdctl/ctlv3/command/get_command.go`, `del_command.go`).
- Added the same `--prefix`/`--from-key` mutual-exclusion check `get`/`del` already have.
- Updated the interactive-mode flag reset/reparse paths so `--from-key` behaves the same
  as the existing `--prefix` flag across repeated interactive `watch` invocations.
- Added an e2e test case in `tests/e2e/ctl_v3_watch_test.go` mirroring the existing
  `--prefix` test case, run against a real spawned etcd server with the built CLI.

The server already fully implements this for Watch requests: `WithFromKey()`'s sentinel
value (`RangeEnd = []byte{0}`) is already handled in
`server/etcdserver/api/v3rpc/watch.go` with a comment saying "support >= key queries",
and the client library (`clientv3.WithFromKey()`) already documents itself as applying to
'Get', 'Delete', 'Watch'. So this PR is purely additive CLI wiring -- no server or client
library changes needed.

Verified: `go build ./...`, `go vet ./etcdctl/...` clean, existing `Test_parseWatchArgs`
unit test still passes, new e2e test (`TestCtlV3Watch`) passes against a real spawned
server running the actual built `etcdctl` binary.