### PR TITLE
feat(mixin): Add dbSizeInUse metric to the dashboard to see visualize…

### DIFF
--- a/contrib/mixin/dashboards/etcd.libsonnet
+++ b/contrib/mixin/dashboards/etcd.libsonnet
@@ -24,7 +24,7 @@
           panels.stat.up('Up', t.up) { gridPos: { x: 0, h: 7, w: 6, y: 0 } },
           panels.timeSeries.rpcRate('RPC rate', [t.rpcRate, t.rpcFailedRate]) { gridPos: { x: 6, h: 7, w: 10, y: 0 } },
           panels.timeSeries.activeStreams('Active streams', [t.watchStreams, t.leaseStreams]) { gridPos: { x: 16, h: 7, w: 8, y: 0 } },
-          panels.timeSeries.dbSize('DB size', [t.dbSize]) { gridPos: { x: 0, h: 7, w: 8, y: 25 } },
+          panels.timeSeries.dbSize('DB size', [t.dbSize, t.dbSizeInUse]) { gridPos: { x: 0, h: 7, w: 8, y: 25 } },
           panels.timeSeries.diskSync('Disk sync duration', [t.walFsync, t.dbFsync]) { gridPos: { x: 8, h: 7, w: 8, y: 25 } },
           panels.timeSeries.memory('Memory', [t.memory]) { gridPos: { x: 16, h: 7, w: 8, y: 25 } },
           panels.timeSeries.traffic('Client traffic in', [t.clientTrafficIn]) { gridPos: { x: 0, h: 7, w: 6, y: 50 } },

--- a/contrib/mixin/dashboards/panels.libsonnet
+++ b/contrib/mixin/dashboards/panels.libsonnet
@@ -38,7 +38,14 @@ local g = import 'g.libsonnet';
       self.base(title, targets),
     dbSize(title, targets):
       self.base(title, targets)
-      + timeSeries.standardOptions.withUnit('bytes'),
+      + timeSeries.standardOptions.withUnit('bytes')
+      + timeSeries.panelOptions.withDescription(
+        |||
+          - `DB size` is the total allocated backend size on disk (etcd_mvcc_db_total_size_in_bytes).
+          - `DB size in use` is the space actually used by live data (etcd_mvcc_db_total_size_in_use_in_bytes).
+          A large gap between them indicates fragmentation; consider running etcd defrag when the in-use ratio is low.
+        |||
+      ),
     diskSync(title, targets):
       self.base(title, targets)
       + timeSeries.standardOptions.withUnit('s'),

--- a/contrib/mixin/dashboards/targets.libsonnet
+++ b/contrib/mixin/dashboards/targets.libsonnet
@@ -41,6 +41,12 @@ function(variables, config) {
       'etcd_mvcc_db_total_size_in_bytes{%s, %s="$cluster"}' % [config.etcd_selector, config.clusterLabel],
     )
     + prometheusQuery.withLegendFormat('{{instance}} DB size'),
+  dbSizeInUse:
+    prometheusQuery.new(
+      '$' + variables.datasource.name,
+      'etcd_mvcc_db_total_size_in_use_in_bytes{%s, %s="$cluster"}' % [config.etcd_selector, config.clusterLabel],
+    )
+    + prometheusQuery.withLegendFormat('{{instance}} DB size in use'),
   walFsync:
     prometheusQuery.new(
       '$' + variables.datasource.name,


### PR DESCRIPTION
This PR adds dbSizeInUse metric  to the existing dbSize panel for visualising fragmentation ratio already tracked in etcdDatabaseHighFragmentationRatio alert.