### PR TITLE
etcdctl: preserve the source prefix when resuming a mirror

### DIFF
--- a/etcdctl/ctlv3/command/make_mirror_command.go
+++ b/etcdctl/ctlv3/command/make_mirror_command.go
@@ -147,6 +147,11 @@ func makeMirror(ctx context.Context, c *clientv3.Client, dc *clientv3.Client) er
 		cobrautl.ExitWithError(cobrautl.ExitBadArgs, errors.New("`--dest-prefix` and `--no-dest-prefix` cannot be set at the same time, choose one"))
 	}
 
+	// Default to the source prefix for both base and incremental syncs.
+	if !mmnodestprefix && len(mmdestprefix) == 0 {
+		mmdestprefix = mmprefix
+	}
+
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
@@ -165,11 +170,6 @@ func makeMirror(ctx context.Context, c *clientv3.Client, dc *clientv3.Client) er
 	// Instead, just start watching the key space starting from the rev
 	if startRev == 0 {
 		rc, errc := s.SyncBase(ctx)
-
-		// if remove destination prefix is false and destination prefix is empty set the value of destination prefix same as prefix
-		if !mmnodestprefix && len(mmdestprefix) == 0 {
-			mmdestprefix = mmprefix
-		}
 
 		for r := range rc {
 			for _, kv := range r.Kvs {

--- a/tests/e2e/ctl_v3_make_mirror_test.go
+++ b/tests/e2e/ctl_v3_make_mirror_test.go
@@ -28,7 +28,27 @@ import (
 func TestCtlV3MakeMirror(t *testing.T)                 { testCtl(t, makeMirrorTest) }
 func TestCtlV3MakeMirrorModifyDestPrefix(t *testing.T) { testCtl(t, makeMirrorModifyDestPrefixTest) }
 func TestCtlV3MakeMirrorNoDestPrefix(t *testing.T)     { testCtl(t, makeMirrorNoDestPrefixTest) }
-func TestCtlV3MakeMirrorWithWatchRev(t *testing.T)     { testCtl(t, makeMirrorWithWatchRev) }
+
+func TestCtlV3MakeMirrorWithWatchRev(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		flags      []string
+		destprefix string
+	}{
+		{name: "preserve-prefix", destprefix: "o_"},
+		{name: "replace-prefix", flags: []string{"--dest-prefix", "d_"}, destprefix: "d_"},
+		{name: "remove-prefix", flags: []string{"--no-dest-prefix"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testCtl(t, func(cx ctlCtx) {
+				flags := append([]string{"--prefix", "o_", "--rev", "4"}, tc.flags...)
+				kvs := []kv{{"o_key1", "val1"}, {"o_key2", "val2"}, {"o_key3", "val3"}, {"o_key4", "val4"}}
+				kvs2 := []kvExec{{key: tc.destprefix + "key3", val: "val3"}, {key: tc.destprefix + "key4", val: "val4"}}
+				testMirrorCommand(cx, flags, kvs, kvs2, "o_", tc.destprefix+"key")
+			})
+		})
+	}
+}
 
 func makeMirrorTest(cx ctlCtx) {
 	var (
@@ -56,18 +76,6 @@ func makeMirrorNoDestPrefixTest(cx ctlCtx) {
 		flags      = []string{"--prefix", "o_", "--no-dest-prefix"}
 		kvs        = []kv{{"o_key1", "val1"}, {"o_key2", "val2"}, {"o_key3", "val3"}}
 		kvs2       = []kvExec{{key: "key1", val: "val1"}, {key: "key2", val: "val2"}, {key: "key3", val: "val3"}}
-		srcprefix  = "o_"
-		destprefix = "key"
-	)
-
-	testMirrorCommand(cx, flags, kvs, kvs2, srcprefix, destprefix)
-}
-
-func makeMirrorWithWatchRev(cx ctlCtx) {
-	var (
-		flags      = []string{"--prefix", "o_", "--no-dest-prefix", "--rev", "4"}
-		kvs        = []kv{{"o_key1", "val1"}, {"o_key2", "val2"}, {"o_key3", "val3"}, {"o_key4", "val4"}}
-		kvs2       = []kvExec{{key: "key3", val: "val3"}, {key: "key4", val: "val4"}}
 		srcprefix  = "o_"
 		destprefix = "key"
 	)


### PR DESCRIPTION
`make-mirror --prefix=app/ --rev=3` currently writes `app/key` to `key` by default. Move destination-prefix initialization before the full/incremental sync branch so resumed mirrors keep the same key mapping.

Extend the existing revision e2e test to cover preserving, replacing, and removing the prefix. The preserve-prefix case fails before the fix. A separate reproduction confirms that both PUT and DELETE now target the expected destination key.

Related to #22421.

Validation:

- `make build`
- `go test -race ./etcdctl/...`
- `go test ./tests/e2e -run '^TestCtlV3MakeMirror' -count=1 -v -timeout=3m` — all six scenarios pass; run in an isolated network namespace because the host cannot bind port 10000.
- `USERMOD=etcdctl make verify-lint`
- `USERMOD=tests PKG=./e2e make verify-lint`
- `git diff --check`

AI assistance: Codex was used for investigation, implementation, and test execution.

<details>
<summary>Prompt and rhyme requested by the PR template</summary>

User request, with stray formatting characters removed:

```text
我想给这个项目提供PR;需要你：评估项目代码、PR、issue。查看是否存在没有被解决的高质量issue，如果没有你成为评估问题的一方，评定当前项目存在什么问题
- 需要提出高质量的问题，以获得高质量的PR
- 代码风格符合项目风格
- 提issue和PR需要符合项目要求；代码测试不应该冗余太长，避免维护中review有负担；评论要简明友好 避免人机味
- 如果评估没有适合的需求 那么就诚实声明没有
- 如果不能给项目贡献考虑自己弄个PI插件的仓库
- 总之一切都要围绕高价值-有实际需求出发。
```

In etcd, mirrored keys should stay,  
With prefixes intact along the way.

</details>
