### PR TITLE
server/proxy/grpcproxy: treat a zero-byte range end as open-ended in the cache

### DIFF
--- a/server/proxy/grpcproxy/cache/store.go
+++ b/server/proxy/grpcproxy/cache/store.go
@@ -89,17 +89,8 @@ func (c *cache) Add(req *pb.RangeRequest, resp *pb.RangeResponse) {
 		return
 	}
 
-	var (
-		iv  *adt.IntervalValue
-		ivl adt.Interval
-	)
-	if len(req.RangeEnd) != 0 {
-		ivl = adt.NewStringAffineInterval(string(req.Key), string(req.RangeEnd))
-	} else {
-		ivl = adt.NewStringAffinePoint(string(req.Key))
-	}
-
-	iv = c.cachedRanges.Find(ivl)
+	ivl := rangeInterval(req.Key, req.RangeEnd)
+	iv := c.cachedRanges.Find(ivl)
 
 	if iv == nil {
 		val := map[string]struct{}{key: {}}
@@ -135,17 +126,8 @@ func (c *cache) Invalidate(key, endkey []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var (
-		ivs []*adt.IntervalValue
-		ivl adt.Interval
-	)
-	if len(endkey) == 0 {
-		ivl = adt.NewStringAffinePoint(string(key))
-	} else {
-		ivl = adt.NewStringAffineInterval(string(key), string(endkey))
-	}
-
-	ivs = c.cachedRanges.Stab(ivl)
+	ivl := rangeInterval(key, endkey)
+	ivs := c.cachedRanges.Stab(ivl)
 	for _, iv := range ivs {
 		keys := iv.Val.(map[string]struct{})
 		for key := range keys {
@@ -154,6 +136,22 @@ func (c *cache) Invalidate(key, endkey []byte) {
 	}
 	// delete after removing all keys since it is destructive to 'ivs'
 	c.cachedRanges.Delete(ivl)
+}
+
+// rangeInterval is the key space a Range or DeleteRange request covers. A
+// range end of a single zero byte is the wire convention for "every key >=
+// key" (the server applies the same rule in mkGteRange), and "" is the
+// largest StringAffineComparable, so that is what an open-ended interval
+// needs; passing the zero byte through would build an interval whose end
+// sorts below its begin, which only ever intersects its own start key.
+func rangeInterval(key, rangeEnd []byte) adt.Interval {
+	if len(rangeEnd) == 0 {
+		return adt.NewStringAffinePoint(string(key))
+	}
+	if len(rangeEnd) == 1 && rangeEnd[0] == 0 {
+		return adt.NewStringAffineInterval(string(key), "")
+	}
+	return adt.NewStringAffineInterval(string(key), string(rangeEnd))
 }
 
 // Compact invalidate all caching response before the given rev.

--- a/server/proxy/grpcproxy/cache/store_test.go
+++ b/server/proxy/grpcproxy/cache/store_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+func TestInvalidateOpenEndedRanges(t *testing.T) {
+	rangeReq := func(key, end string) *pb.RangeRequest {
+		return &pb.RangeRequest{Key: []byte(key), RangeEnd: []byte(end), Serializable: true}
+	}
+	tests := []struct {
+		name            string
+		cached          *pb.RangeRequest
+		writeKey        string
+		writeEnd        string
+		wantInvalidated bool
+	}{
+		{"finite range, put inside", rangeReq("a", "c"), "b", "", true},
+		{"finite range, put outside", rangeReq("a", "c"), "d", "", false},
+		{"finite range, finite delete over it", rangeReq("a", "c"), "a", "z", true},
+		{"from-key range, put above the start key", rangeReq("a", "\x00"), "z", "", true},
+		{"from-key range, put below the start key", rangeReq("b", "\x00"), "a", "", false},
+		{"from-key range, finite delete inside", rangeReq("a", "\x00"), "b", "d", true},
+		{"whole keyspace range, put", rangeReq("\x00", "\x00"), "b", "", true},
+		{"finite range above the key, from-key delete", rangeReq("b", "c"), "a", "\x00", true},
+		{"single key above the key, from-key delete", rangeReq("z", ""), "a", "\x00", true},
+		{"single key below the key, from-key delete", rangeReq("a", ""), "b", "\x00", false},
+		{"finite range, whole keyspace delete", rangeReq("a", "c"), "\x00", "\x00", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCache(16)
+			c.Add(tt.cached, &pb.RangeResponse{})
+			_, err := c.Get(tt.cached)
+			require.NoError(t, err)
+
+			var end []byte
+			if tt.writeEnd != "" {
+				end = []byte(tt.writeEnd)
+			}
+			c.Invalidate([]byte(tt.writeKey), end)
+
+			_, err = c.Get(tt.cached)
+			if tt.wantInvalidated {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #22397.

cache.Add and cache.Invalidate built their intervals from the raw wire RangeEnd, so a single zero byte, which the server executes as "every key >= key" (mkGteRange), became an interval whose end sorts below its begin and only ever intersects its own start key. A serializable range cached with WithFromKey was served unchanged after later writes above its start key, and a DeleteRange with WithFromKey invalidated only the entries at its start key.

The change normalises that end to "", the largest StringAffineComparable, in one helper used by both methods, the rule watch.go:325 and the auth range cache already apply.

TestInvalidateOpenEndedRanges (the cache package had no tests) has eleven rows: the five finite-range rows pass on main and are the controls, the six open-ended rows fail on main and pass here. Through a grpc-proxy with etcdctl the two reads in #22397 now match the linearizable ones. `go test ./server/proxy/grpcproxy/...`, go vet, gofmt and golangci-lint with tools/.golangci.yaml are clean.

Same shape as #22395, which noted these two sites and left them out.
