### PR TITLE
client/v3: stop concurrency waits when session expires

### DIFF
--- a/client/v3/concurrency/election.go
+++ b/client/v3/concurrency/election.go
@@ -90,7 +90,11 @@ func (e *Election) Campaign(ctx context.Context, val string) error {
 		}
 	}
 
-	err = waitDeletes(ctx, client, e.keyPrefix, e.leaderRev-1)
+	err = waitDeletes(ctx, client, e.keyPrefix, e.leaderKey, e.leaderRev-1)
+	if errors.Is(err, errWaitKeyDeleted) {
+		e.leaderSession = nil
+		return ErrElectionNotLeader
+	}
 	if err != nil {
 		// clean up in case of context cancel
 		select {
@@ -100,6 +104,17 @@ func (e *Election) Campaign(ctx context.Context, val string) error {
 			e.leaderSession = nil
 		}
 		return err
+	}
+
+	// Make sure the campaign key still exists before reporting success.
+	gresp, err := client.Get(ctx, e.leaderKey)
+	if err != nil {
+		e.leaderSession = nil
+		return err
+	}
+	if len(gresp.Kvs) == 0 {
+		e.leaderSession = nil
+		return ErrElectionNotLeader
 	}
 	e.hdr = resp.Header
 

--- a/client/v3/concurrency/key.go
+++ b/client/v3/concurrency/key.go
@@ -22,34 +22,72 @@ import (
 	v3 "go.etcd.io/etcd/client/v3"
 )
 
-func waitDelete(ctx context.Context, client *v3.Client, key string, rev int64) error {
+var (
+	errLostWatcher    = errors.New("lost watcher waiting for delete")
+	errWaitKeyDeleted = errors.New("wait key deleted")
+)
+
+func waitDelete(ctx context.Context, client *v3.Client, key string, rev int64, waitCh v3.WatchChan) error {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var wr v3.WatchResponse
 	wch := client.Watch(cctx, key, v3.WithRev(rev))
-	for wr = range wch {
-		for _, ev := range wr.Events {
-			if ev.Type == mvccpb.Event_DELETE {
-				return nil
+	for {
+		select {
+		case wr, ok := <-wch:
+			if !ok {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return errLostWatcher
 			}
+			if err := wr.Err(); err != nil {
+				return err
+			}
+			for _, ev := range wr.Events {
+				if ev.Type == mvccpb.Event_DELETE {
+					return nil
+				}
+			}
+		case wr, ok := <-waitCh:
+			if !ok {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return errLostWatcher
+			}
+			if err := wr.Err(); err != nil {
+				return err
+			}
+			for _, ev := range wr.Events {
+				if ev.Type == mvccpb.Event_DELETE {
+					return errWaitKeyDeleted
+				}
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
-	if err := wr.Err(); err != nil {
-		return err
-	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return errors.New("lost watcher waiting for delete")
 }
 
 // waitDeletes efficiently waits until all keys matching the prefix and no greater
-// than the create revision are deleted.
-func waitDeletes(ctx context.Context, client *v3.Client, pfx string, maxCreateRev int64) error {
+// than the create revision are deleted. It also stops if waitKey is deleted.
+func waitDeletes(ctx context.Context, client *v3.Client, pfx, waitKey string, maxCreateRev int64) error {
+	waitResp, err := client.Get(ctx, waitKey)
+	if err != nil {
+		return err
+	}
+	if len(waitResp.Kvs) == 0 {
+		return errWaitKeyDeleted
+	}
+
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	waitCh := client.Watch(cctx, waitKey, v3.WithRev(waitResp.Header.Revision))
+
 	getOpts := append(v3.WithLastCreate(), v3.WithMaxCreateRev(maxCreateRev))
 	for {
-		resp, err := client.Get(ctx, pfx, getOpts...)
+		resp, err := client.Get(cctx, pfx, getOpts...)
 		if err != nil {
 			return err
 		}
@@ -57,7 +95,7 @@ func waitDeletes(ctx context.Context, client *v3.Client, pfx string, maxCreateRe
 			return nil
 		}
 		lastKey := string(resp.Kvs[0].Key)
-		if err = waitDelete(ctx, client, lastKey, resp.Header.Revision); err != nil {
+		if err = waitDelete(cctx, client, lastKey, resp.Header.Revision, waitCh); err != nil {
 			return err
 		}
 	}

--- a/client/v3/concurrency/mutex.go
+++ b/client/v3/concurrency/mutex.go
@@ -85,8 +85,10 @@ func (m *Mutex) Lock(ctx context.Context) error {
 	}
 	client := m.s.Client()
 	// wait for deletion revisions prior to myKey
-	// TODO: early termination if the session key is deleted before other session keys with smaller revisions.
-	werr := waitDeletes(ctx, client, m.pfx, m.myRev-1)
+	werr := waitDeletes(ctx, client, m.pfx, m.myKey, m.myRev-1)
+	if errors.Is(werr, errWaitKeyDeleted) {
+		return ErrSessionExpired
+	}
 	// release lock key if wait failed
 	if werr != nil {
 		m.Unlock(client.Ctx())

--- a/tests/integration/clientv3/concurrency/election_test.go
+++ b/tests/integration/clientv3/concurrency/election_test.go
@@ -28,6 +28,50 @@ import (
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
 
+func TestElectionCampaignSessionExpired(t *testing.T) {
+	const prefix = "/session-expiry-election"
+
+	cli, err := integration.NewClient(t, clientv3.Config{Endpoints: exampleEndpoints()})
+	require.NoError(t, err)
+	defer cli.Close()
+
+	s1, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	defer s1.Close()
+	e1 := concurrency.NewElection(s1, prefix)
+	require.NoError(t, e1.Campaign(t.Context(), "candidate1"))
+
+	s2, err := concurrency.NewSession(cli)
+	require.NoError(t, err)
+	e2 := concurrency.NewElection(s2, prefix)
+
+	campaignDone := make(chan error, 1)
+	go func() {
+		campaignDone <- e2.Campaign(t.Context(), "candidate2")
+	}()
+
+	// wait until candidate2 has joined the election before revoking its session
+	require.Eventually(t, func() bool {
+		resp, getErr := cli.Get(t.Context(), prefix+"/", clientv3.WithPrefix())
+		return getErr == nil && len(resp.Kvs) == 2
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// candidate2 should stop waiting even though candidate1 is still leader
+	require.NoError(t, s2.Close())
+	select {
+	case err = <-campaignDone:
+		require.ErrorIs(t, err, concurrency.ErrElectionNotLeader)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Campaign did not return after its session expired")
+	}
+
+	leader, err := e1.Leader(t.Context())
+	require.NoError(t, err)
+	require.Len(t, leader.Kvs, 1)
+	require.Equal(t, "candidate1", string(leader.Kvs[0].Value))
+	require.NoError(t, e1.Resign(t.Context()))
+}
+
 func TestResumeElection(t *testing.T) {
 	const prefix = "/resume-election/"
 

--- a/tests/integration/clientv3/concurrency/mutex_test.go
+++ b/tests/integration/clientv3/concurrency/mutex_test.go
@@ -17,6 +17,7 @@ package concurrency_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,21 +44,30 @@ func TestMutexLockSessionExpired(t *testing.T) {
 	// acquire lock for s1
 	require.NoError(t, m1.Lock(t.Context()))
 
-	m2Locked := make(chan struct{})
-	var err2 error
+	m2Locked := make(chan error, 1)
 	go func() {
-		defer close(m2Locked)
 		// m2 blocks since m1 already acquired lock /my-lock/
-		if err2 = m2.Lock(t.Context()); err2 == nil {
-			t.Error("expect session expired error")
-		}
+		m2Locked <- m2.Lock(t.Context())
 	}()
 
-	// revoke the session of m2 before unlock m1
-	require.NoError(t, s2.Close())
-	require.NoError(t, m1.Unlock(t.Context()))
+	// wait until m2 has joined the lock queue before revoking its session
+	require.Eventually(t, func() bool {
+		resp, getErr := cli.Get(t.Context(), "/my-lock/", clientv3.WithPrefix())
+		return getErr == nil && len(resp.Kvs) == 2
+	}, 5*time.Second, 10*time.Millisecond)
 
-	<-m2Locked
+	// revoke m2's session while m1 still holds the lock
+	require.NoError(t, s2.Close())
+
+	select {
+	case err = <-m2Locked:
+		require.ErrorIs(t, err, concurrency.ErrSessionExpired)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Lock did not return after its session expired")
+	}
+
+	// m1 still owns the lock when m2 returns
+	require.NoError(t, m1.Unlock(t.Context()))
 }
 
 func TestMutexUnlock(t *testing.T) {


### PR DESCRIPTION
### Description

When a mutex or election contender is waiting behind an older key, `waitDeletes` only watches the key ahead of it. If the waiting session expires during that time, its own lease-backed key is removed but the operation keeps waiting until the older key is deleted.

This changes the wait logic to also watch the contender's own key and return as soon as that key disappears.

For mutexes this returns the existing `ErrSessionExpired`. For elections it returns `ErrElectionNotLeader`.

I also added regression coverage for both cases so the tests verify that the waiter returns while the current lock holder or election leader is still active.

Fixes #19597

### Testing

* `go test ./client/v3/concurrency -count=1`
* `go test ./tests/integration/clientv3/concurrency -count=1`
* repeated the new mutex and election regression tests 50 times
* ran the relevant tests with the race detector
* `make verify`