### PR TITLE
embed: close active peer connections after shutdown timeout

### DIFF
--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -617,7 +617,10 @@ func (e *Etcd) servePeers() {
 				"stopping serving peer traffic",
 				zap.String("address", u),
 			)
-			srv.Shutdown(ctx)
+			if err := srv.Shutdown(ctx); err != nil {
+				// Shutdown does not close active connections when its context expires.
+				srv.Close()
+			}
 			e.cfg.logger.Info(
 				"stopped serving peer traffic",
 				zap.String("address", u),

--- a/tests/integration/embed/embed_test.go
+++ b/tests/integration/embed/embed_test.go
@@ -20,7 +20,9 @@
 package embed_test
 
 import (
+	"bufio"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -31,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.etcd.io/etcd/api/v3/version"
 	"go.etcd.io/etcd/client/pkg/v3/testutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -126,6 +129,47 @@ func TestEmbedEtcd(t *testing.T) {
 
 func TestEmbedEtcdGracefulStopSecure(t *testing.T)   { testEmbedEtcdGracefulStop(t, true) }
 func TestEmbedEtcdGracefulStopInsecure(t *testing.T) { testEmbedEtcdGracefulStop(t, false) }
+
+func TestEmbedEtcdCloseClosesActivePeerConnections(t *testing.T) {
+	testutil.SkipTestIfShortMode(t, "Cannot start embedded cluster in --short tests")
+
+	cfg := embed.NewConfig()
+	urls := newEmbedURLs(false, 2)
+	setupEmbedCfg(cfg, []url.URL{urls[0]}, []url.URL{urls[1]})
+	cfg.Dir = filepath.Join(t.TempDir(), "embed-etcd")
+
+	e, err := embed.StartEtcd(cfg)
+	require.NoError(t, err)
+	defer func() {
+		if e != nil {
+			e.Close()
+		}
+	}()
+	<-e.Server.ReadyNotify()
+
+	conn, err := net.Dial("unix", urls[1].Host)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "POST /raft HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nExpect: 100-continue\r\nX-Server-From: %s\r\nX-Server-Version: %s\r\nX-Min-Cluster-Version: %s\r\nX-Etcd-Cluster-ID: %s\r\n\r\n", e.Server.MemberID(), version.Version, version.MinClusterVersion, e.Server.Cluster().ID())
+	require.NoError(t, err)
+
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "HTTP/1.1 100 Continue\r\n", statusLine)
+	emptyLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "\r\n", emptyLine)
+
+	e.Close()
+	e = nil
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(100*time.Millisecond)))
+	_, err = reader.ReadByte()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, os.ErrDeadlineExceeded)
+}
 
 // testEmbedEtcdGracefulStop ensures embedded server stops
 // cutting existing transports.


### PR DESCRIPTION
Fixes #22389.

When graceful shutdown of the peer HTTP server exceeds its one-second deadline, `http.Server.Shutdown` returns without closing active connections. Closing cmux afterward does not close connections that the HTTP server has already accepted, so `embed.Etcd.Close` can return while those connections remain open.

This change calls `http.Server.Close` when graceful shutdown returns an error. Requests still receive the existing grace period; only connections that remain afterward are closed immediately.

The regression test uses a Unix peer listener, waits for `100 Continue` to confirm that the Raft handler has started reading the request body, leaves the body incomplete, and checks that the connection is closed after `embed.Etcd.Close` returns. It verifies socket closure, not completion of every request-handler goroutine.

Validation (Go 1.26.7, darwin/amd64):

- `go test ./server/embed -count=1`
- `go test ./tests/integration/embed -count=1`
- `go test ./tests/integration/embed -run '^TestEmbedEtcdCloseClosesActivePeerConnections$' -count=10`
- `go test -race ./tests/integration/embed -run '^TestEmbedEtcdCloseClosesActivePeerConnections$' -count=1`
- `golangci-lint run --config tools/.golangci.yaml ./server/embed/... ./tests/integration/embed/...`
- `make verify-mod-tidy`

AI usage disclosure: OpenAI Codex assisted with investigating the shutdown path, implementing the change, and preparing the test and pull request text. The behavior was reproduced before the change and the commands above were run against the final commit.

Rhyme:

> Give peer requests their time to cease;  
> then close what lingers, clean release.

Prompt: "Investigate whether embedded etcd closes active peer HTTP connections when graceful shutdown times out. Implement an isolated upstream fix and regression test, and create an objective pull request without referring to downstream projects."
