### PR TITLE
pkg/featuregate: add defensive nil check to String() to prevent recovered panic/warning message

### DIFF
--- a/pkg/featuregate/feature_gate.go
+++ b/pkg/featuregate/feature_gate.go
@@ -249,8 +249,15 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 
 // String returns a string containing all enabled feature gates, formatted as "key1=value1,key2=value2,...".
 func (f *featureGate) String() string {
+	enabled := f.enabled.Load()
+	// guards against nil pointer dereference if the feature gate is not initialized
+	// before calling String() e.g. z.Interface().(Value).String() in flag.go
+	if enabled == nil {
+		return ""
+	}
+
 	pairs := []string{}
-	for k, v := range f.enabled.Load().(map[Feature]bool) {
+	for k, v := range enabled.(map[Feature]bool) {
 		pairs = append(pairs, fmt.Sprintf("%s=%t", k, v))
 	}
 	sort.Strings(pairs)

--- a/pkg/featuregate/feature_gate_test.go
+++ b/pkg/featuregate/feature_gate_test.go
@@ -408,6 +408,13 @@ func TestFeatureGateMetrics(t *testing.T) {
 	// TODO(henrybear327): Add tests once feature gate metrics are added.
 }
 
+func TestFeatureGateStringZeroValue(t *testing.T) {
+	var f featureGate
+	// guards against nil pointer dereference if the feature gate is not initialized
+	// before calling String() e.g. z.Interface().(Value).String() in flag.go
+	assert.Empty(t, f.String())
+}
+
 func TestFeatureGateString(t *testing.T) {
 	// gates for testing
 	const testAlphaGate Feature = "TestAlpha"


### PR DESCRIPTION
AI Disclosure:
Copilot was used to find the origin of the panic

This PR adds a nil check to featureGate.String() to prevent panic (recovered) messages printed by flag.go in the standard library. The code path that causes the panic message appears to not be in use (it was overridden), but the default usage function of flag and presumably PrintDefaults() will trigger the panic message. It happens because flag in the standard library seems to call the String() method on an uninitialized featureGate.

I discovered this when looking for inconsistencies between the --help text in help.go and the usage descriptions in the cli flag parser. I will create another issue for the --help text inconsistencies/outdated.

Panic message and cause:
`panic calling String method on zero featuregate.featureGate for flag feature-gates: interface conversion: interface {} is nil, not map[featuregate.Feature]bool`
https://github.com/golang/go/blob/b35e1f9be31698bd1aa71322cc50208a7161c9cb/src/flag/flag.go#L573-L582

Overriden usage function, if you comment this out, the unhappy path will happen:
https://github.com/etcd-io/etcd/blob/6799d48fbd9b1266b9309f0eac6c08300d07037d/server/etcdmain/config.go#L93-L95

Unhappy path call stack:
<img width="684" height="610" alt="image" src="https://github.com/user-attachments/assets/4b2237f8-2494-4733-b912-f440c9de4eae" />