### PR TITLE
server/embed: bound --auto-compaction-retention

### DIFF
--- a/server/embed/config_test.go
+++ b/server/embed/config_test.go
@@ -479,10 +479,16 @@ func TestAutoCompactionModeParse(t *testing.T) {
 		{"revision", "1", false, 1},
 		{"revision", "1h", false, time.Hour},
 		{"revision", "a", true, 0},
+		{"revision", "-1h", true, 0},
 		{"revision", "-1", true, 0},
 		// periodic
 		{"periodic", "1", false, time.Hour},
 		{"periodic", "a", true, 0},
+		{"periodic", "2562047", false, 2562047 * time.Hour},
+		{"periodic", "2562048", true, 0},
+		{"periodic", "5124096", true, 0},
+		{"periodic", "-1h", true, 0},
+		{"periodic", "0s", false, 0},
 		{"revision", "-1", true, 0},
 		// err mode
 		{"errmode", "1", false, 0},

--- a/server/embed/etcd.go
+++ b/server/embed/etcd.go
@@ -925,6 +925,9 @@ func (e *Etcd) GetLogger() *zap.Logger {
 	return l
 }
 
+// maxCompactionRetentionHours is the largest whole-hour retention representable as a time.Duration.
+const maxCompactionRetentionHours = int64(math.MaxInt64 / time.Hour)
+
 func parseCompactionRetention(mode, retention string) (ret time.Duration, err error) {
 	h, err := strconv.Atoi(retention)
 	if err == nil && h >= 0 {
@@ -932,6 +935,9 @@ func parseCompactionRetention(mode, retention string) (ret time.Duration, err er
 		case CompactorModeRevision:
 			ret = time.Duration(int64(h))
 		case CompactorModePeriodic:
+			if int64(h) > maxCompactionRetentionHours {
+				return 0, fmt.Errorf("CompactionRetention %q exceeds the maximum of %d hours", retention, maxCompactionRetentionHours)
+			}
 			ret = time.Duration(int64(h)) * time.Hour
 		case "":
 			return 0, errors.New("--auto-compaction-mode is undefined")
@@ -941,6 +947,9 @@ func parseCompactionRetention(mode, retention string) (ret time.Duration, err er
 		ret, err = time.ParseDuration(retention)
 		if err != nil {
 			return 0, fmt.Errorf("error parsing CompactionRetention: %w", err)
+		}
+		if ret < 0 {
+			return 0, fmt.Errorf("CompactionRetention %q must not be negative", retention)
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
`parseCompactionRetention` (`server/embed/etcd.go:931`) multiplies the parsed hour count by `time.Hour` with no range check, and its fallback branch accepts whatever `time.ParseDuration` returns. Both can produce a retention that is not a valid period:

```
--auto-compaction-retention=2562048   ->  -2562047h34m33.709551616s
--auto-compaction-retention=5124096   ->  25m26.290448384s
--auto-compaction-retention=-1h       ->  -1h0m0s
```

The `5124096` row is why a negative check alone is not enough — it wraps twice and comes back positive, so 585 years of requested retention silently becomes 25 minutes. And `-1h` is why the overflow guard alone is not enough: the bare integer `-1` is already rejected by the existing table, but the same value written as a duration goes through the fallback.

etcd already rejects `--auto-compaction-retention=2562048h` with `time: invalid duration`. The identical value as a bare integer, which means hours in periodic mode (`server/embed/config.go:140`), was accepted.

### The negative is not inert

`server/etcdserver/server.go:383` gates the compactor on `num != 0`, so a negative retention starts it. `getRetryInterval` (`api/v3compactor/periodic.go:183`) returns `period/10`, also negative, so `clock.After` fires immediately, and the `Sub(lastSuccess) < baseInterval` brake at `periodic.go:127` cannot trip against a negative `baseInterval`.

Measured over 200 ms through the exported `v3compactor.New` with a real clock:

```
retention=1h    idle           Rev() polls=1        Compact() calls=0
retention=1h    taking writes  Rev() polls=1        Compact() calls=0
retention=-1h   idle           Rev() polls=292519   Compact() calls=1
retention=-1h   taking writes  Rev() polls=228505   Compact() calls=228495
```

So an idle member busy-loops on `Rev()`, and one taking writes compacts about a million times a second against the backend, indefinitely.

### The change

Two guards, one invariant. `0s` stays valid, since that is how compaction is disabled, and `2562047` hours remains the largest accepted whole-hour retention.

### Testing

Rows added to the existing `TestAutoCompactionModeParse` table, covering both rejected forms, the wrap-back-positive case, the largest accepted value, and `0s`.

- Exactly the four new rejection rows fail on `main`; the accepted rows pass on both trees.
- Mutation-checked, all four caught: rejecting the maximum itself, dropping the overflow guard, rejecting `0s`, and dropping the negative guard.
- `gofmt` clean, `go vet ./server/embed/` clean, `golangci-lint run --config tools/.golangci.yaml ./server/embed/...` reports 0 issues.
- `go test ./server/embed/... ./server/etcdserver/api/v3compactor/...` passes. `GOOS=windows`, `GOOS=darwin` and `GOARCH=386` builds are clean — the 32-bit one matters because the multiply is done as `int64`.

---

### AI disclosure

Per the template: yes, AI tools were used, and following the Kubernetes AI guidance — this patch was found and written by Claude Code, and the numbers and command output above are verbatim from running them against `main`. I have reviewed the change and can answer questions about it.

The template also asks an agent to identify itself in verse and share the driving prompt, so, plainly:

> A key kept safe, a revision old,
> compaction trims what the log still holds —
> but hours that wrap turn keep to purge,
> so bound the count before they merge.

The prompt was not about this file. It was a standing instruction to look for guards on narrowing numeric conversions — specifically the case where a bound is compared in a wider type and rounds, or where a lenient second parse accepts what the strict first parse refused — and then to trace the resulting value forward to see whether anything downstream reads it as a sentinel. `parseCompactionRetention` matched on both halves. Happy to share more of the working notes if that is useful for review.
