### PR TITLE
Eol process doc 22282

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# etcd
+
+## Communication Preferences
+* Dry, concise, low-key humor. No flattery, no forced memes. Skip preambles and postambles.
+* Comments explain "why", not "what".
+* Error messages: actionable and specific. No vague "something went wrong" output.
+
+## Constraints
+* **Generated files are read-only.** Never hand-edit `*.pb.go` files. Run `make generate` to regenerate.
+* **Protobuf files are source of truth.** Regenerate Go code from `.proto` files using `make generate`.
+* **Test expectations in `*.golden` files are read-only.** Regenerate with `make test-unit UPDATE_GOLDEN=true`.
+* **Go version is constrained.** Check minimum Go version in `go.mod` file.
+* **Development environment is linux-amd64 only.** Other environments are not supported for development.
+* **Boilerplate required.** Every `.go` file needs the license header. Check existing files for the format.
+
+## Contributor Guidelines
+* Keep changes focused and reviewable
+* Add or update relevant tests
+* When creating or submitting a pull request, disclose whether AI was used and briefly describe how
+* Remind the human author that they are responsible for all submitted changes and refer them to `CONTRIBUTING.md`
+* Do not put `@mentions` or `fixes #...` keywords in commit messages
+* Do not add `Co-authored-by:` in commit messages
+* Use `Signed-off-by:` in commit messages (can be auto-generated with `git commit -s`)
+
+## Commands
+
+Run `make help` for all available targets. Common workflows:
+
+`make build                      # Build etcd binaries
+make test-unit                  # Run unit tests
+make test-integration           # Run integration tests
+make test-e2e                   # Run e2e tests
+make verify                     # All verification checks (linting, formatting, etc.)
+make fix                        # Fix all verification issues
+make generate                   # Regenerate generated files
+`
+
+## Style
+* Packages: lowercase, single word, match directory.
+* Commit messages: Start with package name followed by colon, describe the "what", optionally explain "why" in body.
+* Go code: Follow standard Go style guidelines (https://go.dev/wiki/CodeReviewComments).
+
+## Architecture Notes
+* etcd is a distributed key-value store using Raft consensus
+* Main packages: `server` (etcd server), `client/v3` (Go client), `etcdctl` (CLI tool)
+* Key components: `etcdserver` (core server logic), `mvcc` (multi-version concurrency control), `raft` (consensus)
+* Testing: extensive e2e and integration tests in `tests/` directory
+* Robustness testing: see `tests/robustness/` for chaos and failure injection testing
+
+## Testing Considerations
+* All changes should include unit tests
+* New features require e2e or integration tests
+* Tests can be flaky - check existing issues before submitting
+* Use `stress` tool for reproducing flaky tests: `go install golang.org/x/tools/cmd/stress@latest`
+
+## Project-Specific Workflows
+* **DCO (Developer Certificate of Origin)**: Every commit needs `Signed-off-by` trailer
+* **Backporting**: Important fixes should be backported to stable release branches
+* **Issue tracking**: All PRs should reference an issue
+* **Multiple small PRs** are preferred over large ones (>500 lines)
+
+## Important Files
+* `CONTRIBUTING.md` - Full contribution guide
+* `Documentation/contributor-guide/` - Detailed contributor documentation
+* `go.mod` - Go version and dependencies
+* `Makefile` - Build and test commands
+* `OWNERS` - Maintainers and code ownership

--- a/Documentation/contributor-guide/eol.md
+++ b/Documentation/contributor-guide/eol.md
@@ -1,0 +1,138 @@
+# End of Life (EOL) Process
+
+This document describes the process for ending support (EOL) for etcd versions.
+
+## Overview
+
+etcd follows a predictable release lifecycle to ensure users have time to upgrade between versions while maintaining security and stability. This document outlines the process for ending support for a version.
+
+## Version Support Policy
+
+etcd maintains support for multiple major versions simultaneously. The general support policy is:
+
+- **Latest major version**: Active development and security fixes
+- **Previous major versions**: Security and critical bug fixes only
+- **Older versions**: No longer supported (EOL)
+
+### Current Support Status
+
+As of the current date, the following etcd versions are supported:
+
+- v3.7.x: Active development (if applicable)
+- v3.6.x: Security and critical bug fixes
+- v3.5.x: Security and critical bug fixes
+- v3.4.x: End of Life (EOL) as of v3.4.45 (2026-06-01)
+
+*Note: Check the latest [etcd releases](https://github.com/etcd-io/etcd/releases) for the most current support status.*
+
+## EOL Process
+
+The EOL process for an etcd version follows these steps:
+
+### 1. Planning and Announcement
+
+- **Timeline**: EOL announcements should be made at least 6 months before the final release
+- **Communication**: EOL plans should be communicated through:
+  - GitHub issues (create a tracking issue)
+  - etcd-dev mailing list
+  - etcd website/blog posts
+  - Documentation updates
+
+### 2. Final Release Preparation
+
+For the final release of a version before EOL:
+
+- Ensure all critical security fixes are included
+- Include a prominent EOL notice in the release notes
+- Update the CHANGELOG with the EOL announcement
+- Add upgrade documentation to help users migrate to supported versions
+
+### 3. Final Release
+
+The final release before EOL should:
+
+- Follow the standard [release process](release.md)
+- Include the EOL notice in the release description
+- Tag the release as the final patch for that version
+- Update version documentation to mark as EOL
+
+### 4. Post-EOL Actions
+
+After a version reaches EOL:
+
+- **Branch management**: 
+  - The release branch remains read-only
+  - No further commits or cherry-picks are accepted
+  - Branch is archived (not deleted)
+
+- **CI/CD**:
+  - Remove the version from active CI pipelines
+  - Keep minimal testing for documentation purposes if needed
+
+- **Documentation**:
+  - Update all documentation to reflect EOL status
+  - Add clear upgrade paths to supported versions
+  - Archive version-specific documentation
+
+- **Security**:
+  - Security vulnerabilities will not be fixed
+  - CVEs may still be filed for documentation purposes
+  - Users are strongly advised to upgrade
+
+## EOL Announcement Template
+
+When announcing the EOL of a version, use the following template:
+
+```
+Subject: etcd v{VERSION} End of Life Announcement
+
+etcd v{VERSION} will reach End of Life (EOL) on {DATE}.
+
+After this date, no further security updates or bug fixes will be released for v{VERSION}. Users are strongly advised to upgrade to a supported version.
+
+Upgrade Path:
+- v{VERSION} → v{NEXT_SUPPORTED_VERSION}
+
+For upgrade instructions, see: {UPGRADE_DOCS_URL}
+
+If you have questions or concerns, please reach out via:
+- GitHub Issues: https://github.com/etcd-io/etcd/issues
+- etcd-dev mailing list: etcd-dev@googlegroups.com
+
+Thank you for using etcd!
+```
+
+## Criteria for EOL
+
+A version should be considered for EOL when:
+
+- A newer major version has been stable for at least 12 months
+- Usage metrics show declining adoption (if available)
+- Maintainer capacity cannot adequately support the version
+- Critical dependencies (Go, protobuf, etc.) become incompatible
+- Security vulnerabilities cannot be reasonably addressed
+
+## Emergency EOL
+
+In rare cases, a version may require emergency EOL due to:
+
+- Critical security vulnerabilities that cannot be safely patched
+- Complete loss of maintainer capacity
+- Fundamental architectural flaws
+
+Emergency EOL follows the same process but with accelerated timelines.
+
+## Related Documentation
+
+- [Release Process](release.md)
+- [Upgrade Documentation](https://etcd.io/docs/latest/upgrades/)
+- [Security Release Process](../../security/security-release-process.md)
+- [Branch Management](branch_management.md)
+
+## Questions
+
+For questions about the EOL process or specific version support status, please:
+
+1. Check the [GitHub releases](https://github.com/etcd-io/etcd/releases) for latest version information
+2. Review the [etcd documentation](https://etcd.io/docs/latest/)
+3. Contact the etcd maintainers via GitHub issues or the etcd-dev mailing list

--- a/Documentation/contributor-guide/release.md
+++ b/Documentation/contributor-guide/release.md
@@ -4,6 +4,8 @@ The guide talks about how to release a new version of etcd.
 
 The procedure includes some manual steps for sanity checking, but it can probably be further scripted. Please keep this document up-to-date if making changes to the release process.
 
+For information about ending support for etcd versions, see [EOL Process](eol.md).
+
 ## Release management
 
 Under the leadership of **James Blair** [@jmhbnz](https://github.com/jmhbnz) and **Ivan Valdes Castillo** [@ivanvc](https://github.com/ivanvc), the following pool of release candidates manages the release of each etcd major/minor version as well as manages patches


### PR DESCRIPTION
## Summary

Add documentation describing the End of Life (EOL) process for etcd versions and link it from the contributor release guide.

## Changes

* Add `Documentation/contributor-guide/eol.md` documenting:

  * etcd version support policy
  * EOL planning and announcement process
  * final release preparation
  * post-EOL actions
  * EOL criteria
  * emergency EOL considerations
  * an EOL announcement template
  * related release, upgrade, security, and branch-management documentation
* Add a reference to the new EOL process from `Documentation/contributor-guide/release.md`.
* Add `AGENTS.md` with repository-specific contribution and development guidance.

## Motivation

The release guide covers the process for releasing etcd versions but does not provide a dedicated description of how support ends. This documentation provides a central reference for maintainers and contributors when planning and communicating an EOL.

## Testing

Documentation-only changes. No code or automated tests are required.
