### PR TITLE
server/etcdserver: detect txn overlap for open-ended delete ranges

### DIFF
--- a/server/etcdserver/api/v3rpc/key.go
+++ b/server/etcdserver/api/v3rpc/key.go
@@ -248,7 +248,14 @@ func checkIntervals(reqs []*pb.RequestOp) (map[string]struct{}, adt.IntervalTree
 		}
 		var iv adt.Interval
 		if len(dreq.RangeEnd) != 0 {
-			iv = adt.NewStringAffineInterval(string(dreq.Key), string(dreq.RangeEnd))
+			rangeEnd := dreq.RangeEnd
+			if len(rangeEnd) == 1 && rangeEnd[0] == 0 {
+				// support >= key deletes, as watch.go does: the open-ended
+				// range end must become "", the largest StringAffineComparable,
+				// not the literal byte 0.
+				rangeEnd = nil
+			}
+			iv = adt.NewStringAffineInterval(string(dreq.Key), string(rangeEnd))
 		} else {
 			iv = adt.NewStringAffinePoint(string(dreq.Key))
 		}

--- a/server/etcdserver/api/v3rpc/key_test.go
+++ b/server/etcdserver/api/v3rpc/key_test.go
@@ -17,6 +17,8 @@ package v3rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
@@ -65,4 +67,60 @@ func getError(err error) string {
 	}
 
 	return err.Error()
+}
+
+func TestCheckIntervalsOpenEndedDeleteRange(t *testing.T) {
+	delOp := func(key, rangeEnd string) *pb.RequestOp {
+		return &pb.RequestOp{Request: &pb.RequestOp_RequestDeleteRange{
+			RequestDeleteRange: &pb.DeleteRangeRequest{Key: []byte(key), RangeEnd: []byte(rangeEnd)},
+		}}
+	}
+	putOp := func(key string) *pb.RequestOp {
+		return &pb.RequestOp{Request: &pb.RequestOp_RequestPut{
+			RequestPut: &pb.PutRequest{Key: []byte(key), Value: []byte("v")},
+		}}
+	}
+
+	tests := []struct {
+		name        string
+		reqs        []*pb.RequestOp
+		expectedErr error
+	}{
+		{
+			name:        "finite range delete overlapping a put",
+			reqs:        []*pb.RequestOp{delOp("a", "c"), putOp("b")},
+			expectedErr: rpctypes.ErrGRPCDuplicateKey,
+		},
+		{
+			name:        "finite range delete not overlapping a put",
+			reqs:        []*pb.RequestOp{delOp("a", "c"), putOp("d")},
+			expectedErr: nil,
+		},
+		{
+			name:        "open ended delete overlapping a put above the start key",
+			reqs:        []*pb.RequestOp{delOp("a", "\x00"), putOp("b")},
+			expectedErr: rpctypes.ErrGRPCDuplicateKey,
+		},
+		{
+			name:        "open ended delete over the whole keyspace overlapping a put",
+			reqs:        []*pb.RequestOp{delOp("\x00", "\x00"), putOp("b")},
+			expectedErr: rpctypes.ErrGRPCDuplicateKey,
+		},
+		{
+			name:        "open ended delete not overlapping a put below the start key",
+			reqs:        []*pb.RequestOp{delOp("a", "\x00"), putOp("0")},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := checkIntervals(tt.reqs)
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.expectedErr.Error())
+		})
+	}
 }


### PR DESCRIPTION
`checkIntervals` (`server/etcdserver/api/v3rpc/key.go:236`) builds an affine interval for each delete range in a txn, so the duplicate-key guard can reject a txn whose put falls inside a delete. It only special-cases an *empty* `RangeEnd`.

etcd's wire convention is that a `RangeEnd` of `"\x00"` means "no upper bound", while the affine comparable's positive infinity is `""` — `pkg/adt/interval_tree.go:863`: *"StringAffineComparable treats `""` as > all other strings"*. So `[key, "\x00")` comes out as an empty interval and the delete is never recorded in the tree the guard consults.

Driving `checkIntervals` directly on `main`:

```
DeleteRange["a","c")  + Put "b"   rejected: etcdserver: duplicate key given in txn request
DeleteRange["a",0x00) + Put "b"   ACCEPTED     <- WithFromKey
DeleteRange[0x00,0x00)+ Put "b"   ACCEPTED     <- WithPrefix on an empty key
DeleteRange["a",0x00) + Put "0"   ACCEPTED     (correct, "0" is below the start key)
DeleteRange["a","c")  + Put "z"   ACCEPTED     (correct, no overlap)
```

The first and second lines describe the same overlap; only the spelling differs. `clientv3.WithFromKey()` sets `op.end = []byte("\x00")` (`client/v3/op.go:450`), and `WithPrefix()` on an empty key sets both key and end to `{0}` (`client/v3/op.go:428`), so both are ordinary client calls.

A client issuing `Txn().Then(OpDelete(k, WithFromKey()), OpPut(k2, v))` therefore has the txn accepted and gets an order-dependent result, while writing the identical overlap with an explicit range end is rejected — which is what the guard exists to prevent.

### Why `"\x00"` and not something else

Three other call sites already normalise it, and the change follows them:

- `server/auth/range_perm_cache.go:185` — `isOpenEnded()` is exactly this test, and the comment above it says *"Treating a range whose rangeEnd with []byte{0x00} as an open-ended comes from the rules of Range() and Watch() API"*.
- `server/auth/range_perm_cache.go:43-45` — the same normalisation inline, before `NewBytesAffineInterval`.
- `server/etcdserver/api/v3rpc/watch.go:325` — in this package, one file over: `if len(creq.RangeEnd) == 1 && creq.RangeEnd[0] == 0 { creq.RangeEnd = []byte{} }`, commented *"support >= key queries"*.

### Testing

`TestCheckIntervalsOpenEndedDeleteRange` in `key_test.go`, five rows: a finite overlap as control, a finite non-overlap, the two open-ended overlaps, and an open-ended non-overlap below the start key.

- Only the two open-ended overlap rows fail on `main`; the other three pass on both trees.
- Mutation-checked: reverting the normalisation brings both failures back; treating every range end as open-ended breaks the finite non-overlap row; and letting the open-ended case swallow the start key breaks the below-the-start-key row. Both directions pinned.
- `go build ./...`, `go vet ./server/etcdserver/api/v3rpc/`, `gofmt` clean.
- `go test ./server/etcdserver/...` passes.

### Scope

This is not a security fix. Authorization does its own range checks with the correct `isOpenEnded` handling, so no permission boundary is crossed, and the same effect is reachable with two separate calls. It is a correctness bug in the txn overlap guard.

The same shape appears at `server/proxy/grpcproxy/cache/store.go:97` and `:145`; I have not verified those and left them out of this change.

---

AI assistance disclosure: this patch was found and written with Claude Code. The table above is verbatim from running `checkIntervals` against `main`.
