### PR TITLE
[release-3.6] fix: fsync snap directory when saving a received snapshot db- #22378

### DIFF
--- a/server/etcdserver/api/snap/db.go
+++ b/server/etcdserver/api/snap/db.go
@@ -30,8 +30,10 @@ import (
 
 var ErrNoDBSnapshot = errors.New("snap: snapshot file doesn't exist")
 
-// SaveDBFrom saves snapshot of the database from the given reader. It
-// guarantees the save operation is atomic.
+// SaveDBFrom atomically saves a database snapshot from r. Before a successful
+// return, it syncs the file and containing directory so the rename is durable
+// on storage that honors fsync. The receiver processes the Raft message only
+// afterward, so its WAL snapshot record cannot precede snap.db.
 func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 	start := time.Now()
 
@@ -54,11 +56,29 @@ func (s *Snapshotter) SaveDBFrom(r io.Reader, id uint64) (int64, error) {
 	fn := s.dbFilePath(id)
 	if fileutil.Exist(fn) {
 		os.Remove(f.Name())
+		// A prior SaveDBFrom can have renamed this file and crashed before
+		// syncing the directory. Sync again before reporting success.
+		if err = s.fsyncDir(s.dir); err != nil {
+			return n, err
+		}
 		return n, nil
 	}
 	err = os.Rename(f.Name(), fn)
 	if err != nil {
 		os.Remove(f.Name())
+		return n, err
+	}
+
+	// gofail: var snapDBRenameBeforeDirSync struct{}
+
+	// The file is synced above. Sync the directory to make the renamed entry
+	// durable before the snapshot receiver processes the Raft message.
+	if err = s.fsyncDir(s.dir); err != nil {
+		s.lg.Warn(
+			"failed to fsync snap directory after saving database snapshot",
+			zap.String("path", fn),
+			zap.Error(err),
+		)
 		return n, err
 	}
 
@@ -96,4 +116,17 @@ func (s *Snapshotter) DBFilePath(id uint64) (string, error) {
 
 func (s *Snapshotter) dbFilePath(id uint64) string {
 	return filepath.Join(s.dir, fmt.Sprintf("%016x.snap.db", id))
+}
+
+// fsyncSnapDir makes a renamed snapshot database durable. On Linux, syncing
+// the file alone does not necessarily persist its containing directory entry.
+func fsyncSnapDir(dir string) error {
+	// gofail: var snapDBDirSyncError string
+	// return errors.New(snapDBDirSyncError)
+	d, err := fileutil.OpenDir(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return fileutil.Fsync(d)
 }

--- a/server/etcdserver/api/snap/db_test.go
+++ b/server/etcdserver/api/snap/db_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snap
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSaveDBFromSyncsDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		existing bool
+	}{
+		{name: "new"},
+		{name: "existing", existing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			s := New(nil, dir)
+			if tc.existing {
+				writeErr := os.WriteFile(s.dbFilePath(1), []byte("old"), 0o600)
+				if writeErr != nil {
+					t.Fatal(writeErr)
+				}
+			}
+
+			syncErr := errors.New("sync failed")
+			syncCalls := 0
+			s.fsyncDir = func(gotDir string) error {
+				if gotDir != dir {
+					t.Errorf("fsync directory = %q, want %q", gotDir, dir)
+				}
+				syncCalls++
+				return syncErr
+			}
+
+			const content = "snapshot"
+			n, err := s.SaveDBFrom(strings.NewReader(content), 1)
+			if !errors.Is(err, syncErr) {
+				t.Errorf("SaveDBFrom error = %v, want %v", err, syncErr)
+			}
+			if n != int64(len(content)) {
+				t.Errorf("SaveDBFrom bytes = %d, want %d", n, len(content))
+			}
+			if syncCalls != 1 {
+				t.Errorf("fsync calls = %d, want 1", syncCalls)
+			}
+		})
+	}
+}

--- a/server/etcdserver/api/snap/snapshotter.go
+++ b/server/etcdserver/api/snap/snapshotter.go
@@ -51,8 +51,9 @@ var (
 )
 
 type Snapshotter struct {
-	lg  *zap.Logger
-	dir string
+	lg       *zap.Logger
+	dir      string
+	fsyncDir func(string) error
 }
 
 func New(lg *zap.Logger, dir string) *Snapshotter {
@@ -60,8 +61,9 @@ func New(lg *zap.Logger, dir string) *Snapshotter {
 		lg = zap.NewNop()
 	}
 	return &Snapshotter{
-		lg:  lg,
-		dir: dir,
+		lg:       lg,
+		dir:      dir,
+		fsyncDir: fsyncSnapDir,
 	}
 }
 

--- a/tests/e2e/snap_db_dirsync_test.go
+++ b/tests/e2e/snap_db_dirsync_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !cluster_proxy
+
+package e2e
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+	"go.etcd.io/etcd/tests/v3/robustness/failpoint"
+)
+
+// These tests cover the receiver's error and recovery paths around
+// Snapshotter.SaveDBFrom's directory fsync. They do not simulate loss of an
+// unsynced directory entry; that behavior follows the operating-system fsync
+// contract.
+
+// newSnapDirSyncCluster builds a 3-member cluster with peer proxies (required
+// for blackholing) and aggressive snapshotting.
+func newSnapDirSyncCluster(t *testing.T) *e2e.EtcdProcessCluster {
+	t.Helper()
+	e2e.BeforeTest(t)
+
+	epc, err := e2e.NewEtcdProcessCluster(t.Context(), t, e2e.WithConfig(e2e.NewConfig(
+		e2e.WithClusterSize(3),
+		e2e.WithKeepDataDir(true),
+		e2e.WithPeerProxy(true),
+		e2e.WithIsPeerTLS(true),
+		e2e.WithSnapshotCount(10),
+		e2e.WithSnapshotCatchUpEntries(10),
+		e2e.WithGoFailEnabled(true),
+	)))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, epc.Close())
+	})
+	return epc
+}
+
+// driveTrafficUntilSnapshot writes while member is blackholed. Blackhole
+// restores traffic after the member is far enough behind to need a snapshot;
+// this function then stops the writes.
+func driveTrafficUntilSnapshot(t *testing.T, epc *e2e.EtcdProcessCluster, member e2e.EtcdProcess) {
+	t.Helper()
+	ctx := t.Context()
+
+	c, err := clientv3.New(clientv3.Config{
+		Endpoints:            []string{epc.Procs[0].EndpointsGRPC()[0]},
+		Logger:               zap.NewNop(),
+		DialKeepAliveTime:    10 * time.Second,
+		DialKeepAliveTimeout: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	defer c.Close()
+
+	trafficCtx, trafficCancel := context.WithCancel(ctx)
+	defer trafficCancel()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-trafficCtx.Done():
+				return
+			default:
+			}
+			putCtx, putCancel := context.WithTimeout(trafficCtx, 50*time.Millisecond)
+			_, _ = c.Put(putCtx, "a", "b")
+			putCancel()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// Blackhole restores traffic after the member is behind by more than
+	// snapshot-count + snapshot-catchup-entries.
+	require.NoError(t, failpoint.Blackhole(ctx, t, member, epc, true))
+
+	trafficCancel()
+	wg.Wait()
+}
+
+// TestSnapDBDirSyncErrorRecovery verifies that a directory-sync failure fails
+// the receive request, then the member receives and applies the retried
+// snapshot after the failure is removed.
+func TestSnapDBDirSyncErrorRecovery(t *testing.T) {
+	epc := newSnapDirSyncCluster(t)
+	ctx := t.Context()
+	member := epc.Procs[2]
+
+	t.Log("inject a snap-directory fsync failure")
+	require.NoError(t, member.Failpoints().SetupHTTP(ctx, "snapDBDirSyncError", `return("injected snap dir fsync failure")`))
+
+	driveTrafficUntilSnapshot(t, epc, member)
+
+	t.Log("wait for the snapshot receive to fail")
+	e2e.AssertProcessLogs(t, member, "failed to save incoming database snapshot")
+	e2e.AssertProcessLogs(t, member, "injected snap dir fsync failure")
+
+	t.Log("remove the failure and verify recovery")
+	require.NoError(t, member.Failpoints().DeactivateHTTP(ctx, "snapDBDirSyncError"))
+	assertKVHash(t, epc)
+}
+
+// TestSnapDBReceiveCrashWindow kills a member after the snap.db rename and
+// before the directory sync. After restart, it must receive another snapshot
+// and catch up. SIGKILL does not test directory-entry durability.
+func TestSnapDBReceiveCrashWindow(t *testing.T) {
+	epc := newSnapDirSyncCluster(t)
+	ctx := t.Context()
+	member := epc.Procs[2]
+
+	t.Log("pause the member after the snap.db rename")
+	require.NoError(t, member.Failpoints().SetupHTTP(ctx, "snapDBRenameBeforeDirSync", `sleep("30s")`))
+
+	driveTrafficUntilSnapshot(t, epc, member)
+
+	t.Log("wait for the snap.db rename")
+	snapDir := filepath.Join(member.Config().DataDirPath, "member", "snap")
+	require.Eventuallyf(t, func() bool {
+		matches, _ := filepath.Glob(filepath.Join(snapDir, "*.snap.db"))
+		return len(matches) > 0
+	}, 60*time.Second, 100*time.Millisecond, "member never received a snapshot db")
+
+	t.Log("kill the member before the directory sync")
+	require.NoError(t, member.Kill())
+	require.NoError(t, member.Wait(ctx))
+
+	t.Log("restart the member and verify snapshot recovery")
+	require.NoError(t, member.Start(ctx))
+	assertKVHash(t, epc)
+}

--- a/tests/robustness/makefile.mk
+++ b/tests/robustness/makefile.mk
@@ -69,7 +69,7 @@ install-gofail: $(GOPATH)/bin/gofail
 
 .PHONY: gofail-enable
 gofail-enable: $(GOPATH)/bin/gofail
-	$(GOPATH)/bin/gofail enable server/etcdserver/ server/lease server/lease/leasehttp server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/v3rpc/ server/etcdserver/api/membership/
+	$(GOPATH)/bin/gofail enable server/etcdserver/ server/lease server/lease/leasehttp server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/v3rpc/ server/etcdserver/api/membership/ server/etcdserver/api/snap/
 	cd ./server && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdutl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdctl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
@@ -77,7 +77,7 @@ gofail-enable: $(GOPATH)/bin/gofail
 
 .PHONY: gofail-disable
 gofail-disable: $(GOPATH)/bin/gofail
-	$(GOPATH)/bin/gofail disable server/etcdserver/ server/lease server/lease/leasehttp server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/v3rpc/ server/etcdserver/api/membership/
+	$(GOPATH)/bin/gofail disable server/etcdserver/ server/lease server/lease/leasehttp server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/v3rpc/ server/etcdserver/api/membership/ server/etcdserver/api/snap/
 	cd ./server && go mod tidy
 	cd ./etcdutl && go mod tidy
 	cd ./etcdctl && go mod tidy


### PR DESCRIPTION
backport of https://github.com/etcd-io/etcd/pull/22314

/cc @fuweid @ahrtr @gyuho 