### PR TITLE
pkg/flags: make UniqueURLs.Set replace the previous value

### DIFF
--- a/pkg/flags/unique_urls.go
+++ b/pkg/flags/unique_urls.go
@@ -36,9 +36,6 @@ type UniqueURLs struct {
 // http://127.0.0.1:2380,http://10.1.1.2:80
 // Implements "flag.Value" interface.
 func (us *UniqueURLs) Set(s string) error {
-	if _, ok := us.Values[s]; ok {
-		return nil
-	}
 	if _, ok := us.Allowed[s]; ok {
 		us.Values[s] = struct{}{}
 		return nil

--- a/pkg/flags/unique_urls_test.go
+++ b/pkg/flags/unique_urls_test.go
@@ -91,6 +91,21 @@ func TestNewUniqueURLsWithExceptions(t *testing.T) {
 	}
 }
 
+func TestUniqueURLsSetReplacesPreviousValue(t *testing.T) {
+	const name = "test"
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.Var(NewUniqueURLsWithExceptions("https://1.2.3.4:1"), name, "usage")
+	require.NoError(t, fs.Parse([]string{
+		"--" + name, "https://1.2.3.4:1,https://1.2.3.4:2",
+		"--" + name, "https://1.2.3.4:1",
+	}))
+
+	require.Equal(t, map[string]struct{}{"https://1.2.3.4:1": {}}, UniqueURLsMapFromFlag(fs, name))
+	uss := UniqueURLsFromFlag(fs, name)
+	require.Len(t, uss, 1)
+	require.Equal(t, "https://1.2.3.4:1", uss[0].String())
+}
+
 func TestUniqueURLsFromFlag(t *testing.T) {
 	const name = "test"
 	urls := []string{


### PR DESCRIPTION
### What

`UniqueURLs.Set` (`pkg/flags/unique_urls.go:38`) opened with

```go
if _, ok := us.Values[s]; ok {
	return nil
}
```

`Values` holds individual URL strings, but `s` is the whole comma-separated flag argument. The check therefore matches whenever a repeated occurrence of the flag names a URL that the previous occurrence already set — and returns before the body, which is the part that replaces `Values` and `uss`.

The result is that repeating a URL flag in order to **narrow** it keeps the URL the operator removed. Driven through `config.parse` in `server/etcdmain`, i.e. the real argument path:

```
etcd --listen-client-urls http://127.0.0.1:2379,http://127.0.0.1:2382 \
     --listen-client-urls http://127.0.0.1:2379 \
     --advertise-client-urls http://127.0.0.1:2379

operator asked for:   http://127.0.0.1:2379
before, cfg.ec.ListenClientUrls:  [http://127.0.0.1:2379 http://127.0.0.1:2382]
after,  cfg.ec.ListenClientUrls:  [http://127.0.0.1:2379]
```

etcd goes on to serve clients on a port the last flag occurrence took away.

Six flags are registered through this type (`server/embed/config.go:593-642`): `--listen-peer-urls`, `--listen-client-urls`, `--listen-client-http-urls`, `--listen-metrics-urls`, `--initial-advertise-peer-urls`, `--advertise-client-urls`, and `--cors` builds one at `:862`.

### The two siblings in the same package

Both other list-valued flags replace unconditionally:

| implementation | behaviour on a repeated flag |
|---|---|
| `pkg/flags/urls.go:32` `URLsValue.Set` | `*us = URLsValue(ss)` — replaces |
| `pkg/flags/unique_strings.go:33` `UniqueStringsValue.Set` | `us.Values = make(...)` — replaces |
| `pkg/flags/unique_urls.go:38` `UniqueURLs.Set` | returned early, kept the old value |

The body of `UniqueURLs.Set` already replaces too; only the early return prevented it from running.

### The change

Three deleted lines. The exception branch stays, because a non-URL exception such as `"*"` cannot go through `types.NewURLs` — removing it makes `NewUniqueURLsWithExceptions("*", "*")` panic, which the existing test catches.

Repeating a flag with an identical single URL still ends in the same state; it now goes through the parse instead of short-circuiting.

### Testing

`TestUniqueURLsSetReplacesPreviousValue` added to `pkg/flags/unique_urls_test.go`. The existing tests all build their value with `NewUniqueURLsWithExceptions` and never call `Set` a second time, so nothing covered a repeated flag.

- Fails on `main`: `expected: map[...]{"https://1.2.3.4:1"}` / `actual: map[...]{"https://1.2.3.4:1", "https://1.2.3.4:2"}`. Passes here.
- Mutation-checked both directions. Restoring the early return brings the failure back. Removing the `Allowed` branch as well fails `TestNewUniqueURLsWithExceptions` with `panic: new UniqueURLs should never fail: URL scheme must be http, https, unix, or unixs: *`, so the branch that must stay is pinned too.
- `go test ./...` in the `pkg` module passes. `go build ./...` and `go test ./etcdmain/ ./embed/` in the `server` module pass. `gofmt` clean, `go vet ./flags/` clean.

I did not change the exception branch's own merge behaviour (`--cors a.com --cors '*'` still ends with both). That is a separate question and `*` is a superset anyway, so it stayed out of this change.

---

### AI disclosure

Per the template: yes, AI tools were used, and following the Kubernetes AI guidance — this patch was found and written by Claude Code. Every number and line of output above is verbatim from running it against `main` and against this branch. I have reviewed the change and can answer questions about it.

The template also asks an agent to identify itself in verse and share the driving prompt, so, plainly:

> Two flags were given, the last meant to pare,
> but the set kept the port that was never to share.
> Its siblings both clear what came earlier on --
> so drop the return, and the extra is gone.

The prompt was not about this file. It was a standing instruction to look for a "setter that merges where its siblings replace": find N implementations of one interface in a package, read what each does on a second call, and promote the one that behaves differently only if the difference is observable through the program's real entry point. `UniqueURLs.Set` was the odd one out among the three `flag.Value` list types in `pkg/flags`, and `server/etcdmain/config.parse` was the entry point that made it observable. Happy to share more of the working notes if that is useful for review.
