### PR TITLE
[release-3.6] fix: deflake TestIssue20271

### DIFF
--- a/tests/e2e/reproduce_20271_test.go
+++ b/tests/e2e/reproduce_20271_test.go
@@ -30,11 +30,20 @@ import (
 
 // TestIssue20271 reproduces the issue: https://github.com/etcd-io/etcd/issues/20271.
 func TestIssue20271(t *testing.T) {
+	const (
+		snapCount = 10
+		// keyCount must be greater than maxInflightMsgs (server/etcdserver/raft.go).
+		// SIGSTOP only freezes the process, the kernel keeps accepting packets for
+		// it, so every MsgApp the leader sends in Step 3 is buffered for the paused
+		// member and replayed on resume. Writing more entries than the leader's
+		// inflight window can hold makes it stop replicating to that member, so it
+		// cannot catch up by itself and the new leader is forced to send a snapshot.
+		keyCount = 1024
+	)
+
 	e2e.BeforeTest(t)
 
 	ctx := t.Context()
-
-	snapCount := 10
 
 	cfg := e2e.NewConfig(
 		e2e.WithSnapshotCount(uint64(snapCount)),
@@ -51,13 +60,12 @@ func TestIssue20271(t *testing.T) {
 	defer func() {
 		require.NoError(t, epc.Close())
 	}()
+	cli := newClient(t, epc.Procs[0].EndpointsGRPC(), e2e.ClientConfig{})
 
 	t.Log("Step 1: Write some data to the cluster")
-	for i := 0; i < snapCount*5; i++ {
-		require.NoError(t, epc.Procs[0].Etcdctl().Put(ctx,
-			fmt.Sprintf("foo%d", i),
-			strings.Repeat("Oops", 1024),
-			config.PutOptions{}))
+	for i := 0; i < keyCount; i++ {
+		_, err = cli.Put(ctx, fmt.Sprintf("foo%d", i), strings.Repeat("Oops", 1024))
+		require.NoError(t, err)
 	}
 
 	t.Log(`Step 2: Config the third member to sleep 15s after OpenSnapshotBackend and use SIGSTOP to pause it.`)
@@ -65,8 +73,8 @@ func TestIssue20271(t *testing.T) {
 	epc.Procs[2].Pause()
 
 	t.Log("Step 3: Delete some key values to trigger new snapshot on the first two members")
-	for i := 0; i < snapCount+20; i++ {
-		_, err = epc.Procs[0].Etcdctl().Delete(ctx, fmt.Sprintf("foo%d", i), config.DeleteOptions{})
+	for i := 0; i < keyCount; i++ {
+		_, err = cli.Delete(ctx, fmt.Sprintf("foo%d", i))
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## Failed tests
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/22401/pull-etcd-e2e-amd64/2097513704835780608
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/etcd-io_etcd/22401/pull-etcd-e2e-amd64/2097329079375106048

Error logs:
```
=== FAIL: e2e TestIssue20271 (44.94s)  
    reproduce_20271_test.go:79: Step 5: After opening snapshot file from new leader, invoke defragment
    reproduce_20271_test.go:81: context done before matching log found: context deadline exceeded
```

Fail point:
```
e2e.AssertProcessLogs(t, epc.Procs[2], "applySnapshot: opened snapshot backend")

func AssertProcessLogs(t *testing.T, ep EtcdProcess, expectLog string) {
    t.Helper()
    var err error
    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) 
    defer cancel()
    _, err = ep.Logs().ExpectWithContext(ctx, expect.ExpectedResponse{Value: expectLog})
    if err != nil {
        t.Fatal(err)
    }
}
```


## Root cause: SIGSTOP doesn't drop packets

The mechanism. EtcdServerProcess.Pause() (tests/framework/e2e/etcd_process.go:280-288) only sends SIGSTOP —
it freezes the process but leaves the network stack alive, so the kernel keeps accepting and queueing inbound
data. Meanwhile the graceful restart path (Restart() → Stop() → SIGTERM → Close()) makes the peer see a TCP
FIN, not an RST. Under Linux semantics FIN does not discard data already sitting in the receiver's kernel
queue; only RST does.

### The causal chain.

1. All three members are level at index 55, then test-2 is SIGSTOP'd (02:58:34.800).
2. test-0 (leader) + test-1 form a 2/3 quorum and commit/apply Step 3's 30 deletes up to index 88 — and the
MsgApp(commit=88) is already written into test-2's kernel socket receive buffer.
3. Step 4 gracefully restarts both test-0 and test-1; test-1's stop takes 8s (leadership transfer is
impossible with only one healthy member), so the cluster has no quorum during that window.
4. SIGCONT on test-2 at 02:58:43.858; within 4ms it drains the backlogged MsgApp and jumps applied 55→88.
That's far too fast for a new election (≥1s election timeout), which proves the entries came from data
already delivered to kernel buffers.

### The consequence. 

The new leader's raftLog has firstIndex=89 (snapshot@88), so it should have been forced to
send MsgSnap. But member 3 had already self-recovered to 88, so no snapshot transfer ever happens — and
"applySnapshot: opened snapshot backend" (server/etcdserver/server.go:1057), the log the test blocks on, is
never printed. AssertProcessLogs times out at 30s → t.Fatal.

### Supporting evidence. 

All snapshot-transfer log lines (sending/receiving/applied database snapshot, opened
snapshot backend, etc.) appear 0 times in the whole test block. skip compaction since there is an inflight
snapshot is also 0, meaning the compaction path itself was healthy — the fault isn't in compaction. The
asserted string and the applyAfterOpenSnapshot failpoint do exist in 3.6 code, so the assertion isn't simply
wrong.


/cc @ahrtr 