### PR TITLE
client/v3: add ResumeMutex to concurrency package

### DIFF
--- a/client/v3/concurrency/mutex.go
+++ b/client/v3/concurrency/mutex.go
@@ -46,6 +46,11 @@ func NewMutex(s *Session, pfx string) *Mutex {
 	return &Mutex{s, pfx + "/", "", -1, nil}
 }
 
+// ResumeMutex initializes a mutex with a known owner.
+func ResumeMutex(s *Session, pfx string, myKey string, myRev int64) *Mutex {
+	return &Mutex{s, pfx + "/", myKey, myRev, nil}
+}
+
 // TryLock locks the mutex if not already locked by another session.
 // If lock is held by another session, return immediately after attempting necessary cleanup
 // The ctx argument is used for the sending/receiving Txn RPC.

--- a/tests/integration/clientv3/concurrency/mutex_test.go
+++ b/tests/integration/clientv3/concurrency/mutex_test.go
@@ -88,3 +88,44 @@ func TestMutexUnlock(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestResumeMutex verifies that a Mutex can be reconstructed from a known
+// owner key and revision (e.g. after a process restart with a surviving
+// lease, via Session's WithLease option), mirroring TestResumeElection.
+func TestResumeMutex(t *testing.T) {
+	const prefix = "/resume-mutex/"
+
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	s1, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer s1.Close()
+
+	m1 := concurrency.NewMutex(s1, prefix)
+	require.NoError(t, m1.Lock(t.Context()))
+
+	myKey := m1.Key()
+	getResp, err := cli.Get(t.Context(), myKey)
+	require.NoError(t, err)
+	require.Lenf(t, getResp.Kvs, 1, "lock key %q should exist on the server after Lock()", myKey)
+	myRev := getResp.Kvs[0].CreateRevision
+
+	// Recreate the mutex, as if this were a different process that only
+	// knows the session, the key it previously wrote, and that key's
+	// creation revision.
+	m2 := concurrency.ResumeMutex(s1, prefix, myKey, myRev)
+
+	// The resumed mutex must still be recognized as the lock owner.
+	txnResp, err := cli.Txn(t.Context()).If(m2.IsOwner()).Then(clientv3.OpGet(myKey)).Commit()
+	require.NoError(t, err)
+	require.Truef(t, txnResp.Succeeded, "resumed Mutex should still be recognized as lock owner via IsOwner()")
+
+	// Unlock() through the resumed handle must release the real key.
+	require.NoError(t, m2.Unlock(t.Context()))
+
+	getResp, err = cli.Get(t.Context(), myKey)
+	require.NoError(t, err)
+	require.Emptyf(t, getResp.Kvs, "Unlock() via resumed Mutex should have deleted the real lock key")
+}


### PR DESCRIPTION
Fixes #22382 

## Problem

`concurrency.Election` has `ResumeElection`, for reconstructing an election handle after
a process restart (used together with `Session`'s `WithLease` option for a surviving
lease). `concurrency.Mutex` has no equivalent -- a restarted process that was holding a
lock has no way to get a working `*Mutex` handle back for it; it can only start over with
a fresh `Lock()` call, losing the distinction between "I already own this lock" and "I
need to compete for it."

## Change

- Added `ResumeMutex(s *Session, pfx, myKey string, myRev int64) *Mutex`, mirroring
  `ResumeElection`'s exact shape and doc-comment style.
- Added `TestResumeMutex` to `tests/integration/clientv3/concurrency/mutex_test.go`,
  mirroring the existing `TestResumeElection` pattern: locks a mutex, reconstructs a
  second `*Mutex` handle purely from the session + observed key/revision (simulating a
  process restart), and verifies `IsOwner()` still recognizes it as the owner and
  `Unlock()` correctly deletes the real server-side key.

`Mutex`'s `myKey`/`myRev` fields are structurally identical to `Election`'s
`leaderKey`/`leaderRev`, and `IsOwner()`/`Unlock()` only depend on those two values being
set correctly -- they have no dependency on which constructor produced them, so this is a
small, mechanical port of a pattern already proven for `Election`.

Verified: `go build ./client/v3/...`, `go vet ./client/v3/concurrency/...` clean, full
existing concurrency integration test suite passes alongside the new test (11/11,
including `TestResumeElection`, `TestMutexLockSessionExpired`, `TestMutexUnlock`, and the
package's `Example*` tests).